### PR TITLE
docs: devlog + API CLAUDE.md for files router session

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -12,6 +12,7 @@
 | tRPC client types | `src/trpc/client-types.ts`        |
 | tRPC init         | `src/trpc/init.ts`                |
 | tRPC context      | `src/trpc/context.ts`             |
+| tusd webhook      | `src/webhooks/tusd.webhook.ts`    |
 | Zitadel webhook   | `src/webhooks/zitadel.webhook.ts` |
 
 ---
@@ -90,6 +91,10 @@ Stripe Checkout only (zero PCI scope). Stripe integration is planned — no hand
 ### Zitadel (built)
 
 `src/webhooks/zitadel.webhook.ts` — verifies `x-zitadel-signature` header, registered in an isolated Fastify scope with `fastify-raw-body`.
+
+### tusd (built)
+
+`src/webhooks/tusd.webhook.ts` — pre-create validates auth/submission/limits, post-finish creates file record idempotently (checks `storageKey` exists before insert). Registered in isolated Fastify scope at `/webhooks/tusd`. Auth: validates forwarded `Authorization` header via JWKS, resolves Zitadel `sub` → local user UUID via `resolveLocalUserId()`. Fails closed when auth cannot be verified.
 
 ### Stripe (planned)
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,41 @@ Newest entries first.
 
 ---
 
+## 2026-02-15 — File Service, tRPC Router & tusd Webhook Handler
+
+### Done
+
+- **PR #63** — File upload/download/delete infrastructure (17 files, ~1700 lines)
+- Created `file.service.ts` with 10 methods: `listBySubmission`, `getById`, `getByStorageKey`, `create`, `delete`, `countBySubmission`, `totalSizeBySubmission`, `validateMimeType`, `validateFileSize`, `validateLimits`
+- Created `s3.ts` thin S3 client wrapper: `createS3Client`, `getPresignedDownloadUrl`, `deleteS3Object`
+- Created `files.ts` tRPC router with 3 procedures: `listBySubmission` (query, owner/editor/admin), `getDownloadUrl` (query, CLEAN only), `delete` (mutation, owner + DRAFT only)
+- Created `tusd.webhook.ts` handler at `/webhooks/tusd` with `pre-create` (auth, validation, ownership, limits) and `post-finish` (idempotent record creation, audit) hooks
+- Extended `packages/types/src/audit.ts` with `FILE_UPLOADED`, `FILE_DELETED` actions and `FILE` resource
+- Added S3/MinIO env vars to `env.ts` (`S3_ENDPOINT`, `S3_BUCKET`, `S3_QUARANTINE_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_REGION`, `TUS_ENDPOINT`)
+- Wired `filesRouter` into `appRouter` (replaced empty stub) and registered tusd webhook scope in `main.ts`
+- 28 new unit tests (15 router + 13 webhook), all 207 tests passing
+- Addressed Codex branch review — all 3 P1 security findings fixed:
+  1. Zitadel `sub` → local user UUID resolution via `resolveLocalUserId()` (same pattern as auth hook)
+  2. Submission ownership check in pre-create (`submitterId !== userId` → reject)
+  3. Post-finish fails closed when auth missing/invalid (returns 401, not undefined userId)
+
+### Decisions
+
+- **`resolveLocalUserId()` uses `db.query.users`** (no RLS) — same pattern as auth hook; user lookup is cross-tenant by design
+- **tusd webhook at `/webhooks/tusd`** (not `/hooks/tusd`) — matches auth skip prefix `PUBLIC_PREFIXES` in auth hook
+- **Lazy S3 client in router** — avoids module-load side effects in unit tests
+- **Post-finish fail closed** — Codex caught that undefined auth should not proceed to write path; any auth failure returns 401
+- **Idempotency via `getByStorageKey()`** — tusd upload ID embedded in S3 key; duplicate post-finish calls are no-ops
+
+### Next
+
+- ClamAV BullMQ processor (virus scanning pipeline)
+- Frontend tus-js-client integration
+- Submission periods CRUD
+- Frontend page rewrites (replace placeholders with real tRPC calls)
+
+---
+
 ## 2026-02-15 — Submission Service + tRPC Router
 
 ### Done


### PR DESCRIPTION
## Summary
- Adds devlog entry for the 2026-02-15 files router session (PR #63)
- Updates API CLAUDE.md: adds tusd webhook to Key Paths table and Webhook Idempotency section

Docs-only follow-up to PR #63 (accidentally merged before end-session docs).