### PR TITLE
chore: ignore major Node version bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
     reviewers:
       - "dmahaffey"
 
-  # Docker base images
+  # Docker base images (pinned to Node 20 LTS)
   - package-ecosystem: "docker"
     directory: "/apps/api"
     schedule:
@@ -39,6 +39,9 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
     reviewers:
       - "dmahaffey"
 
@@ -49,5 +52,8 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
     reviewers:
       - "dmahaffey"


### PR DESCRIPTION
## Summary
- Adds `ignore` rules for major Node version bumps in Docker base image updates
- Docker images are pinned to Node 20 LTS; Dependabot was proposing jumps to non-LTS releases (e.g. Node 25)
- Minor/patch updates to the 20-alpine tag still flow through

## Test plan
- [x] Verify Dependabot no longer opens PRs for Node major version bumps
- [x] Confirm minor/patch Docker updates are unaffected