### PR TITLE
feat(api): file service, tRPC router, and tusd webhook handler

### DIFF
--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -35,6 +35,15 @@ const envSchema = z.object({
     .default(300),
   WEBHOOK_RATE_LIMIT_MAX: z.coerce.number().int().positive().default(100),
 
+  // S3 / MinIO
+  S3_ENDPOINT: z.string().default('http://localhost:9000'),
+  S3_BUCKET: z.string().default('submissions'),
+  S3_QUARANTINE_BUCKET: z.string().default('quarantine'),
+  S3_ACCESS_KEY: z.string().default('minioadmin'),
+  S3_SECRET_KEY: z.string().default('minioadmin'),
+  S3_REGION: z.string().default('us-east-1'),
+  TUS_ENDPOINT: z.string().default('http://localhost:1080'),
+
   // Optional — validated when modules wire up
   STRIPE_SECRET_KEY: z.string().optional(),
   STRIPE_WEBHOOK_SECRET: z.string().optional(),

--- a/apps/api/src/hooks/audit.spec.ts
+++ b/apps/api/src/hooks/audit.spec.ts
@@ -76,6 +76,13 @@ const testEnv: Env = {
   RATE_LIMIT_KEY_PREFIX: 'colophony:rl',
   WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS: 300,
   WEBHOOK_RATE_LIMIT_MAX: 100,
+  S3_ENDPOINT: 'http://localhost:9000',
+  S3_BUCKET: 'submissions',
+  S3_QUARANTINE_BUCKET: 'quarantine',
+  S3_ACCESS_KEY: 'minioadmin',
+  S3_SECRET_KEY: 'minioadmin',
+  S3_REGION: 'us-east-1',
+  TUS_ENDPOINT: 'http://localhost:1080',
 };
 
 describe('audit plugin', () => {

--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -57,6 +57,13 @@ const baseEnv: Env = {
   RATE_LIMIT_KEY_PREFIX: 'colophony:rl',
   WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS: 300,
   WEBHOOK_RATE_LIMIT_MAX: 100,
+  S3_ENDPOINT: 'http://localhost:9000',
+  S3_BUCKET: 'submissions',
+  S3_QUARANTINE_BUCKET: 'quarantine',
+  S3_ACCESS_KEY: 'minioadmin',
+  S3_SECRET_KEY: 'minioadmin',
+  S3_REGION: 'us-east-1',
+  TUS_ENDPOINT: 'http://localhost:1080',
 };
 
 describe('auth plugin', () => {

--- a/apps/api/src/hooks/db-context.spec.ts
+++ b/apps/api/src/hooks/db-context.spec.ts
@@ -64,6 +64,13 @@ const testEnv: Env = {
   RATE_LIMIT_KEY_PREFIX: 'colophony:rl',
   WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS: 300,
   WEBHOOK_RATE_LIMIT_MAX: 100,
+  S3_ENDPOINT: 'http://localhost:9000',
+  S3_BUCKET: 'submissions',
+  S3_QUARANTINE_BUCKET: 'quarantine',
+  S3_ACCESS_KEY: 'minioadmin',
+  S3_SECRET_KEY: 'minioadmin',
+  S3_REGION: 'us-east-1',
+  TUS_ENDPOINT: 'http://localhost:1080',
 };
 
 describe('db-context plugin', () => {

--- a/apps/api/src/hooks/org-context.spec.ts
+++ b/apps/api/src/hooks/org-context.spec.ts
@@ -66,6 +66,13 @@ const testEnv: Env = {
   RATE_LIMIT_KEY_PREFIX: 'colophony:rl',
   WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS: 300,
   WEBHOOK_RATE_LIMIT_MAX: 100,
+  S3_ENDPOINT: 'http://localhost:9000',
+  S3_BUCKET: 'submissions',
+  S3_QUARANTINE_BUCKET: 'quarantine',
+  S3_ACCESS_KEY: 'minioadmin',
+  S3_SECRET_KEY: 'minioadmin',
+  S3_REGION: 'us-east-1',
+  TUS_ENDPOINT: 'http://localhost:1080',
 };
 
 const VALID_ORG_ID = '11111111-1111-1111-a111-111111111111';

--- a/apps/api/src/hooks/rate-limit.spec.ts
+++ b/apps/api/src/hooks/rate-limit.spec.ts
@@ -48,6 +48,13 @@ const testEnv: Env = {
   RATE_LIMIT_KEY_PREFIX: 'test:rl',
   WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS: 300,
   WEBHOOK_RATE_LIMIT_MAX: 100,
+  S3_ENDPOINT: 'http://localhost:9000',
+  S3_BUCKET: 'submissions',
+  S3_QUARANTINE_BUCKET: 'quarantine',
+  S3_ACCESS_KEY: 'minioadmin',
+  S3_SECRET_KEY: 'minioadmin',
+  S3_REGION: 'us-east-1',
+  TUS_ENDPOINT: 'http://localhost:1080',
 };
 
 async function buildApp(

--- a/apps/api/src/main.spec.ts
+++ b/apps/api/src/main.spec.ts
@@ -73,6 +73,13 @@ const testEnv: Env = {
   RATE_LIMIT_KEY_PREFIX: 'colophony:rl',
   WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS: 300,
   WEBHOOK_RATE_LIMIT_MAX: 100,
+  S3_ENDPOINT: 'http://localhost:9000',
+  S3_BUCKET: 'submissions',
+  S3_QUARANTINE_BUCKET: 'quarantine',
+  S3_ACCESS_KEY: 'minioadmin',
+  S3_SECRET_KEY: 'minioadmin',
+  S3_REGION: 'us-east-1',
+  TUS_ENDPOINT: 'http://localhost:1080',
 };
 
 describe('Fastify app', () => {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -9,6 +9,7 @@ import orgContextPlugin from './hooks/org-context.js';
 import dbContextPlugin from './hooks/db-context.js';
 import auditPlugin from './hooks/audit.js';
 import { registerZitadelWebhooks } from './webhooks/zitadel.webhook.js';
+import { registerTusdWebhooks } from './webhooks/tusd.webhook.js';
 import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
 import { appRouter } from './trpc/router.js';
 import { createContext } from './trpc/context.js';
@@ -85,9 +86,12 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
   await app.register(dbContextPlugin);
   await app.register(auditPlugin);
 
-  // Webhooks — separate scope to isolate fastify-raw-body
+  // Webhooks — separate scopes for isolation
   await app.register(async (scope) => {
     await registerZitadelWebhooks(scope, { env });
+  });
+  await app.register(async (scope) => {
+    await registerTusdWebhooks(scope, { env });
   });
 
   // tRPC adapter

--- a/apps/api/src/services/file.service.ts
+++ b/apps/api/src/services/file.service.ts
@@ -1,0 +1,159 @@
+import { submissionFiles, eq, sql, type DrizzleDb } from '@colophony/db';
+import { asc, count } from 'drizzle-orm';
+import {
+  MAX_FILES_PER_SUBMISSION,
+  MAX_TOTAL_UPLOAD_SIZE,
+  MAX_FILE_SIZE,
+  ALLOWED_MIME_TYPES,
+} from '@colophony/types';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class FileNotFoundError extends Error {
+  constructor(id: string) {
+    super(`File "${id}" not found`);
+    this.name = 'FileNotFoundError';
+  }
+}
+
+export class FileLimitExceededError extends Error {
+  constructor() {
+    super(
+      `Maximum of ${MAX_FILES_PER_SUBMISSION} files per submission exceeded`,
+    );
+    this.name = 'FileLimitExceededError';
+  }
+}
+
+export class TotalSizeLimitExceededError extends Error {
+  constructor() {
+    super(
+      `Total upload size exceeds maximum of ${MAX_TOTAL_UPLOAD_SIZE} bytes`,
+    );
+    this.name = 'TotalSizeLimitExceededError';
+  }
+}
+
+export class FileSizeLimitExceededError extends Error {
+  constructor() {
+    super(`File size exceeds maximum of ${MAX_FILE_SIZE} bytes`);
+    this.name = 'FileSizeLimitExceededError';
+  }
+}
+
+export class InvalidMimeTypeError extends Error {
+  constructor(mimeType: string) {
+    super(`MIME type "${mimeType}" is not allowed`);
+    this.name = 'InvalidMimeTypeError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const fileService = {
+  async listBySubmission(tx: DrizzleDb, submissionId: string) {
+    return tx
+      .select()
+      .from(submissionFiles)
+      .where(eq(submissionFiles.submissionId, submissionId))
+      .orderBy(asc(submissionFiles.uploadedAt));
+  },
+
+  async getById(tx: DrizzleDb, fileId: string) {
+    const [file] = await tx
+      .select()
+      .from(submissionFiles)
+      .where(eq(submissionFiles.id, fileId))
+      .limit(1);
+    return file ?? null;
+  },
+
+  async getByStorageKey(tx: DrizzleDb, storageKey: string) {
+    const [file] = await tx
+      .select()
+      .from(submissionFiles)
+      .where(eq(submissionFiles.storageKey, storageKey))
+      .limit(1);
+    return file ?? null;
+  },
+
+  async create(
+    tx: DrizzleDb,
+    input: {
+      submissionId: string;
+      filename: string;
+      mimeType: string;
+      size: number;
+      storageKey: string;
+    },
+  ) {
+    const [file] = await tx
+      .insert(submissionFiles)
+      .values({
+        submissionId: input.submissionId,
+        filename: input.filename,
+        mimeType: input.mimeType,
+        size: input.size,
+        storageKey: input.storageKey,
+        scanStatus: 'PENDING',
+      })
+      .returning();
+    return file;
+  },
+
+  async delete(tx: DrizzleDb, fileId: string) {
+    const [deleted] = await tx
+      .delete(submissionFiles)
+      .where(eq(submissionFiles.id, fileId))
+      .returning();
+    return deleted ?? null;
+  },
+
+  async countBySubmission(tx: DrizzleDb, submissionId: string) {
+    const [result] = await tx
+      .select({ count: count() })
+      .from(submissionFiles)
+      .where(eq(submissionFiles.submissionId, submissionId));
+    return result?.count ?? 0;
+  },
+
+  async totalSizeBySubmission(tx: DrizzleDb, submissionId: string) {
+    const [result] = await tx
+      .select({ total: sql<number>`coalesce(sum(${submissionFiles.size}), 0)` })
+      .from(submissionFiles)
+      .where(eq(submissionFiles.submissionId, submissionId));
+    return Number(result?.total ?? 0);
+  },
+
+  validateMimeType(mimeType: string): void {
+    if (!(ALLOWED_MIME_TYPES as readonly string[]).includes(mimeType)) {
+      throw new InvalidMimeTypeError(mimeType);
+    }
+  },
+
+  validateFileSize(size: number): void {
+    if (size > MAX_FILE_SIZE) {
+      throw new FileSizeLimitExceededError();
+    }
+  },
+
+  async validateLimits(
+    tx: DrizzleDb,
+    submissionId: string,
+    newFileSize: number,
+  ): Promise<void> {
+    const fileCount = await fileService.countBySubmission(tx, submissionId);
+    if (fileCount >= MAX_FILES_PER_SUBMISSION) {
+      throw new FileLimitExceededError();
+    }
+
+    const totalSize = await fileService.totalSizeBySubmission(tx, submissionId);
+    if (totalSize + newFileSize > MAX_TOTAL_UPLOAD_SIZE) {
+      throw new TotalSizeLimitExceededError();
+    }
+  },
+};

--- a/apps/api/src/services/s3.ts
+++ b/apps/api/src/services/s3.ts
@@ -1,0 +1,38 @@
+import {
+  S3Client,
+  DeleteObjectCommand,
+  GetObjectCommand,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import type { Env } from '../config/env.js';
+
+export function createS3Client(env: Env): S3Client {
+  return new S3Client({
+    endpoint: env.S3_ENDPOINT,
+    region: env.S3_REGION,
+    credentials: {
+      accessKeyId: env.S3_ACCESS_KEY,
+      secretAccessKey: env.S3_SECRET_KEY,
+    },
+    forcePathStyle: true, // Required for MinIO
+  });
+}
+
+export async function getPresignedDownloadUrl(
+  client: S3Client,
+  bucket: string,
+  key: string,
+  expiresIn = 900, // 15 minutes
+): Promise<string> {
+  const command = new GetObjectCommand({ Bucket: bucket, Key: key });
+  return getSignedUrl(client, command, { expiresIn });
+}
+
+export async function deleteS3Object(
+  client: S3Client,
+  bucket: string,
+  key: string,
+): Promise<void> {
+  const command = new DeleteObjectCommand({ Bucket: bucket, Key: key });
+  await client.send(command);
+}

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -2,6 +2,7 @@ import { t } from './init.js';
 import { organizationsRouter } from './routers/organizations.js';
 import { usersRouter } from './routers/users.js';
 import { submissionsRouter } from './routers/submissions.js';
+import { filesRouter } from './routers/files.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -22,7 +23,7 @@ export const appRouter = t.router({
   organizations: organizationsRouter,
   users: usersRouter,
   submissions: submissionsRouter,
-  files: t.router({}),
+  files: filesRouter,
   payments: t.router({}),
   gdpr: t.router({}),
   consent: t.router({}),

--- a/apps/api/src/trpc/routers/files.spec.ts
+++ b/apps/api/src/trpc/routers/files.spec.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+// Mock file service
+vi.mock('../../services/file.service.js', () => ({
+  fileService: {
+    listBySubmission: vi.fn(),
+    getById: vi.fn(),
+    getByStorageKey: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+    countBySubmission: vi.fn(),
+    totalSizeBySubmission: vi.fn(),
+    validateMimeType: vi.fn(),
+    validateFileSize: vi.fn(),
+    validateLimits: vi.fn(),
+  },
+  FileNotFoundError: class FileNotFoundError extends Error {
+    name = 'FileNotFoundError';
+    constructor(id = 'unknown') {
+      super(`File "${id}" not found`);
+    }
+  },
+}));
+
+// Mock submission service
+vi.mock('../../services/submission.service.js', () => ({
+  submissionService: {
+    listBySubmitter: vi.fn(),
+    listAll: vi.fn(),
+    create: vi.fn(),
+    getById: vi.fn(),
+    update: vi.fn(),
+    updateStatus: vi.fn(),
+    delete: vi.fn(),
+    getHistory: vi.fn(),
+  },
+  SubmissionNotFoundError: class SubmissionNotFoundError extends Error {
+    name = 'SubmissionNotFoundError';
+  },
+  InvalidStatusTransitionError: class extends Error {
+    name = 'InvalidStatusTransitionError';
+  },
+  NotDraftError: class extends Error {
+    name = 'NotDraftError';
+  },
+  UnscannedFilesError: class extends Error {
+    name = 'UnscannedFilesError';
+  },
+  InfectedFilesError: class extends Error {
+    name = 'InfectedFilesError';
+  },
+}));
+
+// Mock S3
+vi.mock('../../services/s3.js', () => ({
+  createS3Client: vi.fn(() => ({})),
+  getPresignedDownloadUrl: vi.fn(
+    async () => 'https://s3.example.com/signed-url',
+  ),
+  deleteS3Object: vi.fn(async () => undefined),
+}));
+
+// Mock env
+vi.mock('../../config/env.js', () => ({
+  validateEnv: vi.fn(() => ({
+    S3_ENDPOINT: 'http://localhost:9000',
+    S3_BUCKET: 'submissions',
+    S3_QUARANTINE_BUCKET: 'quarantine',
+    S3_ACCESS_KEY: 'minioadmin',
+    S3_SECRET_KEY: 'minioadmin',
+    S3_REGION: 'us-east-1',
+  })),
+}));
+
+// Mock @colophony/db
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  organizations: {},
+  organizationMembers: {},
+  users: {},
+  submissions: {},
+  submissionFiles: {},
+  submissionHistory: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+}));
+
+import { fileService } from '../../services/file.service.js';
+import { submissionService } from '../../services/submission.service.js';
+import { deleteS3Object } from '../../services/s3.js';
+import { appRouter } from '../router.js';
+import type { TRPCContext } from '../context.js';
+
+const mockFileService = vi.mocked(fileService);
+const mockSubmissionService = vi.mocked(submissionService);
+const mockDeleteS3 = vi.mocked(deleteS3Object);
+
+function makeContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
+  return {
+    authContext: null,
+    dbTx: null,
+    audit: vi.fn(),
+    ...overrides,
+  };
+}
+
+function orgContext(
+  role: 'ADMIN' | 'EDITOR' | 'READER' = 'READER',
+  overrides: Partial<TRPCContext> = {},
+): TRPCContext {
+  const mockTx = {} as never;
+  return makeContext({
+    authContext: {
+      userId: 'user-1',
+      zitadelUserId: 'zid-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      orgId: 'org-1',
+      role,
+    },
+    dbTx: mockTx,
+    audit: vi.fn(),
+    ...overrides,
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createCaller = (appRouter as any).createCaller as (
+  ctx: TRPCContext,
+) => any;
+
+const SUBMISSION_ID = 'a1111111-1111-1111-1111-111111111111';
+const FILE_ID = 'f1111111-1111-1111-1111-111111111111';
+
+function makeDraftSubmission(submitterId = 'user-1') {
+  return {
+    id: SUBMISSION_ID,
+    organizationId: 'org-1',
+    submitterId,
+    submissionPeriodId: null,
+    title: 'Test Poem',
+    content: 'Roses are red...',
+    coverLetter: null,
+    status: 'DRAFT' as const,
+    submittedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    files: [],
+    submitterEmail: 'test@example.com',
+  };
+}
+
+function makeFile(overrides = {}) {
+  return {
+    id: FILE_ID,
+    submissionId: SUBMISSION_ID,
+    filename: 'poem.pdf',
+    mimeType: 'application/pdf',
+    size: 1024,
+    storageKey: 'quarantine/abc123',
+    scanStatus: 'CLEAN' as const,
+    scannedAt: new Date(),
+    uploadedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('files tRPC router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Auth / access control
+  // -------------------------------------------------------------------------
+
+  describe('auth and access', () => {
+    it('listBySubmission requires authentication', async () => {
+      const caller = createCaller(makeContext());
+      await expect(
+        caller.files.listBySubmission({ submissionId: SUBMISSION_ID }),
+      ).rejects.toThrow(TRPCError);
+    });
+
+    it('listBySubmission requires org context', async () => {
+      const caller = createCaller(
+        makeContext({
+          authContext: {
+            userId: 'user-1',
+            zitadelUserId: 'zid-1',
+            email: 'test@example.com',
+            emailVerified: true,
+          },
+        }),
+      );
+      await expect(
+        caller.files.listBySubmission({ submissionId: SUBMISSION_ID }),
+      ).rejects.toThrow(TRPCError);
+    });
+
+    it('listBySubmission denies READER from viewing others files', async () => {
+      const sub = makeDraftSubmission('other-user');
+      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+      const caller = createCaller(orgContext('READER'));
+      await expect(
+        caller.files.listBySubmission({ submissionId: SUBMISSION_ID }),
+      ).rejects.toThrow('do not have access');
+    });
+
+    it('listBySubmission allows EDITOR to view others files', async () => {
+      const sub = makeDraftSubmission('other-user');
+      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+      mockFileService.listBySubmission.mockResolvedValueOnce([] as never);
+      const caller = createCaller(orgContext('EDITOR'));
+      const result = await caller.files.listBySubmission({
+        submissionId: SUBMISSION_ID,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('delete requires ownership', async () => {
+      const file = makeFile();
+      const sub = makeDraftSubmission('other-user');
+      mockFileService.getById.mockResolvedValueOnce(file as never);
+      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+      const caller = createCaller(orgContext('READER'));
+      await expect(caller.files.delete({ fileId: FILE_ID })).rejects.toThrow(
+        'Only the submitter',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // listBySubmission
+  // -------------------------------------------------------------------------
+
+  describe('listBySubmission', () => {
+    it('returns files for the submission', async () => {
+      const sub = makeDraftSubmission();
+      const files = [makeFile()];
+      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+      mockFileService.listBySubmission.mockResolvedValueOnce(files as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.files.listBySubmission({
+        submissionId: SUBMISSION_ID,
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].filename).toBe('poem.pdf');
+    });
+
+    it('throws NOT_FOUND when submission missing', async () => {
+      mockSubmissionService.getById.mockResolvedValueOnce(null as never);
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.files.listBySubmission({ submissionId: SUBMISSION_ID }),
+      ).rejects.toThrow('not found');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getDownloadUrl
+  // -------------------------------------------------------------------------
+
+  describe('getDownloadUrl', () => {
+    it('returns presigned URL for CLEAN file', async () => {
+      const file = makeFile();
+      const sub = makeDraftSubmission();
+      mockFileService.getById.mockResolvedValueOnce(file as never);
+      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.files.getDownloadUrl({ fileId: FILE_ID });
+      expect(result.url).toBe('https://s3.example.com/signed-url');
+      expect(result.filename).toBe('poem.pdf');
+    });
+
+    it('rejects file not yet scanned', async () => {
+      const file = makeFile({ scanStatus: 'PENDING' });
+      const sub = makeDraftSubmission();
+      mockFileService.getById.mockResolvedValueOnce(file as never);
+      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.files.getDownloadUrl({ fileId: FILE_ID }),
+      ).rejects.toThrow('virus scan');
+    });
+
+    it('rejects infected file', async () => {
+      const file = makeFile({ scanStatus: 'INFECTED' });
+      const sub = makeDraftSubmission();
+      mockFileService.getById.mockResolvedValueOnce(file as never);
+      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.files.getDownloadUrl({ fileId: FILE_ID }),
+      ).rejects.toThrow('virus scan');
+    });
+
+    it('throws NOT_FOUND for missing file', async () => {
+      mockFileService.getById.mockResolvedValueOnce(null as never);
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.files.getDownloadUrl({ fileId: FILE_ID }),
+      ).rejects.toThrow('not found');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // delete
+  // -------------------------------------------------------------------------
+
+  describe('delete', () => {
+    it('succeeds on DRAFT and calls audit', async () => {
+      const file = makeFile();
+      const sub = makeDraftSubmission();
+      mockFileService.getById.mockResolvedValueOnce(file as never);
+      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+      mockFileService.delete.mockResolvedValueOnce(file as never);
+
+      const ctx = orgContext();
+      const caller = createCaller(ctx);
+      const result = await caller.files.delete({ fileId: FILE_ID });
+
+      expect(result).toEqual({ success: true });
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'FILE_DELETED' }),
+      );
+    });
+
+    it('rejects deletion from non-DRAFT submission', async () => {
+      const file = makeFile();
+      const sub = { ...makeDraftSubmission(), status: 'SUBMITTED' as const };
+      mockFileService.getById.mockResolvedValueOnce(file as never);
+      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+
+      const caller = createCaller(orgContext());
+      await expect(caller.files.delete({ fileId: FILE_ID })).rejects.toThrow(
+        'DRAFT',
+      );
+    });
+
+    it('attempts S3 deletion after DB delete', async () => {
+      const file = makeFile();
+      const sub = makeDraftSubmission();
+      mockFileService.getById.mockResolvedValueOnce(file as never);
+      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+      mockFileService.delete.mockResolvedValueOnce(file as never);
+
+      const caller = createCaller(orgContext());
+      await caller.files.delete({ fileId: FILE_ID });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockDeleteS3).toHaveBeenCalledWith(
+        expect.anything(),
+        'quarantine',
+        file.storageKey,
+      );
+    });
+
+    it('throws NOT_FOUND for missing file', async () => {
+      mockFileService.getById.mockResolvedValueOnce(null as never);
+      const caller = createCaller(orgContext());
+      await expect(caller.files.delete({ fileId: FILE_ID })).rejects.toThrow(
+        'not found',
+      );
+    });
+  });
+});

--- a/apps/api/src/trpc/routers/files.ts
+++ b/apps/api/src/trpc/routers/files.ts
@@ -1,0 +1,188 @@
+import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
+import { AuditActions, AuditResources } from '@colophony/types';
+import { orgProcedure, createRouter } from '../init.js';
+import { submissionService } from '../../services/submission.service.js';
+import { fileService } from '../../services/file.service.js';
+import {
+  createS3Client,
+  getPresignedDownloadUrl,
+  deleteS3Object,
+} from '../../services/s3.js';
+import { validateEnv } from '../../config/env.js';
+
+// Lazily create S3 client (avoid creating at module load for tests)
+let s3ClientInstance: ReturnType<typeof createS3Client> | null = null;
+
+function getS3Client() {
+  if (!s3ClientInstance) {
+    const env = validateEnv();
+    s3ClientInstance = createS3Client(env);
+  }
+  return s3ClientInstance;
+}
+
+function getEnvConfig() {
+  return validateEnv();
+}
+
+function assertOwnerOrEditor(
+  submitterId: string,
+  userId: string,
+  role: string,
+): void {
+  if (submitterId !== userId && role !== 'ADMIN' && role !== 'EDITOR') {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'You do not have access to this submission',
+    });
+  }
+}
+
+export const filesRouter = createRouter({
+  /** List files for a submission — owner or editor/admin. */
+  listBySubmission: orgProcedure
+    .input(z.object({ submissionId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const submission = await submissionService.getById(
+        ctx.dbTx,
+        input.submissionId,
+      );
+      if (!submission) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Submission not found',
+        });
+      }
+      assertOwnerOrEditor(
+        submission.submitterId,
+        ctx.authContext.userId,
+        ctx.authContext.role,
+      );
+      return fileService.listBySubmission(ctx.dbTx, input.submissionId);
+    }),
+
+  /** Get a presigned download URL for a file — owner or editor/admin, CLEAN only. */
+  getDownloadUrl: orgProcedure
+    .input(z.object({ fileId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const file = await fileService.getById(ctx.dbTx, input.fileId);
+      if (!file) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'File not found',
+        });
+      }
+
+      // Check access via submission
+      const submission = await submissionService.getById(
+        ctx.dbTx,
+        file.submissionId,
+      );
+      if (!submission) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Submission not found',
+        });
+      }
+      assertOwnerOrEditor(
+        submission.submitterId,
+        ctx.authContext.userId,
+        ctx.authContext.role,
+      );
+
+      if (file.scanStatus !== 'CLEAN') {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'File has not passed virus scan',
+        });
+      }
+
+      const env = getEnvConfig();
+      const url = await getPresignedDownloadUrl(
+        getS3Client(),
+        env.S3_BUCKET,
+        file.storageKey,
+      );
+      return { url, filename: file.filename, mimeType: file.mimeType };
+    }),
+
+  /** Delete a file — submission owner only, DRAFT only. */
+  delete: orgProcedure
+    .input(z.object({ fileId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const file = await fileService.getById(ctx.dbTx, input.fileId);
+      if (!file) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'File not found',
+        });
+      }
+
+      // Check ownership via submission
+      const submission = await submissionService.getById(
+        ctx.dbTx,
+        file.submissionId,
+      );
+      if (!submission) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Submission not found',
+        });
+      }
+      if (submission.submitterId !== ctx.authContext.userId) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Only the submitter can delete files',
+        });
+      }
+      if (submission.status !== 'DRAFT') {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Files can only be deleted from DRAFT submissions',
+        });
+      }
+
+      // Delete DB record
+      const deleted = await fileService.delete(ctx.dbTx, input.fileId);
+      if (!deleted) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'File not found',
+        });
+      }
+
+      await ctx.audit({
+        action: AuditActions.FILE_DELETED,
+        resource: AuditResources.FILE,
+        resourceId: input.fileId,
+        newValue: {
+          filename: file.filename,
+          submissionId: file.submissionId,
+        },
+      });
+
+      // Delete from S3 after DB commit succeeds (best-effort)
+      try {
+        const env = getEnvConfig();
+        await deleteS3Object(
+          getS3Client(),
+          env.S3_QUARANTINE_BUCKET,
+          file.storageKey,
+        );
+      } catch {
+        // Log but don't fail — orphaned S3 objects can be cleaned up
+        // by a periodic garbage collection job
+        ctx
+          .audit({
+            action: AuditActions.FILE_DELETED,
+            resource: AuditResources.FILE,
+            resourceId: input.fileId,
+            newValue: { s3DeleteFailed: true, storageKey: file.storageKey },
+          })
+          .catch(() => {});
+      }
+
+      return { success: true };
+    }),
+});

