### PR TITLE
chore: improve end-session/start-session skill workflow

### DIFF
--- a/.claude/skills/end-session/SKILL.md
+++ b/.claude/skills/end-session/SKILL.md
@@ -5,16 +5,18 @@ description: End-of-session housekeeping — update docs, clean up git state, an
 
 # /end-session
 
-End-of-session housekeeping: update docs, clean up git state, and summarize work.
+End-of-session housekeeping: address AI review, update docs, push to PR, and summarize work.
 
 ## What this skill does
 
-1. Updates `docs/DEVLOG.md` with a session summary
-2. Checks for any `TODO(CLAUDE.md)` comments and proposes updates
-3. Ensures all changes are committed on a feature branch (not `main`)
-4. Pushes the branch and creates/updates a PR if needed
-5. Checks and addresses AI review comments on the PR
-6. Prints a session summary for the user
+1. Gathers session context from the conversation
+2. Ensures all code changes are committed on a feature branch (not `main`)
+3. Pushes the branch and creates/updates a PR if needed
+4. Checks and addresses AI review comments — fixes code if needed
+5. Updates `docs/DEVLOG.md` with a session summary (captures everything including AI review fixes)
+6. Checks for any `TODO(CLAUDE.md)` comments and proposes updates
+7. Commits and pushes doc updates as the final commit on the branch
+8. Prints a session summary with PR link for user to merge
 
 ## Usage
 
@@ -35,7 +37,92 @@ Scan the conversation to identify:
 - **Issues found** — bugs discovered, quirks encountered, things that need follow-up
 - **Next steps** — open TODOs, planned follow-up work
 
-### Step 2: Update DEVLOG
+### Step 2: Ensure code is committed and pushed
+
+1. **Check branch**: Verify we are NOT on `main`. If on `main` with unpushed commits, create a feature branch first.
+
+2. **Check for uncommitted code changes** (NOT doc updates yet — those come later):
+
+   ```bash
+   git status
+   git diff --stat
+   ```
+
+   If there are uncommitted code changes from this session, stage and commit them with an appropriate conventional commit message.
+
+3. **Push the branch**:
+
+   ```bash
+   git push -u origin <branch-name>
+   ```
+
+4. **Create PR if needed**: Check if a PR already exists for this branch:
+
+   ```bash
+   gh pr list --head <branch-name> --json number --jq '.[0].number'
+   ```
+
+   - If no PR exists, create one with `gh pr create`
+   - If a PR exists, it's already updated by the push
+
+### Step 3: Check and address AI review
+
+If a PR exists for the current branch, check if the AI reviewer has posted comments:
+
+```bash
+gh pr view <number> --comments --json comments --jq '.comments[] | select(.author.login == "github-actions") | {createdAt: .createdAt, body: .body}'
+```
+
+**If AI review comments exist and haven't been addressed yet:**
+
+1. Parse and categorize each finding (critical, important, suggestion)
+2. Evaluate each finding by reading the relevant source code:
+   - **Legitimate issue — fix it**: Apply the minimal fix needed
+   - **Legitimate concern — already handled**: Note why it's already addressed
+   - **False positive — dismiss**: Note reasoning
+3. If code fixes were made, commit and push them:
+
+   ```bash
+   git add <fixed files>
+   git commit -m "fix: address AI review feedback on PR #<number>
+
+   <summary of what was fixed>"
+   git push origin <branch-name>
+   ```
+
+4. Post a response comment on the PR:
+
+   ```bash
+   gh pr comment <number> --body "$(cat <<'COMMENT'
+   ## AI Review Response
+
+   ### Fixed
+   - [description of each fix applied, with file:line references]
+
+   ### Already Handled
+   - [findings that are valid but already addressed, with explanation]
+
+   ### Dismissed
+   - [false positives with reasoning for dismissal]
+   COMMENT
+   )"
+   ```
+
+   Omit any section that has no items.
+
+**If no AI review comments exist yet:**
+
+Check if CI has finished:
+
+```bash
+gh run list --branch <branch-name> --limit 1 --json status,conclusion,name --jq '.[] | select(.name == "CI") | "\(.status) \(.conclusion)"'
+```
+
+If CI is still running or just passed, the AI review may not have triggered yet (it runs via `workflow_run` after CI passes). Note this in the session summary so the user knows to check later or run `/check-ai-review` before merging.
+
+**If AI review was already addressed earlier in the session**, note this and skip to the next step.
+
+### Step 4: Update DEVLOG
 
 Read `docs/DEVLOG.md` to see the latest entry format, then **prepend** a new entry (newest first) using this template:
 
@@ -44,7 +131,7 @@ Read `docs/DEVLOG.md` to see the latest entry format, then **prepend** a new ent
 
 ### Done
 
-- [bullet points of completed work]
+- [bullet points of completed work, INCLUDING any AI review fixes]
 
 ### Decisions
 
@@ -59,13 +146,21 @@ Read `docs/DEVLOG.md` to see the latest entry format, then **prepend** a new ent
 - [planned follow-up work]
 ```
 
-If today already has a DEVLOG entry, **append to the existing entry's sections** rather than creating a duplicate date entry.
+If today already has a DEVLOG entry for this session's work, **append to the existing entry's sections** rather than creating a duplicate.
 
-### Step 3: Check for CLAUDE.md updates
+**Important:** The DEVLOG entry should capture the full session including AI review outcomes (e.g., "Addressed AI review: fixed X, dismissed Y as false positive").
+
+### Step 5: Check for CLAUDE.md and other doc updates
 
 Search the codebase for any `TODO(CLAUDE.md)` comments added during this session using the Grep tool (not bash) to search for `TODO(CLAUDE.md)` in `*.ts`, `*.tsx`, and `*.js` files.
 
-Also review the session for any new patterns, quirks, or constraints discovered. If updates are warranted, propose them:
+Also review the session for any new patterns, quirks, or constraints discovered. Check whether any of these need updates:
+
+- `CLAUDE.md` — Known Quirks, Security Status checklist, Version Pins
+- `docs/testing.md` — test counts, new test tiers, running instructions
+- Other docs referenced in the session
+
+If updates are warranted, propose them:
 
 ```markdown
 ## Suggested Update for CLAUDE.md
@@ -77,98 +172,27 @@ Also review the session for any new patterns, quirks, or constraints discovered.
 
 Ask the user if they want to apply the suggestions before proceeding.
 
-### Step 4: Git hygiene
+### Step 6: Commit and push doc updates
 
-1. **Check branch**: Verify we are NOT on `main`. If on `main` with unpushed commits, create a feature branch first.
-
-2. **Check for uncommitted changes** that belong to this session's work:
-
-   ```bash
-   git status
-   git diff --stat
-   ```
-
-   If there are relevant uncommitted changes (e.g., the DEVLOG update), stage and commit them:
-
-   ```bash
-   git add docs/DEVLOG.md [other session files]
-   git commit -m "docs: update DEVLOG for [session date] session"
-   ```
-
-3. **Push the branch**:
-
-   ```bash
-   git push -u origin <branch-name>
-   ```
-
-4. **Create or update PR**: Check if a PR already exists for this branch:
-
-   ```bash
-   gh pr list --head <branch-name> --json number --jq '.[0].number'
-   ```
-
-   - If no PR exists, create one with `gh pr create`
-   - If a PR exists, it's already updated by the push
-
-5. **Check CI status** on the PR (use Actions API, NOT `gh pr checks`):
-
-   ```bash
-   gh run list --branch <branch-name> --limit 1 --json status,conclusion,name
-   ```
-
-   Report the CI status to the user.
-
-6. **Clean up stale local branches**: Delete local branches whose remote tracking branch has been deleted (i.e., squash-merged PRs):
-
-   ```bash
-   git fetch --prune
-   git branch -vv
-   ```
-
-   Claude parses the `git branch -vv` output:
-   - Lines containing `[gone]` indicate branches whose upstream was deleted (the PR was merged/closed and the remote branch removed)
-   - Lines starting with `*` indicate the current branch
-   - Extract the branch name (first non-whitespace token after `*` or leading spaces)
-   - Skip `main` — never delete main
-
-   If any stale branches are found (upstream `[gone]`), list them and delete:
-
-   ```bash
-   git branch -D "<branch-name>"
-   ```
-
-   Note: Use `-D` (force delete) because squash-merged branches are not recognized as `--merged` by git.
-
-   Also switch to `main` if the current branch's upstream is `[gone]` and the session's PR work is done:
-
-   ```bash
-   git checkout main && git pull origin main
-   ```
-
-### Step 5: Check AI review on PR
-
-If a PR exists for the current branch, check if the AI reviewer has posted comments:
+This is the **final commit** on the branch. Stage all doc changes:
 
 ```bash
-gh pr view <number> --comments --json comments --jq '.comments[] | select(.author.login == "github-actions") | {createdAt: .createdAt, body: .body}'
+git add docs/DEVLOG.md CLAUDE.md docs/testing.md [any other docs]
+git commit -m "docs: update DEVLOG and docs for [session date] session"
+git push origin <branch-name>
 ```
 
-If there are AI review comments that haven't been addressed yet:
+### Step 7: Verify CI and report
 
-1. Use the `/check-ai-review <number>` skill logic to evaluate each finding
-2. Fix legitimate issues, dismiss false positives
-3. Commit and push any fixes
-4. Post a response comment on the PR
-
-If there are no AI review comments, check if CI has finished:
+Check CI status on the branch after the doc push:
 
 ```bash
-gh run list --branch <branch-name> --limit 1 --json status,conclusion,name --jq '.[] | select(.name == "CI") | "\(.status) \(.conclusion)"'
+gh run list --branch <branch-name> --limit 1 --json status,conclusion,name
 ```
 
-If CI is still running or just passed, the AI review may not have triggered yet (it runs via `workflow_run` after CI passes). Note this in the session summary so the user knows to check later.
+Report the status. If CI is running, note that the user should wait for it to pass before merging.
 
-### Step 6: Session summary
+### Step 8: Session summary
 
 Print a summary for the user:
 
@@ -176,26 +200,23 @@ Print a summary for the user:
 ## Session Summary
 
 **Branch:** <branch-name>
-**PR:** <PR URL>
+**PR:** <PR URL> — ready to merge
 **CI:** <status>
 
 ### Changes
 - [list of commits in this session]
 
-### DEVLOG
-- Updated docs/DEVLOG.md with session entry
+### AI Review
+- [findings addressed with counts, or "LGTM — no issues", or "Not yet posted — check with /check-ai-review before merging"]
+
+### Docs Updated
+- [list of doc files updated]
 
 ### CLAUDE.md Updates
 - [any proposed or applied updates, or "None needed"]
 
-### AI Review
-- [findings addressed, or "No AI review comments yet — check after CI passes"]
-
-### Branch Cleanup
-- [branches deleted, or "No stale branches"]
-
 ### Open Items
-- [anything left undone, PRs awaiting review, etc.]
+- [anything left undone, next session priorities]
 ```
 
 ## Important notes
@@ -204,4 +225,6 @@ Print a summary for the user:
 - Use `gh run list/view` for CI status, NOT `gh pr checks` (fine-grained PAT limitation)
 - The DEVLOG entry should be concise but complete — future sessions rely on it for context
 - If the session had multiple unrelated workstreams, consider whether they should be separate PRs
-- Commit the DEVLOG update as the last commit on the branch, after all code changes
+- Doc updates are always the LAST commit — after all code changes and AI review fixes
+- Do NOT switch to `main`, delete branches, or do branch cleanup — that's handled by `/start-session`
+- The PR should be left open for the user to review and merge

--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -10,12 +10,13 @@ Start-of-session orientation: load context, check environment, surface open work
 ## What this skill does
 
 1. Detects incomplete previous sessions (missed /end-session) and offers catch-up
-2. Reads the latest DEVLOG entry for context and planned next steps
-3. Checks git state (branch, uncommitted changes, open PRs)
-4. Checks CI health and open PR status
-5. Verifies infrastructure is running (Docker, DB)
-6. Surfaces open roadmap items and pending work
-7. Prints a briefing for the user
+2. Cleans up stale local branches from merged PRs
+3. Reads the latest DEVLOG entry for context and planned next steps
+4. Checks git state (branch, uncommitted changes, open PRs)
+5. Checks CI health and open PR status
+6. Verifies infrastructure is running (Docker, DB)
+7. Surfaces open roadmap items and pending work
+8. Prints a briefing for the user
 
 ## Usage
 
@@ -83,6 +84,40 @@ Or: I can do the catch-up housekeeping now before the briefing.
 Wait for the user to decide before continuing. If they say to catch up, perform the end-session steps (DEVLOG update, branch cleanup) before proceeding with the rest of the briefing.
 
 If no incomplete session is detected, proceed normally.
+
+### Step 1b: Clean up stale branches
+
+After the incomplete session check (regardless of outcome), clean up any local branches whose remote tracking branch has been deleted (i.e., squash-merged PRs from previous sessions):
+
+```bash
+git fetch --prune
+git branch -vv
+```
+
+Claude parses the `git branch -vv` output:
+
+- Lines containing `[gone]` indicate branches whose upstream was deleted (the PR was merged/closed and the remote branch removed)
+- Lines starting with `*` indicate the current branch
+- Extract the branch name (first non-whitespace token after `*` or leading spaces)
+- Skip `main` — never delete main
+
+If any stale branches are found (upstream `[gone]`), list them and delete:
+
+```bash
+git branch -D "<branch-name>"
+```
+
+Note: Use `-D` (force delete) because squash-merged branches are not recognized as `--merged` by git.
+
+If the **current branch** has upstream `[gone]` (you're on a merged feature branch), switch to `main` first:
+
+```bash
+git checkout main && git pull origin main
+```
+
+Then delete the stale branch. Report what was cleaned up in the briefing.
+
+If no stale branches are found, skip this step silently.
 
 ### Step 2: Load session context from DEVLOG
 
@@ -184,6 +219,7 @@ Next steps planned: [bullet points from DEVLOG "Next" section]
 - Branch: <current branch>
 - Uncommitted changes: [yes/no, summary if yes]
 - Open PRs: [list with CI status and AI review status]
+- Branches cleaned up: [list of deleted stale branches, or "None"]
 
 ### Infrastructure
 - PostgreSQL: [running/stopped]

--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -109,13 +109,14 @@ git branch -D "<branch-name>"
 
 Note: Use `-D` (force delete) because squash-merged branches are not recognized as `--merged` by git.
 
-If the **current branch** has upstream `[gone]` (you're on a merged feature branch), switch to `main` first:
+If the **current branch** has upstream `[gone]` (you're on a merged feature branch), switch to `main` first, then delete it:
 
 ```bash
 git checkout main && git pull origin main
