### PR TITLE
feat(api): add audit logging infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,27 +24,27 @@ API layer and plugin system use the `@colophony/` prefix directly.
 
 > **Note:** These are TARGET paths for the v2 architecture. During the rewrite, files are created incrementally. Check actual existence before referencing.
 
-| What                        | Path                                                             |
-| --------------------------- | ---------------------------------------------------------------- |
-| **Drizzle schema**          | `packages/db/src/schema/` (one file per table group)             |
-| **Drizzle migrations**      | `packages/db/migrations/`                                        |
-| **Drizzle client**          | `packages/db/src/client.ts`                                      |
-| **RLS policies**            | `packages/db/src/schema/*.ts` (via `pgPolicy` in Drizzle schema) |
-| **Shared Zod schemas**      | `packages/types/src/`                                            |
-| **ts-rest contracts**       | `packages/api-contracts/src/`                                    |
-| **Zitadel auth client**     | `packages/auth-client/src/`                                      |
-| **Fastify app entry**       | `apps/api/src/main.ts`                                           |
-| **REST routes (ts-rest)**   | `apps/api/src/rest/`                                             |
-| **GraphQL (Pothos + Yoga)** | `apps/api/src/graphql/`                                          |
-| **tRPC (internal)**         | `apps/api/src/trpc/`                                             |
-| **Fastify hooks**           | `apps/api/src/hooks/` (auth, rate-limit, org-context)            |
-| **Service layer**           | `apps/api/src/services/`                                         |
-| **BullMQ processors**       | `apps/api/src/jobs/`                                             |
-| **Zitadel webhooks**        | `apps/api/src/webhooks/zitadel.webhook.ts`                       |
-| **Stripe webhooks**         | `apps/api/src/webhooks/stripe.webhook.ts`                        |
-| **Federation endpoints**    | `apps/api/src/federation/`                                       |
-| **Next.js frontend**        | `apps/web/`                                                      |
-| **tRPC client**             | `apps/web/src/lib/trpc.ts`                                       |
+| What                        | Path                                                                     |
+| --------------------------- | ------------------------------------------------------------------------ |
+| **Drizzle schema**          | `packages/db/src/schema/` (one file per table group)                     |
+| **Drizzle migrations**      | `packages/db/migrations/`                                                |
+| **Drizzle client**          | `packages/db/src/client.ts`                                              |
+| **RLS policies**            | `packages/db/src/schema/*.ts` (via `pgPolicy` in Drizzle schema)         |
+| **Shared Zod schemas**      | `packages/types/src/`                                                    |
+| **ts-rest contracts**       | `packages/api-contracts/src/`                                            |
+| **Zitadel auth client**     | `packages/auth-client/src/`                                              |
+| **Fastify app entry**       | `apps/api/src/main.ts`                                                   |
+| **REST routes (ts-rest)**   | `apps/api/src/rest/`                                                     |
+| **GraphQL (Pothos + Yoga)** | `apps/api/src/graphql/`                                                  |
+| **tRPC (internal)**         | `apps/api/src/trpc/`                                                     |
+| **Fastify hooks**           | `apps/api/src/hooks/` (auth, rate-limit, org-context, db-context, audit) |
+| **Service layer**           | `apps/api/src/services/`                                                 |
+| **BullMQ processors**       | `apps/api/src/jobs/`                                                     |
+| **Zitadel webhooks**        | `apps/api/src/webhooks/zitadel.webhook.ts`                               |
+| **Stripe webhooks**         | `apps/api/src/webhooks/stripe.webhook.ts`                                |
+| **Federation endpoints**    | `apps/api/src/federation/`                                               |
+| **Next.js frontend**        | `apps/web/`                                                              |
+| **tRPC client**             | `apps/web/src/lib/trpc.ts`                                               |
 
 Full project structure: [docs/architecture-v2-planning.md](docs/architecture-v2-planning.md)
 

--- a/apps/api/src/hooks/audit.spec.ts
+++ b/apps/api/src/hooks/audit.spec.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import type { Env } from '../config/env.js';
+
+const { mockClientQuery, mockClientRelease, mockPoolConnect, mockAuditLog } =
+  vi.hoisted(() => {
+    const mockClientQuery = vi.fn().mockResolvedValue({ rows: [] });
+    const mockClientRelease = vi.fn();
+    const mockPoolConnect = vi.fn().mockResolvedValue({
+      query: mockClientQuery,
+      release: mockClientRelease,
+    });
+    const mockAuditLog = vi.fn().mockResolvedValue(undefined);
+    return {
+      mockClientQuery,
+      mockClientRelease,
+      mockPoolConnect,
+      mockAuditLog,
+    };
+  });
+
+vi.mock('@colophony/db', () => ({
+  db: {
+    query: {
+      users: { findFirst: vi.fn() },
+      organizations: { findFirst: vi.fn() },
+      organizationMembers: { findFirst: vi.fn() },
+    },
+  },
+  eq: vi.fn((_col: unknown, val: unknown) => val),
+  and: vi.fn((...args: unknown[]) => args),
+  users: { zitadelUserId: 'zitadel_user_id' },
+  organizations: { id: 'id' },
+  organizationMembers: {
+    organizationId: 'organization_id',
+    userId: 'user_id',
+  },
+  auditEvents: { _: 'audit_events_table_ref' },
+  pool: {
+    connect: mockPoolConnect,
+    query: vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
+  },
+  DrizzleDb: {},
+}));
+
+vi.mock('@colophony/auth-client', () => ({
+  createJwksVerifier: vi.fn(),
+}));
+
+vi.mock('drizzle-orm/node-postgres', () => ({
+  drizzle: vi.fn(() => ({ __mock: true })),
+}));
+
+vi.mock('../services/audit.service.js', () => ({
+  auditService: { log: mockAuditLog },
+}));
+
+import authPlugin from './auth.js';
+import orgContextPlugin from './org-context.js';
+import dbContextPlugin from './db-context.js';
+import auditPlugin from './audit.js';
+
+const testEnv: Env = {
+  DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  PORT: 0,
+  HOST: '127.0.0.1',
+  NODE_ENV: 'test',
+  LOG_LEVEL: 'fatal',
+  REDIS_HOST: 'localhost',
+  REDIS_PORT: 6379,
+  REDIS_PASSWORD: '',
+  CORS_ORIGIN: 'http://localhost:3000',
+  RATE_LIMIT_DEFAULT_MAX: 60,
+  RATE_LIMIT_AUTH_MAX: 200,
+  RATE_LIMIT_WINDOW_SECONDS: 60,
+  RATE_LIMIT_KEY_PREFIX: 'colophony:rl',
+};
+
+describe('audit plugin', () => {
+  beforeEach(() => {
+    mockClientQuery.mockClear();
+    mockClientRelease.mockClear();
+    mockPoolConnect.mockClear();
+    mockAuditLog.mockClear().mockResolvedValue(undefined);
+    mockPoolConnect.mockResolvedValue({
+      query: mockClientQuery,
+      release: mockClientRelease,
+    });
+  });
+
+  async function buildApp(): Promise<FastifyInstance> {
+    const app = Fastify({ logger: false });
+    await app.register(authPlugin, { env: testEnv });
+    await app.register(orgContextPlugin);
+    await app.register(dbContextPlugin);
+    await app.register(auditPlugin);
+    return app;
+  }
+
+  it('provides request.audit on unauthenticated requests (no-op)', async () => {
+    const app = await buildApp();
+    app.get('/test', async (request) => {
+      await request.audit({
+        resource: 'user',
+        action: 'USER_CREATED',
+      });
+      return { ok: true };
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/test' });
+    expect(response.statusCode).toBe(200);
+    // No dbTx → no-op, auditService.log should NOT be called
+    expect(mockAuditLog).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('calls auditService.log with correct context for authenticated requests', async () => {
+    const app = await buildApp();
+    app.get('/test', async (request) => {
+      await request.audit({
+        resource: 'user',
+        action: 'USER_CREATED',
+        resourceId: 'res-1',
+        newValue: { email: 'test@example.com' },
+      });
+      return { ok: true };
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/test',
+      headers: {
+        'x-test-user-id': 'user-42',
+        'user-agent': 'TestAgent/1.0',
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    expect(mockAuditLog).toHaveBeenCalledOnce();
+
+    const [tx, params] = mockAuditLog.mock.calls[0];
+    expect(tx).toBeDefined();
+    expect(params.action).toBe('USER_CREATED');
+    expect(params.resource).toBe('user');
+    expect(params.resourceId).toBe('res-1');
+    expect(params.actorId).toBe('user-42');
+    expect(params.ipAddress).toBe('127.0.0.1');
+    expect(params.userAgent).toBe('TestAgent/1.0');
+    expect(params.newValue).toEqual({ email: 'test@example.com' });
+    await app.close();
+  });
+
+  it('propagates errors from auditService.log', async () => {
+    mockAuditLog.mockRejectedValue(new Error('Audit write failed'));
+
+    const app = await buildApp();
+    app.get('/test', async (request) => {
+      await request.audit({
+        resource: 'user',
+        action: 'USER_CREATED',
+      });
+      return { ok: true };
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/test',
+      headers: { 'x-test-user-id': 'user-42' },
+    });
+    // Error propagates through the route handler → 500
+    expect(response.statusCode).toBe(500);
+    await app.close();
+  });
+});

--- a/apps/api/src/hooks/audit.ts
+++ b/apps/api/src/hooks/audit.ts
@@ -1,0 +1,61 @@
+import fp from 'fastify-plugin';
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { auditService } from '../services/audit.service.js';
+import type { AuditLogParams } from '@prospector/types';
+
+type RequestAuditFn = (
+  params: Omit<
+    AuditLogParams,
+    'actorId' | 'organizationId' | 'ipAddress' | 'userAgent'
+  >,
+) => Promise<void>;
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    audit: RequestAuditFn;
+  }
+}
+
+const noop: RequestAuditFn = async () => {};
+
+export default fp(
+  async function auditPlugin(app: FastifyInstance) {
+    app.decorateRequest('audit', noop);
+
+    app.addHook(
+      'onRequest',
+      async function auditOnRequest(request: FastifyRequest) {
+        if (!request.dbTx) {
+          // No transaction — provide a no-op that warns only when called
+          request.audit = async () => {
+            request.log.warn(
+              'audit.log called without a database transaction (dbTx is null)',
+            );
+          };
+          return;
+        }
+
+        const tx = request.dbTx;
+        const actorId = request.authContext?.userId;
+        const organizationId = request.authContext?.orgId;
+        const ipAddress = request.ip;
+        const userAgent = request.headers['user-agent'];
+
+        request.audit = async (params) => {
+          await auditService.log(tx, {
+            ...params,
+            actorId,
+            organizationId,
+            ipAddress,
+            userAgent,
+          } as AuditLogParams);
+        };
+      },
+    );
+  },
+  {
+    name: 'colophony-audit',
+    dependencies: ['colophony-db-context'],
+    fastify: '5.x',
+  },
+);

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -7,6 +7,7 @@ import authPlugin from './hooks/auth.js';
 import rateLimitPlugin from './hooks/rate-limit.js';
 import orgContextPlugin from './hooks/org-context.js';
 import dbContextPlugin from './hooks/db-context.js';
+import auditPlugin from './hooks/audit.js';
 import { registerZitadelWebhooks } from './webhooks/zitadel.webhook.js';
 
 export async function buildApp(env: Env): Promise<FastifyInstance> {
@@ -79,6 +80,7 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
   await app.register(rateLimitPlugin, { env });
   await app.register(orgContextPlugin);
   await app.register(dbContextPlugin);
+  await app.register(auditPlugin);
 
   // Webhooks — separate scope to isolate fastify-raw-body
   await app.register(async (scope) => {

--- a/apps/api/src/services/audit.service.spec.ts
+++ b/apps/api/src/services/audit.service.spec.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockValues = vi.fn().mockResolvedValue(undefined);
+const mockInsert = vi.fn(() => ({ values: mockValues }));
+
+vi.mock('@colophony/db', () => ({
+  auditEvents: { _: 'audit_events_table_ref' },
+}));
+
+import { auditService, serializeValue } from './audit.service.js';
+import type { DrizzleDb } from '@colophony/db';
+import type { AuditLogParams } from '@prospector/types';
+
+function makeTx() {
+  mockInsert.mockClear();
+  mockValues.mockClear().mockResolvedValue(undefined);
+  return { insert: mockInsert } as unknown as DrizzleDb;
+}
+
+describe('serializeValue', () => {
+  it('returns null for null/undefined', () => {
+    expect(serializeValue(null)).toBeNull();
+    expect(serializeValue(undefined)).toBeNull();
+  });
+
+  it('serializes objects to JSON', () => {
+    expect(serializeValue({ a: 1 })).toBe('{"a":1}');
+  });
+
+  it('serializes strings', () => {
+    expect(serializeValue('hello')).toBe('"hello"');
+  });
+
+  it('scrubs secret keys', () => {
+    const input = {
+      email: 'test@example.com',
+      password: 's3cret',
+      accessToken: 'tok_123',
+      authorization: 'Bearer xxx',
+      secretKey: 'key_456',
+    };
+    const result = JSON.parse(serializeValue(input)!);
+    expect(result.email).toBe('test@example.com');
+    expect(result.password).toBe('[REDACTED]');
+    expect(result.accessToken).toBe('[REDACTED]');
+    expect(result.authorization).toBe('[REDACTED]');
+    expect(result.secretKey).toBe('[REDACTED]');
+  });
+
+  it('truncates values exceeding 8KB', () => {
+    const large = { data: 'x'.repeat(10_000) };
+    const result = JSON.parse(serializeValue(large)!);
+    expect(result._truncated).toBe(true);
+    expect(result._originalSize).toBeGreaterThan(8192);
+  });
+
+  it('handles circular references without throwing', () => {
+    const obj: Record<string, unknown> = { a: 1 };
+    obj.self = obj;
+    const result = JSON.parse(serializeValue(obj)!);
+    expect(result.a).toBe(1);
+    expect(result.self).toBe('[Circular]');
+  });
+});
+
+describe('auditService.log', () => {
+  let tx: DrizzleDb;
+
+  beforeEach(() => {
+    tx = makeTx();
+  });
+
+  it('inserts with all fields populated', async () => {
+    const params: AuditLogParams = {
+      resource: 'user',
+      action: 'USER_CREATED',
+      resourceId: 'res-1',
+      actorId: 'actor-1',
+      organizationId: 'org-1',
+      oldValue: null,
+      newValue: { email: 'alice@example.com' },
+      ipAddress: '192.168.1.1',
+      userAgent: 'TestAgent/1.0',
+    };
+
+    await auditService.log(tx, params);
+
+    expect(mockInsert).toHaveBeenCalledOnce();
+    expect(mockValues).toHaveBeenCalledOnce();
+    const row = mockValues.mock.calls[0][0];
+    expect(row.action).toBe('USER_CREATED');
+    expect(row.resource).toBe('user');
+    expect(row.resourceId).toBe('res-1');
+    expect(row.actorId).toBe('actor-1');
+    expect(row.organizationId).toBe('org-1');
+    expect(row.oldValue).toBeNull();
+    expect(JSON.parse(row.newValue)).toEqual({ email: 'alice@example.com' });
+    expect(row.ipAddress).toBe('192.168.1.1');
+    expect(row.userAgent).toBe('TestAgent/1.0');
+  });
+
+  it('inserts with null optional fields', async () => {
+    const params: AuditLogParams = {
+      resource: 'user',
+      action: 'USER_DEACTIVATED',
+    };
+
+    await auditService.log(tx, params);
+
+    const row = mockValues.mock.calls[0][0];
+    expect(row.action).toBe('USER_DEACTIVATED');
+    expect(row.resource).toBe('user');
+    expect(row.resourceId).toBeUndefined();
+    expect(row.actorId).toBeUndefined();
+    expect(row.organizationId).toBeUndefined();
+    expect(row.oldValue).toBeNull();
+    expect(row.newValue).toBeNull();
+    expect(row.ipAddress).toBeUndefined();
+    expect(row.userAgent).toBeUndefined();
+  });
+
+  it('serializes object oldValue and newValue', async () => {
+    const params: AuditLogParams = {
+      resource: 'organization',
+      action: 'ORG_UPDATED',
+      oldValue: { name: 'Old Org' },
+      newValue: { name: 'New Org' },
+    };
+
+    await auditService.log(tx, params);
+
+    const row = mockValues.mock.calls[0][0];
+    expect(JSON.parse(row.oldValue)).toEqual({ name: 'Old Org' });
+    expect(JSON.parse(row.newValue)).toEqual({ name: 'New Org' });
+  });
+
+  it('propagates database errors', async () => {
+    mockValues.mockRejectedValue(new Error('DB write failed'));
+
+    const params: AuditLogParams = {
+      resource: 'user',
+      action: 'USER_CREATED',
+    };
+
+    await expect(auditService.log(tx, params)).rejects.toThrow(
+      'DB write failed',
+    );
+  });
+});

--- a/apps/api/src/services/audit.service.ts
+++ b/apps/api/src/services/audit.service.ts
@@ -1,0 +1,62 @@
+import { auditEvents, type DrizzleDb } from '@colophony/db';
+import type { AuditLogParams } from '@prospector/types';
+
+const MAX_VALUE_LENGTH = 8192;
+
+const SECRET_PATTERN = /token|secret|password|authorization/i;
+
+/**
+ * Safely serialize a value to JSON for audit storage.
+ *
+ * - Scrubs keys matching common secret patterns
+ * - Truncates output exceeding 8KB
+ * - Handles circular references
+ */
+export function serializeValue(value: unknown): string | null {
+  if (value == null) return null;
+
+  const seen = new WeakSet();
+
+  const json = JSON.stringify(value, (_key, val) => {
+    // Scrub secret keys
+    if (_key && SECRET_PATTERN.test(_key)) {
+      return '[REDACTED]';
+    }
+    // Handle circular references
+    if (typeof val === 'object' && val !== null) {
+      if (seen.has(val)) {
+        return '[Circular]';
+      }
+      seen.add(val);
+    }
+    return val;
+  });
+
+  if (json.length > MAX_VALUE_LENGTH) {
+    return JSON.stringify({ _truncated: true, _originalSize: json.length });
+  }
+
+  return json;
+}
+
+/**
+ * Core audit logging service.
+ *
+ * Inserts into the `audit_events` table using the caller's transaction.
+ * Errors propagate — audit is atomic with the business operation.
+ */
+export const auditService = {
+  async log(tx: DrizzleDb, params: AuditLogParams): Promise<void> {
+    await tx.insert(auditEvents).values({
+      action: params.action,
+      resource: params.resource,
+      resourceId: params.resourceId,
+      actorId: params.actorId,
+      organizationId: params.organizationId,
+      oldValue: serializeValue(params.oldValue),
+      newValue: serializeValue(params.newValue),
+      ipAddress: params.ipAddress,
+      userAgent: params.userAgent,
+    });
+  },
+};

--- a/apps/api/src/webhooks/zitadel.webhook.spec.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.spec.ts
@@ -18,6 +18,7 @@ const {
   mockClientRelease,
   mockTxInsert,
   mockTxUpdate,
+  mockAuditLog,
 } = vi.hoisted(() => {
   const mockClientQuery = vi.fn().mockResolvedValue({ rows: [] });
   const mockClientRelease = vi.fn();
@@ -33,6 +34,7 @@ const {
   const where = vi.fn().mockResolvedValue({ rowCount: 1 });
   const set = vi.fn(() => ({ where }));
   const mockTxUpdate = vi.fn(() => ({ set }));
+  const mockAuditLog = vi.fn().mockResolvedValue(undefined);
 
   return {
     mockPoolConnect,
@@ -40,6 +42,7 @@ const {
     mockClientRelease,
     mockTxInsert,
     mockTxUpdate,
+    mockAuditLog,
   };
 });
 
@@ -61,6 +64,10 @@ vi.mock('drizzle-orm/node-postgres', () => ({
     insert: mockTxInsert,
     update: mockTxUpdate,
   })),
+}));
+
+vi.mock('../services/audit.service.js', () => ({
+  auditService: { log: mockAuditLog },
 }));
 
 import { registerZitadelWebhooks } from './zitadel.webhook.js';
@@ -123,6 +130,7 @@ describe('Zitadel webhook handler', () => {
     mockPoolConnect.mockClear();
     mockTxInsert.mockClear();
     mockTxUpdate.mockClear();
+    mockAuditLog.mockClear().mockResolvedValue(undefined);
 
     // Default: insert returns 1 row (new event), not a duplicate
     mockPoolConnect.mockResolvedValue({
@@ -241,6 +249,103 @@ describe('Zitadel webhook handler', () => {
     });
     expect(response.statusCode).toBe(400);
     expect(response.json().error).toBe('invalid_payload');
+  });
+
+  it('logs audit event for user.created', async () => {
+    const body = JSON.stringify(makePayload());
+    const sig = signPayload(body);
+
+    await app.inject({
+      method: 'POST',
+      url: '/webhooks/zitadel',
+      headers: {
+        'content-type': 'application/json',
+        'x-zitadel-signature': sig,
+      },
+      payload: body,
+    });
+
+    expect(mockAuditLog).toHaveBeenCalledOnce();
+    const params = mockAuditLog.mock.calls[0][1];
+    expect(params.action).toBe('USER_CREATED');
+    expect(params.resource).toBe('user');
+    expect(params.actorId).toBeUndefined();
+    expect(params.organizationId).toBeUndefined();
+    expect(params.newValue).toEqual({
+      zitadelUserId: 'zitadel-user-1',
+      email: 'alice@example.com',
+      emailVerified: true,
+    });
+  });
+
+  it('logs audit event for user.deactivated', async () => {
+    const body = JSON.stringify(
+      makePayload({ eventType: 'user.deactivated', eventId: 'evt-deact' }),
+    );
+    const sig = signPayload(body);
+
+    await app.inject({
+      method: 'POST',
+      url: '/webhooks/zitadel',
+      headers: {
+        'content-type': 'application/json',
+        'x-zitadel-signature': sig,
+      },
+      payload: body,
+    });
+
+    expect(mockAuditLog).toHaveBeenCalledOnce();
+    const params = mockAuditLog.mock.calls[0][1];
+    expect(params.action).toBe('USER_DEACTIVATED');
+    expect(params.resource).toBe('user');
+  });
+
+  it('logs USER_UPDATED audit for user.changed', async () => {
+    const body = JSON.stringify(
+      makePayload({ eventType: 'user.changed', eventId: 'evt-changed' }),
+    );
+    const sig = signPayload(body);
+
+    await app.inject({
+      method: 'POST',
+      url: '/webhooks/zitadel',
+      headers: {
+        'content-type': 'application/json',
+        'x-zitadel-signature': sig,
+      },
+      payload: body,
+    });
+
+    expect(mockAuditLog).toHaveBeenCalledOnce();
+    const params = mockAuditLog.mock.calls[0][1];
+    expect(params.action).toBe('USER_UPDATED');
+  });
+
+  it('does not log audit for duplicate webhook delivery', async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (
+        typeof sql === 'string' &&
+        sql.includes('INSERT INTO zitadel_webhook_events')
+      ) {
+        return { rows: [] }; // duplicate
+      }
+      return { rows: [] };
+    });
+
+    const body = JSON.stringify(makePayload({ eventId: 'evt-dup-audit' }));
+    const sig = signPayload(body);
+
+    await app.inject({
+      method: 'POST',
+      url: '/webhooks/zitadel',
+      headers: {
+        'content-type': 'application/json',
+        'x-zitadel-signature': sig,
+      },
+      payload: body,
+    });
+
+    expect(mockAuditLog).not.toHaveBeenCalled();
   });
 
   it('returns 500 on processing error and rolls back', async () => {

--- a/apps/api/src/webhooks/zitadel.webhook.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.ts
@@ -5,6 +5,8 @@ import type { ZitadelWebhookPayload } from '@colophony/auth-client';
 import { eq, pool, users } from '@colophony/db';
 import type { DrizzleDb } from '@colophony/db';
 import type { Env } from '../config/env.js';
+import { auditService } from '../services/audit.service.js';
+import { AuditActions, AuditResources } from '@prospector/types';
 
 export interface ZitadelWebhookOptions {
   env: Env;
@@ -160,6 +162,20 @@ async function processEvent(
             updatedAt: new Date(),
           },
         });
+      await auditService.log(tx, {
+        resource: AuditResources.USER,
+        action:
+          eventType === 'user.created'
+            ? AuditActions.USER_CREATED
+            : AuditActions.USER_UPDATED,
+        newValue: {
+          zitadelUserId: userData.userId,
+          email: userData.email,
+          emailVerified: userData.emailVerified,
+        },
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+      });
       request.log.info(
         { zitadelUserId: userData.userId, eventType },
         'User upserted from webhook',
@@ -178,6 +194,13 @@ async function processEvent(
           'user.deactivated: user not found locally',
         );
       }
+      await auditService.log(tx, {
+        resource: AuditResources.USER,
+        action: AuditActions.USER_DEACTIVATED,
+        newValue: { zitadelUserId: userData.userId },
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+      });
       break;
     }
 
@@ -192,6 +215,13 @@ async function processEvent(
           'user.reactivated: user not found locally',
         );
       }
+      await auditService.log(tx, {
+        resource: AuditResources.USER,
+        action: AuditActions.USER_REACTIVATED,
+        newValue: { zitadelUserId: userData.userId },
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+      });
       break;
     }
 
@@ -219,6 +249,16 @@ async function processEvent(
           'User anonymized (GDPR removal)',
         );
       }
+      await auditService.log(tx, {
+        resource: AuditResources.USER,
+        action: AuditActions.USER_REMOVED,
+        newValue: {
+          zitadelUserId: userData.userId,
+          email: anonymizedEmail,
+        },
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+      });
       break;
     }
 
@@ -237,6 +277,13 @@ async function processEvent(
           'user.email.verified: user not found locally',
         );
       }
+      await auditService.log(tx, {
+        resource: AuditResources.USER,
+        action: AuditActions.USER_EMAIL_VERIFIED,
+        newValue: { zitadelUserId: userData.userId },
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+      });
       break;
     }
 

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -4,6 +4,43 @@ Append-only session log. Newest entries first.
 
 ---
 
+## 2026-02-12 — Audit Logging Infrastructure (Track 1)
+
+### Done
+
+- **PR #44** — Audit logging infrastructure for sensitive lifecycle events (9 files, 672 insertions)
+- Created shared audit types in `packages/types/src/audit.ts`: `AuditActions` and `AuditResources` constants, discriminated union `AuditLogParams` that enforces valid action↔resource pairs at compile time
+- Created `apps/api/src/services/audit.service.ts` — first v2 service; core `auditService.log(tx, params)` with `serializeValue()` helper: secret key scrubbing (`/token|secret|password|authorization/i`), 8KB truncation, circular reference handling via WeakSet
+- Created `apps/api/src/hooks/audit.ts` — Fastify plugin decorating `request.audit` pre-bound to request context (actorId, orgId, IP, user-agent); depends on `colophony-db-context`; provides warning no-op when dbTx is null
+- Integrated audit logging into all 6 Zitadel webhook event types: `user.created` → `USER_CREATED`, `user.changed` → `USER_UPDATED`, `user.deactivated` → `USER_DEACTIVATED`, `user.reactivated` → `USER_REACTIVATED`, `user.removed` → `USER_REMOVED`, `user.email.verified` → `USER_EMAIL_VERIFIED`
+- Webhook audit events use `auditService.log(tx, ...)` directly (not `request.audit`) because webhooks run in a separate Fastify scope without auth/org-context/db-context hooks
+- Registered audit plugin in `main.ts` after db-context (hook order: auth → rate-limit → org-context → db-context → audit)
+- 17 new tests across 3 files: 10 audit service (serialization, scrubbing, truncation, circular refs, error propagation), 3 audit plugin (no-op without dbTx, context passing, error propagation), 4 webhook audit assertions
+- All 217 tests passing, type-check and lint clean
+- AI review: LGTM, no blocking issues
+
+### Decisions
+
+- **Discriminated union for type safety** — prevents logging `USER_CREATED` against resource `SUBMISSION`; each resource type has its own set of valid actions
+- **Errors propagate (no swallowing)** — if audit insert fails, the enclosing transaction rolls back; audit is atomic with the business operation
+- **Webhook audit calls `auditService.log()` directly** — webhooks manage their own `pool.connect()` transaction, so `request.audit` (which relies on `request.dbTx`) is not available
+- **System events have `actorId = undefined`, `organizationId = undefined`** — webhook-triggered events are not user- or org-scoped; NULL org rows are visible to all org-scoped queries (acceptable for now; documented for future refinement)
+- **IP in webhook audit = Zitadel server IP** — not the end user's; documented as acceptable since it records "who triggered the system event"
+
+### Issues Found
+
+- **Lint: unused destructured vars** — `const [_tx, params] = mock.calls[0]` flagged by `@typescript-eslint/no-unused-vars` even with underscore prefix; fixed by using `mock.calls[0][1]` index access instead
+
+### Next
+
+- Integration testing with real DB for RLS audit event isolation
+- Auth failure auditing (happens before db-context hook, needs separate `pool.connect` pattern)
+- Audit query/list endpoints (tRPC/REST routes when API surfaces are wired)
+- Request correlation (requestId/method/route columns — requires migration adding metadata JSONB column)
+- Frontend OIDC flow (Track 1 continuation)
+
+---
+
 ## 2026-02-12 — Zitadel OIDC Auth Integration (Track 1)
 
 ### Done