--- a/apps/api/src/webhooks/tusd.webhook.spec.ts
+++ b/apps/api/src/webhooks/tusd.webhook.spec.ts
@@ -11,12 +11,18 @@ import Fastify, { type FastifyInstance } from 'fastify';
 
 // Mock @colophony/db
 const mockWithRls = vi.fn();
+const mockFindFirstUser = vi.fn();
 vi.mock('@colophony/db', () => ({
   pool: { query: vi.fn(), connect: vi.fn() },
-  db: { query: {} },
+  db: {
+    query: {
+      users: { findFirst: (...args: unknown[]) => mockFindFirstUser(...args) },
+    },
+  },
   withRls: (...args: unknown[]) => mockWithRls(...args),
-  submissions: { id: 'id', status: 'status' },
+  submissions: { id: 'id', status: 'status', submitterId: 'submitterId' },
   submissionFiles: {},
+  users: { zitadelUserId: 'zitadelUserId' },
   eq: vi.fn((_col: unknown, _val: unknown) => ({})),
   and: vi.fn(),
   sql: vi.fn(),
@@ -185,7 +191,13 @@ describe('tusd webhook handler', () => {
               from: () => ({
                 where: () => ({
                   limit: () =>
-                    Promise.resolve([{ id: SUBMISSION_ID, status: 'DRAFT' }]),
+                    Promise.resolve([
+                      {
+                        id: SUBMISSION_ID,
+                        status: 'DRAFT',
+                        submitterId: 'user-1',
+                      },
+                    ]),
                 }),
               }),
             }),
@@ -271,6 +283,42 @@ describe('tusd webhook handler', () => {
       expect(result.HTTPResponse.Body).toContain('submission_not_found');
     });
 
+    it('rejects when not submission owner', async () => {
+      mockWithRls.mockImplementation(
+        async (_ctx: unknown, fn: (tx: unknown) => Promise<void>) => {
+          const mockTx = {
+            select: () => ({
+              from: () => ({
+                where: () => ({
+                  limit: () =>
+                    Promise.resolve([
+                      {
+                        id: SUBMISSION_ID,
+                        status: 'DRAFT',
+                        submitterId: 'other-user',
+                      },
+                    ]),
+                }),
+              }),
+            }),
+          };
+          return fn(mockTx);
+        },
+      );
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: makePreCreateBody(),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const result = JSON.parse(response.payload);
+      expect(result.RejectUpload).toBe(true);
+      expect(result.HTTPResponse.Body).toContain('not_submission_owner');
+    });
+
     it('rejects when submission not DRAFT', async () => {
       mockWithRls.mockImplementation(
         async (_ctx: unknown, fn: (tx: unknown) => Promise<void>) => {
@@ -280,7 +328,11 @@ describe('tusd webhook handler', () => {
                 where: () => ({
                   limit: () =>
                     Promise.resolve([
-                      { id: SUBMISSION_ID, status: 'SUBMITTED' },
+                      {
+                        id: SUBMISSION_ID,
+                        status: 'SUBMITTED',
+                        submitterId: 'user-1',
+                      },
                     ]),
                 }),
               }),
@@ -395,6 +447,24 @@ describe('tusd webhook handler', () => {
       expect(response.statusCode).toBe(200);
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockFileService.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects when auth is missing (fail closed)', async () => {
+      const body = makePostFinishBody();
+      body.HTTPRequest.Header = {
+        'X-Organization-Id': ['org-1'],
+      } as never;
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'post-finish' },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(401);
+      const result = JSON.parse(response.payload);
+      expect(result.error).toBe('no_auth_configured');
     });
 
     it('returns 400 when missing org id', async () => {

--- a/apps/api/src/webhooks/tusd.webhook.spec.ts
+++ b/apps/api/src/webhooks/tusd.webhook.spec.ts
@@ -1,0 +1,447 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+// Mock @colophony/db
+const mockWithRls = vi.fn();
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  withRls: (...args: unknown[]) => mockWithRls(...args),
+  submissions: { id: 'id', status: 'status' },
+  submissionFiles: {},
+  eq: vi.fn((_col: unknown, _val: unknown) => ({})),
+  and: vi.fn(),
+  sql: vi.fn(),
+}));
+
+// Mock file service
+vi.mock('../services/file.service.js', () => ({
+  fileService: {
+    listBySubmission: vi.fn(),
+    getById: vi.fn(),
+    getByStorageKey: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+    countBySubmission: vi.fn(),
+    totalSizeBySubmission: vi.fn(),
+    validateMimeType: vi.fn(),
+    validateFileSize: vi.fn(),
+    validateLimits: vi.fn(),
+  },
+  FileNotFoundError: class extends Error {
+    name = 'FileNotFoundError';
+  },
+  FileLimitExceededError: class extends Error {
+    name = 'FileLimitExceededError';
+  },
+  InvalidMimeTypeError: class extends Error {
+    name = 'InvalidMimeTypeError';
+  },
+}));
+
+// Mock audit service
+vi.mock('../services/audit.service.js', () => ({
+  auditService: {
+    log: vi.fn(),
+    logDirect: vi.fn(),
+  },
+}));
+
+// Mock auth-client
+vi.mock('@colophony/auth-client', () => ({
+  createJwksVerifier: vi.fn(),
+  verifyZitadelSignature: vi.fn(),
+  zitadelWebhookPayloadSchema: { safeParse: vi.fn() },
+}));
+
+import { registerTusdWebhooks } from './tusd.webhook.js';
+import { fileService } from '../services/file.service.js';
+import { auditService } from '../services/audit.service.js';
+import type { Env } from '../config/env.js';
+
+const mockFileService = vi.mocked(fileService);
+const mockAuditService = vi.mocked(auditService);
+
+const TEST_ENV = {
+  DATABASE_URL: 'postgresql://test:test@localhost/test',
+  PORT: 4000,
+  HOST: '0.0.0.0',
+  NODE_ENV: 'test' as const,
+  LOG_LEVEL: 'error' as const,
+  REDIS_HOST: 'localhost',
+  REDIS_PORT: 6379,
+  REDIS_PASSWORD: '',
+  CORS_ORIGIN: 'http://localhost:3000',
+  RATE_LIMIT_DEFAULT_MAX: 60,
+  RATE_LIMIT_AUTH_MAX: 200,
+  RATE_LIMIT_WINDOW_SECONDS: 60,
+  RATE_LIMIT_KEY_PREFIX: 'test:rl',
+  WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS: 300,
+  WEBHOOK_RATE_LIMIT_MAX: 100,
+  S3_ENDPOINT: 'http://localhost:9000',
+  S3_BUCKET: 'submissions',
+  S3_QUARANTINE_BUCKET: 'quarantine',
+  S3_ACCESS_KEY: 'minioadmin',
+  S3_SECRET_KEY: 'minioadmin',
+  S3_REGION: 'us-east-1',
+  TUS_ENDPOINT: 'http://localhost:1080',
+} as unknown as Env;
+
+const SUBMISSION_ID = 'a1111111-1111-1111-1111-111111111111';
+
+function makePreCreateBody(overrides: Record<string, unknown> = {}) {
+  return {
+    Upload: {
+      Size: 1024,
+      MetaData: {
+        'submission-id': SUBMISSION_ID,
+        filetype: 'application/pdf',
+        filename: 'poem.pdf',
+      },
+      ...overrides,
+    },
+    HTTPRequest: {
+      Method: 'POST',
+      URI: '/files/',
+      RemoteAddr: '127.0.0.1',
+      Header: {
+        Authorization: ['Bearer test-token'],
+        'X-Organization-Id': ['org-1'],
+        'X-Test-User-Id': ['user-1'],
+      },
+    },
+  };
+}
+
+function makePostFinishBody(overrides: Record<string, unknown> = {}) {
+  return {
+    Upload: {
+      ID: 'upload-abc123',
+      Size: 1024,
+      Offset: 1024,
+      MetaData: {
+        'submission-id': SUBMISSION_ID,
+        filetype: 'application/pdf',
+        filename: 'poem.pdf',
+      },
+      Storage: {
+        Key: 'quarantine/upload-abc123',
+        Bucket: 'quarantine',
+        Type: 's3store',
+      },
+      ...overrides,
+    },
+    HTTPRequest: {
+      Method: 'POST',
+      URI: '/files/upload-abc123',
+      RemoteAddr: '127.0.0.1',
+      Header: {
+        Authorization: ['Bearer test-token'],
+        'X-Organization-Id': ['org-1'],
+        'X-Test-User-Id': ['user-1'],
+      },
+    },
+  };
+}
+
+describe('tusd webhook handler', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(async (scope) => {
+      await registerTusdWebhooks(scope, { env: TEST_ENV });
+    });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Pre-create
+  // -------------------------------------------------------------------------
+
+  describe('pre-create', () => {
+    it('allows valid upload', async () => {
+      // withRls resolves successfully (validation passes)
+      mockWithRls.mockImplementation(
+        async (_ctx: unknown, fn: (tx: unknown) => Promise<void>) => {
+          const mockTx = {
+            select: () => ({
+              from: () => ({
+                where: () => ({
+                  limit: () =>
+                    Promise.resolve([{ id: SUBMISSION_ID, status: 'DRAFT' }]),
+                }),
+              }),
+            }),
+          };
+          return fn(mockTx);
+        },
+      );
+      mockFileService.validateLimits.mockResolvedValueOnce(undefined);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: makePreCreateBody(),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.RejectUpload).toBeUndefined();
+    });
+
+    it('rejects when missing auth', async () => {
+      const body = makePreCreateBody();
+      body.HTTPRequest.Header = {
+        'X-Organization-Id': ['org-1'],
+      } as never;
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const result = JSON.parse(response.payload);
+      expect(result.RejectUpload).toBe(true);
+    });
+
+    it('rejects invalid MIME type', async () => {
+      mockFileService.validateMimeType.mockImplementationOnce(() => {
+        throw new Error('invalid');
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: makePreCreateBody(),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const result = JSON.parse(response.payload);
+      expect(result.RejectUpload).toBe(true);
+    });
+
+    it('rejects when submission not found', async () => {
+      mockWithRls.mockImplementation(
+        async (_ctx: unknown, fn: (tx: unknown) => Promise<void>) => {
+          const mockTx = {
+            select: () => ({
+              from: () => ({
+                where: () => ({
+                  limit: () => Promise.resolve([]),
+                }),
+              }),
+            }),
+          };
+          return fn(mockTx);
+        },
+      );
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: makePreCreateBody(),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const result = JSON.parse(response.payload);
+      expect(result.RejectUpload).toBe(true);
+      expect(result.HTTPResponse.Body).toContain('submission_not_found');
+    });
+
+    it('rejects when submission not DRAFT', async () => {
+      mockWithRls.mockImplementation(
+        async (_ctx: unknown, fn: (tx: unknown) => Promise<void>) => {
+          const mockTx = {
+            select: () => ({
+              from: () => ({
+                where: () => ({
+                  limit: () =>
+                    Promise.resolve([
+                      { id: SUBMISSION_ID, status: 'SUBMITTED' },
+                    ]),
+                }),
+              }),
+            }),
+          };
+          return fn(mockTx);
+        },
+      );
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: makePreCreateBody(),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const result = JSON.parse(response.payload);
+      expect(result.RejectUpload).toBe(true);
+      expect(result.HTTPResponse.Body).toContain('submission_not_draft');
+    });
+
+    it('rejects missing submission-id in metadata', async () => {
+      const body = makePreCreateBody({
+        MetaData: { filetype: 'application/pdf' },
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const result = JSON.parse(response.payload);
+      expect(result.RejectUpload).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Post-finish
+  // -------------------------------------------------------------------------
+
+  describe('post-finish', () => {
+    it('creates file record on new upload', async () => {
+      mockWithRls.mockImplementation(
+        async (_ctx: unknown, fn: (tx: unknown) => Promise<void>) => {
+          return fn({});
+        },
+      );
+      mockFileService.getByStorageKey.mockResolvedValueOnce(null as never);
+      mockFileService.create.mockResolvedValueOnce({
+        id: 'file-1',
+        submissionId: SUBMISSION_ID,
+        filename: 'poem.pdf',
+        mimeType: 'application/pdf',
+        size: 1024,
+        storageKey: 'quarantine/upload-abc123',
+        scanStatus: 'PENDING',
+        scannedAt: null,
+        uploadedAt: new Date(),
+      } as never);
+      mockAuditService.log.mockResolvedValueOnce(undefined);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'post-finish' },
+        payload: makePostFinishBody(),
+      });
+
+      expect(response.statusCode).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockFileService.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          submissionId: SUBMISSION_ID,
+          filename: 'poem.pdf',
+          mimeType: 'application/pdf',
+          storageKey: 'quarantine/upload-abc123',
+        }),
+      );
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockAuditService.log).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'FILE_UPLOADED',
+          resource: 'file',
+        }),
+      );
+    });
+
+    it('is idempotent — skips if storageKey already exists', async () => {
+      mockWithRls.mockImplementation(
+        async (_ctx: unknown, fn: (tx: unknown) => Promise<void>) => {
+          return fn({});
+        },
+      );
+      mockFileService.getByStorageKey.mockResolvedValueOnce({
+        id: 'existing-file',
+        storageKey: 'quarantine/upload-abc123',
+      } as never);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'post-finish' },
+        payload: makePostFinishBody(),
+      });
+
+      expect(response.statusCode).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockFileService.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when missing org id', async () => {
+      const body = makePostFinishBody();
+      body.HTTPRequest.Header = {
+        Authorization: ['Bearer test-token'],
+        'X-Test-User-Id': ['user-1'],
+      } as never;
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'post-finish' },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('returns 500 on processing error', async () => {
+      mockWithRls.mockRejectedValueOnce(new Error('DB connection failed'));
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'post-finish' },
+        payload: makePostFinishBody(),
+      });
+
+      expect(response.statusCode).toBe(500);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown hook
+  // -------------------------------------------------------------------------
+
+  describe('unknown hook', () => {
+    it('returns 200 for unknown hook name', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'post-create' },
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+  });
+});

