### PR TITLE
docs: devlog + backlog for service layer extraction session

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -57,7 +57,13 @@
 
 ### Code
 
-- [ ] Service layer extraction from tRPC routers — PR 1 (foundation: types, errors, user service, error mapper) done 2026-02-17; PR 2 (router refactor: move access control + audit into services) pending — (architecture doc Track 2)
+- [ ] Service layer extraction from tRPC routers — PR 1 (foundation: types, errors, user service, error mapper) done 2026-02-17; PR 2 (router refactor) pending — (architecture doc Track 2)
+  - **PR 2 scope:** Move access control + audit logging from routers into service methods that accept `ServiceContext`. Routers become thin: input validation → service call (wrapped in `mapServiceError`) → response shaping.
+  - **Submissions router** (`src/trpc/routers/submissions.ts`): ownership checks (`submitterId !== userId`), `assertEditorOrAdmin` role guard, audit calls on create/update/submit/delete/withdraw/updateStatus, repetitive try/catch blocks for `NotDraftError`/`SubmissionNotFoundError`/`InvalidStatusTransitionError`/`UnscannedFilesError`/`InfectedFilesError` — all move to `submissionService` methods that take `ServiceContext`; try/catch replaced by `mapServiceError`.
+  - **Files router** (`src/trpc/routers/files.ts`): `assertOwnerOrEditor` guard (checks submission ownership), scan status check for downloads, audit on delete, lazy S3 client management (`getS3Client()`/`getEnvConfig()`) — move to `fileService` methods; S3 client init stays in router or moves to a shared factory.
+  - **Organizations router** (`src/trpc/routers/organizations.ts:47-61`): try/catch for `UserNotFoundError` + PG 23505 unique violation on member add — replace with `mapServiceError`. `LastAdminError` on member remove similarly.
+  - **Pattern:** Each router mutation becomes ~3 lines: `const result = await someService.method(toServiceContext(ctx), input);` → return result, wrapped in try/catch with `mapServiceError`. Queries similarly thin.
+  - **Not moved:** `adminProcedure` role enforcement stays in tRPC middleware (it's surface-specific). Pool-based methods (`organizationService.listUserOrganizations`, `.create`, `.isSlugAvailable`) keep current signatures. BullMQ workers unchanged (use `withRls` + `auditService.log` directly).
 - [ ] ts-rest REST API surface with Fastify adapter — (architecture doc Track 2)
 - [ ] Pothos + GraphQL Yoga surface — decision point at Month 3: Pothos vs TypeGraphQL — (architecture doc Track 2, Section 6.6)
 - [ ] SDK generation (TypeScript, Python) — (architecture doc Track 2)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -24,7 +24,7 @@ Newest entries first.
 - `AuditFn` Omit set matches existing `RequestAuditFn` exactly (4 fields: `actorId | organizationId | ipAddress | userAgent`) — defined independently so services don't import from tRPC or Fastify
 - Error mapper is tRPC-specific (`apps/api/src/trpc/error-mapper.ts`); REST and GraphQL surfaces will have their own mappers
 - No barrel export at `services/index.ts` — services imported by path (existing convention preserved)
-- Two-PR strategy: this PR is additive-only (foundation); PR 2 will rewire routers to use ServiceContext + move access control into services
+- Two-PR strategy: this PR is additive-only (foundation); PR 2 will rewire routers to use `ServiceContext` + move access control into services. See `docs/backlog.md` Track 2 for detailed PR 2 scope (which routers, which logic moves, what stays)
 
 ---
 


### PR DESCRIPTION
## Summary

- Add devlog entry for 2026-02-17 service layer extraction session (PR #94)
- Update backlog Track 2 with detailed PR 2 scope for router refactor (what moves, what stays, per-router breakdown)

Docs-only — no code changes.