### PR TITLE
feat(api): add API key authentication with scopes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ All other version pins are in their respective per-directory CLAUDE.md files.
 - [x] Secrets in environment only (never committed). Validate env schema with Zod at startup; canonical definition: `apps/api/src/config/env.ts`
 - [x] Pre-commit hook blocks secrets (husky + `scripts/check-secrets.sh`)
 - [x] Zitadel OIDC token validation on all protected routes (default-deny auth hook)
-- [ ] API key authentication with scopes
+- [x] API key authentication with scopes (scopes stored, enforcement deferred to Track 2)
 - [ ] Audit log for all sensitive actions
 - [x] File virus scanning before production bucket (ClamAV via BullMQ)
 - [x] RLS policies on all tenant tables via Drizzle `pgPolicy` with FORCE — see `packages/db/CLAUDE.md`

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -28,7 +28,7 @@ Each hook decorates the Fastify request:
 | Hook               | Decorates                        | Purpose                                                     |
 | ------------------ | -------------------------------- | ----------------------------------------------------------- |
 | `rateLimitPlugin`  | —                                | Redis-based sliding window rate limiting (runs before auth) |
-| `authPlugin`       | `request.authContext`            | Validates Zitadel OIDC token, extracts user identity        |
+| `authPlugin`       | `request.authContext`            | Validates OIDC token or X-Api-Key, extracts user identity   |
 | `orgContextPlugin` | `request.authContext.orgId/role` | Resolves `X-Organization-Id` header, checks membership      |
 | `dbContextPlugin`  | `request.dbTx`                   | Opens RLS transaction via `SET LOCAL` with org/user context |
 | `auditPlugin`      | `request.audit`                  | Provides `audit(action, details)` helper for logging        |
@@ -37,15 +37,29 @@ Each hook decorates the Fastify request:
 
 ---
 
-## Authentication (Zitadel OIDC)
+## Authentication
 
-Zitadel handles all authentication: login, signup, MFA, session management, token issuance. The API validates Zitadel-issued tokens via the `auth` hook (`onRequest`).
+Dual auth: Zitadel OIDC tokens for interactive users, API keys for programmatic access.
 
-**Default-deny model:** The auth hook rejects all requests to non-public routes that lack a valid Authorization header (returns 401). Public routes are explicitly allowlisted in `auth.ts` via `PUBLIC_EXACT` and `PUBLIC_PREFIXES`. This provides defense-in-depth — even if a tRPC procedure accidentally uses `publicProcedure`, the hook layer still requires auth unless the route is explicitly allowlisted.
+**Default-deny model:** The auth hook rejects all requests to non-public routes that lack a valid `Authorization` header or `X-Api-Key` header (returns 401). Public routes are explicitly allowlisted in `auth.ts` via `PUBLIC_EXACT` and `PUBLIC_PREFIXES`. This provides defense-in-depth — even if a tRPC procedure accidentally uses `publicProcedure`, the hook layer still requires auth unless the route is explicitly allowlisted.
 
-- **Interactive users:** Zitadel OIDC tokens (access + refresh)
-- **API consumers:** API keys (planned — stored in DB, scoped per org)
+**Auth precedence:** Bearer token (OIDC) is checked first. `X-Api-Key` is the fallback when no `Authorization` header is present. When both are present, Bearer wins.
+
+- **Interactive users:** Zitadel OIDC tokens (access + refresh) — sets `authMethod: 'oidc'`
+- **API consumers:** API keys via `X-Api-Key` header — sets `authMethod: 'apikey'`
 - **Dev bypass:** Set `DEV_AUTH_BYPASS=true` to allow unauthenticated requests in development when `ZITADEL_AUTHORITY` is not configured. Never effective in production.
+
+### API Key Authentication
+
+- **Key format:** `col_live_<32 hex chars>` (41 chars total, 128 bits of entropy)
+- **Storage:** SHA-256 hash stored in `api_keys` table. Plain text shown once on creation, never stored.
+- **Org-scoped:** Each key belongs to an organization. `createdBy` tracks the creating user.
+- **Auth context:** Uses the creator's `userId` for audit trail and RLS. Pre-sets `orgId` from the key.
+- **Scopes:** Stored in `scopes` JSONB column. Enforcement deferred to Track 2 (REST/GraphQL surfaces).
+- **Lookup:** `verify_api_key()` SECURITY DEFINER function bypasses RLS for cross-org hash lookup.
+- **`lastUsedAt`:** Updated fire-and-forget via `touch_api_key_last_used()` SECURITY DEFINER function.
+- **CRUD:** tRPC router at `apiKeys.*`. Only ADMIN can create/revoke/delete. All org members can list.
+- **Fail closed:** If the key creator is no longer an org member, the org-context hook rejects with 403.
 
 User lifecycle events are synced from Zitadel to the local DB via webhooks.
 

