### PR TITLE
docs: add gh pr edit workaround and session DEVLOG entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ tRPC client for internal API calls. Zitadel handles login/signup UI. `ProtectedR
 | **tRPC TS2742 under NodeNext**                        | `typeof appRouter` can't be named without internal `@trpc/server/dist/core/router` reference. Use `AnyRouter` annotation; refine to concrete type when procedures are added |
 | **WSL husky hooks need nvm PATH**                     | Husky v9 runs hooks under `sh`/`dash`; `nvm.sh` can't be sourced. Hooks add nvm node bin to PATH directly. `lint-staged` called without `npx`                               |
 | **CI: workspace deps need build before Vitest**       | Vitest resolves workspace packages via `exports` field (pointing to `dist/`). CI must build deps before running tests                                                       |
+| **`gh pr edit` broken (Projects Classic)**            | Returns GraphQL error about Projects Classic deprecation. Use `gh api repos/{owner}/{repo}/pulls/{number} -X PATCH -f title="..." -f body="..."` instead                    |
 
 **Version pins (do not upgrade without testing):**
 

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -4,6 +4,42 @@ Append-only session log. Newest entries first.
 
 ---
 
+## 2026-02-12 — Claude Code GitHub App Trial & Revert
+
+### Done
+
+- Installed Claude Code GitHub App via `/install-github-app` skill (PR #37 merged)
+  - Required `gh auth refresh -h github.com -s repo,workflow` for PAT scopes
+  - Added `claude-code-review.yml` (auto-review on PR events) and `claude.yml` (@claude mention handler)
+- Closed PR #38 as empty duplicate (second `/install-github-app` run, no diff)
+- Discovered `claude-code-action` code-review plugin is not production-ready:
+  - Churns through tools (YAML validation, fetching action source, etc.) without producing review output
+  - No short-circuit for empty diffs — ran 7+ minutes on PR #38 with zero file changes
+  - Still running on PR #39 after 10+ minutes with no output
+  - `pull-requests: read` permission may be insufficient to post comments
+- Reverted: PR #39 removes both Claude Code workflow files, restores Kimi/OpenRouter review
+- Added `gh pr edit` workaround to CLAUDE.md Known Quirks (returns GraphQL Projects Classic deprecation error; use `gh api` PATCH instead)
+- Cleaned up 4 stale `add-claude-github-actions-*` remote branches
+
+### Decisions
+
+- **Keep Kimi K2.5 via OpenRouter** for AI code review — working and produces useful output
+- **Remove Claude Code review workflows** — plugin not mature enough; revisit when it improves
+- **Keep `@claude` mention workflow removed too** — both workflows used the same OAuth token setup; cleaner to remove both
+
+### Issues Found
+
+- **`/install-github-app` skill auth detection**: Reports "not authenticated" even when `gh auth status` confirms login — likely checks for OAuth vs PAT differently
+- **`gh pr edit` broken**: Returns GraphQL error about Projects Classic deprecation — use `gh api` PATCH as workaround
+
+### Next
+
+- Optionally remove `CLAUDE_CODE_OAUTH_TOKEN` secret from repo settings
+- Continue Track 1: Zitadel auth integration
+- Revisit Claude Code review when `claude-code-action` plugin matures
+
+---
+
 ## 2026-02-12 — Husky Hook Fixes + Session Skill Improvements
 
 ### Done


### PR DESCRIPTION
## Summary
- Add `gh pr edit` GraphQL Projects Classic workaround to CLAUDE.md Known Quirks table
- Re-add DEVLOG entry for Claude Code GitHub App trial session (lost in squash merge of PR #39)

## Test plan
- Docs-only change, no code affected