### PR TITLE
chore: fix all ESLint warnings and disable auto-deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,10 @@
 name: Deploy
 
 on:
-  # Auto-deploy to staging on merge to main
-  push:
-    branches: [main]
-  # Manual deploy to production
+  # Auto-deploy to staging on merge to main (enable when staging server is configured)
+  # push:
+  #   branches: [main]
+  # Manual deploy to staging or production
   workflow_dispatch:
     inputs:
       environment:

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -95,4 +95,4 @@ async function bootstrap() {
   console.log(`tRPC endpoint: http://localhost:${port}/trpc`);
 }
 
-bootstrap();
+void bootstrap();

--- a/apps/api/src/modules/gdpr/gdpr.service.ts
+++ b/apps/api/src/modules/gdpr/gdpr.service.ts
@@ -285,7 +285,7 @@ export class GdprService {
         { name: 'metadata.json' },
       );
 
-      archive.finalize();
+      void archive.finalize();
     });
   }
 

--- a/apps/api/src/modules/redis/redis.service.ts
+++ b/apps/api/src/modules/redis/redis.service.ts
@@ -33,7 +33,7 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
   }
 
   onModuleDestroy() {
-    this.client?.quit();
+    void this.client?.quit();
   }
 
   getClient(): Redis {

--- a/apps/web/e2e/helpers/auth.ts
+++ b/apps/web/e2e/helpers/auth.ts
@@ -7,7 +7,7 @@
  */
 
 import { type Page } from "@playwright/test";
-import { registerUser, loginUser, getMe } from "./api-client";
+import { registerUser } from "./api-client";
 import { createOrg, addMember, getUserByEmail } from "./db";
 
 /**

--- a/apps/web/src/app/(dashboard)/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/page.tsx
@@ -57,7 +57,7 @@ export default function SettingsPage() {
         );
         setIsExporting(false);
       }, 2000);
-    } catch (error) {
+    } catch {
       toast.error("Failed to export data");
       setIsExporting(false);
     }

--- a/apps/web/src/components/auth/protected-route.tsx
+++ b/apps/web/src/components/auth/protected-route.tsx
@@ -22,7 +22,7 @@ export function ProtectedRoute({
   requireOrganization = true,
 }: ProtectedRouteProps) {
   const router = useRouter();
-  const { user, isLoading, isAuthenticated, isEmailVerified } = useAuth();
+  const { isLoading, isAuthenticated, isEmailVerified } = useAuth();
   const { currentOrg, isEditor, isAdmin, hasOrganizations } = useOrganization();
 
   useEffect(() => {

--- a/apps/web/src/components/auth/register-form.tsx
+++ b/apps/web/src/components/auth/register-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -38,7 +37,6 @@ const registerFormSchema = registerSchema.extend({
 type RegisterFormInput = z.infer<typeof registerFormSchema>;
 
 export function RegisterForm() {
-  const router = useRouter();
   const { register, isRegisterLoading, registerError } = useAuth();
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { useOrganization } from "@/hooks/use-organization";
-import { FileText, LayoutDashboard, Settings, Users } from "lucide-react";
+import { FileText, LayoutDashboard, Settings } from "lucide-react";
 
 const navigation = [
   { name: "My Submissions", href: "/submissions", icon: FileText },

--- a/apps/web/src/components/layout/user-menu.tsx
+++ b/apps/web/src/components/layout/user-menu.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { LogOut, Settings, User } from "lucide-react";
+import { LogOut, Settings } from "lucide-react";
 
 export function UserMenu() {
   const { user, logout, isLogoutLoading } = useAuth();

--- a/apps/web/src/components/submissions/__tests__/submission-form.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/submission-form.spec.tsx
@@ -32,7 +32,7 @@ jest.mock("@/lib/trpc", () => ({
   trpc: {
     submissions: {
       getById: {
-        useQuery: (_input: unknown, _opts: unknown) => ({
+        useQuery: () => ({
           data: mockExistingSubmission,
           isLoading: mockIsLoadingSubmission,
         }),

--- a/apps/web/src/components/submissions/file-upload.tsx
+++ b/apps/web/src/components/submissions/file-upload.tsx
@@ -182,7 +182,7 @@ export function FileUpload({ submissionId, disabled }: FileUploadProps) {
   const deleteMutation = trpc.files.delete.useMutation();
   const utils = trpc.useUtils();
 
-  const { uploads, uploadFiles, removeUpload, isUploading } = useFileUpload({
+  const { uploads, uploadFiles, removeUpload } = useFileUpload({
     submissionId,
     onUploadComplete: () => {
       utils.files.getBySubmission.invalidate({ submissionId });

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -22,7 +22,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";

--- a/apps/web/src/components/submissions/submission-form.tsx
+++ b/apps/web/src/components/submissions/submission-form.tsx
@@ -6,10 +6,6 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { trpc } from "@/lib/trpc";
-import {
-  createSubmissionSchema,
-  updateSubmissionSchema,
-} from "@prospector/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";

--- a/apps/web/src/hooks/__tests__/use-auth.spec.tsx
+++ b/apps/web/src/hooks/__tests__/use-auth.spec.tsx
@@ -20,7 +20,7 @@ jest.mock("@/lib/trpc", () => ({
   trpc: {
     auth: {
       me: {
-        useQuery: (input: unknown, opts: unknown) => ({
+        useQuery: () => ({
           data: mockMeData,
           isLoading: mockMeIsLoading,
           error: mockMeError,
@@ -72,10 +72,7 @@ jest.mock("@/lib/trpc", () => ({
         }),
       },
       refresh: {
-        useMutation: (opts: {
-          onSuccess?: (data: unknown) => void;
-          onError?: () => void;
-        }) => ({
+        useMutation: () => ({
           mutate: mockRefreshMutate,
           isPending: false,
         }),

--- a/apps/web/src/hooks/use-organization.ts
+++ b/apps/web/src/hooks/use-organization.ts
@@ -1,8 +1,8 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { getCurrentOrgId, setCurrentOrgId, trpc } from "@/lib/trpc";
-import { useAuth, type UserProfile } from "./use-auth";
+import { useAuth } from "./use-auth";
 
 export type OrgRole = "ADMIN" | "EDITOR" | "READER";
 
@@ -18,13 +18,16 @@ export function useOrganization() {
   const utils = trpc.useUtils();
 
   // Get organizations from user profile
-  const organizations: Organization[] =
-    user?.organizations?.map((m) => ({
-      id: m.organization.id,
-      name: m.organization.name,
-      slug: m.organization.slug,
-      role: m.role,
-    })) ?? [];
+  const organizations: Organization[] = useMemo(
+    () =>
+      user?.organizations?.map((m) => ({
+        id: m.organization.id,
+        name: m.organization.name,
+        slug: m.organization.slug,
+        role: m.role,
+      })) ?? [],
+    [user?.organizations],
+  );
 
   // Get current org ID from storage
   const currentOrgId = typeof window !== "undefined" ? getCurrentOrgId() : null;

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -4,6 +4,31 @@ Append-only session log. Newest entries first.
 
 ---
 
+## 2026-02-10 — Dependabot Triage & ESLint Cleanup
+
+### Done
+
+- Verified `workflow_run` AI review trigger works: CI on PR → AI review posts comment (confirmed on PR #1)
+- Created GitHub labels (`dependencies`, `ci`, `docker`) for Dependabot
+- Merged Dependabot PRs #1 (`actions/checkout` v4→v6) and #2 (`actions/setup-node` v4→v6)
+- Closed Dependabot PRs #3, #4 (Node 25-alpine — non-LTS, project pinned to Node 20)
+- Added `ignore` rules to `dependabot.yml` to block major Node version bumps in Docker images
+- Fixed all 19 ESLint warnings in web app (unused imports/vars, `useMemo` for exhaustive-deps)
+- Fixed 3 ESLint warnings in API (floating promises)
+- Updated GitHub token permissions: organization read/write access to projects
+
+### Decisions
+
+- Dependabot Docker updates ignore major Node bumps — upgrade to next LTS manually
+- `workflow_run` AI review correctly skips pushes to main (only reviews PRs)
+
+### Next
+
+- Email verification enforcement
+- Zod validation for env vars at API startup
+
+---
+
 ## 2026-02-10 — CI Debugging & Pre-Push Hook
 
 ### Done


### PR DESCRIPTION
## Summary
- Fix all 19 ESLint warnings in web app (unused imports/vars, `useMemo` for `react-hooks/exhaustive-deps`)
- Fix all 3 ESLint warnings in API (`@typescript-eslint/no-floating-promises`)
- Disable deploy workflow `push` trigger until staging server is configured (stops failure emails)
- Update DEVLOG with Dependabot triage and cleanup notes

## Test plan
- [x] `pnpm --filter @prospector/web lint` — 0 warnings (was 19)
- [x] `pnpm --filter @prospector/api lint` — 0 warnings (was 3)
- [x] Web unit tests: 117 passing
- [x] API unit tests: 185 passing
- [x] Type check passes