--- a/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
+++ b/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
@@ -11,6 +11,7 @@ const RLS_TABLES = [
   'audit_events',
   'retention_policies',
   'user_consents',
+  'api_keys',
 ];
 
 const NON_RLS_TABLES = [
@@ -30,7 +31,7 @@ describe('RLS Infrastructure', () => {
   // No teardown — pools are shared across test files (singleFork mode)
 
   describe('Row-level security enabled', () => {
-    it('should have relrowsecurity = true on all 9 RLS tables', async () => {
+    it('should have relrowsecurity = true on all 10 RLS tables', async () => {
       const admin = getAdminPool();
       const { rows } = await admin.query<{
         relname: string;
@@ -53,7 +54,7 @@ describe('RLS Infrastructure', () => {
       }
     });
 
-    it('should have relforcerowsecurity = true on all 9 RLS tables', async () => {
+    it('should have relforcerowsecurity = true on all 10 RLS tables', async () => {
       const admin = getAdminPool();
       const { rows } = await admin.query<{
         relname: string;

--- a/apps/api/src/hooks/audit.spec.ts
+++ b/apps/api/src/hooks/audit.spec.ts
@@ -74,6 +74,7 @@ const fakeAuthPlugin = fp(
           zitadelUserId: testUserId,
           email: 'test@example.com',
           emailVerified: true,
+          authMethod: 'test',
         } satisfies AuthContext;
       }
     });

--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -41,6 +41,16 @@ vi.mock('@colophony/auth-client', () => ({
   createJwksVerifier: vi.fn(() => mockVerifyToken),
 }));
 
+// Mock api-key service
+const mockVerifyKey = vi.fn();
+const mockTouchLastUsed = vi.fn().mockResolvedValue(undefined);
+vi.mock('../services/api-key.service.js', () => ({
+  apiKeyService: {
+    verifyKey: (...args: unknown[]) => mockVerifyKey(...args),
+    touchLastUsed: (...args: unknown[]) => mockTouchLastUsed(...args),
+  },
+}));
+
 const baseEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
   PORT: 0,
@@ -617,6 +627,291 @@ describe('auth plugin', () => {
       const serialized = JSON.stringify(params);
       expect(serialized).not.toContain('super-secret-token');
       expect(serialized).not.toContain('Bearer');
+    });
+  });
+
+  describe('API key authentication', () => {
+    const flushPromises = () => new Promise((r) => process.nextTick(r));
+
+    let app: FastifyInstance;
+
+    const envWithAuth: Env = {
+      ...baseEnv,
+      NODE_ENV: 'development' as const,
+      ZITADEL_AUTHORITY: 'http://localhost:8080',
+      ZITADEL_CLIENT_ID: 'my-client',
+    };
+
+    beforeAll(async () => {
+      app = Fastify({ logger: false });
+      await app.register(authPlugin, { env: envWithAuth });
+      app.get('/protected', async (request) => ({
+        authContext: request.authContext,
+      }));
+    });
+
+    beforeEach(() => {
+      mockVerifyKey.mockReset();
+      mockTouchLastUsed.mockReset().mockResolvedValue(undefined);
+      mockLogDirect.mockClear().mockResolvedValue(undefined);
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it('authenticates with valid X-Api-Key header', async () => {
+      mockVerifyKey.mockResolvedValueOnce({
+        apiKey: {
+          id: 'key-1',
+          organizationId: 'org-1',
+          createdBy: 'user-1',
+          name: 'Test Key',
+          scopes: ['submissions:read'],
+          expiresAt: null,
+          revokedAt: null,
+          lastUsedAt: null,
+          createdAt: new Date(),
+        },
+        creator: {
+          id: 'user-1',
+          email: 'alice@example.com',
+          emailVerified: true,
+          deletedAt: null,
+        },
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { 'x-api-key': 'col_live_abcdef1234567890abcdef1234567890' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.authContext.userId).toBe('user-1');
+      expect(body.authContext.email).toBe('alice@example.com');
+      expect(body.authContext.authMethod).toBe('apikey');
+      expect(body.authContext.apiKeyId).toBe('key-1');
+      expect(body.authContext.orgId).toBe('org-1');
+    });
+
+    it('sets authMethod to apikey', async () => {
+      mockVerifyKey.mockResolvedValueOnce({
+        apiKey: {
+          id: 'key-1',
+          organizationId: 'org-1',
+          createdBy: 'user-1',
+          name: 'Test Key',
+          scopes: ['submissions:read'],
+          expiresAt: null,
+          revokedAt: null,
+          lastUsedAt: null,
+          createdAt: new Date(),
+        },
+        creator: {
+          id: 'user-1',
+          email: 'alice@example.com',
+          emailVerified: true,
+          deletedAt: null,
+        },
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { 'x-api-key': 'col_live_abcdef1234567890abcdef1234567890' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().authContext.authMethod).toBe('apikey');
+    });
+
+    it('pre-sets orgId from API key', async () => {
+      mockVerifyKey.mockResolvedValueOnce({
+        apiKey: {
+          id: 'key-1',
+          organizationId: 'org-42',
+          createdBy: 'user-1',
+          name: 'Test Key',
+          scopes: ['submissions:read'],
+          expiresAt: null,
+          revokedAt: null,
+          lastUsedAt: null,
+          createdAt: new Date(),
+        },
+        creator: {
+          id: 'user-1',
+          email: 'alice@example.com',
+          emailVerified: true,
+          deletedAt: null,
+        },
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { 'x-api-key': 'col_live_abcdef1234567890abcdef1234567890' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().authContext.orgId).toBe('org-42');
+    });
+
+    it('rejects invalid API key', async () => {
+      mockVerifyKey.mockResolvedValueOnce(null);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { 'x-api-key': 'col_live_invalid' },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.json().message).toBe('Invalid API key');
+    });
+
+    it('rejects expired API key', async () => {
+      mockVerifyKey.mockResolvedValueOnce({
+        apiKey: {
+          id: 'key-1',
+          organizationId: 'org-1',
+          createdBy: 'user-1',
+          name: 'Test Key',
+          scopes: ['submissions:read'],
+          expiresAt: new Date('2020-01-01'), // expired
+          revokedAt: null,
+          lastUsedAt: null,
+          createdAt: new Date(),
+        },
+        creator: {
+          id: 'user-1',
+          email: 'alice@example.com',
+          emailVerified: true,
+          deletedAt: null,
+        },
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { 'x-api-key': 'col_live_abcdef1234567890abcdef1234567890' },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.json().message).toBe('API key has expired');
+    });
+
+    it('rejects revoked API key', async () => {
+      mockVerifyKey.mockResolvedValueOnce({
+        apiKey: {
+          id: 'key-1',
+          organizationId: 'org-1',
+          createdBy: 'user-1',
+          name: 'Test Key',
+          scopes: ['submissions:read'],
+          expiresAt: null,
+          revokedAt: new Date(), // revoked
+          lastUsedAt: null,
+          createdAt: new Date(),
+        },
+        creator: {
+          id: 'user-1',
+          email: 'alice@example.com',
+          emailVerified: true,
+          deletedAt: null,
+        },
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { 'x-api-key': 'col_live_abcdef1234567890abcdef1234567890' },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.json().message).toBe('API key has been revoked');
+    });
+
+    it('prefers Bearer token over X-Api-Key when both present', async () => {
+      // When Authorization header is present, API key is not checked
+      mockVerifyToken.mockResolvedValueOnce({
+        payload: { sub: 'zitadel-user-1' },
+        header: { alg: 'RS256' },
+      });
+
+      const dbModule = await import('@colophony/db');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(dbModule.db.query.users.findFirst).mockResolvedValueOnce({
+        id: 'user-1',
+        email: 'alice@example.com',
+        zitadelUserId: 'zitadel-user-1',
+        emailVerified: true,
+        emailVerifiedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+        lastEventAt: null,
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: {
+          authorization: 'Bearer valid-token',
+          'x-api-key': 'col_live_abcdef1234567890abcdef1234567890',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().authContext.authMethod).toBe('oidc');
+      expect(mockVerifyKey).not.toHaveBeenCalled();
+    });
+
+    it('audits failed API key auth', async () => {
+      mockVerifyKey.mockResolvedValueOnce(null);
+
+      await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { 'x-api-key': 'col_live_invalid_key_here' },
+      });
+      await flushPromises();
+
+      expect(mockLogDirect).toHaveBeenCalledOnce();
+      const params = mockLogDirect.mock.calls[0][0];
+      expect(params.action).toBe('API_KEY_AUTH_FAILED');
+    });
+
+    it('updates lastUsedAt on successful auth', async () => {
+      mockVerifyKey.mockResolvedValueOnce({
+        apiKey: {
+          id: 'key-1',
+          organizationId: 'org-1',
+          createdBy: 'user-1',
+          name: 'Test Key',
+          scopes: ['submissions:read'],
+          expiresAt: null,
+          revokedAt: null,
+          lastUsedAt: null,
+          createdAt: new Date(),
+        },
+        creator: {
+          id: 'user-1',
+          email: 'alice@example.com',
+          emailVerified: true,
+          deletedAt: null,
+        },
+      });
+
+      await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { 'x-api-key': 'col_live_abcdef1234567890abcdef1234567890' },
+      });
+      await flushPromises();
+
+      expect(mockTouchLastUsed).toHaveBeenCalledWith('key-1');
     });
   });
 });

--- a/apps/api/src/hooks/auth.ts
+++ b/apps/api/src/hooks/auth.ts
@@ -2,10 +2,16 @@ import fp from 'fastify-plugin';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { createJwksVerifier } from '@colophony/auth-client';
 import { db, eq, users } from '@colophony/db';
-import type { AuthContext, AuthAuditParams } from '@colophony/types';
+import type {
+  AuthContext,
+  AuthAuditParams,
+  ApiKeyAuditParams,
+  ApiKeyScope,
+} from '@colophony/types';
 import { AuditActions, AuditResources } from '@colophony/types';
 import type { Env } from '../config/env.js';
 import { auditService } from '../services/audit.service.js';
+import { apiKeyService } from '../services/api-key.service.js';
 
 declare module 'fastify' {
   interface FastifyRequest {
@@ -71,19 +77,24 @@ export default fp(
     /** Log an auth failure audit event. Never throws — swallows errors. */
     async function logAuthFailure(
       request: FastifyRequest,
-      action: AuthAuditParams['action'],
+      action: AuthAuditParams['action'] | ApiKeyAuditParams['action'],
       details: Record<string, unknown>,
       actorId?: string,
     ): Promise<void> {
       try {
+        const isApiKeyAction = action.startsWith('API_KEY_');
+        const resource = isApiKeyAction
+          ? AuditResources.API_KEY
+          : AuditResources.AUTH;
+
         await auditService.logDirect({
           action,
-          resource: AuditResources.AUTH,
+          resource,
           ipAddress: request.ip,
           userAgent: request.headers['user-agent'],
           newValue: details,
           actorId,
-        });
+        } as AuthAuditParams | ApiKeyAuditParams);
       } catch (err) {
         request.log.warn({ err }, 'Failed to log auth failure audit event');
       }
@@ -119,6 +130,7 @@ export default fp(
                 (request.headers['x-test-zitadel-id'] as string) ?? testUserId,
               email: testEmail ?? 'test@example.com',
               emailVerified: true,
+              authMethod: 'test',
             };
             return;
           }
@@ -133,6 +145,67 @@ export default fp(
         // Extract Bearer token
         const authHeader = request.headers.authorization;
         if (!authHeader) {
+          // Check for API key before rejecting
+          const apiKeyHeader = request.headers['x-api-key'] as
+            | string
+            | undefined;
+          if (apiKeyHeader) {
+            const result = await apiKeyService.verifyKey(apiKeyHeader);
+            if (!result) {
+              void logAuthFailure(request, AuditActions.API_KEY_AUTH_FAILED, {
+                reason: 'invalid_key',
+                keyPrefix: apiKeyHeader.substring(0, 12),
+              });
+              return reply.status(401).send({
+                error: 'unauthorized',
+                message: 'Invalid API key',
+              });
+            }
+            const { apiKey, creator } = result;
+            if (apiKey.expiresAt && apiKey.expiresAt < new Date()) {
+              void logAuthFailure(request, AuditActions.API_KEY_AUTH_FAILED, {
+                reason: 'expired',
+                keyId: apiKey.id,
+              });
+              return reply.status(401).send({
+                error: 'unauthorized',
+                message: 'API key has expired',
+              });
+            }
+            if (apiKey.revokedAt) {
+              void logAuthFailure(request, AuditActions.API_KEY_AUTH_FAILED, {
+                reason: 'revoked',
+                keyId: apiKey.id,
+              });
+              return reply.status(401).send({
+                error: 'unauthorized',
+                message: 'API key has been revoked',
+              });
+            }
+            if (creator.deletedAt) {
+              void logAuthFailure(request, AuditActions.API_KEY_AUTH_FAILED, {
+                reason: 'creator_deactivated',
+                keyId: apiKey.id,
+              });
+              return reply.status(401).send({
+                error: 'unauthorized',
+                message: 'API key creator account has been deactivated',
+              });
+            }
+            request.authContext = {
+              userId: creator.id,
+              email: creator.email,
+              emailVerified: creator.emailVerified,
+              authMethod: 'apikey',
+              apiKeyId: apiKey.id,
+              apiKeyScopes: apiKey.scopes as ApiKeyScope[],
+              orgId: apiKey.organizationId,
+            };
+            // Fire-and-forget: update lastUsedAt
+            void apiKeyService.touchLastUsed(apiKey.id);
+            return;
+          }
+
           // Dev bypass: allow unauthenticated requests in dev mode when explicitly enabled
           if (devAuthBypass) {
             request.log.debug(
@@ -237,6 +310,7 @@ export default fp(
           zitadelUserId: sub,
           email: user.email,
           emailVerified: user.emailVerified,
+          authMethod: 'oidc',
         };
       },
     );

--- a/apps/api/src/hooks/db-context.spec.ts
+++ b/apps/api/src/hooks/db-context.spec.ts
@@ -62,6 +62,7 @@ const fakeAuthPlugin = fp(
           zitadelUserId: testUserId,
           email: 'test@example.com',
           emailVerified: true,
+          authMethod: 'test',
         } satisfies AuthContext;
       }
     });

--- a/apps/api/src/hooks/org-context.spec.ts
+++ b/apps/api/src/hooks/org-context.spec.ts
@@ -64,6 +64,7 @@ const fakeAuthPlugin = fp(
           zitadelUserId: testUserId,
           email: 'test@example.com',
           emailVerified: true,
+          authMethod: 'test',
         } satisfies AuthContext;
       }
     });

--- a/apps/api/src/hooks/org-context.ts
+++ b/apps/api/src/hooks/org-context.ts
@@ -16,6 +16,49 @@ export default fp(
         // Must run after auth hook — skip if no auth context
         if (!request.authContext) return;
 
+        // API key auth pre-sets orgId — resolve role from membership, fail closed
+        if (
+          request.authContext.orgId &&
+          request.authContext.authMethod === 'apikey'
+        ) {
+          const client = await pool.connect();
+          let role: string | undefined;
+          try {
+            await client.query('BEGIN READ ONLY');
+            await client.query('SELECT set_config($1, $2, true)', [
+              'app.current_org',
+              request.authContext.orgId,
+            ]);
+            await client.query('SELECT set_config($1, $2, true)', [
+              'app.user_id',
+              request.authContext.userId,
+            ]);
+            const memberResult = await client.query<{ role: string }>(
+              'SELECT role FROM organization_members WHERE organization_id = $1 AND user_id = $2',
+              [request.authContext.orgId, request.authContext.userId],
+            );
+            if (memberResult.rows.length > 0) {
+              role = memberResult.rows[0].role;
+            }
+            await client.query('COMMIT');
+          } catch (err) {
+            await client.query('ROLLBACK').catch(() => {});
+            throw err;
+          } finally {
+            client.release();
+          }
+
+          if (!role) {
+            return reply.status(403).send({
+              error: 'not_a_member',
+              message:
+                'API key creator is no longer a member of this organization',
+            });
+          }
+          request.authContext.role = role as 'ADMIN' | 'EDITOR' | 'READER';
+          return;
+        }
+
         const orgIdHeader = request.headers['x-organization-id'] as
           | string
           | undefined;

--- a/apps/api/src/hooks/rate-limit.spec.ts
+++ b/apps/api/src/hooks/rate-limit.spec.ts
@@ -48,6 +48,7 @@ const fakeAuthPlugin = fp(
           email:
             (request.headers['x-test-email'] as string) ?? 'test@example.com',
           emailVerified: true,
+          authMethod: 'test',
         } satisfies AuthContext;
       }
     });

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -91,6 +91,7 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
       'Authorization',
       'X-Organization-Id',
       'X-Request-Id',
+      'X-Api-Key',
     ],
     exposedHeaders: [
       'X-RateLimit-Limit',

--- a/apps/api/src/services/api-key.service.spec.ts
+++ b/apps/api/src/services/api-key.service.spec.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import crypto from 'node:crypto';
+
+// vi.hoisted runs before vi.mock hoisting — safe to reference in factories
+const { mockPoolQuery } = vi.hoisted(() => {
+  const mockPoolQuery = vi.fn();
+  return { mockPoolQuery };
+});
+
+// Mock @colophony/db
+vi.mock('@colophony/db', () => ({
+  pool: { query: mockPoolQuery },
+  apiKeys: {
+    id: 'id',
+    organizationId: 'organization_id',
+    createdBy: 'created_by',
+    name: 'name',
+    keyHash: 'key_hash',
+    keyPrefix: 'key_prefix',
+    scopes: 'scopes',
+    expiresAt: 'expires_at',
+    revokedAt: 'revoked_at',
+    lastUsedAt: 'last_used_at',
+    createdAt: 'created_at',
+  },
+  eq: vi.fn((_col: unknown, val: unknown) => val),
+  and: vi.fn((...args: unknown[]) => args),
+  sql: vi.fn(),
+  DrizzleDb: {},
+}));
+
+import { apiKeyService } from './api-key.service.js';
+
+describe('apiKeyService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('verifyKey', () => {
+    it('returns key data when key exists', async () => {
+      const plainTextKey = 'col_live_abcdef1234567890abcdef1234567890';
+      const expectedHash = crypto
+        .createHash('sha256')
+        .update(plainTextKey)
+        .digest('hex');
+
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'key-1',
+            organization_id: 'org-1',
+            created_by: 'user-1',
+            name: 'Test Key',
+            scopes: ['submissions:read'],
+            expires_at: null,
+            revoked_at: null,
+            last_used_at: null,
+            created_at: new Date(),
+            creator_email: 'test@example.com',
+            creator_email_verified: true,
+            creator_deleted_at: null,
+          },
+        ],
+      });
+
+      const result = await apiKeyService.verifyKey(plainTextKey);
+
+      expect(mockPoolQuery).toHaveBeenCalledWith(
+        'SELECT * FROM verify_api_key($1)',
+        [expectedHash],
+      );
+      expect(result).not.toBeNull();
+      expect(result!.apiKey.id).toBe('key-1');
+      expect(result!.apiKey.organizationId).toBe('org-1');
+      expect(result!.creator.email).toBe('test@example.com');
+    });
+
+    it('returns null for unknown key', async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+      const result = await apiKeyService.verifyKey('col_live_unknown');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('touchLastUsed', () => {
+    it('calls the SECURITY DEFINER function', async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+      await apiKeyService.touchLastUsed('key-1');
+
+      expect(mockPoolQuery).toHaveBeenCalledWith(
+        'SELECT touch_api_key_last_used($1, $2)',
+        ['key-1', expect.any(Date)],
+      );
+    });
+
+    it('swallows errors silently', async () => {
+      mockPoolQuery.mockRejectedValueOnce(new Error('DB down'));
+
+      // Should not throw
+      await apiKeyService.touchLastUsed('key-1');
+    });
+  });
+
+  describe('create', () => {
+    it('generates key with col_live_ prefix and stores hash', async () => {
+      const mockTx = {
+        insert: vi.fn().mockReturnThis(),
+        values: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([
+          {
+            id: 'key-1',
+            name: 'My Key',
+            scopes: ['submissions:read'],
+            keyPrefix: 'col_live_',
+            createdAt: new Date(),
+            expiresAt: null,
+            lastUsedAt: null,
+            revokedAt: null,
+          },
+        ]),
+      } as unknown as Parameters<typeof apiKeyService.create>[0];
+
+      const result = await apiKeyService.create(mockTx, 'org-1', 'user-1', {
+        name: 'My Key',
+        scopes: ['submissions:read'],
+      });
+
+      expect(result.plainTextKey).toMatch(/^col_live_[0-9a-f]{32}$/);
+      expect(result.id).toBe('key-1');
+    });
+  });
+
+  describe('revoke', () => {
+    it('sets revokedAt on the key', async () => {
+      const mockTx = {
+        update: vi.fn().mockReturnThis(),
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi
+          .fn()
+          .mockResolvedValue([
+            { id: 'key-1', name: 'My Key', revokedAt: new Date() },
+          ]),
+      } as unknown as Parameters<typeof apiKeyService.revoke>[0];
+
+      const result = await apiKeyService.revoke(mockTx, 'key-1');
+      expect(result).not.toBeNull();
+      expect(result?.revokedAt).toBeInstanceOf(Date);
+    });
+
+    it('returns null when key not found', async () => {
+      const mockTx = {
+        update: vi.fn().mockReturnThis(),
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([]),
+      } as unknown as Parameters<typeof apiKeyService.revoke>[0];
+
+      const result = await apiKeyService.revoke(mockTx, 'nonexistent');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('list', () => {
+    it('returns paginated results without keyHash', async () => {
+      const items = [
+        {
+          id: 'key-1',
+          name: 'Key 1',
+          scopes: ['submissions:read'],
+          keyPrefix: 'col_live_',
+          createdAt: new Date(),
+          expiresAt: null,
+          lastUsedAt: null,
+          revokedAt: null,
+        },
+      ];
+
+      const mockTx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockResolvedValue(items),
+              }),
+            }),
+          }),
+        }),
+      } as unknown as Parameters<typeof apiKeyService.list>[0];
+
+      // Mock the count query — list() calls tx.select() twice via Promise.all
+      // We need to override select to return different chains for the two calls
+      let callCount = 0;
+      (mockTx as unknown as { select: ReturnType<typeof vi.fn> }).select = vi
+        .fn()
+        .mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            // Items query
+            return {
+              from: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue(items),
+                  }),
+                }),
+              }),
+            };
+          }
+          // Count query
+          return {
+            from: vi.fn().mockResolvedValue([{ count: 1 }]),
+          };
+        });
+
+      const result = await apiKeyService.list(mockTx, { page: 1, limit: 20 });
+
+      expect(result.items).toEqual(items);
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+      expect(result.totalPages).toBe(1);
+      // Ensure no keyHash in returned items
+      for (const item of result.items) {
+        expect(item).not.toHaveProperty('keyHash');
+      }
+    });
+  });
+});

--- a/apps/api/src/services/api-key.service.ts
+++ b/apps/api/src/services/api-key.service.ts
@@ -1,0 +1,214 @@
+import crypto from 'node:crypto';
+import { pool, apiKeys, eq, and, sql, type DrizzleDb } from '@colophony/db';
+import type { CreateApiKeyInput, PaginationInput } from '@colophony/types';
+
+const KEY_PREFIX = 'col_live_';
+
+/**
+ * Generate a new API key.
+ * Format: col_live_<32 random hex chars> (41 chars total, 128 bits of entropy).
+ */
+function generateKey(): {
+  plainTextKey: string;
+  keyHash: string;
+  keyPrefix: string;
+} {
+  const randomPart = crypto.randomBytes(16).toString('hex'); // 32 hex chars
+  const plainTextKey = `${KEY_PREFIX}${randomPart}`;
+  const keyHash = crypto
+    .createHash('sha256')
+    .update(plainTextKey)
+    .digest('hex');
+  return { plainTextKey, keyHash, keyPrefix: KEY_PREFIX };
+}
+
+function hashKey(plainTextKey: string): string {
+  return crypto.createHash('sha256').update(plainTextKey).digest('hex');
+}
+
+export const apiKeyService = {
+  /**
+   * Create a new API key. Returns the plain text key (shown once).
+   * Runs inside the caller's RLS transaction.
+   */
+  async create(
+    tx: DrizzleDb,
+    orgId: string,
+    createdBy: string,
+    input: CreateApiKeyInput,
+  ) {
+    const { plainTextKey, keyHash, keyPrefix } = generateKey();
+
+    const [row] = await tx
+      .insert(apiKeys)
+      .values({
+        organizationId: orgId,
+        createdBy,
+        name: input.name,
+        keyHash,
+        keyPrefix,
+        scopes: input.scopes,
+        expiresAt: input.expiresAt ?? null,
+      })
+      .returning({
+        id: apiKeys.id,
+        name: apiKeys.name,
+        scopes: apiKeys.scopes,
+        keyPrefix: apiKeys.keyPrefix,
+        createdAt: apiKeys.createdAt,
+        expiresAt: apiKeys.expiresAt,
+        lastUsedAt: apiKeys.lastUsedAt,
+        revokedAt: apiKeys.revokedAt,
+      });
+
+    return { ...row, plainTextKey };
+  },
+
+  /**
+   * List API keys for the current org (RLS handles filtering).
+   * Never returns keyHash.
+   */
+  async list(tx: DrizzleDb, pagination: PaginationInput) {
+    const { page, limit } = pagination;
+    const offset = (page - 1) * limit;
+
+    const [items, countResult] = await Promise.all([
+      tx
+        .select({
+          id: apiKeys.id,
+          name: apiKeys.name,
+          scopes: apiKeys.scopes,
+          keyPrefix: apiKeys.keyPrefix,
+          createdAt: apiKeys.createdAt,
+          expiresAt: apiKeys.expiresAt,
+          lastUsedAt: apiKeys.lastUsedAt,
+          revokedAt: apiKeys.revokedAt,
+        })
+        .from(apiKeys)
+        .orderBy(apiKeys.createdAt)
+        .limit(limit)
+        .offset(offset),
+      tx.select({ count: sql<number>`count(*)::int` }).from(apiKeys),
+    ]);
+
+    const total = countResult[0]?.count ?? 0;
+
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  /**
+   * Get a single API key by ID. RLS scoped.
+   */
+  async getById(tx: DrizzleDb, keyId: string) {
+    const [row] = await tx
+      .select({
+        id: apiKeys.id,
+        name: apiKeys.name,
+        scopes: apiKeys.scopes,
+        keyPrefix: apiKeys.keyPrefix,
+        createdAt: apiKeys.createdAt,
+        expiresAt: apiKeys.expiresAt,
+        lastUsedAt: apiKeys.lastUsedAt,
+        revokedAt: apiKeys.revokedAt,
+      })
+      .from(apiKeys)
+      .where(eq(apiKeys.id, keyId))
+      .limit(1);
+    return row ?? null;
+  },
+
+  /**
+   * Revoke an API key by setting revokedAt.
+   */
+  async revoke(tx: DrizzleDb, keyId: string) {
+    const [updated] = await tx
+      .update(apiKeys)
+      .set({ revokedAt: new Date() })
+      .where(and(eq(apiKeys.id, keyId)))
+      .returning({
+        id: apiKeys.id,
+        name: apiKeys.name,
+        revokedAt: apiKeys.revokedAt,
+      });
+    return updated ?? null;
+  },
+
+  /**
+   * Hard delete an API key.
+   */
+  async delete(tx: DrizzleDb, keyId: string) {
+    const [deleted] = await tx
+      .delete(apiKeys)
+      .where(eq(apiKeys.id, keyId))
+      .returning({ id: apiKeys.id });
+    return deleted ?? null;
+  },
+
+  /**
+   * Verify an API key by hashing and looking up via SECURITY DEFINER function.
+   * Bypasses RLS for cross-org lookup (same pattern as list_user_organizations).
+   * Returns key details + creator info, or null if not found.
+   */
+  async verifyKey(plainTextKey: string) {
+    const keyHash = hashKey(plainTextKey);
+
+    const result = await pool.query<{
+      id: string;
+      organization_id: string;
+      created_by: string;
+      name: string;
+      scopes: string[];
+      expires_at: Date | null;
+      revoked_at: Date | null;
+      last_used_at: Date | null;
+      created_at: Date;
+      creator_email: string;
+      creator_email_verified: boolean;
+      creator_deleted_at: Date | null;
+    }>('SELECT * FROM verify_api_key($1)', [keyHash]);
+
+    if (result.rows.length === 0) return null;
+
+    const row = result.rows[0];
+    return {
+      apiKey: {
+        id: row.id,
+        organizationId: row.organization_id,
+        createdBy: row.created_by,
+        name: row.name,
+        scopes: row.scopes,
+        expiresAt: row.expires_at,
+        revokedAt: row.revoked_at,
+        lastUsedAt: row.last_used_at,
+        createdAt: row.created_at,
+      },
+      creator: {
+        id: row.created_by,
+        email: row.creator_email,
+        emailVerified: row.creator_email_verified,
+        deletedAt: row.creator_deleted_at,
+      },
+    };
+  },
+
+  /**
+   * Fire-and-forget update of lastUsedAt via SECURITY DEFINER function.
+   * Errors are swallowed — callers use `void apiKeyService.touchLastUsed(...)`.
+   */
+  async touchLastUsed(keyId: string): Promise<void> {
+    try {
+      await pool.query('SELECT touch_api_key_last_used($1, $2)', [
+        keyId,
+        new Date(),
+      ]);
+    } catch {
+      // Swallow — non-critical update
+    }
+  },
+};

--- a/apps/api/src/services/audit.service.ts
+++ b/apps/api/src/services/audit.service.ts
@@ -1,5 +1,9 @@
 import { auditEvents, db, type DrizzleDb } from '@colophony/db';
-import type { AuditLogParams, AuthAuditParams } from '@colophony/types';
+import type {
+  AuditLogParams,
+  AuthAuditParams,
+  ApiKeyAuditParams,
+} from '@colophony/types';
 
 const MAX_VALUE_LENGTH = 8192;
 
@@ -64,12 +68,13 @@ export const auditService = {
    * Insert an audit event directly via the shared `db` instance.
    *
    * Used for events that occur before a per-request transaction exists
-   * (e.g. auth failures). Only accepts AuthAuditParams — org-scoped
-   * events must use `log()` inside an RLS transaction context.
+   * (e.g. auth failures, API key auth failures). Only accepts
+   * AuthAuditParams or ApiKeyAuditParams — org-scoped events must
+   * use `log()` inside an RLS transaction context.
    *
    * Errors propagate — caller is responsible for try/catch.
    */
-  async logDirect(params: AuthAuditParams): Promise<void> {
+  async logDirect(params: AuthAuditParams | ApiKeyAuditParams): Promise<void> {
     if (params.organizationId) {
       throw new Error(
         'logDirect must not include organizationId — use auditService.log() inside a transaction for org-scoped events',

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -3,6 +3,7 @@ import { organizationsRouter } from './routers/organizations.js';
 import { usersRouter } from './routers/users.js';
 import { submissionsRouter } from './routers/submissions.js';
 import { filesRouter } from './routers/files.js';
+import { apiKeysRouter } from './routers/api-keys.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -24,6 +25,7 @@ export const appRouter = t.router({
   users: usersRouter,
   submissions: submissionsRouter,
   files: filesRouter,
+  apiKeys: apiKeysRouter,
   payments: t.router({}),
   gdpr: t.router({}),
   consent: t.router({}),

--- a/apps/api/src/trpc/routers/api-keys.spec.ts
+++ b/apps/api/src/trpc/routers/api-keys.spec.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { TRPCContext } from '../context.js';
+
+// vi.hoisted runs before vi.mock hoisting — safe to reference in factories
+const { mockApiKeyService } = vi.hoisted(() => {
+  const mockApiKeyService = {
+    list: vi.fn(),
+    create: vi.fn(),
+    revoke: vi.fn(),
+    delete: vi.fn(),
+  };
+  return { mockApiKeyService };
+});
+
+vi.mock('../../services/api-key.service.js', () => ({
+  apiKeyService: mockApiKeyService,
+}));
+
+// Import after mocks
+import { appRouter } from '../router.js';
+
+function makeContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
+  return {
+    authContext: null,
+    dbTx: null,
+    audit: vi.fn(),
+    ...overrides,
+  };
+}
+
+function orgContext(
+  role: 'ADMIN' | 'EDITOR' | 'READER' = 'ADMIN',
+  overrides: Partial<TRPCContext> = {},
+): TRPCContext {
+  const mockTx = {} as never;
+  return makeContext({
+    authContext: {
+      userId: 'user-1',
+      zitadelUserId: 'zid-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+      orgId: 'org-1',
+      role,
+    },
+    dbTx: mockTx,
+    audit: vi.fn(),
+    ...overrides,
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createCaller = (appRouter as any).createCaller as (
+  ctx: TRPCContext,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+) => any;
+
+describe('apiKeys router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('list', () => {
+    it('returns paginated keys for org members', async () => {
+      const keys = {
+        items: [
+          {
+            id: 'a1111111-1111-1111-1111-111111111111',
+            name: 'Test Key',
+            scopes: ['submissions:read'],
+            keyPrefix: 'col_live_',
+            createdAt: new Date(),
+            expiresAt: null,
+            lastUsedAt: null,
+            revokedAt: null,
+          },
+        ],
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      };
+      mockApiKeyService.list.mockResolvedValueOnce(keys);
+
+      const caller = createCaller(orgContext('READER'));
+      const result = await caller.apiKeys.list({ page: 1, limit: 20 });
+
+      expect(result).toEqual(keys);
+      expect(mockApiKeyService.list).toHaveBeenCalledOnce();
+    });
+
+    it('requires org context', async () => {
+      const caller = createCaller(
+        makeContext({
+          authContext: {
+            userId: 'user-1',
+            zitadelUserId: 'zid-1',
+            email: 'test@example.com',
+            emailVerified: true,
+            authMethod: 'test',
+          },
+        }),
+      );
+      await expect(
+        caller.apiKeys.list({ page: 1, limit: 20 }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('create', () => {
+    it('returns plain text key on creation', async () => {
+      const created = {
+        id: 'a1111111-1111-1111-1111-111111111111',
+        name: 'My Key',
+        scopes: ['submissions:read'],
+        keyPrefix: 'col_live_',
+        plainTextKey: 'col_live_abcdef1234567890abcdef1234567890',
+        createdAt: new Date(),
+        expiresAt: null,
+        lastUsedAt: null,
+        revokedAt: null,
+      };
+      mockApiKeyService.create.mockResolvedValueOnce(created);
+
+      const ctx = orgContext('ADMIN');
+      const caller = createCaller(ctx);
+      const result = await caller.apiKeys.create({
+        name: 'My Key',
+        scopes: ['submissions:read'],
+      });
+
+      expect(result.plainTextKey).toBe(created.plainTextKey);
+      expect(mockApiKeyService.create).toHaveBeenCalledWith(
+        expect.anything(),
+        'org-1',
+        'user-1',
+        { name: 'My Key', scopes: ['submissions:read'] },
+      );
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'API_KEY_CREATED',
+          resource: 'api_key',
+          resourceId: 'a1111111-1111-1111-1111-111111111111',
+        }),
+      );
+    });
+
+    it('rejects non-admin users', async () => {
+      const caller = createCaller(orgContext('READER'));
+      await expect(
+        caller.apiKeys.create({
+          name: 'My Key',
+          scopes: ['submissions:read'],
+        }),
+      ).rejects.toThrow('Admin role required');
+    });
+
+    it('rejects EDITOR users', async () => {
+      const caller = createCaller(orgContext('EDITOR'));
+      await expect(
+        caller.apiKeys.create({
+          name: 'My Key',
+          scopes: ['submissions:read'],
+        }),
+      ).rejects.toThrow('Admin role required');
+    });
+  });
+
+  describe('revoke', () => {
+    it('revokes a key and audits', async () => {
+      mockApiKeyService.revoke.mockResolvedValueOnce({
+        id: 'a1111111-1111-1111-1111-111111111111',
+        name: 'My Key',
+        revokedAt: new Date(),
+      });
+
+      const ctx = orgContext('ADMIN');
+      const caller = createCaller(ctx);
+      const result = await caller.apiKeys.revoke({
+        keyId: 'a1111111-1111-1111-1111-111111111111',
+      });
+
+      expect(result.revokedAt).toBeInstanceOf(Date);
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'API_KEY_REVOKED',
+          resource: 'api_key',
+          resourceId: 'a1111111-1111-1111-1111-111111111111',
+        }),
+      );
+    });
+
+    it('throws NOT_FOUND when key does not exist', async () => {
+      mockApiKeyService.revoke.mockResolvedValueOnce(null);
+
+      const caller = createCaller(orgContext('ADMIN'));
+      await expect(
+        caller.apiKeys.revoke({
+          keyId: 'b2222222-2222-2222-2222-222222222222',
+        }),
+      ).rejects.toThrow('API key not found');
+    });
+
+    it('rejects non-admin users', async () => {
+      const caller = createCaller(orgContext('READER'));
+      await expect(
+        caller.apiKeys.revoke({
+          keyId: 'a1111111-1111-1111-1111-111111111111',
+        }),
+      ).rejects.toThrow('Admin role required');
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes a key and audits', async () => {
+      mockApiKeyService.delete.mockResolvedValueOnce({
+        id: 'a1111111-1111-1111-1111-111111111111',
+      });
+
+      const ctx = orgContext('ADMIN');
+      const caller = createCaller(ctx);
+      const result = await caller.apiKeys.delete({
+        keyId: 'a1111111-1111-1111-1111-111111111111',
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'API_KEY_DELETED',
+          resource: 'api_key',
+          resourceId: 'a1111111-1111-1111-1111-111111111111',
+        }),
+      );
+    });
+
+    it('throws NOT_FOUND when key does not exist', async () => {
+      mockApiKeyService.delete.mockResolvedValueOnce(null);
+
+      const caller = createCaller(orgContext('ADMIN'));
+      await expect(
+        caller.apiKeys.delete({
+          keyId: 'b2222222-2222-2222-2222-222222222222',
+        }),
+      ).rejects.toThrow('API key not found');
+    });
+
+    it('rejects non-admin users', async () => {
+      const caller = createCaller(orgContext('EDITOR'));
+      await expect(
+        caller.apiKeys.delete({
+          keyId: 'a1111111-1111-1111-1111-111111111111',
+        }),
+      ).rejects.toThrow('Admin role required');
+    });
+  });
+});

--- a/apps/api/src/trpc/routers/api-keys.ts
+++ b/apps/api/src/trpc/routers/api-keys.ts
@@ -1,0 +1,71 @@
+import { TRPCError } from '@trpc/server';
+import {
+  createApiKeySchema,
+  revokeApiKeySchema,
+  deleteApiKeySchema,
+  paginationSchema,
+  AuditActions,
+  AuditResources,
+} from '@colophony/types';
+import { orgProcedure, adminProcedure, createRouter } from '../init.js';
+import { apiKeyService } from '../../services/api-key.service.js';
+
+export const apiKeysRouter = createRouter({
+  list: orgProcedure.input(paginationSchema).query(async ({ ctx, input }) => {
+    return apiKeyService.list(ctx.dbTx, input);
+  }),
+
+  create: adminProcedure
+    .input(createApiKeySchema)
+    .mutation(async ({ ctx, input }) => {
+      const result = await apiKeyService.create(
+        ctx.dbTx,
+        ctx.authContext.orgId,
+        ctx.authContext.userId,
+        input,
+      );
+      await ctx.audit({
+        action: AuditActions.API_KEY_CREATED,
+        resource: AuditResources.API_KEY,
+        resourceId: result.id,
+        newValue: { name: input.name, scopes: input.scopes },
+      });
+      return result;
+    }),
+
+  revoke: adminProcedure
+    .input(revokeApiKeySchema)
+    .mutation(async ({ ctx, input }) => {
+      const revoked = await apiKeyService.revoke(ctx.dbTx, input.keyId);
+      if (!revoked) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'API key not found',
+        });
+      }
+      await ctx.audit({
+        action: AuditActions.API_KEY_REVOKED,
+        resource: AuditResources.API_KEY,
+        resourceId: revoked.id,
+      });
+      return revoked;
+    }),
+
+  delete: adminProcedure
+    .input(deleteApiKeySchema)
+    .mutation(async ({ ctx, input }) => {
+      const deleted = await apiKeyService.delete(ctx.dbTx, input.keyId);
+      if (!deleted) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'API key not found',
+        });
+      }
+      await ctx.audit({
+        action: AuditActions.API_KEY_DELETED,
+        resource: AuditResources.API_KEY,
+        resourceId: deleted.id,
+      });
+      return { success: true };
+    }),
+});

