### PR TITLE
feat(api): type-only AppRouter export layer

### DIFF
--- a/.claude/skills/end-session/SKILL.md
+++ b/.claude/skills/end-session/SKILL.md
@@ -110,16 +110,21 @@ If today already has a DEVLOG entry for this session's work, **append to the exi
 
 Search the codebase for any `TODO(CLAUDE.md)` comments added during this session using the Grep tool (not bash) to search for `TODO(CLAUDE.md)` in `*.ts`, `*.tsx`, and `*.js` files.
 
-Also review the session for any new patterns, quirks, or constraints discovered. Check whether any of these need updates:
+Also review the session for any new patterns, quirks, or constraints discovered. Check whether any of these CLAUDE.md files need updates:
 
-- `CLAUDE.md` — Known Quirks, Security Status checklist, Version Pins
+- `CLAUDE.md` (root) — Known Quirks, Security Status checklist, Version Pins, Key File Locations
+- `packages/db/CLAUDE.md` — RLS rules, schema files, migration workflow
+- `apps/api/CLAUDE.md` — Key Paths, hook chain, tRPC procedures, quirks
+- `apps/web/CLAUDE.md` — tRPC client, providers, conventions, quirks
 - `docs/testing.md` — test counts, new test tiers, running instructions
 - Other docs referenced in the session
+
+Domain-specific discoveries should go in the relevant per-directory CLAUDE.md, not the root. The root file covers cross-cutting concerns only.
 
 If updates are warranted, propose them:
 
 ```markdown
-## Suggested Update for CLAUDE.md
+## Suggested Update for [file path]
 
 **Section**: [section name]
 **Addition**: [new content]

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -2,16 +2,17 @@
 
 ## Key Paths
 
-| What             | Path                              |
-| ---------------- | --------------------------------- |
-| App entry        | `src/main.ts`                     |
-| Env config (Zod) | `src/config/env.ts`               |
-| Fastify hooks    | `src/hooks/`                      |
-| Service layer    | `src/services/`                   |
-| tRPC router      | `src/trpc/router.ts`              |
-| tRPC init        | `src/trpc/init.ts`                |
-| tRPC context     | `src/trpc/context.ts`             |
-| Zitadel webhook  | `src/webhooks/zitadel.webhook.ts` |
+| What              | Path                              |
+| ----------------- | --------------------------------- |
+| App entry         | `src/main.ts`                     |
+| Env config (Zod)  | `src/config/env.ts`               |
+| Fastify hooks     | `src/hooks/`                      |
+| Service layer     | `src/services/`                   |
+| tRPC router       | `src/trpc/router.ts`              |
+| tRPC client types | `src/trpc/client-types.ts`        |
+| tRPC init         | `src/trpc/init.ts`                |
+| tRPC context      | `src/trpc/context.ts`             |
+| Zitadel webhook   | `src/webhooks/zitadel.webhook.ts` |
 
 ---
 
@@ -98,12 +99,12 @@ When built: check processed status in `stripe_webhook_events` table before handl
 
 ## Quirks
 
-| Quirk                                 | Details                                                                                                                                                                                                                   |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Zitadel webhook signatures**        | Verify `x-zitadel-signature` header on all webhook payloads. Use shared secret from Zitadel Actions config                                                                                                                |
-| **BullMQ Redis password**             | Uses `REDIS_HOST`/`REDIS_PORT`/`REDIS_PASSWORD` (not `REDIS_URL`). Pass password in worker/queue config                                                                                                                   |
-| **tRPC TS2742 under NodeNext**        | `typeof appRouter` can't be named without internal `@trpc/server/dist/core/router` reference. Workaround: `declaration: false` in API tsconfig. Web app resolves `AppRouter` via source path aliases (bundler resolution) |
-| **`@fastify/raw-body` doesn't exist** | Official `@fastify/` scoped package not published on npm. Use `fastify-raw-body` (community package, v5.0.0 for Fastify 5)                                                                                                |
+| Quirk                                 | Details                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Zitadel webhook signatures**        | Verify `x-zitadel-signature` header on all webhook payloads. Use shared secret from Zitadel Actions config                                                                                                                                                                                                               |
+| **BullMQ Redis password**             | Uses `REDIS_HOST`/`REDIS_PORT`/`REDIS_PASSWORD` (not `REDIS_URL`). Pass password in worker/queue config                                                                                                                                                                                                                  |
+| **tRPC TS2742 under NodeNext**        | `typeof appRouter` can't be named without internal `@trpc/server/dist/core/router` reference. Workaround: `declaration: false` in API tsconfig. Web app resolves `AppRouter` via source path alias pointing to `src/trpc/client-types.ts` (bundler resolution). All web-facing type exports go through `client-types.ts` |
+| **`@fastify/raw-body` doesn't exist** | Official `@fastify/` scoped package not published on npm. Use `fastify-raw-body` (community package, v5.0.0 for Fastify 5)                                                                                                                                                                                               |
 
 ## Version Pins
 

--- a/apps/api/src/trpc/client-types.ts
+++ b/apps/api/src/trpc/client-types.ts
@@ -1,0 +1,5 @@
+/**
+ * Type-only exports for the tRPC web client.
+ * This is the ONLY file apps/web should import from @colophony/api.
+ */
+export type { AppRouter } from './router.js';

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -19,7 +19,7 @@
 export const trpc = createTRPCReact<AppRouter>();
 ```
 
