### PR TITLE
feat(web): org management UI — create, settings, members

### DIFF
--- a/apps/api/src/services/organization.service.ts
+++ b/apps/api/src/services/organization.service.ts
@@ -245,6 +245,24 @@ export const organizationService = {
    * Update a member's role.
    */
   async updateMemberRole(tx: DrizzleDb, memberId: string, role: Role) {
+    // If demoting an admin, check they aren't the last one
+    if (role !== 'ADMIN') {
+      const [member] = await tx
+        .select()
+        .from(organizationMembers)
+        .where(eq(organizationMembers.id, memberId))
+        .limit(1);
+
+      if (member?.role === 'ADMIN') {
+        const adminRows = await tx.execute<{ id: string }>(
+          sql`SELECT id FROM organization_members WHERE organization_id = ${member.organizationId} AND role = 'ADMIN' FOR UPDATE`,
+        );
+        if (adminRows.rows.length <= 1) {
+          throw new LastAdminError();
+        }
+      }
+    }
+
     const [updated] = await tx
       .update(organizationMembers)
       .set({ role, updatedAt: new Date() })

--- a/apps/api/src/trpc/routers/organizations.ts
+++ b/apps/api/src/trpc/routers/organizations.ts
@@ -96,24 +96,34 @@ const membersRouter = createRouter({
   updateRole: adminProcedure
     .input(updateMemberRoleSchema)
     .mutation(async ({ ctx, input }) => {
-      const updated = await organizationService.updateMemberRole(
-        ctx.dbTx,
-        input.memberId,
-        input.role,
-      );
-      if (!updated) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Member not found',
+      try {
+        const updated = await organizationService.updateMemberRole(
+          ctx.dbTx,
+          input.memberId,
+          input.role,
+        );
+        if (!updated) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Member not found',
+          });
+        }
+        await ctx.audit({
+          action: AuditActions.ORG_MEMBER_ROLE_CHANGED,
+          resource: AuditResources.ORGANIZATION,
+          resourceId: updated.id,
+          newValue: { role: input.role },
         });
+        return updated;
+      } catch (e) {
+        if (e instanceof LastAdminError) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: e.message,
+          });
+        }
+        throw e;
       }
-      await ctx.audit({
-        action: AuditActions.ORG_MEMBER_ROLE_CHANGED,
-        resource: AuditResources.ORGANIZATION,
-        resourceId: updated.id,
-        newValue: { role: input.role },
-      });
-      return updated;
     }),
 });
 

--- a/apps/api/src/trpc/routers/organizations.ts
+++ b/apps/api/src/trpc/routers/organizations.ts
@@ -51,6 +51,12 @@ const membersRouter = createRouter({
             message: e.message,
           });
         }
+        if ((e as { code?: string }).code === '23505') {
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: 'User is already a member of this organization',
+          });
+        }
         throw e;
       }
     }),

--- a/apps/web/src/app/(dashboard)/organizations/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/organizations/settings/page.tsx
@@ -1,0 +1,5 @@
+import { OrgSettings } from "@/components/organizations/org-settings";
+
+export default function OrganizationSettingsPage() {
+  return <OrgSettings />;
+}

--- a/apps/web/src/app/(dashboard)/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useAuth } from "@/hooks/use-auth";
 import { useOrganization } from "@/hooks/use-organization";
 import { trpc } from "@/lib/trpc";
@@ -24,11 +26,18 @@ import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
 import { format } from "date-fns";
-import { Download, Trash2, Building2 } from "lucide-react";
+import {
+  Download,
+  Trash2,
+  Building2,
+  Plus,
+  Settings as SettingsIcon,
+} from "lucide-react";
 
 export default function SettingsPage() {
   const { user, logout } = useAuth();
-  const { organizations, currentOrg } = useOrganization();
+  const router = useRouter();
+  const { organizations, currentOrg, switchOrganization } = useOrganization();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
 
@@ -152,11 +161,32 @@ export default function SettingsPage() {
                     {currentOrg?.id === org.id && (
                       <Badge variant="outline">Current</Badge>
                     )}
+                    {org.role === "ADMIN" && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          switchOrganization(org.id);
+                          router.push("/organizations/settings");
+                        }}
+                      >
+                        <SettingsIcon className="mr-1 h-3 w-3" />
+                        Manage
+                      </Button>
+                    )}
                   </div>
                 </div>
               ))}
             </div>
           )}
