### PR TITLE
chore: upgrade Zod 3 → 4

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -46,7 +46,7 @@
     "ioredis": "^5.9.3",
     "nodemailer": "^7.0.13",
     "stripe": "^20.3.1",
-    "zod": "^3.23.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@colophony/eslint-config": "workspace:*",

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -49,8 +49,8 @@ const envSchema = z.object({
   CLAMAV_PORT: z.coerce.number().int().positive().default(3310),
   VIRUS_SCAN_ENABLED: z
     .enum(['true', 'false'])
-    .transform((v) => v === 'true')
-    .default('true'),
+    .default('true')
+    .transform((v) => v === 'true'),
 
   // Optional — validated when modules wire up
   STRIPE_SECRET_KEY: z.string().optional(),
@@ -60,13 +60,13 @@ const envSchema = z.object({
   ZITADEL_WEBHOOK_SECRET: z.string().optional(),
   DEV_AUTH_BYPASS: z
     .enum(['true', 'false'])
-    .transform((v) => v === 'true')
-    .default('false'),
+    .default('false')
+    .transform((v) => v === 'true'),
   FEDERATION_DOMAIN: z.string().optional(),
   FEDERATION_ENABLED: z
     .enum(['true', 'false'])
-    .transform((v) => v === 'true')
-    .optional(),
+    .default('false')
+    .transform((v) => v === 'true'),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -78,6 +78,7 @@ const baseEnv: Env = {
   CLAMAV_PORT: 3310,
   VIRUS_SCAN_ENABLED: true,
   DEV_AUTH_BYPASS: false,
+  FEDERATION_ENABLED: false,
 };
 
 describe('auth plugin', () => {

--- a/apps/api/src/hooks/rate-limit.spec.ts
+++ b/apps/api/src/hooks/rate-limit.spec.ts
@@ -83,6 +83,7 @@ const testEnv: Env = {
   CLAMAV_PORT: 3310,
   VIRUS_SCAN_ENABLED: true,
   DEV_AUTH_BYPASS: false,
+  FEDERATION_ENABLED: false,
 };
 
 async function buildApp(

--- a/apps/api/src/main.spec.ts
+++ b/apps/api/src/main.spec.ts
@@ -84,6 +84,7 @@ const testEnv: Env = {
   CLAMAV_PORT: 3310,
   VIRUS_SCAN_ENABLED: true,
   DEV_AUTH_BYPASS: false,
+  FEDERATION_ENABLED: false,
 };
 
 describe('Fastify app', () => {

--- a/apps/api/src/trpc/routers/api-keys.spec.ts
+++ b/apps/api/src/trpc/routers/api-keys.spec.ts
@@ -65,7 +65,7 @@ describe('apiKeys router', () => {
       const keys = {
         items: [
           {
-            id: 'a1111111-1111-1111-1111-111111111111',
+            id: 'a1111111-1111-1111-a111-111111111111',
             name: 'Test Key',
             scopes: ['submissions:read'],
             keyPrefix: 'col_live_',
@@ -110,7 +110,7 @@ describe('apiKeys router', () => {
   describe('create', () => {
     it('returns plain text key on creation', async () => {
       const created = {
-        id: 'a1111111-1111-1111-1111-111111111111',
+        id: 'a1111111-1111-1111-a111-111111111111',
         name: 'My Key',
         scopes: ['submissions:read'],
         keyPrefix: 'col_live_',
@@ -140,7 +140,7 @@ describe('apiKeys router', () => {
         expect.objectContaining({
           action: 'API_KEY_CREATED',
           resource: 'api_key',
-          resourceId: 'a1111111-1111-1111-1111-111111111111',
+          resourceId: 'a1111111-1111-1111-a111-111111111111',
         }),
       );
     });
@@ -169,7 +169,7 @@ describe('apiKeys router', () => {
   describe('revoke', () => {
     it('revokes a key and audits', async () => {
       mockApiKeyService.revoke.mockResolvedValueOnce({
-        id: 'a1111111-1111-1111-1111-111111111111',
+        id: 'a1111111-1111-1111-a111-111111111111',
         name: 'My Key',
         revokedAt: new Date(),
       });
@@ -177,7 +177,7 @@ describe('apiKeys router', () => {
       const ctx = orgContext('ADMIN');
       const caller = createCaller(ctx);
       const result = await caller.apiKeys.revoke({
-        keyId: 'a1111111-1111-1111-1111-111111111111',
+        keyId: 'a1111111-1111-1111-a111-111111111111',
       });
 
       expect(result.revokedAt).toBeInstanceOf(Date);
@@ -185,7 +185,7 @@ describe('apiKeys router', () => {
         expect.objectContaining({
           action: 'API_KEY_REVOKED',
           resource: 'api_key',
-          resourceId: 'a1111111-1111-1111-1111-111111111111',
+          resourceId: 'a1111111-1111-1111-a111-111111111111',
         }),
       );
     });
@@ -196,7 +196,7 @@ describe('apiKeys router', () => {
       const caller = createCaller(orgContext('ADMIN'));
       await expect(
         caller.apiKeys.revoke({
-          keyId: 'b2222222-2222-2222-2222-222222222222',
+          keyId: 'b2222222-2222-2222-a222-222222222222',
         }),
       ).rejects.toThrow('API key not found');
     });
@@ -205,7 +205,7 @@ describe('apiKeys router', () => {
       const caller = createCaller(orgContext('READER'));
       await expect(
         caller.apiKeys.revoke({
-          keyId: 'a1111111-1111-1111-1111-111111111111',
+          keyId: 'a1111111-1111-1111-a111-111111111111',
         }),
       ).rejects.toThrow('Admin role required');
     });
@@ -214,13 +214,13 @@ describe('apiKeys router', () => {
   describe('delete', () => {
     it('deletes a key and audits', async () => {
       mockApiKeyService.delete.mockResolvedValueOnce({
-        id: 'a1111111-1111-1111-1111-111111111111',
+        id: 'a1111111-1111-1111-a111-111111111111',
       });
 
       const ctx = orgContext('ADMIN');
       const caller = createCaller(ctx);
       const result = await caller.apiKeys.delete({
-        keyId: 'a1111111-1111-1111-1111-111111111111',
+        keyId: 'a1111111-1111-1111-a111-111111111111',
       });
 
       expect(result).toEqual({ success: true });
@@ -228,7 +228,7 @@ describe('apiKeys router', () => {
         expect.objectContaining({
           action: 'API_KEY_DELETED',
           resource: 'api_key',
-          resourceId: 'a1111111-1111-1111-1111-111111111111',
+          resourceId: 'a1111111-1111-1111-a111-111111111111',
         }),
       );
     });
@@ -239,7 +239,7 @@ describe('apiKeys router', () => {
       const caller = createCaller(orgContext('ADMIN'));
       await expect(
         caller.apiKeys.delete({
-          keyId: 'b2222222-2222-2222-2222-222222222222',
+          keyId: 'b2222222-2222-2222-a222-222222222222',
         }),
       ).rejects.toThrow('API key not found');
     });
@@ -248,7 +248,7 @@ describe('apiKeys router', () => {
       const caller = createCaller(orgContext('EDITOR'));
       await expect(
         caller.apiKeys.delete({
-          keyId: 'a1111111-1111-1111-1111-111111111111',
+          keyId: 'a1111111-1111-1111-a111-111111111111',
         }),
       ).rejects.toThrow('Admin role required');
     });

--- a/apps/api/src/trpc/routers/files.spec.ts
+++ b/apps/api/src/trpc/routers/files.spec.ts
@@ -133,8 +133,8 @@ const createCaller = (appRouter as any).createCaller as (
   ctx: TRPCContext,
 ) => any;
 
-const SUBMISSION_ID = 'a1111111-1111-1111-1111-111111111111';
-const FILE_ID = 'f1111111-1111-1111-1111-111111111111';
+const SUBMISSION_ID = 'a1111111-1111-1111-a111-111111111111';
+const FILE_ID = 'f1111111-1111-1111-a111-111111111111';
 
 function makeDraftSubmission(submitterId = 'user-1') {
   return {

--- a/apps/api/src/trpc/routers/organizations.spec.ts
+++ b/apps/api/src/trpc/routers/organizations.spec.ts
@@ -312,7 +312,7 @@ describe('organizations tRPC router', () => {
       const ctx = orgContext('ADMIN');
       const caller = createCaller(ctx);
       const result = await caller.organizations.members.remove({
-        memberId: 'a1111111-1111-1111-1111-111111111111',
+        memberId: 'a1111111-1111-1111-a111-111111111111',
       });
       expect(result).toEqual({ success: true });
     });
@@ -326,7 +326,7 @@ describe('organizations tRPC router', () => {
       const caller = createCaller(orgContext('ADMIN'));
       await expect(
         caller.organizations.members.remove({
-          memberId: 'a1111111-1111-1111-1111-111111111111',
+          memberId: 'a1111111-1111-1111-a111-111111111111',
         }),
       ).rejects.toThrow('last admin');
     });
@@ -342,7 +342,7 @@ describe('organizations tRPC router', () => {
       const ctx = orgContext('ADMIN');
       const caller = createCaller(ctx);
       const result = await caller.organizations.members.updateRole({
-        memberId: 'a1111111-1111-1111-1111-111111111111',
+        memberId: 'a1111111-1111-1111-a111-111111111111',
         role: 'EDITOR',
       });
       expect(result.role).toBe('EDITOR');

--- a/apps/api/src/trpc/routers/submissions.spec.ts
+++ b/apps/api/src/trpc/routers/submissions.spec.ts
@@ -120,7 +120,7 @@ const createCaller = (appRouter as any).createCaller as (
   ctx: TRPCContext,
 ) => any;
 
-const SUBMISSION_ID = 'a1111111-1111-1111-1111-111111111111';
+const SUBMISSION_ID = 'a1111111-1111-1111-a111-111111111111';
 
 function makeDraftSubmission(submitterId = 'user-1') {
   return {

--- a/apps/api/src/webhooks/tusd.webhook.spec.ts
+++ b/apps/api/src/webhooks/tusd.webhook.spec.ts
@@ -137,7 +137,7 @@ const TEST_ENV = {
   CLAMAV_PORT: 3310,
 } as unknown as Env;
 
-const SUBMISSION_ID = 'a1111111-1111-1111-1111-111111111111';
+const SUBMISSION_ID = 'a1111111-1111-1111-a111-111111111111';
 
 function makePreCreateBody(overrides: Record<string, unknown> = {}) {
   return {

--- a/apps/api/src/webhooks/zitadel.webhook.spec.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.spec.ts
@@ -140,6 +140,7 @@ const testEnv: Env = {
   CLAMAV_PORT: 3310,
   VIRUS_SCAN_ENABLED: true,
   DEV_AUTH_BYPASS: false,
+  FEDERATION_ENABLED: false,
 };
 
 function signPayload(body: string): string {

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -80,7 +80,7 @@ Key functions in `trpc.ts`:
 
 ## Version Pins
 
-| Package        | Pinned | Notes                              |
-| -------------- | ------ | ---------------------------------- |
-| TanStack Query | 4.36   | `isLoading` behavior changes in v5 |
-| tus-js-client  | 4.3.1  | —                                  |
+| Package        | Pinned | Notes                                             |
+| -------------- | ------ | ------------------------------------------------- |
+| TanStack Query | 4.36   | Blocked by tRPC 10 peer dep; upgrade with tRPC 11 |
+| tus-js-client  | 4.3.1  | —                                                 |

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,7 +48,7 @@
     "tailwind-merge": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "tus-js-client": "^4.3.1",
-    "zod": "^3.25.76"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@colophony/db": "workspace:*",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -177,13 +177,13 @@
 
 ### [P1] High — Major versions, actively maintained
 
-- [ ] Zod 3 → 4 — ground-up rewrite (stable May 2025); touches types package, all tRPC inputs, env config; largest migration surface — (dependabot #80)
-- [ ] TanStack Query 4 → 5 — `isLoading` → `isPending` split; shipped Oct 2023; requires auditing all query usages in web app — (dependabot #74)
-- [ ] tRPC 10 → 11 — currently pinned for Zod error behavior; evaluate whether Zod 4 changes the calculus — (CLAUDE.md version pin)
+- [x] Zod 3 → 4 — ground-up rewrite (stable May 2025); touches types package, all tRPC inputs, env config; largest migration surface — (dependabot #80; done 2026-02-17)
+- [ ] TanStack Query 4 → 5 — blocked by tRPC 10; `@trpc/react-query@10.45` has hard peer dep on TQ4. Must upgrade tRPC first — (dependabot #74; attempted 2026-02-17)
+- [ ] tRPC 10 → 11 — unblocked by Zod 4 completion; combined tRPC 11 + TQ5 migration needed — (CLAUDE.md version pin)
 
 ### [P2] Medium — Dev tooling, lower risk
 
-- [ ] Vitest 3 → 4 — shipped Oct 2025; dev-only, but 261+ tests need validation — (dependabot #76)
+- [x] Vitest 3 → 4 — shipped Oct 2025; dev-only, but 261+ tests need validation — (dependabot #76; done 2026-02-17)
 - [x] @testing-library/react 14 → 16 — dev-only; skipped v15; bundled with Next 16 + React 19 upgrade — (dependabot #78; done 2026-02-16)
 
 ### [P3] Low — Unused or minimal impact

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,34 @@ Newest entries first.
 
 ---
 
+## 2026-02-17 — Dependency Upgrades: Vitest 4 + Zod 4
+
+### Done
+
+- **PR #86** (`chore/vitest-4`) — Vitest 3 → 4 upgrade across `apps/api` and `packages/auth-client`
+  - Fixed 6 arrow function mocks → function expressions (Vitest 4 enforces that `vi.fn()` arrow mocks can't be called with `new`)
+  - Affected mocks: ioredis (3 files), BullMQ Queue (1 file), BullMQ Worker (1 file), clamscan (1 file)
+  - All 296 tests pass on Vitest 4.0.18
+- **PR #87** (`chore/zod-4`) — Zod 3 → 4 upgrade across all 4 packages (types, auth-client, api, web)
+  - Fixed 8 `z.record()` calls: added explicit key schema (Zod 4 requires 2 args)
+  - Replaced 2 `.passthrough()` usages with `z.looseObject()` in auth-client webhook schemas
+  - Reordered `.transform().default()` → `.default().transform()` in env.ts (Zod 4 `.default()` after `.transform()` expects output type)
+  - Changed `FEDERATION_ENABLED` from `.optional().transform()` to `.default('false').transform()` (Zod 4 always runs transform on optional, making field required)
+  - Fixed UUID variant nibble in 5 spec files (Zod 4 enforces RFC 4122 variant bits at position 20)
+  - Added `FEDERATION_ENABLED: false` to 4 test env fixtures
+- **TanStack Query 5 — abandoned**: `@trpc/react-query@10.45` only supports TQ4 as peer dep. Requires combined tRPC 10→11 + TQ5 migration
+- Codex plan review: identified z.record count discrepancy (4→5 in file.ts) and additional TQ5 isLoading usages — both addressed
+- Codex implementation reviews on both PRs: no regressions found
+- Local verification per PR: `pnpm install`, type-check, 296 tests, lint, build all pass
+
+### Decisions
+
+- **TQ5 deferred until tRPC 11** — `@trpc/react-query@10.45` has hard peer dep on `@tanstack/react-query@^4.18.0`; types incompatible (queryKey required, cacheTime→gcTime). Must upgrade tRPC first
+- **Zod 4 `z.looseObject()` over `z.object().passthrough()`** — `.passthrough()` removed in Zod 4; `z.looseObject()` is the direct replacement for allowing extra keys
+- **`FEDERATION_ENABLED` changed from optional to defaulted** — Zod 4's optional+transform always runs transform (producing boolean), making it required in the output type. Using `.default('false')` is semantically equivalent and avoids breaking tests
+
+---
+
 ## 2026-02-16 — Next.js 15 → 16 + React 18 → 19 Upgrade
 
 ### Done

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "jose": "^6.0.0",
-    "zod": "^3.23.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@colophony/typescript-config": "workspace:*",

--- a/packages/auth-client/src/types.ts
+++ b/packages/auth-client/src/types.ts
@@ -30,25 +30,21 @@ export const zitadelEventTypeSchema = z.enum([
 ]);
 export type ZitadelEventType = z.infer<typeof zitadelEventTypeSchema>;
 
-export const zitadelWebhookUserSchema = z
-  .object({
-    userId: z.string().optional(),
-    username: z.string().optional(),
-    email: z.string().optional(),
-    emailVerified: z.boolean().optional(),
-    displayName: z.string().optional(),
-  })
-  .passthrough();
+export const zitadelWebhookUserSchema = z.looseObject({
+  userId: z.string().optional(),
+  username: z.string().optional(),
+  email: z.string().optional(),
+  emailVerified: z.boolean().optional(),
+  displayName: z.string().optional(),
+});
 
 /** eventType is z.string() (not z.enum) so unknown types pass validation
  *  and reach the switch default case for logging + idempotency recording. */
-export const zitadelWebhookPayloadSchema = z
-  .object({
-    eventType: z.string().min(1),
-    eventId: z.string().min(1),
-    creationDate: z.string().min(1),
-    user: zitadelWebhookUserSchema.optional(),
-  })
-  .passthrough();
+export const zitadelWebhookPayloadSchema = z.looseObject({
+  eventType: z.string().min(1),
+  eventId: z.string().min(1),
+  creationDate: z.string().min(1),
+  user: zitadelWebhookUserSchema.optional(),
+});
 
 export type ZitadelWebhookPayload = z.infer<typeof zitadelWebhookPayloadSchema>;

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,7 +16,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "zod": "^3.23.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@colophony/typescript-config": "workspace:*",

--- a/packages/types/src/file.ts
+++ b/packages/types/src/file.ts
@@ -123,17 +123,17 @@ export const tusdPreCreateHookSchema = z.object({
     Size: z.number().optional(),
     SizeIsDeferred: z.boolean().optional(),
     Offset: z.number().optional(),
-    MetaData: z.record(z.string()).optional(),
+    MetaData: z.record(z.string(), z.string()).optional(),
     IsPartial: z.boolean().optional(),
     IsFinal: z.boolean().optional(),
     PartialUploads: z.array(z.string()).optional().nullable(),
-    Storage: z.record(z.unknown()).optional().nullable(),
+    Storage: z.record(z.string(), z.unknown()).optional().nullable(),
   }),
   HTTPRequest: z.object({
     Method: z.string(),
     URI: z.string(),
     RemoteAddr: z.string(),
-    Header: z.record(z.array(z.string())),
+    Header: z.record(z.string(), z.array(z.string())),
   }),
 });
 
@@ -148,7 +148,7 @@ export const tusdPostFinishHookSchema = z.object({
     Size: z.number(),
     SizeIsDeferred: z.boolean().optional(),
     Offset: z.number(),
-    MetaData: z.record(z.string()).optional(),
+    MetaData: z.record(z.string(), z.string()).optional(),
     IsPartial: z.boolean().optional(),
     IsFinal: z.boolean().optional(),
     PartialUploads: z.array(z.string()).optional().nullable(),
@@ -165,7 +165,7 @@ export const tusdPostFinishHookSchema = z.object({
     Method: z.string(),
     URI: z.string(),
     RemoteAddr: z.string(),
-    Header: z.record(z.array(z.string())),
+    Header: z.record(z.string(), z.array(z.string())),
   }),
 });
 

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -4,7 +4,7 @@ export const organizationSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
   slug: z.string(),
-  settings: z.record(z.unknown()),
+  settings: z.record(z.string(), z.unknown()),
   createdAt: z.date(),
   updatedAt: z.date(),
 });
@@ -29,7 +29,7 @@ export type CreateOrganizationInput = z.infer<typeof createOrganizationSchema>;
 
 export const updateOrganizationSchema = z.object({
   name: z.string().min(1).max(255).optional(),
-  settings: z.record(z.unknown()).optional(),
+  settings: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type UpdateOrganizationInput = z.infer<typeof updateOrganizationSchema>;

--- a/packages/types/src/payment.ts
+++ b/packages/types/src/payment.ts
@@ -19,7 +19,7 @@ export const paymentSchema = z.object({
   amount: z.number(),
   currency: z.string(),
   status: paymentStatusSchema,
-  metadata: z.record(z.unknown()),
+  metadata: z.record(z.string(), z.unknown()),
   createdAt: z.date(),
   updatedAt: z.date(),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^20.3.1
         version: 20.3.1(@types/node@25.2.3)
       zod:
-        specifier: ^3.23.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@colophony/eslint-config':
         specifier: workspace:*
@@ -244,8 +244,8 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@colophony/db':
         specifier: workspace:*
@@ -311,8 +311,8 @@ importers:
         specifier: ^6.0.0
         version: 6.1.3
       zod:
-        specifier: ^3.23.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@colophony/typescript-config':
         specifier: workspace:*
@@ -379,8 +379,8 @@ importers:
   packages/types:
     dependencies:
       zod:
-        specifier: ^3.23.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@colophony/typescript-config':
         specifier: workspace:*
@@ -6298,8 +6298,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -10098,8 +10098,8 @@ snapshots:
       '@babel/parser': 7.29.0
       eslint: 9.39.2(jiti@1.21.7)
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.3.6
+      zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -13040,8 +13040,8 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.7.0
 
-  zod-validation-error@4.0.2(zod@3.25.76):
+  zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
-      zod: 3.25.76
+      zod: 4.3.6
 
-  zod@3.25.76: {}
+  zod@4.3.6: {}


### PR DESCRIPTION
## Summary
- Upgrades Zod from `^3.23.0` to `^4.3.6` across all packages (`types`, `auth-client`, `api`, `web`)
- Fixes `z.record()` calls to require 2 args (key + value schema) — 8 usages in types package
- Replaces `.passthrough()` with `z.looseObject()` in auth-client webhook schemas
- Reorders `.default().transform()` for boolean env vars (Zod 4 `.default()` after `.transform()` expects output type)
- Fixes test UUIDs to comply with Zod 4's stricter RFC 4122 variant bit validation
- `FEDERATION_ENABLED` env var now defaults to `false` instead of being optional (Zod 4 `.optional().transform()` makes the field required in output)

## Test plan
- [x] `pnpm install` — clean install
- [x] `pnpm type-check` — no TypeScript errors
- [x] `pnpm test` — all 296 tests pass
- [x] `pnpm lint` — no new lint errors (only pre-existing warnings)
- [x] `pnpm build` — production build succeeds
- [x] tRPC 10.45 input validation works correctly with Zod 4

Closes Dependabot PR #80 after merge.