### PR TITLE
feat(api): service layer PR 2 — router refactor with access-aware methods

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -16,6 +16,16 @@
 | Zitadel webhook   | `src/webhooks/zitadel.webhook.ts` |
 | Stripe webhook    | `src/webhooks/stripe.webhook.ts`  |
 
+### Service Method Naming
+
+| Suffix       | Meaning                                                  |
+| ------------ | -------------------------------------------------------- |
+| `WithAccess` | Checks owner-or-editor access via `ServiceContext.actor` |
+| `AsOwner`    | Checks ownership (submitterId === actor.userId) + audits |
+| `WithAudit`  | Wraps a mutation with audit logging                      |
+
+Pure data methods keep `(tx, ...)` signatures for worker/internal use. Access-aware methods accept `ServiceContext` and throw `ForbiddenError`/`NotFoundError` — callers use `mapServiceError()` to translate to surface-specific errors.
+
 ---
 
 ## Hook Registration Order (from `main.ts`)

--- a/apps/api/src/main.spec.ts
+++ b/apps/api/src/main.spec.ts
@@ -119,7 +119,7 @@ describe('Fastify app', () => {
 
   it('GET /ready returns 503 when DB is unreachable', async () => {
     const dbModule = await import('@colophony/db');
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+
     (dbModule.pool.query as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
       new Error('connection refused'),
     );

--- a/apps/api/src/services/errors.ts
+++ b/apps/api/src/services/errors.ts
@@ -22,3 +22,35 @@ export class NotFoundError extends Error {
     super(message);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Access-control helpers — shared across service methods
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert the caller is the resource owner, or has EDITOR/ADMIN role.
+ * Throws {@link ForbiddenError} if neither condition is met.
+ */
+export function assertOwnerOrEditor(
+  actorUserId: string,
+  actorRole: string,
+  resourceOwnerId: string,
+): void {
+  if (
+    resourceOwnerId !== actorUserId &&
+    actorRole !== 'ADMIN' &&
+    actorRole !== 'EDITOR'
+  ) {
+    throw new ForbiddenError('You do not have access to this submission');
+  }
+}
+
+/**
+ * Assert the caller has EDITOR or ADMIN role.
+ * Throws {@link ForbiddenError} if the role is insufficient.
+ */
+export function assertEditorOrAdmin(role: string): void {
+  if (role !== 'ADMIN' && role !== 'EDITOR') {
+    throw new ForbiddenError('Editor or admin role required');
+  }
+}

--- a/apps/api/src/services/file.service.ts
+++ b/apps/api/src/services/file.service.ts
@@ -7,8 +7,17 @@ import {
   MAX_TOTAL_UPLOAD_SIZE,
   MAX_FILE_SIZE,
   ALLOWED_MIME_TYPES,
+  AuditActions,
+  AuditResources,
 } from '@colophony/types';
 import { getPresignedDownloadUrl, deleteS3Object } from './s3.js';
+import type { ServiceContext } from './types.js';
+import { ForbiddenError, assertOwnerOrEditor } from './errors.js';
+import {
+  submissionService,
+  SubmissionNotFoundError,
+  NotDraftError,
+} from './submission.service.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -236,5 +245,117 @@ export const fileService = {
     await deleteS3Object(s3Client, targetBucket, deleted.storageKey);
 
     return deleted;
+  },
+
+  // ---------------------------------------------------------------------------
+  // Access-aware methods (PR 2) — bundle access control + audit
+  // ---------------------------------------------------------------------------
+
+  /**
+   * List files for a submission — owner or editor/admin access check.
+   */
+  async listBySubmissionWithAccess(svc: ServiceContext, submissionId: string) {
+    const submission = await submissionService.getById(svc.tx, submissionId);
+    if (!submission) throw new SubmissionNotFoundError(submissionId);
+    assertOwnerOrEditor(
+      svc.actor.userId,
+      svc.actor.role,
+      submission.submitterId,
+    );
+    return fileService.listBySubmission(svc.tx, submissionId);
+  },
+
+  /**
+   * Get a presigned download URL — owner or editor/admin, CLEAN files only.
+   */
+  async getDownloadUrlWithAccess(
+    svc: ServiceContext,
+    fileId: string,
+    s3Client: S3Client,
+    bucket: string,
+  ) {
+    const file = await fileService.getById(svc.tx, fileId);
+    if (!file) throw new FileNotFoundError(fileId);
+
+    const submission = await submissionService.getById(
+      svc.tx,
+      file.submissionId,
+    );
+    if (!submission) throw new SubmissionNotFoundError(file.submissionId);
+    assertOwnerOrEditor(
+      svc.actor.userId,
+      svc.actor.role,
+      submission.submitterId,
+    );
+
+    if (file.scanStatus !== 'CLEAN') {
+      throw new FileNotCleanError(fileId, file.scanStatus);
+    }
+
+    const url = await getPresignedDownloadUrl(
+      s3Client,
+      bucket,
+      file.storageKey,
+    );
+    return { url, filename: file.filename, mimeType: file.mimeType };
+  },
+
+  /**
+   * Delete a file — submission owner only, DRAFT only, with audit + S3 cleanup.
+   */
+  async deleteAsOwner(
+    svc: ServiceContext,
+    fileId: string,
+    s3Client: S3Client,
+    bucket: string,
+    quarantineBucket: string,
+  ) {
+    const file = await fileService.getById(svc.tx, fileId);
+    if (!file) throw new FileNotFoundError(fileId);
+
+    const submission = await submissionService.getById(
+      svc.tx,
+      file.submissionId,
+    );
+    if (!submission) throw new SubmissionNotFoundError(file.submissionId);
+    if (submission.submitterId !== svc.actor.userId) {
+      throw new ForbiddenError('Only the submitter can delete files');
+    }
+    if (submission.status !== 'DRAFT') {
+      throw new NotDraftError();
+    }
+
+    const deleted = await fileService.delete(svc.tx, fileId);
+    if (!deleted) throw new FileNotFoundError(fileId);
+
+    await svc.audit({
+      action: AuditActions.FILE_DELETED,
+      resource: AuditResources.FILE,
+      resourceId: fileId,
+      newValue: {
+        filename: file.filename,
+        submissionId: file.submissionId,
+      },
+    });
+
+    // S3 cleanup — best-effort
+    try {
+      const targetBucket =
+        file.scanStatus === 'CLEAN' ? bucket : quarantineBucket;
+      await deleteS3Object(s3Client, targetBucket, file.storageKey);
+    } catch {
+      // Log but don't fail — orphaned S3 objects can be cleaned up
+      // by a periodic garbage collection job
+      svc
+        .audit({
+          action: AuditActions.FILE_DELETED,
+          resource: AuditResources.FILE,
+          resourceId: fileId,
+          newValue: { s3DeleteFailed: true, storageKey: file.storageKey },
+        })
+        .catch(() => {});
+    }
+
+    return { success: true as const };
   },
 };

--- a/apps/api/src/services/organization.service.ts
+++ b/apps/api/src/services/organization.service.ts
@@ -14,6 +14,9 @@ import type {
   PaginationInput,
   Role,
 } from '@colophony/types';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { ServiceContext, AuditFn } from './types.js';
+import { NotFoundError } from './errors.js';
 
 export class UserNotFoundError extends Error {
   constructor(email: string) {
@@ -269,5 +272,106 @@ export const organizationService = {
       .where(eq(organizationMembers.id, memberId))
       .returning();
     return updated ?? null;
+  },
+
+  // ---------------------------------------------------------------------------
+  // Access-aware methods (PR 2) — bundle access control + audit
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Add a member with audit logging. Admin role enforced by tRPC middleware.
+   */
+  async addMemberWithAudit(svc: ServiceContext, email: string, role: Role) {
+    const member = await organizationService.addMember(
+      svc.tx,
+      svc.actor.orgId,
+      email,
+      role,
+    );
+    await svc.audit({
+      action: AuditActions.ORG_MEMBER_ADDED,
+      resource: AuditResources.ORGANIZATION,
+      resourceId: member.id,
+      newValue: { email, role },
+    });
+    return member;
+  },
+
+  /**
+   * Remove a member with audit logging. Admin role enforced by tRPC middleware.
+   */
+  async removeMemberWithAudit(svc: ServiceContext, memberId: string) {
+    const deleted = await organizationService.removeMember(svc.tx, memberId);
+    if (!deleted) throw new NotFoundError('Member not found');
+    await svc.audit({
+      action: AuditActions.ORG_MEMBER_REMOVED,
+      resource: AuditResources.ORGANIZATION,
+      resourceId: deleted.id,
+      oldValue: { userId: deleted.userId, role: deleted.role },
+    });
+    return { success: true as const };
+  },
+
+  /**
+   * Update a member's role with audit logging. Admin role enforced by tRPC middleware.
+   */
+  async updateMemberRoleWithAudit(
+    svc: ServiceContext,
+    memberId: string,
+    role: Role,
+  ) {
+    const updated = await organizationService.updateMemberRole(
+      svc.tx,
+      memberId,
+      role,
+    );
+    if (!updated) throw new NotFoundError('Member not found');
+    await svc.audit({
+      action: AuditActions.ORG_MEMBER_ROLE_CHANGED,
+      resource: AuditResources.ORGANIZATION,
+      resourceId: updated.id,
+      newValue: { role },
+    });
+    return updated;
+  },
+
+  /**
+   * Update an organization with audit logging. Admin role enforced by tRPC middleware.
+   */
+  async updateWithAudit(svc: ServiceContext, input: UpdateOrganizationInput) {
+    const old = await organizationService.getById(svc.tx, svc.actor.orgId);
+    const updated = await organizationService.update(
+      svc.tx,
+      svc.actor.orgId,
+      input,
+    );
+    if (!updated) throw new NotFoundError('Organization not found');
+    await svc.audit({
+      action: AuditActions.ORG_UPDATED,
+      resource: AuditResources.ORGANIZATION,
+      resourceId: updated.id,
+      oldValue: old ? { name: old.name, settings: old.settings } : undefined,
+      newValue: input,
+    });
+    return updated;
+  },
+
+  /**
+   * Create an organization with audit logging.
+   * Special case: no org context exists yet, so takes AuditFn directly.
+   */
+  async createWithAudit(
+    audit: AuditFn,
+    input: CreateOrganizationInput,
+    userId: string,
+  ) {
+    const result = await organizationService.create(input, userId);
+    await audit({
+      action: AuditActions.ORG_CREATED,
+      resource: AuditResources.ORGANIZATION,
+      resourceId: result.organization.id,
+      newValue: { name: input.name, slug: input.slug },
+    });
+    return result;
   },
 };

--- a/apps/api/src/services/submission.service.access.spec.ts
+++ b/apps/api/src/services/submission.service.access.spec.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ServiceContext } from './types.js';
+import { ForbiddenError } from './errors.js';
+
+// We need to spy on the "inner" methods (getById, create, etc.) that the
+// "outer" access-aware methods delegate to. Vitest's vi.mock auto-mocks
+// replace the entire module with vi.fn() stubs, but since the outer methods
+// call inner methods on the *same* object, we can't use vi.mock. Instead we
+// use vi.spyOn after importing the real module.
+
+// Mock @colophony/db
+vi.mock('@colophony/db', () => ({
+  submissions: {},
+  submissionFiles: {},
+  submissionHistory: {},
+  users: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+}));
+
+// Mock drizzle-orm
+vi.mock('drizzle-orm', () => ({
+  desc: vi.fn(),
+  asc: vi.fn(),
+  ilike: vi.fn(),
+  count: vi.fn(),
+}));
+
+// Mock @colophony/types — provide status transition functions
+vi.mock('@colophony/types', () => ({
+  isValidStatusTransition: vi.fn(() => true),
+  isEditorAllowedTransition: vi.fn(() => true),
+  AuditActions: {
+    SUBMISSION_CREATED: 'SUBMISSION_CREATED',
+    SUBMISSION_UPDATED: 'SUBMISSION_UPDATED',
+    SUBMISSION_SUBMITTED: 'SUBMISSION_SUBMITTED',
+    SUBMISSION_STATUS_CHANGED: 'SUBMISSION_STATUS_CHANGED',
+    SUBMISSION_DELETED: 'SUBMISSION_DELETED',
+    SUBMISSION_WITHDRAWN: 'SUBMISSION_WITHDRAWN',
+  },
+  AuditResources: {
+    SUBMISSION: 'submission',
+  },
+}));
+
+import {
+  submissionService,
+  SubmissionNotFoundError,
+} from './submission.service.js';
+
+function makeSvc(overrides: Partial<ServiceContext> = {}): ServiceContext {
+  return {
+    tx: {} as never,
+    actor: { userId: 'user-1', orgId: 'org-1', role: 'READER' },
+    audit: vi.fn(),
+    ...overrides,
+  };
+}
+
+const SUBMISSION_ID = 'a1111111-1111-1111-a111-111111111111';
+
+function makeSubmission(submitterId = 'user-1') {
+  return {
+    id: SUBMISSION_ID,
+    organizationId: 'org-1',
+    submitterId,
+    submissionPeriodId: null,
+    title: 'Test Poem',
+    content: 'Roses are red...',
+    coverLetter: null,
+    status: 'DRAFT' as const,
+    submittedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    files: [],
+    submitterEmail: 'test@example.com',
+  };
+}
+
+// Use spyOn with eslint-disable for the unbound-method rule.
+// These spies intercept the inner methods so the outer access-aware methods
+// don't hit real DB calls.
+function setupSpies() {
+  vi.spyOn(submissionService, 'getById');
+  vi.spyOn(submissionService, 'create');
+  vi.spyOn(submissionService, 'update');
+  vi.spyOn(submissionService, 'updateStatus');
+  vi.spyOn(submissionService, 'delete');
+  vi.spyOn(submissionService, 'getHistory');
+}
+
+describe('submissionService access-aware methods', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupSpies();
+  });
+
+  describe('getByIdWithAccess', () => {
+    it('returns submission for owner', async () => {
+      const sub = makeSubmission('user-1');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValueOnce(sub as never);
+
+      const svc = makeSvc();
+      const result = await submissionService.getByIdWithAccess(
+        svc,
+        SUBMISSION_ID,
+      );
+      expect(result.id).toBe(SUBMISSION_ID);
+    });
+
+    it('returns submission for EDITOR viewing others', async () => {
+      const sub = makeSubmission('other-user');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValueOnce(sub as never);
+
+      const svc = makeSvc({
+        actor: { userId: 'user-1', orgId: 'org-1', role: 'EDITOR' },
+      });
+      const result = await submissionService.getByIdWithAccess(
+        svc,
+        SUBMISSION_ID,
+      );
+      expect(result.id).toBe(SUBMISSION_ID);
+    });
+
+    it('throws ForbiddenError when READER views others', async () => {
+      const sub = makeSubmission('other-user');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValueOnce(sub as never);
+
+      const svc = makeSvc();
+      await expect(
+        submissionService.getByIdWithAccess(svc, SUBMISSION_ID),
+      ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('throws SubmissionNotFoundError when not found', async () => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValueOnce(null as never);
+
+      const svc = makeSvc();
+      await expect(
+        submissionService.getByIdWithAccess(svc, SUBMISSION_ID),
+      ).rejects.toThrow(SubmissionNotFoundError);
+    });
+  });
+
+  describe('createWithAudit', () => {
+    it('calls create and audit', async () => {
+      const sub = makeSubmission();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.create).mockResolvedValueOnce(sub as never);
+
+      const svc = makeSvc();
+      const result = await submissionService.createWithAudit(svc, {
+        title: 'Test',
+      });
+
+      expect(result.id).toBe(SUBMISSION_ID);
+      expect(svc.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'SUBMISSION_CREATED' }),
+      );
+    });
+  });
+
+  describe('updateAsOwner', () => {
+    it('updates and audits for owner', async () => {
+      const sub = makeSubmission('user-1');
+      const updated = { ...sub, title: 'Updated' };
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValueOnce(sub as never);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.update).mockResolvedValueOnce(
+        updated as never,
+      );
+
+      const svc = makeSvc();
+      const result = await submissionService.updateAsOwner(svc, SUBMISSION_ID, {
+        title: 'Updated',
+      });
+
+      expect(result.title).toBe('Updated');
+      expect(svc.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'SUBMISSION_UPDATED' }),
+      );
+    });
+
+    it('throws ForbiddenError for non-owner', async () => {
+      const sub = makeSubmission('other-user');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValueOnce(sub as never);
+
+      const svc = makeSvc();
+      await expect(
+        submissionService.updateAsOwner(svc, SUBMISSION_ID, {
+          title: 'Updated',
+        }),
+      ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('throws SubmissionNotFoundError when not found', async () => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValueOnce(null as never);
+
+      const svc = makeSvc();
+      await expect(
+        submissionService.updateAsOwner(svc, SUBMISSION_ID, {
+          title: 'Updated',
+        }),
+      ).rejects.toThrow(SubmissionNotFoundError);
+    });
+  });
+
+  describe('deleteAsOwner', () => {
+    it('deletes and audits for owner', async () => {
+      const sub = makeSubmission('user-1');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValueOnce(sub as never);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.delete).mockResolvedValueOnce(sub as never);
+
+      const svc = makeSvc();
+      const result = await submissionService.deleteAsOwner(svc, SUBMISSION_ID);
+
+      expect(result).toEqual({ success: true });
+      expect(svc.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'SUBMISSION_DELETED' }),
+      );
+    });
+
+    it('throws ForbiddenError for non-owner', async () => {
+      const sub = makeSubmission('other-user');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValueOnce(sub as never);
+
+      const svc = makeSvc();
+      await expect(
+        submissionService.deleteAsOwner(svc, SUBMISSION_ID),
+      ).rejects.toThrow(ForbiddenError);
+    });
+  });
+
+  describe('submitAsOwner', () => {
+    it('submits and audits for owner', async () => {
+      const sub = makeSubmission('user-1');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValueOnce(sub as never);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.updateStatus).mockResolvedValueOnce({
+        submission: { ...sub, status: 'SUBMITTED' },
+        historyEntry: { id: 'h-1' },
+      } as never);
+
+      const svc = makeSvc();
+      const result = await submissionService.submitAsOwner(svc, SUBMISSION_ID);
+
+      expect(result.submission.status).toBe('SUBMITTED');
+      expect(svc.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'SUBMISSION_SUBMITTED' }),
+      );
+    });
+
+    it('throws ForbiddenError for non-owner', async () => {
+      const sub = makeSubmission('other-user');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValueOnce(sub as never);
+
+      const svc = makeSvc();
+      await expect(
+        submissionService.submitAsOwner(svc, SUBMISSION_ID),
+      ).rejects.toThrow(ForbiddenError);
+    });
+  });
+
+  describe('withdrawAsOwner', () => {
+    it('withdraws and audits for owner', async () => {
+      const sub = makeSubmission('user-1');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValueOnce(sub as never);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.updateStatus).mockResolvedValueOnce({
+        submission: { ...sub, status: 'WITHDRAWN' },
+        historyEntry: { id: 'h-2' },
+      } as never);
+
+      const svc = makeSvc();
+      const result = await submissionService.withdrawAsOwner(
+        svc,
+        SUBMISSION_ID,
+      );
+
+      expect(result.submission.status).toBe('WITHDRAWN');
+      expect(svc.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'SUBMISSION_WITHDRAWN' }),
+      );
+    });
+  });
+
+  describe('updateStatusAsEditor', () => {
+    it('updates status and audits for editor', async () => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.updateStatus).mockResolvedValueOnce({
+        submission: { id: SUBMISSION_ID, status: 'UNDER_REVIEW' },
+        historyEntry: { id: 'h-3' },
+      } as never);
+
+      const svc = makeSvc({
+        actor: { userId: 'user-1', orgId: 'org-1', role: 'EDITOR' },
+      });
+      const result = await submissionService.updateStatusAsEditor(
+        svc,
+        SUBMISSION_ID,
+        'UNDER_REVIEW' as never,
+        undefined,
+      );
+
+      expect(result.submission.status).toBe('UNDER_REVIEW');
+      expect(svc.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'SUBMISSION_STATUS_CHANGED' }),
+      );
+    });
+
+    it('throws ForbiddenError for READER', async () => {
+      const svc = makeSvc();
+      await expect(
+        submissionService.updateStatusAsEditor(
+          svc,
+          SUBMISSION_ID,
+          'UNDER_REVIEW' as never,
+          undefined,
+        ),
+      ).rejects.toThrow(ForbiddenError);
+    });
+  });
+
+  describe('getHistoryWithAccess', () => {
+    it('returns history for owner', async () => {
+      const sub = makeSubmission('user-1');
+      const history = [{ id: 'h-1', toStatus: 'DRAFT' }];
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValueOnce(sub as never);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getHistory).mockResolvedValueOnce(
+        history as never,
+      );
+
+      const svc = makeSvc();
+      const result = await submissionService.getHistoryWithAccess(
+        svc,
+        SUBMISSION_ID,
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('throws ForbiddenError when READER views others history', async () => {
+      const sub = makeSubmission('other-user');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValueOnce(sub as never);
+
+      const svc = makeSvc();
+      await expect(
+        submissionService.getHistoryWithAccess(svc, SUBMISSION_ID),
+      ).rejects.toThrow(ForbiddenError);
+    });
+  });
+});

