### PR TITLE
docs: enforce Codex review steps via task list blocking

### DIFF
--- a/.claude/skills/codex-review/SKILL.md
+++ b/.claude/skills/codex-review/SKILL.md
@@ -154,3 +154,4 @@ Which findings would you like me to address? (Enter numbers, "all", or "none")
 - Plan review uses `codex exec -s read-only` since it's not a git diff operation and `exec` accepts stdin prompts
 - nvm must be sourced explicitly in every command because Bash tool runs non-interactive shells
 - For interactive Codex sessions with live progress, see the **Interactive Codex (tmux)** section in CLAUDE.md
+- **Plans enforce Codex review via task list**: Per CLAUDE.md, non-trivial plans must create `/codex-review plan` and evaluation as the first two task list entries, with all implementation tasks blocked by them via `addBlockedBy`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,15 @@ All other version pins are in their respective per-directory CLAUDE.md files.
 
 For interactive Codex in tmux: source nvm, `nvm use v20.20.0`, then `codex`. Use `codex resume` or `codex fork --last` for follow-up.
 
+### Plan Structure: Codex Review as First Steps
+
+Every non-trivial plan **must enforce Codex review via task list entries**. When creating task list entries for a plan, always create these two tasks first:
+
+1. **"Run Codex plan review"** — Execute `/codex-review plan` to get a second opinion on the plan
+2. **"Evaluate Codex findings and adjust plan"** — Review Codex output, update the plan for any critical/important issues, note dismissed suggestions with rationale
+
+All implementation tasks **must use `addBlockedBy`** to depend on these two review tasks. This ensures the review is mechanically enforced — the implementation tasks cannot be started until the review tasks are marked completed. Skip for trivial plans (typo fix, single config change).
+
 ### MCP Servers (restart Claude Code to activate)
 
 - **postgres**: Direct DB queries (`@modelcontextprotocol/server-postgres`)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,23 @@ Newest entries first.
 
 ---
 
+## 2026-02-15 — Enforce Codex Review via Task List
+
+### Done
+
+- Updated `CLAUDE.md` "Plan Structure" section to mandate Codex review as task list entries with `addBlockedBy` blocking on implementation tasks
+- Updated `.claude/skills/codex-review/SKILL.md` "Important notes" bullet to reference task list enforcement
+
+### Decisions
+
+- Mechanical enforcement (task list `addBlockedBy`) chosen over textual plan instructions — the latter was being skipped in practice
+
+### Next
+
+- Verify enforcement works on next non-trivial plan execution
+
+---
+
 ## 2026-02-15 — Zitadel Webhook Hardening (Track 1)
 
 ### Done


### PR DESCRIPTION
## Summary

- Rewrites CLAUDE.md "Plan Structure" section to mandate code review as task list entries with `addBlockedBy` dependencies, replacing text-only instructions that were being skipped
- Updates codex-review SKILL.md to reference the new task list enforcement mechanism

## Test plan

- [x] Both files read correctly after editing
- [ ] Verify on next non-trivial plan that review tasks are created and block implementation tasks