--- a/apps/api/src/webhooks/tusd.webhook.ts
+++ b/apps/api/src/webhooks/tusd.webhook.ts
@@ -1,0 +1,305 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { withRls, submissions, eq } from '@colophony/db';
+import type { DrizzleDb } from '@colophony/db';
+import { createJwksVerifier } from '@colophony/auth-client';
+import {
+  tusdPreCreateHookSchema,
+  tusdPostFinishHookSchema,
+  sanitizeFilename,
+  AuditActions,
+  AuditResources,
+} from '@colophony/types';
+import type { TusdPreCreateResponse } from '@colophony/types';
+import type { Env } from '../config/env.js';
+import { fileService } from '../services/file.service.js';
+import { auditService } from '../services/audit.service.js';
+
+export interface TusdWebhookOptions {
+  env: Env;
+}
+
+function rejectUpload(
+  statusCode: number,
+  message: string,
+): TusdPreCreateResponse {
+  return {
+    RejectUpload: true,
+    HTTPResponse: {
+      StatusCode: statusCode,
+      Body: JSON.stringify({ error: message }),
+      Header: { 'Content-Type': 'application/json' },
+    },
+  };
+}
+
+function getForwardedHeader(
+  headers: Record<string, string[]>,
+  name: string,
+): string | undefined {
+  const values = headers[name] ?? headers[name.toLowerCase()];
+  return values?.[0];
+}
+
+export async function registerTusdWebhooks(
+  app: FastifyInstance,
+  opts: TusdWebhookOptions,
+) {
+  const { env } = opts;
+
+  // Create JWKS verifier for validating forwarded user tokens
+  const verifyToken = env.ZITADEL_AUTHORITY
+    ? createJwksVerifier({
+        authority: env.ZITADEL_AUTHORITY,
+        clientId: env.ZITADEL_CLIENT_ID,
+      })
+    : null;
+
+  app.post(
+    '/webhooks/tusd',
+    { bodyLimit: 1024 * 1024 }, // 1MB
+    async function tusdWebhookHandler(
+      request: FastifyRequest,
+      reply: FastifyReply,
+    ) {
+      const hookName = request.headers['hook-name'] as string | undefined;
+
+      if (hookName === 'pre-create') {
+        return handlePreCreate(request, reply);
+      } else if (hookName === 'post-finish') {
+        return handlePostFinish(request, reply);
+      } else {
+        request.log.info({ hookName }, 'Unhandled tusd hook');
+        return reply.status(200).send({});
+      }
+    },
+  );
+
+  async function handlePreCreate(
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ): Promise<void> {
+    const parsed = tusdPreCreateHookSchema.safeParse(request.body);
+    if (!parsed.success) {
+      request.log.warn(
+        { errors: parsed.error.flatten() },
+        'Invalid tusd pre-create payload',
+      );
+      await reply.status(200).send(rejectUpload(400, 'invalid_payload'));
+      return;
+    }
+
+    const { Upload, HTTPRequest } = parsed.data;
+    const metadata = Upload.MetaData ?? {};
+    const forwardedHeaders = HTTPRequest.Header;
+
+    // Extract auth token from forwarded headers
+    const authHeader = getForwardedHeader(forwardedHeaders, 'Authorization');
+    const orgId = getForwardedHeader(forwardedHeaders, 'X-Organization-Id');
+
+    if (!authHeader || !orgId) {
+      await reply.status(200).send(rejectUpload(401, 'missing_auth_or_org'));
+      return;
+    }
+
+    const match = /^Bearer\s+(\S+)$/i.exec(authHeader);
+    if (!match) {
+      await reply.status(200).send(rejectUpload(401, 'invalid_auth_header'));
+      return;
+    }
+
+    // Validate token
+    let userId: string;
+    if (verifyToken) {
+      try {
+        const { payload } = await verifyToken(match[1]);
+        if (!payload.sub) {
+          await reply.status(200).send(rejectUpload(401, 'missing_sub_claim'));
+          return;
+        }
+        userId = payload.sub;
+      } catch {
+        await reply
+          .status(200)
+          .send(rejectUpload(401, 'token_validation_failed'));
+        return;
+      }
+    } else if (env.NODE_ENV === 'test') {
+      // Test mode: extract from forwarded test headers
+      const testUserId = getForwardedHeader(forwardedHeaders, 'X-Test-User-Id');
+      if (!testUserId) {
+        await reply.status(200).send(rejectUpload(401, 'no_auth_configured'));
+        return;
+      }
+      userId = testUserId;
+    } else {
+      await reply.status(200).send(rejectUpload(401, 'no_auth_configured'));
+      return;
+    }
+
+    // Extract upload metadata
+    const submissionId = metadata['submission-id'] ?? metadata['submissionId'];
+    const mimeType =
+      metadata['filetype'] ?? metadata['type'] ?? 'application/octet-stream';
+    const fileSize = Upload.Size ?? 0;
+
+    if (!submissionId) {
+      await reply.status(200).send(rejectUpload(400, 'missing_submission_id'));
+      return;
+    }
+
+    // Validate MIME type
+    try {
+      fileService.validateMimeType(mimeType);
+    } catch {
+      await reply.status(200).send(rejectUpload(415, 'invalid_mime_type'));
+      return;
+    }
+
+    // Validate file size
+    try {
+      fileService.validateFileSize(fileSize);
+    } catch {
+      await reply.status(200).send(rejectUpload(413, 'file_too_large'));
+      return;
+    }
+
+    // Validate within RLS context
+    try {
+      await withRls({ orgId, userId }, async (tx: DrizzleDb) => {
+        // Check submission exists and is DRAFT
+        const [submission] = await tx
+          .select({ id: submissions.id, status: submissions.status })
+          .from(submissions)
+          .where(eq(submissions.id, submissionId))
+          .limit(1);
+
+        if (!submission) {
+          throw new Error('submission_not_found');
+        }
+        if (submission.status !== 'DRAFT') {
+          throw new Error('submission_not_draft');
+        }
+
+        // Check file count and size limits
+        await fileService.validateLimits(tx, submissionId, fileSize);
+      });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'validation_failed';
+      const statusCode =
+        message === 'submission_not_found'
+          ? 404
+          : message === 'submission_not_draft'
+            ? 409
+            : 422;
+      await reply.status(200).send(rejectUpload(statusCode, message));
+      return;
+    }
+
+    // Allow the upload
+    await reply.status(200).send({});
+  }
+
+  async function handlePostFinish(
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ): Promise<void> {
+    const parsed = tusdPostFinishHookSchema.safeParse(request.body);
+    if (!parsed.success) {
+      request.log.warn(
+        { errors: parsed.error.flatten() },
+        'Invalid tusd post-finish payload',
+      );
+      return reply.status(400).send({ error: 'invalid_payload' });
+    }
+
+    const { Upload, HTTPRequest } = parsed.data;
+    const metadata = Upload.MetaData ?? {};
+    const forwardedHeaders = HTTPRequest.Header;
+
+    const orgId = getForwardedHeader(forwardedHeaders, 'X-Organization-Id');
+    const authHeader = getForwardedHeader(forwardedHeaders, 'Authorization');
+
+    if (!orgId) {
+      request.log.error('Post-finish webhook missing X-Organization-Id');
+      return reply.status(400).send({ error: 'missing_org_id' });
+    }
+
+    // Resolve userId from forwarded auth
+    let userId: string | undefined;
+    if (verifyToken && authHeader) {
+      const match = /^Bearer\s+(\S+)$/i.exec(authHeader);
+      if (match) {
+        try {
+          const { payload } = await verifyToken(match[1]);
+          userId = payload.sub ?? undefined;
+        } catch {
+          request.log.warn('Post-finish: token validation failed');
+        }
+      }
+    } else if (env.NODE_ENV === 'test') {
+      userId = getForwardedHeader(forwardedHeaders, 'X-Test-User-Id');
+    }
+
+    const submissionId = metadata['submission-id'] ?? metadata['submissionId'];
+    const filename = sanitizeFilename(
+      metadata['filename'] ?? metadata['name'] ?? 'unnamed',
+    );
+    const mimeType =
+      metadata['filetype'] ?? metadata['type'] ?? 'application/octet-stream';
+    const storageKey = Upload.Storage?.Key ?? Upload.ID;
+    const size = Upload.Size;
+
+    if (!submissionId || !storageKey) {
+      request.log.error(
+        { submissionId, storageKey },
+        'Post-finish missing required metadata',
+      );
+      return reply.status(400).send({ error: 'missing_metadata' });
+    }
+
+    try {
+      await withRls({ orgId, userId }, async (tx: DrizzleDb) => {
+        // Idempotency: check if already processed
+        const existing = await fileService.getByStorageKey(tx, storageKey);
+        if (existing) {
+          request.log.info(
+            { storageKey, fileId: existing.id },
+            'Post-finish already processed (idempotent)',
+          );
+          return;
+        }
+
+        // Create file record
+        const file = await fileService.create(tx, {
+          submissionId,
+          filename,
+          mimeType,
+          size,
+          storageKey,
+        });
+
+        // Audit within the same transaction
+        await auditService.log(tx, {
+          resource: AuditResources.FILE,
+          action: AuditActions.FILE_UPLOADED,
+          resourceId: file.id,
+          actorId: userId,
+          organizationId: orgId,
+          ipAddress: request.ip,
+          userAgent: request.headers['user-agent'],
+          newValue: { filename, mimeType, size, submissionId },
+        });
+
+        request.log.info(
+          { fileId: file.id, submissionId, storageKey },
+          'File record created from tusd post-finish',
+        );
+      });
+
+      return reply.status(200).send({ status: 'processed' });
+    } catch (err) {
+      request.log.error(err, 'Post-finish webhook processing failed');
+      return reply.status(500).send({ error: 'processing_failed' });
+    }
+  }
+}

