### PR TITLE
fix(api): two-step idempotency for Zitadel webhook

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -109,7 +109,7 @@ Stripe Checkout only (zero PCI scope). Webhook handler built at `src/webhooks/st
 
 ### Zitadel (built)
 
-`src/webhooks/zitadel.webhook.ts` — verifies `x-zitadel-signature` header, registered in an isolated Fastify scope with `fastify-raw-body`.
+`src/webhooks/zitadel.webhook.ts` — verifies `x-zitadel-signature` header, registered in an isolated Fastify scope with `fastify-raw-body`. Two-step idempotency: INSERT event into `zitadel_webhook_events`, then SELECT `processed` status. If `processed = true`, skip. If `processed = false` (crash recovery or new event), reprocess. Timestamp freshness check rejects events older than `WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS` or >60s in the future. Out-of-order guard via `setWhere`/`WHERE` on `lastEventAt`. Webhook-specific rate limiting via Redis Lua script (key prefix `:wh:zitadel:`).
 
 ### tusd (built)
 

--- a/apps/api/src/webhooks/zitadel.webhook.spec.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.spec.ts
@@ -191,7 +191,7 @@ describe('Zitadel webhook handler', () => {
     mockRedisEval.mockClear().mockResolvedValue([1, 60000]);
     mockRedisQuit.mockClear();
 
-    // Default: insert returns 1 row (new event), not a duplicate
+    // Default: INSERT succeeds (new event), SELECT returns processed = false
     mockPoolConnect.mockResolvedValue({
       query: mockClientQuery,
       release: mockClientRelease,
@@ -201,13 +201,19 @@ describe('Zitadel webhook handler', () => {
         typeof sql === 'string' &&
         sql.includes('INSERT INTO zitadel_webhook_events')
       ) {
-        return { rows: [{ id: 'webhook-evt-id' }] };
+        return { rows: [] }; // INSERT ... ON CONFLICT DO NOTHING (no RETURNING)
+      }
+      if (
+        typeof sql === 'string' &&
+        sql.includes('SELECT processed FROM zitadel_webhook_events')
+      ) {
+        return { rows: [{ processed: false }] }; // New event, not yet processed
       }
       if (
         typeof sql === 'string' &&
         sql.includes('UPDATE zitadel_webhook_events')
       ) {
-        return { rows: [{ id: 'webhook-evt-id' }] };
+        return { rows: [{ processed: true }] };
       }
       return { rows: [] };
     });
@@ -270,13 +276,19 @@ describe('Zitadel webhook handler', () => {
   });
 
   it('returns 200 for duplicate event (idempotency)', async () => {
-    // Simulate: INSERT returns no rows (conflict = already seen)
+    // Simulate: INSERT conflicts, SELECT returns processed = true
     mockClientQuery.mockImplementation((sql: string) => {
       if (
         typeof sql === 'string' &&
         sql.includes('INSERT INTO zitadel_webhook_events')
       ) {
-        return { rows: [] }; // No rows = already exists
+        return { rows: [] }; // INSERT ON CONFLICT DO NOTHING
+      }
+      if (
+        typeof sql === 'string' &&
+        sql.includes('SELECT processed FROM zitadel_webhook_events')
+      ) {
+        return { rows: [{ processed: true }] }; // Already fully processed
       }
       return { rows: [] };
     });
@@ -295,6 +307,50 @@ describe('Zitadel webhook handler', () => {
     });
     expect(response.statusCode).toBe(200);
     expect(response.json().status).toBe('already_processed');
+    expect(mockClientRelease).toHaveBeenCalledOnce();
+  });
+
+  it('reprocesses event after crash recovery (processed = false)', async () => {
+    // Simulate: INSERT conflicts (row exists from prior crash), SELECT returns processed = false
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (
+        typeof sql === 'string' &&
+        sql.includes('INSERT INTO zitadel_webhook_events')
+      ) {
+        return { rows: [] }; // INSERT ON CONFLICT DO NOTHING (row already exists)
+      }
+      if (
+        typeof sql === 'string' &&
+        sql.includes('SELECT processed FROM zitadel_webhook_events')
+      ) {
+        return { rows: [{ processed: false }] }; // Crash recovery: not yet processed
+      }
+      if (
+        typeof sql === 'string' &&
+        sql.includes('UPDATE zitadel_webhook_events')
+      ) {
+        return { rows: [{ processed: true }] };
+      }
+      return { rows: [] };
+    });
+
+    const body = JSON.stringify(makePayload({ eventId: 'evt-crash-recovery' }));
+    const sig = signPayload(body);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/zitadel',
+      headers: {
+        'content-type': 'application/json',
+        'x-zitadel-signature': sig,
+      },
+      payload: body,
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json().status).toBe('processed');
+    // Should have called processEvent (tx.insert for user upsert)
+    expect(mockTxInsert).toHaveBeenCalled();
+    expect(mockAuditLog).toHaveBeenCalled();
     expect(mockClientRelease).toHaveBeenCalledOnce();
   });
 
@@ -479,7 +535,13 @@ describe('Zitadel webhook handler', () => {
         typeof sql === 'string' &&
         sql.includes('INSERT INTO zitadel_webhook_events')
       ) {
-        return { rows: [] }; // duplicate
+        return { rows: [] }; // INSERT ON CONFLICT DO NOTHING
+      }
+      if (
+        typeof sql === 'string' &&
+        sql.includes('SELECT processed FROM zitadel_webhook_events')
+      ) {
+        return { rows: [{ processed: true }] }; // Already fully processed
       }
       return { rows: [] };
     });
@@ -513,7 +575,13 @@ describe('Zitadel webhook handler', () => {
         typeof sql === 'string' &&
         sql.includes('INSERT INTO zitadel_webhook_events')
       ) {
-        return { rows: [{ id: 'webhook-evt-id' }] };
+        return { rows: [] }; // INSERT ON CONFLICT DO NOTHING
+      }
+      if (
+        typeof sql === 'string' &&
+        sql.includes('SELECT processed FROM zitadel_webhook_events')
+      ) {
+        return { rows: [{ processed: false }] }; // New event
       }
       return { rows: [] };
     });

--- a/apps/api/src/webhooks/zitadel.webhook.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.ts
@@ -97,7 +97,7 @@ export async function registerZitadelWebhooks(
 
         const windowMs = env.RATE_LIMIT_WINDOW_SECONDS * 1000;
         const windowId = Math.floor(Date.now() / windowMs);
-        const key = `${env.RATE_LIMIT_KEY_PREFIX}:wh:${windowId}:${request.ip}`;
+        const key = `${env.RATE_LIMIT_KEY_PREFIX}:wh:zitadel:${windowId}:${request.ip}`;
 
         try {
           const result = (await redisClient.eval(
@@ -197,22 +197,27 @@ export async function registerZitadelWebhooks(
       try {
         await client.query('BEGIN');
 
-        // Attempt to insert — ON CONFLICT means already processed
-        const insertResult = await client.query(
+        // Two-step idempotency: INSERT then SELECT processed status.
+        // This handles crash recovery: if server crashes after INSERT but
+        // before marking processed, the row exists with processed = false.
+        // On retry, INSERT conflicts (no-op), SELECT finds processed = false,
+        // and we reprocess — preventing lost events.
+        await client.query(
           `INSERT INTO zitadel_webhook_events (id, event_id, type, payload, processed, received_at)
            VALUES (gen_random_uuid(), $1, $2, $3, false, now())
-           ON CONFLICT (event_id) DO NOTHING
-           RETURNING id`,
+           ON CONFLICT (event_id) DO NOTHING`,
           [payload.eventId, payload.eventType, JSON.stringify(payload)],
         );
 
-        // If no rows inserted, this event was already seen
-        if (insertResult.rows.length === 0) {
+        const statusResult = await client.query(
+          `SELECT processed FROM zitadel_webhook_events WHERE event_id = $1`,
+          [payload.eventId],
+        );
+
+        if (statusResult.rows[0]?.processed === true) {
           await client.query('COMMIT');
           return reply.status(200).send({ status: 'already_processed' });
         }
-
-        const webhookEventId = insertResult.rows[0].id as string;
 
         // Process event using a Drizzle instance on the same transaction client
         // so that user state changes are atomic with the idempotency record.
@@ -221,8 +226,8 @@ export async function registerZitadelWebhooks(
 
         // Mark as processed
         await client.query(
-          `UPDATE zitadel_webhook_events SET processed = true, processed_at = now() WHERE id = $1`,
-          [webhookEventId],
+          `UPDATE zitadel_webhook_events SET processed = true, processed_at = now() WHERE event_id = $1`,
+          [payload.eventId],
         );
 
         await client.query('COMMIT');

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -25,7 +25,7 @@
 - [x] In-memory per-IP throttle for auth failure auditing — DoS protection — (DEVLOG 2026-02-12, 2026-02-13; done 2026-02-17 PR #89)
 - [x] Restore two-tier rate limiting (AUTH_MAX for authenticated users) via second-pass hook after auth — (DEVLOG 2026-02-15, Codex review; done 2026-02-17 PR #89)
 - [x] Request correlation columns (`requestId`, `method`, `route`) in `audit_events` — requires schema migration — (DEVLOG 2026-02-12, 2026-02-13; done 2026-02-17 PR #89)
-- [ ] Zitadel webhook two-step idempotency — current one-step pattern doesn't handle crash recovery (row inserted but `processed=false`); align with Stripe webhook's two-step pattern — (Codex review 2026-02-17)
+- [x] Zitadel webhook two-step idempotency — current one-step pattern doesn't handle crash recovery (row inserted but `processed=false`); align with Stripe webhook's two-step pattern — (Codex review 2026-02-17; done 2026-02-17)
 - [ ] Audit query/list endpoints — wait for API surfaces — (DEVLOG 2026-02-13)
 - [ ] Seed data (`packages/db/src/seed.ts` has TODO) — wait for API layer — (code TODO)
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,23 @@ Newest entries first.
 
 ---
 
+## 2026-02-17 — Zitadel Webhook Idempotency Fix
+
+### Done
+
+- Replaced one-step `INSERT...RETURNING` idempotency with two-step `INSERT` + `SELECT processed` pattern in Zitadel webhook — handles crash recovery (row inserted but `processed=false` no longer treated as duplicate)
+- Fixed rate limit key namespace from `:wh:` to `:wh:zitadel:` for symmetry with Stripe's `:wh:stripe:` prefix
+- Added crash recovery test case — INSERT conflicts but `processed=false` triggers reprocessing
+- Updated mock dispatcher and existing idempotency/audit tests for new two-step pattern
+- All 292 API tests pass, type-check + lint clean
+
+### Decisions
+
+- Aligned Zitadel webhook with Stripe's existing two-step idempotency pattern for consistency
+- Used `event_id` (external ID) as stable key for UPDATE, removed internal `webhookEventId` variable
+
+---
+
 ## 2026-02-17 — React 19 Housekeeping
 
 ### Done


### PR DESCRIPTION
## Summary

- Replace one-step `INSERT...RETURNING` idempotency with two-step `INSERT` + `SELECT processed` pattern in Zitadel webhook handler — handles crash recovery where server crashes after INSERT but before marking `processed = true`
- Fix rate limit key namespace from `:wh:` to `:wh:zitadel:` for symmetry with Stripe's `:wh:stripe:` prefix
- Add crash recovery test case and update existing idempotency mocks

## Test plan

- [x] All 292 API unit tests pass (27 in Zitadel webhook spec)
- [x] New crash recovery test: INSERT conflicts + `processed = false` → reprocesses event
- [x] Existing duplicate test: INSERT conflicts + `processed = true` → returns `already_processed`
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean (0 errors)