--- a/apps/api/src/trpc/routers/files.spec.ts
+++ b/apps/api/src/trpc/routers/files.spec.ts
@@ -118,6 +118,7 @@ function orgContext(
       zitadelUserId: 'zid-1',
       email: 'test@example.com',
       emailVerified: true,
+      authMethod: 'test',
       orgId: 'org-1',
       role,
     },
@@ -193,6 +194,7 @@ describe('files tRPC router', () => {
             zitadelUserId: 'zid-1',
             email: 'test@example.com',
             emailVerified: true,
+            authMethod: 'test',
           },
         }),
       );

--- a/apps/api/src/trpc/routers/organizations.spec.ts
+++ b/apps/api/src/trpc/routers/organizations.spec.ts
@@ -62,6 +62,7 @@ function authedContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
       zitadelUserId: 'zid-1',
       email: 'test@example.com',
       emailVerified: true,
+      authMethod: 'test',
     },
     ...overrides,
   });
@@ -78,6 +79,7 @@ function orgContext(
       zitadelUserId: 'zid-1',
       email: 'test@example.com',
       emailVerified: true,
+      authMethod: 'test',
       orgId: 'org-1',
       role,
     },

--- a/apps/api/src/trpc/routers/submissions.spec.ts
+++ b/apps/api/src/trpc/routers/submissions.spec.ts
@@ -84,6 +84,7 @@ function authedContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
       zitadelUserId: 'zid-1',
       email: 'test@example.com',
       emailVerified: true,
