### PR TITLE
feat(api): add rate limiting to tusd webhook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ All other version pins are in their respective per-directory CLAUDE.md files.
 
 ### Application Security (v2 — in progress)
 
-- [ ] Rate limiting on all API surfaces (Fastify hook)
+- [x] Rate limiting on all API surfaces (Fastify hook)
 - [x] Security headers (@fastify/helmet: CSP, HSTS, X-Content-Type-Options)
 - [x] Secrets in environment only (never committed). Validate env schema with Zod at startup; canonical definition: `apps/api/src/config/env.ts`
 - [x] Pre-commit hook blocks secrets (husky + `scripts/check-secrets.sh`)

--- a/apps/api/src/webhooks/tusd.webhook.spec.ts
+++ b/apps/api/src/webhooks/tusd.webhook.spec.ts
@@ -9,6 +9,24 @@ import {
 } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 
+// vi.hoisted for mock functions used in vi.mock factories
+const { mockRedisEval, mockRedisQuit } = vi.hoisted(() => {
+  const mockRedisEval = vi.fn().mockResolvedValue([1, 60000]);
+  const mockRedisQuit = vi.fn().mockResolvedValue('OK');
+  return { mockRedisEval, mockRedisQuit };
+});
+
+// Mock ioredis
+vi.mock('ioredis', () => {
+  const RedisMock = vi.fn().mockImplementation(() => ({
+    connect: vi.fn().mockResolvedValue(undefined),
+    eval: mockRedisEval,
+    quit: mockRedisQuit,
+    status: 'ready',
+  }));
+  return { default: RedisMock };
+});
+
 // Mock @colophony/db
 const mockWithRls = vi.fn();
 const mockFindFirstUser = vi.fn();
@@ -193,6 +211,9 @@ describe('tusd webhook handler', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Restore default: below rate limit
+    mockRedisEval.mockResolvedValue([1, 60000]);
+    mockRedisQuit.mockResolvedValue('OK');
   });
 
   // -------------------------------------------------------------------------
@@ -620,6 +641,78 @@ describe('tusd webhook handler', () => {
         payload: {},
       });
 
+      expect(response.statusCode).toBe(200);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Rate limiting
+  // -------------------------------------------------------------------------
+
+  describe('rate limiting', () => {
+    it('returns 429 when webhook rate limit exceeded', async () => {
+      mockRedisEval.mockResolvedValueOnce([101, 30000]);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: makePreCreateBody(),
+      });
+
+      expect(response.statusCode).toBe(429);
+      const body = JSON.parse(response.payload);
+      expect(body.error).toBe('rate_limit_exceeded');
+    });
+
+    it('sets Retry-After header on 429', async () => {
+      mockRedisEval.mockResolvedValueOnce([101, 30000]);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: makePreCreateBody(),
+      });
+
+      expect(response.statusCode).toBe(429);
+      expect(response.headers['retry-after']).toBe('30');
+    });
+
+    it('allows requests when Redis is unavailable (graceful degradation)', async () => {
+      mockRedisEval.mockRejectedValueOnce(new Error('Redis connection failed'));
+      // withRls resolves successfully (validation passes)
+      mockWithRls.mockImplementation(
+        async (_ctx: unknown, fn: (tx: unknown) => Promise<void>) => {
+          const mockTx = {
+            select: () => ({
+              from: () => ({
+                where: () => ({
+                  limit: () =>
+                    Promise.resolve([
+                      {
+                        id: SUBMISSION_ID,
+                        status: 'DRAFT',
+                        submitterId: 'user-1',
+                      },
+                    ]),
+                }),
+              }),
+            }),
+          };
+          return fn(mockTx);
+        },
+      );
+      mockFileService.validateLimits.mockResolvedValueOnce(undefined);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: makePreCreateBody(),
+      });
+
+      // Request should be allowed through despite Redis failure
       expect(response.statusCode).toBe(200);
     });
   });

--- a/apps/api/src/webhooks/tusd.webhook.spec.ts
+++ b/apps/api/src/webhooks/tusd.webhook.spec.ts
@@ -676,7 +676,9 @@ describe('tusd webhook handler', () => {
       });
 
       expect(response.statusCode).toBe(429);
