### PR TITLE
feat: block public access on MinIO buckets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ All other version pins are in their respective per-directory CLAUDE.md files.
 - [ ] Input validation with Zod on all API surfaces
 - [x] Zitadel webhook signature verification + timestamp freshness + event ordering + webhook rate limiting
 - [ ] Stripe webhook signature verification + idempotency
-- [ ] Storage: block public access via MinIO policy
+- [x] Storage: block public access via MinIO policy
 
 ### Production Deployment Checklist
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -184,10 +184,12 @@ services:
         condition: service_healthy
     entrypoint: >
       /bin/sh -c "
+      set -e;
       mc alias set minio http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD};
       mc mb minio/submissions --ignore-existing;
       mc mb minio/quarantine --ignore-existing;
-      exit 0;
+      mc anonymous set none minio/submissions;
+      mc anonymous set none minio/quarantine;
       "
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -181,10 +181,12 @@ services:
         condition: service_healthy
     entrypoint: >
       /bin/sh -c "
+      set -e;
       mc alias set minio http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD};
       mc mb minio/submissions --ignore-existing;
       mc mb minio/quarantine --ignore-existing;
-      exit 0;
+      mc anonymous set none minio/submissions;
+      mc anonymous set none minio/quarantine;
       "
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,10 +83,12 @@ services:
         condition: service_healthy
     entrypoint: >
       /bin/sh -c "
+      set -e;
       mc alias set minio http://minio:9000 minioadmin minioadmin;
       mc mb minio/submissions --ignore-existing;
       mc mb minio/quarantine --ignore-existing;
-      exit 0;
+      mc anonymous set none minio/submissions;
+      mc anonymous set none minio/quarantine;
       "
 
   # tusd for resumable file uploads (tus protocol)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,18 @@ Newest entries first.
 
 ---
 
+## 2026-02-17 — MinIO Bucket Policy Enforcement
+
+### Done
+
+- **PR #90** (`feat/minio-bucket-policy`) — security checklist item: block public access on MinIO buckets
+  - Added `mc anonymous set none` on `submissions` and `quarantine` buckets in all three docker-compose files (dev, staging, prod)
+  - Replaced `exit 0` with `set -e` in `minio-setup` entrypoint so failures surface instead of being silently swallowed
+  - Checked off security checklist item in `CLAUDE.md` and `docs/backlog.md`
+- Codex branch review: LGTM, no findings
+
+---
+
 ## 2026-02-17 — Audit Hardening (Correlation, audit_writer, Auth Throttle, Two-Tier Rate Limiting)
 
 ### Done


### PR DESCRIPTION
## Summary

- Explicitly set `mc anonymous set none` on `submissions` and `quarantine` buckets in all three docker-compose files (dev, staging, prod)
- Replace `exit 0` with `set -e` in `minio-setup` entrypoint so bucket creation/policy failures surface immediately
- Check off "Storage: block public access via MinIO bucket policy" in security checklist (`CLAUDE.md`) and backlog

## Test plan

- [ ] `docker compose up minio -d && docker compose run --rm minio-setup` — exits 0
- [ ] `mc anonymous get minio/submissions` reports `none`
- [ ] `curl http://localhost:9000/submissions/` returns `AccessDenied`
- [ ] Temporarily introduce a typo in bucket name — verify `set -e` causes non-zero exit