@@ -40,7 +77,7 @@ Append-only session log. Newest entries first.
 ### Next
 
 - Rate limiting across all API surfaces (roadmap item flagged by AI reviewer)
-- Audit logging infrastructure for sensitive lifecycle events
+- ~~Audit logging infrastructure for sensitive lifecycle events~~ ✅ Done (PR #44)
 - Integration testing with real DB for org-context + db-context RLS flow
 - Frontend OIDC flow (Track 1 continuation, separate session)
 

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -1,0 +1,72 @@
+// ---------------------------------------------------------------------------
+// Audit logging — shared constants and typed params
+// ---------------------------------------------------------------------------
+
+/** Audit action constants. */
+export const AuditActions = {
+  // User lifecycle (synced from Zitadel webhooks)
+  USER_CREATED: "USER_CREATED",
+  USER_UPDATED: "USER_UPDATED",
+  USER_DEACTIVATED: "USER_DEACTIVATED",
+  USER_REACTIVATED: "USER_REACTIVATED",
+  USER_REMOVED: "USER_REMOVED",
+  USER_EMAIL_VERIFIED: "USER_EMAIL_VERIFIED",
+
+  // Organization lifecycle
+  ORG_CREATED: "ORG_CREATED",
+  ORG_UPDATED: "ORG_UPDATED",
+  ORG_DELETED: "ORG_DELETED",
+  ORG_MEMBER_ADDED: "ORG_MEMBER_ADDED",
+  ORG_MEMBER_REMOVED: "ORG_MEMBER_REMOVED",
+  ORG_MEMBER_ROLE_CHANGED: "ORG_MEMBER_ROLE_CHANGED",
+} as const;
+
+export type AuditAction = (typeof AuditActions)[keyof typeof AuditActions];
+
+/** Audit resource constants. */
+export const AuditResources = {
+  USER: "user",
+  ORGANIZATION: "organization",
+} as const;
+
+export type AuditResource =
+  (typeof AuditResources)[keyof typeof AuditResources];
+
+// ---------------------------------------------------------------------------
+// Discriminated union — enforces valid action↔resource pairs
+// ---------------------------------------------------------------------------
+
+interface BaseAuditParams {
+  resourceId?: string;
+  oldValue?: unknown;
+  newValue?: unknown;
+  actorId?: string;
+  organizationId?: string;
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+export interface UserAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.USER;
+  action:
+    | typeof AuditActions.USER_CREATED
+    | typeof AuditActions.USER_UPDATED
+    | typeof AuditActions.USER_DEACTIVATED
+    | typeof AuditActions.USER_REACTIVATED
+    | typeof AuditActions.USER_REMOVED
+    | typeof AuditActions.USER_EMAIL_VERIFIED;
+}
+
+export interface OrgAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.ORGANIZATION;
+  action:
+    | typeof AuditActions.ORG_CREATED
+    | typeof AuditActions.ORG_UPDATED
+    | typeof AuditActions.ORG_DELETED
+    | typeof AuditActions.ORG_MEMBER_ADDED
+    | typeof AuditActions.ORG_MEMBER_REMOVED
+    | typeof AuditActions.ORG_MEMBER_ROLE_CHANGED;
+}
+
+/** Union of all resource-specific param types. */
+export type AuditLogParams = UserAuditParams | OrgAuditParams;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,3 +5,4 @@ export * from "./submission";
 export * from "./payment";
 export * from "./file";
 export * from "./common";
+export * from "./audit";


### PR DESCRIPTION
## Summary

- Add shared audit types (`AuditActions`, `AuditResources`, discriminated union `AuditLogParams`) in `@prospector/types` — enforces valid action↔resource pairs at compile time
- Add core `auditService.log(tx, params)` with safe serialization: secret key scrubbing, 8KB truncation, and circular reference handling
- Add Fastify `auditPlugin` that decorates `request.audit` pre-bound to request context (actorId, orgId, IP, user-agent) for one-liner audit calls in route handlers
- Integrate audit logging into all 6 Zitadel webhook event handlers (user.created, user.changed, user.deactivated, user.reactivated, user.removed, user.email.verified)
- 17 new tests across 3 test files (audit service, audit plugin, webhook audit assertions)

## Test plan

- [x] `pnpm --filter @prospector/types build` — types package builds cleanly
- [x] `pnpm test` — all 217 tests pass (82 API, 18 auth-client, 117 web)
- [x] `pnpm --filter @colophony/api type-check` — no TypeScript errors
- [x] `pnpm lint` — no lint errors
- [ ] Manual: send test webhook payloads and verify audit rows inserted (requires Docker infra)