### PR TITLE
fix: resolve WSL husky hook failures (node/npx not found)

### DIFF
--- a/.claude/skills/end-session/SKILL.md
+++ b/.claude/skills/end-session/SKILL.md
@@ -63,11 +63,7 @@ If today already has a DEVLOG entry, **append to the existing entry's sections**
 
 ### Step 3: Check for CLAUDE.md updates
 
-Search the codebase for any `TODO(CLAUDE.md)` comments added during this session:
-
-```bash
-grep -r "TODO(CLAUDE.md)" --include="*.ts" --include="*.tsx" --include="*.js" .
-```
+Search the codebase for any `TODO(CLAUDE.md)` comments added during this session using the Grep tool (not bash) to search for `TODO(CLAUDE.md)` in `*.ts`, `*.tsx`, and `*.js` files.
 
 Also review the session for any new patterns, quirks, or constraints discovered. If updates are warranted, propose them:
 
@@ -122,20 +118,28 @@ Ask the user if they want to apply the suggestions before proceeding.
 
    Report the CI status to the user.
 
-6. **Clean up stale local branches**: Delete local branches that have already been merged to `origin/main`:
+6. **Clean up stale local branches**: Delete local branches whose remote tracking branch has been deleted (i.e., squash-merged PRs):
 
    ```bash
-   git fetch origin main
-   git branch --merged origin/main | grep -v '^\*\|main$' | sed 's/^[* ] *//'
+   git fetch --prune
+   git branch -vv
    ```
 
-   If any stale branches are found, list them and delete:
+   Claude parses the `git branch -vv` output:
+   - Lines containing `[gone]` indicate branches whose upstream was deleted (the PR was merged/closed and the remote branch removed)
+   - Lines starting with `*` indicate the current branch
+   - Extract the branch name (first non-whitespace token after `*` or leading spaces)
+   - Skip `main` — never delete main
+
+   If any stale branches are found (upstream `[gone]`), list them and delete:
 
    ```bash
-   git branch -d "<branch-name>"
+   git branch -D "<branch-name>"
    ```
 
-   Also switch to `main` if the current branch was already merged and the session's PR work is done:
+   Note: Use `-D` (force delete) because squash-merged branches are not recognized as `--merged` by git.
+
+   Also switch to `main` if the current branch's upstream is `[gone]` and the session's PR work is done:
 
    ```bash
    git checkout main && git pull origin main

--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -38,27 +38,34 @@ git fetch origin main
 Then run these in parallel:
 
 ```bash
-# Get the date from the latest DEVLOG entry
-grep -m1 -oE '## [0-9]{4}-[0-9]{2}-[0-9]{2}' docs/DEVLOG.md | sed 's/## //'
-
 # Get the date of the most recent commit on main
 git log origin/main -1 --format='%cs'
 
 # Get recently merged PRs (10 most recent)
 gh pr list --state merged --limit 10 --json number,title,mergedAt,headRefName
 
-# Check for stale local branches (merged remotely but still local)
-git branch --merged origin/main | grep -v '^\*\|main$' | sed 's/^[* ] *//'
-
-# Check if current branch is a feature branch already merged to main
-git branch --merged origin/main | grep '^\*' | grep -v 'main$' | sed 's/^\* //'
+# Check for stale local branches (squash-merged PRs leave branches whose upstream is gone)
+# AND check if current branch is a feature branch whose upstream was deleted
+git fetch --prune
+git branch -vv
 ```
+
+For the DEVLOG date, use the Grep tool (not bash) to find the first `## YYYY-MM-DD` heading in `docs/DEVLOG.md` and extract the date.
+
+For the `git branch -vv` output, Claude parses it directly:
+
+- Lines containing `[gone]` indicate branches whose remote tracking branch was deleted (PR merged/closed)
+- Lines starting with `*` indicate the current branch
+- Extract the branch name (first non-whitespace token after `*` or leading spaces)
+- Skip `main` — never flag main
+- Branches with `[gone]` upstream (excluding main) are stale branches
+- If the `*` (current) branch has `[gone]` upstream, the current branch is a merged feature branch
 
 Flag an **incomplete session** if ANY of these are true:
 
 1. **DEVLOG is stale**: The most recent commit date on `origin/main` is newer than the latest DEVLOG entry date. This means work was merged without a DEVLOG update.