+      authMethod: 'test',
     },
     ...overrides,
   });
@@ -100,6 +101,7 @@ function orgContext(
       zitadelUserId: 'zid-1',
       email: 'test@example.com',
       emailVerified: true,
+      authMethod: 'test',
       orgId: 'org-1',
       role,
     },

--- a/apps/api/src/trpc/routers/users.spec.ts
+++ b/apps/api/src/trpc/routers/users.spec.ts
@@ -67,6 +67,7 @@ function authedContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
       zitadelUserId: 'zid-1',
       email: 'test@example.com',
       emailVerified: true,
+      authMethod: 'test',
     },
     ...overrides,
   });

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -17,7 +17,7 @@
 - [x] Endpoint-specific `Cache-Control` for authenticated JSON responses — (Codex review 2026-02-15)
 - [x] Wire rate limiting globally on all API surfaces — hook exists in `apps/api/src/hooks/rate-limit.ts`, needs registration on all routes — (security checklist)
 - [x] Zitadel OIDC token validation enforced on all protected routes — (security checklist, PR #72)
-- [ ] API key authentication with scopes — blocks Track 2 REST API — (security checklist)
+- [x] API key authentication with scopes — blocks Track 2 REST API — (security checklist, PR pending 2026-02-15)
 - [ ] Input validation with Zod on all API surfaces — tRPC has it, needs enforcement on future REST/GraphQL — (security checklist)
 - [ ] Storage: block public access via MinIO bucket policy — (security checklist)
 - [ ] Stripe webhook signature verification + idempotency — no Stripe handler exists yet — (security checklist)
@@ -159,6 +159,40 @@
 - [ ] Email templates + provider integration (SendGrid) — (architecture doc, Relay)
 - [ ] Webhook delivery system (outbound) — (architecture doc, Relay)
 - [ ] In-app notification center — (architecture doc, Relay)
+
+---
+
+## Dependency Upgrades
+
+> Most dependencies were not deliberately pinned — they were current-at-the-time when v2 started (Feb 2026).
+> Several were already behind at that point. Prioritized by EOL risk and security impact.
+
+### [P0] Urgent — EOL / Security
+
+- [ ] Node.js 20 → 22 LTS — Node 20 EOL is April 30, 2026; currently on v20.20.0 via `.nvmrc` — (dependabot 2026-02-15)
+- [ ] Next.js 15 → 16 + React 18 → 19 + eslint-config-next 15 → 16 — bundled upgrade; Next 16 requires React 19; Next 16 shipped Oct 2025 — (dependabot #79, #81, #75)
+
+### [P1] High — Major versions, actively maintained
+
+- [ ] Zod 3 → 4 — ground-up rewrite (stable May 2025); touches types package, all tRPC inputs, env config; largest migration surface — (dependabot #80)
+- [ ] TanStack Query 4 → 5 — `isLoading` → `isPending` split; shipped Oct 2023; requires auditing all query usages in web app — (dependabot #74)
+- [ ] tRPC 10 → 11 — currently pinned for Zod error behavior; evaluate whether Zod 4 changes the calculus — (CLAUDE.md version pin)
+
+### [P2] Medium — Dev tooling, lower risk
+
+- [ ] Vitest 3 → 4 — shipped Oct 2025; dev-only, but 261+ tests need validation — (dependabot #76)
+- [ ] @testing-library/react 14 → 16 — dev-only; skipped v15 — (dependabot #78)
+
+### [P3] Low — Unused or minimal impact
+
+- [ ] nodemailer 7 → 8 — Relay not built yet; upgrade when starting Relay — (dependabot #77)
+
+### Upgrade order notes
+
+- **Node 22** can be done independently — update `.nvmrc`, engines fields, CI matrix, test
+- **Next 16 + React 19** must move together; eslint-config-next follows
+- **Zod 4** should happen before or alongside **tRPC 11** since tRPC's Zod error behavior is the pin reason
+- **TanStack Query 5** is independent but touches the same web app files as React 19
 
 ---
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,36 @@ Newest entries first.
 
 ---
 
+## 2026-02-15 — API Key Authentication
+
+### Done
+
+- **PR #83** — Full API key authentication with scopes (feat/api-key-auth branch)
+- New types: `ApiKeyScope` enum, CRUD schemas, response schemas in `packages/types/src/api-key.ts`
+- Extended `AuthContext` with `authMethod` discriminator, optional `apiKeyId`/`apiKeyScopes`
+- Added `API_KEY_*` audit actions and `api_key` audit resource to discriminated union
+- DB schema: `api_keys` table with RLS policies, FORCE RLS, SECURITY DEFINER functions
+- Service layer: key generation (`col_live_<32 hex>`), SHA-256 hashing, CRUD, verify via `pool.query`
+- Auth hook: `X-Api-Key` fallback when no Bearer token; checks expired/revoked/deactivated creator
+- Org-context hook: handles pre-set `orgId` from API key auth, resolves creator membership, fails closed on missing membership
+- tRPC router: `apiKeys.list` (orgProcedure), `create`/`revoke`/`delete` (adminProcedure) with audit logging
+- CORS: added `X-Api-Key` to allowedHeaders
+- 27 new tests across service spec, router spec, and auth hook spec; all 261 API tests pass
+- Addressed Codex branch review: added `SECURITY DEFINER` to `verify_api_key()` and `touch_api_key_last_used()` (critical — without it, FORCE RLS blocks cross-org key lookup from auth hook)
+- Merged dependabot PRs #73 (minor-and-patch group, 9 updates) and #82 (eslint-config-prettier 9→10)
+- Audited all dependency versions — most were not deliberate pins, several already behind at v2 start
+- Added Dependency Upgrades section to backlog with P0–P3 priorities
+
+### Decisions
+
+- **Scope enforcement deferred to Track 2** — scopes are stored in JSONB column but not checked at tRPC level; enforcement will come with REST/GraphQL surfaces
+- **Bearer takes priority over X-Api-Key** — when both headers present, OIDC wins
+- **Fail closed on missing membership** — if API key creator is no longer an org member, reject 403 (not default to READER)
+- **`lastUsedAt` is fire-and-forget** — errors swallowed silently to avoid blocking auth
+- **Node 20 → 22 is P0 urgent** — EOL April 30, 2026; 8 major dependabot PRs deferred to dedicated session
+
+---
+
 ## 2026-02-15 — Default-Deny Auth Enforcement
 
 ### Done

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -11,9 +11,9 @@
 | Type exports   | `src/types.ts`                           |
 | Migrations     | `migrations/`                            |
 
-### Schema Files (11 domain files + barrel)
+### Schema Files (12 domain files + barrel)
 
-`audit.ts`, `compliance.ts`, `enums.ts`, `members.ts`, `messaging.ts`, `organizations.ts`, `payments.ts`, `relations.ts`, `submissions.ts`, `users.ts`, `webhooks.ts`, `index.ts`
+`api-keys.ts`, `audit.ts`, `compliance.ts`, `enums.ts`, `members.ts`, `messaging.ts`, `organizations.ts`, `payments.ts`, `relations.ts`, `submissions.ts`, `users.ts`, `webhooks.ts`, `index.ts`
 
 ---
 

--- a/packages/db/migrations/0007_lonely_toxin.sql
+++ b/packages/db/migrations/0007_lonely_toxin.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "api_keys" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"created_by" uuid NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"key_hash" varchar(128) NOT NULL,
+	"key_prefix" varchar(12) NOT NULL,
+	"scopes" jsonb NOT NULL,
+	"expires_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	"last_used_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "api_keys_key_hash_unique" UNIQUE("key_hash")
+);
+--> statement-breakpoint
+ALTER TABLE "api_keys" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "api_keys_organization_id_idx" ON "api_keys" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "api_keys_key_hash_idx" ON "api_keys" USING btree ("key_hash");--> statement-breakpoint
+CREATE POLICY "api_keys_select" ON "api_keys" AS PERMISSIVE FOR SELECT TO public USING (organization_id = current_org_id());--> statement-breakpoint
+CREATE POLICY "api_keys_modify" ON "api_keys" AS PERMISSIVE FOR ALL TO public USING (organization_id = current_org_id()) WITH CHECK (organization_id = current_org_id());

--- a/packages/db/migrations/0008_api_keys_rls.sql
+++ b/packages/db/migrations/0008_api_keys_rls.sql
@@ -14,7 +14,7 @@ RETURNS TABLE(
   creator_email varchar, creator_email_verified boolean,
   creator_deleted_at timestamptz
 )
-LANGUAGE sql STABLE
+LANGUAGE sql STABLE SECURITY DEFINER
 SET search_path = public
 AS $$
   SELECT ak.id, ak.organization_id, ak.created_by, ak.name,
@@ -32,7 +32,7 @@ GRANT EXECUTE ON FUNCTION verify_api_key(varchar) TO app_user;
 -- SECURITY DEFINER function: fire-and-forget lastUsedAt update
 CREATE OR REPLACE FUNCTION touch_api_key_last_used(p_key_id uuid, p_ts timestamptz)
 RETURNS void
-LANGUAGE sql VOLATILE
+LANGUAGE sql VOLATILE SECURITY DEFINER
 SET search_path = public
 AS $$
   UPDATE public.api_keys SET last_used_at = p_ts WHERE id = p_key_id;

--- a/packages/db/migrations/0008_api_keys_rls.sql
+++ b/packages/db/migrations/0008_api_keys_rls.sql
@@ -1,0 +1,42 @@
+-- FORCE ROW LEVEL SECURITY (Drizzle only generates ENABLE, not FORCE)
+ALTER TABLE "api_keys" FORCE ROW LEVEL SECURITY;
+
+-- Grant DML permissions to app_user
+GRANT SELECT, INSERT, UPDATE, DELETE ON "api_keys" TO app_user;
+
+-- SECURITY DEFINER function: cross-org API key lookup by hash
+-- Same hardening pattern as list_user_organizations (0005_membership_helpers.sql)
+CREATE OR REPLACE FUNCTION verify_api_key(p_key_hash varchar)
+RETURNS TABLE(
+  id uuid, organization_id uuid, created_by uuid, name varchar,
+  scopes jsonb, expires_at timestamptz, revoked_at timestamptz,
+  last_used_at timestamptz, created_at timestamptz,
+  creator_email varchar, creator_email_verified boolean,
+  creator_deleted_at timestamptz
+)
+LANGUAGE sql STABLE
+SET search_path = public
+AS $$
+  SELECT ak.id, ak.organization_id, ak.created_by, ak.name,
+         ak.scopes, ak.expires_at, ak.revoked_at,
+         ak.last_used_at, ak.created_at,
+         u.email, u.email_verified, u.deleted_at
+  FROM public.api_keys ak
+  JOIN public.users u ON u.id = ak.created_by
+  WHERE ak.key_hash = p_key_hash
+$$;
+
+REVOKE ALL ON FUNCTION verify_api_key(varchar) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION verify_api_key(varchar) TO app_user;
+
+-- SECURITY DEFINER function: fire-and-forget lastUsedAt update
+CREATE OR REPLACE FUNCTION touch_api_key_last_used(p_key_id uuid, p_ts timestamptz)
+RETURNS void
+LANGUAGE sql VOLATILE
+SET search_path = public
+AS $$
+  UPDATE public.api_keys SET last_used_at = p_ts WHERE id = p_key_id;
+$$;
+
+REVOKE ALL ON FUNCTION touch_api_key_last_used(uuid, timestamptz) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION touch_api_key_last_used(uuid, timestamptz) TO app_user;

--- a/packages/db/migrations/meta/0007_snapshot.json
+++ b/packages/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,2169 @@
+{
+  "id": "762276e8-bec3-4c4f-86b6-130a2f65f37b",
+  "prevId": "6e146a97-fedb-41e6-8493-999f9e59616f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_organization_id_idx": {
+          "name": "api_keys_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_organization_id_organizations_id_fk": {
+          "name": "api_keys_organization_id_organizations_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_created_by_users_id_fk": {
+          "name": "api_keys_created_by_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key_hash"]
+        }
+      },
+      "policies": {
+        "api_keys_select": {
+          "name": "api_keys_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["public"],
+          "using": "organization_id = current_org_id()"
+        },
+        "api_keys_modify": {
+          "name": "api_keys_modify",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["public"],
+          "using": "organization_id = current_org_id()",
+          "withCheck": "organization_id = current_org_id()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_organization_id_idx": {
+          "name": "audit_events_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_actor_id_idx": {
+          "name": "audit_events_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_actor_created_idx": {
+          "name": "audit_events_actor_created_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_org_created_idx": {
+          "name": "audit_events_org_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_organization_id_organizations_id_fk": {
+          "name": "audit_events_organization_id_organizations_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "audit_events_actor_id_users_id_fk": {
+          "name": "audit_events_actor_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "audit_events_org_isolation_select": {
+          "name": "audit_events_org_isolation_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["public"],
+          "using": "organization_id = current_org_id()"
+        },
+        "audit_events_org_isolation_insert": {
+          "name": "audit_events_org_isolation_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": ["public"],
+          "withCheck": "organization_id IS NULL OR organization_id = current_org_id()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.dsar_requests": {
+      "name": "dsar_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "DsarType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "DsarStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dsar_requests_user_id_idx": {
+          "name": "dsar_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dsar_requests_status_due_idx": {
+          "name": "dsar_requests_status_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dsar_requests_user_id_users_id_fk": {
+          "name": "dsar_requests_user_id_users_id_fk",
+          "tableFrom": "dsar_requests",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_policies": {
+      "name": "retention_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_policies_org_resource_idx": {
+          "name": "retention_policies_org_resource_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_policies_organization_id_idx": {
+          "name": "retention_policies_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_policies_organization_id_organizations_id_fk": {
+          "name": "retention_policies_organization_id_organizations_id_fk",
+          "tableFrom": "retention_policies",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "retention_policies_org_isolation": {
+          "name": "retention_policies_org_isolation",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["public"],
+          "using": "organization_id IS NULL OR organization_id = current_org_id()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_consents": {
+      "name": "user_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_consents_user_id_idx": {
+          "name": "user_consents_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_consents_organization_id_idx": {
+          "name": "user_consents_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_consents_user_consent_type_idx": {
+          "name": "user_consents_user_consent_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_consents_user_id_users_id_fk": {
+          "name": "user_consents_user_id_users_id_fk",
+          "tableFrom": "user_consents",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_consents_organization_id_organizations_id_fk": {
+          "name": "user_consents_organization_id_organizations_id_fk",
+          "tableFrom": "user_consents",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_consents_org_isolation": {
+          "name": "user_consents_org_isolation",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["public"],
+          "using": "organization_id IS NULL OR organization_id = current_org_id()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_lower_slug_idx": {
+          "name": "organizations_lower_slug_idx",
+          "columns": [
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizations_settings_gin_idx": {
+          "name": "organizations_settings_gin_idx",
+          "columns": [
+            {
+              "expression": "\"settings\" jsonb_path_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zitadel_user_id": {
+          "name": "zitadel_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_lower_email_idx": {
+          "name": "users_lower_email_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_zitadel_user_id_idx": {
+          "name": "users_zitadel_user_id_idx",
+          "columns": [
+            {
+              "expression": "zitadel_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"zitadel_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_members": {
+      "name": "organization_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "Role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'READER'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_members_org_user_idx": {
+          "name": "organization_members_org_user_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "organization_members_select": {
+          "name": "organization_members_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["public"],
+          "using": "organization_id = current_org_id()"
+        },
+        "organization_members_modify": {
+          "name": "organization_members_modify",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["public"],
+          "using": "organization_id = current_org_id()",
+          "withCheck": "organization_id = current_org_id()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.submission_files": {
+      "name": "submission_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scan_status": {
+          "name": "scan_status",
+          "type": "ScanStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "submission_files_submission_id_idx": {
+          "name": "submission_files_submission_id_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submission_files_scan_status_idx": {
+          "name": "submission_files_scan_status_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scan_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "uploaded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submission_files_submission_id_submissions_id_fk": {
+          "name": "submission_files_submission_id_submissions_id_fk",
+          "tableFrom": "submission_files",
+          "tableTo": "submissions",
+          "columnsFrom": ["submission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "submission_files_org_isolation": {
+          "name": "submission_files_org_isolation",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["public"],
+          "using": "submission_id IN (\n        SELECT id FROM submissions\n        WHERE organization_id = current_org_id()\n      )"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.submission_history": {
+      "name": "submission_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "SubmissionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "SubmissionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "submission_history_submission_id_idx": {
+          "name": "submission_history_submission_id_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submission_history_changed_at_idx": {
+          "name": "submission_history_changed_at_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submission_history_submission_id_submissions_id_fk": {
+          "name": "submission_history_submission_id_submissions_id_fk",
+          "tableFrom": "submission_history",
+          "tableTo": "submissions",
+          "columnsFrom": ["submission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "submission_history_org_isolation": {
+          "name": "submission_history_org_isolation",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["public"],
+          "using": "submission_id IN (\n        SELECT id FROM submissions\n        WHERE organization_id = current_org_id()\n      )"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.submission_periods": {
+      "name": "submission_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opens_at": {
+          "name": "opens_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_submissions": {
+          "name": "max_submissions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "submission_periods_organization_id_idx": {
+          "name": "submission_periods_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submission_periods_org_dates_idx": {
+          "name": "submission_periods_org_dates_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opens_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closes_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submission_periods_organization_id_organizations_id_fk": {
+          "name": "submission_periods_organization_id_organizations_id_fk",
+          "tableFrom": "submission_periods",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_isolation": {
+          "name": "org_isolation",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["public"],
+          "using": "organization_id = current_org_id()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitter_id": {
+          "name": "submitter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_period_id": {
+          "name": "submission_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_letter": {
+          "name": "cover_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "SubmissionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "submissions_organization_id_idx": {
+          "name": "submissions_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_submitter_id_idx": {
+          "name": "submissions_submitter_id_idx",
+          "columns": [
+            {
+              "expression": "submitter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_submitter_status_idx": {
+          "name": "submissions_submitter_status_idx",
+          "columns": [
+            {
+              "expression": "submitter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_submission_period_id_idx": {
+          "name": "submissions_submission_period_id_idx",
+          "columns": [
+            {
+              "expression": "submission_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_org_status_submitted_idx": {
+          "name": "submissions_org_status_submitted_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_search_vector_idx": {
+          "name": "submissions_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_organization_id_organizations_id_fk": {
+          "name": "submissions_organization_id_organizations_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "submissions_submitter_id_users_id_fk": {
+          "name": "submissions_submitter_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": ["submitter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "submissions_submission_period_id_submission_periods_id_fk": {
+          "name": "submissions_submission_period_id_submission_periods_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "submission_periods",
+          "columnsFrom": ["submission_period_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "org_isolation": {
+          "name": "org_isolation",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["public"],
+          "using": "organization_id = current_org_id()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "status": {
+          "name": "status",
+          "type": "PaymentStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_organization_id_idx": {
+          "name": "payments_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_submission_id_idx": {
+          "name": "payments_submission_id_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_metadata_gin_idx": {
+          "name": "payments_metadata_gin_idx",
+          "columns": [
+            {
+              "expression": "\"metadata\" jsonb_path_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_organization_id_organizations_id_fk": {
+          "name": "payments_organization_id_organizations_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "payments_submission_id_submissions_id_fk": {
+          "name": "payments_submission_id_submissions_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "submissions",
+          "columnsFrom": ["submission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payments_stripe_payment_id_unique": {
+          "name": "payments_stripe_payment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_payment_id"]
+        },
+        "payments_stripe_session_id_unique": {
+          "name": "payments_stripe_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_session_id"]
+        }
+      },
+      "policies": {
+        "payments_org_isolation": {
+          "name": "payments_org_isolation",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": ["public"],
+          "using": "organization_id = current_org_id()"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed": {
+          "name": "processed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_webhook_events_polling_idx": {
+          "name": "stripe_webhook_events_polling_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stripe_webhook_events_stripe_id_unique": {
+          "name": "stripe_webhook_events_stripe_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outbox_events": {
+      "name": "outbox_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "outbox_events_ready_idx": {
+          "name": "outbox_events_ready_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zitadel_webhook_events": {
+      "name": "zitadel_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed": {
+          "name": "processed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zitadel_webhook_events_event_id_idx": {
+          "name": "zitadel_webhook_events_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zitadel_webhook_events_ready_idx": {
+          "name": "zitadel_webhook_events_ready_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.DsarStatus": {
+      "name": "DsarStatus",
+      "schema": "public",
+      "values": ["PENDING", "IN_PROGRESS", "COMPLETED", "REJECTED"]
+    },
+    "public.DsarType": {
+      "name": "DsarType",
+      "schema": "public",
+      "values": ["ACCESS", "ERASURE", "RECTIFICATION", "PORTABILITY"]
+    },
+    "public.PaymentStatus": {
+      "name": "PaymentStatus",
+      "schema": "public",
+      "values": ["PENDING", "PROCESSING", "SUCCEEDED", "FAILED", "REFUNDED"]
+    },
+    "public.Role": {
+      "name": "Role",
+      "schema": "public",
+      "values": ["ADMIN", "EDITOR", "READER"]
+    },
+    "public.ScanStatus": {
+      "name": "ScanStatus",
+      "schema": "public",
+      "values": ["PENDING", "SCANNING", "CLEAN", "INFECTED", "FAILED"]
+    },
+    "public.SubmissionStatus": {
+      "name": "SubmissionStatus",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "SUBMITTED",
+        "UNDER_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+        "HOLD",
+        "WITHDRAWN"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -50,6 +50,20 @@
       "when": 1771200000001,
       "tag": "0006_add_users_last_event_at",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1771208876530,
+      "tag": "0007_lonely_toxin",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1771208876531,
+      "tag": "0008_api_keys_rls",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/api-keys.ts
+++ b/packages/db/src/schema/api-keys.ts
@@ -1,0 +1,48 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  jsonb,
+  timestamp,
+  index,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { organizations } from "./organizations";
+import { users } from "./users";
+
+export const apiKeys = pgTable(
+  "api_keys",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    createdBy: uuid("created_by")
+      .notNull()
+      .references(() => users.id, { onDelete: "restrict" }),
+    name: varchar("name", { length: 255 }).notNull(),
+    keyHash: varchar("key_hash", { length: 128 }).notNull().unique(),
+    keyPrefix: varchar("key_prefix", { length: 12 }).notNull(),
+    scopes: jsonb("scopes").notNull().$type<string[]>(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("api_keys_organization_id_idx").on(table.organizationId),
+    index("api_keys_key_hash_idx").on(table.keyHash),
+    pgPolicy("api_keys_select", {
+      for: "select",
+      using: sql`organization_id = current_org_id()`,
+    }),
+    pgPolicy("api_keys_modify", {
+      for: "all",
+      using: sql`organization_id = current_org_id()`,
+      withCheck: sql`organization_id = current_org_id()`,
+    }),
+  ],
+).enableRLS();

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -8,4 +8,5 @@ export * from "./audit";
 export * from "./compliance";
 export * from "./messaging";
 export * from "./webhooks";
+export * from "./api-keys";
 export * from "./relations";

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -11,6 +11,7 @@ import {
 import { payments } from "./payments";
 import { auditEvents, dsarRequests } from "./audit";
 import { retentionPolicies, userConsents } from "./compliance";
+import { apiKeys } from "./api-keys";
 
 // --- organizations ---
 
@@ -22,6 +23,7 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   auditEvents: many(auditEvents),
   retentionPolicies: many(retentionPolicies),
   userConsents: many(userConsents),
+  apiKeys: many(apiKeys),
 }));
 
 // --- users ---
@@ -32,6 +34,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   auditEvents: many(auditEvents),
   dsarRequests: many(dsarRequests),
   userConsents: many(userConsents),
+  apiKeys: many(apiKeys),
 }));
 
 // --- organization_members ---
@@ -164,5 +167,18 @@ export const userConsentsRelations = relations(userConsents, ({ one }) => ({
   organization: one(organizations, {
     fields: [userConsents.organizationId],
     references: [organizations.id],
+  }),
+}));
+
+// --- api_keys ---
+
+export const apiKeysRelations = relations(apiKeys, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [apiKeys.organizationId],
+    references: [organizations.id],
+  }),
+  creator: one(users, {
+    fields: [apiKeys.createdBy],
+    references: [users.id],
   }),
 }));

--- a/packages/types/src/api-key.ts
+++ b/packages/types/src/api-key.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// API Key Scopes — stored now, enforced in Track 2
+// ---------------------------------------------------------------------------
+
+export const apiKeyScopeSchema = z.enum([
+  "submissions:read",
+  "submissions:write",
+  "files:read",
+  "files:write",
+  "payments:read",
+  "organizations:read",
+  "webhooks:manage",
+]);
+
+export type ApiKeyScope = z.infer<typeof apiKeyScopeSchema>;
+
+// ---------------------------------------------------------------------------
+// CRUD schemas
+// ---------------------------------------------------------------------------
+
+export const createApiKeySchema = z.object({
+  name: z.string().min(1).max(255),
+  scopes: z.array(apiKeyScopeSchema).min(1),
+  expiresAt: z.coerce.date().optional(),
+});
+
+export type CreateApiKeyInput = z.infer<typeof createApiKeySchema>;
+
+export const revokeApiKeySchema = z.object({
+  keyId: z.string().uuid(),
+});
+
+export const deleteApiKeySchema = z.object({
+  keyId: z.string().uuid(),
+});
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+export const apiKeyResponseSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  scopes: z.array(apiKeyScopeSchema),
+  keyPrefix: z.string(),
+  createdAt: z.date(),
+  expiresAt: z.date().nullable(),
+  lastUsedAt: z.date().nullable(),
+  revokedAt: z.date().nullable(),
+});
+
+export type ApiKeyResponse = z.infer<typeof apiKeyResponseSchema>;
+
+/** Only returned once on creation — plainTextKey is shown once, never stored. */
+export const createApiKeyResponseSchema = apiKeyResponseSchema.extend({
+  plainTextKey: z.string(),
+});
+
+export type CreateApiKeyResponse = z.infer<typeof createApiKeyResponseSchema>;

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -40,6 +40,13 @@ export const AuditActions = {
   AUTH_TOKEN_EXPIRED: "AUTH_TOKEN_EXPIRED",
   AUTH_USER_NOT_PROVISIONED: "AUTH_USER_NOT_PROVISIONED",
   AUTH_USER_DEACTIVATED: "AUTH_USER_DEACTIVATED",
+
+  // API key lifecycle
+  API_KEY_CREATED: "API_KEY_CREATED",
+  API_KEY_REVOKED: "API_KEY_REVOKED",
+  API_KEY_DELETED: "API_KEY_DELETED",
+  API_KEY_AUTH_SUCCESS: "API_KEY_AUTH_SUCCESS",
+  API_KEY_AUTH_FAILED: "API_KEY_AUTH_FAILED",
 } as const;
 
 export type AuditAction = (typeof AuditActions)[keyof typeof AuditActions];
@@ -51,6 +58,7 @@ export const AuditResources = {
   SUBMISSION: "submission",
   FILE: "file",
   AUTH: "auth",
+  API_KEY: "api_key",
 } as const;
 
 export type AuditResource =
@@ -122,10 +130,21 @@ export interface AuthAuditParams extends BaseAuditParams {
     | typeof AuditActions.AUTH_USER_DEACTIVATED;
 }
 
+export interface ApiKeyAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.API_KEY;
+  action:
+    | typeof AuditActions.API_KEY_CREATED
+    | typeof AuditActions.API_KEY_REVOKED
+    | typeof AuditActions.API_KEY_DELETED
+    | typeof AuditActions.API_KEY_AUTH_SUCCESS
+    | typeof AuditActions.API_KEY_AUTH_FAILED;
+}
+
 /** Union of all resource-specific param types. */
 export type AuditLogParams =
   | UserAuditParams
   | OrgAuditParams
   | SubmissionAuditParams
   | FileAuditParams
-  | AuthAuditParams;
+  | AuthAuditParams
+  | ApiKeyAuditParams;

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { ApiKeyScope } from "./api-key";
 
 // ---------------------------------------------------------------------------
 // v2 — Zitadel OIDC types
@@ -25,9 +26,15 @@ export type OidcTokenClaims = z.infer<typeof oidcTokenClaimsSchema>;
 /** Per-request auth context populated by the auth hook. */
 export interface AuthContext {
   userId: string;
-  zitadelUserId: string;
   email: string;
   emailVerified: boolean;
+  authMethod: "oidc" | "apikey" | "test";
+  /** Zitadel user ID — set for OIDC auth only. */
+  zitadelUserId?: string;
+  /** API key ID — set for API key auth only. */
+  apiKeyId?: string;
+  /** API key scopes — set for API key auth only. */
+  apiKeyScopes?: ApiKeyScope[];
   orgId?: string;
   role?: "ADMIN" | "EDITOR" | "READER";
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -6,3 +6,4 @@ export * from "./payment";
 export * from "./file";
 export * from "./common";
 export * from "./audit";
+export * from "./api-key";


### PR DESCRIPTION
## Summary

- Adds API key authentication as a second auth path alongside Zitadel OIDC
- Key format: `col_live_<32 hex chars>` (SHA-256 hashed, never stored in plain text)
- Org-scoped keys with creator tracking for audit trail and RLS context
- Default-deny: Bearer token checked first, `X-Api-Key` is fallback
- Fail-closed: if key creator loses org membership, auth is rejected (403)
- Scopes stored but enforcement deferred to Track 2 (REST/GraphQL surfaces)
- CRUD management via tRPC router (`apiKeys.*`): ADMIN create/revoke/delete, all members list

## Changes

### New files
- `packages/types/src/api-key.ts` — Zod schemas, scope enum, types
- `packages/db/src/schema/api-keys.ts` — Table with RLS policies
- `apps/api/src/services/api-key.service.ts` — Key generation, CRUD, verify, touch
- `apps/api/src/trpc/routers/api-keys.ts` — tRPC CRUD router
- `packages/db/migrations/0007_lonely_toxin.sql` — Auto-generated table migration
- `packages/db/migrations/0008_api_keys_rls.sql` — FORCE RLS + SECURITY DEFINER functions

### Modified files
- `packages/types/src/auth.ts` — Extended AuthContext (authMethod, optional zitadelUserId, apiKeyId, apiKeyScopes)
- `packages/types/src/audit.ts` — API_KEY audit actions/resources
- `apps/api/src/hooks/auth.ts` — X-Api-Key fallback path
- `apps/api/src/hooks/org-context.ts` — Handle pre-set orgId from API key auth
- `apps/api/src/main.ts` — X-Api-Key in CORS allowedHeaders
- `apps/api/src/trpc/router.ts` — Register apiKeys router
- 8 test files updated for new AuthContext shape

### Tests
- 8 new tests in `auth.spec.ts` for API key auth path
- `api-key.service.spec.ts` — 8 tests for service layer
- `api-keys.spec.ts` — 11 tests for tRPC router
- `rls-infrastructure.test.ts` — api_keys added to RLS verification
- All 261 API tests + 35 web tests pass

### code review
- 1 critical finding (missing SECURITY DEFINER on SQL functions) — fixed in follow-up commit

## Test plan

- [x] `pnpm type-check` passes across all 8 workspace packages
- [x] `pnpm test` — 261 API + 35 web tests pass
- [x] `pnpm lint` clean
- [x] branch review — 1 finding addressed
- [ ] Manual QA with Docker Compose + Zitadel (deferred — no live Zitadel instance in dev currently)