+          <div className="mt-4">
+            <Button variant="outline" asChild>
+              <Link href="/organizations/new">
+                <Plus className="mr-2 h-4 w-4" />
+                Create Organization
+              </Link>
+            </Button>
+          </div>
         </CardContent>
       </Card>
 

--- a/apps/web/src/app/(onboarding)/layout.tsx
+++ b/apps/web/src/app/(onboarding)/layout.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { ProtectedRoute } from "@/components/auth/protected-route";
+import { Toaster } from "@/components/ui/sonner";
+
+export default function OnboardingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <ProtectedRoute requireOrganization={false}>
+      <div className="min-h-screen flex items-center justify-center p-4">
+        {children}
+      </div>
+      <Toaster />
+    </ProtectedRoute>
+  );
+}

--- a/apps/web/src/app/(onboarding)/organizations/new/page.tsx
+++ b/apps/web/src/app/(onboarding)/organizations/new/page.tsx
@@ -1,0 +1,5 @@
+import { CreateOrgForm } from "@/components/organizations/create-org-form";
+
+export default function NewOrganizationPage() {
+  return <CreateOrgForm />;
+}

--- a/apps/web/src/components/auth/protected-route.tsx
+++ b/apps/web/src/components/auth/protected-route.tsx
@@ -37,8 +37,7 @@ export function ProtectedRoute({
 
     // Organization required but user has none
     if (requireOrganization && !hasOrganizations) {
-      // TODO: Redirect to org creation or onboarding
-      router.push("/dashboard?no-org=true");
+      router.push("/organizations/new");
       return;
     }
 

--- a/apps/web/src/components/layout/org-switcher.tsx
+++ b/apps/web/src/components/layout/org-switcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Building2, Check, ChevronsUpDown } from "lucide-react";
+import Link from "next/link";
+import { Building2, Check, ChevronsUpDown, Plus, Settings } from "lucide-react";
 import { useOrganization } from "@/hooks/use-organization";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -21,7 +22,8 @@ const roleColors = {
 };
 
 export function OrgSwitcher() {
-  const { currentOrg, organizations, switchOrganization } = useOrganization();
+  const { currentOrg, organizations, switchOrganization, isAdmin } =
+    useOrganization();
 
   if (organizations.length === 0) {
     return null;
@@ -72,6 +74,21 @@ export function OrgSwitcher() {
             </div>
           </DropdownMenuItem>
         ))}
+        <DropdownMenuSeparator />
+        {isAdmin && (
+          <DropdownMenuItem asChild>
+            <Link href="/organizations/settings" className="cursor-pointer">
+              <Settings className="mr-2 h-4 w-4" />
+              Org Settings
+            </Link>
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem asChild>
+          <Link href="/organizations/new" className="cursor-pointer">
+            <Plus className="mr-2 h-4 w-4" />
+            Create Organization
+          </Link>
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { useOrganization } from "@/hooks/use-organization";
-import { FileText, LayoutDashboard, Settings } from "lucide-react";
+import { Building2, FileText, LayoutDashboard, Settings } from "lucide-react";
 
 const navigation = [
   { name: "My Submissions", href: "/submissions", icon: FileText },
@@ -15,9 +15,17 @@ const editorNavigation = [
   { name: "Editor Dashboard", href: "/editor", icon: LayoutDashboard },
 ];
 
+const adminNavigation = [
+  {
+    name: "Organization",
+    href: "/organizations/settings",
+    icon: Building2,
+  },
+];
+
 export function Sidebar() {
   const pathname = usePathname();
-  const { isEditor } = useOrganization();
+  const { isEditor, isAdmin } = useOrganization();
 
   return (
     <div className="flex flex-col h-full bg-background">
@@ -58,6 +66,34 @@ export function Sidebar() {
               Editor
             </p>
             {editorNavigation.map((item) => {
+              const isActive = pathname.startsWith(item.href);
+              return (
+                <Link
+                  key={item.name}
+                  href={item.href}
+                  className={cn(
+                    "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors",
+                    isActive
+                      ? "bg-accent text-accent-foreground"
+                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                  )}
+                >
+                  <item.icon className="h-4 w-4" />
+                  {item.name}
+                </Link>
+              );
+            })}
+          </>
+        )}
+
+        {/* Admin navigation */}
+        {isAdmin && (
+          <>
+            <div className="my-4 border-t" />
+            <p className="px-3 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              Admin
+            </p>
+            {adminNavigation.map((item) => {
               const isActive = pathname.startsWith(item.href);
               return (
                 <Link

--- a/apps/web/src/components/organizations/create-org-form.tsx
+++ b/apps/web/src/components/organizations/create-org-form.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { trpc, setCurrentOrgId } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { useSlugCheck } from "@/hooks/use-slug-check";
+import { slugSchema } from "@colophony/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { toast } from "sonner";
+import { Loader2, Check, X } from "lucide-react";
+
+const formSchema = z.object({
+  name: z.string().min(1, "Name is required").max(255),
+  slug: slugSchema,
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export function CreateOrgForm() {
+  const router = useRouter();
+  const utils = trpc.useUtils();
+  const { hasOrganizations } = useOrganization();
+  const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { name: "", slug: "" },
+  });
+
+  const slugValue = form.watch("slug");
+  const { isChecking, isAvailable } = useSlugCheck(
+    slugValue,
+    slugValue.length >= 3,
+  );
+
+  const createMutation = trpc.organizations.create.useMutation({
+    onSuccess: async (result) => {
+      setCurrentOrgId(result.organization.id);
+      await utils.users.me.invalidate();
+      toast.success("Organization created");
+      router.push("/organizations/settings");
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const onSubmit = (data: FormData) => {
+    createMutation.mutate(data);
+  };
+
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>Create Organization</CardTitle>
+        <CardDescription>
+          Set up a new organization to manage submissions and publications.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Organization Name</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="My Literary Magazine"
+                      {...field}
+                      onChange={(e) => {
+                        field.onChange(e);
+                        if (!slugManuallyEdited) {
+                          form.setValue("slug", slugify(e.target.value), {
+                            shouldValidate: true,
+                          });
+                        }
+                      }}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="slug"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>URL Slug</FormLabel>
+                  <FormControl>
+                    <div className="relative">
+                      <Input
+                        placeholder="my-literary-magazine"
+                        {...field}
+                        onChange={(e) => {
+                          field.onChange(e);
+                          setSlugManuallyEdited(true);
+                        }}
+                      />
+                      {slugValue.length >= 3 && (
+                        <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                          {isChecking ? (
+                            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                          ) : isAvailable === true ? (
+                            <Check className="h-4 w-4 text-green-600" />
+                          ) : isAvailable === false ? (
+                            <X className="h-4 w-4 text-destructive" />
+                          ) : null}
+                        </div>
+                      )}
+                    </div>
+                  </FormControl>
+                  <p className="text-xs text-muted-foreground">
+                    Lowercase letters, numbers, and hyphens. 3-63 characters.
+                  </p>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex justify-between pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() =>
+                  router.push(hasOrganizations ? "/settings" : "/")
+                }
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={
+                  createMutation.isPending ||
+                  isAvailable === false ||
+                  isChecking
+                }
+              >
+                {createMutation.isPending && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                Create Organization
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/organizations/invite-member-dialog.tsx
+++ b/apps/web/src/components/organizations/invite-member-dialog.tsx
@@ -31,7 +31,6 @@ import {
 } from "@/components/ui/select";
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
-import type { Role } from "@colophony/types";
 
 const formSchema = z.object({
   email: z.string().email("Invalid email address"),

--- a/apps/web/src/components/organizations/invite-member-dialog.tsx
+++ b/apps/web/src/components/organizations/invite-member-dialog.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import type { Role } from "@colophony/types";
+
+const formSchema = z.object({
+  email: z.string().email("Invalid email address"),
+  role: z.enum(["ADMIN", "EDITOR", "READER"]),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+interface InviteMemberDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function InviteMemberDialog({
+  open,
+  onOpenChange,
+}: InviteMemberDialogProps) {
+  const utils = trpc.useUtils();
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { email: "", role: "READER" },
+  });
+
+  const addMutation = trpc.organizations.members.add.useMutation({
+    onSuccess: () => {
+      utils.organizations.members.list.invalidate();
+      toast.success("Member added");
+      form.reset();
+      onOpenChange(false);
+    },
+    onError: (err) => {
+      if (err.data?.code === "NOT_FOUND") {
+        toast.error("No user found with that email address");
+      } else if (err.data?.code === "CONFLICT") {
+        toast.error("This user is already a member");
+      } else {
+        toast.error(err.message);
+      }
+    },
+  });
+
+  const onSubmit = (data: FormData) => {
+    addMutation.mutate(data);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Invite Member</DialogTitle>
+          <DialogDescription>
+            Add a user to this organization by their email address.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input placeholder="user@example.com" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Role</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="READER">Reader</SelectItem>
+                      <SelectItem value="EDITOR">Editor</SelectItem>
+                      <SelectItem value="ADMIN">Admin</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={addMutation.isPending}>
+                {addMutation.isPending && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                Add Member
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/organizations/invite-member-dialog.tsx
+++ b/apps/web/src/components/organizations/invite-member-dialog.tsx
@@ -109,10 +109,7 @@ export function InviteMemberDialog({
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Role</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
+                  <Select onValueChange={field.onChange} value={field.value}>
                     <FormControl>
                       <SelectTrigger>
                         <SelectValue />

--- a/apps/web/src/components/organizations/member-list.tsx
+++ b/apps/web/src/components/organizations/member-list.tsx
@@ -60,6 +60,7 @@ export function MemberList() {
   const updateRoleMutation = trpc.organizations.members.updateRole.useMutation({
     onSuccess: () => {
       utils.organizations.members.list.invalidate();
+      utils.users.me.invalidate();
       toast.success("Role updated");
     },
     onError: (err) => {
@@ -70,6 +71,7 @@ export function MemberList() {
   const removeMutation = trpc.organizations.members.remove.useMutation({
     onSuccess: () => {
       utils.organizations.members.list.invalidate();
+      utils.users.me.invalidate();
       toast.success("Member removed");
       setRemovingMember(null);
     },

--- a/apps/web/src/components/organizations/member-list.tsx
+++ b/apps/web/src/components/organizations/member-list.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState } from "react";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { InviteMemberDialog } from "./invite-member-dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "sonner";
+import { format } from "date-fns";
+import { UserPlus, Trash2 } from "lucide-react";
+import type { Role } from "@colophony/types";
+
+const roleColors: Record<string, string> = {
+  ADMIN: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+  EDITOR: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+  READER: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+};
+
+export function MemberList() {
+  const { isAdmin } = useOrganization();
+  const utils = trpc.useUtils();
+  const [page, setPage] = useState(1);
+  const limit = 20;
+  const [showInvite, setShowInvite] = useState(false);
+  const [removingMember, setRemovingMember] = useState<{
+    id: string;
+    email: string;
+  } | null>(null);
+
+  const { data, isLoading, error } = trpc.organizations.members.list.useQuery({
+    page,
+    limit,
+  });
+
+  const updateRoleMutation = trpc.organizations.members.updateRole.useMutation({
+    onSuccess: () => {
+      utils.organizations.members.list.invalidate();
+      toast.success("Role updated");
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const removeMutation = trpc.organizations.members.remove.useMutation({
+    onSuccess: () => {
+      utils.organizations.members.list.invalidate();
+      toast.success("Member removed");
+      setRemovingMember(null);
+    },
+    onError: (err) => {
+      toast.error(err.message);
+      setRemovingMember(null);
+    },
+  });
+
+  if (error) {
+    return (
+      <p className="text-destructive">
+        Failed to load members: {error.message}
+      </p>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  const members = data?.items ?? [];
+  const totalPages = data?.totalPages ?? 1;
+
+  return (
+    <div className="space-y-4">
+      {isAdmin && (
+        <div className="flex justify-end">
+          <Button onClick={() => setShowInvite(true)}>
+            <UserPlus className="mr-2 h-4 w-4" />
+            Invite Member
+          </Button>
+        </div>
+      )}
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Email</TableHead>
+            <TableHead>Role</TableHead>
+            <TableHead>Joined</TableHead>
+            {isAdmin && <TableHead className="w-[100px]">Actions</TableHead>}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {members.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={isAdmin ? 4 : 3}
+                className="text-center text-muted-foreground"
+              >
+                No members found.
+              </TableCell>
+            </TableRow>
+          ) : (
+            members.map((member) => (
+              <TableRow key={member.id}>
+                <TableCell>{member.email}</TableCell>
+                <TableCell>
+                  {isAdmin ? (
+                    <Select
+                      value={member.role}
+                      onValueChange={(role: Role) =>
+                        updateRoleMutation.mutate({
+                          memberId: member.id,
+                          role,
+                        })
+                      }
+                    >
+                      <SelectTrigger className="w-[120px]">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="READER">Reader</SelectItem>
+                        <SelectItem value="EDITOR">Editor</SelectItem>
+                        <SelectItem value="ADMIN">Admin</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <Badge
+                      variant="secondary"
+                      className={roleColors[member.role]}
+                    >
+                      {member.role.toLowerCase()}
+                    </Badge>
+                  )}
+                </TableCell>
+                <TableCell>
+                  {format(new Date(member.createdAt), "PPP")}
+                </TableCell>
+                {isAdmin && (
+                  <TableCell>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() =>
+                        setRemovingMember({
+                          id: member.id,
+                          email: member.email,
+                        })
+                      }
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </TableCell>
+                )}
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+
+      {totalPages > 1 && (
+        <div className="flex justify-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+          >
+            Previous
+          </Button>
+          <span className="flex items-center text-sm text-muted-foreground">
+            Page {page} of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page === totalPages}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+
+      <InviteMemberDialog open={showInvite} onOpenChange={setShowInvite} />
+
+      {/* Remove confirmation dialog */}
+      <Dialog
+        open={!!removingMember}
+        onOpenChange={(open) => !open && setRemovingMember(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove member?</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to remove {removingMember?.email} from this
+              organization? They will lose access immediately.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRemovingMember(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={removeMutation.isPending}
+              onClick={() => {
+                if (removingMember) {
+                  removeMutation.mutate({ memberId: removingMember.id });
+                }
+              }}
+            >
+              {removeMutation.isPending ? "Removing..." : "Remove"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/components/organizations/org-settings.tsx
+++ b/apps/web/src/components/organizations/org-settings.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import Link from "next/link";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { MemberList } from "./member-list";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+
+const nameFormSchema = z.object({
+  name: z.string().min(1, "Name is required").max(255),
+});
+
+type NameFormData = z.infer<typeof nameFormSchema>;
+
+export function OrgSettings() {
+  const { currentOrg, isAdmin } = useOrganization();
+  const utils = trpc.useUtils();
+
+  const { data: org, isLoading } = trpc.organizations.get.useQuery(undefined, {
+    enabled: !!currentOrg,
+  });
+
+  const form = useForm<NameFormData>({
+    resolver: zodResolver(nameFormSchema),
+    defaultValues: { name: "" },
+  });
+
+  useEffect(() => {
+    if (org) {
+      form.reset({ name: org.name });
+    }
+  }, [org, form]);
+
+  const updateMutation = trpc.organizations.update.useMutation({
+    onSuccess: () => {
+      utils.organizations.get.invalidate();
+      utils.users.me.invalidate();
+      toast.success("Organization updated");
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const onSubmit = (data: NameFormData) => {
+    updateMutation.mutate(data);
+  };
+
+  if (!currentOrg) {
+    return (
+      <div className="space-y-6 max-w-3xl">
+        <div>
+          <h1 className="text-2xl font-bold">Organization Settings</h1>
+          <p className="text-muted-foreground">
+            You don&apos;t have an organization selected.
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/organizations/new">Create Organization</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6 max-w-3xl">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      <div>
+        <h1 className="text-2xl font-bold">Organization Settings</h1>
+        <p className="text-muted-foreground">
+          Manage settings for {org?.name ?? currentOrg.name}
+        </p>
+      </div>
+
+      <Tabs defaultValue="general">
+        <TabsList>
+          <TabsTrigger value="general">General</TabsTrigger>
+          <TabsTrigger value="members">Members</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="general" className="mt-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>General</CardTitle>
+              <CardDescription>
+                {isAdmin
+                  ? "Update your organization details."
+                  : "Organization details (read-only)."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {isAdmin ? (
+                <Form {...form}>
+                  <form
+                    onSubmit={form.handleSubmit(onSubmit)}
+                    className="space-y-4"
+                  >
+                    <FormField
+                      control={form.control}
+                      name="name"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Organization Name</FormLabel>
+                          <FormControl>
+                            <Input {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <div>
+                      <p className="text-sm font-medium mb-1">Slug</p>
+                      <p className="text-sm text-muted-foreground">
+                        {org?.slug ?? currentOrg.slug}
+                      </p>
+                    </div>
+                    <Button type="submit" disabled={updateMutation.isPending}>
+                      {updateMutation.isPending && (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      )}
+                      Save Changes
+                    </Button>
+                  </form>
+                </Form>
+              ) : (
+                <div className="space-y-4">
+                  <div>
+                    <p className="text-sm font-medium">Name</p>
+                    <p className="text-sm text-muted-foreground">
+                      {org?.name ?? currentOrg.name}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">Slug</p>
+                    <p className="text-sm text-muted-foreground">
+                      {org?.slug ?? currentOrg.slug}
+                    </p>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="members" className="mt-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Members</CardTitle>
+              <CardDescription>
+                {isAdmin
+                  ? "Manage organization members and their roles."
+                  : "Organization members."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <MemberList />
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-slug-check.ts
+++ b/apps/web/src/hooks/use-slug-check.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { trpc } from "@/lib/trpc";
+
+const SLUG_REGEX = /^[a-z0-9-]+$/;
+
+export function useSlugCheck(slug: string, enabled: boolean) {
+  const [debouncedSlug, setDebouncedSlug] = useState(slug);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSlug(slug), 300);
+    return () => clearTimeout(timer);
+  }, [slug]);
+
+  // Client-side format validation
+  const isValidFormat =
+    debouncedSlug.length >= 3 &&
+    debouncedSlug.length <= 63 &&
+    SLUG_REGEX.test(debouncedSlug);
+
+  const { data, isFetching } = trpc.organizations.checkSlug.useQuery(
+    { slug: debouncedSlug },
+    { enabled: enabled && isValidFormat },
+  );
+
+  return {
+    isChecking: isFetching,
+    isAvailable: isValidFormat ? (data?.available ?? null) : null,
+    debouncedSlug,
+  };
+}

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,33 @@ Newest entries first.
 
 ---
 
+## 2026-02-13 — Org Management UI (Track 1)
+
+### Done
+
+- **PR #56** — Full org management UI: create, settings, member CRUD (14 files, +936 lines)
+- Create org page at `/organizations/new` in `(onboarding)` route group with auto-slug generation, debounced availability checking via `useSlugCheck` hook, and post-create flow using `setCurrentOrgId` directly to avoid stale-list race
+- Org settings page at `/organizations/settings` with tabbed General (name edit for admins, read-only for others) and Members views
+- Member management: paginated table, inline role editing via Select, remove with confirmation dialog, invite dialog with email + role
+- Navigation wiring: sidebar admin section (Building2 icon), org-switcher create/settings links, settings page Manage buttons, ProtectedRoute orgless redirect to `/organizations/new`
+- Backend: duplicate member `23505` → `CONFLICT` catch in `members.add`, `organizationMemberSchema` field rename `joinedAt` → `createdAt`
+- Codex review round 2 (plan): 2 findings incorporated
+- Codex review round 3 (implementation): 3 findings addressed — last-admin guard on `updateMemberRole` (prevents org lockout), `users.me` invalidation on membership mutations (fixes stale auth context), controlled Select in invite dialog (fixes post-reset drift)
+
+### Decisions
+
+- **Onboarding route group** — `/organizations/new` lives outside `(dashboard)` so orgless users can reach it without triggering the org-required redirect loop
+- **`setCurrentOrgId` over `switchOrganization` post-create** — `switchOrganization` validates against the stale org list; setting directly + invalidating `users.me` is the correct sequence
+- **`FOR UPDATE` row locking for last-admin guard** — same pattern as `removeMember`; prevents race between concurrent role changes
+
+### Next
+
+- Manual QA of full org management flow once Zitadel + dev services are running
+- Consider adding org deletion (deferred — needs careful cascade handling)
+- Out-of-scope items still tracked: Zitadel webhook double client release, inline Zod schema in organizations router, webhook payload Zod validation
+
+---
+
 ## 2026-02-13 — Type-Only AppRouter Export Layer (Track 2)
 
 ### Done

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -42,7 +42,7 @@ export const organizationMemberSchema = z.object({
   userId: z.string().uuid(),
   email: z.string().email(),
   role: roleSchema,
-  joinedAt: z.date(),
+  createdAt: z.date(),
 });
 
 export type OrganizationMember = z.infer<typeof organizationMemberSchema>;


### PR DESCRIPTION
## Summary

- Add create organization page at `/organizations/new` (onboarding route group) with auto-slug generation, debounced availability checking, and post-create flow that sets org context directly to avoid stale-list race
- Add org settings page at `/organizations/settings` with tabbed General (name edit for admins, read-only for others) and Members (paginated table, role editing, remove with confirmation, invite dialog) views
- Wire navigation: sidebar admin section, org-switcher create/settings links, settings page manage buttons, ProtectedRoute orgless redirect to `/organizations/new`
- Backend: add duplicate member `23505` catch in `members.add`, fix `organizationMemberSchema` `joinedAt` → `createdAt` field name, add last-admin safeguard on `updateMemberRole`

## Codex Review

Two rounds of code review were incorporated:

**Round 2 (plan review):** duplicate-member backend catch, `createdAt` field rename
**Round 3 (implementation review):**
- **High:** Last-admin guard added to `updateMemberRole` service + router (prevents org lockout via role demotion)
- **Medium:** Membership mutations now invalidate `users.me` so role/nav context updates immediately
- **Low:** Invite dialog role Select changed from `defaultValue` to controlled `value`

## Test plan

- [ ] Log in as user with no orgs — redirects to `/organizations/new`, create org, land on settings
- [ ] Create org: name auto-slugifies, slug checks availability (spinner/check/X), submit creates org
- [ ] Post-create: lands on `/organizations/settings` without redirect bounce, org appears in switcher
- [ ] Org settings (admin): edit name, save, verify reflected in switcher
- [ ] Org settings (non-admin): read-only view, no edit/invite/remove actions visible
- [ ] Members: list paginated, invite by email, change role, remove with confirmation dialog
- [ ] Invite edge cases: "User not found" and "already a member" show proper error toasts
- [ ] Last-admin guard: demoting the only admin shows error, not silent lockout
- [ ] Settings page "Manage" button switches org before navigating
- [ ] Navigation: sidebar admin link, org-switcher links all work correctly