### PR TITLE
feat(api): add auth failure audit logging

### DIFF
--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  vi,
+} from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 import authPlugin from './auth.js';
 import type { Env } from '../config/env.js';
@@ -16,6 +24,14 @@ vi.mock('@colophony/db', () => ({
   users: { zitadelUserId: 'zitadel_user_id' },
   pool: {
     query: vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
+  },
+}));
+
+// Mock audit service
+const mockLogDirect = vi.fn().mockResolvedValue(undefined);
+vi.mock('../services/audit.service.js', () => ({
+  auditService: {
+    logDirect: (...args: unknown[]) => mockLogDirect(...args),
   },
 }));
 
@@ -176,9 +192,9 @@ describe('auth plugin', () => {
     });
 
     it('returns 401 for expired token', async () => {
-      mockVerifyToken.mockRejectedValueOnce(
-        new Error('"exp" claim timestamp check failed'),
-      );
+      const expiredErr = new Error('"exp" claim timestamp check failed');
+      expiredErr.name = 'JWTExpired';
+      mockVerifyToken.mockRejectedValueOnce(expiredErr);
 
       const response = await app.inject({
         method: 'GET',
@@ -280,6 +296,178 @@ describe('auth plugin', () => {
         }),
       ).rejects.toThrow('ZITADEL_AUTHORITY is required in production');
       await app.close();
+    });
+  });
+
+  describe('auth failure auditing', () => {
+    let app: FastifyInstance;
+
+    const envWithAuth: Env = {
+      ...baseEnv,
+      NODE_ENV: 'development' as const,
+      ZITADEL_AUTHORITY: 'http://localhost:8080',
+      ZITADEL_CLIENT_ID: 'my-client',
+    };
+
+    beforeAll(async () => {
+      app = Fastify({ logger: false });
+      await app.register(authPlugin, { env: envWithAuth });
+      app.get('/protected', async (request) => ({
+        authContext: request.authContext,
+      }));
+    });
+
+    beforeEach(() => {
+      mockLogDirect.mockClear().mockResolvedValue(undefined);
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it('audits malformed Authorization header as AUTH_TOKEN_INVALID', async () => {
+      await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { authorization: 'Basic dXNlcjpwYXNz' },
+      });
+
+      expect(mockLogDirect).toHaveBeenCalledOnce();
+      const params = mockLogDirect.mock.calls[0][0];
+      expect(params.action).toBe('AUTH_TOKEN_INVALID');
+      expect(params.resource).toBe('auth');
+      expect(params.newValue).toEqual({ reason: 'invalid_header_format' });
+      expect(params.actorId).toBeUndefined();
+    });
+
+    it('audits token validation failure as AUTH_TOKEN_INVALID', async () => {
+      mockVerifyToken.mockRejectedValueOnce(new Error('invalid signature'));
+
+      await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { authorization: 'Bearer bad-token' },
+      });
+
+      expect(mockLogDirect).toHaveBeenCalledOnce();
+      const params = mockLogDirect.mock.calls[0][0];
+      expect(params.action).toBe('AUTH_TOKEN_INVALID');
+      expect(params.resource).toBe('auth');
+      expect(params.newValue).toEqual({ reason: 'signature_failed' });
+      expect(params.actorId).toBeUndefined();
+    });
+
+    it('audits expired token as AUTH_TOKEN_EXPIRED using error.name', async () => {
+      const expiredErr = new Error('token expired');
+      expiredErr.name = 'JWTExpired';
+      mockVerifyToken.mockRejectedValueOnce(expiredErr);
+
+      await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { authorization: 'Bearer expired-token' },
+      });
+
+      expect(mockLogDirect).toHaveBeenCalledOnce();
+      const params = mockLogDirect.mock.calls[0][0];
+      expect(params.action).toBe('AUTH_TOKEN_EXPIRED');
+      expect(params.resource).toBe('auth');
+      expect(params.newValue).toEqual({ reason: 'expired' });
+      expect(params.actorId).toBeUndefined();
+    });
+
+    it('audits user not provisioned as AUTH_USER_NOT_PROVISIONED with zitadelUserId', async () => {
+      mockVerifyToken.mockResolvedValueOnce({
+        payload: { sub: 'zitadel-unknown-user' },
+        header: { alg: 'RS256' },
+      });
+
+      const dbModule = await import('@colophony/db');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(dbModule.db.query.users.findFirst).mockResolvedValueOnce(
+        undefined,
+      );
+
+      await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { authorization: 'Bearer valid-token' },
+      });
+
+      expect(mockLogDirect).toHaveBeenCalledOnce();
+      const params = mockLogDirect.mock.calls[0][0];
+      expect(params.action).toBe('AUTH_USER_NOT_PROVISIONED');
+      expect(params.resource).toBe('auth');
+      expect(params.newValue).toEqual({
+        reason: 'not_provisioned',
+        zitadelUserId: 'zitadel-unknown-user',
+      });
+      expect(params.actorId).toBeUndefined();
+    });
+
+    it('audits deactivated user as AUTH_USER_DEACTIVATED with actorId', async () => {
+      mockVerifyToken.mockResolvedValueOnce({
+        payload: { sub: 'zitadel-deactivated' },
+        header: { alg: 'RS256' },
+      });
+
+      const dbModule = await import('@colophony/db');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(dbModule.db.query.users.findFirst).mockResolvedValueOnce({
+        id: 'local-user-deactivated',
+        email: 'deleted@example.com',
+        zitadelUserId: 'zitadel-deactivated',
+        emailVerified: true,
+        emailVerifiedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: new Date(),
+      });
+
+      await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { authorization: 'Bearer valid-token' },
+      });
+
+      expect(mockLogDirect).toHaveBeenCalledOnce();
+      const params = mockLogDirect.mock.calls[0][0];
+      expect(params.action).toBe('AUTH_USER_DEACTIVATED');
+      expect(params.resource).toBe('auth');
+      expect(params.newValue).toEqual({
+        reason: 'deactivated',
+        zitadelUserId: 'zitadel-deactivated',
+      });
+      expect(params.actorId).toBe('local-user-deactivated');
+    });
+
+    it('still returns correct error when audit service throws', async () => {
+      mockLogDirect.mockRejectedValueOnce(new Error('DB unavailable'));
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { authorization: 'Basic dXNlcjpwYXNz' },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.json().error).toBe('unauthorized');
+    });
+
+    it('never includes token or Authorization header in audit details', async () => {
+      mockVerifyToken.mockRejectedValueOnce(new Error('invalid signature'));
+
+      await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { authorization: 'Bearer super-secret-token' },
+      });
+
+      expect(mockLogDirect).toHaveBeenCalledOnce();
+      const params = mockLogDirect.mock.calls[0][0];
+      const serialized = JSON.stringify(params);
+      expect(serialized).not.toContain('super-secret-token');
+      expect(serialized).not.toContain('Bearer');
     });
   });
 });

