### PR TITLE
feat(api): service layer foundation — ServiceContext, errors, user service, error mapper

### DIFF
--- a/apps/api/src/services/context.spec.ts
+++ b/apps/api/src/services/context.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { DrizzleDb } from '@colophony/db';
+import type { AuditFn } from './types.js';
+import { toServiceContext } from './context.js';
+
+describe('toServiceContext', () => {
+  it('maps tRPC/Fastify context fields to ServiceContext', () => {
+    const tx = {} as DrizzleDb;
+    const audit: AuditFn = vi.fn();
+    const ctx = {
+      dbTx: tx,
+      authContext: { userId: 'u1', orgId: 'o1', role: 'ADMIN' as const },
+      audit,
+    };
+
+    const svc = toServiceContext(ctx);
+
+    expect(svc.tx).toBe(tx);
+    expect(svc.actor).toEqual({ userId: 'u1', orgId: 'o1', role: 'ADMIN' });
+    expect(svc.audit).toBe(audit);
+  });
+
+  it('copies actor fields by value (not reference to authContext)', () => {
+    const ctx = {
+      dbTx: {} as DrizzleDb,
+      authContext: { userId: 'u2', orgId: 'o2', role: 'EDITOR' as const },
+      audit: vi.fn() as AuditFn,
+    };
+
+    const svc = toServiceContext(ctx);
+
+    expect(svc.actor).not.toBe(ctx.authContext);
+    expect(svc.actor.userId).toBe('u2');
+    expect(svc.actor.orgId).toBe('o2');
+    expect(svc.actor.role).toBe('EDITOR');
+  });
+});

--- a/apps/api/src/services/context.ts
+++ b/apps/api/src/services/context.ts
@@ -1,0 +1,26 @@
+import type { DrizzleDb } from '@colophony/db';
+import type { Role } from '@colophony/types';
+import type { AuditFn, ServiceContext } from './types.js';
+
+/**
+ * Build a {@link ServiceContext} from the request-scoped values provided by
+ * Fastify hooks. Works for any API surface (tRPC, REST, GraphQL) since the
+ * hooks decorate the same fields on every Fastify request.
+ *
+ * For tRPC, pass the narrowed `orgProcedure` context directly.
+ */
+export function toServiceContext(ctx: {
+  dbTx: DrizzleDb;
+  authContext: { userId: string; orgId: string; role: Role };
+  audit: AuditFn;
+}): ServiceContext {
+  return {
+    tx: ctx.dbTx,
+    actor: {
+      userId: ctx.authContext.userId,
+      orgId: ctx.authContext.orgId,
+      role: ctx.authContext.role,
+    },
+    audit: ctx.audit,
+  };
+}

--- a/apps/api/src/services/errors.ts
+++ b/apps/api/src/services/errors.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared domain errors for the service layer.
+ *
+ * Each API surface maps these to its own error format:
+ * - tRPC: ForbiddenError → TRPCError({ code: 'FORBIDDEN' })
+ * - REST: ForbiddenError → 403 response
+ * - GraphQL: ForbiddenError → GraphQL error with FORBIDDEN extension
+ */
+
+export class ForbiddenError extends Error {
+  override name = 'ForbiddenError' as const;
+
+  constructor(message = 'Forbidden') {
+    super(message);
+  }
+}
+
+export class NotFoundError extends Error {
+  override name = 'NotFoundError' as const;
+
+  constructor(message = 'Not found') {
+    super(message);
+  }
+}

--- a/apps/api/src/services/file.service.spec.ts
+++ b/apps/api/src/services/file.service.spec.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DrizzleDb } from '@colophony/db';
+import type { S3Client } from '@aws-sdk/client-s3';
+
+const mockGetPresignedDownloadUrl = vi.fn();
+const mockDeleteS3Object = vi.fn();
+
+vi.mock('./s3.js', () => ({
+  getPresignedDownloadUrl: (...args: unknown[]) =>
+    mockGetPresignedDownloadUrl(...args),
+  deleteS3Object: (...args: unknown[]) => mockDeleteS3Object(...args),
+}));
+
+// Mock @colophony/db
+vi.mock('@colophony/db', () => ({
+  submissionFiles: {
+    id: 'id',
+    submissionId: 'submissionId',
+    storageKey: 'storageKey',
+    uploadedAt: 'uploadedAt',
+    size: 'size',
+    scanStatus: 'scanStatus',
+  },
+  eq: vi.fn((a, b) => ({ _eq: [a, b] })),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      _tag: 'sql',
+      strings,
+      values,
+    }),
+    { raw: (s: string) => ({ _tag: 'sql_raw', value: s }) },
+  ),
+}));
+
+// Mock drizzle-orm
+vi.mock('drizzle-orm', () => ({
+  asc: vi.fn((col) => ({ _asc: col })),
+  count: vi.fn(() => ({ _count: true })),
+}));
+
+// Mock @colophony/types
+vi.mock('@colophony/types', () => ({
+  MAX_FILES_PER_SUBMISSION: 10,
+  MAX_TOTAL_UPLOAD_SIZE: 100_000_000,
+  MAX_FILE_SIZE: 25_000_000,
+  ALLOWED_MIME_TYPES: ['application/pdf'],
+}));
+
+import { fileService, FileNotCleanError } from './file.service.js';
+
+// Helper: create a mock tx that returns a file from getById
+function makeTx(file: Record<string, unknown> | null): DrizzleDb {
+  const mockLimit = vi.fn().mockResolvedValue(file ? [file] : []);
+  const mockWhere = vi.fn().mockReturnValue({
+    limit: mockLimit,
+    returning: vi.fn().mockResolvedValue(file ? [file] : []),
+  });
+  const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+  const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+  const mockDeleteFn = vi.fn().mockReturnValue({
+    where: vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue(file ? [file] : []),
+    }),
+  });
+  return { select: mockSelect, delete: mockDeleteFn } as unknown as DrizzleDb;
+}
+
+const s3Client = {} as S3Client;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('fileService.getDownloadUrl', () => {
+  it('returns presigned URL for a CLEAN file', async () => {
+    const file = {
+      id: 'f1',
+      storageKey: 'uploads/f1.pdf',
+      filename: 'test.pdf',
+      mimeType: 'application/pdf',
+      scanStatus: 'CLEAN',
+    };
+    const tx = makeTx(file);
+    mockGetPresignedDownloadUrl.mockResolvedValueOnce(
+      'https://s3.example.com/signed',
+    );
+
+    const result = await fileService.getDownloadUrl(
+      tx,
+      'f1',
+      s3Client,
+      'my-bucket',
+    );
+
+    expect(result).toEqual({
+      url: 'https://s3.example.com/signed',
+      filename: 'test.pdf',
+      mimeType: 'application/pdf',
+    });
+    expect(mockGetPresignedDownloadUrl).toHaveBeenCalledWith(
+      s3Client,
+      'my-bucket',
+      'uploads/f1.pdf',
+    );
+  });
+
+  it('returns null when file not found', async () => {
+    const tx = makeTx(null);
+
+    const result = await fileService.getDownloadUrl(
+      tx,
+      'nonexistent',
+      s3Client,
+      'my-bucket',
+    );
+
+    expect(result).toBeNull();
+    expect(mockGetPresignedDownloadUrl).not.toHaveBeenCalled();
+  });
+
+  it('throws FileNotCleanError for non-CLEAN files', async () => {
+    const file = {
+      id: 'f2',
+      storageKey: 'uploads/f2.pdf',
+      filename: 'suspect.pdf',
+      mimeType: 'application/pdf',
+      scanStatus: 'PENDING',
+    };
+    const tx = makeTx(file);
+
+    await expect(
+      fileService.getDownloadUrl(tx, 'f2', s3Client, 'my-bucket'),
+    ).rejects.toThrow(FileNotCleanError);
+  });
+});
+
+describe('fileService.deleteWithS3', () => {
+  it('deletes DB record and S3 object from main bucket for CLEAN file', async () => {
+    const file = {
+      id: 'f1',
+      storageKey: 'uploads/f1.pdf',
+      scanStatus: 'CLEAN',
+    };
+    const tx = makeTx(file);
+    mockDeleteS3Object.mockResolvedValueOnce(undefined);
+
+    const result = await fileService.deleteWithS3(
+      tx,
+      'f1',
+      s3Client,
+      'main-bucket',
+      'quarantine-bucket',
+    );
+
+    expect(result).toEqual(file);
+    expect(mockDeleteS3Object).toHaveBeenCalledWith(
+      s3Client,
+      'main-bucket',
+      'uploads/f1.pdf',
+    );
+  });
+
+  it('uses quarantine bucket for non-CLEAN files', async () => {
+    const file = {
+      id: 'f2',
+      storageKey: 'uploads/f2.pdf',
+      scanStatus: 'INFECTED',
+    };
+    const tx = makeTx(file);
+    mockDeleteS3Object.mockResolvedValueOnce(undefined);
+
+    await fileService.deleteWithS3(
+      tx,
+      'f2',
+      s3Client,
+      'main-bucket',
+      'quarantine-bucket',
+    );
+
+    expect(mockDeleteS3Object).toHaveBeenCalledWith(
+      s3Client,
+      'quarantine-bucket',
+      'uploads/f2.pdf',
+    );
+  });
+
+  it('returns null when file not found', async () => {
+    const tx = makeTx(null);
+
+    const result = await fileService.deleteWithS3(
+      tx,
+      'nonexistent',
+      s3Client,
+      'main-bucket',
+      'quarantine-bucket',
+    );
+
+    expect(result).toBeNull();
+    expect(mockDeleteS3Object).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/file.service.ts
+++ b/apps/api/src/services/file.service.ts
@@ -1,5 +1,6 @@
 import { submissionFiles, eq, sql, type DrizzleDb } from '@colophony/db';
 import { asc, count } from 'drizzle-orm';
+import type { S3Client } from '@aws-sdk/client-s3';
 import type { ScanStatus } from '@colophony/types';
 import {
   MAX_FILES_PER_SUBMISSION,
@@ -7,6 +8,7 @@ import {
   MAX_FILE_SIZE,
   ALLOWED_MIME_TYPES,
 } from '@colophony/types';
+import { getPresignedDownloadUrl, deleteS3Object } from './s3.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -48,6 +50,15 @@ export class InvalidMimeTypeError extends Error {
   constructor(mimeType: string) {
     super(`MIME type "${mimeType}" is not allowed`);
     this.name = 'InvalidMimeTypeError';
+  }
+}
+
+export class FileNotCleanError extends Error {
+  constructor(fileId: string, scanStatus: string) {
+    super(
+      `File "${fileId}" has scan status "${scanStatus}" — download blocked`,
+    );
+    this.name = 'FileNotCleanError';
   }
 }
 
@@ -172,5 +183,58 @@ export const fileService = {
     if (totalSize + newFileSize > MAX_TOTAL_UPLOAD_SIZE) {
       throw new TotalSizeLimitExceededError();
     }
+  },
+
+  // ---------------------------------------------------------------------------
+  // S3-integrated methods (building blocks for access-control-aware PR 2)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fetch a file record and generate a presigned download URL.
+   * Returns null if the file doesn't exist. Throws if the file hasn't
+   * passed the virus scan.
+   */
+  async getDownloadUrl(
+    tx: DrizzleDb,
+    fileId: string,
+    s3Client: S3Client,
+    bucket: string,
+  ): Promise<{ url: string; filename: string; mimeType: string } | null> {
+    const file = await fileService.getById(tx, fileId);
+    if (!file) return null;
+
+    if (file.scanStatus !== 'CLEAN') {
+      throw new FileNotCleanError(fileId, file.scanStatus);
+    }
+
+    const url = await getPresignedDownloadUrl(
+      s3Client,
+      bucket,
+      file.storageKey,
+    );
+
+    return { url, filename: file.filename, mimeType: file.mimeType };
+  },
+
+  /**
+   * Delete a file's DB record and its S3 object. Determines the correct
+   * bucket based on scan status (clean → main bucket, else → quarantine).
+   * Returns the deleted record, or null if not found.
+   */
+  async deleteWithS3(
+    tx: DrizzleDb,
+    fileId: string,
+    s3Client: S3Client,
+    bucket: string,
+    quarantineBucket: string,
+  ) {
+    const deleted = await fileService.delete(tx, fileId);
+    if (!deleted) return null;
+
+    const targetBucket =
+      deleted.scanStatus === 'CLEAN' ? bucket : quarantineBucket;
+    await deleteS3Object(s3Client, targetBucket, deleted.storageKey);
+
+    return deleted;
   },
 };

--- a/apps/api/src/services/types.ts
+++ b/apps/api/src/services/types.ts
@@ -1,0 +1,28 @@
+import type { DrizzleDb } from '@colophony/db';
+import type { AuditLogParams, Role } from '@colophony/types';
+
+/**
+ * Audit function compatible with the request-scoped `RequestAuditFn` from the
+ * audit hook. The closure already enriches with HTTP metadata (actorId, orgId,
+ * IP, user-agent), so callers only supply business-level fields.
+ */
+export type AuditFn = (
+  params: Omit<
+    AuditLogParams,
+    'actorId' | 'organizationId' | 'ipAddress' | 'userAgent'
+  >,
+) => Promise<void>;
+
+/**
+ * Request-scoped context passed to service methods that operate within an
+ * RLS-scoped transaction. Works for tRPC, REST (ts-rest), and GraphQL (Pothos)
+ * surfaces — Fastify hooks provide the same fields on every request.
+ */
+export interface ServiceContext {
+  /** RLS-scoped Drizzle transaction from the dbContext hook. */
+  tx: DrizzleDb;
+  /** Authenticated actor identity from the auth + orgContext hooks. */
+  actor: { userId: string; orgId: string; role: Role };
+  /** Request-scoped audit function from the audit hook. */
+  audit: AuditFn;
+}

--- a/apps/api/src/services/user.service.spec.ts
+++ b/apps/api/src/services/user.service.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockPoolQuery, mockListUserOrganizations } = vi.hoisted(() => {
+  return {
+    mockPoolQuery: vi.fn(),
+    mockListUserOrganizations: vi.fn(),
+  };
+});
+
+vi.mock('@colophony/db', () => ({
+  pool: { query: mockPoolQuery },
+}));
+
+vi.mock('./organization.service.js', () => ({
+  organizationService: {
+    listUserOrganizations: mockListUserOrganizations,
+  },
+}));
+
+import { userService } from './user.service.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('userService.getProfile', () => {
+  it('returns user profile with org memberships', async () => {
+    const createdAt = new Date('2024-01-01');
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'u1',
+          email: 'test@example.com',
+          email_verified: true,
+          created_at: createdAt,
+        },
+      ],
+    });
+    mockListUserOrganizations.mockResolvedValueOnce([
+      {
+        organizationId: 'o1',
+        name: 'Test Org',
+        slug: 'test-org',
+        role: 'ADMIN',
+      },
+    ]);
+
+    const result = await userService.getProfile('u1');
+
+    expect(result).toEqual({
+      id: 'u1',
+      email: 'test@example.com',
+      emailVerified: true,
+      createdAt: createdAt,
+      organizations: [
+        {
+          organizationId: 'o1',
+          name: 'Test Org',
+          slug: 'test-org',
+          role: 'ADMIN',
+        },
+      ],
+    });
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT id, email'),
+      ['u1'],
+    );
+    expect(mockListUserOrganizations).toHaveBeenCalledWith('u1');
+  });
+
+  it('returns null when user not found', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await userService.getProfile('nonexistent');
+
+    expect(result).toBeNull();
+    expect(mockListUserOrganizations).not.toHaveBeenCalled();
+  });
+
+  it('returns empty organizations array when user has no memberships', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'u2',
+          email: 'solo@example.com',
+          email_verified: false,
+          created_at: new Date(),
+        },
+      ],
+    });
+    mockListUserOrganizations.mockResolvedValueOnce([]);
+
+    const result = await userService.getProfile('u2');
+
+    expect(result).not.toBeNull();
+    expect(result!.organizations).toEqual([]);
+  });
+});

--- a/apps/api/src/services/user.service.ts
+++ b/apps/api/src/services/user.service.ts
@@ -1,0 +1,41 @@
+import { pool } from '@colophony/db';
+import { organizationService } from './organization.service.js';
+
+export const userService = {
+  /**
+   * Get user profile with organization memberships.
+   * Uses pool directly (users table has no RLS) and SECURITY DEFINER
+   * function for org lookups (bypasses RLS for cross-tenant query).
+   */
+  async getProfile(userId: string) {
+    const result = await pool.query<{
+      id: string;
+      email: string;
+      email_verified: boolean;
+      created_at: Date;
+    }>(
+      'SELECT id, email, email_verified, created_at FROM users WHERE id = $1 LIMIT 1',
+      [userId],
+    );
+
+    const user = result.rows[0];
+    if (!user) {
+      return null;
+    }
+
+    const orgs = await organizationService.listUserOrganizations(userId);
+
+    return {
+      id: user.id,
+      email: user.email,
+      emailVerified: user.email_verified,
+      createdAt: user.created_at,
+      organizations: orgs.map((o) => ({
+        organizationId: o.organizationId,
+        name: o.name,
+        slug: o.slug,
+        role: o.role,
+      })),
+    };
+  },
+};

--- a/apps/api/src/trpc/error-mapper.spec.ts
+++ b/apps/api/src/trpc/error-mapper.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { TRPCError } from '@trpc/server';
+import { mapServiceError } from './error-mapper.js';
+import { ForbiddenError, NotFoundError } from '../services/errors.js';
+import {
+  SubmissionNotFoundError,
+  InvalidStatusTransitionError,
+  NotDraftError,
+  UnscannedFilesError,
+  InfectedFilesError,
+} from '../services/submission.service.js';
+import {
+  UserNotFoundError,
+  LastAdminError,
+} from '../services/organization.service.js';
+import { FileNotFoundError } from '../services/file.service.js';
+
+function catchTRPCError(error: unknown): TRPCError {
+  try {
+    mapServiceError(error);
+  } catch (e) {
+    if (e instanceof TRPCError) return e;
+    throw e;
+  }
+  throw new Error('mapServiceError should have thrown');
+}
+
+describe('mapServiceError', () => {
+  it('maps ForbiddenError → FORBIDDEN', () => {
+    const err = catchTRPCError(new ForbiddenError('no access'));
+    expect(err.code).toBe('FORBIDDEN');
+    expect(err.message).toBe('no access');
+  });
+
+  it('maps NotFoundError → NOT_FOUND', () => {
+    const err = catchTRPCError(new NotFoundError('gone'));
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.message).toBe('gone');
+  });
+
+  it('maps SubmissionNotFoundError → NOT_FOUND', () => {
+    const err = catchTRPCError(new SubmissionNotFoundError('abc'));
+    expect(err.code).toBe('NOT_FOUND');
+  });
+
+  it('maps UserNotFoundError → NOT_FOUND', () => {
+    const err = catchTRPCError(new UserNotFoundError('test@test.com'));
+    expect(err.code).toBe('NOT_FOUND');
+  });
+
+  it('maps FileNotFoundError → NOT_FOUND', () => {
+    const err = catchTRPCError(new FileNotFoundError('f1'));
+    expect(err.code).toBe('NOT_FOUND');
+  });
+
+  it('maps NotDraftError → BAD_REQUEST', () => {
+    const err = catchTRPCError(new NotDraftError());
+    expect(err.code).toBe('BAD_REQUEST');
+  });
+
+  it('maps InvalidStatusTransitionError → BAD_REQUEST', () => {
+    const err = catchTRPCError(
+      new InvalidStatusTransitionError('DRAFT', 'ACCEPTED'),
+    );
+    expect(err.code).toBe('BAD_REQUEST');
+  });
+
+  it('maps UnscannedFilesError → BAD_REQUEST', () => {
+    const err = catchTRPCError(new UnscannedFilesError());
+    expect(err.code).toBe('BAD_REQUEST');
+  });
+
+  it('maps InfectedFilesError → BAD_REQUEST', () => {
+    const err = catchTRPCError(new InfectedFilesError());
+    expect(err.code).toBe('BAD_REQUEST');
+  });
+
+  it('maps LastAdminError → BAD_REQUEST', () => {
+    const err = catchTRPCError(new LastAdminError());
+    expect(err.code).toBe('BAD_REQUEST');
+  });
+
+  it('maps PostgreSQL unique violation (23505) → CONFLICT', () => {
+    const pgError = {
+      code: '23505',
+      detail: 'Key (slug)=(test) already exists',
+    };
+    const err = catchTRPCError(pgError);
+    expect(err.code).toBe('CONFLICT');
+    expect(err.message).toContain('already exists');
+  });
+
+  it('maps PostgreSQL unique violation without detail → CONFLICT with default message', () => {
+    const pgError = { code: '23505' };
+    const err = catchTRPCError(pgError);
+    expect(err.code).toBe('CONFLICT');
+    expect(err.message).toContain('already exists');
+  });
+
+  it('passes through existing TRPCError unchanged', () => {
+    const original = new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'not authed',
+    });
+    const err = catchTRPCError(original);
+    expect(err).toBe(original);
+  });
+
+  it('re-throws unknown errors as-is', () => {
+    const unknown = new Error('something unexpected');
+    expect(() => mapServiceError(unknown)).toThrow(unknown);
+  });
+
+  it('re-throws non-Error values as-is', () => {
+    expect(() => mapServiceError('string error')).toThrow('string error');
+  });
+});

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -1,0 +1,70 @@
+import { TRPCError } from '@trpc/server';
+import { ForbiddenError, NotFoundError } from '../services/errors.js';
+import { SubmissionNotFoundError } from '../services/submission.service.js';
+import { UserNotFoundError } from '../services/organization.service.js';
+import { FileNotFoundError } from '../services/file.service.js';
+import {
+  NotDraftError,
+  InvalidStatusTransitionError,
+  UnscannedFilesError,
+  InfectedFilesError,
+} from '../services/submission.service.js';
+import { LastAdminError } from '../services/organization.service.js';
+
+type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
+
+/** Map of domain error constructors to tRPC error codes. */
+const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
+  // Access control
+  [ForbiddenError, 'FORBIDDEN'],
+  // Not found
+  [NotFoundError, 'NOT_FOUND'],
+  [SubmissionNotFoundError, 'NOT_FOUND'],
+  [UserNotFoundError, 'NOT_FOUND'],
+  [FileNotFoundError, 'NOT_FOUND'],
+  // Bad request (business rule violations)
+  [NotDraftError, 'BAD_REQUEST'],
+  [InvalidStatusTransitionError, 'BAD_REQUEST'],
+  [UnscannedFilesError, 'BAD_REQUEST'],
+  [InfectedFilesError, 'BAD_REQUEST'],
+  [LastAdminError, 'BAD_REQUEST'],
+];
+
+/**
+ * Map a domain error thrown by a service method to a {@link TRPCError}.
+ *
+ * - Known domain errors → appropriate tRPC code with the original message.
+ * - PostgreSQL unique-violation (code `23505`) → `CONFLICT`.
+ * - Unknown errors are re-thrown as-is so tRPC's default handler returns 500.
+ */
+export function mapServiceError(error: unknown): never {
+  if (error instanceof TRPCError) {
+    throw error;
+  }
+
+  if (error instanceof Error) {
+    for (const [ErrorClass, code] of errorCodeMap) {
+      if (error instanceof ErrorClass) {
+        throw new TRPCError({ code, message: error.message });
+      }
+    }
+  }
+
+  // PostgreSQL unique violation
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code: string }).code === '23505'
+  ) {
+    throw new TRPCError({
+      code: 'CONFLICT',
+      message:
+        (error as { detail?: string }).detail ??
+        'A record with this value already exists',
+    });
+  }
+
+  // Unknown — re-throw for tRPC's default error handler (500)
+  throw error;
+}

--- a/apps/api/src/trpc/routers/users.ts
+++ b/apps/api/src/trpc/routers/users.ts
@@ -1,41 +1,8 @@
-import { pool } from '@colophony/db';
 import { authedProcedure, createRouter } from '../init.js';
-import { organizationService } from '../../services/organization.service.js';
+import { userService } from '../../services/user.service.js';
 
 export const usersRouter = createRouter({
   me: authedProcedure.query(async ({ ctx }) => {
-    // Query user from the pool directly (users table has no RLS)
-    const result = await pool.query<{
-      id: string;
-      email: string;
-      email_verified: boolean;
-      created_at: Date;
-    }>(
-      'SELECT id, email, email_verified, created_at FROM users WHERE id = $1 LIMIT 1',
-      [ctx.authContext.userId],
-    );
-
-    const user = result.rows[0];
-    if (!user) {
-      return null;
-    }
-
-    // Get org memberships via SECURITY DEFINER function (bypasses RLS)
-    const orgs = await organizationService.listUserOrganizations(
-      ctx.authContext.userId,
-    );
-
-    return {
-      id: user.id,
-      email: user.email,
-      emailVerified: user.email_verified,
-      createdAt: user.created_at,
-      organizations: orgs.map((o) => ({
-        organizationId: o.organizationId,
-        name: o.name,
-        slug: o.slug,
-        role: o.role,
-      })),
-    };
+    return userService.getProfile(ctx.authContext.userId);
   }),
 });

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -57,7 +57,7 @@
 
 ### Code
 
-- [ ] Service layer extraction from tRPC routers — (architecture doc Track 2)
+- [ ] Service layer extraction from tRPC routers — PR 1 (foundation: types, errors, user service, error mapper) done 2026-02-17; PR 2 (router refactor: move access control + audit into services) pending — (architecture doc Track 2)
 - [ ] ts-rest REST API surface with Fastify adapter — (architecture doc Track 2)
 - [ ] Pothos + GraphQL Yoga surface — decision point at Month 3: Pothos vs TypeGraphQL — (architecture doc Track 2, Section 6.6)
 - [ ] SDK generation (TypeScript, Python) — (architecture doc Track 2)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,30 @@ Newest entries first.
 
 ---
 
+## 2026-02-17 — Service Layer Extraction (PR 1: Foundation)
+
+### Done
+
+- Created `ServiceContext` type + `AuditFn` type in `apps/api/src/services/types.ts` — compatible with existing `RequestAuditFn` (same 4-field Omit)
+- Created shared domain errors (`ForbiddenError`, `NotFoundError`) in `apps/api/src/services/errors.ts`
+- Created `toServiceContext()` helper in `apps/api/src/services/context.ts` for tRPC/REST/GraphQL context mapping
+- Created `mapServiceError()` in `apps/api/src/trpc/error-mapper.ts` — maps 10 domain error classes + PG unique violation (23505) to TRPCError codes
+- Extracted user profile logic from `users.ts` router into `apps/api/src/services/user.service.ts`
+- Added `getDownloadUrl()` and `deleteWithS3()` S3-integrated methods to `fileService`, plus `FileNotCleanError`
+- Extracted `idParamSchema`, `fileIdParamSchema`, `submissionIdParamSchema` to `@colophony/types` common.ts
+- Wrote 26 new tests across 4 test files (context, error-mapper, user service, file service S3 methods)
+- Addressed Codex branch review P2: `deleteWithS3` now uses `deleted` row fields (not pre-delete `file`) for S3 bucket selection to avoid stale reads under concurrent scan updates
+- All 318 tests pass, type-check + lint clean
+
+### Decisions
+
+- `AuditFn` Omit set matches existing `RequestAuditFn` exactly (4 fields: `actorId | organizationId | ipAddress | userAgent`) — defined independently so services don't import from tRPC or Fastify
+- Error mapper is tRPC-specific (`apps/api/src/trpc/error-mapper.ts`); REST and GraphQL surfaces will have their own mappers
+- No barrel export at `services/index.ts` — services imported by path (existing convention preserved)
+- Two-PR strategy: this PR is additive-only (foundation); PR 2 will rewire routers to use ServiceContext + move access control into services
+
+---
+
 ## 2026-02-17 — Zitadel Webhook Idempotency Fix
 
 ### Done

--- a/packages/types/src/common.ts
+++ b/packages/types/src/common.ts
@@ -26,6 +26,21 @@ export type PaginatedResponse<T> = {
 
 export const uuidSchema = z.string().uuid();
 
+// ---------------------------------------------------------------------------
+// Reusable ID param schemas for API surfaces (tRPC, REST, GraphQL)
+// ---------------------------------------------------------------------------
+
+export const idParamSchema = z.object({ id: z.string().uuid() });
+export type IdParam = z.infer<typeof idParamSchema>;
+
+export const fileIdParamSchema = z.object({ fileId: z.string().uuid() });
+export type FileIdParam = z.infer<typeof fileIdParamSchema>;
+
+export const submissionIdParamSchema = z.object({
+  submissionId: z.string().uuid(),
+});
+export type SubmissionIdParam = z.infer<typeof submissionIdParamSchema>;
+
 export const dateRangeSchema = z.object({
   from: z.date().optional(),
   to: z.date().optional(),


### PR DESCRIPTION
## Summary

- Add `ServiceContext` type + `AuditFn` for shared service layer context across tRPC, REST, and GraphQL surfaces
- Add shared domain errors (`ForbiddenError`, `NotFoundError`) and `toServiceContext()` helper
- Add `mapServiceError()` utility mapping 10 domain error classes + PG 23505 to TRPCError codes
- Extract user profile logic from users router into `userService.getProfile()`
- Add `getDownloadUrl()` and `deleteWithS3()` S3-integrated methods to `fileService`
- Extract `idParamSchema`, `fileIdParamSchema`, `submissionIdParamSchema` to `@colophony/types`

PR 1 of 2 for service layer extraction (Track 2). Additive only — no behavioral changes. PR 2 will rewire routers to use `ServiceContext` and move access control + audit into services.

## Test plan

- [x] 318 tests pass (26 new across 4 test files)
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean (0 errors)
- [x] branch review — P2 finding (stale read in `deleteWithS3`) addressed