--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -18,7 +18,15 @@ import type {
 import {
   isValidStatusTransition,
   isEditorAllowedTransition,
+  AuditActions,
+  AuditResources,
 } from '@colophony/types';
+import type { ServiceContext } from './types.js';
+import {
+  ForbiddenError,
+  assertOwnerOrEditor,
+  assertEditorOrAdmin,
+} from './errors.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -348,5 +356,178 @@ export const submissionService = {
       .from(submissionHistory)
       .where(eq(submissionHistory.submissionId, submissionId))
       .orderBy(asc(submissionHistory.changedAt));
+  },
+
+  // ---------------------------------------------------------------------------
+  // Access-aware methods (PR 2) — bundle access control + audit
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Get submission by ID with owner-or-editor access check.
+   */
+  async getByIdWithAccess(svc: ServiceContext, id: string) {
+    const submission = await submissionService.getById(svc.tx, id);
+    if (!submission) throw new SubmissionNotFoundError(id);
+    assertOwnerOrEditor(
+      svc.actor.userId,
+      svc.actor.role,
+      submission.submitterId,
+    );
+    return submission;
+  },
+
+  /**
+   * Create a new submission with audit logging.
+   */
+  async createWithAudit(svc: ServiceContext, input: CreateSubmissionInput) {
+    const submission = await submissionService.create(
+      svc.tx,
+      input,
+      svc.actor.orgId,
+      svc.actor.userId,
+    );
+    await svc.audit({
+      action: AuditActions.SUBMISSION_CREATED,
+      resource: AuditResources.SUBMISSION,
+      resourceId: submission.id,
+      newValue: { title: input.title },
+    });
+    return submission;
+  },
+
+  /**
+   * Update a DRAFT submission — owner only, with audit.
+   */
+  async updateAsOwner(
+    svc: ServiceContext,
+    id: string,
+    data: UpdateSubmissionInput,
+  ) {
+    const existing = await submissionService.getById(svc.tx, id);
+    if (!existing) throw new SubmissionNotFoundError(id);
+    if (existing.submitterId !== svc.actor.userId) {
+      throw new ForbiddenError('Only the submitter can update this submission');
+    }
+    const updated = await submissionService.update(svc.tx, id, data);
+    if (!updated) throw new SubmissionNotFoundError(id);
+    await svc.audit({
+      action: AuditActions.SUBMISSION_UPDATED,
+      resource: AuditResources.SUBMISSION,
+      resourceId: id,
+      newValue: data,
+    });
+    return updated;
+  },
+
+  /**
+   * Submit a DRAFT submission (DRAFT→SUBMITTED) — owner only, with audit.
+   */
+  async submitAsOwner(svc: ServiceContext, id: string) {
+    const existing = await submissionService.getById(svc.tx, id);
+    if (!existing) throw new SubmissionNotFoundError(id);
+    if (existing.submitterId !== svc.actor.userId) {
+      throw new ForbiddenError('Only the submitter can submit this submission');
+    }
+    const result = await submissionService.updateStatus(
+      svc.tx,
+      id,
+      'SUBMITTED',
+      svc.actor.userId,
+      undefined,
+      'submitter',
+    );
+    await svc.audit({
+      action: AuditActions.SUBMISSION_SUBMITTED,
+      resource: AuditResources.SUBMISSION,
+      resourceId: id,
+    });
+    return result;
+  },
+
+  /**
+   * Delete a DRAFT submission — owner only, with audit.
+   */
+  async deleteAsOwner(svc: ServiceContext, id: string) {
+    const existing = await submissionService.getById(svc.tx, id);
+    if (!existing) throw new SubmissionNotFoundError(id);
+    if (existing.submitterId !== svc.actor.userId) {
+      throw new ForbiddenError('Only the submitter can delete this submission');
+    }
+    const deleted = await submissionService.delete(svc.tx, id);
+    if (!deleted) throw new SubmissionNotFoundError(id);
+    await svc.audit({
+      action: AuditActions.SUBMISSION_DELETED,
+      resource: AuditResources.SUBMISSION,
+      resourceId: id,
+    });
+    return { success: true as const };
+  },
+
+  /**
+   * Withdraw a submission — owner only, with audit.
+   */
+  async withdrawAsOwner(svc: ServiceContext, id: string) {
+    const existing = await submissionService.getById(svc.tx, id);
+    if (!existing) throw new SubmissionNotFoundError(id);
+    if (existing.submitterId !== svc.actor.userId) {
+      throw new ForbiddenError(
+        'Only the submitter can withdraw this submission',
+      );
+    }
+    const result = await submissionService.updateStatus(
+      svc.tx,
+      id,
+      'WITHDRAWN',
+      svc.actor.userId,
+      undefined,
+      'submitter',
+    );
+    await svc.audit({
+      action: AuditActions.SUBMISSION_WITHDRAWN,
+      resource: AuditResources.SUBMISSION,
+      resourceId: id,
+    });
+    return result;
+  },
+
+  /**
+   * Editor/admin status transition with audit.
+   */
+  async updateStatusAsEditor(
+    svc: ServiceContext,
+    id: string,
+    status: SubmissionStatus,
+    comment: string | undefined,
+  ) {
+    assertEditorOrAdmin(svc.actor.role);
+    const result = await submissionService.updateStatus(
+      svc.tx,
+      id,
+      status,
+      svc.actor.userId,
+      comment,
+      'editor',
+    );
+    await svc.audit({
+      action: AuditActions.SUBMISSION_STATUS_CHANGED,
+      resource: AuditResources.SUBMISSION,
+      resourceId: id,
+      newValue: { status, comment },
+    });
+    return result;
+  },
+
+  /**
+   * Get submission history — owner or editor/admin access check.
+   */
+  async getHistoryWithAccess(svc: ServiceContext, submissionId: string) {
+    const submission = await submissionService.getById(svc.tx, submissionId);
+    if (!submission) throw new SubmissionNotFoundError(submissionId);
+    assertOwnerOrEditor(
+      svc.actor.userId,
+      svc.actor.role,
+      submission.submitterId,
+    );
+    return submissionService.getHistory(svc.tx, submissionId);
   },
 };

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -2,7 +2,10 @@ import { TRPCError } from '@trpc/server';
 import { ForbiddenError, NotFoundError } from '../services/errors.js';
 import { SubmissionNotFoundError } from '../services/submission.service.js';
 import { UserNotFoundError } from '../services/organization.service.js';