--- a/apps/api/src/hooks/auth.ts
+++ b/apps/api/src/hooks/auth.ts
@@ -2,8 +2,10 @@ import fp from 'fastify-plugin';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { createJwksVerifier } from '@colophony/auth-client';
 import { db, eq, users } from '@colophony/db';
-import type { AuthContext } from '@prospector/types';
+import type { AuthContext, AuthAuditParams } from '@prospector/types';
+import { AuditActions, AuditResources } from '@prospector/types';
 import type { Env } from '../config/env.js';
+import { auditService } from '../services/audit.service.js';
 
 declare module 'fastify' {
   interface FastifyRequest {
@@ -49,6 +51,27 @@ export default fp(
       );
     }
 
+    /** Log an auth failure audit event. Never throws — swallows errors. */
+    async function logAuthFailure(
+      request: FastifyRequest,
+      action: AuthAuditParams['action'],
+      details: Record<string, unknown>,
+      actorId?: string,
+    ): Promise<void> {
+      try {
+        await auditService.logDirect({
+          action,
+          resource: AuditResources.AUTH,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'] as string | undefined,
+          newValue: details,
+          actorId,
+        });
+      } catch (err) {
+        request.log.warn({ err }, 'Failed to log auth failure audit event');
+      }
+    }
+
     // Create JWKS verifier if authority is configured
     const verifyToken = env.ZITADEL_AUTHORITY
       ? createJwksVerifier({
@@ -90,6 +113,9 @@ export default fp(
 
         const match = /^Bearer\s+(\S+)$/i.exec(authHeader);
         if (!match) {
+          await logAuthFailure(request, AuditActions.AUTH_TOKEN_INVALID, {
+            reason: 'invalid_header_format',
+          });
           return reply.status(401).send({
             error: 'unauthorized',
             message:
@@ -118,10 +144,15 @@ export default fp(
           }
           sub = payload.sub;
         } catch (err) {
-          const detail =
-            err instanceof Error ? err.message : 'Token validation failed';
-          const isExpired = detail.includes('exp');
+          const isExpired = err instanceof Error && err.name === 'JWTExpired';
           request.log.warn({ err }, 'Token validation failed');
+          await logAuthFailure(
+            request,
+            isExpired
+              ? AuditActions.AUTH_TOKEN_EXPIRED
+              : AuditActions.AUTH_TOKEN_INVALID,
+            { reason: isExpired ? 'expired' : 'signature_failed' },
+          );
           return reply.status(401).send({
             error: isExpired ? 'token_expired' : 'token_invalid',
             message: isExpired
@@ -136,6 +167,11 @@ export default fp(
         });
 
         if (!user) {
+          await logAuthFailure(
+            request,
+            AuditActions.AUTH_USER_NOT_PROVISIONED,
+            { reason: 'not_provisioned', zitadelUserId: sub },
+          );
           return reply.status(403).send({
             error: 'user_not_provisioned',
             message:
@@ -144,6 +180,12 @@ export default fp(
         }
 
         if (user.deletedAt) {
+          await logAuthFailure(
+            request,
+            AuditActions.AUTH_USER_DEACTIVATED,
+            { reason: 'deactivated', zitadelUserId: sub },
+            user.id,
+          );
           return reply.status(403).send({
             error: 'user_deactivated',
             message: 'Account has been deactivated.',

--- a/apps/api/src/hooks/auth.ts
+++ b/apps/api/src/hooks/auth.ts
@@ -63,7 +63,7 @@ export default fp(
           action,
           resource: AuditResources.AUTH,
           ipAddress: request.ip,
-          userAgent: request.headers['user-agent'] as string | undefined,
+          userAgent: request.headers['user-agent'],
           newValue: details,
           actorId,
         });

--- a/apps/api/src/services/audit.service.spec.ts
+++ b/apps/api/src/services/audit.service.spec.ts
@@ -3,8 +3,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockValues = vi.fn().mockResolvedValue(undefined);
 const mockInsert = vi.fn(() => ({ values: mockValues }));
 
+const { mockDbValues, mockDbInsert } = vi.hoisted(() => {
+  const mockDbValues = vi.fn().mockResolvedValue(undefined);
+  const mockDbInsert = vi.fn().mockReturnValue({ values: mockDbValues });
+  return { mockDbValues, mockDbInsert };
+});
+
 vi.mock('@colophony/db', () => ({
   auditEvents: { _: 'audit_events_table_ref' },
+  db: { insert: mockDbInsert },
 }));
 
 import { auditService, serializeValue } from './audit.service.js';
@@ -144,6 +151,68 @@ describe('auditService.log', () => {
 
     await expect(auditService.log(tx, params)).rejects.toThrow(
       'DB write failed',
+    );
+  });
+});
+
+describe('auditService.logDirect', () => {
+  beforeEach(() => {
+    mockDbInsert.mockClear();
+    mockDbValues.mockClear().mockResolvedValue(undefined);
+  });
+
+  it('inserts via shared db with correct fields', async () => {
+    const params: AuditLogParams = {
+      resource: 'auth',
+      action: 'AUTH_TOKEN_INVALID',
+      ipAddress: '10.0.0.1',
+      userAgent: 'TestAgent/2.0',
+      newValue: { reason: 'invalid_header_format' },
+    };
+
+    await auditService.logDirect(params);
+
+    expect(mockDbInsert).toHaveBeenCalledOnce();
+    expect(mockDbValues).toHaveBeenCalledOnce();
+    const row = mockDbValues.mock.calls[0][0];
+    expect(row.action).toBe('AUTH_TOKEN_INVALID');
+    expect(row.resource).toBe('auth');
+    expect(row.ipAddress).toBe('10.0.0.1');
+    expect(row.userAgent).toBe('TestAgent/2.0');
+    expect(JSON.parse(row.newValue)).toEqual({
+      reason: 'invalid_header_format',
+    });
+    expect(row.actorId).toBeUndefined();
+    expect(row.organizationId).toBeUndefined();
+  });
+
+  it('applies serializeValue to values', async () => {
+    const params: AuditLogParams = {
+      resource: 'auth',
+      action: 'AUTH_USER_DEACTIVATED',
+      oldValue: { name: 'before' },
+      newValue: { reason: 'deactivated', secretToken: 'should-redact' },
+    };
+
+    await auditService.logDirect(params);
+
+    const row = mockDbValues.mock.calls[0][0];
+    const newVal = JSON.parse(row.newValue);
+    expect(newVal.reason).toBe('deactivated');
+    expect(newVal.secretToken).toBe('[REDACTED]');
+    expect(JSON.parse(row.oldValue)).toEqual({ name: 'before' });
+  });
+
+  it('propagates insertion errors', async () => {
+    mockDbValues.mockRejectedValue(new Error('connection refused'));
+
+    const params: AuditLogParams = {
+      resource: 'auth',
+      action: 'AUTH_TOKEN_EXPIRED',
+    };
+
+    await expect(auditService.logDirect(params)).rejects.toThrow(
+      'connection refused',
     );
   });
 });

--- a/apps/api/src/services/audit.service.ts
+++ b/apps/api/src/services/audit.service.ts
@@ -1,4 +1,4 @@
-import { auditEvents, type DrizzleDb } from '@colophony/db';
+import { auditEvents, db, type DrizzleDb } from '@colophony/db';
 import type { AuditLogParams } from '@prospector/types';
 
 const MAX_VALUE_LENGTH = 8192;
@@ -48,6 +48,27 @@ export function serializeValue(value: unknown): string | null {
 export const auditService = {
   async log(tx: DrizzleDb, params: AuditLogParams): Promise<void> {
     await tx.insert(auditEvents).values({
+      action: params.action,
+      resource: params.resource,
+      resourceId: params.resourceId,
+      actorId: params.actorId,
+      organizationId: params.organizationId,
+      oldValue: serializeValue(params.oldValue),
+      newValue: serializeValue(params.newValue),
+      ipAddress: params.ipAddress,
+      userAgent: params.userAgent,
+    });
+  },
+
+  /**
+   * Insert an audit event directly via the shared `db` instance.
+   *
+   * Used for events that occur before a per-request transaction exists
+   * (e.g. auth failures). Errors propagate — caller is responsible
+   * for try/catch.
+   */
+  async logDirect(params: AuditLogParams): Promise<void> {
+    await db.insert(auditEvents).values({
       action: params.action,
       resource: params.resource,
       resourceId: params.resourceId,

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -4,6 +4,40 @@ Append-only session log. Newest entries first.
 
 ---
 
+## 2026-02-12 — Auth Failure Audit Logging (Track 1)
+
+### Done
+
+- **PR #47** — Auth failure audit logging for events that occur before per-request transaction exists (5 files, ~340 insertions)
+- New `logDirect()` method on `auditService` inserts directly via shared `db` instance (bypasses per-request transaction)
+- 4 new audit actions: `AUTH_TOKEN_INVALID`, `AUTH_TOKEN_EXPIRED`, `AUTH_USER_NOT_PROVISIONED`, `AUTH_USER_DEACTIVATED`
+- New `AUTH` resource type added to discriminated union in `@prospector/types`
+- `logAuthFailure()` helper in auth hook — try/catch wrapper ensures audit failures never block auth responses
+- 5 audit points in auth hook: malformed header, JOSE signature failure, JOSE expired, user not provisioned, user deactivated
+- Replaced heuristic `detail.includes('exp')` with deterministic `err.name === 'JWTExpired'` for JOSE error classification
+- Strict sanitization: never log raw tokens; `zitadelUserId` only logged after signature verification succeeds
+- `actorId` set only for `AUTH_USER_DEACTIVATED` (user presenting credentials); undefined for unauthenticated failures
+- 10 new tests (3 for `logDirect`, 7 for auth failure auditing) — all 92 tests passing
+- Type-check and lint clean
+
+### Decisions
+
+- **Shared `db` instance over transaction** — auth failures occur in `authPlugin` (hook 1) before `dbContextPlugin` (hook 4) creates a transaction. The shared `db` connects as `app_user`, and `audit_events` RLS allows `organization_id IS NULL` inserts (verified by existing RLS tests)
+- **Deterministic JOSE error classification** — `error.name === 'JWTExpired'` instead of substring matching on error message; more reliable and forwards-compatible
+- **`vi.hoisted()` for mock initialization** — Vitest hoists `vi.mock()` factories to top of file; mocks referenced inside factories must use `vi.hoisted()` to avoid `ReferenceError: Cannot access before initialization`
+
+### Next
+
+- Check AI review on PR #47 with `/check-ai-review` before merging
+- Deferred: dedicated `audit_writer` role with INSERT-only on `audit_events` (production hardening)
+- Deferred: in-memory per-IP throttle for auth failure auditing (DoS protection)
+- Deferred: request correlation columns (`requestId`, `method`, `route`) — requires schema migration
+- Deferred: counter metrics for auth failures (needs monitoring infrastructure)
+- Audit query/list endpoints (tRPC/REST routes when API surfaces are wired)
+- Frontend OIDC flow (Track 1 continuation)
+
+---
+
 ## 2026-02-12 — RLS Integration Tests + Session Skill Workflow (Track 1)
 
 ### Done

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -19,6 +19,12 @@ export const AuditActions = {
   ORG_MEMBER_ADDED: "ORG_MEMBER_ADDED",
   ORG_MEMBER_REMOVED: "ORG_MEMBER_REMOVED",
   ORG_MEMBER_ROLE_CHANGED: "ORG_MEMBER_ROLE_CHANGED",
+
+  // Authentication failures
+  AUTH_TOKEN_INVALID: "AUTH_TOKEN_INVALID",
+  AUTH_TOKEN_EXPIRED: "AUTH_TOKEN_EXPIRED",
+  AUTH_USER_NOT_PROVISIONED: "AUTH_USER_NOT_PROVISIONED",
+  AUTH_USER_DEACTIVATED: "AUTH_USER_DEACTIVATED",
 } as const;
 
 export type AuditAction = (typeof AuditActions)[keyof typeof AuditActions];
@@ -27,6 +33,7 @@ export type AuditAction = (typeof AuditActions)[keyof typeof AuditActions];
 export const AuditResources = {
   USER: "user",
   ORGANIZATION: "organization",
+  AUTH: "auth",
 } as const;
 
 export type AuditResource =
@@ -68,5 +75,14 @@ export interface OrgAuditParams extends BaseAuditParams {
     | typeof AuditActions.ORG_MEMBER_ROLE_CHANGED;
 }
 
+export interface AuthAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.AUTH;
+  action:
+    | typeof AuditActions.AUTH_TOKEN_INVALID
+    | typeof AuditActions.AUTH_TOKEN_EXPIRED
+    | typeof AuditActions.AUTH_USER_NOT_PROVISIONED
+    | typeof AuditActions.AUTH_USER_DEACTIVATED;
+}
+
 /** Union of all resource-specific param types. */
-export type AuditLogParams = UserAuditParams | OrgAuditParams;
+export type AuditLogParams = UserAuditParams | OrgAuditParams | AuthAuditParams;


### PR DESCRIPTION
## Summary

- Add audit logging for authentication failures that occur before the per-request database transaction exists
- New `logDirect()` method on audit service inserts directly via the shared `db` instance
- Four new audit actions: `AUTH_TOKEN_INVALID`, `AUTH_TOKEN_EXPIRED`, `AUTH_USER_NOT_PROVISIONED`, `AUTH_USER_DEACTIVATED`
- Replace heuristic `detail.includes('exp')` with deterministic `err.name === 'JWTExpired'` for JOSE error classification
- Audit calls wrapped in try/catch so failures never block auth responses
- Strict sanitization: never log raw tokens, only log `zitadelUserId` after signature verification succeeds

## Test plan

- [x] `logDirect()` inserts via shared db with correct fields
- [x] `logDirect()` applies `serializeValue()` (secret scrubbing)
- [x] `logDirect()` propagates insertion errors to caller
- [x] Malformed auth header → `AUTH_TOKEN_INVALID` audit event
- [x] Token validation failure → `AUTH_TOKEN_INVALID` audit event
- [x] Expired token (JWTExpired error name) → `AUTH_TOKEN_EXPIRED` audit event
- [x] User not provisioned → `AUTH_USER_NOT_PROVISIONED` with zitadelUserId
- [x] User deactivated → `AUTH_USER_DEACTIVATED` with actorId
- [x] Audit service error → auth still returns correct 401/403
- [x] No token or Authorization header values leak into audit details
- [x] All 92 existing + new tests pass
- [x] Type-check passes for `@prospector/types` and `@colophony/api`