### PR TITLE
test(api): audit service integration tests + Codex workflow rewrite

### DIFF
--- a/.claude/skills/codex-review/SKILL.md
+++ b/.claude/skills/codex-review/SKILL.md
@@ -1,26 +1,25 @@
 ---
 name: codex-review
-description: Run Codex code review in a tmux session (plan, diff, branch; default branch).
+description: Run Codex code review non-interactively (plan, diff, branch; default branch).
 ---
 
 # /codex-review
 
-Run a local code review via Codex CLI in a tmux session.
+Run a local code review via `codex review` (non-interactive). For interactive Codex sessions with live progress visibility, see **Interactive Codex (tmux)** in CLAUDE.md.
 
 ## What this skill does
 
-1. Verifies prerequisites (tmux, nvm, node, codex)
-2. Manages a dedicated `codex-review` tmux session (lazy-init, context isolation between reviews)
-3. Sends a review prompt to Codex with project rules and sentinel detection
-4. Polls for completion and captures output
-5. Presents findings structured by severity
+1. Verifies prerequisites (nvm, node, codex)
+2. Builds a review prompt with project rules
+3. Runs `codex review` non-interactively with the appropriate flags
+4. Captures output and presents findings structured by severity
 
 ## Usage
 
 ```
 /codex-review              # Review all changes on current branch vs origin/main (default)
 /codex-review branch       # Same as above
-/codex-review diff         # Review staged changes (falls back to unstaged if nothing staged)
+/codex-review diff         # Review staged/unstaged changes
 /codex-review plan         # Review the current plan file
 ```
 
@@ -28,22 +27,10 @@ Run a local code review via Codex CLI in a tmux session.
 
 When the user invokes `/codex-review`, perform these steps in order:
 
-### Step 1: Preflight checks
-
-Run these checks before anything else:
-
-```bash
-command -v tmux
-```
+### Step 1: Preflight check
 
 ```bash
 export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use v20.20.0 > /dev/null 2>&1 && command -v codex
-```
-
-If tmux is not installed, print:
-
-```
-tmux is not installed. Install it with: sudo apt install tmux
 ```
 
 If nvm/node/codex are not available, print:
@@ -54,93 +41,23 @@ Codex CLI not found. Ensure nvm is installed, node v20.20.0 is available, and co
   npm install -g @openai/codex
 ```
 
-If any check fails, stop here — do not proceed.
+If the check fails, stop here — do not proceed.
 
-### Step 2: Determine review type
+### Step 2: Determine review type and build command
 
 Parse the argument (if any) from the skill invocation:
 
-- No argument or `branch` → **branch review** (all changes on current branch vs `origin/main`)
-- `diff` → **diff review** (staged changes; fall back to unstaged if nothing is staged)
-- `plan` → **plan review** (review the current plan file)
+- No argument or `branch` → **branch review**
+- `diff` → **diff review**
+- `plan` → **plan review**
 
-For branch review, fetch the latest main first:
+### Step 3: Project rules (applied automatically)
 
-```bash
-git fetch origin main
-```
+For **branch** and **diff** reviews, `codex review` does not accept an inline prompt — `--base` and `--uncommitted` are mutually exclusive with the `[PROMPT]` argument. Project-specific review rules are loaded automatically from Codex's rules files (`.codex/instructions.md` in the repo root, or `~/.codex/rules/`).
 
-For diff review, check if there are staged changes:
-
-```bash
-git diff --cached --stat
-```
-
-If nothing is staged, fall back to unstaged:
-
-```bash
-git diff --stat
-```
-
-If there are no changes at all, tell the user and exit.
-
-For plan review, find the most recent plan file:
-
-```bash
-ls -t ~/.claude/plans/*.md 2>/dev/null | head -1
-```
-
-If no plan file exists, tell the user and exit.
-
-### Step 3: Manage tmux session
-
-Check if the `codex-review` session already exists:
-
-```bash
-tmux has-session -t codex-review 2>/dev/null
-```
-
-**If the session does NOT exist**, create it and launch Codex:
-
-```bash
-tmux new-session -d -s codex-review -x 200 -y 50
-```
-
-Then send the nvm + Codex launch command:
-
-```bash
-tmux send-keys -t codex-review 'export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use v20.20.0 > /dev/null 2>&1 && cd /home/dmahaffey/projects/prospector && codex' Enter
-```
-
-**If the session DOES exist**, kill the old Codex process and relaunch for fresh context:
-
-```bash
-tmux send-keys -t codex-review C-c
-```
-
-Wait 2 seconds, then:
-
-```bash
-tmux send-keys -t codex-review 'export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use v20.20.0 > /dev/null 2>&1 && cd /home/dmahaffey/projects/prospector && codex' Enter
-```
-
-**Wait for Codex to be ready** — poll every 3 seconds for up to 30 seconds, checking for the Codex interactive prompt:
-
-```bash
-tmux capture-pane -t codex-review -p -S -50
-```
-
-Look for the `>` prompt character or "Codex" in the output indicating Codex is ready to accept input.
-
-### Step 4: Build and send the review prompt
-
-Construct the review prompt based on review type. The prompt has four parts:
-
-**Part 1 — Preamble** (same for all review types):
+For **plan** review only, a custom prompt is built and passed via stdin to `codex exec`. Build it from these project rules:
 
 ```
-You are reviewing code in the Colophony project at /home/dmahaffey/projects/prospector.
-
 Key project rules to enforce:
 - Multi-tenancy via RLS: all tenant table queries MUST use SET LOCAL inside transactions, never session-level SET. app_user MUST NOT be superuser. All tenant tables MUST have FORCE ROW LEVEL SECURITY.
 - Webhook idempotency: ALL webhook handlers (Stripe, Zitadel) MUST check processed status before handling. Use DB transactions.
@@ -155,111 +72,72 @@ Format your review as markdown:
 - Be concise — skip formatting nits (handled by linters)
 ```
 
-**Part 2 — Task** (varies by review type):
+### Step 4: Run the review
 
-For **branch** review:
+**For branch review:**
 
-```
-Review all changes on the current branch compared to origin/main.
-Run: git fetch origin main && git diff origin/main...HEAD
-Also run: git log origin/main...HEAD --oneline
-to understand the commit history. Then read any files you need for full context.
-```
+```bash
+git fetch origin main
 
-For **diff** review:
-
-```
-Review the currently staged changes (or unstaged if nothing is staged).
-Run: git diff --cached
-(If empty, run: git diff)
-Read any surrounding files you need for context.
+export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use v20.20.0 > /dev/null 2>&1 && cd /home/dmahaffey/projects/prospector && codex review --base origin/main
 ```
 
-For **plan** review:
+**For diff review:**
 
+First check if there are changes:
+
+```bash
+git diff --cached --stat
 ```
+
+If nothing staged, check unstaged:
+
+```bash
+git diff --stat
+```
+
+If no changes at all, tell the user and exit.
+
+Then run:
+
+```bash
+export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use v20.20.0 > /dev/null 2>&1 && cd /home/dmahaffey/projects/prospector && codex review --uncommitted
+```
+
+**For plan review:**
+
+Find the most recent plan file:
+
+```bash
+ls -t ~/.claude/plans/*.md 2>/dev/null | head -1
+```
+
+If no plan file exists, tell the user and exit.
+
+Then run (using `codex exec` since plan review isn't a git diff — `exec` accepts stdin prompts):
+
+```bash
+cat > /tmp/codex-review-prompt.txt << 'PROMPT_EOF'
 Review the plan file at: [path to plan file]
 Read the plan file, then explore the codebase to verify the plan's assumptions.
 Check that referenced files exist, patterns match reality, and the approach is sound.
-```
 
-**Part 3 — Sentinel**:
-
-```
-When you are completely finished with your review, print the exact line: __CODEX_REVIEW_DONE__
-```
-
-Send the complete prompt to Codex:
-
-```bash
-tmux send-keys -t codex-review '<full prompt text>' Enter
-```
-
-**Important:** The prompt must be sent as a single `send-keys` command. If it's very long, use `tmux load-buffer` + `tmux paste-buffer` instead:
-
-```bash
-# Write prompt to temp file
-cat > /tmp/codex-review-prompt.txt << 'PROMPT_EOF'
-<full prompt text>
+<project rules prompt from Step 3>
 PROMPT_EOF
 
-tmux load-buffer /tmp/codex-review-prompt.txt
-tmux paste-buffer -t codex-review
-tmux send-keys -t codex-review '' Enter
+export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use v20.20.0 > /dev/null 2>&1 && cd /home/dmahaffey/projects/prospector && codex exec -s read-only - < /tmp/codex-review-prompt.txt
 ```
 
-### Step 5: Poll for completion
+**Important:** Run the codex command in the background using the Bash tool's `run_in_background` parameter. Set a timeout of 300000ms (5 minutes). Tell the user the review is running and check back on it periodically.
 
-Wait 10 seconds initially, then poll every 5 seconds:
+### Step 5: Present output
 
-```bash
-sleep 10
-```
-
-Then in a loop (up to 180 seconds total):
-
-```bash
-tmux capture-pane -t codex-review -p -S -200
-```
-
-Check the captured output for:
-
-1. **Primary signal**: Output contains `__CODEX_REVIEW_DONE__`
-2. **Fallback signal**: Output contains `Token usage:` followed by a shell prompt (e.g., `$` at start of line)
-
-If either signal is detected, proceed to Step 6.
-
-If 180 seconds pass without completion:
-
-```
-Review is still running. You can check progress with:
-  tmux attach -t codex-review
-
-Partial output captured — see below.
-```
-
-Then proceed to Step 6 with whatever output is available.
-
-### Step 6: Capture and present output
-
-Capture the full scrollback:
-
-```bash
-tmux capture-pane -t codex-review -p -S -500
-```
-
-Parse the output:
-
-- Find the review content between the prompt echo and the sentinel (`__CODEX_REVIEW_DONE__`) or `Token usage:` line
-- Strip the prompt echo and sentinel from the output
-- If the output contains a verdict line (LGTM, Minor issues, Issues found), use it as the header
-
-Present the review to the user with clear formatting:
+When the command completes, present the review to the user with clear formatting:
 
 ```
 ## Codex Review Results
 
-[parsed review content]
+[review output]
 ```
 
 Then ask the user which findings (if any) they want to address:
@@ -270,10 +148,9 @@ Which findings would you like me to address? (Enter numbers, "all", or "none")
 
 ## Important notes
 
-- The tmux session is named `codex-review` to avoid conflicts with user sessions
-- Codex is killed and relaunched between reviews for context isolation
-- Always use `origin/main` (not local `main`) for branch diffs to avoid stale comparisons
-- The sentinel `__CODEX_REVIEW_DONE__` is critical for reliable idle detection
-- If tmux send-keys has issues with special characters in the prompt, use the load-buffer approach
-- The review prompt tells Codex to explore the codebase itself — do NOT paste large diffs into the prompt
-- nvm must be sourced explicitly because tmux runs non-interactive shells
+- `codex review` runs non-interactively — no tmux session management needed
+- **`codex review --base` and `--uncommitted` cannot be combined with a `[PROMPT]` argument** — they are mutually exclusive. Custom review instructions must come from Codex project rules files, not inline
+- Always uses `origin/main` (fetched) for branch diffs to avoid stale comparisons
+- Plan review uses `codex exec -s read-only` since it's not a git diff operation and `exec` accepts stdin prompts
+- nvm must be sourced explicitly in every command because Bash tool runs non-interactive shells
+- For interactive Codex sessions with live progress, see the **Interactive Codex (tmux)** section in CLAUDE.md

--- a/.codex/instructions.md
+++ b/.codex/instructions.md
@@ -1,0 +1,19 @@
+# Colophony — Codex Review Rules
+
+When reviewing code in this project, enforce these rules:
+
+## Critical Rules
+
+- **Multi-tenancy via RLS:** All tenant table queries MUST use `SET LOCAL` inside transactions, never session-level `SET`. `app_user` MUST NOT be superuser. All tenant tables MUST have `FORCE ROW LEVEL SECURITY`.
+- **Webhook idempotency:** ALL webhook handlers (Stripe, Zitadel) MUST check processed status before handling. Use DB transactions.
+- **PCI compliance:** NEVER log card numbers or CVV. NEVER store card data. Stripe Checkout only.
+- **Audit logging:** Sensitive operations MUST be audit logged.
+- **Input validation:** Use Zod schemas from `@colophony/types` on all API surfaces.
+
+## Review Format
+
+- Start with a one-line verdict: **LGTM**, **Minor issues**, or **Issues found**
+- Group findings by severity: Critical, Important, Suggestions
+- Reference specific file paths and line numbers (`file:line` format)
+- Be concise — skip formatting nits (handled by linters)
+- Run tests when possible to validate changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,8 @@ tRPC client for internal API calls. Zitadel handles login/signup UI. `ProtectedR
 | **`gh pr edit` broken (Projects Classic)**                  | Returns GraphQL error about Projects Classic deprecation. Use `gh api repos/{owner}/{repo}/pulls/{number} -X PATCH -f title="..." -f body="..."` instead                                                                                                                                                                              |
 | **`@fastify/raw-body` doesn't exist**                       | Official `@fastify/` scoped package not published on npm. Use `fastify-raw-body` (community package, v5.0.0 for Fastify 5)                                                                                                                                                                                                            |
 | **Codex CLI needs nvm in non-interactive shells**           | Codex installed via npm under nvm. tmux `send-keys` runs non-interactive shells; must source nvm manually before invoking `codex`. The `/codex-review` skill handles this automatically.                                                                                                                                              |
+| **Codex interactive: Enter adds newline**                   | In interactive Codex CLI, Enter adds a newline to the input field instead of submitting. Use **Escape then Enter** to submit multiline prompts, or pass the prompt as an argument: `codex "prompt"`. For long prompts, pipe via stdin: `codex - < /tmp/prompt.txt`                                                                    |
+| **Codex `review --base` excludes `[PROMPT]`**               | `codex review --base <branch>` and `--uncommitted` are mutually exclusive with the `[PROMPT]` positional argument. Custom review instructions must come from Codex project rules files (`~/.codex/rules/` or `.codex/instructions.md`), not inline. `codex exec` does accept stdin prompts via `-`                                    |
 
 **Version pins (do not upgrade without testing):**
 
@@ -433,13 +435,44 @@ The v1 MVP is tagged as `v1.0.0-mvp`.
 
 ### Codex Review Integration
 
-Code reviews are performed locally via Codex CLI in a tmux session, managed by Claude Code.
+Two modes for running Codex code reviews:
 
-- **Skill:** `/codex-review [plan|diff|branch]` (default: branch)
-- **tmux session:** `codex-review` (lazy-initialized on first invocation)
-- **Context isolation:** Codex is killed and relaunched between reviews
-- **Idle detection:** Polls tmux capture-pane for `__CODEX_REVIEW_DONE__` sentinel
-- **Branch diffs:** Always uses `origin/main` (fetched) to avoid stale local main
+#### Non-Interactive (Claude Code skill)
+
+`/codex-review [plan|diff|branch]` — runs `codex review` non-interactively. Claude Code invokes Codex, captures stdout, and presents findings. No tmux required.
+
+- **Branch review:** `codex review --base origin/main` (default)
+- **Diff review:** `codex review --uncommitted`
+- **Plan review:** `codex exec -s read-only` with plan file prompt
+- Always fetches `origin/main` to avoid stale local main
+
+#### Interactive Codex (tmux)
+
+For live progress visibility, re-review, and ad-hoc follow-up, run Codex in a tmux pane alongside Claude Code.
+
+**Setup (one-time per terminal session):**
+
+```bash
+# Split your Claude Code tmux window into two panes (left: Claude, right: Codex)
+# From within tmux, press Ctrl+B then % (vertical split) or " (horizontal split)
+
+# In the new pane, launch Codex:
+export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" \
+  && nvm use v20.20.0 && cd /home/dmahaffey/projects/prospector && codex
+```
+
+**Submitting prompts in interactive Codex:**
+
+- Codex's input field treats Enter as a newline, not submit. Press **Escape then Enter** to submit.
+- **Alternative:** Pass the prompt as an argument when launching: `codex "your prompt here"`
+- **Long prompts from file:** Use `codex - < /tmp/prompt.txt` or launch with `codex "$(cat /tmp/prompt.txt)"`
+
+**Workflow:**
+
+1. Keep Codex running between reviews — no need to kill/relaunch
+2. Use `codex resume` or `codex fork --last` to continue from a previous session
+3. Switch to the Codex pane with `Ctrl+B` then arrow key
+4. Codex persists after reviews for follow-up questions or re-review
 
 ### MCP Servers (restart Claude Code to activate)
 

--- a/apps/api/src/__tests__/rls/audit-write-path.test.ts
+++ b/apps/api/src/__tests__/rls/audit-write-path.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Integration tests for auditService.logDirect() and auditService.log()
+ * against PostgreSQL with RLS policies enforced.
+ *
+ * Codex review finding #4: logDirect() was only unit-tested with mocked DB.
+ * These tests exercise the actual service methods as app_user with RLS.
+ *
+ * Requires: postgres-test container running on port 5433
+ * Config:   vitest.config.rls.ts sets DATABASE_URL → app_user test DB
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import {
+  auditEvents,
+  pool as colophonyPool,
+  type AuditEvent,
+} from '@colophony/db';
+import {
+  AuditActions,
+  AuditResources,
+  type AuthAuditParams,
+} from '@prospector/types';
+import { auditService, serializeValue } from '../../services/audit.service';
+import {
+  globalSetup,
+  getAdminPool,
+  getAppPool,
+  type DrizzleDb,
+} from '../rls/helpers/db-setup';
+import { withTestRls } from '../rls/helpers/rls-context';
+import {
+  createOrganization,
+  createUser,
+  createOrgMember,
+} from '../rls/helpers/factories';
+import { truncateAllTables } from '../rls/helpers/cleanup';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function adminDb(): DrizzleDb {
+  return drizzle(getAdminPool());
+}
+
+/** Read all audit_events via admin (bypasses RLS). */
+async function allAuditEvents(): Promise<AuditEvent[]> {
+  return adminDb().select().from(auditEvents);
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+let orgA: { id: string };
+let orgB: { id: string };
+let userA: { id: string };
+let userB: { id: string };
+
+const AUTH_FAILURE_ACTIONS = [
+  AuditActions.AUTH_TOKEN_INVALID,
+  AuditActions.AUTH_TOKEN_EXPIRED,
+  AuditActions.AUTH_USER_NOT_PROVISIONED,
+  AuditActions.AUTH_USER_DEACTIVATED,
+] as const;
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  await globalSetup();
+
+  [orgA, orgB] = await Promise.all([
+    createOrganization(),
+    createOrganization(),
+  ]);
+  [userA, userB] = await Promise.all([createUser(), createUser()]);
+  await Promise.all([
+    createOrgMember(orgA.id, userA.id),
+    createOrgMember(orgB.id, userB.id),
+  ]);
+});
+
+beforeEach(async () => {
+  // Truncate only audit_events between tests for isolation
+  await getAdminPool().query('TRUNCATE audit_events RESTART IDENTITY CASCADE');
+});
+
+afterAll(async () => {
+  await truncateAllTables();
+  await colophonyPool.end();
+});
+
+// ===========================================================================
+// 1. logDirect() — auth failure write path
+// ===========================================================================
+
+describe('logDirect() auth failure write path', () => {
+  it.each(AUTH_FAILURE_ACTIONS)(
+    'inserts %s event with correct fields',
+    async (action) => {
+      const params: AuthAuditParams = {
+        action,
+        resource: AuditResources.AUTH,
+        ipAddress: '192.168.1.42',
+        userAgent: 'TestAgent/1.0',
+      };
+
+      await auditService.logDirect(params);
+
+      const rows = await allAuditEvents();
+      expect(rows).toHaveLength(1);
+
+      const row = rows[0];
+      expect(row.action).toBe(action);
+      expect(row.resource).toBe('auth');
+      expect(row.ipAddress).toBe('192.168.1.42');
+      expect(row.userAgent).toBe('TestAgent/1.0');
+      expect(row.organizationId).toBeNull();
+      expect(row.createdAt).toBeInstanceOf(Date);
+    },
+  );
+
+  it('stores actorId when provided (AUTH_USER_DEACTIVATED)', async () => {
+    await auditService.logDirect({
+      action: AuditActions.AUTH_USER_DEACTIVATED,
+      resource: AuditResources.AUTH,
+      actorId: userA.id,
+      ipAddress: '10.0.0.1',
+    });
+
+    const rows = await allAuditEvents();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].actorId).toBe(userA.id);
+  });
+
+  it('rejects params with organizationId', async () => {
+    await expect(
+      auditService.logDirect({
+        action: AuditActions.AUTH_TOKEN_INVALID,
+        resource: AuditResources.AUTH,
+        organizationId: orgA.id,
+      } as AuthAuditParams),
+    ).rejects.toThrow('logDirect must not include organizationId');
+
+    // Verify nothing was written
+    const rows = await allAuditEvents();
+    expect(rows).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
+// 2. logDirect() and RLS interaction
+// ===========================================================================
+
+describe('logDirect() and RLS interaction', () => {
+  it('INSERT...RETURNING for NULL-org row throws 42501 (confirms why logDirect omits .returning())', async () => {
+    // The SELECT policy requires organization_id = current_org_id(), so
+    // reading back a NULL-org row via RETURNING fails with insufficient_privilege.
+    const appPool = getAppPool();
+    const client = await appPool.connect();
+    try {
+      const result = client.query(
+        `INSERT INTO audit_events (action, resource)
+         VALUES ('AUTH_TOKEN_INVALID', 'auth')
+         RETURNING *`,
+      );
+      await expect(result).rejects.toMatchObject({
+        code: '42501', // insufficient_privilege
+      });
+    } finally {
+      client.release();
+    }
+  });
+});
+
+// ===========================================================================
+// 3. log() — org-scoped write via RLS transaction
+// ===========================================================================
+
+describe('log() org-scoped write via RLS transaction', () => {
+  it('inserts event visible within same org context', async () => {
+    await withTestRls({ orgId: orgA.id, userId: userA.id }, (tx) =>
+      auditService.log(tx, {
+        action: AuditActions.ORG_UPDATED,
+        resource: AuditResources.ORGANIZATION,
+        resourceId: orgA.id,
+        actorId: userA.id,
+        organizationId: orgA.id,
+        ipAddress: '172.16.0.1',
+      }),
+    );
+
+    // Verify via admin pool (bypasses RLS)
+    const rows = await allAuditEvents();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].organizationId).toBe(orgA.id);
+    expect(rows[0].actorId).toBe(userA.id);
+    expect(rows[0].action).toBe('ORG_UPDATED');
+    expect(rows[0].resource).toBe('organization');
+
+    // Also verify tenant isolation: org A event visible in org A context
+    const orgARows = await withTestRls(
+      { orgId: orgA.id, userId: userA.id },
+      (tx) => tx.select().from(auditEvents),
+    );
+    expect(orgARows).toHaveLength(1);
+    expect(orgARows[0].id).toBe(rows[0].id);
+  });
+
+  it('org A audit event is invisible to org B (tenant isolation)', async () => {
+    // Insert via org A
+    await withTestRls({ orgId: orgA.id, userId: userA.id }, (tx) =>
+      auditService.log(tx, {
+        action: AuditActions.ORG_CREATED,
+        resource: AuditResources.ORGANIZATION,
+        actorId: userA.id,
+        organizationId: orgA.id,
+      }),
+    );
+
+    // Org B sees nothing
+    const orgBRows = await withTestRls(
+      { orgId: orgB.id, userId: userB.id },
+      (tx) => tx.select().from(auditEvents),
+    );
+    expect(orgBRows).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
+// 4. Transaction rollback atomicity
+// ===========================================================================
+
+describe('transaction rollback atomicity', () => {
+  it('rolled-back audit event produces 0 rows', async () => {
+    const appPool = getAppPool();
+    const client = await appPool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query('SELECT set_config($1, $2, true)', [
+        'app.current_org',
+        orgA.id,
+      ]);
+      await client.query('SELECT set_config($1, $2, true)', [
+        'app.user_id',
+        userA.id,
+      ]);
+
+      const tx = drizzle(client);
+      await auditService.log(tx, {
+        action: AuditActions.ORG_DELETED,
+        resource: AuditResources.ORGANIZATION,
+        actorId: userA.id,
+        organizationId: orgA.id,
+      });
+
+      // Rollback instead of commit
+      await client.query('ROLLBACK');
+    } finally {
+      client.release();
+    }
+
+    const rows = await allAuditEvents();
+    expect(rows).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
+// 5. Serialized values round-trip
+// ===========================================================================
+
+describe('serialized values round-trip', () => {
+  it('serializeValue() output with [REDACTED] markers survives PostgreSQL text column', async () => {
+    const sensitivePayload = {
+      username: 'testuser',
+      token: 'should-be-scrubbed',
+      password: 'also-scrubbed',
+      details: { nested: true },
+    };
+
+    const serialized = serializeValue(sensitivePayload);
+    expect(serialized).toContain('[REDACTED]');
+    expect(serialized).not.toContain('should-be-scrubbed');
+
+    // Write via logDirect with newValue containing redacted data
+    await auditService.logDirect({
+      action: AuditActions.AUTH_TOKEN_INVALID,
+      resource: AuditResources.AUTH,
+      newValue: sensitivePayload,
+      ipAddress: '127.0.0.1',
+    });
+
+    // Read back via admin
+    const rows = await allAuditEvents();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].newValue).toBe(serialized);
+
+    // Parse and verify redaction markers survived the round-trip
+    const parsed = JSON.parse(rows[0].newValue!);
+    expect(parsed.username).toBe('testuser');
+    expect(parsed.token).toBe('[REDACTED]');
+    expect(parsed.password).toBe('[REDACTED]');
+    expect(parsed.details).toEqual({ nested: true });
+  });
+});

--- a/apps/api/vitest.config.rls.ts
+++ b/apps/api/vitest.config.rls.ts
@@ -17,7 +17,9 @@ export default defineConfig({
       // Point @colophony/db's pool at the test database so that
       // auditService.logDirect() (which uses the shared `db` export)
       // exercises the real write path as app_user with RLS enforced.
+      // Uses the same env var / fallback as db-setup.ts's getAppPool().
       DATABASE_URL:
+        process.env.DATABASE_APP_URL ??
         'postgresql://app_user:app_password@localhost:5433/prospector_test',
     },
   },

--- a/apps/api/vitest.config.rls.ts
+++ b/apps/api/vitest.config.rls.ts
@@ -13,5 +13,12 @@ export default defineConfig({
         singleFork: true,
       },
     },
+    env: {
+      // Point @colophony/db's pool at the test database so that
+      // auditService.logDirect() (which uses the shared `db` export)
+      // exercises the real write path as app_user with RLS enforced.
+      DATABASE_URL:
+        'postgresql://app_user:app_password@localhost:5433/prospector_test',
+    },
   },
 });

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -4,6 +4,39 @@ Append-only session log. Newest entries first.
 
 ---
 
+## 2026-02-13 — Audit Integration Tests + Codex Workflow Rewrite (Track 1)
+
+### Done
+
+- **PR #49** — Audit service integration tests + Codex workflow rewrite
+- 11 integration tests in `audit-write-path.test.ts` exercising `auditService.logDirect()` and `auditService.log()` against PostgreSQL with RLS enforced as `app_user` — closes Codex review finding #4 from 2026-02-12 session
+- Tests cover: all 4 auth failure actions (it.each), actorId storage, organizationId rejection guard, `INSERT...RETURNING` 42501 confirmation, org-scoped writes with tenant isolation, transaction rollback atomicity, `serializeValue()` round-trip through PostgreSQL text column
+- Added `DATABASE_URL` env to `vitest.config.rls.ts` with `DATABASE_APP_URL` fallback for CI portability (Codex non-interactive review finding, fixed same session)
+- **Rewrote `/codex-review` skill to use non-interactive `codex review`:** no tmux session management needed; `codex review --base origin/main` runs directly from Bash tool
+- Documented interactive two-pane tmux workflow in CLAUDE.md for live progress visibility and follow-up
+- Created `.codex/instructions.md` with project review rules — loaded automatically by `codex review`
+- Added 2 new Known Quirks: Codex Enter key behavior (Esc+Enter to submit), `--base`/`[PROMPT]` mutual exclusivity
+- Fixed 2 documentation contradictions found by interactive Codex review (Enter key docs, SKILL.md Step 3/4 inconsistency)
+- Removed unused `eq` import (Codex review finding from first review cycle)
+- Cleaned up GitHub repo: removed `OPENROUTER_API_KEY` secret, `CLAUDE_CODE_OAUTH_TOKEN` secret (both unused by CI)
+- All 81 RLS tests passing (7 files), type-check and lint clean
+
+### Decisions
+
+- **Two-mode Codex workflow** — non-interactive (`codex review --base`) for `/codex-review` skill (Claude Code runs it, captures stdout); interactive tmux pane for live progress and follow-up. Context persistence is the key differentiator for interactive mode
+- **`codex review --base` can't take inline prompts** — `--base` and `[PROMPT]` are mutually exclusive (Codex CLI 0.101.0). Project rules go in `.codex/instructions.md` instead; `codex exec` still accepts stdin for plan reviews
+- **`DATABASE_URL` env var fallback** — `vitest.config.rls.ts` uses `process.env.DATABASE_APP_URL` with hardcoded fallback, matching the pattern in `db-setup.ts`. Ensures CI portability
+
+### Next
+
+- Deferred: dedicated `audit_writer` role with INSERT-only on `audit_events` (production hardening)
+- Deferred: in-memory per-IP throttle for auth failure auditing (DoS protection)
+- Deferred: request correlation columns (`requestId`, `method`, `route`) — requires schema migration
+- Audit query/list endpoints (tRPC/REST routes when API surfaces are wired)
+- Frontend OIDC flow (Track 1 continuation)
+
+---
+
 ## 2026-02-12 — Auth Failure Auditing + Codex Review Integration (Track 1)
 
 ### Done


### PR DESCRIPTION
## Summary

- **Audit integration tests:** 11 tests exercising `auditService.logDirect()` and `auditService.log()` against PostgreSQL with RLS enforced as `app_user` — closes code review finding #4 (deferred from 2026-02-12)
- **Codex workflow rewrite:** `code review` skill now uses `codex review --base` (non-interactive), with interactive two-pane tmux workflow documented in CLAUDE.md
- **Codex project rules:** Added `.codex/instructions.md` so `codex review` automatically loads project-specific review rules

### Audit tests cover:
- `logDirect()` write path for all 4 auth failure actions (`it.each`)
- `actorId` storage, `organizationId` rejection guard
- `INSERT...RETURNING` 42501 confirmation (why `logDirect` omits `.returning()`)
- `log()` org-scoped writes with tenant isolation
- Transaction rollback atomicity
- `serializeValue()` round-trip through PostgreSQL text column

### Codex workflow changes:
- Rewrote SKILL.md: `codex review --base` replaces tmux session management
- Fixed `--base`/`[PROMPT]` mutual exclusivity (discovered during testing)
- Documented Enter key quirk (Esc+Enter to submit in interactive mode)
- `DATABASE_URL` in vitest config uses `DATABASE_APP_URL` env var fallback (code review finding)

## Test plan

- [x] `pnpm --filter @colophony/api test:rls` — 81 tests pass (7 files, 0 regressions)
- [x] Non-interactive `codex review --base origin/main` — verified working
- [x] Interactive code review in tmux pane — verified working
- [x] Pre-push hooks pass (type-check + lint)