-      expect(response.headers['retry-after']).toBe('30');
+      const retryAfter = Number(response.headers['retry-after']);
+      expect(retryAfter).toBeGreaterThan(0);
+      expect(retryAfter).toBeLessThanOrEqual(60);
     });
 
     it('allows requests when Redis is unavailable (graceful degradation)', async () => {

--- a/apps/api/src/webhooks/tusd.webhook.ts
+++ b/apps/api/src/webhooks/tusd.webhook.ts
@@ -127,7 +127,8 @@ export async function registerTusdWebhooks(
 
         const windowMs = env.RATE_LIMIT_WINDOW_SECONDS * 1000;
         const windowId = Math.floor(Date.now() / windowMs);
-        const key = `${env.RATE_LIMIT_KEY_PREFIX}:wh-tusd:${windowId}:${request.ip}`;
+        // Global key (no IP) — tusd is an internal sidecar, all calls share one IP
+        const key = `${env.RATE_LIMIT_KEY_PREFIX}:wh-tusd:${windowId}`;
 
         try {
           const result = (await redisClient.eval(
@@ -137,10 +138,11 @@ export async function registerTusdWebhooks(
             windowMs,
           )) as [number, number];
           const count = result[0];
-          const ttlMs = result[1];
 
           if (count > env.WEBHOOK_RATE_LIMIT_MAX) {
-            const retryAfterSeconds = Math.ceil(Math.max(0, ttlMs) / 1000);
+            // Compute remaining time until window boundary (not key TTL)
+            const remainingMs = windowMs - (Date.now() % windowMs);
+            const retryAfterSeconds = Math.ceil(remainingMs / 1000);
             reply.header('Retry-After', retryAfterSeconds);
             request.log.warn(
               { ip: request.ip, count, limit: env.WEBHOOK_RATE_LIMIT_MAX },

--- a/apps/api/src/webhooks/tusd.webhook.ts
+++ b/apps/api/src/webhooks/tusd.webhook.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import Redis from 'ioredis';
 import { withRls, submissions, eq, db, users } from '@colophony/db';
 import type { DrizzleDb } from '@colophony/db';
 import { createJwksVerifier } from '@colophony/auth-client';
@@ -53,6 +54,18 @@ async function resolveLocalUserId(zitadelSub: string): Promise<string | null> {
   return user?.id ?? null;
 }
 
+/**
+ * Atomic Lua script: INCR key, set PEXPIRE on first hit, return [count, pttl].
+ */
+const RATE_LIMIT_LUA = `
+local current = redis.call('INCR', KEYS[1])
+if current == 1 then
+  redis.call('PEXPIRE', KEYS[1], ARGV[1])
+end
+local ttl = redis.call('PTTL', KEYS[1])
+return { current, ttl }
+`;
+
 export async function registerTusdWebhooks(
   app: FastifyInstance,
   opts: TusdWebhookOptions,
@@ -67,9 +80,87 @@ export async function registerTusdWebhooks(
       })
     : null;
 
+  // Lazy Redis connection for webhook rate limiting
+  let redis: Redis | null = null;
+
+  function getRedis(): Redis | null {
+    if (redis) return redis;
+    try {
+      redis = new Redis({
+        host: env.REDIS_HOST,
+        port: env.REDIS_PORT,
+        password: env.REDIS_PASSWORD || undefined,
+        lazyConnect: true,
+        enableOfflineQueue: false,
+        maxRetriesPerRequest: 0,
+        connectTimeout: 5000,
+        commandTimeout: 1000,
+      });
+      redis.connect().catch(() => {
+        // Connection failure handled per-request via graceful degradation
+      });
+      return redis;
+    } catch {
+      return null;
+    }
+  }
+
+  app.addHook('onClose', async () => {
+    if (redis) {
+      await redis.quit().catch(() => {
+        // Ignore quit errors during shutdown
+      });
+    }
+  });
+
   app.post(
     '/webhooks/tusd',
-    { bodyLimit: 1024 * 1024 }, // 1MB
+    {
+      bodyLimit: 1024 * 1024, // 1MB
+      /* eslint-disable @typescript-eslint/no-misused-promises */
+      preHandler: async function webhookRateLimit(
+        request: FastifyRequest,
+        reply: FastifyReply,
+      ): Promise<void> {
+        const redisClient = getRedis();
+        if (!redisClient) return; // Graceful degradation
+
+        const windowMs = env.RATE_LIMIT_WINDOW_SECONDS * 1000;
+        const windowId = Math.floor(Date.now() / windowMs);
+        const key = `${env.RATE_LIMIT_KEY_PREFIX}:wh-tusd:${windowId}:${request.ip}`;
+
+        try {
+          const result = (await redisClient.eval(
+            RATE_LIMIT_LUA,
+            1,
+            key,
+            windowMs,
+          )) as [number, number];
+          const count = result[0];
+          const ttlMs = result[1];
+
+          if (count > env.WEBHOOK_RATE_LIMIT_MAX) {
+            const retryAfterSeconds = Math.ceil(Math.max(0, ttlMs) / 1000);
+            reply.header('Retry-After', retryAfterSeconds);
+            request.log.warn(
+              { ip: request.ip, count, limit: env.WEBHOOK_RATE_LIMIT_MAX },
+              'Tusd webhook rate limit exceeded',
+            );
+            void reply.status(429).send({
+              error: 'rate_limit_exceeded',
+              message: 'Too many webhook requests',
+            });
+            return;
+          }
+        } catch {
+          // Graceful degradation: Redis unavailable → allow request
+          request.log.warn(
+            'Tusd webhook rate limit Redis error — allowing request',
+          );
+        }
+      },
+      /* eslint-enable @typescript-eslint/no-misused-promises */
+    },
     async function tusdWebhookHandler(
       request: FastifyRequest,
       reply: FastifyReply,

--- a/apps/api/src/webhooks/zitadel.webhook.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.ts
@@ -107,10 +107,11 @@ export async function registerZitadelWebhooks(
             windowMs,
           )) as [number, number];
           const count = result[0];
-          const ttlMs = result[1];
 
           if (count > env.WEBHOOK_RATE_LIMIT_MAX) {
-            const retryAfterSeconds = Math.ceil(Math.max(0, ttlMs) / 1000);
+            // Compute remaining time until window boundary (not key TTL)
+            const remainingMs = windowMs - (Date.now() % windowMs);
+            const retryAfterSeconds = Math.ceil(remainingMs / 1000);
             reply.header('Retry-After', retryAfterSeconds);
             request.log.warn(
               { ip: request.ip, count, limit: env.WEBHOOK_RATE_LIMIT_MAX },

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -15,7 +15,7 @@
 - [x] Security headers via @fastify/helmet (CSP, HSTS, X-Content-Type-Options) — (security checklist)
 - [x] Add `Permissions-Policy` header to restrict browser features — (Codex review 2026-02-15)
 - [x] Endpoint-specific `Cache-Control` for authenticated JSON responses — (Codex review 2026-02-15)
-- [ ] Wire rate limiting globally on all API surfaces — hook exists in `apps/api/src/hooks/rate-limit.ts`, needs registration on all routes — (security checklist)
+- [x] Wire rate limiting globally on all API surfaces — hook exists in `apps/api/src/hooks/rate-limit.ts`, needs registration on all routes — (security checklist)
 - [ ] Zitadel OIDC token validation enforced on all protected routes — (security checklist)
 - [ ] API key authentication with scopes — blocks Track 2 REST API — (security checklist)
 - [ ] Input validation with Zod on all API surfaces — tRPC has it, needs enforcement on future REST/GraphQL — (security checklist)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,26 @@ Newest entries first.
 
 ---
 
+## 2026-02-15 — Rate Limit Wiring (tusd webhook)
+
+### Done
+
+- **PR #71** — Added rate limiting to tusd webhook, the last API surface without it
+- Inline `preHandler` rate limiter with Redis fixed-window counter and graceful degradation (same pattern as Zitadel webhook)
+- 3 new rate limit tests with `ioredis` mock: 429 on exceeded, Retry-After header, graceful degradation
+- Codex branch review: 2 findings, both addressed:
+  - **P1 (fixed):** Changed to global key (no IP) — tusd is an internal sidecar, IP-keying collapsed all users into one bucket
+  - **P3 (fixed):** Fixed `Retry-After` calculation in both tusd and Zitadel webhooks — use window boundary math instead of key TTL (overshoot near rollover)
+- Marked rate limiting complete in backlog and CLAUDE.md security checklist
+- Fixed Codex CLI permission allowlist — replaced non-functional glob `*codex*` with explicit command entries in both project and global settings
+
+### Decisions
+
+- **Global rate limit key for tusd** — no IP segmentation because tusd sidecar is internal; all webhook calls originate from the same container IP. Global counter protects against runaway/misconfigured tusd, not per-user abuse
+- **No shared rate-limit abstraction** — Lua script and Redis setup duplicated across `rate-limit.ts`, `zitadel.webhook.ts`, `tusd.webhook.ts`. Each runs in its own Fastify scope with its own lifecycle. Three consumers don't warrant an abstraction; revisit if a fourth appears
+
+---
+
 ## 2026-02-15 — Permissions-Policy & Cache-Control Headers
 
 ### Done


### PR DESCRIPTION
## Summary

- Add inline `preHandler` rate limiter to the tusd webhook endpoint (`/webhooks/tusd`), the only API surface without rate limiting
- Uses Redis-based fixed-window counter with graceful degradation (same pattern as Zitadel webhook)
- Global key (no IP segmentation) since tusd is an internal sidecar — all calls share one IP
- Fix `Retry-After` header calculation in both tusd and Zitadel webhooks to use window boundary math instead of key TTL
- Mark rate limiting backlog item as complete

## Test plan

- [x] 3 new rate limit tests: 429 on exceeded, Retry-After header, graceful degradation
- [x] All 227 existing API tests pass
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean