### PR TITLE
chore(ci): skip CI pipeline for docs-only and skill-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.claude/skills/**'
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.claude/skills/**'
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,11 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
-      - '.claude/skills/**'
   push:
     branches: [main]
     paths-ignore:
       - '**.md'
       - 'docs/**'
-      - '.claude/skills/**'
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Adds `paths-ignore` to CI workflow for `**.md`, `docs/**`, and `.claude/skills/**`
- Docs-only PRs no longer wait ~1 min for type-check/lint/test/build that can't fail on markdown
- Pre-commit hook already enforces Prettier on `.md` files
- CI still runs normally when a PR includes any code changes alongside docs
- AI review (triggered via `workflow_run` on CI) is also skipped for docs-only PRs

## Test plan
- [ ] Push a docs-only PR — CI should not trigger
- [ ] Push a PR with docs + code changes — CI should still trigger