### PR TITLE
feat(web): migrate submission pages from v1 stubs to functional components

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -72,9 +72,10 @@ Key functions in `trpc.ts`:
 
 ## Quirks
 
-| Quirk                             | Details                                                                                                      |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **TanStack Query v4 `isLoading`** | `isLoading` is `true` even when query is disabled (`enabled: false`). Check `fetchStatus !== 'idle'` instead |
+| Quirk                                  | Details                                                                                                                                                                                       |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **TanStack Query v4 `isLoading`**      | `isLoading` is `true` even when query is disabled (`enabled: false`). Check `fetchStatus !== 'idle'` instead                                                                                  |
+| **React 18 + Next.js 15 async params** | Next.js 15 types require `params: Promise<>` but React 18 doesn't export `use()`. Dynamic route pages must be async server components (`await params`), not `"use client"` with `use(params)` |
 
 ## Version Pins
 

--- a/apps/web/src/app/(dashboard)/submissions/[id]/edit/page.tsx
+++ b/apps/web/src/app/(dashboard)/submissions/[id]/edit/page.tsx
@@ -1,10 +1,15 @@
-export default function EditSubmissionPage() {
+import { SubmissionForm } from "@/components/submissions/submission-form";
+
+export default async function EditSubmissionPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold">Edit Submission</h1>
-      <p className="text-muted-foreground mt-2">
-        Coming soon — v2 submission editor under development.
-      </p>
+      <SubmissionForm mode="edit" submissionId={id} />
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/submissions/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/submissions/[id]/page.tsx
@@ -1,10 +1,15 @@
-export default function SubmissionDetailPage() {
+import { SubmissionDetail } from "@/components/submissions/submission-detail";
+
+export default async function SubmissionDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold">Submission Detail</h1>
-      <p className="text-muted-foreground mt-2">
-        Coming soon — v2 submission detail view under development.
-      </p>
+      <SubmissionDetail submissionId={id} />
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/submissions/new/page.tsx
+++ b/apps/web/src/app/(dashboard)/submissions/new/page.tsx
@@ -1,10 +1,11 @@
+"use client";
+
+import { SubmissionForm } from "@/components/submissions/submission-form";
+
 export default function NewSubmissionPage() {
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold">New Submission</h1>
-      <p className="text-muted-foreground mt-2">
-        Coming soon — v2 submission form under development.
-      </p>
+      <SubmissionForm mode="create" />
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/submissions/page.tsx
+++ b/apps/web/src/app/(dashboard)/submissions/page.tsx
@@ -1,10 +1,11 @@
+"use client";
+
+import { SubmissionList } from "@/components/submissions/submission-list";
+
 export default function SubmissionsPage() {
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold">Submissions</h1>
-      <p className="text-muted-foreground mt-2">
-        Coming soon — v2 submission management under development.
-      </p>
+      <SubmissionList />
     </div>
   );
 }

--- a/apps/web/src/components/submissions/status-badge.tsx
+++ b/apps/web/src/components/submissions/status-badge.tsx
@@ -1,0 +1,56 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { SubmissionStatus } from "@colophony/types";
+
+const statusConfig: Record<
+  SubmissionStatus,
+  { label: string; className: string }
+> = {
+  DRAFT: {
+    label: "Draft",
+    className: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+  },
+  SUBMITTED: {
+    label: "Submitted",
+    className: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+  },
+  UNDER_REVIEW: {
+    label: "Under Review",
+    className:
+      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+  },
+  ACCEPTED: {
+    label: "Accepted",
+    className:
+      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  },
+  REJECTED: {
+    label: "Rejected",
+    className: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+  },
+  HOLD: {
+    label: "On Hold",
+    className:
+      "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
+  },
+  WITHDRAWN: {
+    label: "Withdrawn",
+    className:
+      "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+  },
+};
+
+interface StatusBadgeProps {
+  status: SubmissionStatus;
+  className?: string;
+}
+
+export function StatusBadge({ status, className }: StatusBadgeProps) {
+  const config = statusConfig[status];
+
+  return (
+    <Badge variant="secondary" className={cn(config.className, className)}>
+      {config.label}
+    </Badge>
+  );
+}

--- a/apps/web/src/components/submissions/status-transition.tsx
+++ b/apps/web/src/components/submissions/status-transition.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState } from "react";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+import {
+  EDITOR_ALLOWED_TRANSITIONS,
+  type SubmissionStatus,
+} from "@colophony/types";
+
+interface StatusTransitionProps {
+  submissionId: string;
+  currentStatus: SubmissionStatus;
+  onStatusChange?: () => void;
+}
+
+const statusLabels: Record<SubmissionStatus, string> = {
+  DRAFT: "Draft",
+  SUBMITTED: "Submitted",
+  UNDER_REVIEW: "Under Review",
+  ACCEPTED: "Accept",
+  REJECTED: "Reject",
+  HOLD: "Put on Hold",
+  WITHDRAWN: "Withdrawn",
+};
+
+const statusButtonVariants: Record<
+  SubmissionStatus,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  DRAFT: "outline",
+  SUBMITTED: "outline",
+  UNDER_REVIEW: "secondary",
+  ACCEPTED: "default",
+  REJECTED: "destructive",
+  HOLD: "outline",
+  WITHDRAWN: "outline",
+};
+
+export function StatusTransition({
+  submissionId,
+  currentStatus,
+  onStatusChange,
+}: StatusTransitionProps) {
+  const [selectedStatus, setSelectedStatus] = useState<SubmissionStatus | null>(
+    null,
+  );
+  const [comment, setComment] = useState("");
+  const utils = trpc.useUtils();
+
+  const updateStatusMutation = trpc.submissions.updateStatus.useMutation({
+    onSuccess: () => {
+      toast.success(`Status updated to ${statusLabels[selectedStatus!]}`);
+      utils.submissions.getById.invalidate({ id: submissionId });
+      utils.submissions.getHistory.invalidate({ submissionId });
+      utils.submissions.list.invalidate();
+      setSelectedStatus(null);
+      setComment("");
+      onStatusChange?.();
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const allowedTransitions = EDITOR_ALLOWED_TRANSITIONS[currentStatus];
+
+  if (allowedTransitions.length === 0) {
+    return null;
+  }
+
+  const handleConfirm = () => {
+    if (!selectedStatus) return;
+
+    // v2: flattened input — { id, status, comment } instead of { id, data: { status, comment } }
+    updateStatusMutation.mutate({
+      id: submissionId,
+      status: selectedStatus,
+      comment: comment || undefined,
+    });
+  };
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2">
+        {allowedTransitions.map((status) => (
+          <Button
+            key={status}
+            variant={statusButtonVariants[status]}
+            onClick={() => setSelectedStatus(status)}
+          >
+            {statusLabels[status]}
+          </Button>
+        ))}
+      </div>
+
+      <Dialog
+        open={selectedStatus !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedStatus(null);
+            setComment("");
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {selectedStatus === "REJECTED"
+                ? "Reject Submission"
+                : selectedStatus === "ACCEPTED"
+                  ? "Accept Submission"
+                  : `Change Status to ${selectedStatus ? statusLabels[selectedStatus] : ""}`}
+            </DialogTitle>
+            <DialogDescription>
+              {selectedStatus === "REJECTED"
+                ? "This will reject the submission. Consider providing feedback."
+                : selectedStatus === "ACCEPTED"
+                  ? "This will accept the submission for publication."
+                  : "Add an optional comment for this status change."}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="comment">Comment (optional)</Label>
+              <Textarea
+                id="comment"
+                placeholder={
+                  selectedStatus === "REJECTED"
+                    ? "Provide feedback for the submitter..."
+                    : "Add a note about this status change..."
+                }
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setSelectedStatus(null);
+                setComment("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant={
+                selectedStatus === "REJECTED" ? "destructive" : "default"
+              }
+              onClick={handleConfirm}
+              disabled={updateStatusMutation.isPending}
+            >
+              {updateStatusMutation.isPending
+                ? "Updating..."
+                : `Confirm ${selectedStatus ? statusLabels[selectedStatus] : ""}`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/submissions/submission-card.tsx
+++ b/apps/web/src/components/submissions/submission-card.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { formatDistanceToNow } from "date-fns";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { StatusBadge } from "./status-badge";
+import type { SubmissionStatus } from "@colophony/types";
+
+interface SubmissionCardProps {
+  submission: {
+    id: string;
+    title: string | null;
+    status: SubmissionStatus;
+    createdAt: Date | string;
+    submittedAt: Date | string | null;
+  };
+}
+
+export function SubmissionCard({ submission }: SubmissionCardProps) {
+  const date = submission.submittedAt ?? submission.createdAt;
+
+  return (
+    <Link href={`/submissions/${submission.id}`}>
+      <Card className="hover:border-primary/50 transition-colors cursor-pointer">
+        <CardHeader className="pb-2">
+          <div className="flex items-start justify-between gap-2">
+            <CardTitle className="text-base line-clamp-2">
+              {submission.title ?? "Untitled"}
+            </CardTitle>
+            <StatusBadge status={submission.status} />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            {submission.submittedAt ? "Submitted" : "Created"}{" "}
+            {formatDistanceToNow(new Date(date), { addSuffix: true })}
+          </p>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -1,0 +1,432 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { formatDistanceToNow, format } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { StatusBadge } from "./status-badge";
+import { StatusTransition } from "./status-transition";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { toast } from "sonner";
+import {
+  Edit,
+  Trash2,
+  ArrowLeft,
+  File,
+  Download,
+  Clock,
+  CheckCircle,
+  AlertCircle,
+  Loader2,
+} from "lucide-react";
+import type { ScanStatus, SubmissionStatus } from "@colophony/types";
+
+interface SubmissionDetailProps {
+  submissionId: string;
+}
+
+const scanStatusIcons: Record<
+  ScanStatus,
+  React.ComponentType<{ className?: string }>
+> = {
+  PENDING: Clock,
+  SCANNING: Loader2,
+  CLEAN: CheckCircle,
+  INFECTED: AlertCircle,
+  FAILED: AlertCircle,
+};
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function SubmissionDetail({ submissionId }: SubmissionDetailProps) {
+  const router = useRouter();
+  const { isEditor, isAdmin } = useOrganization();
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showWithdrawDialog, setShowWithdrawDialog] = useState(false);
+  const utils = trpc.useUtils();
+
+  const { data: submission, isLoading } = trpc.submissions.getById.useQuery({
+    id: submissionId,
+  });
+
+  // v2: listBySubmission (renamed from getBySubmission)
+  const { data: files } = trpc.files.listBySubmission.useQuery({
+    submissionId,
+  });
+
+  const { data: history } = trpc.submissions.getHistory.useQuery({
+    submissionId,
+  });
+
+  const deleteMutation = trpc.submissions.delete.useMutation({
+    onSuccess: () => {
+      toast.success("Submission deleted");
+      router.push("/submissions");
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const withdrawMutation = trpc.submissions.withdraw.useMutation({
+    onSuccess: () => {
+      toast.success("Submission withdrawn");
+      utils.submissions.getById.invalidate({ id: submissionId });
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const handleDownload = async (fileId: string) => {
+    try {
+      const { url } = await utils.files.getDownloadUrl.fetch({ fileId });
+      window.open(url, "_blank");
+    } catch {
+      toast.error("Failed to get download link");
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (!submission) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">Submission not found</p>
+        <Link href="/submissions">
+          <Button variant="link">Back to submissions</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  const canEdit = submission.status === "DRAFT";
+  const canDelete = submission.status === "DRAFT";
+  const canWithdraw = ["SUBMITTED", "UNDER_REVIEW", "HOLD"].includes(
+    submission.status,
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="space-y-1">
+          <Link
+            href="/submissions"
+            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            Back to submissions
+          </Link>
+          <h1 className="text-2xl font-bold">{submission.title}</h1>
+          <div className="flex items-center gap-2">
+            <StatusBadge status={submission.status as SubmissionStatus} />
+            <span className="text-sm text-muted-foreground">
+              Created{" "}
+              {formatDistanceToNow(new Date(submission.createdAt), {
+                addSuffix: true,
+              })}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex gap-2">
+          {canEdit && (
+            <Link href={`/submissions/${submissionId}/edit`}>
+              <Button variant="outline">
+                <Edit className="mr-2 h-4 w-4" />
+                Edit
+              </Button>
+            </Link>
+          )}
+          {canWithdraw && (
+            <Button
+              variant="outline"
+              onClick={() => setShowWithdrawDialog(true)}
+            >
+              Withdraw
+            </Button>
+          )}
+          {canDelete && (
+            <Button
+              variant="destructive"
+              onClick={() => setShowDeleteDialog(true)}
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Delete
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Editor status transitions */}
+      {(isEditor || isAdmin) && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Editor Actions</CardTitle>
+            <CardDescription>
+              Change the status of this submission
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <StatusTransition
+              submissionId={submissionId}
+              currentStatus={submission.status as SubmissionStatus}
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Content */}
+      <div className="grid gap-6 md:grid-cols-3">
+        <div className="md:col-span-2 space-y-6">
+          {/* Main content */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Content</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {submission.content ? (
+                <div className="whitespace-pre-wrap text-sm">
+                  {submission.content}
+                </div>
+              ) : (
+                <p className="text-muted-foreground text-sm">
+                  No text content provided
+                </p>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Cover letter */}
+          {submission.coverLetter && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Cover Letter</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="whitespace-pre-wrap text-sm">
+                  {submission.coverLetter}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Files */}
+          {files && files.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Files</CardTitle>
+                <CardDescription>
+                  {files.length} file{files.length !== 1 ? "s" : ""} attached
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-2">
+                  {files.map((file) => {
+                    const Icon = scanStatusIcons[file.scanStatus as ScanStatus];
+                    return (
+                      <div
+                        key={file.id}
+                        className="flex items-center gap-3 p-3 border rounded-lg"
+                      >
+                        <File className="h-8 w-8 text-muted-foreground" />
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium truncate">
+                            {file.filename}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {formatFileSize(file.size)}
+                          </p>
+                        </div>
+                        <Badge
+                          variant={
+                            file.scanStatus === "CLEAN"
+                              ? "default"
+                              : file.scanStatus === "INFECTED"
+                                ? "destructive"
+                                : "secondary"
+                          }
+                          className="gap-1"
+                        >
+                          <Icon
+                            className={`h-3 w-3 ${
+                              file.scanStatus === "SCANNING"
+                                ? "animate-spin"
+                                : ""
+                            }`}
+                          />
+                          {file.scanStatus}
+                        </Badge>
+                        {file.scanStatus === "CLEAN" && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleDownload(file.id)}
+                          >
+                            <Download className="h-4 w-4" />
+                          </Button>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+          {/* History */}
+          <Card>
+            <CardHeader>
+              <CardTitle>History</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {history && history.length > 0 ? (
+                <div className="space-y-4">
+                  {history.map((event, index) => (
+                    <div key={event.id} className="relative">
+                      {index < history.length - 1 && (
+                        <div className="absolute left-2 top-8 bottom-0 w-px bg-border" />
+                      )}
+                      <div className="flex gap-3">
+                        <div className="w-4 h-4 mt-1 rounded-full bg-primary flex-shrink-0" />
+                        <div className="space-y-1">
+                          <p className="text-sm">
+                            {event.fromStatus ? (
+                              <>
+                                Changed from{" "}
+                                <Badge variant="outline" className="text-xs">
+                                  {event.fromStatus}
+                                </Badge>{" "}
+                                to{" "}
+                                <Badge variant="outline" className="text-xs">
+                                  {event.toStatus}
+                                </Badge>
+                              </>
+                            ) : (
+                              <>
+                                Status set to{" "}
+                                <Badge variant="outline" className="text-xs">
+                                  {event.toStatus}
+                                </Badge>
+                              </>
+                            )}
+                          </p>
+                          {event.comment && (
+                            <p className="text-sm text-muted-foreground">
+                              &ldquo;{event.comment}&rdquo;
+                            </p>
+                          )}
+                          <p className="text-xs text-muted-foreground">
+                            {format(new Date(event.changedAt), "PPp")}
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">No history yet</p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete submission?</DialogTitle>
+            <DialogDescription>
+              This action cannot be undone. This will permanently delete your
+              submission and all associated files.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowDeleteDialog(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                deleteMutation.mutate({ id: submissionId });
+                setShowDeleteDialog(false);
+              }}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Withdraw confirmation dialog */}
+      <Dialog open={showWithdrawDialog} onOpenChange={setShowWithdrawDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Withdraw submission?</DialogTitle>
+            <DialogDescription>
+              This will withdraw your submission from consideration. You will
+              not be able to resubmit this submission.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowWithdrawDialog(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                withdrawMutation.mutate({ id: submissionId });
+                setShowWithdrawDialog(false);
+              }}
+              disabled={withdrawMutation.isPending}
+            >
+              {withdrawMutation.isPending ? "Withdrawing..." : "Withdraw"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/components/submissions/submission-form.tsx
+++ b/apps/web/src/components/submissions/submission-form.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Separator } from "@/components/ui/separator";
+import { FileUpload } from "./file-upload";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+
+const formSchema = z.object({
+  title: z.string().min(1, "Title is required").max(500),
+  content: z.string().max(50000).optional(),
+  coverLetter: z.string().max(10000).optional(),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+interface SubmissionFormProps {
+  mode: "create" | "edit";
+  submissionId?: string;
+}
+
+export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const utils = trpc.useUtils();
+
+  // Fetch existing submission for edit mode
+  const { data: existingSubmission, isLoading: isLoadingSubmission } =
+    trpc.submissions.getById.useQuery(
+      { id: submissionId! },
+      { enabled: mode === "edit" && !!submissionId },
+    );
+
+  // Fetch files for the submission (v2: listBySubmission)
+  const { data: existingFiles } = trpc.files.listBySubmission.useQuery(
+    { submissionId: submissionId! },
+    { enabled: mode === "edit" && !!submissionId },
+  );
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      title: "",
+      content: "",
+      coverLetter: "",
+    },
+  });
+
+  // Populate form when editing
+  useEffect(() => {
+    if (existingSubmission && mode === "edit") {
+      form.reset({
+        title: existingSubmission.title ?? "",
+        content: existingSubmission.content ?? "",
+        coverLetter: existingSubmission.coverLetter ?? "",
+      });
+    }
+  }, [existingSubmission, mode, form]);
+
+  // Create mutation
+  const createMutation = trpc.submissions.create.useMutation({
+    onSuccess: (data) => {
+      toast.success("Submission created");
+      router.push(`/submissions/${data.id}`);
+    },
+    onError: (err) => {
+      setError(err.message);
+    },
+  });
+
+  // Update mutation (v2: flattened input)
+  const updateMutation = trpc.submissions.update.useMutation({
+    onSuccess: () => {
+      toast.success("Submission saved");
+      utils.submissions.getById.invalidate({ id: submissionId! });
+    },
+    onError: (err) => {
+      setError(err.message);
+    },
+  });
+
+  // Submit mutation (for submitting draft)
+  const submitMutation = trpc.submissions.submit.useMutation({
+    onSuccess: () => {
+      toast.success("Submission submitted!");
+      router.push(`/submissions/${submissionId}`);
+    },
+    onError: (err) => {
+      setError(err.message);
+    },
+  });
+
+  const onSubmit = async (data: FormData) => {
+    setError(null);
+
+    if (mode === "create") {
+      await createMutation.mutateAsync(data);
+    } else if (submissionId) {
+      // v2: flattened input — { id, ...data } instead of { id, data }
+      await updateMutation.mutateAsync({
+        id: submissionId,
+        ...data,
+      });
+    }
+  };
+
+  const handleSubmitForReview = async () => {
+    if (!submissionId) return;
+
+    // Validate form first
+    const isValid = await form.trigger();
+    if (!isValid) return;
+
+    // Save changes first (v2: flattened input)
+    const data = form.getValues();
+    await updateMutation.mutateAsync({
+      id: submissionId,
+      ...data,
+    });
+
+    // Check for pending/infected files
+    if (
+      existingFiles?.some(
+        (f) => f.scanStatus === "PENDING" || f.scanStatus === "SCANNING",
+      )
+    ) {
+      toast.error("Please wait for file scans to complete");
+      return;
+    }
+
+    if (existingFiles?.some((f) => f.scanStatus === "INFECTED")) {
+      toast.error("Please remove infected files before submitting");
+      return;
+    }
+
+    // Submit
+    await submitMutation.mutateAsync({ id: submissionId });
+  };
+
+  const isLoading =
+    createMutation.isPending ||
+    updateMutation.isPending ||
+    submitMutation.isPending;
+
+  const canEdit = existingSubmission?.status === "DRAFT" || mode === "create";
+
+  if (mode === "edit" && isLoadingSubmission) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (mode === "edit" && existingSubmission && !canEdit) {
+    return (
+      <Alert>
+        <AlertDescription>
+          This submission cannot be edited because it has already been
+          submitted.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">
+          {mode === "create" ? "New Submission" : "Edit Submission"}
+        </h1>
+        <p className="text-muted-foreground">
+          {mode === "create"
+            ? "Create a new submission for review"
+            : "Make changes to your draft submission"}
+        </p>
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Submission Details</CardTitle>
+              <CardDescription>
+                Provide the details for your submission
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <FormField
+                control={form.control}
+                name="title"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Title *</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Enter submission title"
+                        disabled={!canEdit}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="content"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Content</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Enter your submission content (optional if uploading files)"
+                        className="min-h-[200px]"
+                        disabled={!canEdit}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      You can paste your text here or upload files below
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="coverLetter"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Cover Letter</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Optional cover letter or notes for the editors"
+                        className="min-h-[100px]"
+                        disabled={!canEdit}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          {/* File upload - only shown after creation */}
+          {mode === "edit" && submissionId && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Files</CardTitle>
+                <CardDescription>
+                  Upload supporting documents for your submission
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <FileUpload submissionId={submissionId} disabled={!canEdit} />
+              </CardContent>
+            </Card>
+          )}
+
+          <Separator />
+
+          {/* Actions */}
+          <div className="flex justify-between">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => router.back()}
+            >
+              Cancel
+            </Button>
+
+            <div className="flex gap-2">
+              <Button type="submit" disabled={isLoading || !canEdit}>
+                {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {mode === "create" ? "Create Draft" : "Save Draft"}
+              </Button>
+
+              {mode === "edit" && submissionId && (
+                <Button
+                  type="button"
+                  onClick={handleSubmitForReview}
+                  disabled={isLoading || !canEdit}
+                >
+                  {submitMutation.isPending && (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  )}
+                  Submit for Review
+                </Button>
+              )}
+            </div>
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/apps/web/src/components/submissions/submission-list.tsx
+++ b/apps/web/src/components/submissions/submission-list.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+import { SubmissionCard } from "./submission-card";
+import { Plus, FileText } from "lucide-react";
+import type { SubmissionStatus } from "@colophony/types";
+
+const statusTabs: Array<{ value: SubmissionStatus | "ALL"; label: string }> = [
+  { value: "ALL", label: "All" },
+  { value: "DRAFT", label: "Drafts" },
+  { value: "SUBMITTED", label: "Submitted" },
+  { value: "UNDER_REVIEW", label: "Under Review" },
+  { value: "ACCEPTED", label: "Accepted" },
+  { value: "REJECTED", label: "Rejected" },
+];
+
+export function SubmissionList() {
+  const [statusFilter, setStatusFilter] = useState<SubmissionStatus | "ALL">(
+    "ALL",
+  );
+  const [page, setPage] = useState(1);
+  const limit = 10;
+
+  const { data, isLoading, error } = trpc.submissions.mySubmissions.useQuery({
+    status: statusFilter === "ALL" ? undefined : statusFilter,
+    page,
+    limit,
+  });
+
+  if (error) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-destructive">
+          Failed to load submissions: {error.message}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">My Submissions</h1>
+          <p className="text-muted-foreground">
+            Manage and track your submissions
+          </p>
+        </div>
+        <Link href="/submissions/new">
+          <Button>
+            <Plus className="mr-2 h-4 w-4" />
+            New Submission
+          </Button>
+        </Link>
+      </div>
+
+      {/* Status filter tabs */}
+      <Tabs
+        value={statusFilter}
+        onValueChange={(v) => {
+          setStatusFilter(v as SubmissionStatus | "ALL");
+          setPage(1);
+        }}
+      >
+        <TabsList>
+          {statusTabs.map((tab) => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      {/* Loading state */}
+      {isLoading && (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-32" />
+          ))}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && data?.items.length === 0 && (
+        <div className="text-center py-12 border rounded-lg">
+          <FileText className="mx-auto h-12 w-12 text-muted-foreground" />
+          <h3 className="mt-4 text-lg font-semibold">No submissions</h3>
+          <p className="text-muted-foreground">
+            {statusFilter === "ALL"
+              ? "You haven't created any submissions yet."
+              : `You don't have any ${statusFilter.toLowerCase().replace("_", " ")} submissions.`}
+          </p>
+          {statusFilter === "ALL" && (
+            <Link href="/submissions/new">
+              <Button className="mt-4">
+                <Plus className="mr-2 h-4 w-4" />
+                Create your first submission
+              </Button>
+            </Link>
+          )}
+        </div>
+      )}
+
+      {/* Submissions grid */}
+      {!isLoading && data && data.items.length > 0 && (
+        <>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {data.items.map((submission) => (
+              <SubmissionCard key={submission.id} submission={submission} />
+            ))}
+          </div>
+
+          {/* Pagination */}
+          {data.totalPages > 1 && (
+            <div className="flex justify-center gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+              >
+                Previous
+              </Button>
+              <span className="flex items-center px-4 text-sm text-muted-foreground">
+                Page {page} of {data.totalPages}
+              </span>
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))}
+                disabled={page === data.totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,35 @@ Newest entries first.
 
 ---
 
+## 2026-02-15 — Submission Form & Page Rewrites
+
+### Done
+
+- **PR #67** — Migrated 6 v1 components to v2, rewrote 4 stub pages (10 files, ~1,200 lines)
+- Created `status-badge.tsx`, `submission-card.tsx`, `submission-list.tsx` (clean copies from v1)
+- Created `submission-form.tsx` — adapted from v1: `files.listBySubmission` rename, flattened update mutation payload (`{ id, ...data }` not `{ id, data }`), file scan validation before submit
+- Created `submission-detail.tsx` — adapted from v1: wired file downloads via `files.getDownloadUrl`, added editor status transitions via `useOrganization` hook
+- Created `status-transition.tsx` — adapted from v1 editor component: flattened `updateStatus` payload (`{ id, status, comment }`)
+- Replaced 4 stub pages: `/submissions`, `/submissions/new`, `/submissions/[id]`, `/submissions/[id]/edit`
+- Addressed Codex branch review — 2 findings fixed:
+  1. P1: Replaced `React.use(params)` with async server components (`await params`) — `use` not exported from React 18.3
+  2. P2: Added `submissions.getHistory` invalidation in status-transition `onSuccess`
+
+### Decisions
+
+- **Async server components for dynamic routes** — React 18 doesn't export `use()`, but Next.js 15 types require `params: Promise<>`. Solution: drop `"use client"` from page wrappers, make them `async` server components that `await params` and pass id to client components
+- **Nullable title handling** — DB schema returns `title: string | null`; `SubmissionCard` accepts nullable and renders "Untitled" fallback
+
+### Next
+
+- Manual testing of all 4 pages with dev server
+- E2E tests for submission flow (separate session)
+- Editor dashboard rewrite (`/editor` page — separate scope)
+- Submission periods UI
+- Clean up v1 components (`_v1/` directory)
+
+---
+
 ## 2026-02-15 — Frontend tus-js-client Integration
 
 ### Done


### PR DESCRIPTION
## Summary
- Replace 4 "Coming soon" stub pages (`/submissions`, `/new`, `/[id]`, `/[id]/edit`) with functional submission management UI
- Migrate and adapt 6 v1 components to v2 location (`components/submissions/`), fixing API mismatches: `files.listBySubmission` rename, flattened mutation payloads, wired file downloads via `getDownloadUrl`
- Add editor status transitions on detail page via `useOrganization` hook, with history cache invalidation
- Dynamic route pages use async server components (`await params`) for React 18 + Next.js 15 compatibility

## Test plan
- [x] `pnpm --filter @colophony/web type-check` — passes
- [x] `pnpm --filter @colophony/web lint` — clean (0 errors, 0 warnings)
- [x] `pnpm --filter @colophony/web test` — 35/35 tests pass
- [x] branch review — both findings (React.use + stale history) addressed
- [ ] Manual: verify each page renders with dev server
- [ ] E2E tests (separate session)