-2. **Stale branches exist**: Local branches that are already merged to main but weren't cleaned up (indicates session ended without housekeeping).
-3. **On a merged branch**: The current branch is a feature branch whose PR has already been merged.
+2. **Stale branches exist**: Local branches whose remote tracking branch is `[gone]` (squash-merged PRs not cleaned up — indicates session ended without housekeeping).
+3. **On a merged branch**: The current branch is a feature branch whose upstream is `[gone]`.
 
 If an incomplete session is detected, alert the user prominently:
 
@@ -95,8 +102,10 @@ Run these commands in parallel:
 git branch --show-current
 git status --short
 git log --oneline -5
-git branch --list --format='%(refname:short) %(upstream:track)' | grep -v '^\s*$'
+git branch --list --format='%(refname:short) %(upstream:track)'
 ```
+
+For the branch tracking output, Claude filters out blank lines when parsing the result.
 
 Report:
 
@@ -158,11 +167,7 @@ Do NOT auto-start services — just report status so the user can decide.
 
 Read the Post-MVP Roadmap section of `CLAUDE.md` (search for `## Post-MVP Roadmap`) and list the unchecked `[ ]` items from the "Immediate (pre-launch)" and "Short-term" sections.
 
-Also check for any `TODO(CLAUDE.md)` comments in the codebase:
-
-```bash
-grep -r "TODO(CLAUDE.md)" --include="*.ts" --include="*.tsx" --include="*.js" . 2>/dev/null
-```
+Also check for any `TODO(CLAUDE.md)` comments in the codebase using the Grep tool (not bash) to search for `TODO(CLAUDE.md)` in `*.ts`, `*.tsx`, and `*.js` files.
 
 ### Step 7: Print briefing
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,12 @@
+# WSL: node/pnpm aren't in husky's default sh PATH; add nvm node
+NVM_NODE="$HOME/.nvm/versions/node"
+for d in "$NVM_NODE"/*/bin; do
+  PATH="$d:$PATH"
+done
+export PATH
+
 # Secret scanning (blocks commit on live keys, private keys, env files)
 sh scripts/check-secrets.sh
 
 # Lint and format staged files
-npx lint-staged
+lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,10 @@
+# WSL: node/pnpm aren't in husky's default sh PATH; add nvm node
+NVM_NODE="$HOME/.nvm/versions/node"
+for d in "$NVM_NODE"/*/bin; do
+  PATH="$d:$PATH"
+done
+export PATH
+
 # Run the same checks CI runs, so failures are caught before pushing
 echo "Running pre-push checks..."
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,22 +154,22 @@ tRPC client for internal API calls. Zitadel handles login/signup UI. `ProtectedR
 
 ## Known Quirks & Gotchas
 
-| Quirk                                                 | Details                                                                                                                      |
-| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| **Drizzle `pgPolicy` requires `drizzle-orm/pg-core`** | Import `pgPolicy` from `drizzle-orm/pg-core`, not the top-level export                                                       |
-| **Drizzle JSONB queries need raw SQL**                | No native JSONB operators yet. Use `sql` template tag for JSONB path queries. Track Drizzle JSONB roadmap (Q2 2026)          |
-| **Pothos has no Drizzle plugin**                      | Manual type definitions, manual DataLoader setup, manual cursor pagination for every model. See architecture doc section 5.5 |
-| **Zitadel webhook signatures**                        | Verify `x-zitadel-signature` header on all webhook payloads. Use shared secret from Zitadel Actions config                   |
-| **`@ts-rest/fastify` adapter**                        | `initServer()` then `s.router(contract, handlers)` — different from the NestJS adapter pattern                               |
-| **GraphQL Yoga + Fastify**                            | Mount via `app.route()` with `handleNodeRequest`, not a Fastify plugin. Must forward headers manually                        |
-| **BullMQ Redis password**                             | Uses `REDIS_HOST`/`REDIS_PORT`/`REDIS_PASSWORD` (not `REDIS_URL`). Pass password in worker/queue config                      |
-| **Docker Compose env_file**                           | `env_file:` sets container env only. For YAML `${VAR}` substitution, use `--env-file .env` on CLI                            |
-| **PostgreSQL init-db.sh**                             | Only runs on first DB creation. Must `docker compose down -v` to re-run after changes                                        |
-| **TanStack Query v4 isLoading**                       | `isLoading` is `true` even when query is disabled (`enabled: false`). Check `fetchStatus !== 'idle'` instead                 |
-| **GitHub PAT: no Checks perm**                        | Fine-grained PATs lack `Checks` permission. Use `gh run list/view` (Actions API), NOT `gh pr checks`                         |
+| Quirk                                                 | Details                                                                                                                                                                     |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Drizzle `pgPolicy` requires `drizzle-orm/pg-core`** | Import `pgPolicy` from `drizzle-orm/pg-core`, not the top-level export                                                                                                      |
+| **Drizzle JSONB queries need raw SQL**                | No native JSONB operators yet. Use `sql` template tag for JSONB path queries. Track Drizzle JSONB roadmap (Q2 2026)                                                         |
+| **Pothos has no Drizzle plugin**                      | Manual type definitions, manual DataLoader setup, manual cursor pagination for every model. See architecture doc section 5.5                                                |
+| **Zitadel webhook signatures**                        | Verify `x-zitadel-signature` header on all webhook payloads. Use shared secret from Zitadel Actions config                                                                  |
+| **`@ts-rest/fastify` adapter**                        | `initServer()` then `s.router(contract, handlers)` — different from the NestJS adapter pattern                                                                              |
+| **GraphQL Yoga + Fastify**                            | Mount via `app.route()` with `handleNodeRequest`, not a Fastify plugin. Must forward headers manually                                                                       |
+| **BullMQ Redis password**                             | Uses `REDIS_HOST`/`REDIS_PORT`/`REDIS_PASSWORD` (not `REDIS_URL`). Pass password in worker/queue config                                                                     |
+| **Docker Compose env_file**                           | `env_file:` sets container env only. For YAML `${VAR}` substitution, use `--env-file .env` on CLI                                                                           |
+| **PostgreSQL init-db.sh**                             | Only runs on first DB creation. Must `docker compose down -v` to re-run after changes                                                                                       |
+| **TanStack Query v4 isLoading**                       | `isLoading` is `true` even when query is disabled (`enabled: false`). Check `fetchStatus !== 'idle'` instead                                                                |
+| **GitHub PAT: no Checks perm**                        | Fine-grained PATs lack `Checks` permission. Use `gh run list/view` (Actions API), NOT `gh pr checks`                                                                        |
 | **tRPC TS2742 under NodeNext**                        | `typeof appRouter` can't be named without internal `@trpc/server/dist/core/router` reference. Use `AnyRouter` annotation; refine to concrete type when procedures are added |
-| **WSL `npx` resolves to Windows**                     | Pre-commit `npx lint-staged` fails in WSL when Windows npm is in PATH. Use `pnpm exec` instead of `npx` in hooks             |
-| **CI: workspace deps need build before Vitest**       | Vitest resolves workspace packages via `exports` field (pointing to `dist/`). CI must build deps before running tests         |
+| **WSL husky hooks need nvm PATH**                     | Husky v9 runs hooks under `sh`/`dash`; `nvm.sh` can't be sourced. Hooks add nvm node bin to PATH directly. `lint-staged` called without `npx`                               |
+| **CI: workspace deps need build before Vitest**       | Vitest resolves workspace packages via `exports` field (pointing to `dist/`). CI must build deps before running tests                                                       |
 
 **Version pins (do not upgrade without testing):**
 

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -4,6 +4,35 @@ Append-only session log. Newest entries first.
 
 ---
 
+## 2026-02-12 — Husky Hook Fixes + Session Skill Improvements
+
+### Done
+
+- Fixed WSL husky hook issue — `npx lint-staged` resolved to Windows npm; now calls `lint-staged` directly (husky prepends `node_modules/.bin` to PATH)
+- Fixed `node: not found` in husky hooks — husky v9 runs hooks under `sh`/`dash` where `nvm.sh` can't be sourced; added nvm node bin directory to PATH directly in both pre-commit and pre-push hooks
+- Created `~/.config/husky/init.sh` as a backup PATH setup (husky v9 sources this before hooks)
+- Updated start-session and end-session skills: use Grep tool instead of bash `grep`, detect stale branches via `[gone]` upstream (correct for squash-merged PRs)
+- Reviewed previous session's permission prompts for policy consistency
+- Whitelisted `Bash(export *)` in `.claude/settings.local.json` for environment setup commands
+
+### Decisions
+
+- **Direct nvm bin PATH**: Can't source `nvm.sh` under `dash`/`sh` — instead loop over `$HOME/.nvm/versions/node/*/bin` and prepend to PATH
+- **`lint-staged` direct call**: Works because husky already puts `node_modules/.bin` first in PATH
+- **`--no-verify` stays gated**: Per CLAUDE.md policy, `--no-verify` should not be whitelisted; the root cause (missing node in PATH) is now fixed
+- **`Bash(export *)` whitelisted**: Safe — covers read-only environment setup commands like `export NVM_DIR=...`
+
+### Issues Found
+
+- **Husky v9 `~/.config/husky/init.sh` unreliable**: Despite being documented, the init.sh wasn't sourced in practice — the in-hook PATH fix was needed as primary solution
+
+### Next
+
+- Continue Track 1: Zitadel auth integration (OIDC token validation hook, webhook handler)
+- Consider deduplicating nvm PATH setup (currently in both hooks AND init.sh)
+
+---
+
 ## 2026-02-12 — Track 1: Fastify 5 Entry Point (Step 2)
 
 ### Done
@@ -37,7 +66,7 @@ Append-only session log. Newest entries first.
 
 ### Issues Found
 
-- **WSL `npx` resolves to Windows npm**: Pre-commit hook calls `npx lint-staged` which hits Windows `npx` in WSL. Workaround: `--no-verify` + manual verification. Should fix pre-commit hook to use `pnpm exec` instead of `npx`
+- ~~**WSL `npx` resolves to Windows npm**~~ ✅ Fixed in next session — hooks now call `lint-staged` directly with nvm node bin in PATH
 - **AI review `build-review-context.sh` fragile under `pipefail`**: Any `grep` in a pipeline that returns no matches kills the script. Fixed for one instance; other `grep` calls in the script may have the same issue
 
 ### Next


### PR DESCRIPTION
## Summary

- Fix pre-commit hook: replace `npx lint-staged` with direct `lint-staged` call (WSL `npx` resolved to Windows npm)
- Fix both hooks: add nvm node bin to PATH directly (husky v9 runs under `sh`/`dash` where `nvm.sh` can't be sourced)
- Update start-session and end-session skills: use Grep tool instead of bash `grep`, detect stale branches via `[gone]` upstream (correct for squash-merged PRs)
- Update CLAUDE.md quirks table to reflect resolved WSL issue

## Test plan

- [x] Pre-commit hook runs successfully (`lint-staged` formats staged files)
- [x] Pre-push hook runs successfully (type-check + lint pass)
- [x] No `--no-verify` workaround needed