### PR TITLE
fix(api): add Permissions-Policy and Cache-Control headers

### DIFF
--- a/apps/api/src/main.spec.ts
+++ b/apps/api/src/main.spec.ts
@@ -150,4 +150,37 @@ describe('Fastify app', () => {
       'http://localhost:3000',
     );
   });
+
+  it('includes permissions-policy header on responses', async () => {
+    const response = await app.inject({ method: 'GET', url: '/health' });
+    expect(response.headers['permissions-policy']).toBe(
+      'camera=(), microphone=(), geolocation=(), interest-cohort=()',
+    );
+  });
+
+  it('sets cache-control: no-store on authenticated responses', async () => {
+    // Build a separate app instance so we can add a test route before ready
+    const authApp = await buildApp(testEnv);
+    authApp.get('/test-auth-cache', async (request, reply) => {
+      request.authContext = {
+        userId: '00000000-0000-0000-0000-000000000001',
+        zitadelUserId: 'test-zitadel-id',
+        email: 'test@example.com',
+        emailVerified: true,
+      };
+      return reply.send({ ok: true });
+    });
+
+    const response = await authApp.inject({
+      method: 'GET',
+      url: '/test-auth-cache',
+    });
+    expect(response.headers['cache-control']).toBe('no-store');
+    await authApp.close();
+  });
+
+  it('does not set cache-control: no-store on unauthenticated responses', async () => {
+    const response = await app.inject({ method: 'GET', url: '/health' });
+    expect(response.headers['cache-control']).toBeUndefined();
+  });
 });

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -46,6 +46,21 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
     // (cross-origin fetch/XHR is governed by CORS, not CORP)
   });
 
+  // Permissions-Policy — helmet v8 dropped support; set manually
+  app.addHook('onSend', async (_request, reply) => {
+    void reply.header(
+      'permissions-policy',
+      'camera=(), microphone=(), geolocation=(), interest-cohort=()',
+    );
+  });
+
+  // Cache-Control: no-store for authenticated responses
+  app.addHook('onSend', async (request, reply) => {
+    if (request.authContext) {
+      void reply.header('cache-control', 'no-store');
+    }
+  });
+
   // CORS
   const origins = env.CORS_ORIGIN.split(',').map((o) => o.trim());
   const hasWildcard = origins.includes('*');

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -13,8 +13,8 @@
 ### Code
 
 - [x] Security headers via @fastify/helmet (CSP, HSTS, X-Content-Type-Options) — (security checklist)
-- [ ] Add `Permissions-Policy` header to restrict browser features — (Codex review 2026-02-15)
-- [ ] Endpoint-specific `Cache-Control` for authenticated JSON responses — (Codex review 2026-02-15)
+- [x] Add `Permissions-Policy` header to restrict browser features — (Codex review 2026-02-15)
+- [x] Endpoint-specific `Cache-Control` for authenticated JSON responses — (Codex review 2026-02-15)
 - [ ] Wire rate limiting globally on all API surfaces — hook exists in `apps/api/src/hooks/rate-limit.ts`, needs registration on all routes — (security checklist)
 - [ ] Zitadel OIDC token validation enforced on all protected routes — (security checklist)
 - [ ] API key authentication with scopes — blocks Track 2 REST API — (security checklist)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,25 @@ Newest entries first.
 
 ---
 
+## 2026-02-15 — Permissions-Policy & Cache-Control Headers
+
+### Done
+
+- **PR #70** — Added `Permissions-Policy` and `Cache-Control` security headers (both from Codex review findings in earlier session)
+- Added `Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()` via `onSend` hook — helmet v8 removed support entirely
+- Added `Cache-Control: no-store` on authenticated responses to prevent proxy/CDN caching of sensitive data
+- 3 new unit tests in `main.spec.ts` (permissions-policy present, cache-control on auth, no cache-control on unauth)
+- Codex branch review: LGTM, no findings
+- Marked both backlog items as done
+- Fixed codex CLI command whitelist in `.claude/settings.local.json` (project-local settings were shadowing user-level permissions)
+
+### Decisions
+
+- **`onSend` hook placement** — after helmet registration, before CORS. `onSend` (not `onRequest`) so headers are set on the response object
+- **Cache-Control scope** — only authenticated responses (`request.authContext` non-null). Public endpoints (`/health`, `/ready`, `/`) remain cacheable
+
+---
+
 ## 2026-02-15 — Helmet Security Headers Audit
 
 ### Done


### PR DESCRIPTION
## Summary
- Add `Permissions-Policy` header via `onSend` hook (helmet v8 dropped support) — disables camera, microphone, geolocation, and interest-cohort
- Add `Cache-Control: no-store` on authenticated responses to prevent proxy/CDN caching of sensitive data
- Mark both backlog items as done

## Test plan
- [x] Unit tests pass (`pnpm --filter @colophony/api test` — 224 passing)
- [x] Type check passes (`pnpm type-check`)
- [x] branch review: LGTM, no issues found
- [ ] CI pipeline