### PR TITLE
feat(web): tus-js-client upload hook and FileUpload component

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,8 @@ CORS_ORIGIN=http://localhost:3000
 # API URL (for frontend to call)
 NEXT_PUBLIC_API_URL=http://localhost:4000
 API_URL=http://localhost:4000
+# tusd endpoint for resumable uploads (frontend)
+NEXT_PUBLIC_TUS_URL=http://localhost:1080/files/
 
 # =============================================================================
 # RATE LIMITING

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -15,6 +15,8 @@ FROM deps AS builder
 RUN apk add --no-cache openssl
 ARG NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_TUS_URL
+ENV NEXT_PUBLIC_TUS_URL=$NEXT_PUBLIC_TUS_URL
 COPY packages/ packages/
 COPY apps/web/ apps/web/
 # Prisma generate needed because @colophony/types may depend on Prisma types

--- a/apps/web/src/components/submissions/file-upload.tsx
+++ b/apps/web/src/components/submissions/file-upload.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import { trpc } from "@/lib/trpc";
+import { useFileUpload, type UploadingFile } from "@/hooks/use-file-upload";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import {
+  Upload,
+  File,
+  X,
+  CheckCircle,
+  AlertCircle,
+  Clock,
+  Loader2,
+} from "lucide-react";
+import {
+  MAX_FILE_SIZE,
+  MAX_FILES_PER_SUBMISSION,
+  ALLOWED_MIME_TYPES,
+  type ScanStatus,
+} from "@colophony/types";
+
+interface FileUploadProps {
+  submissionId: string;
+  disabled?: boolean;
+}
+
+const scanStatusConfig: Record<
+  ScanStatus,
+  {
+    label: string;
+    icon: React.ComponentType<{ className?: string }>;
+    className: string;
+  }
+> = {
+  PENDING: {
+    label: "Pending scan",
+    icon: Clock,
+    className: "bg-gray-100 text-gray-800",
+  },
+  SCANNING: {
+    label: "Scanning...",
+    icon: Loader2,
+    className: "bg-blue-100 text-blue-800",
+  },
+  CLEAN: {
+    label: "Clean",
+    icon: CheckCircle,
+    className: "bg-green-100 text-green-800",
+  },
+  INFECTED: {
+    label: "Infected",
+    icon: AlertCircle,
+    className: "bg-red-100 text-red-800",
+  },
+  FAILED: {
+    label: "Scan failed",
+    icon: AlertCircle,
+    className: "bg-orange-100 text-orange-800",
+  },
+};
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function ScanStatusBadge({ status }: { status: ScanStatus }) {
+  const config = scanStatusConfig[status];
+  const Icon = config.icon;
+
+  return (
+    <Badge variant="secondary" className={cn("gap-1", config.className)}>
+      <Icon
+        className={cn("h-3 w-3", status === "SCANNING" && "animate-spin")}
+      />
+      {config.label}
+    </Badge>
+  );
+}
+
+function UploadingFileItem({
+  upload,
+  onCancel,
+  onRemove,
+}: {
+  upload: UploadingFile;
+  onCancel: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 p-3 border rounded-lg">
+      <File className="h-8 w-8 text-muted-foreground flex-shrink-0" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium truncate">{upload.file.name}</p>
+        <p className="text-xs text-muted-foreground">
+          {formatFileSize(upload.file.size)}
+        </p>
+        {upload.status === "uploading" && (
+          <Progress value={upload.progress} className="h-1 mt-2" />
+        )}
+        {upload.status === "error" && (
+          <p className="text-xs text-destructive mt-1">{upload.error}</p>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        {upload.status === "uploading" && (
+          <span className="text-xs text-muted-foreground">
+            {upload.progress}%
+          </span>
+        )}
+        {upload.status === "processing" && upload.scanStatus && (
+          <ScanStatusBadge status={upload.scanStatus} />
+        )}
+        {upload.status === "complete" && (
+          <CheckCircle className="h-5 w-5 text-green-600" />
+        )}
+        {upload.status === "error" && (
+          <AlertCircle className="h-5 w-5 text-destructive" />
+        )}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={upload.status === "uploading" ? onCancel : onRemove}
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ExistingFileItem({
+  file,
+  onDelete,
+  canDelete,
+}: {
+  file: {
+    id: string;
+    filename: string;
+    size: number;
+    scanStatus: ScanStatus;
+  };
+  onDelete: () => void;
+  canDelete: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-3 p-3 border rounded-lg">
+      <File className="h-8 w-8 text-muted-foreground flex-shrink-0" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium truncate">{file.filename}</p>
+        <p className="text-xs text-muted-foreground">
+          {formatFileSize(file.size)}
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <ScanStatusBadge status={file.scanStatus} />
+        {canDelete && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={onDelete}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function FileUpload({ submissionId, disabled }: FileUploadProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Poll while any file is still being scanned
+  const { data: existingFiles, isLoading } =
+    trpc.files.listBySubmission.useQuery(
+      { submissionId },
+      {
+        refetchInterval: (data) => {
+          const files = data as Array<{ scanStatus: ScanStatus }> | undefined;
+          const hasPending = files?.some(
+            (f) => f.scanStatus === "PENDING" || f.scanStatus === "SCANNING",
+          );
+          return hasPending ? 3000 : false;
+        },
+      },
+    );
+
+  const deleteMutation = trpc.files.delete.useMutation();
+  const utils = trpc.useUtils();
+
+  const { uploads, uploadFiles, removeUpload, cancelUpload } = useFileUpload({
+    submissionId,
+    onUploadComplete: () => {
+      utils.files.listBySubmission.invalidate({ submissionId });
+    },
+  });
+
+  const handleFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files;
+      if (files && files.length > 0) {
+        uploadFiles(files);
+      }
+      // Reset input
+      if (inputRef.current) {
+        inputRef.current.value = "";
+      }
+    },
+    [uploadFiles],
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const files = e.dataTransfer.files;
+      if (files && files.length > 0) {
+        uploadFiles(files);
+      }
+    },
+    [uploadFiles],
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+  }, []);
+
+  const handleDeleteFile = useCallback(
+    async (fileId: string) => {
+      try {
+        await deleteMutation.mutateAsync({ fileId });
+        utils.files.listBySubmission.invalidate({ submissionId });
+      } catch (error) {
+        console.error("Failed to delete file:", error);
+      }
+    },
+    [deleteMutation, utils.files.listBySubmission, submissionId],
+  );
+
+  const totalFiles = (existingFiles?.length ?? 0) + uploads.length;
+  const canUpload = !disabled && totalFiles < MAX_FILES_PER_SUBMISSION;
+
+  const acceptedTypes = ALLOWED_MIME_TYPES.join(",");
+
+  return (
+    <div className="space-y-4">
+      {/* Drop zone */}
+      <div
+        className={cn(
+          "border-2 border-dashed rounded-lg p-8 text-center transition-colors",
+          canUpload
+            ? "border-muted-foreground/25 hover:border-primary/50 cursor-pointer"
+            : "border-muted opacity-50 cursor-not-allowed",
+        )}
+        onDrop={canUpload ? handleDrop : undefined}
+        onDragOver={canUpload ? handleDragOver : undefined}
+        onClick={() => canUpload && inputRef.current?.click()}
+      >
+        <Upload className="mx-auto h-12 w-12 text-muted-foreground" />
+        <p className="mt-2 text-sm font-medium">
+          {canUpload
+            ? "Drop files here or click to upload"
+            : "Upload limit reached"}
+        </p>
+        <p className="text-xs text-muted-foreground mt-1">
+          Max {formatFileSize(MAX_FILE_SIZE)} per file.{" "}
+          {MAX_FILES_PER_SUBMISSION} files max.
+        </p>
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          accept={acceptedTypes}
+          onChange={handleFileSelect}
+          className="hidden"
+          disabled={!canUpload}
+        />
+      </div>
+
+      {/* Uploading files */}
+      {uploads.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Uploading</p>
+          {uploads.map((upload) => (
+            <UploadingFileItem
+              key={upload.id}
+              upload={upload}
+              onCancel={() => cancelUpload(upload.id)}
+              onRemove={() => removeUpload(upload.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Existing files */}
+      {!isLoading && existingFiles && existingFiles.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Uploaded files</p>
+          {existingFiles.map((file) => (
+            <ExistingFileItem
+              key={file.id}
+              file={file}
+              onDelete={() => handleDeleteFile(file.id)}
+              canDelete={!disabled}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Warning about pending scans */}
+      {existingFiles?.some(
+        (f) => f.scanStatus === "PENDING" || f.scanStatus === "SCANNING",
+      ) && (
+        <p className="text-sm text-yellow-600 dark:text-yellow-400">
+          Some files are still being scanned. You can submit after all scans
+          complete.
+        </p>
+      )}
+
+      {/* Warning about infected files */}
+      {existingFiles?.some((f) => f.scanStatus === "INFECTED") && (
+        <p className="text-sm text-destructive">
+          Some files were flagged as infected. Please remove them before
+          submitting.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/__tests__/use-file-upload.spec.ts
+++ b/apps/web/src/hooks/__tests__/use-file-upload.spec.ts
@@ -1,0 +1,250 @@
+import { renderHook, act } from "@testing-library/react";
+import { useFileUpload } from "../use-file-upload";
+
+// Track tus Upload instances
+let tusOnProgress:
+  | ((bytesUploaded: number, bytesTotal: number) => void)
+  | undefined;
+let tusOnSuccess: (() => void) | undefined;
+let tusOnError: ((error: Error) => void) | undefined;
+const mockTusStart = jest.fn();
+const mockTusAbort = jest.fn();
+
+jest.mock("tus-js-client", () => ({
+  Upload: jest.fn().mockImplementation(
+    (
+      _file: File,
+      options: {
+        onProgress?: (bytesUploaded: number, bytesTotal: number) => void;
+        onSuccess?: () => void;
+        onError?: (error: Error) => void;
+      },
+    ) => {
+      tusOnProgress = options.onProgress;
+      tusOnSuccess = options.onSuccess;
+      tusOnError = options.onError;
+      return { start: mockTusStart, abort: mockTusAbort };
+    },
+  ),
+}));
+
+// Mock tRPC
+const trpcMock = {
+  invalidateFiles: jest.fn(),
+};
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    useUtils: () => ({
+      files: {
+        listBySubmission: {
+          invalidate: (...args: unknown[]) => trpcMock.invalidateFiles(...args),
+        },
+      },
+    }),
+  },
+  getAccessToken: jest.fn(() => Promise.resolve("test-token")),
+  getCurrentOrgId: jest.fn(() => "org-123"),
+  getTusEndpoint: jest.fn(() => "http://localhost:1080/files/"),
+}));
+
+const mockInvalidateFiles = trpcMock.invalidateFiles;
+
+describe("useFileUpload", () => {
+  const defaultOptions = {
+    submissionId: "sub-123",
+    onUploadComplete: jest.fn(),
+    onError: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tusOnProgress = undefined;
+    tusOnSuccess = undefined;
+    tusOnError = undefined;
+  });
+
+  it("should start with no uploads", () => {
+    const { result } = renderHook(() => useFileUpload(defaultOptions));
+    expect(result.current.uploads).toEqual([]);
+    expect(result.current.isUploading).toBe(false);
+  });
+
+  it("should add file to uploads and start tus upload", async () => {
+    const { result } = renderHook(() => useFileUpload(defaultOptions));
+    const file = new File(["content"], "test.pdf", {
+      type: "application/pdf",
+    });
+
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    expect(mockTusStart).toHaveBeenCalled();
+    expect(result.current.uploads.length).toBe(1);
+    expect(result.current.uploads[0].status).toBe("uploading");
+    expect(result.current.isUploading).toBe(true);
+  });
+
+  it("should track upload progress", async () => {
+    const { result } = renderHook(() => useFileUpload(defaultOptions));
+    const file = new File(["content"], "test.pdf", {
+      type: "application/pdf",
+    });
+
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    act(() => {
+      tusOnProgress?.(50, 100);
+    });
+
+    expect(result.current.uploads[0].progress).toBe(50);
+  });
+
+  it("should handle upload success", async () => {
+    const { result } = renderHook(() => useFileUpload(defaultOptions));
+    const file = new File(["content"], "test.pdf", {
+      type: "application/pdf",
+    });
+
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    act(() => {
+      tusOnSuccess?.();
+    });
+
+    expect(result.current.uploads[0].status).toBe("processing");
+    expect(result.current.uploads[0].scanStatus).toBe("PENDING");
+    expect(mockInvalidateFiles).toHaveBeenCalledWith({
+      submissionId: "sub-123",
+    });
+    expect(defaultOptions.onUploadComplete).toHaveBeenCalled();
+  });
+
+  it("should handle upload error", async () => {
+    const { result } = renderHook(() => useFileUpload(defaultOptions));
+    const file = new File(["content"], "test.pdf", {
+      type: "application/pdf",
+    });
+
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    act(() => {
+      tusOnError?.(new Error("Network failure"));
+    });
+
+    expect(result.current.uploads[0].status).toBe("error");
+    expect(result.current.uploads[0].error).toBe("Network failure");
+    expect(defaultOptions.onError).toHaveBeenCalledWith("Network failure");
+  });
+
+  it("should reject disallowed MIME types client-side", async () => {
+    const { result } = renderHook(() => useFileUpload(defaultOptions));
+    const file = new File(["content"], "test.exe", {
+      type: "application/x-msdownload",
+    });
+
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    expect(mockTusStart).not.toHaveBeenCalled();
+    expect(result.current.uploads[0].status).toBe("error");
+    expect(result.current.uploads[0].error).toContain("not allowed");
+    expect(defaultOptions.onError).toHaveBeenCalled();
+  });
+
+  it("should reject files exceeding max size client-side", async () => {
+    const { result } = renderHook(() => useFileUpload(defaultOptions));
+    // Create a file object that reports a large size
+    const file = new File(["x"], "large.pdf", { type: "application/pdf" });
+    Object.defineProperty(file, "size", { value: 100 * 1024 * 1024 });
+
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    expect(mockTusStart).not.toHaveBeenCalled();
+    expect(result.current.uploads[0].status).toBe("error");
+    expect(result.current.uploads[0].error).toContain("maximum size");
+    expect(defaultOptions.onError).toHaveBeenCalled();
+  });
+
+  it("should cancel upload and call abort", async () => {
+    const { result } = renderHook(() => useFileUpload(defaultOptions));
+    const file = new File(["content"], "test.pdf", {
+      type: "application/pdf",
+    });
+
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    const uploadId = result.current.uploads[0].id;
+
+    act(() => {
+      result.current.cancelUpload(uploadId);
+    });
+
+    expect(mockTusAbort).toHaveBeenCalledWith(true);
+    expect(result.current.uploads).toEqual([]);
+  });
+
+  it("should remove upload from list", async () => {
+    const { result } = renderHook(() => useFileUpload(defaultOptions));
+    const file = new File(["content"], "test.pdf", {
+      type: "application/pdf",
+    });
+
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    const uploadId = result.current.uploads[0].id;
+
+    act(() => {
+      result.current.removeUpload(uploadId);
+    });
+
+    expect(result.current.uploads).toEqual([]);
+  });
+
+  it("should report isUploading correctly", async () => {
+    const { result } = renderHook(() => useFileUpload(defaultOptions));
+    const file = new File(["content"], "test.pdf", {
+      type: "application/pdf",
+    });
+
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    expect(result.current.isUploading).toBe(true);
+
+    act(() => {
+      tusOnSuccess?.();
+    });
+
+    expect(result.current.isUploading).toBe(false);
+  });
+
+  it("should upload multiple files sequentially", async () => {
+    const { result } = renderHook(() => useFileUpload(defaultOptions));
+    const file1 = new File(["a"], "a.pdf", { type: "application/pdf" });
+    const file2 = new File(["b"], "b.pdf", { type: "application/pdf" });
+
+    await act(async () => {
+      await result.current.uploadFiles([file1, file2]);
+    });
+
+    // Both files should be in the uploads list
+    expect(result.current.uploads.length).toBe(2);
+    expect(mockTusStart).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/hooks/use-file-upload.ts
+++ b/apps/web/src/hooks/use-file-upload.ts
@@ -1,0 +1,232 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import * as tus from "tus-js-client";
+import {
+  trpc,
+  getAccessToken,
+  getCurrentOrgId,
+  getTusEndpoint,
+} from "@/lib/trpc";
+import {
+  MAX_FILE_SIZE,
+  isAllowedMimeType,
+  type ScanStatus,
+} from "@colophony/types";
+
+export interface UploadingFile {
+  id: string;
+  file: File;
+  progress: number;
+  status: "pending" | "uploading" | "processing" | "complete" | "error";
+  error?: string;
+  fileId?: string;
+  scanStatus?: ScanStatus;
+}
+
+interface UseFileUploadOptions {
+  submissionId: string;
+  onUploadComplete?: (uploadId: string) => void;
+  onError?: (error: string) => void;
+}
+
+function mapTusError(error: tus.DetailedError | Error): string {
+  if ("originalResponse" in error) {
+    const detailed = error as tus.DetailedError;
+    const status = detailed.originalResponse?.getStatus();
+    if (status === 413) return "File is too large";
+    if (status === 415) return "File type not allowed";
+    if (status === 403) return "Not authorized to upload";
+    if (status === 429) return "Too many uploads. Please try again later";
+  }
+  return error.message || "Upload failed";
+}
+
+export function useFileUpload({
+  submissionId,
+  onUploadComplete,
+  onError,
+}: UseFileUploadOptions) {
+  const [uploads, setUploads] = useState<Map<string, UploadingFile>>(new Map());
+  const tusInstances = useRef<Map<string, tus.Upload>>(new Map());
+  const utils = trpc.useUtils();
+
+  const updateUpload = useCallback(
+    (id: string, update: Partial<UploadingFile>) => {
+      setUploads((prev) => {
+        const newMap = new Map(prev);
+        const existing = newMap.get(id);
+        if (existing) {
+          newMap.set(id, { ...existing, ...update });
+        }
+        return newMap;
+      });
+    },
+    [],
+  );
+
+  const removeUpload = useCallback((id: string) => {
+    tusInstances.current.delete(id);
+    setUploads((prev) => {
+      const newMap = new Map(prev);
+      newMap.delete(id);
+      return newMap;
+    });
+  }, []);
+
+  const cancelUpload = useCallback(
+    (id: string) => {
+      const instance = tusInstances.current.get(id);
+      if (instance) {
+        instance.abort(true);
+      }
+      removeUpload(id);
+    },
+    [removeUpload],
+  );
+
+  const uploadFile = useCallback(
+    async (file: File) => {
+      const uploadId = crypto.randomUUID();
+
+      // Client-side pre-validation
+      if (!isAllowedMimeType(file.type || "application/octet-stream")) {
+        const errorMsg = `File type "${file.type || "unknown"}" is not allowed`;
+        setUploads((prev) => {
+          const newMap = new Map(prev);
+          newMap.set(uploadId, {
+            id: uploadId,
+            file,
+            progress: 0,
+            status: "error",
+            error: errorMsg,
+          });
+          return newMap;
+        });
+        onError?.(errorMsg);
+        return;
+      }
+
+      if (file.size > MAX_FILE_SIZE) {
+        const errorMsg = `File exceeds maximum size of ${MAX_FILE_SIZE / (1024 * 1024)}MB`;
+        setUploads((prev) => {
+          const newMap = new Map(prev);
+          newMap.set(uploadId, {
+            id: uploadId,
+            file,
+            progress: 0,
+            status: "error",
+            error: errorMsg,
+          });
+          return newMap;
+        });
+        onError?.(errorMsg);
+        return;
+      }
+
+      // Add to uploads map
+      setUploads((prev) => {
+        const newMap = new Map(prev);
+        newMap.set(uploadId, {
+          id: uploadId,
+          file,
+          progress: 0,
+          status: "uploading",
+        });
+        return newMap;
+      });
+
+      try {
+        const token = await getAccessToken();
+        const orgId = getCurrentOrgId();
+
+        const headers: Record<string, string> = {};
+        if (token) {
+          headers["Authorization"] = `Bearer ${token}`;
+        }
+        if (orgId) {
+          headers["X-Organization-Id"] = orgId;
+        }
+
+        // Create tus upload — uploads directly to tusd sidecar
+        const upload = new tus.Upload(file, {
+          endpoint: getTusEndpoint(),
+          retryDelays: [0, 1000, 3000, 5000],
+          chunkSize: 5 * 1024 * 1024, // 5MB chunks
+          metadata: {
+            filename: file.name,
+            filetype: file.type || "application/octet-stream",
+            "submission-id": submissionId,
+          },
+          headers,
+          onProgress: (bytesUploaded, bytesTotal) => {
+            const progress = Math.round((bytesUploaded / bytesTotal) * 100);
+            updateUpload(uploadId, { progress });
+          },
+          onSuccess: () => {
+            updateUpload(uploadId, {
+              progress: 100,
+              status: "processing",
+              scanStatus: "PENDING",
+            });
+            tusInstances.current.delete(uploadId);
+            // Invalidate file queries to pick up the new file
+            utils.files.listBySubmission.invalidate({ submissionId });
+            onUploadComplete?.(uploadId);
+          },
+          onError: (error) => {
+            const message = mapTusError(error);
+            updateUpload(uploadId, {
+              status: "error",
+              error: message,
+            });
+            tusInstances.current.delete(uploadId);
+            onError?.(message);
+          },
+        });
+
+        // Store instance for cancel support
+        tusInstances.current.set(uploadId, upload);
+
+        // Start the upload
+        upload.start();
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Failed to start upload";
+        updateUpload(uploadId, {
+          status: "error",
+          error: message,
+        });
+        onError?.(message);
+      }
+    },
+    [
+      submissionId,
+      updateUpload,
+      utils.files.listBySubmission,
+      onUploadComplete,
+      onError,
+    ],
+  );
+
+  const uploadFiles = useCallback(
+    async (files: FileList | File[]) => {
+      const fileArray = Array.from(files);
+      for (const file of fileArray) {
+        await uploadFile(file);
+      }
+    },
+    [uploadFile],
+  );
+
+  return {
+    uploads: Array.from(uploads.values()),
+    uploadFile,
+    uploadFiles,
+    removeUpload,
+    cancelUpload,
+    isUploading: Array.from(uploads.values()).some(
+      (u) => u.status === "uploading" || u.status === "pending",
+    ),
+  };
+}

--- a/apps/web/src/lib/trpc.ts
+++ b/apps/web/src/lib/trpc.ts
@@ -59,6 +59,13 @@ export async function getAccessToken(): Promise<string | null> {
 }
 
 /**
+ * Get the tusd upload endpoint URL
+ */
+export function getTusEndpoint(): string {
+  return process.env.NEXT_PUBLIC_TUS_URL || "http://localhost:1080/files/";
+}
+
+/**
  * tRPC client configuration
  */
 export function getTrpcClient() {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -212,7 +212,7 @@ services:
       - -s3-object-prefix
       - uploads/
       - -hooks-http
-      - http://api:4000/hooks/tusd
+      - http://api:4000/webhooks/tusd
       - -hooks-http-forward-headers
       - Authorization,X-Organization-Id
       - -behind-proxy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -80,6 +80,7 @@ services:
       dockerfile: apps/web/Dockerfile
       args:
         NEXT_PUBLIC_API_URL: http://${DOMAIN:-localhost}/trpc
+        NEXT_PUBLIC_TUS_URL: http://${DOMAIN:-localhost}/upload/files/
     container_name: colophony-web
     expose:
       - "3000"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -208,7 +208,7 @@ services:
       - -s3-object-prefix
       - uploads/
       - -hooks-http
-      - http://api:4000/hooks/tusd
+      - http://api:4000/webhooks/tusd
       - -hooks-http-forward-headers
       - Authorization,X-Organization-Id
       - -behind-proxy

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -81,6 +81,7 @@ services:
       dockerfile: apps/web/Dockerfile
       args:
         NEXT_PUBLIC_API_URL: http://${DOMAIN:-localhost}/trpc
+        NEXT_PUBLIC_TUS_URL: http://${DOMAIN:-localhost}/upload/files/
     container_name: colophony-staging-web
     expose:
       - "3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
       - -s3-object-prefix
       - uploads/
       - -hooks-http
-      - http://host.docker.internal:4000/hooks/tusd
+      - http://host.docker.internal:4000/webhooks/tusd
       - -hooks-http-forward-headers
       - Authorization,X-Organization-Id
       - -behind-proxy

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -40,7 +40,7 @@ Newest entries first.
 - Frontend tus-js-client integration
 - Submission periods CRUD
 - Frontend page rewrites (replace placeholders with real tRPC calls)
-- Add ClamAV to Docker Compose (`clamav/clamav` image with `--profile full`)
+- ~~Add ClamAV to Docker Compose~~ (already done in PR #65)
 
 ---
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,34 @@ Newest entries first.
 
 ---
 
+## 2026-02-15 — Frontend tus-js-client Integration
+
+### Done
+
+- **PR #66** — `useFileUpload` hook, `FileUpload` component, webhook path fix, TUS URL config
+- Created `apps/web/src/hooks/use-file-upload.ts`: direct-to-tusd uploads (no API initiation step), client-side MIME/size validation, tus instance tracking for cancel/abort, error mapping for tusd HTTP status codes
+- Created `apps/web/src/components/submissions/file-upload.tsx`: drag-and-drop zone, progress bars, scan status badges, polls `files.listBySubmission` with `refetchInterval: 3000` while PENDING/SCANNING
+- Fixed tusd webhook path mismatch in all 3 Docker Compose files (`/hooks/tusd` → `/webhooks/tusd`) — would have caused all uploads to fail
+- Added `NEXT_PUBLIC_TUS_URL` env var with `getTusEndpoint()` in `trpc.ts`, Dockerfile build arg, `.env.example` entry
+- 11 unit tests for `useFileUpload` hook (all passing), type-check clean, lint clean
+- Addressed Codex branch review — 1 finding fixed:
+  1. P1: Added `NEXT_PUBLIC_TUS_URL` build arg to staging/prod compose (without it, deployed builds bake in localhost default)
+
+### Decisions
+
+- **Direct-to-tusd uploads** — No API initiation step; tusd pre-create webhook handles auth, org, submission ownership, MIME type, size, and file count validation
+- **Scan status polling** — `refetchInterval: 3000` on `files.listBySubmission` while any file is PENDING/SCANNING, stops polling when all files resolve
+- **Client-side pre-validation** — Check MIME type and file size before starting tus upload to avoid unnecessary network round-trips
+
+### Next
+
+- Submission form/page rewrites to integrate FileUpload component
+- Submission periods CRUD
+- Frontend page rewrites (replace placeholders with real tRPC calls)
+- E2E tests for upload flow (needs tusd + MinIO in CI)
+
+---
+
 ## 2026-02-15 — ClamAV Virus Scanning Processor (BullMQ)
 
 ### Done


### PR DESCRIPTION
## Summary

- Add `useFileUpload` hook for resumable file uploads directly to tusd sidecar (no API initiation step)
- Add `FileUpload` component with drag-and-drop, progress bars, and scan status polling
- Fix tusd webhook path mismatch in all Docker Compose files (`/hooks/tusd` → `/webhooks/tusd`)
- Add `NEXT_PUBLIC_TUS_URL` env var with Dockerfile build arg for per-environment tusd endpoint

## Details

**Hook (`apps/web/src/hooks/use-file-upload.ts`):** Direct-to-tusd uploads with auth headers, client-side MIME/size validation, tus instance tracking for cancel/abort, error mapping for tusd HTTP status codes.

**Component (`apps/web/src/components/submissions/file-upload.tsx`):** Polls `files.listBySubmission` with `refetchInterval: 3000` while files are PENDING/SCANNING. Drag-and-drop zone, progress bars, scan status badges, delete support.

**Bug fix:** All three compose files pointed tusd webhooks at `/hooks/tusd` but the API registers at `/webhooks/tusd`. Without this fix, tusd uploads would fail.

**code review:** Addressed finding that staging/prod compose files were missing `NEXT_PUBLIC_TUS_URL` build arg, which would bake in localhost default for deployed builds.

## Test plan

- [x] 11 unit tests for `useFileUpload` hook (all passing)
- [x] `pnpm --filter @colophony/web type-check` — clean
- [x] `pnpm --filter @colophony/web lint` — clean
- [ ] Manual test: upload file via UI with tusd + MinIO running
- [ ] E2E tests (separate effort — needs tusd + MinIO in CI)