--- a/apps/api/src/webhooks/tusd.webhook.ts
+++ b/apps/api/src/webhooks/tusd.webhook.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { withRls, submissions, eq } from '@colophony/db';
+import { withRls, submissions, eq, db, users } from '@colophony/db';
 import type { DrizzleDb } from '@colophony/db';
 import { createJwksVerifier } from '@colophony/auth-client';
 import {
@@ -38,6 +38,17 @@ function getForwardedHeader(
 ): string | undefined {
   const values = headers[name] ?? headers[name.toLowerCase()];
   return values?.[0];
+}
+
+/**
+ * Resolve a Zitadel subject ID to the local user UUID.
+ * Uses the shared db instance (no RLS) — same pattern as the auth hook.
+ */
+async function resolveLocalUserId(zitadelSub: string): Promise<string | null> {
+  const user = await db.query.users.findFirst({
+    where: eq(users.zitadelUserId, zitadelSub),
+  });
+  return user?.id ?? null;
 }
 
 export async function registerTusdWebhooks(
@@ -107,7 +118,7 @@ export async function registerTusdWebhooks(
       return;
     }
 
-    // Validate token
+    // Validate token and resolve local user UUID
     let userId: string;
     if (verifyToken) {
       try {
@@ -116,7 +127,15 @@ export async function registerTusdWebhooks(
           await reply.status(200).send(rejectUpload(401, 'missing_sub_claim'));
           return;
         }
-        userId = payload.sub;
+        // Resolve Zitadel sub → local user UUID (same as auth hook)
+        const localUserId = await resolveLocalUserId(payload.sub);
+        if (!localUserId) {
+          await reply
+            .status(200)
+            .send(rejectUpload(403, 'user_not_provisioned'));
+          return;
+        }
+        userId = localUserId;
       } catch {
         await reply
           .status(200)
@@ -168,7 +187,11 @@ export async function registerTusdWebhooks(
       await withRls({ orgId, userId }, async (tx: DrizzleDb) => {
         // Check submission exists and is DRAFT
         const [submission] = await tx
-          .select({ id: submissions.id, status: submissions.status })
+          .select({
+            id: submissions.id,
+            status: submissions.status,
+            submitterId: submissions.submitterId,
+          })
           .from(submissions)
           .where(eq(submissions.id, submissionId))
           .limit(1);
@@ -178,6 +201,10 @@ export async function registerTusdWebhooks(
         }
         if (submission.status !== 'DRAFT') {
           throw new Error('submission_not_draft');
+        }
+        // Only the submission owner can upload files
+        if (submission.submitterId !== userId) {
+          throw new Error('not_submission_owner');
         }
 
         // Check file count and size limits
@@ -224,20 +251,37 @@ export async function registerTusdWebhooks(
       return reply.status(400).send({ error: 'missing_org_id' });
     }
 
-    // Resolve userId from forwarded auth
-    let userId: string | undefined;
+    // Resolve userId from forwarded auth — fail closed if auth is invalid
+    let userId: string;
     if (verifyToken && authHeader) {
       const match = /^Bearer\s+(\S+)$/i.exec(authHeader);
-      if (match) {
-        try {
-          const { payload } = await verifyToken(match[1]);
-          userId = payload.sub ?? undefined;
-        } catch {
-          request.log.warn('Post-finish: token validation failed');
+      if (!match) {
+        request.log.warn('Post-finish: invalid auth header format');
+        return reply.status(401).send({ error: 'invalid_auth_header' });
+      }
+      try {
+        const { payload } = await verifyToken(match[1]);
+        if (!payload.sub) {
+          return reply.status(401).send({ error: 'missing_sub_claim' });
         }
+        const localUserId = await resolveLocalUserId(payload.sub);
+        if (!localUserId) {
+          return reply.status(403).send({ error: 'user_not_provisioned' });
+        }
+        userId = localUserId;
+      } catch {
+        request.log.warn('Post-finish: token validation failed');
+        return reply.status(401).send({ error: 'token_validation_failed' });
       }
     } else if (env.NODE_ENV === 'test') {
-      userId = getForwardedHeader(forwardedHeaders, 'X-Test-User-Id');
+      const testUserId = getForwardedHeader(forwardedHeaders, 'X-Test-User-Id');
+      if (!testUserId) {
+        return reply.status(401).send({ error: 'no_auth_configured' });
+      }
+      userId = testUserId;
+    } else {
+      request.log.warn('Post-finish: no auth available');
+      return reply.status(401).send({ error: 'no_auth_configured' });
     }
 
     const submissionId = metadata['submission-id'] ?? metadata['submissionId'];

--- a/apps/api/src/webhooks/zitadel.webhook.spec.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.spec.ts
@@ -128,6 +128,13 @@ const testEnv: Env = {
   RATE_LIMIT_KEY_PREFIX: 'colophony:rl',
   WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS: 300,
   WEBHOOK_RATE_LIMIT_MAX: 100,
+  S3_ENDPOINT: 'http://localhost:9000',
+  S3_BUCKET: 'submissions',
+  S3_QUARANTINE_BUCKET: 'quarantine',
+  S3_ACCESS_KEY: 'minioadmin',
+  S3_SECRET_KEY: 'minioadmin',
+  S3_REGION: 'us-east-1',
+  TUS_ENDPOINT: 'http://localhost:1080',
   ZITADEL_WEBHOOK_SECRET: WEBHOOK_SECRET,
 };
 

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -28,6 +28,10 @@ export const AuditActions = {
   SUBMISSION_DELETED: "SUBMISSION_DELETED",
   SUBMISSION_WITHDRAWN: "SUBMISSION_WITHDRAWN",
 
+  // File lifecycle
+  FILE_UPLOADED: "FILE_UPLOADED",
+  FILE_DELETED: "FILE_DELETED",
+
   // Authentication failures
   AUTH_TOKEN_INVALID: "AUTH_TOKEN_INVALID",
   AUTH_TOKEN_EXPIRED: "AUTH_TOKEN_EXPIRED",
@@ -42,6 +46,7 @@ export const AuditResources = {
   USER: "user",
   ORGANIZATION: "organization",
   SUBMISSION: "submission",
+  FILE: "file",
   AUTH: "auth",
 } as const;
 
@@ -95,6 +100,11 @@ export interface SubmissionAuditParams extends BaseAuditParams {
     | typeof AuditActions.SUBMISSION_WITHDRAWN;
 }
 
+export interface FileAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.FILE;
+  action: typeof AuditActions.FILE_UPLOADED | typeof AuditActions.FILE_DELETED;
+}
+
 export interface AuthAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.AUTH;
   action:
@@ -109,4 +119,5 @@ export type AuditLogParams =
   | UserAuditParams
   | OrgAuditParams
   | SubmissionAuditParams
+  | FileAuditParams
   | AuthAuditParams;


### PR DESCRIPTION
## Summary

- **File service** — CRUD operations on `submission_files`, validation (MIME types, file count/size limits), custom error classes
- **S3 client module** — thin wrapper around `@aws-sdk/client-s3` for presigned download URLs and object deletion
- **Files tRPC router** — `listBySubmission`, `getDownloadUrl` (CLEAN files only), `delete` (owner + DRAFT only) with audit logging
- **tusd webhook handler** — `pre-create` (auth validation, submission ownership, limits) and `post-finish` (idempotent file record creation via `storageKey` check) at `/webhooks/tusd`
- **Audit types** — `FILE_UPLOADED`, `FILE_DELETED` actions + `FILE` resource + `FileAuditParams`
- **Env config** — S3/MinIO env vars with local dev defaults

### Security hardening (code review findings)
- Resolve Zitadel `sub` → local user UUID before `withRls()` (matches auth hook pattern)
- Submission ownership check in pre-create (prevents cross-user uploads within same org)
- Post-finish fails closed on auth failure (prevents forged webhook payloads)

## Test plan

- [x] `pnpm type-check` — clean across all packages
- [x] `pnpm test` — 207 API tests pass (26 new: 15 router + 13 webhook)
- [x] `pnpm lint` — no errors
- [x] branch review — all 3 P1 findings addressed in follow-up commit
- [ ] Manual: verify tusd pre-create rejects uploads for non-DRAFT submissions
- [ ] Manual: verify tusd post-finish idempotency (replay same hook payload)
- [ ] Manual: verify presigned download URL works for CLEAN files