### PR TITLE
feat(api): submission service + tRPC router

### DIFF
--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -1,0 +1,352 @@
+import {
+  submissions,
+  submissionFiles,
+  submissionHistory,
+  users,
+  eq,
+  and,
+  sql,
+  type DrizzleDb,
+} from '@colophony/db';
+import { desc, asc, ilike, count } from 'drizzle-orm';
+import type {
+  CreateSubmissionInput,
+  UpdateSubmissionInput,
+  ListSubmissionsInput,
+  SubmissionStatus,
+} from '@colophony/types';
+import {
+  isValidStatusTransition,
+  isEditorAllowedTransition,
+} from '@colophony/types';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class SubmissionNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Submission "${id}" not found`);
+    this.name = 'SubmissionNotFoundError';
+  }
+}
+
+export class InvalidStatusTransitionError extends Error {
+  constructor(from: string, to: string) {
+    super(`Invalid status transition from "${from}" to "${to}"`);
+    this.name = 'InvalidStatusTransitionError';
+  }
+}
+
+export class NotDraftError extends Error {
+  constructor() {
+    super('Submission must be in DRAFT status for this operation');
+    this.name = 'NotDraftError';
+  }
+}
+
+export class UnscannedFilesError extends Error {
+  constructor() {
+    super(
+      'Cannot submit: one or more files are still pending or being scanned',
+    );
+    this.name = 'UnscannedFilesError';
+  }
+}
+
+export class InfectedFilesError extends Error {
+  constructor() {
+    super('Cannot submit: one or more files have been flagged as infected');
+    this.name = 'InfectedFilesError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const submissionService = {
+  /**
+   * List submissions for a specific submitter (their own view).
+   * RLS handles org filtering; we add submitterId filter.
+   */
+  async listBySubmitter(
+    tx: DrizzleDb,
+    submitterId: string,
+    input: ListSubmissionsInput,
+  ) {
+    const { status, submissionPeriodId, search, page, limit } = input;
+    const offset = (page - 1) * limit;
+
+    const conditions = [eq(submissions.submitterId, submitterId)];
+    if (status) conditions.push(eq(submissions.status, status));
+    if (submissionPeriodId)
+      conditions.push(eq(submissions.submissionPeriodId, submissionPeriodId));
+    if (search) {
+      if (search.length >= 3) {
+        conditions.push(
+          sql`${submissions.searchVector} @@ plainto_tsquery('english', ${search})`,
+        );
+      } else {
+        conditions.push(ilike(submissions.title, `%${search}%`));
+      }
+    }
+
+    const where = and(...conditions);
+
+    const [items, countResult] = await Promise.all([
+      tx
+        .select()
+        .from(submissions)
+        .where(where)
+        .orderBy(desc(submissions.createdAt))
+        .limit(limit)
+        .offset(offset),
+      tx.select({ count: count() }).from(submissions).where(where),
+    ]);
+
+    const total = countResult[0]?.count ?? 0;
+    return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
+  },
+
+  /**
+   * List all submissions in the org (editor view).
+   * RLS handles org filtering.
+   */
+  async listAll(tx: DrizzleDb, input: ListSubmissionsInput) {
+    const { status, submissionPeriodId, search, page, limit } = input;
+    const offset = (page - 1) * limit;
+
+    const conditions = [];
+    if (status) conditions.push(eq(submissions.status, status));
+    if (submissionPeriodId)
+      conditions.push(eq(submissions.submissionPeriodId, submissionPeriodId));
+    if (search) {
+      if (search.length >= 3) {
+        conditions.push(
+          sql`${submissions.searchVector} @@ plainto_tsquery('english', ${search})`,
+        );
+      } else {
+        conditions.push(ilike(submissions.title, `%${search}%`));
+      }
+    }
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const [items, countResult] = await Promise.all([
+      tx
+        .select()
+        .from(submissions)
+        .where(where)
+        .orderBy(desc(submissions.createdAt))
+        .limit(limit)
+        .offset(offset),
+      tx.select({ count: count() }).from(submissions).where(where),
+    ]);
+
+    const total = countResult[0]?.count ?? 0;
+    return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
+  },
+
+  /**
+   * Create a new submission in DRAFT status with initial history record.
+   */
+  async create(
+    tx: DrizzleDb,
+    input: CreateSubmissionInput,
+    orgId: string,
+    submitterId: string,
+  ) {
+    const [submission] = await tx
+      .insert(submissions)
+      .values({
+        organizationId: orgId,
+        submitterId,
+        title: input.title,
+        content: input.content ?? null,
+        coverLetter: input.coverLetter ?? null,
+        submissionPeriodId: input.submissionPeriodId ?? null,
+        status: 'DRAFT',
+      })
+      .returning();
+
+    await tx.insert(submissionHistory).values({
+      submissionId: submission.id,
+      fromStatus: null,
+      toStatus: 'DRAFT',
+      changedBy: submitterId,
+    });
+
+    return submission;
+  },
+
+  /**
+   * Get submission by ID with files and submitter email.
+   */
+  async getById(tx: DrizzleDb, id: string) {
+    const [submission] = await tx
+      .select()
+      .from(submissions)
+      .where(eq(submissions.id, id))
+      .limit(1);
+
+    if (!submission) return null;
+
+    const [files, [submitter]] = await Promise.all([
+      tx
+        .select()
+        .from(submissionFiles)
+        .where(eq(submissionFiles.submissionId, id))
+        .orderBy(asc(submissionFiles.uploadedAt)),
+      tx
+        .select({ email: users.email })
+        .from(users)
+        .where(eq(users.id, submission.submitterId))
+        .limit(1),
+    ]);
+
+    return {
+      ...submission,
+      files,
+      submitterEmail: submitter?.email ?? null,
+    };
+  },
+
+  /**
+   * Update a submission (DRAFT only). Uses FOR UPDATE lock.
+   */
+  async update(tx: DrizzleDb, id: string, input: UpdateSubmissionInput) {
+    const rows = await tx.execute<{
+      id: string;
+      status: string;
+    }>(sql`SELECT id, status FROM submissions WHERE id = ${id} FOR UPDATE`);
+
+    const existing = rows.rows[0];
+    if (!existing) return null;
+    if (existing.status !== 'DRAFT') throw new NotDraftError();
+
+    const [updated] = await tx
+      .update(submissions)
+      .set({
+        ...(input.title !== undefined ? { title: input.title } : {}),
+        ...(input.content !== undefined ? { content: input.content } : {}),
+        ...(input.coverLetter !== undefined
+          ? { coverLetter: input.coverLetter }
+          : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(submissions.id, id))
+      .returning();
+
+    return updated ?? null;
+  },
+
+  /**
+   * Transition submission status with validation and history tracking.
+   */
+  async updateStatus(
+    tx: DrizzleDb,
+    id: string,
+    newStatus: SubmissionStatus,
+    changedBy: string,
+    comment: string | undefined,
+    callerRole: 'submitter' | 'editor',
+  ) {
+    const rows = await tx.execute<{
+      id: string;
+      status: SubmissionStatus;
+    }>(sql`SELECT id, status FROM submissions WHERE id = ${id} FOR UPDATE`);
+
+    const existing = rows.rows[0];
+    if (!existing) throw new SubmissionNotFoundError(id);
+
+    const fromStatus = existing.status;
+
+    // Validate transition based on caller role
+    if (callerRole === 'submitter') {
+      if (!isValidStatusTransition(fromStatus, newStatus)) {
+        throw new InvalidStatusTransitionError(fromStatus, newStatus);
+      }
+    } else {
+      if (!isEditorAllowedTransition(fromStatus, newStatus)) {
+        throw new InvalidStatusTransitionError(fromStatus, newStatus);
+      }
+    }
+
+    // On DRAFT→SUBMITTED, verify file scan statuses
+    if (fromStatus === 'DRAFT' && newStatus === 'SUBMITTED') {
+      const files = await tx
+        .select({ scanStatus: submissionFiles.scanStatus })
+        .from(submissionFiles)
+        .where(eq(submissionFiles.submissionId, id));
+
+      const hasUnscanned = files.some(
+        (f) => f.scanStatus === 'PENDING' || f.scanStatus === 'SCANNING',
+      );
+      if (hasUnscanned) throw new UnscannedFilesError();
+
+      const hasInfected = files.some((f) => f.scanStatus === 'INFECTED');
+      if (hasInfected) throw new InfectedFilesError();
+    }
+
+    const updateData: Record<string, unknown> = {
+      status: newStatus,
+      updatedAt: new Date(),
+    };
+    if (newStatus === 'SUBMITTED') {
+      updateData.submittedAt = new Date();
+    }
+
+    const [submission] = await tx
+      .update(submissions)
+      .set(updateData)
+      .where(eq(submissions.id, id))
+      .returning();
+
+    const [historyEntry] = await tx
+      .insert(submissionHistory)
+      .values({
+        submissionId: id,
+        fromStatus,
+        toStatus: newStatus,
+        changedBy,
+        comment: comment ?? null,
+      })
+      .returning();
+
+    return { submission, historyEntry };
+  },
+
+  /**
+   * Delete a submission (DRAFT only). Uses FOR UPDATE lock.
+   * CASCADE handles children (files, history).
+   */
+  async delete(tx: DrizzleDb, id: string) {
+    const rows = await tx.execute<{
+      id: string;
+      status: string;
+    }>(sql`SELECT id, status FROM submissions WHERE id = ${id} FOR UPDATE`);
+
+    const existing = rows.rows[0];
+    if (!existing) return null;
+    if (existing.status !== 'DRAFT') throw new NotDraftError();
+
+    const [deleted] = await tx
+      .delete(submissions)
+      .where(eq(submissions.id, id))
+      .returning();
+
+    return deleted ?? null;
+  },
+
+  /**
+   * Get submission history ordered by changedAt ASC.
+   */
+  async getHistory(tx: DrizzleDb, submissionId: string) {
+    return tx
+      .select()
+      .from(submissionHistory)
+      .where(eq(submissionHistory.submissionId, submissionId))
+      .orderBy(asc(submissionHistory.changedAt));
+  },
+};

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -1,6 +1,7 @@
 import { t } from './init.js';
 import { organizationsRouter } from './routers/organizations.js';
 import { usersRouter } from './routers/users.js';
+import { submissionsRouter } from './routers/submissions.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -20,7 +21,7 @@ export const appRouter = t.router({
   health: t.procedure.query(() => ({ status: 'ok' as const })),
   organizations: organizationsRouter,
   users: usersRouter,
-  submissions: t.router({}),
+  submissions: submissionsRouter,
   files: t.router({}),
   payments: t.router({}),
   gdpr: t.router({}),

--- a/apps/api/src/trpc/routers/submissions.spec.ts
+++ b/apps/api/src/trpc/routers/submissions.spec.ts
@@ -1,0 +1,615 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+// Mock the submission service before importing the router
+vi.mock('../../services/submission.service.js', () => ({
+  submissionService: {
+    listBySubmitter: vi.fn(),
+    listAll: vi.fn(),
+    create: vi.fn(),
+    getById: vi.fn(),
+    update: vi.fn(),
+    updateStatus: vi.fn(),
+    delete: vi.fn(),
+    getHistory: vi.fn(),
+  },
+  SubmissionNotFoundError: class SubmissionNotFoundError extends Error {
+    name = 'SubmissionNotFoundError';
+    constructor(id = 'unknown') {
+      super(`Submission "${id}" not found`);
+    }
+  },
+  InvalidStatusTransitionError: class InvalidStatusTransitionError extends Error {
+    name = 'InvalidStatusTransitionError';
+    constructor(from = 'X', to = 'Y') {
+      super(`Invalid status transition from "${from}" to "${to}"`);
+    }
+  },
+  NotDraftError: class NotDraftError extends Error {
+    name = 'NotDraftError';
+    constructor() {
+      super('Submission must be in DRAFT status for this operation');
+    }
+  },
+  UnscannedFilesError: class UnscannedFilesError extends Error {
+    name = 'UnscannedFilesError';
+    constructor() {
+      super(
+        'Cannot submit: one or more files are still pending or being scanned',
+      );
+    }
+  },
+  InfectedFilesError: class InfectedFilesError extends Error {
+    name = 'InfectedFilesError';
+    constructor() {
+      super('Cannot submit: one or more files have been flagged as infected');
+    }
+  },
+}));
+
+// Mock @colophony/db
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  organizations: {},
+  organizationMembers: {},
+  users: {},
+  submissions: {},
+  submissionFiles: {},
+  submissionHistory: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+}));
+
+import { submissionService } from '../../services/submission.service.js';
+import { appRouter } from '../router.js';
+import type { TRPCContext } from '../context.js';
+
+const mockService = vi.mocked(submissionService);
+
+function makeContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
+  return {
+    authContext: null,
+    dbTx: null,
+    audit: vi.fn(),
+    ...overrides,
+  };
+}
+
+function authedContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
+  return makeContext({
+    authContext: {
+      userId: 'user-1',
+      zitadelUserId: 'zid-1',
+      email: 'test@example.com',
+      emailVerified: true,
+    },
+    ...overrides,
+  });
+}
+
+function orgContext(
+  role: 'ADMIN' | 'EDITOR' | 'READER' = 'READER',
+  overrides: Partial<TRPCContext> = {},
+): TRPCContext {
+  const mockTx = {} as never;
+  return makeContext({
+    authContext: {
+      userId: 'user-1',
+      zitadelUserId: 'zid-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      orgId: 'org-1',
+      role,
+    },
+    dbTx: mockTx,
+    audit: vi.fn(),
+    ...overrides,
+  });
+}
+
+function editorContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
+  return orgContext('EDITOR', overrides);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createCaller = (appRouter as any).createCaller as (
+  ctx: TRPCContext,
+) => any;
+
+const SUBMISSION_ID = 'a1111111-1111-1111-1111-111111111111';
+
+function makeDraftSubmission(submitterId = 'user-1') {
+  return {
+    id: SUBMISSION_ID,
+    organizationId: 'org-1',
+    submitterId,
+    submissionPeriodId: null,
+    title: 'Test Poem',
+    content: 'Roses are red...',
+    coverLetter: null,
+    status: 'DRAFT' as const,
+    submittedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    files: [],
+    submitterEmail: 'test@example.com',
+  };
+}
+
+describe('submissions tRPC router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Auth / access control
+  // -------------------------------------------------------------------------
+
+  describe('auth and access', () => {
+    it('mySubmissions requires authentication', async () => {
+      const caller = createCaller(makeContext());
+      await expect(
+        caller.submissions.mySubmissions({ page: 1, limit: 20 }),
+      ).rejects.toThrow(TRPCError);
+    });
+
+    it('mySubmissions requires org context', async () => {
+      const caller = createCaller(authedContext());
+      await expect(
+        caller.submissions.mySubmissions({ page: 1, limit: 20 }),
+      ).rejects.toThrow(TRPCError);
+    });
+
+    it('list requires EDITOR or ADMIN role', async () => {
+      const caller = createCaller(orgContext('READER'));
+      await expect(
+        caller.submissions.list({ page: 1, limit: 20 }),
+      ).rejects.toThrow('Editor or admin role required');
+    });
+
+    it('list allows EDITOR role', async () => {
+      mockService.listAll.mockResolvedValueOnce({
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 0,
+      } as never);
+      const caller = createCaller(editorContext());
+      const result = await caller.submissions.list({ page: 1, limit: 20 });
+      expect(result.items).toEqual([]);
+    });
+
+    it('updateStatus requires EDITOR or ADMIN role', async () => {
+      const caller = createCaller(orgContext('READER'));
+      await expect(
+        caller.submissions.updateStatus({
+          id: SUBMISSION_ID,
+          status: 'UNDER_REVIEW',
+        }),
+      ).rejects.toThrow('Editor or admin role required');
+    });
+
+    it('update requires ownership', async () => {
+      mockService.getById.mockResolvedValueOnce(
+        makeDraftSubmission('other-user') as never,
+      );
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.submissions.update({ id: SUBMISSION_ID, title: 'New Title' }),
+      ).rejects.toThrow('Only the submitter');
+    });
+
+    it('submit requires ownership', async () => {
+      mockService.getById.mockResolvedValueOnce(
+        makeDraftSubmission('other-user') as never,
+      );
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.submissions.submit({ id: SUBMISSION_ID }),
+      ).rejects.toThrow('Only the submitter');
+    });
+
+    it('delete requires ownership', async () => {
+      mockService.getById.mockResolvedValueOnce(
+        makeDraftSubmission('other-user') as never,
+      );
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.submissions.delete({ id: SUBMISSION_ID }),
+      ).rejects.toThrow('Only the submitter');
+    });
+
+    it('withdraw requires ownership', async () => {
+      mockService.getById.mockResolvedValueOnce(
+        makeDraftSubmission('other-user') as never,
+      );
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.submissions.withdraw({ id: SUBMISSION_ID }),
+      ).rejects.toThrow('Only the submitter');
+    });
+
+    it('getById allows owner to view', async () => {
+      const sub = makeDraftSubmission('user-1');
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      const caller = createCaller(orgContext('READER'));
+      const result = await caller.submissions.getById({ id: SUBMISSION_ID });
+      expect(result.id).toBe(SUBMISSION_ID);
+    });
+
+    it('getById allows EDITOR to view others submissions', async () => {
+      const sub = makeDraftSubmission('other-user');
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      const caller = createCaller(editorContext());
+      const result = await caller.submissions.getById({ id: SUBMISSION_ID });
+      expect(result.id).toBe(SUBMISSION_ID);
+    });
+
+    it('getById denies READER from viewing others submissions', async () => {
+      const sub = makeDraftSubmission('other-user');
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      const caller = createCaller(orgContext('READER'));
+      await expect(
+        caller.submissions.getById({ id: SUBMISSION_ID }),
+      ).rejects.toThrow('do not have access');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Queries
+  // -------------------------------------------------------------------------
+
+  describe('mySubmissions', () => {
+    it('passes userId filter to service', async () => {
+      const response = {
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 0,
+      };
+      mockService.listBySubmitter.mockResolvedValueOnce(response as never);
+
+      const caller = createCaller(orgContext());
+      await caller.submissions.mySubmissions({ page: 1, limit: 20 });
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.listBySubmitter).toHaveBeenCalledWith(
+        expect.anything(),
+        'user-1',
+        { page: 1, limit: 20 },
+      );
+    });
+  });
+
+  describe('list', () => {
+    it('calls listAll (not listBySubmitter)', async () => {
+      const response = {
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 0,
+      };
+      mockService.listAll.mockResolvedValueOnce(response as never);
+
+      const caller = createCaller(orgContext('ADMIN'));
+      await caller.submissions.list({ page: 1, limit: 20 });
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.listAll).toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.listBySubmitter).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getById', () => {
+    it('returns submission when found', async () => {
+      const sub = makeDraftSubmission();
+      mockService.getById.mockResolvedValueOnce(sub as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.submissions.getById({ id: SUBMISSION_ID });
+      expect(result).toEqual(sub);
+    });
+
+    it('throws NOT_FOUND when missing', async () => {
+      mockService.getById.mockResolvedValueOnce(null as never);
+
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.submissions.getById({ id: SUBMISSION_ID }),
+      ).rejects.toThrow('not found');
+    });
+  });
+
+  describe('getHistory', () => {
+    it('returns history array', async () => {
+      const history = [
+        {
+          id: 'h-1',
+          submissionId: SUBMISSION_ID,
+          fromStatus: null,
+          toStatus: 'DRAFT',
+          changedBy: 'user-1',
+          comment: null,
+          changedAt: new Date(),
+        },
+      ];
+      mockService.getHistory.mockResolvedValueOnce(history as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.submissions.getHistory({
+        submissionId: SUBMISSION_ID,
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].toStatus).toBe('DRAFT');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Mutations
+  // -------------------------------------------------------------------------
+
+  describe('create', () => {
+    it('returns submission and calls audit', async () => {
+      const sub = {
+        id: SUBMISSION_ID,
+        title: 'My Poem',
+        status: 'DRAFT',
+      };
+      mockService.create.mockResolvedValueOnce(sub as never);
+
+      const ctx = orgContext();
+      const caller = createCaller(ctx);
+      const result = await caller.submissions.create({ title: 'My Poem' });
+
+      expect(result.id).toBe(SUBMISSION_ID);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.create).toHaveBeenCalledWith(
+        expect.anything(),
+        { title: 'My Poem' },
+        'org-1',
+        'user-1',
+      );
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'SUBMISSION_CREATED' }),
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('succeeds on DRAFT and calls audit', async () => {
+      const sub = makeDraftSubmission();
+      const updated = { ...sub, title: 'Updated Title' };
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      mockService.update.mockResolvedValueOnce(updated as never);
+
+      const ctx = orgContext();
+      const caller = createCaller(ctx);
+      const result = await caller.submissions.update({
+        id: SUBMISSION_ID,
+        title: 'Updated Title',
+      });
+
+      expect(result.title).toBe('Updated Title');
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'SUBMISSION_UPDATED' }),
+      );
+    });
+
+    it('throws BAD_REQUEST on non-DRAFT', async () => {
+      const sub = makeDraftSubmission();
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      const { NotDraftError } =
+        await import('../../services/submission.service.js');
+      mockService.update.mockRejectedValueOnce(new NotDraftError());
+
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.submissions.update({
+          id: SUBMISSION_ID,
+          title: 'Updated Title',
+        }),
+      ).rejects.toThrow('DRAFT');
+    });
+  });
+
+  describe('submit', () => {
+    it('DRAFT→SUBMITTED succeeds and calls audit', async () => {
+      const sub = makeDraftSubmission();
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      mockService.updateStatus.mockResolvedValueOnce({
+        submission: { ...sub, status: 'SUBMITTED' },
+        historyEntry: { id: 'h-1' },
+      } as never);
+
+      const ctx = orgContext();
+      const caller = createCaller(ctx);
+      const result = await caller.submissions.submit({ id: SUBMISSION_ID });
+
+      expect(result.submission.status).toBe('SUBMITTED');
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'SUBMISSION_SUBMITTED' }),
+      );
+    });
+
+    it('throws BAD_REQUEST with unscanned files', async () => {
+      const sub = makeDraftSubmission();
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      const { UnscannedFilesError } =
+        await import('../../services/submission.service.js');
+      mockService.updateStatus.mockRejectedValueOnce(new UnscannedFilesError());
+
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.submissions.submit({ id: SUBMISSION_ID }),
+      ).rejects.toThrow('pending or being scanned');
+    });
+
+    it('throws BAD_REQUEST with infected files', async () => {
+      const sub = makeDraftSubmission();
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      const { InfectedFilesError } =
+        await import('../../services/submission.service.js');
+      mockService.updateStatus.mockRejectedValueOnce(new InfectedFilesError());
+
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.submissions.submit({ id: SUBMISSION_ID }),
+      ).rejects.toThrow('infected');
+    });
+  });
+
+  describe('delete', () => {
+    it('succeeds on DRAFT and calls audit', async () => {
+      const sub = makeDraftSubmission();
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      mockService.delete.mockResolvedValueOnce(sub as never);
+
+      const ctx = orgContext();
+      const caller = createCaller(ctx);
+      const result = await caller.submissions.delete({ id: SUBMISSION_ID });
+
+      expect(result).toEqual({ success: true });
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'SUBMISSION_DELETED' }),
+      );
+    });
+
+    it('throws BAD_REQUEST on non-DRAFT', async () => {
+      const sub = makeDraftSubmission();
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      const { NotDraftError } =
+        await import('../../services/submission.service.js');
+      mockService.delete.mockRejectedValueOnce(new NotDraftError());
+
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.submissions.delete({ id: SUBMISSION_ID }),
+      ).rejects.toThrow('DRAFT');
+    });
+  });
+
+  describe('withdraw', () => {
+    it('succeeds from valid state and calls audit', async () => {
+      const sub = { ...makeDraftSubmission(), status: 'SUBMITTED' as const };
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      mockService.updateStatus.mockResolvedValueOnce({
+        submission: { ...sub, status: 'WITHDRAWN' },
+        historyEntry: { id: 'h-2' },
+      } as never);
+
+      const ctx = orgContext();
+      const caller = createCaller(ctx);
+      const result = await caller.submissions.withdraw({ id: SUBMISSION_ID });
+
+      expect(result.submission.status).toBe('WITHDRAWN');
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'SUBMISSION_WITHDRAWN' }),
+      );
+    });
+
+    it('throws BAD_REQUEST from terminal state', async () => {
+      const sub = { ...makeDraftSubmission(), status: 'ACCEPTED' as const };
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      const { InvalidStatusTransitionError } =
+        await import('../../services/submission.service.js');
+      mockService.updateStatus.mockRejectedValueOnce(
+        new InvalidStatusTransitionError('ACCEPTED', 'WITHDRAWN'),
+      );
+
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.submissions.withdraw({ id: SUBMISSION_ID }),
+      ).rejects.toThrow(TRPCError);
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('editor transition succeeds and calls audit', async () => {
+      mockService.updateStatus.mockResolvedValueOnce({
+        submission: { id: SUBMISSION_ID, status: 'UNDER_REVIEW' },
+        historyEntry: { id: 'h-3' },
+      } as never);
+
+      const ctx = editorContext();
+      const caller = createCaller(ctx);
+      const result = await caller.submissions.updateStatus({
+        id: SUBMISSION_ID,
+        status: 'UNDER_REVIEW',
+      });
+
+      expect(result.submission.status).toBe('UNDER_REVIEW');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.updateStatus).toHaveBeenCalledWith(
+        expect.anything(),
+        SUBMISSION_ID,
+        'UNDER_REVIEW',
+        'user-1',
+        undefined,
+        'editor',
+      );
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'SUBMISSION_STATUS_CHANGED' }),
+      );
+    });
+
+    it('throws NOT_FOUND when submission missing', async () => {
+      const { SubmissionNotFoundError } =
+        await import('../../services/submission.service.js');
+      mockService.updateStatus.mockRejectedValueOnce(
+        new SubmissionNotFoundError(SUBMISSION_ID),
+      );
+
+      const caller = createCaller(editorContext());
+      await expect(
+        caller.submissions.updateStatus({
+          id: SUBMISSION_ID,
+          status: 'UNDER_REVIEW',
+        }),
+      ).rejects.toThrow(TRPCError);
+    });
+
+    it('throws BAD_REQUEST on invalid transition', async () => {
+      const { InvalidStatusTransitionError } =
+        await import('../../services/submission.service.js');
+      mockService.updateStatus.mockRejectedValueOnce(
+        new InvalidStatusTransitionError('DRAFT', 'UNDER_REVIEW'),
+      );
+
+      const caller = createCaller(editorContext());
+      await expect(
+        caller.submissions.updateStatus({
+          id: SUBMISSION_ID,
+          status: 'UNDER_REVIEW',
+        }),
+      ).rejects.toThrow(TRPCError);
+    });
+
+    it('passes comment to service', async () => {
+      mockService.updateStatus.mockResolvedValueOnce({
+        submission: { id: SUBMISSION_ID, status: 'REJECTED' },
+        historyEntry: { id: 'h-4' },
+      } as never);
+
+      const caller = createCaller(orgContext('ADMIN'));
+      await caller.submissions.updateStatus({
+        id: SUBMISSION_ID,
+        status: 'REJECTED',
+        comment: 'Not a good fit',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.updateStatus).toHaveBeenCalledWith(
+        expect.anything(),
+        SUBMISSION_ID,
+        'REJECTED',
+        'user-1',
+        'Not a good fit',
+        'editor',
+      );
+    });
+  });
+});

--- a/apps/api/src/trpc/routers/submissions.spec.ts
+++ b/apps/api/src/trpc/routers/submissions.spec.ts
@@ -325,7 +325,8 @@ describe('submissions tRPC router', () => {
   });
 
   describe('getHistory', () => {
-    it('returns history array', async () => {
+    it('returns history array for owner', async () => {
+      const sub = makeDraftSubmission('user-1');
       const history = [
         {
           id: 'h-1',
@@ -337,6 +338,7 @@ describe('submissions tRPC router', () => {
           changedAt: new Date(),
         },
       ];
+      mockService.getById.mockResolvedValueOnce(sub as never);
       mockService.getHistory.mockResolvedValueOnce(history as never);
 
       const caller = createCaller(orgContext());
@@ -345,6 +347,37 @@ describe('submissions tRPC router', () => {
       });
       expect(result).toHaveLength(1);
       expect(result[0].toStatus).toBe('DRAFT');
+    });
+
+    it('allows EDITOR to view history of others submissions', async () => {
+      const sub = makeDraftSubmission('other-user');
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      mockService.getHistory.mockResolvedValueOnce([] as never);
+
+      const caller = createCaller(editorContext());
+      const result = await caller.submissions.getHistory({
+        submissionId: SUBMISSION_ID,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('denies READER from viewing others submission history', async () => {
+      const sub = makeDraftSubmission('other-user');
+      mockService.getById.mockResolvedValueOnce(sub as never);
+
+      const caller = createCaller(orgContext('READER'));
+      await expect(
+        caller.submissions.getHistory({ submissionId: SUBMISSION_ID }),
+      ).rejects.toThrow('do not have access');
+    });
+
+    it('throws NOT_FOUND when submission missing', async () => {
+      mockService.getById.mockResolvedValueOnce(null as never);
+
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.submissions.getHistory({ submissionId: SUBMISSION_ID }),
+      ).rejects.toThrow('not found');
     });
   });
 
@@ -460,6 +493,21 @@ describe('submissions tRPC router', () => {
         caller.submissions.submit({ id: SUBMISSION_ID }),
       ).rejects.toThrow('infected');
     });
+
+    it('maps SubmissionNotFoundError to NOT_FOUND on concurrent deletion', async () => {
+      const sub = makeDraftSubmission();
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      const { SubmissionNotFoundError } =
+        await import('../../services/submission.service.js');
+      mockService.updateStatus.mockRejectedValueOnce(
+        new SubmissionNotFoundError(SUBMISSION_ID),
+      );
+
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.submissions.submit({ id: SUBMISSION_ID }),
+      ).rejects.toThrow('not found');
+    });
   });
 
   describe('delete', () => {
@@ -524,6 +572,21 @@ describe('submissions tRPC router', () => {
       await expect(
         caller.submissions.withdraw({ id: SUBMISSION_ID }),
       ).rejects.toThrow(TRPCError);
+    });
+
+    it('maps SubmissionNotFoundError to NOT_FOUND on concurrent deletion', async () => {
+      const sub = { ...makeDraftSubmission(), status: 'SUBMITTED' as const };
+      mockService.getById.mockResolvedValueOnce(sub as never);
+      const { SubmissionNotFoundError } =
+        await import('../../services/submission.service.js');
+      mockService.updateStatus.mockRejectedValueOnce(
+        new SubmissionNotFoundError(SUBMISSION_ID),
+      );
+
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.submissions.withdraw({ id: SUBMISSION_ID }),
+      ).rejects.toThrow('not found');
     });
   });
 

--- a/apps/api/src/trpc/routers/submissions.ts
+++ b/apps/api/src/trpc/routers/submissions.ts
@@ -165,6 +165,9 @@ export const submissionsRouter = createRouter({
         });
         return result;
       } catch (e) {
+        if (e instanceof SubmissionNotFoundError) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: e.message });
+        }
         if (e instanceof InvalidStatusTransitionError) {
           throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
         }
@@ -250,6 +253,9 @@ export const submissionsRouter = createRouter({
         });
         return result;
       } catch (e) {
+        if (e instanceof SubmissionNotFoundError) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: e.message });
+        }
         if (e instanceof InvalidStatusTransitionError) {
           throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
         }
@@ -292,10 +298,30 @@ export const submissionsRouter = createRouter({
       }
     }),
 
-  /** Get submission history — any org member (RLS scopes). */
+  /** Get submission history — owner or editor/admin. */
   getHistory: orgProcedure
     .input(z.object({ submissionId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
+      const submission = await submissionService.getById(
+        ctx.dbTx,
+        input.submissionId,
+      );
+      if (!submission) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Submission not found',
+        });
+      }
+      if (
+        submission.submitterId !== ctx.authContext.userId &&
+        ctx.authContext.role !== 'ADMIN' &&
+        ctx.authContext.role !== 'EDITOR'
+      ) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'You do not have access to this submission',
+        });
+      }
       return submissionService.getHistory(ctx.dbTx, input.submissionId);
     }),
 });

--- a/apps/api/src/trpc/routers/submissions.ts
+++ b/apps/api/src/trpc/routers/submissions.ts
@@ -1,0 +1,301 @@
+import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
+import {
+  createSubmissionSchema,
+  updateSubmissionSchema,
+  updateSubmissionStatusSchema,
+  listSubmissionsSchema,
+  AuditActions,
+  AuditResources,
+} from '@colophony/types';
+import { orgProcedure, createRouter } from '../init.js';
+import {
+  submissionService,
+  SubmissionNotFoundError,
+  InvalidStatusTransitionError,
+  NotDraftError,
+  UnscannedFilesError,
+  InfectedFilesError,
+} from '../../services/submission.service.js';
+
+function assertEditorOrAdmin(role: string): void {
+  if (role !== 'ADMIN' && role !== 'EDITOR') {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Editor or admin role required',
+    });
+  }
+}
+
+export const submissionsRouter = createRouter({
+  /** Submitter's own submissions (any org member). */
+  mySubmissions: orgProcedure
+    .input(listSubmissionsSchema)
+    .query(async ({ ctx, input }) => {
+      return submissionService.listBySubmitter(
+        ctx.dbTx,
+        ctx.authContext.userId,
+        input,
+      );
+    }),
+
+  /** Editor/admin view of all submissions in the org. */
+  list: orgProcedure
+    .input(listSubmissionsSchema)
+    .query(async ({ ctx, input }) => {
+      assertEditorOrAdmin(ctx.authContext.role);
+      return submissionService.listAll(ctx.dbTx, input);
+    }),
+
+  /** Create a new DRAFT submission. */
+  create: orgProcedure
+    .input(createSubmissionSchema)
+    .mutation(async ({ ctx, input }) => {
+      const submission = await submissionService.create(
+        ctx.dbTx,
+        input,
+        ctx.authContext.orgId,
+        ctx.authContext.userId,
+      );
+      await ctx.audit({
+        action: AuditActions.SUBMISSION_CREATED,
+        resource: AuditResources.SUBMISSION,
+        resourceId: submission.id,
+        newValue: { title: input.title },
+      });
+      return submission;
+    }),
+
+  /** Get submission by ID — owner or editor/admin. */
+  getById: orgProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const submission = await submissionService.getById(ctx.dbTx, input.id);
+      if (!submission) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Submission not found',
+        });
+      }
+      // Owner or editor/admin can view
+      if (
+        submission.submitterId !== ctx.authContext.userId &&
+        ctx.authContext.role !== 'ADMIN' &&
+        ctx.authContext.role !== 'EDITOR'
+      ) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'You do not have access to this submission',
+        });
+      }
+      return submission;
+    }),
+
+  /** Update a DRAFT submission — owner only. */
+  update: orgProcedure
+    .input(z.object({ id: z.string().uuid() }).merge(updateSubmissionSchema))
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      const existing = await submissionService.getById(ctx.dbTx, id);
+      if (!existing) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Submission not found',
+        });
+      }
+      if (existing.submitterId !== ctx.authContext.userId) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Only the submitter can update this submission',
+        });
+      }
+      try {
+        const updated = await submissionService.update(ctx.dbTx, id, data);
+        if (!updated) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Submission not found',
+          });
+        }
+        await ctx.audit({
+          action: AuditActions.SUBMISSION_UPDATED,
+          resource: AuditResources.SUBMISSION,
+          resourceId: id,
+          newValue: data,
+        });
+        return updated;
+      } catch (e) {
+        if (e instanceof NotDraftError) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
+        }
+        throw e;
+      }
+    }),
+
+  /** Submit a DRAFT submission (DRAFT→SUBMITTED) — owner only. */
+  submit: orgProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const existing = await submissionService.getById(ctx.dbTx, input.id);
+      if (!existing) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Submission not found',
+        });
+      }
+      if (existing.submitterId !== ctx.authContext.userId) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Only the submitter can submit this submission',
+        });
+      }
+      try {
+        const result = await submissionService.updateStatus(
+          ctx.dbTx,
+          input.id,
+          'SUBMITTED',
+          ctx.authContext.userId,
+          undefined,
+          'submitter',
+        );
+        await ctx.audit({
+          action: AuditActions.SUBMISSION_SUBMITTED,
+          resource: AuditResources.SUBMISSION,
+          resourceId: input.id,
+        });
+        return result;
+      } catch (e) {
+        if (e instanceof InvalidStatusTransitionError) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
+        }
+        if (e instanceof UnscannedFilesError) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
+        }
+        if (e instanceof InfectedFilesError) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
+        }
+        throw e;
+      }
+    }),
+
+  /** Delete a DRAFT submission — owner only. */
+  delete: orgProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const existing = await submissionService.getById(ctx.dbTx, input.id);
+      if (!existing) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Submission not found',
+        });
+      }
+      if (existing.submitterId !== ctx.authContext.userId) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Only the submitter can delete this submission',
+        });
+      }
+      try {
+        const deleted = await submissionService.delete(ctx.dbTx, input.id);
+        if (!deleted) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Submission not found',
+          });
+        }
+        await ctx.audit({
+          action: AuditActions.SUBMISSION_DELETED,
+          resource: AuditResources.SUBMISSION,
+          resourceId: input.id,
+        });
+        return { success: true };
+      } catch (e) {
+        if (e instanceof NotDraftError) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
+        }
+        throw e;
+      }
+    }),
+
+  /** Withdraw a submission — owner only. */
+  withdraw: orgProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const existing = await submissionService.getById(ctx.dbTx, input.id);
+      if (!existing) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Submission not found',
+        });
+      }
+      if (existing.submitterId !== ctx.authContext.userId) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Only the submitter can withdraw this submission',
+        });
+      }
+      try {
+        const result = await submissionService.updateStatus(
+          ctx.dbTx,
+          input.id,
+          'WITHDRAWN',
+          ctx.authContext.userId,
+          undefined,
+          'submitter',
+        );
+        await ctx.audit({
+          action: AuditActions.SUBMISSION_WITHDRAWN,
+          resource: AuditResources.SUBMISSION,
+          resourceId: input.id,
+        });
+        return result;
+      } catch (e) {
+        if (e instanceof InvalidStatusTransitionError) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
+        }
+        throw e;
+      }
+    }),
+
+  /** Editor/admin status transition. */
+  updateStatus: orgProcedure
+    .input(
+      z.object({ id: z.string().uuid() }).merge(updateSubmissionStatusSchema),
+    )
+    .mutation(async ({ ctx, input }) => {
+      assertEditorOrAdmin(ctx.authContext.role);
+      const { id, status, comment } = input;
+      try {
+        const result = await submissionService.updateStatus(
+          ctx.dbTx,
+          id,
+          status,
+          ctx.authContext.userId,
+          comment,
+          'editor',
+        );
+        await ctx.audit({
+          action: AuditActions.SUBMISSION_STATUS_CHANGED,
+          resource: AuditResources.SUBMISSION,
+          resourceId: id,
+          newValue: { status, comment },
+        });
+        return result;
+      } catch (e) {
+        if (e instanceof SubmissionNotFoundError) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: e.message });
+        }
+        if (e instanceof InvalidStatusTransitionError) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
+        }
+        throw e;
+      }
+    }),
+
+  /** Get submission history — any org member (RLS scopes). */
+  getHistory: orgProcedure
+    .input(z.object({ submissionId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      return submissionService.getHistory(ctx.dbTx, input.submissionId);
+    }),
+});

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,33 @@ Newest entries first.
 
 ---
 
+## 2026-02-15 — Submission Service + tRPC Router
+
+### Done
+
+- **PR #62** — First business-domain routes for the v2 rewrite
+- Created `submission.service.ts` with 8 methods: `listBySubmitter`, `listAll`, `create`, `getById`, `update`, `updateStatus`, `delete`, `getHistory`
+- Created `submissions.ts` tRPC router with 10 procedures: submitter (`mySubmissions`, `create`, `getById`, `update`, `submit`, `delete`, `withdraw`, `getHistory`) and editor (`list`, `updateStatus`)
+- Extended `packages/types/src/audit.ts` with 6 submission audit actions and `SUBMISSION` resource
+- Wired `submissionsRouter` into `appRouter` (replaced empty stub)
+- 36 unit tests covering auth, access control, queries, mutations, and error mapping
+- Addressed Codex branch review: fixed `getHistory` missing ownership/editor check; added `SubmissionNotFoundError` mapping in `submit`/`withdraw` for concurrent deletion races
+
+### Decisions
+
+- Followed established org service/router patterns (RLS via `dbTx`, `FOR UPDATE` locks, `Promise.all` pagination)
+- Full-text search: `plainto_tsquery` for 3+ char terms, `ilike(title)` fallback for shorter
+- `getHistory` enforces same access rules as `getById` (owner or editor/admin) — Codex caught the gap
+- Single-field `{ id: uuid }` inputs use inline Zod (matches org router); complex schemas reused from `@colophony/types`
+
+### Next
+
+- Files router (follow-up — service + tRPC procedures for upload/download/delete)
+- Submission periods CRUD
+- Frontend page rewrites (replace placeholders with real tRPC calls)
+
+---
+
 ## 2026-02-15 — Fix Web Type-Check Errors (~55 errors)
 
 ### Done

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -20,6 +20,14 @@ export const AuditActions = {
   ORG_MEMBER_REMOVED: "ORG_MEMBER_REMOVED",
   ORG_MEMBER_ROLE_CHANGED: "ORG_MEMBER_ROLE_CHANGED",
 
+  // Submission lifecycle
+  SUBMISSION_CREATED: "SUBMISSION_CREATED",
+  SUBMISSION_UPDATED: "SUBMISSION_UPDATED",
+  SUBMISSION_SUBMITTED: "SUBMISSION_SUBMITTED",
+  SUBMISSION_STATUS_CHANGED: "SUBMISSION_STATUS_CHANGED",
+  SUBMISSION_DELETED: "SUBMISSION_DELETED",
+  SUBMISSION_WITHDRAWN: "SUBMISSION_WITHDRAWN",
+
   // Authentication failures
   AUTH_TOKEN_INVALID: "AUTH_TOKEN_INVALID",
   AUTH_TOKEN_EXPIRED: "AUTH_TOKEN_EXPIRED",
@@ -33,6 +41,7 @@ export type AuditAction = (typeof AuditActions)[keyof typeof AuditActions];
 export const AuditResources = {
   USER: "user",
   ORGANIZATION: "organization",
+  SUBMISSION: "submission",
   AUTH: "auth",
 } as const;
 
@@ -75,6 +84,17 @@ export interface OrgAuditParams extends BaseAuditParams {
     | typeof AuditActions.ORG_MEMBER_ROLE_CHANGED;
 }
 
+export interface SubmissionAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.SUBMISSION;
+  action:
+    | typeof AuditActions.SUBMISSION_CREATED
+    | typeof AuditActions.SUBMISSION_UPDATED
+    | typeof AuditActions.SUBMISSION_SUBMITTED
+    | typeof AuditActions.SUBMISSION_STATUS_CHANGED
+    | typeof AuditActions.SUBMISSION_DELETED
+    | typeof AuditActions.SUBMISSION_WITHDRAWN;
+}
+
 export interface AuthAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.AUTH;
   action:
@@ -85,4 +105,8 @@ export interface AuthAuditParams extends BaseAuditParams {
 }
 
 /** Union of all resource-specific param types. */
-export type AuditLogParams = UserAuditParams | OrgAuditParams | AuthAuditParams;
+export type AuditLogParams =
+  | UserAuditParams
+  | OrgAuditParams
+  | SubmissionAuditParams
+  | AuthAuditParams;


### PR DESCRIPTION
## Summary

- **Submission service** with 8 methods: CRUD, status transitions with validation, file scan checks on submit, full-text search, and history tracking — follows established org service patterns (RLS via `dbTx`, `FOR UPDATE` locks, paginated queries)
- **10 tRPC procedures**: submitter (`mySubmissions`, `create`, `getById`, `update`, `submit`, `delete`, `withdraw`, `getHistory`) and editor (`list`, `updateStatus`) with owner/role access control
- **Audit types** extended with 6 submission actions (`SUBMISSION_CREATED/UPDATED/SUBMITTED/STATUS_CHANGED/DELETED/WITHDRAWN`) and `SUBMISSION` resource
- **36 unit tests** covering auth, access control, queries, mutations, error mapping, and concurrent deletion races
- branch review passed — both findings (getHistory access control, concurrent-deletion error mapping) addressed in follow-up commit

## Test plan

- [x] `pnpm type-check` — all packages pass (including web AppRouter propagation)
- [x] `pnpm test --filter @colophony/api` — 179 tests pass (36 new)
- [x] `pnpm lint` — clean
- [ ] CI pipeline (quality, unit-tests, build)