+git branch -D "<previous-branch-name>"
 ```
 
-Then delete the stale branch. Report what was cleaned up in the briefing.
+Report what was cleaned up in the briefing.
 
 If no stale branches are found, skip this step silently.
 

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -4,10 +4,15 @@ Append-only session log. Newest entries first.
 
 ---
 
-## 2026-02-12 — RLS Integration Tests (Track 1)
+## 2026-02-12 — RLS Integration Tests + Session Skill Workflow (Track 1)
 
 ### Done
 
+- **PR #46** — Improved `/end-session` and `/start-session` skill workflow to produce single mergeable PRs
+  - Reordered `/end-session`: AI review + code fixes before doc updates (DEVLOG captures everything)
+  - Moved branch cleanup from `/end-session` to `/start-session` (new Step 1b)
+  - Doc commit is always the final commit on the branch; summary ends with "PR ready to merge"
+  - Addressed AI review suggestion: added explicit `git branch -D` after switching to main
 - **PR #45** — 70 RLS integration tests across 6 files verifying tenant isolation against a real PostgreSQL instance (15 files, 1,678 insertions)
 - Dual-client pattern: superuser (admin) for setup, `app_user` (NOSUPERUSER NOBYPASSRLS) for RLS-enforced queries
 - All 3 RLS policy patterns covered:
@@ -32,6 +37,7 @@ Append-only session log. Newest entries first.
 - **`{ cause: { code: "42501" } }` assertion pattern** — Drizzle 0.44+ wraps pg errors in `DrizzleQueryError` with original error in `.cause`. Tests match the exact SQLSTATE code at the correct nesting level.
 - **Shared pool lifecycle via `process.on('beforeExit')`** — In `singleFork` mode, pools are module singletons shared across all test files. Individual `afterAll` only truncates data; pool teardown happens at process exit.
 - **RLS tests excluded from default `pnpm test`** — requires separate `pnpm test:rls` with postgres-test running; prevents failures when developers run unit tests without Docker
+- **Single-PR session workflow** — `/end-session` now handles AI review, code fixes, and doc updates in one branch so the user merges once. Branch cleanup deferred to `/start-session` since it can only run after the PR is merged
 
 ### Issues Found
 


### PR DESCRIPTION
## Summary

- Restructure `/end-session` to produce a single mergeable PR (eliminates PR → merge → PR for docs cycle)
- Move branch cleanup from `/end-session` to `/start-session`
- Reorder `/end-session` steps: AI review + code fixes happen BEFORE doc updates, so DEVLOG captures everything

### Key changes

**`/end-session` (revised flow):**
1. Gather context → 2. Commit/push code → 3. AI review + fixes → 4. DEVLOG (captures all) → 5. CLAUDE.md/docs → 6. Final doc commit → 7. Summary with "PR ready to merge"

**`/start-session` (new Step 1b):**
- Cleans up stale local branches (upstream `[gone]`) at session start
- Switches to `main` if current branch was merged
- Reports cleanup in briefing

## Test plan

- [ ] Run `/start-session` on next session — verify branch cleanup works
- [ ] Run `/end-session` on next session — verify single-PR flow works
- [ ] Verify AI review findings are captured in DEVLOG entry