-- `AppRouter` type imported via source path alias: `@colophony/api/trpc/router` (bundler resolution, not `.d.ts`)
+- `AppRouter` type imported via source path alias: `@colophony/api/trpc/client-types` (bundler resolution, not `.d.ts`). This is the only allowed import from `@colophony/api` — enforced by ESLint `no-restricted-imports`
 - `httpBatchLink` to `${NEXT_PUBLIC_API_URL}/trpc`
 - Headers: `Authorization: Bearer <token>` + `x-organization-id` from localStorage
 - Token sourced from `oidc-client-ts` `UserManager` (async `getUser()`)

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -14,6 +14,22 @@ const eslintConfig = [
   {
     ignores: [".next/**", "out/**", "build/**", "tailwind.config.js", "postcss.config.js", "next-env.d.ts"],
   },
+  {
+    rules: {
+      "no-restricted-imports": ["error", {
+        patterns: [{
+          group: ["@colophony/api/**"],
+          message: "Import types from @colophony/api/trpc/client-types only (via src/lib/trpc.ts).",
+        }],
+      }],
+    },
+  },
+  {
+    files: ["src/lib/trpc.ts"],
+    rules: {
+      "no-restricted-imports": "off",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -18,7 +18,9 @@ const config: Config = {
           isolatedModules: true,
           paths: {
             "@/*": ["./src/*"],
-            "@colophony/api/*": ["../api/src/*"],
+            "@colophony/api/trpc/client-types": [
+              "../api/src/trpc/client-types.ts",
+            ],
           },
         },
       },
@@ -26,6 +28,8 @@ const config: Config = {
   },
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
+    "^@colophony/api/trpc/client-types$":
+      "<rootDir>/../api/src/trpc/client-types.ts",
     "^@colophony/types$": "<rootDir>/../../packages/types/src/index.ts",
     "^@colophony/types/(.*)$": "<rootDir>/../../packages/types/src/$1",
   },

--- a/apps/web/src/lib/trpc.ts
+++ b/apps/web/src/lib/trpc.ts
@@ -1,6 +1,6 @@
 import { createTRPCReact } from "@trpc/react-query";
 import { httpBatchLink } from "@trpc/client";
-import type { AppRouter } from "@colophony/api/trpc/router";
+import type { AppRouter } from "@colophony/api/trpc/client-types";
 
 /**
  * tRPC React client

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -21,7 +21,7 @@
     ],
     "paths": {
       "@/*": ["./src/*"],
-      "@colophony/api/*": ["../api/src/*"]
+      "@colophony/api/trpc/client-types": ["../api/src/trpc/client-types.ts"]
     }
   },
   "include": [

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,35 @@ Newest entries first.
 
 ---
 
+## 2026-02-13 — Type-Only AppRouter Export Layer (Track 2)
+
+### Done
+
+- **PR #55** — Formalized the cross-package type boundary between API and web app (7 files)
+- Created `apps/api/src/trpc/client-types.ts` — type barrel re-exporting only `AppRouter` for the web client
+- Updated `apps/web/src/lib/trpc.ts` import path from `@colophony/api/trpc/router` to `@colophony/api/trpc/client-types`
+- Narrowed `apps/web/tsconfig.json` path alias from wildcard (`@colophony/api/*`) to exact path (`@colophony/api/trpc/client-types`)
+- Added ESLint `no-restricted-imports` guard in `apps/web/eslint.config.mjs` blocking any `@colophony/api/**` import (file-level override exempts `src/lib/trpc.ts`)
+- Updated Jest config: narrowed tsconfig paths + added `moduleNameMapper` entry for `client-types`
+- Updated `apps/api/CLAUDE.md` (Key Paths table, TS2742 quirk) and `apps/web/CLAUDE.md` (tRPC Client section)
+- Codex branch review: **LGTM**, no regressions found
+
+### Decisions
+
+- **File-level ESLint override instead of `!` negation** — ESLint 8's `no-restricted-imports` uses the `ignore` package (gitignore semantics) which doesn't support re-including files when a parent directory pattern is excluded. `src/lib/trpc.ts` gets a clean override instead
+- **Source import (not `.d.ts`)** — TS2742 blocks declaration emit for `typeof appRouter`; this is the standard tRPC monorepo pattern (t3-app, create-t3-turbo)
+
+### Issues Found
+
+- **ESLint `no-restricted-imports` negation broken** — `['@colophony/api/**', '!@colophony/api/trpc/client-types']` in `group` array doesn't exempt `client-types` as documented. The `ignore` package follows gitignore rules where re-including under an excluded parent is impossible
+
+### Next
+
+- Org management UI (create org, invite members, switch orgs)
+- Out-of-scope items tracked: Zitadel webhook double client release, inline Zod schema in organizations router, webhook payload Zod validation
+
+---
+
 ## 2026-02-13 — Frontend OIDC Flow with Zitadel (Track 1)
 
 ### Done


### PR DESCRIPTION
## Summary

- Create `apps/api/src/trpc/client-types.ts` as the single type barrel for web client imports (`AppRouter`)
- Narrow `apps/web/tsconfig.json` path alias from wildcard (`@colophony/api/*`) to exact path (`@colophony/api/trpc/client-types`)
- Add ESLint `no-restricted-imports` guard blocking any `@colophony/api/**` import except through the barrel
- Update Jest config (`moduleNameMapper` + tsconfig paths) to match
- Update `apps/api/CLAUDE.md` and `apps/web/CLAUDE.md` documentation

## Test plan

- [x] `pnpm type-check` — `AppRouter` resolves correctly (all web errors are pre-existing)
- [x] `pnpm --filter @colophony/web lint` — ESLint passes; barrel import not flagged
- [x] No stale imports: `grep` confirms all `@colophony/api/` refs in `apps/web` point to `client-types` only
- [x] No relative cross-package imports (`../api/src/`) in `apps/web`
- [x] code review — LGTM, no regressions