-import { FileNotFoundError } from '../services/file.service.js';
+import {
+  FileNotFoundError,
+  FileNotCleanError,
+} from '../services/file.service.js';
 import {
   NotDraftError,
   InvalidStatusTransitionError,
@@ -28,6 +31,8 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [UnscannedFilesError, 'BAD_REQUEST'],
   [InfectedFilesError, 'BAD_REQUEST'],
   [LastAdminError, 'BAD_REQUEST'],
+  // Precondition
+  [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];
 
 /**

--- a/apps/api/src/trpc/routers/api-keys.spec.ts
+++ b/apps/api/src/trpc/routers/api-keys.spec.ts
@@ -49,10 +49,8 @@ function orgContext(
   });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const createCaller = (appRouter as any).createCaller as (
   ctx: TRPCContext,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ) => any;
 
 describe('apiKeys router', () => {

--- a/apps/api/src/trpc/routers/files.spec.ts
+++ b/apps/api/src/trpc/routers/files.spec.ts
@@ -14,11 +14,25 @@ vi.mock('../../services/file.service.js', () => ({
     validateMimeType: vi.fn(),
     validateFileSize: vi.fn(),
     validateLimits: vi.fn(),
+    getDownloadUrl: vi.fn(),
+    deleteWithS3: vi.fn(),
+    // Access-aware methods (PR 2)
+    listBySubmissionWithAccess: vi.fn(),
+    getDownloadUrlWithAccess: vi.fn(),
+    deleteAsOwner: vi.fn(),
   },
   FileNotFoundError: class FileNotFoundError extends Error {
     name = 'FileNotFoundError';
     constructor(id = 'unknown') {
       super(`File "${id}" not found`);
+    }
+  },
+  FileNotCleanError: class FileNotCleanError extends Error {
+    name = 'FileNotCleanError';
+    constructor(fileId = 'unknown', scanStatus = 'PENDING') {
+      super(
+        `File "${fileId}" has scan status "${scanStatus}" — download blocked`,
+      );
     }
   },
 }));
@@ -34,15 +48,29 @@ vi.mock('../../services/submission.service.js', () => ({
     updateStatus: vi.fn(),
     delete: vi.fn(),
     getHistory: vi.fn(),
+    getByIdWithAccess: vi.fn(),
+    createWithAudit: vi.fn(),
+    updateAsOwner: vi.fn(),
+    submitAsOwner: vi.fn(),
+    deleteAsOwner: vi.fn(),
+    withdrawAsOwner: vi.fn(),
+    updateStatusAsEditor: vi.fn(),
+    getHistoryWithAccess: vi.fn(),
   },
   SubmissionNotFoundError: class SubmissionNotFoundError extends Error {
     name = 'SubmissionNotFoundError';
+    constructor(id = 'unknown') {
+      super(`Submission "${id}" not found`);
+    }
   },
   InvalidStatusTransitionError: class extends Error {
     name = 'InvalidStatusTransitionError';
   },
   NotDraftError: class extends Error {
     name = 'NotDraftError';
+    constructor() {
+      super('Submission must be in DRAFT status for this operation');
+    }
   },
   UnscannedFilesError: class extends Error {
     name = 'UnscannedFilesError';
@@ -89,14 +117,11 @@ vi.mock('@colophony/db', () => ({
 }));
 
 import { fileService } from '../../services/file.service.js';
-import { submissionService } from '../../services/submission.service.js';
-import { deleteS3Object } from '../../services/s3.js';
+import { ForbiddenError } from '../../services/errors.js';
 import { appRouter } from '../router.js';
 import type { TRPCContext } from '../context.js';
 
 const mockFileService = vi.mocked(fileService);
-const mockSubmissionService = vi.mocked(submissionService);
-const mockDeleteS3 = vi.mocked(deleteS3Object);
 
 function makeContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
   return {
@@ -128,46 +153,12 @@ function orgContext(
   });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const createCaller = (appRouter as any).createCaller as (
   ctx: TRPCContext,
 ) => any;
 
 const SUBMISSION_ID = 'a1111111-1111-1111-a111-111111111111';
 const FILE_ID = 'f1111111-1111-1111-a111-111111111111';
-
-function makeDraftSubmission(submitterId = 'user-1') {
-  return {
-    id: SUBMISSION_ID,
-    organizationId: 'org-1',
-    submitterId,
-    submissionPeriodId: null,
-    title: 'Test Poem',
-    content: 'Roses are red...',
-    coverLetter: null,
-    status: 'DRAFT' as const,
-    submittedAt: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    files: [],
-    submitterEmail: 'test@example.com',
-  };
-}
-
-function makeFile(overrides = {}) {
-  return {
-    id: FILE_ID,
-    submissionId: SUBMISSION_ID,
-    filename: 'poem.pdf',
-    mimeType: 'application/pdf',
-    size: 1024,
-    storageKey: 'quarantine/abc123',
-    scanStatus: 'CLEAN' as const,
-    scannedAt: new Date(),
-    uploadedAt: new Date(),
-    ...overrides,
-  };
-}
 
 describe('files tRPC router', () => {
   beforeEach(() => {
@@ -203,19 +194,20 @@ describe('files tRPC router', () => {
       ).rejects.toThrow(TRPCError);
     });
 
-    it('listBySubmission denies READER from viewing others files', async () => {
-      const sub = makeDraftSubmission('other-user');
-      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+    it('listBySubmission maps ForbiddenError from service', async () => {
+      mockFileService.listBySubmissionWithAccess.mockRejectedValueOnce(
+        new ForbiddenError('You do not have access to this submission'),
+      );
       const caller = createCaller(orgContext('READER'));
       await expect(
         caller.files.listBySubmission({ submissionId: SUBMISSION_ID }),
       ).rejects.toThrow('do not have access');
     });
 
-    it('listBySubmission allows EDITOR to view others files', async () => {
-      const sub = makeDraftSubmission('other-user');
-      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
-      mockFileService.listBySubmission.mockResolvedValueOnce([] as never);
+    it('listBySubmission succeeds for EDITOR', async () => {
+      mockFileService.listBySubmissionWithAccess.mockResolvedValueOnce(
+        [] as never,
+      );
       const caller = createCaller(orgContext('EDITOR'));
       const result = await caller.files.listBySubmission({
         submissionId: SUBMISSION_ID,
@@ -223,11 +215,10 @@ describe('files tRPC router', () => {
       expect(result).toEqual([]);
     });
 
-    it('delete requires ownership', async () => {
-      const file = makeFile();
-      const sub = makeDraftSubmission('other-user');
-      mockFileService.getById.mockResolvedValueOnce(file as never);
-      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+    it('delete maps ForbiddenError from service', async () => {
+      mockFileService.deleteAsOwner.mockRejectedValueOnce(
+        new ForbiddenError('Only the submitter can delete files'),
+      );
       const caller = createCaller(orgContext('READER'));
       await expect(caller.files.delete({ fileId: FILE_ID })).rejects.toThrow(
         'Only the submitter',
@@ -241,10 +232,22 @@ describe('files tRPC router', () => {
 
   describe('listBySubmission', () => {
     it('returns files for the submission', async () => {
-      const sub = makeDraftSubmission();
-      const files = [makeFile()];
-      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
-      mockFileService.listBySubmission.mockResolvedValueOnce(files as never);
+      const files = [
+        {
+          id: FILE_ID,
+          submissionId: SUBMISSION_ID,
+          filename: 'poem.pdf',
+          mimeType: 'application/pdf',
+          size: 1024,
+          storageKey: 'quarantine/abc123',
+          scanStatus: 'CLEAN',
+          scannedAt: new Date(),
+          uploadedAt: new Date(),
+        },
+      ];
+      mockFileService.listBySubmissionWithAccess.mockResolvedValueOnce(
+        files as never,
+      );
 
       const caller = createCaller(orgContext());
       const result = await caller.files.listBySubmission({
@@ -254,8 +257,12 @@ describe('files tRPC router', () => {
       expect(result[0].filename).toBe('poem.pdf');
     });
 
-    it('throws NOT_FOUND when submission missing', async () => {
-      mockSubmissionService.getById.mockResolvedValueOnce(null as never);
+    it('maps SubmissionNotFoundError to NOT_FOUND', async () => {
+      const { SubmissionNotFoundError } =
+        await import('../../services/submission.service.js');
+      mockFileService.listBySubmissionWithAccess.mockRejectedValueOnce(
+        new SubmissionNotFoundError(SUBMISSION_ID),
+      );
       const caller = createCaller(orgContext());
       await expect(
         caller.files.listBySubmission({ submissionId: SUBMISSION_ID }),
@@ -269,10 +276,11 @@ describe('files tRPC router', () => {
 
   describe('getDownloadUrl', () => {
     it('returns presigned URL for CLEAN file', async () => {
-      const file = makeFile();
-      const sub = makeDraftSubmission();
-      mockFileService.getById.mockResolvedValueOnce(file as never);
-      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+      mockFileService.getDownloadUrlWithAccess.mockResolvedValueOnce({
+        url: 'https://s3.example.com/signed-url',
+        filename: 'poem.pdf',
+        mimeType: 'application/pdf',
+      } as never);
 
       const caller = createCaller(orgContext());
       const result = await caller.files.getDownloadUrl({ fileId: FILE_ID });
@@ -280,32 +288,25 @@ describe('files tRPC router', () => {
       expect(result.filename).toBe('poem.pdf');
     });
 
-    it('rejects file not yet scanned', async () => {
-      const file = makeFile({ scanStatus: 'PENDING' });
-      const sub = makeDraftSubmission();
-      mockFileService.getById.mockResolvedValueOnce(file as never);
-      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+    it('maps FileNotCleanError to PRECONDITION_FAILED', async () => {
+      const { FileNotCleanError } =
+        await import('../../services/file.service.js');
+      mockFileService.getDownloadUrlWithAccess.mockRejectedValueOnce(
+        new FileNotCleanError(FILE_ID, 'PENDING'),
+      );
 
       const caller = createCaller(orgContext());
       await expect(
         caller.files.getDownloadUrl({ fileId: FILE_ID }),
-      ).rejects.toThrow('virus scan');
+      ).rejects.toThrow('download blocked');
     });
 
-    it('rejects infected file', async () => {
-      const file = makeFile({ scanStatus: 'INFECTED' });
-      const sub = makeDraftSubmission();
-      mockFileService.getById.mockResolvedValueOnce(file as never);
-      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
-
-      const caller = createCaller(orgContext());
-      await expect(
-        caller.files.getDownloadUrl({ fileId: FILE_ID }),
-      ).rejects.toThrow('virus scan');
-    });
-
-    it('throws NOT_FOUND for missing file', async () => {
-      mockFileService.getById.mockResolvedValueOnce(null as never);
+    it('maps FileNotFoundError to NOT_FOUND', async () => {
+      const { FileNotFoundError } =
+        await import('../../services/file.service.js');
+      mockFileService.getDownloadUrlWithAccess.mockRejectedValueOnce(
+        new FileNotFoundError(FILE_ID),
+      );
       const caller = createCaller(orgContext());
       await expect(
         caller.files.getDownloadUrl({ fileId: FILE_ID }),
@@ -318,28 +319,22 @@ describe('files tRPC router', () => {
   // -------------------------------------------------------------------------
 
   describe('delete', () => {
-    it('succeeds on DRAFT and calls audit', async () => {
-      const file = makeFile();
-      const sub = makeDraftSubmission();
-      mockFileService.getById.mockResolvedValueOnce(file as never);
-      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
-      mockFileService.delete.mockResolvedValueOnce(file as never);
+    it('succeeds and returns success', async () => {
+      mockFileService.deleteAsOwner.mockResolvedValueOnce({
+        success: true,
+      } as never);
 
       const ctx = orgContext();
       const caller = createCaller(ctx);
       const result = await caller.files.delete({ fileId: FILE_ID });
 
       expect(result).toEqual({ success: true });
-      expect(ctx.audit).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'FILE_DELETED' }),
-      );
     });
 
-    it('rejects deletion from non-DRAFT submission', async () => {
-      const file = makeFile();
-      const sub = { ...makeDraftSubmission(), status: 'SUBMITTED' as const };
-      mockFileService.getById.mockResolvedValueOnce(file as never);
-      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
+    it('maps NotDraftError to BAD_REQUEST', async () => {
+      const { NotDraftError } =
+        await import('../../services/submission.service.js');
+      mockFileService.deleteAsOwner.mockRejectedValueOnce(new NotDraftError());
 
       const caller = createCaller(orgContext());
       await expect(caller.files.delete({ fileId: FILE_ID })).rejects.toThrow(
@@ -347,26 +342,12 @@ describe('files tRPC router', () => {
       );
     });
 
-    it('attempts S3 deletion after DB delete', async () => {
-      const file = makeFile();
-      const sub = makeDraftSubmission();
-      mockFileService.getById.mockResolvedValueOnce(file as never);
-      mockSubmissionService.getById.mockResolvedValueOnce(sub as never);
-      mockFileService.delete.mockResolvedValueOnce(file as never);
-
-      const caller = createCaller(orgContext());
-      await caller.files.delete({ fileId: FILE_ID });
-
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockDeleteS3).toHaveBeenCalledWith(
-        expect.anything(),
-        'submissions', // CLEAN files live in submissions bucket after scan
-        file.storageKey,
+    it('maps FileNotFoundError to NOT_FOUND', async () => {
+      const { FileNotFoundError } =
+        await import('../../services/file.service.js');
+      mockFileService.deleteAsOwner.mockRejectedValueOnce(
+        new FileNotFoundError(FILE_ID),
       );
-    });
-
-    it('throws NOT_FOUND for missing file', async () => {
-      mockFileService.getById.mockResolvedValueOnce(null as never);
       const caller = createCaller(orgContext());
       await expect(caller.files.delete({ fileId: FILE_ID })).rejects.toThrow(
         'not found',

--- a/apps/api/src/trpc/routers/files.ts
+++ b/apps/api/src/trpc/routers/files.ts
@@ -1,15 +1,10 @@
 import { z } from 'zod';
-import { TRPCError } from '@trpc/server';
-import { AuditActions, AuditResources } from '@colophony/types';
 import { orgProcedure, createRouter } from '../init.js';
-import { submissionService } from '../../services/submission.service.js';
 import { fileService } from '../../services/file.service.js';
-import {
-  createS3Client,
-  getPresignedDownloadUrl,
-  deleteS3Object,
-} from '../../services/s3.js';
+import { createS3Client } from '../../services/s3.js';
 import { validateEnv } from '../../config/env.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
 
 // Lazily create S3 client (avoid creating at module load for tests)
 let s3ClientInstance: ReturnType<typeof createS3Client> | null = null;
@@ -26,163 +21,53 @@ function getEnvConfig() {
   return validateEnv();
 }
 
-function assertOwnerOrEditor(
-  submitterId: string,
-  userId: string,
-  role: string,
-): void {
-  if (submitterId !== userId && role !== 'ADMIN' && role !== 'EDITOR') {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message: 'You do not have access to this submission',
-    });
-  }
-}
-
 export const filesRouter = createRouter({
   /** List files for a submission — owner or editor/admin. */
   listBySubmission: orgProcedure
     .input(z.object({ submissionId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
-      const submission = await submissionService.getById(
-        ctx.dbTx,
-        input.submissionId,
-      );
-      if (!submission) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Submission not found',
-        });
+      try {
+        return await fileService.listBySubmissionWithAccess(
+          toServiceContext(ctx),
+          input.submissionId,
+        );
+      } catch (e) {
+        mapServiceError(e);
       }
-      assertOwnerOrEditor(
-        submission.submitterId,
-        ctx.authContext.userId,
-        ctx.authContext.role,
-      );
-      return fileService.listBySubmission(ctx.dbTx, input.submissionId);
     }),
 
   /** Get a presigned download URL for a file — owner or editor/admin, CLEAN only. */
   getDownloadUrl: orgProcedure
     .input(z.object({ fileId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
-      const file = await fileService.getById(ctx.dbTx, input.fileId);
-      if (!file) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'File not found',
-        });
+      try {
+        const env = getEnvConfig();
+        return await fileService.getDownloadUrlWithAccess(
+          toServiceContext(ctx),
+          input.fileId,
+          getS3Client(),
+          env.S3_BUCKET,
+        );
+      } catch (e) {
+        mapServiceError(e);
       }
-
-      // Check access via submission
-      const submission = await submissionService.getById(
-        ctx.dbTx,
-        file.submissionId,
-      );
-      if (!submission) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Submission not found',
-        });
-      }
-      assertOwnerOrEditor(
-        submission.submitterId,
-        ctx.authContext.userId,
-        ctx.authContext.role,
-      );
-
-      if (file.scanStatus !== 'CLEAN') {
-        throw new TRPCError({
-          code: 'PRECONDITION_FAILED',
-          message: 'File has not passed virus scan',
-        });
-      }
-
-      const env = getEnvConfig();
-      const url = await getPresignedDownloadUrl(
-        getS3Client(),
-        env.S3_BUCKET,
-        file.storageKey,
-      );
-      return { url, filename: file.filename, mimeType: file.mimeType };
     }),
 
   /** Delete a file — submission owner only, DRAFT only. */
   delete: orgProcedure
     .input(z.object({ fileId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      const file = await fileService.getById(ctx.dbTx, input.fileId);
-      if (!file) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'File not found',
-        });
-      }
-
-      // Check ownership via submission
-      const submission = await submissionService.getById(
-        ctx.dbTx,
-        file.submissionId,
-      );
-      if (!submission) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Submission not found',
-        });
-      }
-      if (submission.submitterId !== ctx.authContext.userId) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: 'Only the submitter can delete files',
-        });
-      }
-      if (submission.status !== 'DRAFT') {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Files can only be deleted from DRAFT submissions',
-        });
-      }
-
-      // Delete DB record
-      const deleted = await fileService.delete(ctx.dbTx, input.fileId);
-      if (!deleted) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'File not found',
-        });
-      }
-
-      await ctx.audit({
-        action: AuditActions.FILE_DELETED,
-        resource: AuditResources.FILE,
-        resourceId: input.fileId,
-        newValue: {
-          filename: file.filename,
-          submissionId: file.submissionId,
-        },
-      });
-
-      // Delete from correct S3 bucket based on scan status (best-effort)
       try {
         const env = getEnvConfig();
-        const bucket =
-          file.scanStatus === 'CLEAN'
-            ? env.S3_BUCKET
-            : env.S3_QUARANTINE_BUCKET;
-        await deleteS3Object(getS3Client(), bucket, file.storageKey);
-      } catch {
-        // Log but don't fail — orphaned S3 objects can be cleaned up
-        // by a periodic garbage collection job
-        ctx
-          .audit({
-            action: AuditActions.FILE_DELETED,
-            resource: AuditResources.FILE,
-            resourceId: input.fileId,
-            newValue: { s3DeleteFailed: true, storageKey: file.storageKey },
-          })
-          .catch(() => {});
+        return await fileService.deleteAsOwner(
+          toServiceContext(ctx),
+          input.fileId,
+          getS3Client(),
+          env.S3_BUCKET,
+          env.S3_QUARANTINE_BUCKET,
+        );
+      } catch (e) {
+        mapServiceError(e);
       }
-
-      return { success: true };
     }),
 });

--- a/apps/api/src/trpc/routers/organizations.spec.ts
+++ b/apps/api/src/trpc/routers/organizations.spec.ts
@@ -13,6 +13,12 @@ vi.mock('../../services/organization.service.js', () => ({
     addMember: vi.fn(),
     removeMember: vi.fn(),
     updateMemberRole: vi.fn(),
+    // Access-aware methods (PR 2)
+    addMemberWithAudit: vi.fn(),
+    removeMemberWithAudit: vi.fn(),
+    updateMemberRoleWithAudit: vi.fn(),
+    updateWithAudit: vi.fn(),
+    createWithAudit: vi.fn(),
   },
   UserNotFoundError: class UserNotFoundError extends Error {
     name = 'UserNotFoundError';
@@ -41,6 +47,7 @@ vi.mock('@colophony/db', () => ({
 }));
 
 import { organizationService } from '../../services/organization.service.js';
+import { NotFoundError } from '../../services/errors.js';
 import { appRouter } from '../router.js';
 import type { TRPCContext } from '../context.js';
 
@@ -91,7 +98,7 @@ function orgContext(
 
 // Create a caller factory for testing.
 // Cast to any for test caller access. Procedure shapes are tested at runtime.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 const createCaller = (appRouter as any).createCaller as (
   ctx: TRPCContext,
 ) => any;
@@ -133,9 +140,9 @@ describe('organizations tRPC router', () => {
       ).rejects.toThrow(TRPCError);
     });
 
-    it('checks slug availability and creates org', async () => {
+    it('checks slug availability and creates org via createWithAudit', async () => {
       mockService.isSlugAvailable.mockResolvedValueOnce(true);
-      mockService.create.mockResolvedValueOnce({
+      mockService.createWithAudit.mockResolvedValueOnce({
         organization: { id: 'org-new', name: 'Test', slug: 'test' },
         membership: { id: 'mem-1', role: 'ADMIN' },
       } as never);
@@ -150,7 +157,8 @@ describe('organizations tRPC router', () => {
       expect(result.organization.id).toBe('org-new');
       expect(mockService.isSlugAvailable).toHaveBeenCalledWith('test'); // eslint-disable-line @typescript-eslint/unbound-method
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockService.create).toHaveBeenCalledWith(
+      expect(mockService.createWithAudit).toHaveBeenCalledWith(
+        expect.any(Function), // audit fn
         { name: 'Test', slug: 'test' },
         'user-1',
       );
@@ -165,18 +173,18 @@ describe('organizations tRPC router', () => {
       ).rejects.toThrow('already taken');
     });
 
-    it('throws CONFLICT on unique constraint race (23505)', async () => {
+    it('maps 23505 to CONFLICT on unique constraint race', async () => {
       mockService.isSlugAvailable.mockResolvedValueOnce(true);
       const pgError = new Error(
         'duplicate key value violates unique constraint',
       );
       (pgError as unknown as { code: string }).code = '23505';
-      mockService.create.mockRejectedValueOnce(pgError);
+      mockService.createWithAudit.mockRejectedValueOnce(pgError);
 
       const caller = createCaller(authedContext());
       await expect(
         caller.organizations.create({ name: 'Test', slug: 'race' }),
-      ).rejects.toThrow('already taken');
+      ).rejects.toThrow('already exists');
     });
   });
 
@@ -211,19 +219,25 @@ describe('organizations tRPC router', () => {
       ).rejects.toThrow('Admin role required');
     });
 
-    it('updates organization and audits', async () => {
-      const old = { id: 'org-1', name: 'Old', settings: {} };
+    it('updates organization via updateWithAudit', async () => {
       const updated = { id: 'org-1', name: 'New' };
-      mockService.getById.mockResolvedValueOnce(old as never);
-      mockService.update.mockResolvedValueOnce(updated as never);
+      mockService.updateWithAudit.mockResolvedValueOnce(updated as never);
 
       const ctx = orgContext('ADMIN');
       const caller = createCaller(ctx);
       const result = await caller.organizations.update({ name: 'New' });
       expect(result).toEqual(updated);
-      expect(ctx.audit).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'ORG_UPDATED' }),
+    });
+
+    it('maps NotFoundError to NOT_FOUND', async () => {
+      mockService.updateWithAudit.mockRejectedValueOnce(
+        new NotFoundError('Organization not found'),
       );
+
+      const caller = createCaller(orgContext('ADMIN'));
+      await expect(
+        caller.organizations.update({ name: 'New' }),
+      ).rejects.toThrow('not found');
     });
   });
 
@@ -284,9 +298,9 @@ describe('organizations tRPC router', () => {
       ).rejects.toThrow('Admin role required');
     });
 
-    it('adds member and audits', async () => {
+    it('adds member via addMemberWithAudit', async () => {
       const member = { id: 'mem-new', userId: 'u-2', role: 'READER' };
-      mockService.addMember.mockResolvedValueOnce(member as never);
+      mockService.addMemberWithAudit.mockResolvedValueOnce(member as never);
 
       const ctx = orgContext('ADMIN');
       const caller = createCaller(ctx);
@@ -295,18 +309,43 @@ describe('organizations tRPC router', () => {
         role: 'READER',
       });
       expect(result).toEqual(member);
-      expect(ctx.audit).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'ORG_MEMBER_ADDED' }),
+    });
+
+    it('maps UserNotFoundError to NOT_FOUND', async () => {
+      const { UserNotFoundError } =
+        await import('../../services/organization.service.js');
+      mockService.addMemberWithAudit.mockRejectedValueOnce(
+        new UserNotFoundError('nobody@example.com'),
       );
+
+      const caller = createCaller(orgContext('ADMIN'));
+      await expect(
+        caller.organizations.members.add({
+          email: 'nobody@example.com',
+          role: 'READER',
+        }),
+      ).rejects.toThrow(TRPCError);
+    });
+
+    it('maps 23505 to CONFLICT', async () => {
+      const pgError = new Error('duplicate key');
+      (pgError as unknown as { code: string }).code = '23505';
+      mockService.addMemberWithAudit.mockRejectedValueOnce(pgError);
+
+      const caller = createCaller(orgContext('ADMIN'));
+      await expect(
+        caller.organizations.members.add({
+          email: 'dup@example.com',
+          role: 'READER',
+        }),
+      ).rejects.toThrow('already exists');
     });
   });
 
   describe('organizations.members.remove', () => {
-    it('removes member and audits', async () => {
-      mockService.removeMember.mockResolvedValueOnce({
-        id: 'mem-1',
-        userId: 'u-1',
-        role: 'EDITOR',
+    it('removes member via removeMemberWithAudit', async () => {
+      mockService.removeMemberWithAudit.mockResolvedValueOnce({
+        success: true,
       } as never);
 
       const ctx = orgContext('ADMIN');
@@ -317,11 +356,25 @@ describe('organizations tRPC router', () => {
       expect(result).toEqual({ success: true });
     });
 
-    it('prevents removing last admin', async () => {
-      // Service now throws LastAdminError atomically (FOR UPDATE lock)
+    it('maps NotFoundError to NOT_FOUND', async () => {
+      mockService.removeMemberWithAudit.mockRejectedValueOnce(
+        new NotFoundError('Member not found'),
+      );
+
+      const caller = createCaller(orgContext('ADMIN'));
+      await expect(
+        caller.organizations.members.remove({
+          memberId: 'a1111111-1111-1111-a111-111111111111',
+        }),
+      ).rejects.toThrow('not found');
+    });
+
+    it('maps LastAdminError to BAD_REQUEST', async () => {
       const { LastAdminError } =
         await import('../../services/organization.service.js');
-      mockService.removeMember.mockRejectedValueOnce(new LastAdminError());
+      mockService.removeMemberWithAudit.mockRejectedValueOnce(
+        new LastAdminError(),
+      );
 
       const caller = createCaller(orgContext('ADMIN'));
       await expect(
@@ -333,8 +386,8 @@ describe('organizations tRPC router', () => {
   });
 
   describe('organizations.members.updateRole', () => {
-    it('updates role and audits', async () => {
-      mockService.updateMemberRole.mockResolvedValueOnce({
+    it('updates role via updateMemberRoleWithAudit', async () => {
+      mockService.updateMemberRoleWithAudit.mockResolvedValueOnce({
         id: 'mem-1',
         role: 'EDITOR',
       } as never);
@@ -346,9 +399,22 @@ describe('organizations tRPC router', () => {
         role: 'EDITOR',
       });
       expect(result.role).toBe('EDITOR');
-      expect(ctx.audit).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'ORG_MEMBER_ROLE_CHANGED' }),
+    });
+
+    it('maps LastAdminError to BAD_REQUEST', async () => {
+      const { LastAdminError } =
+        await import('../../services/organization.service.js');
+      mockService.updateMemberRoleWithAudit.mockRejectedValueOnce(
+        new LastAdminError(),
       );
+
+      const caller = createCaller(orgContext('ADMIN'));
+      await expect(
+        caller.organizations.members.updateRole({
+          memberId: 'a1111111-1111-1111-a111-111111111111',
+          role: 'READER',
+        }),
+      ).rejects.toThrow('last admin');
     });
   });
 });

--- a/apps/api/src/trpc/routers/organizations.ts
+++ b/apps/api/src/trpc/routers/organizations.ts
@@ -7,8 +7,6 @@ import {
   updateMemberRoleSchema,
   paginationSchema,
   checkSlugSchema,
-  AuditActions,
-  AuditResources,
 } from '@colophony/types';
 import {
   authedProcedure,
@@ -16,11 +14,9 @@ import {
   adminProcedure,
   createRouter,
 } from '../init.js';
-import {
-  organizationService,
-  UserNotFoundError,
-  LastAdminError,
-} from '../../services/organization.service.js';
+import { organizationService } from '../../services/organization.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
 
 const membersRouter = createRouter({
   list: orgProcedure.input(paginationSchema).query(async ({ ctx, input }) => {
@@ -31,33 +27,13 @@ const membersRouter = createRouter({
     .input(inviteMemberSchema)
     .mutation(async ({ ctx, input }) => {
       try {
-        const member = await organizationService.addMember(
-          ctx.dbTx,
-          ctx.authContext.orgId,
+        return await organizationService.addMemberWithAudit(
+          toServiceContext(ctx),
           input.email,
           input.role,
         );
-        await ctx.audit({
-          action: AuditActions.ORG_MEMBER_ADDED,
-          resource: AuditResources.ORGANIZATION,
-          resourceId: member.id,
-          newValue: { email: input.email, role: input.role },
-        });
-        return member;
       } catch (e) {
-        if (e instanceof UserNotFoundError) {
-          throw new TRPCError({
-            code: 'NOT_FOUND',
-            message: e.message,
-          });
-        }
-        if ((e as { code?: string }).code === '23505') {
-          throw new TRPCError({
-            code: 'CONFLICT',
-            message: 'User is already a member of this organization',
-          });
-        }
-        throw e;
+        mapServiceError(e);
       }
     }),
 
@@ -65,31 +41,12 @@ const membersRouter = createRouter({
     .input(z.object({ memberId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       try {
-        const deleted = await organizationService.removeMember(
-          ctx.dbTx,
+        return await organizationService.removeMemberWithAudit(
+          toServiceContext(ctx),
           input.memberId,
         );
-        if (!deleted) {
-          throw new TRPCError({
-            code: 'NOT_FOUND',
-            message: 'Member not found',
-          });
-        }
-        await ctx.audit({
-          action: AuditActions.ORG_MEMBER_REMOVED,
-          resource: AuditResources.ORGANIZATION,
-          resourceId: deleted.id,
-          oldValue: { userId: deleted.userId, role: deleted.role },
-        });
-        return { success: true };
       } catch (e) {
-        if (e instanceof LastAdminError) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: e.message,
-          });
-        }
-        throw e;
+        mapServiceError(e);
       }
     }),
 
@@ -97,32 +54,13 @@ const membersRouter = createRouter({
     .input(updateMemberRoleSchema)
     .mutation(async ({ ctx, input }) => {
       try {
-        const updated = await organizationService.updateMemberRole(
-          ctx.dbTx,
+        return await organizationService.updateMemberRoleWithAudit(
+          toServiceContext(ctx),
           input.memberId,
           input.role,
         );
-        if (!updated) {
-          throw new TRPCError({
-            code: 'NOT_FOUND',
-            message: 'Member not found',
-          });
-        }
-        await ctx.audit({
-          action: AuditActions.ORG_MEMBER_ROLE_CHANGED,
-          resource: AuditResources.ORGANIZATION,
-          resourceId: updated.id,
-          newValue: { role: input.role },
-        });
-        return updated;
       } catch (e) {
-        if (e instanceof LastAdminError) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: e.message,
-          });
-        }
-        throw e;
+        mapServiceError(e);
       }
     }),
 });
@@ -144,40 +82,15 @@ export const organizationsRouter = createRouter({
         });
       }
 
-      let result;
       try {
-        result = await organizationService.create(
+        return await organizationService.createWithAudit(
+          ctx.audit,
           input,
           ctx.authContext.userId,
         );
       } catch (e) {
-        // Catch unique constraint violation on slug (race between pre-check and insert)
-        if (
-          e instanceof Error &&
-          'code' in e &&
-          (e as { code: string }).code === '23505'
-        ) {
-          throw new TRPCError({
-            code: 'CONFLICT',
-            message: `Slug "${input.slug}" is already taken`,
-          });
-        }
-        throw e;
+        mapServiceError(e);
       }
-
-      // Atomicity note: create() commits org+membership in its own transaction
-      // (necessary because no org context exists yet for RLS). Audit runs in the
-      // request's separate transaction. If audit fails, org is committed but the
-      // request errors. This is acceptable: audit failure on CREATE is extremely
-      // unlikely, and the failure mode is recoverable (org exists, audit can be
-      // replayed). This is the same class of issue as Stripe charge-then-record.
-      await ctx.audit({
-        action: AuditActions.ORG_CREATED,
-        resource: AuditResources.ORGANIZATION,
-        resourceId: result.organization.id,
-        newValue: { name: input.name, slug: input.slug },
-      });
-      return result;
     }),
 
   get: orgProcedure.query(async ({ ctx }) => {
@@ -197,29 +110,14 @@ export const organizationsRouter = createRouter({
   update: adminProcedure
     .input(updateOrganizationSchema)
     .mutation(async ({ ctx, input }) => {
-      const old = await organizationService.getById(
-        ctx.dbTx,
-        ctx.authContext.orgId,
-      );
-      const updated = await organizationService.update(
-        ctx.dbTx,
-        ctx.authContext.orgId,
-        input,
-      );
-      if (!updated) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Organization not found',
-        });
+      try {
+        return await organizationService.updateWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
       }
-      await ctx.audit({
-        action: AuditActions.ORG_UPDATED,
-        resource: AuditResources.ORGANIZATION,
-        resourceId: updated.id,
-        oldValue: old ? { name: old.name, settings: old.settings } : undefined,
-        newValue: input,
-      });
-      return updated;
     }),
 
   checkSlug: authedProcedure.input(checkSlugSchema).query(async ({ input }) => {

--- a/apps/api/src/trpc/routers/submissions.spec.ts
+++ b/apps/api/src/trpc/routers/submissions.spec.ts
@@ -12,6 +12,15 @@ vi.mock('../../services/submission.service.js', () => ({
     updateStatus: vi.fn(),
     delete: vi.fn(),
     getHistory: vi.fn(),
+    // Access-aware methods (PR 2)
+    getByIdWithAccess: vi.fn(),
+    createWithAudit: vi.fn(),
+    updateAsOwner: vi.fn(),
+    submitAsOwner: vi.fn(),
+    deleteAsOwner: vi.fn(),
+    withdrawAsOwner: vi.fn(),
+    updateStatusAsEditor: vi.fn(),
+    getHistoryWithAccess: vi.fn(),
   },
   SubmissionNotFoundError: class SubmissionNotFoundError extends Error {
     name = 'SubmissionNotFoundError';
@@ -63,6 +72,7 @@ vi.mock('@colophony/db', () => ({
 }));
 
 import { submissionService } from '../../services/submission.service.js';
+import { ForbiddenError } from '../../services/errors.js';
 import { appRouter } from '../router.js';
 import type { TRPCContext } from '../context.js';
 
@@ -115,7 +125,6 @@ function editorContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
   return orgContext('EDITOR', overrides);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const createCaller = (appRouter as any).createCaller as (
   ctx: TRPCContext,
 ) => any;
@@ -184,7 +193,10 @@ describe('submissions tRPC router', () => {
       expect(result.items).toEqual([]);
     });
 
-    it('updateStatus requires EDITOR or ADMIN role', async () => {
+    it('updateStatus maps ForbiddenError from service', async () => {
+      mockService.updateStatusAsEditor.mockRejectedValueOnce(
+        new ForbiddenError('Editor or admin role required'),
+      );
       const caller = createCaller(orgContext('READER'));
       await expect(
         caller.submissions.updateStatus({
@@ -194,9 +206,9 @@ describe('submissions tRPC router', () => {
       ).rejects.toThrow('Editor or admin role required');
     });
 
-    it('update requires ownership', async () => {
-      mockService.getById.mockResolvedValueOnce(
-        makeDraftSubmission('other-user') as never,
+    it('update maps ForbiddenError from service', async () => {
+      mockService.updateAsOwner.mockRejectedValueOnce(
+        new ForbiddenError('Only the submitter can update this submission'),
       );
       const caller = createCaller(orgContext());
       await expect(
@@ -204,9 +216,9 @@ describe('submissions tRPC router', () => {
       ).rejects.toThrow('Only the submitter');
     });
 
-    it('submit requires ownership', async () => {
-      mockService.getById.mockResolvedValueOnce(
-        makeDraftSubmission('other-user') as never,
+    it('submit maps ForbiddenError from service', async () => {
+      mockService.submitAsOwner.mockRejectedValueOnce(
+        new ForbiddenError('Only the submitter can submit this submission'),
       );
       const caller = createCaller(orgContext());
       await expect(
@@ -214,9 +226,9 @@ describe('submissions tRPC router', () => {
       ).rejects.toThrow('Only the submitter');
     });
 
-    it('delete requires ownership', async () => {
-      mockService.getById.mockResolvedValueOnce(
-        makeDraftSubmission('other-user') as never,
+    it('delete maps ForbiddenError from service', async () => {
+      mockService.deleteAsOwner.mockRejectedValueOnce(
+        new ForbiddenError('Only the submitter can delete this submission'),
       );
       const caller = createCaller(orgContext());
       await expect(
@@ -224,9 +236,9 @@ describe('submissions tRPC router', () => {
       ).rejects.toThrow('Only the submitter');
     });
 
-    it('withdraw requires ownership', async () => {
-      mockService.getById.mockResolvedValueOnce(
-        makeDraftSubmission('other-user') as never,
+    it('withdraw maps ForbiddenError from service', async () => {
+      mockService.withdrawAsOwner.mockRejectedValueOnce(
+        new ForbiddenError('Only the submitter can withdraw this submission'),
       );
       const caller = createCaller(orgContext());
       await expect(
@@ -236,7 +248,7 @@ describe('submissions tRPC router', () => {
 
     it('getById allows owner to view', async () => {
       const sub = makeDraftSubmission('user-1');
-      mockService.getById.mockResolvedValueOnce(sub as never);
+      mockService.getByIdWithAccess.mockResolvedValueOnce(sub as never);
       const caller = createCaller(orgContext('READER'));
       const result = await caller.submissions.getById({ id: SUBMISSION_ID });
       expect(result.id).toBe(SUBMISSION_ID);
@@ -244,15 +256,16 @@ describe('submissions tRPC router', () => {
 
     it('getById allows EDITOR to view others submissions', async () => {
       const sub = makeDraftSubmission('other-user');
-      mockService.getById.mockResolvedValueOnce(sub as never);
+      mockService.getByIdWithAccess.mockResolvedValueOnce(sub as never);
       const caller = createCaller(editorContext());
       const result = await caller.submissions.getById({ id: SUBMISSION_ID });
       expect(result.id).toBe(SUBMISSION_ID);
     });
 
-    it('getById denies READER from viewing others submissions', async () => {
-      const sub = makeDraftSubmission('other-user');
-      mockService.getById.mockResolvedValueOnce(sub as never);
+    it('getById maps ForbiddenError when READER views others', async () => {
+      mockService.getByIdWithAccess.mockRejectedValueOnce(
+        new ForbiddenError('You do not have access to this submission'),
+      );
       const caller = createCaller(orgContext('READER'));
       await expect(
         caller.submissions.getById({ id: SUBMISSION_ID }),
@@ -309,15 +322,19 @@ describe('submissions tRPC router', () => {
   describe('getById', () => {
     it('returns submission when found', async () => {
       const sub = makeDraftSubmission();
-      mockService.getById.mockResolvedValueOnce(sub as never);
+      mockService.getByIdWithAccess.mockResolvedValueOnce(sub as never);
 
       const caller = createCaller(orgContext());
       const result = await caller.submissions.getById({ id: SUBMISSION_ID });
       expect(result).toEqual(sub);
     });
 
-    it('throws NOT_FOUND when missing', async () => {
-      mockService.getById.mockResolvedValueOnce(null as never);
+    it('maps SubmissionNotFoundError to NOT_FOUND', async () => {
+      const { SubmissionNotFoundError } =
+        await import('../../services/submission.service.js');
+      mockService.getByIdWithAccess.mockRejectedValueOnce(
+        new SubmissionNotFoundError(SUBMISSION_ID),
+      );
 
       const caller = createCaller(orgContext());
       await expect(
@@ -328,7 +345,6 @@ describe('submissions tRPC router', () => {
 
   describe('getHistory', () => {
     it('returns history array for owner', async () => {
-      const sub = makeDraftSubmission('user-1');
       const history = [
         {
           id: 'h-1',
@@ -340,8 +356,7 @@ describe('submissions tRPC router', () => {
           changedAt: new Date(),
         },
       ];
-      mockService.getById.mockResolvedValueOnce(sub as never);
-      mockService.getHistory.mockResolvedValueOnce(history as never);
+      mockService.getHistoryWithAccess.mockResolvedValueOnce(history as never);
 
       const caller = createCaller(orgContext());
       const result = await caller.submissions.getHistory({
@@ -351,21 +366,10 @@ describe('submissions tRPC router', () => {
       expect(result[0].toStatus).toBe('DRAFT');
     });
 
-    it('allows EDITOR to view history of others submissions', async () => {
-      const sub = makeDraftSubmission('other-user');
-      mockService.getById.mockResolvedValueOnce(sub as never);
-      mockService.getHistory.mockResolvedValueOnce([] as never);
-
-      const caller = createCaller(editorContext());
-      const result = await caller.submissions.getHistory({
-        submissionId: SUBMISSION_ID,
-      });
-      expect(result).toEqual([]);
-    });
-
-    it('denies READER from viewing others submission history', async () => {
-      const sub = makeDraftSubmission('other-user');
-      mockService.getById.mockResolvedValueOnce(sub as never);
+    it('maps ForbiddenError when READER views others history', async () => {
+      mockService.getHistoryWithAccess.mockRejectedValueOnce(
+        new ForbiddenError('You do not have access to this submission'),
+      );
 
       const caller = createCaller(orgContext('READER'));
       await expect(
@@ -373,8 +377,12 @@ describe('submissions tRPC router', () => {
       ).rejects.toThrow('do not have access');
     });
 
-    it('throws NOT_FOUND when submission missing', async () => {
-      mockService.getById.mockResolvedValueOnce(null as never);
+    it('maps SubmissionNotFoundError to NOT_FOUND', async () => {
+      const { SubmissionNotFoundError } =
+        await import('../../services/submission.service.js');
+      mockService.getHistoryWithAccess.mockRejectedValueOnce(
+        new SubmissionNotFoundError(SUBMISSION_ID),
+      );
 
       const caller = createCaller(orgContext());
       await expect(
@@ -388,58 +396,56 @@ describe('submissions tRPC router', () => {
   // -------------------------------------------------------------------------
 
   describe('create', () => {
-    it('returns submission and calls audit', async () => {
+    it('returns submission from createWithAudit', async () => {
       const sub = {
         id: SUBMISSION_ID,
         title: 'My Poem',
         status: 'DRAFT',
       };
-      mockService.create.mockResolvedValueOnce(sub as never);
+      mockService.createWithAudit.mockResolvedValueOnce(sub as never);
 
-      const ctx = orgContext();
-      const caller = createCaller(ctx);
+      const caller = createCaller(orgContext());
       const result = await caller.submissions.create({ title: 'My Poem' });
 
       expect(result.id).toBe(SUBMISSION_ID);
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockService.create).toHaveBeenCalledWith(
-        expect.anything(),
+      expect(mockService.createWithAudit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tx: expect.anything(),
+          actor: expect.objectContaining({ userId: 'user-1', orgId: 'org-1' }),
+          audit: expect.any(Function),
+        }),
         { title: 'My Poem' },
-        'org-1',
-        'user-1',
-      );
-      expect(ctx.audit).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'SUBMISSION_CREATED' }),
       );
     });
   });
 
   describe('update', () => {
-    it('succeeds on DRAFT and calls audit', async () => {
-      const sub = makeDraftSubmission();
-      const updated = { ...sub, title: 'Updated Title' };
-      mockService.getById.mockResolvedValueOnce(sub as never);
-      mockService.update.mockResolvedValueOnce(updated as never);
+    it('calls updateAsOwner with correct args', async () => {
+      const updated = { ...makeDraftSubmission(), title: 'Updated Title' };
+      mockService.updateAsOwner.mockResolvedValueOnce(updated as never);
 
-      const ctx = orgContext();
-      const caller = createCaller(ctx);
+      const caller = createCaller(orgContext());
       const result = await caller.submissions.update({
         id: SUBMISSION_ID,
         title: 'Updated Title',
       });
 
       expect(result.title).toBe('Updated Title');
-      expect(ctx.audit).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'SUBMISSION_UPDATED' }),
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.updateAsOwner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actor: expect.objectContaining({ userId: 'user-1' }),
+        }),
+        SUBMISSION_ID,
+        { title: 'Updated Title' },
       );
     });
 
-    it('throws BAD_REQUEST on non-DRAFT', async () => {
-      const sub = makeDraftSubmission();
-      mockService.getById.mockResolvedValueOnce(sub as never);
+    it('maps NotDraftError to BAD_REQUEST', async () => {
       const { NotDraftError } =
         await import('../../services/submission.service.js');
-      mockService.update.mockRejectedValueOnce(new NotDraftError());
+      mockService.updateAsOwner.mockRejectedValueOnce(new NotDraftError());
 
       const caller = createCaller(orgContext());
       await expect(
@@ -452,30 +458,25 @@ describe('submissions tRPC router', () => {
   });
 
   describe('submit', () => {
-    it('DRAFT→SUBMITTED succeeds and calls audit', async () => {
+    it('DRAFT→SUBMITTED succeeds', async () => {
       const sub = makeDraftSubmission();
-      mockService.getById.mockResolvedValueOnce(sub as never);
-      mockService.updateStatus.mockResolvedValueOnce({
+      mockService.submitAsOwner.mockResolvedValueOnce({
         submission: { ...sub, status: 'SUBMITTED' },
         historyEntry: { id: 'h-1' },
       } as never);
 
-      const ctx = orgContext();
-      const caller = createCaller(ctx);
+      const caller = createCaller(orgContext());
       const result = await caller.submissions.submit({ id: SUBMISSION_ID });
 
       expect(result.submission.status).toBe('SUBMITTED');
-      expect(ctx.audit).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'SUBMISSION_SUBMITTED' }),
-      );
     });
 
-    it('throws BAD_REQUEST with unscanned files', async () => {
-      const sub = makeDraftSubmission();
-      mockService.getById.mockResolvedValueOnce(sub as never);
+    it('maps UnscannedFilesError to BAD_REQUEST', async () => {
       const { UnscannedFilesError } =
         await import('../../services/submission.service.js');
-      mockService.updateStatus.mockRejectedValueOnce(new UnscannedFilesError());
+      mockService.submitAsOwner.mockRejectedValueOnce(
+        new UnscannedFilesError(),
+      );
 
       const caller = createCaller(orgContext());
       await expect(
@@ -483,12 +484,10 @@ describe('submissions tRPC router', () => {
       ).rejects.toThrow('pending or being scanned');
     });
 
-    it('throws BAD_REQUEST with infected files', async () => {
-      const sub = makeDraftSubmission();
-      mockService.getById.mockResolvedValueOnce(sub as never);
+    it('maps InfectedFilesError to BAD_REQUEST', async () => {
       const { InfectedFilesError } =
         await import('../../services/submission.service.js');
-      mockService.updateStatus.mockRejectedValueOnce(new InfectedFilesError());
+      mockService.submitAsOwner.mockRejectedValueOnce(new InfectedFilesError());
 
       const caller = createCaller(orgContext());
       await expect(
@@ -497,11 +496,9 @@ describe('submissions tRPC router', () => {
     });
 
     it('maps SubmissionNotFoundError to NOT_FOUND on concurrent deletion', async () => {
-      const sub = makeDraftSubmission();
-      mockService.getById.mockResolvedValueOnce(sub as never);
       const { SubmissionNotFoundError } =
         await import('../../services/submission.service.js');
-      mockService.updateStatus.mockRejectedValueOnce(
+      mockService.submitAsOwner.mockRejectedValueOnce(
         new SubmissionNotFoundError(SUBMISSION_ID),
       );
 
@@ -513,27 +510,21 @@ describe('submissions tRPC router', () => {
   });
 
   describe('delete', () => {
-    it('succeeds on DRAFT and calls audit', async () => {
-      const sub = makeDraftSubmission();
-      mockService.getById.mockResolvedValueOnce(sub as never);
-      mockService.delete.mockResolvedValueOnce(sub as never);
+    it('succeeds and returns success', async () => {
+      mockService.deleteAsOwner.mockResolvedValueOnce({
+        success: true,
+      } as never);
 
-      const ctx = orgContext();
-      const caller = createCaller(ctx);
+      const caller = createCaller(orgContext());
       const result = await caller.submissions.delete({ id: SUBMISSION_ID });
 
       expect(result).toEqual({ success: true });
-      expect(ctx.audit).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'SUBMISSION_DELETED' }),
-      );
     });
 
-    it('throws BAD_REQUEST on non-DRAFT', async () => {
-      const sub = makeDraftSubmission();
-      mockService.getById.mockResolvedValueOnce(sub as never);
+    it('maps NotDraftError to BAD_REQUEST', async () => {
       const { NotDraftError } =
         await import('../../services/submission.service.js');
-      mockService.delete.mockRejectedValueOnce(new NotDraftError());
+      mockService.deleteAsOwner.mockRejectedValueOnce(new NotDraftError());
 
       const caller = createCaller(orgContext());
       await expect(
@@ -543,30 +534,23 @@ describe('submissions tRPC router', () => {
   });
 
   describe('withdraw', () => {
-    it('succeeds from valid state and calls audit', async () => {
+    it('succeeds from valid state', async () => {
       const sub = { ...makeDraftSubmission(), status: 'SUBMITTED' as const };
-      mockService.getById.mockResolvedValueOnce(sub as never);
-      mockService.updateStatus.mockResolvedValueOnce({
+      mockService.withdrawAsOwner.mockResolvedValueOnce({
         submission: { ...sub, status: 'WITHDRAWN' },
         historyEntry: { id: 'h-2' },
       } as never);
 
-      const ctx = orgContext();
-      const caller = createCaller(ctx);
+      const caller = createCaller(orgContext());
       const result = await caller.submissions.withdraw({ id: SUBMISSION_ID });
 
       expect(result.submission.status).toBe('WITHDRAWN');
-      expect(ctx.audit).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'SUBMISSION_WITHDRAWN' }),
-      );
     });
 
-    it('throws BAD_REQUEST from terminal state', async () => {
-      const sub = { ...makeDraftSubmission(), status: 'ACCEPTED' as const };
-      mockService.getById.mockResolvedValueOnce(sub as never);
+    it('maps InvalidStatusTransitionError to BAD_REQUEST', async () => {
       const { InvalidStatusTransitionError } =
         await import('../../services/submission.service.js');
-      mockService.updateStatus.mockRejectedValueOnce(
+      mockService.withdrawAsOwner.mockRejectedValueOnce(
         new InvalidStatusTransitionError('ACCEPTED', 'WITHDRAWN'),
       );
 
@@ -577,11 +561,9 @@ describe('submissions tRPC router', () => {
     });
 
     it('maps SubmissionNotFoundError to NOT_FOUND on concurrent deletion', async () => {
-      const sub = { ...makeDraftSubmission(), status: 'SUBMITTED' as const };
-      mockService.getById.mockResolvedValueOnce(sub as never);
       const { SubmissionNotFoundError } =
         await import('../../services/submission.service.js');
-      mockService.updateStatus.mockRejectedValueOnce(
+      mockService.withdrawAsOwner.mockRejectedValueOnce(
         new SubmissionNotFoundError(SUBMISSION_ID),
       );
 
@@ -593,14 +575,13 @@ describe('submissions tRPC router', () => {
   });
 
   describe('updateStatus', () => {
-    it('editor transition succeeds and calls audit', async () => {
-      mockService.updateStatus.mockResolvedValueOnce({
+    it('editor transition succeeds', async () => {
+      mockService.updateStatusAsEditor.mockResolvedValueOnce({
         submission: { id: SUBMISSION_ID, status: 'UNDER_REVIEW' },
         historyEntry: { id: 'h-3' },
       } as never);
 
-      const ctx = editorContext();
-      const caller = createCaller(ctx);
+      const caller = createCaller(editorContext());
       const result = await caller.submissions.updateStatus({
         id: SUBMISSION_ID,
         status: 'UNDER_REVIEW',
@@ -608,23 +589,20 @@ describe('submissions tRPC router', () => {
 
       expect(result.submission.status).toBe('UNDER_REVIEW');
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockService.updateStatus).toHaveBeenCalledWith(
-        expect.anything(),
+      expect(mockService.updateStatusAsEditor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actor: expect.objectContaining({ userId: 'user-1' }),
+        }),
         SUBMISSION_ID,
         'UNDER_REVIEW',
-        'user-1',
         undefined,
-        'editor',
-      );
-      expect(ctx.audit).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'SUBMISSION_STATUS_CHANGED' }),
       );
     });
 
-    it('throws NOT_FOUND when submission missing', async () => {
+    it('maps SubmissionNotFoundError to NOT_FOUND', async () => {
       const { SubmissionNotFoundError } =
         await import('../../services/submission.service.js');
-      mockService.updateStatus.mockRejectedValueOnce(
+      mockService.updateStatusAsEditor.mockRejectedValueOnce(
         new SubmissionNotFoundError(SUBMISSION_ID),
       );
 
@@ -637,10 +615,10 @@ describe('submissions tRPC router', () => {
       ).rejects.toThrow(TRPCError);
     });
 
-    it('throws BAD_REQUEST on invalid transition', async () => {
+    it('maps InvalidStatusTransitionError to BAD_REQUEST', async () => {
       const { InvalidStatusTransitionError } =
         await import('../../services/submission.service.js');
-      mockService.updateStatus.mockRejectedValueOnce(
+      mockService.updateStatusAsEditor.mockRejectedValueOnce(
         new InvalidStatusTransitionError('DRAFT', 'UNDER_REVIEW'),
       );
 
@@ -654,7 +632,7 @@ describe('submissions tRPC router', () => {
     });
 
     it('passes comment to service', async () => {
-      mockService.updateStatus.mockResolvedValueOnce({
+      mockService.updateStatusAsEditor.mockResolvedValueOnce({
         submission: { id: SUBMISSION_ID, status: 'REJECTED' },
         historyEntry: { id: 'h-4' },
       } as never);
@@ -667,13 +645,11 @@ describe('submissions tRPC router', () => {
       });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockService.updateStatus).toHaveBeenCalledWith(
+      expect(mockService.updateStatusAsEditor).toHaveBeenCalledWith(
         expect.anything(),
         SUBMISSION_ID,
         'REJECTED',
-        'user-1',
         'Not a good fit',
-        'editor',
       );
     });
   });

--- a/apps/api/src/trpc/routers/submissions.ts
+++ b/apps/api/src/trpc/routers/submissions.ts
@@ -1,31 +1,15 @@
 import { z } from 'zod';
-import { TRPCError } from '@trpc/server';
 import {
   createSubmissionSchema,
   updateSubmissionSchema,
   updateSubmissionStatusSchema,
   listSubmissionsSchema,
-  AuditActions,
-  AuditResources,
 } from '@colophony/types';
 import { orgProcedure, createRouter } from '../init.js';
-import {
-  submissionService,
-  SubmissionNotFoundError,
-  InvalidStatusTransitionError,
-  NotDraftError,
-  UnscannedFilesError,
-  InfectedFilesError,
-} from '../../services/submission.service.js';
-
-function assertEditorOrAdmin(role: string): void {
-  if (role !== 'ADMIN' && role !== 'EDITOR') {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message: 'Editor or admin role required',
-    });
-  }
-}
+import { submissionService } from '../../services/submission.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { assertEditorOrAdmin } from '../../services/errors.js';
+import { mapServiceError } from '../error-mapper.js';
 
 export const submissionsRouter = createRouter({
   /** Submitter's own submissions (any org member). */
@@ -43,52 +27,40 @@ export const submissionsRouter = createRouter({
   list: orgProcedure
     .input(listSubmissionsSchema)
     .query(async ({ ctx, input }) => {
-      assertEditorOrAdmin(ctx.authContext.role);
-      return submissionService.listAll(ctx.dbTx, input);
+      try {
+        assertEditorOrAdmin(ctx.authContext.role);
+        return await submissionService.listAll(ctx.dbTx, input);
+      } catch (e) {
+        mapServiceError(e);
+      }
     }),
 
   /** Create a new DRAFT submission. */
   create: orgProcedure
     .input(createSubmissionSchema)
     .mutation(async ({ ctx, input }) => {
-      const submission = await submissionService.create(
-        ctx.dbTx,
-        input,
-        ctx.authContext.orgId,
-        ctx.authContext.userId,
-      );
-      await ctx.audit({
-        action: AuditActions.SUBMISSION_CREATED,
-        resource: AuditResources.SUBMISSION,
-        resourceId: submission.id,
-        newValue: { title: input.title },
-      });
-      return submission;
+      try {
+        return await submissionService.createWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
     }),
 
   /** Get submission by ID — owner or editor/admin. */
   getById: orgProcedure
     .input(z.object({ id: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
-      const submission = await submissionService.getById(ctx.dbTx, input.id);
-      if (!submission) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Submission not found',
-        });
+      try {
+        return await submissionService.getByIdWithAccess(
+          toServiceContext(ctx),
+          input.id,
+        );
+      } catch (e) {
+        mapServiceError(e);
       }
-      // Owner or editor/admin can view
-      if (
-        submission.submitterId !== ctx.authContext.userId &&
-        ctx.authContext.role !== 'ADMIN' &&
-        ctx.authContext.role !== 'EDITOR'
-      ) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: 'You do not have access to this submission',
-        });
-      }
-      return submission;
     }),
 
   /** Update a DRAFT submission — owner only. */
@@ -96,39 +68,14 @@ export const submissionsRouter = createRouter({
     .input(z.object({ id: z.string().uuid() }).merge(updateSubmissionSchema))
     .mutation(async ({ ctx, input }) => {
       const { id, ...data } = input;
-      const existing = await submissionService.getById(ctx.dbTx, id);
-      if (!existing) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Submission not found',
-        });
-      }
-      if (existing.submitterId !== ctx.authContext.userId) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: 'Only the submitter can update this submission',
-        });
-      }
       try {
-        const updated = await submissionService.update(ctx.dbTx, id, data);
-        if (!updated) {
-          throw new TRPCError({
-            code: 'NOT_FOUND',
-            message: 'Submission not found',
-          });
-        }
-        await ctx.audit({
-          action: AuditActions.SUBMISSION_UPDATED,
-          resource: AuditResources.SUBMISSION,
-          resourceId: id,
-          newValue: data,
-        });
-        return updated;
+        return await submissionService.updateAsOwner(
+          toServiceContext(ctx),
+          id,
+          data,
+        );
       } catch (e) {
-        if (e instanceof NotDraftError) {
-          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
-        }
-        throw e;
+        mapServiceError(e);
       }
     }),
 
@@ -136,48 +83,13 @@ export const submissionsRouter = createRouter({
   submit: orgProcedure
     .input(z.object({ id: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      const existing = await submissionService.getById(ctx.dbTx, input.id);
-      if (!existing) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Submission not found',
-        });
-      }
-      if (existing.submitterId !== ctx.authContext.userId) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: 'Only the submitter can submit this submission',
-        });
-      }
       try {
-        const result = await submissionService.updateStatus(
-          ctx.dbTx,
+        return await submissionService.submitAsOwner(
+          toServiceContext(ctx),
           input.id,
-          'SUBMITTED',
-          ctx.authContext.userId,
-          undefined,
-          'submitter',
         );
-        await ctx.audit({
-          action: AuditActions.SUBMISSION_SUBMITTED,
-          resource: AuditResources.SUBMISSION,
-          resourceId: input.id,
-        });
-        return result;
       } catch (e) {
-        if (e instanceof SubmissionNotFoundError) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: e.message });
-        }
-        if (e instanceof InvalidStatusTransitionError) {
-          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
-        }
-        if (e instanceof UnscannedFilesError) {
-          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
-        }
-        if (e instanceof InfectedFilesError) {
-          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
-        }
-        throw e;
+        mapServiceError(e);
       }
     }),
 
@@ -185,38 +97,13 @@ export const submissionsRouter = createRouter({
   delete: orgProcedure
     .input(z.object({ id: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      const existing = await submissionService.getById(ctx.dbTx, input.id);
-      if (!existing) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Submission not found',
-        });
-      }
-      if (existing.submitterId !== ctx.authContext.userId) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: 'Only the submitter can delete this submission',
-        });
-      }
       try {
-        const deleted = await submissionService.delete(ctx.dbTx, input.id);
-        if (!deleted) {
-          throw new TRPCError({
-            code: 'NOT_FOUND',
-            message: 'Submission not found',
-          });
-        }
-        await ctx.audit({
-          action: AuditActions.SUBMISSION_DELETED,
-          resource: AuditResources.SUBMISSION,
-          resourceId: input.id,
-        });
-        return { success: true };
+        return await submissionService.deleteAsOwner(
+          toServiceContext(ctx),
+          input.id,
+        );
       } catch (e) {
-        if (e instanceof NotDraftError) {
-          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
-        }
-        throw e;
+        mapServiceError(e);
       }
     }),
 
@@ -224,42 +111,13 @@ export const submissionsRouter = createRouter({
   withdraw: orgProcedure
     .input(z.object({ id: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      const existing = await submissionService.getById(ctx.dbTx, input.id);
-      if (!existing) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Submission not found',
-        });
-      }
-      if (existing.submitterId !== ctx.authContext.userId) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: 'Only the submitter can withdraw this submission',
-        });
-      }
       try {
-        const result = await submissionService.updateStatus(
-          ctx.dbTx,
+        return await submissionService.withdrawAsOwner(
+          toServiceContext(ctx),
           input.id,
-          'WITHDRAWN',
-          ctx.authContext.userId,
-          undefined,
-          'submitter',
         );
-        await ctx.audit({
-          action: AuditActions.SUBMISSION_WITHDRAWN,
-          resource: AuditResources.SUBMISSION,
-          resourceId: input.id,
-        });
-        return result;
       } catch (e) {
-        if (e instanceof SubmissionNotFoundError) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: e.message });
-        }
-        if (e instanceof InvalidStatusTransitionError) {
-          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
-        }
-        throw e;
+        mapServiceError(e);
       }
     }),
 
@@ -269,32 +127,16 @@ export const submissionsRouter = createRouter({
       z.object({ id: z.string().uuid() }).merge(updateSubmissionStatusSchema),
     )
     .mutation(async ({ ctx, input }) => {
-      assertEditorOrAdmin(ctx.authContext.role);
       const { id, status, comment } = input;
       try {
-        const result = await submissionService.updateStatus(
-          ctx.dbTx,
+        return await submissionService.updateStatusAsEditor(
+          toServiceContext(ctx),
           id,
           status,
-          ctx.authContext.userId,
           comment,
-          'editor',
         );
-        await ctx.audit({
-          action: AuditActions.SUBMISSION_STATUS_CHANGED,
-          resource: AuditResources.SUBMISSION,
-          resourceId: id,
-          newValue: { status, comment },
-        });
-        return result;
       } catch (e) {
-        if (e instanceof SubmissionNotFoundError) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: e.message });
-        }
-        if (e instanceof InvalidStatusTransitionError) {
-          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
-        }
-        throw e;
+        mapServiceError(e);
       }
     }),
 
@@ -302,26 +144,13 @@ export const submissionsRouter = createRouter({
   getHistory: orgProcedure
     .input(z.object({ submissionId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
-      const submission = await submissionService.getById(
-        ctx.dbTx,
-        input.submissionId,
-      );
-      if (!submission) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Submission not found',
-        });
+      try {
+        return await submissionService.getHistoryWithAccess(
+          toServiceContext(ctx),
+          input.submissionId,
+        );
+      } catch (e) {
+        mapServiceError(e);
       }
-      if (
-        submission.submitterId !== ctx.authContext.userId &&
-        ctx.authContext.role !== 'ADMIN' &&
-        ctx.authContext.role !== 'EDITOR'
-      ) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: 'You do not have access to this submission',
-        });
-      }
-      return submissionService.getHistory(ctx.dbTx, input.submissionId);
     }),
 });

--- a/apps/api/src/trpc/routers/users.spec.ts
+++ b/apps/api/src/trpc/routers/users.spec.ts
@@ -73,7 +73,6 @@ function authedContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
   });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const createCaller = (appRouter as any).createCaller as (
   ctx: TRPCContext,
 ) => any;

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -57,13 +57,7 @@
 
 ### Code
 
-- [ ] Service layer extraction from tRPC routers — PR 1 (foundation: types, errors, user service, error mapper) done 2026-02-17; PR 2 (router refactor) pending — (architecture doc Track 2)
-  - **PR 2 scope:** Move access control + audit logging from routers into service methods that accept `ServiceContext`. Routers become thin: input validation → service call (wrapped in `mapServiceError`) → response shaping.
-  - **Submissions router** (`src/trpc/routers/submissions.ts`): ownership checks (`submitterId !== userId`), `assertEditorOrAdmin` role guard, audit calls on create/update/submit/delete/withdraw/updateStatus, repetitive try/catch blocks for `NotDraftError`/`SubmissionNotFoundError`/`InvalidStatusTransitionError`/`UnscannedFilesError`/`InfectedFilesError` — all move to `submissionService` methods that take `ServiceContext`; try/catch replaced by `mapServiceError`.
-  - **Files router** (`src/trpc/routers/files.ts`): `assertOwnerOrEditor` guard (checks submission ownership), scan status check for downloads, audit on delete, lazy S3 client management (`getS3Client()`/`getEnvConfig()`) — move to `fileService` methods; S3 client init stays in router or moves to a shared factory.
-  - **Organizations router** (`src/trpc/routers/organizations.ts:47-61`): try/catch for `UserNotFoundError` + PG 23505 unique violation on member add — replace with `mapServiceError`. `LastAdminError` on member remove similarly.
-  - **Pattern:** Each router mutation becomes ~3 lines: `const result = await someService.method(toServiceContext(ctx), input);` → return result, wrapped in try/catch with `mapServiceError`. Queries similarly thin.
-  - **Not moved:** `adminProcedure` role enforcement stays in tRPC middleware (it's surface-specific). Pool-based methods (`organizationService.listUserOrganizations`, `.create`, `.isSlugAvailable`) keep current signatures. BullMQ workers unchanged (use `withRls` + `auditService.log` directly).
+- [x] Service layer extraction from tRPC routers — PR 1 (foundation) done 2026-02-17 #94; PR 2 (router refactor) done 2026-02-17 — (architecture doc Track 2)
 - [ ] ts-rest REST API surface with Fastify adapter — (architecture doc Track 2)
 - [ ] Pothos + GraphQL Yoga surface — decision point at Month 3: Pothos vs TypeGraphQL — (architecture doc Track 2, Section 6.6)
 - [ ] SDK generation (TypeScript, Python) — (architecture doc Track 2)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,31 @@ Newest entries first.
 
 ---
 
+## 2026-02-17 — Service Layer PR 2: Router Refactor
+
+### Done
+
+- Moved access control (ownership checks, role guards) from 3 tRPC routers into service-layer methods accepting `ServiceContext`
+- Moved audit logging from routers into service methods — routers no longer call `ctx.audit()` directly
+- Added shared access helpers `assertOwnerOrEditor()` and `assertEditorOrAdmin()` to `services/errors.ts`
+- Added 8 access-aware methods to `submissionService`: `getByIdWithAccess`, `createWithAudit`, `updateAsOwner`, `submitAsOwner`, `deleteAsOwner`, `withdrawAsOwner`, `updateStatusAsEditor`, `getHistoryWithAccess`
+- Added 3 access-aware methods to `fileService`: `listBySubmissionWithAccess`, `getDownloadUrlWithAccess`, `deleteAsOwner`
+- Added 5 access-aware methods to `organizationService`: `addMemberWithAudit`, `removeMemberWithAudit`, `updateMemberRoleWithAudit`, `updateWithAudit`, `createWithAudit`
+- Added `FileNotCleanError` → `PRECONDITION_FAILED` mapping to `error-mapper.ts`
+- Thinned out `submissions.ts`, `files.ts`, `organizations.ts` routers — each mutation is now ~3 lines (service call + `mapServiceError`)
+- Wrote 17 new tests in `submission.service.access.spec.ts`, updated all 3 router spec files
+- All 337 tests pass (17 new), type-check + lint clean
+- Codex branch review: LGTM — no findings to address
+
+### Decisions
+
+- `org.create` uses `createWithAudit(audit, input, userId)` instead of `ServiceContext` — no org exists yet at creation time
+- `adminProcedure` role enforcement stays in tRPC middleware (surface-specific)
+- S3 client init (`getS3Client()`/`getEnvConfig()`) stays in files router — services accept injected S3 client
+- Owner-only methods consolidate pre-flight `getById` + mutation into one service call; inner method's `FOR UPDATE` lock prevents TOCTOU races
+
+---
+
 ## 2026-02-17 — Service Layer Extraction (PR 1: Foundation)
 
 ### Done


### PR DESCRIPTION
## Summary

- Moves access control (ownership checks, role guards) and audit logging from 3 tRPC routers into service-layer methods accepting `ServiceContext`
- Adds 16 access-aware service methods across `submissionService`, `fileService`, and `organizationService` with `WithAccess`, `AsOwner`, and `WithAudit` naming conventions
- Thins out `submissions.ts`, `files.ts`, and `organizations.ts` routers — each mutation is now ~3 lines: service call + `mapServiceError`
- Adds shared `assertOwnerOrEditor()` and `assertEditorOrAdmin()` helpers to `services/errors.ts`
- Adds `FileNotCleanError` → `PRECONDITION_FAILED` to error mapper
- 17 new tests in `submission.service.access.spec.ts`, all 337 tests pass

This unblocks Track 2 REST and GraphQL surfaces by ensuring business logic is surface-agnostic.

## Test plan

- [x] All 337 tests pass (`pnpm test`)
- [x] Type-check clean (`pnpm type-check`)
- [x] Lint clean (`pnpm lint`)
- [x] branch review: LGTM, no findings