### PR TITLE
feat(api): oRPC REST API — submissions, files, users, api-keys + OpenAPI

### DIFF
--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -218,6 +218,22 @@ describe('auth plugin', () => {
       expect(response.statusCode).toBe(404);
     });
 
+    it('skips auth for /v1/docs/ (trailing slash)', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/v1/docs/',
+      });
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('skips auth for /v1/openapi.json/ (trailing slash)', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/v1/openapi.json/',
+      });
+      expect(response.statusCode).toBe(404);
+    });
+
     it('returns 401 when no Authorization header', async () => {
       const response = await app.inject({
         method: 'GET',

--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -201,6 +201,23 @@ describe('auth plugin', () => {
       expect(response.statusCode).toBe(404);
     });
 
+    it('skips auth for /v1/openapi.json', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/v1/openapi.json',
+      });
+      // 404 because no route registered in this test, but auth hook didn't block
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('skips auth for /v1/docs', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/v1/docs',
+      });
+      expect(response.statusCode).toBe(404);
+    });
+
     it('returns 401 when no Authorization header', async () => {
       const response = await app.inject({
         method: 'GET',

--- a/apps/api/src/hooks/auth.ts
+++ b/apps/api/src/hooks/auth.ts
@@ -28,7 +28,14 @@ declare module 'fastify' {
  * 3. Document in apps/api/CLAUDE.md
  */
 const PUBLIC_PREFIXES = ['/health', '/ready', '/webhooks/', '/.well-known/'];
-const PUBLIC_EXACT = ['/', '/health', '/ready', '/trpc/health'];
+const PUBLIC_EXACT = [
+  '/',
+  '/health',
+  '/ready',
+  '/trpc/health',
+  '/v1/openapi.json',
+  '/v1/docs',
+];
 
 function isPublicRoute(url: string): boolean {
   const path = url.split('?')[0];

--- a/apps/api/src/hooks/auth.ts
+++ b/apps/api/src/hooks/auth.ts
@@ -38,7 +38,7 @@ const PUBLIC_EXACT = [
 ];
 
 function isPublicRoute(url: string): boolean {
-  const path = url.split('?')[0];
+  const path = url.split('?')[0].replace(/\/+$/, '') || '/';
   if (PUBLIC_EXACT.includes(path)) return true;
   return PUBLIC_PREFIXES.some((prefix) => path.startsWith(prefix));
 }

--- a/apps/api/src/rest/router.ts
+++ b/apps/api/src/rest/router.ts
@@ -1,13 +1,37 @@
 import type { FastifyInstance } from 'fastify';
 import { OpenAPIHandler } from '@orpc/openapi/fastify';
+import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins';
 import { organizationsRouter } from './routers/organizations.js';
+import { submissionsRouter } from './routers/submissions.js';
+import { filesRouter } from './routers/files.js';
+import { usersRouter } from './routers/users.js';
+import { apiKeysRouter } from './routers/api-keys.js';
 import type { RestContext } from './context.js';
 
 const restRouter = {
   organizations: organizationsRouter,
+  submissions: submissionsRouter,
+  files: filesRouter,
+  users: usersRouter,
+  apiKeys: apiKeysRouter,
 };
 
-const openApiHandler = new OpenAPIHandler<RestContext>(restRouter);
+const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
+  plugins: [
+    new OpenAPIReferencePlugin({
+      specPath: '/openapi.json',
+      docsPath: '/docs',
+      specGenerateOptions: {
+        info: {
+          title: 'Colophony API',
+          version: '2.0.0',
+          description: 'REST API for the Colophony literary magazine platform.',
+        },
+        servers: [{ url: '/v1' }],
+      },
+    }),
+  ],
+});
 
 /**
  * Fastify plugin that registers the oRPC REST API surface at `/v1/*`.

--- a/apps/api/src/rest/routers/api-keys.spec.ts
+++ b/apps/api/src/rest/routers/api-keys.spec.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ORPCError } from '@orpc/server';
+
+vi.mock('../../services/api-key.service.js', () => ({
+  apiKeyService: {
+    list: vi.fn(),
+    create: vi.fn(),
+    revoke: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  apiKeys: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+}));
+
+import { apiKeyService } from '../../services/api-key.service.js';
+import { apiKeysRouter } from './api-keys.js';
+import type { RestContext } from '../context.js';
+import { createProcedureClient } from '@orpc/server';
+
+const mockService = vi.mocked(apiKeyService);
+
+const USER_ID = 'a0000000-0000-4000-a000-000000000001';
+const ORG_ID = 'b0000000-0000-4000-a000-000000000001';
+const KEY_ID = 'f0000000-0000-4000-a000-000000000001';
+
+function baseContext(): RestContext {
+  return { authContext: null, dbTx: null, audit: vi.fn() };
+}
+
+function authedContext(): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: 'zid-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+    },
+    dbTx: null,
+    audit: vi.fn(),
+  };
+}
+
+function orgContext(
+  role: 'ADMIN' | 'EDITOR' | 'READER' = 'ADMIN',
+): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: 'zid-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+      orgId: ORG_ID,
+      role,
+    },
+    dbTx: {} as never,
+    audit: vi.fn(),
+  };
+}
+
+function client<T>(procedure: T, context: RestContext) {
+  return createProcedureClient(procedure as any, { context }) as any;
+}
+
+describe('api-keys REST router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api-keys
+  // -------------------------------------------------------------------------
+
+  describe('GET /api-keys (list)', () => {
+    it('requires auth', async () => {
+      const call = client(apiKeysRouter.list, baseContext());
+      await expect(call({ page: 1, limit: 20 })).rejects.toThrow(ORPCError);
+    });
+
+    it('requires org context', async () => {
+      const call = client(apiKeysRouter.list, authedContext());
+      await expect(call({ page: 1, limit: 20 })).rejects.toThrow(ORPCError);
+    });
+
+    it('returns paginated API keys for any org member', async () => {
+      const response = {
+        items: [{ id: KEY_ID, name: 'Test Key' }],
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      };
+      mockService.list.mockResolvedValueOnce(response as never);
+
+      const call = client(apiKeysRouter.list, orgContext('READER'));
+      const result = await call({ page: 1, limit: 20 });
+      expect(result.items).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /api-keys
+  // -------------------------------------------------------------------------
+
+  describe('POST /api-keys (create)', () => {
+    it('requires admin role', async () => {
+      const call = client(apiKeysRouter.create, orgContext('EDITOR'));
+      await expect(
+        call({ name: 'Test', scopes: ['submissions:read'] }),
+      ).rejects.toThrow('Admin role required');
+    });
+
+    it('creates an API key and audits', async () => {
+      const result = {
+        id: KEY_ID,
+        name: 'Test Key',
+        scopes: ['submissions:read'],
+        plainTextKey: 'col_live_abc123',
+        keyPrefix: 'col_live_',
+        createdAt: new Date(),
+        expiresAt: null,
+        lastUsedAt: null,
+        revokedAt: null,
+      };
+      mockService.create.mockResolvedValueOnce(result as never);
+
+      const ctx = orgContext('ADMIN');
+      const call = client(apiKeysRouter.create, ctx);
+      const response = await call({
+        name: 'Test Key',
+        scopes: ['submissions:read'],
+      });
+
+      expect(response.id).toBe(KEY_ID);
+      expect(response.plainTextKey).toBe('col_live_abc123');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.create).toHaveBeenCalledWith(
+        expect.anything(),
+        ORG_ID,
+        USER_ID,
+        expect.objectContaining({
+          name: 'Test Key',
+          scopes: ['submissions:read'],
+        }),
+      );
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'API_KEY_CREATED',
+          resourceId: KEY_ID,
+        }),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /api-keys/{keyId}/revoke
+  // -------------------------------------------------------------------------
+
+  describe('POST /api-keys/{keyId}/revoke', () => {
+    it('requires admin role', async () => {
+      const call = client(apiKeysRouter.revoke, orgContext('READER'));
+      await expect(call({ keyId: KEY_ID })).rejects.toThrow(
+        'Admin role required',
+      );
+    });
+
+    it('revokes an API key and audits', async () => {
+      const revoked = {
+        id: KEY_ID,
+        name: 'Test Key',
+        revokedAt: new Date(),
+      };
+      mockService.revoke.mockResolvedValueOnce(revoked as never);
+
+      const ctx = orgContext('ADMIN');
+      const call = client(apiKeysRouter.revoke, ctx);
+      const result = await call({ keyId: KEY_ID });
+
+      expect(result.id).toBe(KEY_ID);
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'API_KEY_REVOKED',
+          resourceId: KEY_ID,
+        }),
+      );
+    });
+
+    it('throws NOT_FOUND when key does not exist', async () => {
+      mockService.revoke.mockResolvedValueOnce(null as never);
+
+      const call = client(apiKeysRouter.revoke, orgContext('ADMIN'));
+      await expect(call({ keyId: KEY_ID })).rejects.toThrow(
+        'API key not found',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // DELETE /api-keys/{keyId}
+  // -------------------------------------------------------------------------
+
+  describe('DELETE /api-keys/{keyId}', () => {
+    it('requires admin role', async () => {
+      const call = client(apiKeysRouter.delete, orgContext('EDITOR'));
+      await expect(call({ keyId: KEY_ID })).rejects.toThrow(
+        'Admin role required',
+      );
+    });
+
+    it('deletes an API key and audits', async () => {
+      const deleted = { id: KEY_ID, name: 'Test Key' };
+      mockService.delete.mockResolvedValueOnce(deleted as never);
+
+      const ctx = orgContext('ADMIN');
+      const call = client(apiKeysRouter.delete, ctx);
+      const result = await call({ keyId: KEY_ID });
+
+      expect(result).toEqual({ success: true });
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'API_KEY_DELETED',
+          resourceId: KEY_ID,
+        }),
+      );
+    });
+
+    it('throws NOT_FOUND when key does not exist', async () => {
+      mockService.delete.mockResolvedValueOnce(null as never);
+
+      const call = client(apiKeysRouter.delete, orgContext('ADMIN'));
+      await expect(call({ keyId: KEY_ID })).rejects.toThrow(
+        'API key not found',
+      );
+    });
+  });
+});

--- a/apps/api/src/rest/routers/api-keys.ts
+++ b/apps/api/src/rest/routers/api-keys.ts
@@ -1,0 +1,89 @@
+import { ORPCError } from '@orpc/server';
+import { z } from 'zod';
+import {
+  createApiKeySchema,
+  AuditActions,
+  AuditResources,
+} from '@colophony/types';
+import { restPaginationQuery } from '@colophony/api-contracts';
+import { apiKeyService } from '../../services/api-key.service.js';
+import { orgProcedure, adminProcedure } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// Path param schemas
+// ---------------------------------------------------------------------------
+
+const keyIdParam = z.object({ keyId: z.string().uuid() });
+
+// ---------------------------------------------------------------------------
+// API key routes
+// ---------------------------------------------------------------------------
+
+const list = orgProcedure
+  .route({ method: 'GET', path: '/api-keys' })
+  .input(restPaginationQuery)
+  .handler(async ({ input, context }) => {
+    return apiKeyService.list(context.dbTx, input);
+  });
+
+const create = adminProcedure
+  .route({ method: 'POST', path: '/api-keys', successStatus: 201 })
+  .input(createApiKeySchema)
+  .handler(async ({ input, context }) => {
+    const result = await apiKeyService.create(
+      context.dbTx,
+      context.authContext.orgId,
+      context.authContext.userId,
+      input,
+    );
+    await context.audit({
+      action: AuditActions.API_KEY_CREATED,
+      resource: AuditResources.API_KEY,
+      resourceId: result.id,
+      newValue: { name: input.name, scopes: input.scopes },
+    });
+    return result;
+  });
+
+const revoke = adminProcedure
+  .route({ method: 'POST', path: '/api-keys/{keyId}/revoke' })
+  .input(keyIdParam)
+  .handler(async ({ input, context }) => {
+    const revoked = await apiKeyService.revoke(context.dbTx, input.keyId);
+    if (!revoked) {
+      throw new ORPCError('NOT_FOUND', { message: 'API key not found' });
+    }
+    await context.audit({
+      action: AuditActions.API_KEY_REVOKED,
+      resource: AuditResources.API_KEY,
+      resourceId: revoked.id,
+    });
+    return revoked;
+  });
+
+const del = adminProcedure
+  .route({ method: 'DELETE', path: '/api-keys/{keyId}' })
+  .input(keyIdParam)
+  .handler(async ({ input, context }) => {
+    const deleted = await apiKeyService.delete(context.dbTx, input.keyId);
+    if (!deleted) {
+      throw new ORPCError('NOT_FOUND', { message: 'API key not found' });
+    }
+    await context.audit({
+      action: AuditActions.API_KEY_DELETED,
+      resource: AuditResources.API_KEY,
+      resourceId: deleted.id,
+    });
+    return { success: true as const };
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const apiKeysRouter = {
+  list,
+  create,
+  revoke,
+  delete: del,
+};

--- a/apps/api/src/rest/routers/files.spec.ts
+++ b/apps/api/src/rest/routers/files.spec.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ORPCError } from '@orpc/server';
+
+// Mock file service
+vi.mock('../../services/file.service.js', () => ({
+  fileService: {
+    listBySubmission: vi.fn(),
+    listBySubmissionWithAccess: vi.fn(),
+    getById: vi.fn(),
+    getDownloadUrl: vi.fn(),
+    getDownloadUrlWithAccess: vi.fn(),
+    delete: vi.fn(),
+    deleteWithS3: vi.fn(),
+    deleteAsOwner: vi.fn(),
+  },
+  FileNotFoundError: class FileNotFoundError extends Error {
+    name = 'FileNotFoundError';
+  },
+  FileNotCleanError: class FileNotCleanError extends Error {
+    name = 'FileNotCleanError';
+    constructor(fileId: string, scanStatus: string) {
+      super(
+        `File "${fileId}" has scan status "${scanStatus}" — download blocked`,
+      );
+    }
+  },
+}));
+
+// Mock submission service (needed by file service access methods)
+vi.mock('../../services/submission.service.js', () => ({
+  submissionService: {},
+  SubmissionNotFoundError: class SubmissionNotFoundError extends Error {
+    name = 'SubmissionNotFoundError';
+  },
+  NotDraftError: class NotDraftError extends Error {
+    name = 'NotDraftError';
+    constructor() {
+      super('Submission must be in DRAFT status for this operation');
+    }
+  },
+  InvalidStatusTransitionError: class InvalidStatusTransitionError extends Error {
+    name = 'InvalidStatusTransitionError';
+  },
+  UnscannedFilesError: class UnscannedFilesError extends Error {
+    name = 'UnscannedFilesError';
+  },
+  InfectedFilesError: class InfectedFilesError extends Error {
+    name = 'InfectedFilesError';
+  },
+}));
+
+// Mock S3
+vi.mock('../../services/s3.js', () => ({
+  createS3Client: vi.fn(() => ({ __mock: true })),
+  getPresignedDownloadUrl: vi.fn(),
+  deleteS3Object: vi.fn(),
+}));
+
+// Mock env
+vi.mock('../../config/env.js', () => ({
+  validateEnv: vi.fn(() => ({
+    S3_BUCKET: 'submissions',
+    S3_QUARANTINE_BUCKET: 'quarantine',
+    S3_ENDPOINT: 'http://localhost:9000',
+    S3_ACCESS_KEY: 'minioadmin',
+    S3_SECRET_KEY: 'minioadmin',
+    S3_REGION: 'us-east-1',
+  })),
+}));
+
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  submissionFiles: {},
+  eq: vi.fn(),
+  sql: vi.fn(),
+}));
+
+import { fileService } from '../../services/file.service.js';
+import { ForbiddenError } from '../../services/errors.js';
+import { filesRouter } from './files.js';
+import type { RestContext } from '../context.js';
+import { createProcedureClient } from '@orpc/server';
+
+const mockFileService = vi.mocked(fileService);
+
+const USER_ID = 'a0000000-0000-4000-a000-000000000001';
+const ORG_ID = 'b0000000-0000-4000-a000-000000000001';
+const SUBMISSION_ID = 'd0000000-0000-4000-a000-000000000001';
+const FILE_ID = 'e0000000-0000-4000-a000-000000000001';
+
+function baseContext(): RestContext {
+  return { authContext: null, dbTx: null, audit: vi.fn() };
+}
+
+function orgContext(
+  role: 'ADMIN' | 'EDITOR' | 'READER' = 'ADMIN',
+): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: 'zid-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+      orgId: ORG_ID,
+      role,
+    },
+    dbTx: {} as never,
+    audit: vi.fn(),
+  };
+}
+
+function client<T>(procedure: T, context: RestContext) {
+  return createProcedureClient(procedure as any, { context }) as any;
+}
+
+describe('files REST router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /submissions/{submissionId}/files
+  // -------------------------------------------------------------------------
+
+  describe('GET /submissions/{submissionId}/files (list)', () => {
+    it('requires auth', async () => {
+      const call = client(filesRouter.list, baseContext());
+      await expect(call({ submissionId: SUBMISSION_ID })).rejects.toThrow(
+        ORPCError,
+      );
+    });
+
+    it('returns files for a submission', async () => {
+      const files = [
+        { id: FILE_ID, filename: 'test.pdf', submissionId: SUBMISSION_ID },
+      ];
+      mockFileService.listBySubmissionWithAccess.mockResolvedValueOnce(
+        files as never,
+      );
+
+      const call = client(filesRouter.list, orgContext('READER'));
+      const result = await call({ submissionId: SUBMISSION_ID });
+      expect(result).toHaveLength(1);
+    });
+
+    it('maps ForbiddenError', async () => {
+      mockFileService.listBySubmissionWithAccess.mockRejectedValueOnce(
+        new ForbiddenError('No access'),
+      );
+
+      const call = client(filesRouter.list, orgContext('READER'));
+      await expect(call({ submissionId: SUBMISSION_ID })).rejects.toThrow(
+        'No access',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /files/{fileId}/download
+  // -------------------------------------------------------------------------
+
+  describe('GET /files/{fileId}/download', () => {
+    it('requires auth', async () => {
+      const call = client(filesRouter.download, baseContext());
+      await expect(call({ fileId: FILE_ID })).rejects.toThrow(ORPCError);
+    });
+
+    it('returns presigned download URL', async () => {
+      const downloadInfo = {
+        url: 'https://s3.example.com/file',
+        filename: 'test.pdf',
+        mimeType: 'application/pdf',
+      };
+      mockFileService.getDownloadUrlWithAccess.mockResolvedValueOnce(
+        downloadInfo as never,
+      );
+
+      const call = client(filesRouter.download, orgContext('READER'));
+      const result = await call({ fileId: FILE_ID });
+      expect(result.url).toBe('https://s3.example.com/file');
+      expect(result.filename).toBe('test.pdf');
+    });
+
+    it('maps FileNotFoundError to NOT_FOUND', async () => {
+      const { FileNotFoundError } =
+        await import('../../services/file.service.js');
+      mockFileService.getDownloadUrlWithAccess.mockRejectedValueOnce(
+        new FileNotFoundError(FILE_ID),
+      );
+
+      const call = client(filesRouter.download, orgContext('READER'));
+      await expect(call({ fileId: FILE_ID })).rejects.toThrow(ORPCError);
+    });
+
+    it('maps FileNotCleanError to BAD_REQUEST', async () => {
+      const { FileNotCleanError } =
+        await import('../../services/file.service.js');
+      mockFileService.getDownloadUrlWithAccess.mockRejectedValueOnce(
+        new FileNotCleanError(FILE_ID, 'INFECTED'),
+      );
+
+      const call = client(filesRouter.download, orgContext('READER'));
+      await expect(call({ fileId: FILE_ID })).rejects.toThrow('INFECTED');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // DELETE /files/{fileId}
+  // -------------------------------------------------------------------------
+
+  describe('DELETE /files/{fileId}', () => {
+    it('requires auth', async () => {
+      const call = client(filesRouter.delete, baseContext());
+      await expect(call({ fileId: FILE_ID })).rejects.toThrow(ORPCError);
+    });
+
+    it('deletes a file', async () => {
+      mockFileService.deleteAsOwner.mockResolvedValueOnce({
+        success: true,
+      } as never);
+
+      const call = client(filesRouter.delete, orgContext('READER'));
+      const result = await call({ fileId: FILE_ID });
+      expect(result).toEqual({ success: true });
+    });
+
+    it('maps NotDraftError to BAD_REQUEST', async () => {
+      const { NotDraftError } =
+        await import('../../services/submission.service.js');
+      mockFileService.deleteAsOwner.mockRejectedValueOnce(new NotDraftError());
+
+      const call = client(filesRouter.delete, orgContext('READER'));
+      await expect(call({ fileId: FILE_ID })).rejects.toThrow('DRAFT');
+    });
+
+    it('maps FileNotFoundError to NOT_FOUND', async () => {
+      const { FileNotFoundError } =
+        await import('../../services/file.service.js');
+      mockFileService.deleteAsOwner.mockRejectedValueOnce(
+        new FileNotFoundError(FILE_ID),
+      );
+
+      const call = client(filesRouter.delete, orgContext('READER'));
+      await expect(call({ fileId: FILE_ID })).rejects.toThrow(ORPCError);
+    });
+  });
+});

--- a/apps/api/src/rest/routers/files.ts
+++ b/apps/api/src/rest/routers/files.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+import { fileService } from '../../services/file.service.js';
+import { createS3Client } from '../../services/s3.js';
+import { validateEnv } from '../../config/env.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+import { orgProcedure } from '../context.js';
+
+// Lazily create S3 client (avoid creating at module load for tests)
+let s3ClientInstance: ReturnType<typeof createS3Client> | null = null;
+
+function getS3Client() {
+  if (!s3ClientInstance) {
+    const env = validateEnv();
+    s3ClientInstance = createS3Client(env);
+  }
+  return s3ClientInstance;
+}
+
+function getEnvConfig() {
+  return validateEnv();
+}
+
+// ---------------------------------------------------------------------------
+// Path param schemas
+// ---------------------------------------------------------------------------
+
+const submissionIdParam = z.object({ submissionId: z.string().uuid() });
+const fileIdParam = z.object({ fileId: z.string().uuid() });
+
+// ---------------------------------------------------------------------------
+// File routes
+// ---------------------------------------------------------------------------
+
+const list = orgProcedure
+  .route({ method: 'GET', path: '/submissions/{submissionId}/files' })
+  .input(submissionIdParam)
+  .handler(async ({ input, context }) => {
+    try {
+      return await fileService.listBySubmissionWithAccess(
+        toServiceContext(context),
+        input.submissionId,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const download = orgProcedure
+  .route({ method: 'GET', path: '/files/{fileId}/download' })
+  .input(fileIdParam)
+  .handler(async ({ input, context }) => {
+    try {
+      const env = getEnvConfig();
+      return await fileService.getDownloadUrlWithAccess(
+        toServiceContext(context),
+        input.fileId,
+        getS3Client(),
+        env.S3_BUCKET,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const del = orgProcedure
+  .route({ method: 'DELETE', path: '/files/{fileId}' })
+  .input(fileIdParam)
+  .handler(async ({ input, context }) => {
+    try {
+      const env = getEnvConfig();
+      return await fileService.deleteAsOwner(
+        toServiceContext(context),
+        input.fileId,
+        getS3Client(),
+        env.S3_BUCKET,
+        env.S3_QUARANTINE_BUCKET,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const filesRouter = {
+  list,
+  download,
+  delete: del,
+};

--- a/apps/api/src/rest/routers/submissions.spec.ts
+++ b/apps/api/src/rest/routers/submissions.spec.ts
@@ -1,0 +1,556 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ORPCError } from '@orpc/server';
+
+// Mock the submission service before importing the router
+vi.mock('../../services/submission.service.js', () => ({
+  submissionService: {
+    listBySubmitter: vi.fn(),
+    listAll: vi.fn(),
+    create: vi.fn(),
+    getById: vi.fn(),
+    update: vi.fn(),
+    updateStatus: vi.fn(),
+    delete: vi.fn(),
+    getHistory: vi.fn(),
+    getByIdWithAccess: vi.fn(),
+    createWithAudit: vi.fn(),
+    updateAsOwner: vi.fn(),
+    submitAsOwner: vi.fn(),
+    deleteAsOwner: vi.fn(),
+    withdrawAsOwner: vi.fn(),
+    updateStatusAsEditor: vi.fn(),
+    getHistoryWithAccess: vi.fn(),
+  },
+  SubmissionNotFoundError: class SubmissionNotFoundError extends Error {
+    name = 'SubmissionNotFoundError';
+  },
+  NotDraftError: class NotDraftError extends Error {
+    name = 'NotDraftError';
+    constructor() {
+      super('Submission must be in DRAFT status for this operation');
+    }
+  },
+  InvalidStatusTransitionError: class InvalidStatusTransitionError extends Error {
+    name = 'InvalidStatusTransitionError';
+    constructor(from: string, to: string) {
+      super(`Invalid status transition from "${from}" to "${to}"`);
+    }
+  },
+  UnscannedFilesError: class UnscannedFilesError extends Error {
+    name = 'UnscannedFilesError';
+  },
+  InfectedFilesError: class InfectedFilesError extends Error {
+    name = 'InfectedFilesError';
+  },
+}));
+
+vi.mock('../../services/errors.js', async (importOriginal) => {
+  return importOriginal();
+});
+
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  submissions: {},
+  submissionFiles: {},
+  submissionHistory: {},
+  users: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+}));
+
+import { submissionService } from '../../services/submission.service.js';
+import { ForbiddenError } from '../../services/errors.js';
+import { submissionsRouter } from './submissions.js';
+import type { RestContext } from '../context.js';
+import { createProcedureClient } from '@orpc/server';
+
+const mockService = vi.mocked(submissionService);
+
+// Deterministic UUIDs for tests
+const USER_ID = 'a0000000-0000-4000-a000-000000000001';
+const ORG_ID = 'b0000000-0000-4000-a000-000000000001';
+const SUBMISSION_ID = 'd0000000-0000-4000-a000-000000000001';
+
+// ---------------------------------------------------------------------------
+// Context helpers
+// ---------------------------------------------------------------------------
+
+function baseContext(): RestContext {
+  return {
+    authContext: null,
+    dbTx: null,
+    audit: vi.fn(),
+  };
+}
+
+function authedContext(): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: 'zid-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+    },
+    dbTx: null,
+    audit: vi.fn(),
+  };
+}
+
+function orgContext(
+  role: 'ADMIN' | 'EDITOR' | 'READER' = 'ADMIN',
+): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: 'zid-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+      orgId: ORG_ID,
+      role,
+    },
+    dbTx: {} as never,
+    audit: vi.fn(),
+  };
+}
+
+function client<T>(procedure: T, context: RestContext) {
+  return createProcedureClient(procedure as any, { context }) as any;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('submissions REST router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /submissions/mine
+  // -------------------------------------------------------------------------
+
+  describe('GET /submissions/mine (mine)', () => {
+    it('requires authentication', async () => {
+      const call = client(submissionsRouter.mine, baseContext());
+      await expect(call({})).rejects.toThrow(ORPCError);
+    });
+
+    it('requires org context', async () => {
+      const call = client(submissionsRouter.mine, authedContext());
+      await expect(call({})).rejects.toThrow(ORPCError);
+    });
+
+    it('returns submissions for the current user', async () => {
+      const response = {
+        items: [{ id: SUBMISSION_ID, title: 'My Sub' }],
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      };
+      mockService.listBySubmitter.mockResolvedValueOnce(response as never);
+
+      const call = client(submissionsRouter.mine, orgContext('READER'));
+      const result = await call({ page: 1, limit: 20 });
+      expect(result.items).toHaveLength(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.listBySubmitter).toHaveBeenCalledWith(
+        expect.anything(),
+        USER_ID,
+        expect.objectContaining({ page: 1, limit: 20 }),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /submissions
+  // -------------------------------------------------------------------------
+
+  describe('GET /submissions (list)', () => {
+    it('requires org context', async () => {
+      const call = client(submissionsRouter.list, authedContext());
+      await expect(call({})).rejects.toThrow(ORPCError);
+    });
+
+    it('rejects READER role', async () => {
+      const call = client(submissionsRouter.list, orgContext('READER'));
+      await expect(call({ page: 1, limit: 20 })).rejects.toThrow(
+        'Editor or admin role required',
+      );
+    });
+
+    it('returns all submissions for EDITOR', async () => {
+      const response = {
+        items: [{ id: SUBMISSION_ID }],
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      };
+      mockService.listAll.mockResolvedValueOnce(response as never);
+
+      const call = client(submissionsRouter.list, orgContext('EDITOR'));
+      const result = await call({ page: 1, limit: 20 });
+      expect(result.items).toHaveLength(1);
+    });
+
+    it('returns all submissions for ADMIN', async () => {
+      const response = {
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 0,
+      };
+      mockService.listAll.mockResolvedValueOnce(response as never);
+
+      const call = client(submissionsRouter.list, orgContext('ADMIN'));
+      const result = await call({ page: 1, limit: 20 });
+      expect(result.items).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /submissions
+  // -------------------------------------------------------------------------
+
+  describe('POST /submissions (create)', () => {
+    it('requires org context', async () => {
+      const call = client(submissionsRouter.create, authedContext());
+      await expect(call({ title: 'Test' })).rejects.toThrow(ORPCError);
+    });
+
+    it('creates a submission', async () => {
+      const submission = {
+        id: SUBMISSION_ID,
+        title: 'Test',
+        status: 'DRAFT',
+      };
+      mockService.createWithAudit.mockResolvedValueOnce(submission as never);
+
+      const call = client(submissionsRouter.create, orgContext('READER'));
+      const result = await call({ title: 'Test' });
+      expect(result.id).toBe(SUBMISSION_ID);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /submissions/{id}
+  // -------------------------------------------------------------------------
+
+  describe('GET /submissions/{id} (get)', () => {
+    it('requires org context', async () => {
+      const call = client(submissionsRouter.get, authedContext());
+      await expect(call({ id: SUBMISSION_ID })).rejects.toThrow(ORPCError);
+    });
+
+    it('returns submission with details', async () => {
+      const submission = {
+        id: SUBMISSION_ID,
+        title: 'Test',
+        files: [],
+        submitterEmail: 'test@example.com',
+      };
+      mockService.getByIdWithAccess.mockResolvedValueOnce(submission as never);
+
+      const call = client(submissionsRouter.get, orgContext('READER'));
+      const result = await call({ id: SUBMISSION_ID });
+      expect(result.id).toBe(SUBMISSION_ID);
+    });
+
+    it('maps SubmissionNotFoundError to NOT_FOUND', async () => {
+      const { SubmissionNotFoundError } =
+        await import('../../services/submission.service.js');
+      mockService.getByIdWithAccess.mockRejectedValueOnce(
+        new SubmissionNotFoundError(SUBMISSION_ID),
+      );
+
+      const call = client(submissionsRouter.get, orgContext('READER'));
+      await expect(call({ id: SUBMISSION_ID })).rejects.toThrow(ORPCError);
+    });
+
+    it('maps ForbiddenError to FORBIDDEN', async () => {
+      mockService.getByIdWithAccess.mockRejectedValueOnce(
+        new ForbiddenError('You do not have access'),
+      );
+
+      const call = client(submissionsRouter.get, orgContext('READER'));
+      await expect(call({ id: SUBMISSION_ID })).rejects.toThrow(
+        'You do not have access',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // PATCH /submissions/{id}
+  // -------------------------------------------------------------------------
+
+  describe('PATCH /submissions/{id} (update)', () => {
+    it('requires org context', async () => {
+      const call = client(submissionsRouter.update, authedContext());
+      await expect(
+        call({ id: SUBMISSION_ID, title: 'New Title' }),
+      ).rejects.toThrow(ORPCError);
+    });
+
+    it('updates a DRAFT submission', async () => {
+      const updated = { id: SUBMISSION_ID, title: 'New Title' };
+      mockService.updateAsOwner.mockResolvedValueOnce(updated as never);
+
+      const call = client(submissionsRouter.update, orgContext('READER'));
+      const result = await call({ id: SUBMISSION_ID, title: 'New Title' });
+      expect(result.title).toBe('New Title');
+    });
+
+    it('maps NotDraftError to BAD_REQUEST', async () => {
+      const { NotDraftError } =
+        await import('../../services/submission.service.js');
+      mockService.updateAsOwner.mockRejectedValueOnce(new NotDraftError());
+
+      const call = client(submissionsRouter.update, orgContext('READER'));
+      await expect(call({ id: SUBMISSION_ID, title: 'New' })).rejects.toThrow(
+        'DRAFT',
+      );
+    });
+
+    it('maps ForbiddenError when not owner', async () => {
+      mockService.updateAsOwner.mockRejectedValueOnce(
+        new ForbiddenError('Only the submitter can update'),
+      );
+
+      const call = client(submissionsRouter.update, orgContext('READER'));
+      await expect(call({ id: SUBMISSION_ID, title: 'New' })).rejects.toThrow(
+        'submitter',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /submissions/{id}/submit
+  // -------------------------------------------------------------------------
+
+  describe('POST /submissions/{id}/submit', () => {
+    it('requires org context', async () => {
+      const call = client(submissionsRouter.submit, authedContext());
+      await expect(call({ id: SUBMISSION_ID })).rejects.toThrow(ORPCError);
+    });
+
+    it('submits a DRAFT submission', async () => {
+      const result = {
+        submission: { id: SUBMISSION_ID, status: 'SUBMITTED' },
+        historyEntry: { id: 'h-1' },
+      };
+      mockService.submitAsOwner.mockResolvedValueOnce(result as never);
+
+      const call = client(submissionsRouter.submit, orgContext('READER'));
+      const response = await call({ id: SUBMISSION_ID });
+      expect(response.submission.status).toBe('SUBMITTED');
+    });
+
+    it('maps ForbiddenError when not owner', async () => {
+      mockService.submitAsOwner.mockRejectedValueOnce(
+        new ForbiddenError('Only the submitter can submit'),
+      );
+
+      const call = client(submissionsRouter.submit, orgContext('READER'));
+      await expect(call({ id: SUBMISSION_ID })).rejects.toThrow('submitter');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // DELETE /submissions/{id}
+  // -------------------------------------------------------------------------
+
+  describe('DELETE /submissions/{id} (delete)', () => {
+    it('requires org context', async () => {
+      const call = client(submissionsRouter.delete, authedContext());
+      await expect(call({ id: SUBMISSION_ID })).rejects.toThrow(ORPCError);
+    });
+
+    it('deletes a DRAFT submission', async () => {
+      mockService.deleteAsOwner.mockResolvedValueOnce({
+        success: true,
+      } as never);
+
+      const call = client(submissionsRouter.delete, orgContext('READER'));
+      const result = await call({ id: SUBMISSION_ID });
+      expect(result).toEqual({ success: true });
+    });
+
+    it('maps NotDraftError to BAD_REQUEST', async () => {
+      const { NotDraftError } =
+        await import('../../services/submission.service.js');
+      mockService.deleteAsOwner.mockRejectedValueOnce(new NotDraftError());
+
+      const call = client(submissionsRouter.delete, orgContext('READER'));
+      await expect(call({ id: SUBMISSION_ID })).rejects.toThrow('DRAFT');
+    });
+
+    it('maps SubmissionNotFoundError to NOT_FOUND', async () => {
+      const { SubmissionNotFoundError } =
+        await import('../../services/submission.service.js');
+      mockService.deleteAsOwner.mockRejectedValueOnce(
+        new SubmissionNotFoundError(SUBMISSION_ID),
+      );
+
+      const call = client(submissionsRouter.delete, orgContext('READER'));
+      await expect(call({ id: SUBMISSION_ID })).rejects.toThrow(ORPCError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /submissions/{id}/withdraw
+  // -------------------------------------------------------------------------
+
+  describe('POST /submissions/{id}/withdraw', () => {
+    it('requires org context', async () => {
+      const call = client(submissionsRouter.withdraw, authedContext());
+      await expect(call({ id: SUBMISSION_ID })).rejects.toThrow(ORPCError);
+    });
+
+    it('withdraws a submission', async () => {
+      const result = {
+        submission: { id: SUBMISSION_ID, status: 'WITHDRAWN' },
+        historyEntry: { id: 'h-1' },
+      };
+      mockService.withdrawAsOwner.mockResolvedValueOnce(result as never);
+
+      const call = client(submissionsRouter.withdraw, orgContext('READER'));
+      const response = await call({ id: SUBMISSION_ID });
+      expect(response.submission.status).toBe('WITHDRAWN');
+    });
+
+    it('maps ForbiddenError when not owner', async () => {
+      mockService.withdrawAsOwner.mockRejectedValueOnce(
+        new ForbiddenError('Only the submitter can withdraw'),
+      );
+
+      const call = client(submissionsRouter.withdraw, orgContext('READER'));
+      await expect(call({ id: SUBMISSION_ID })).rejects.toThrow('submitter');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // PATCH /submissions/{id}/status
+  // -------------------------------------------------------------------------
+
+  describe('PATCH /submissions/{id}/status (updateStatus)', () => {
+    it('requires org context', async () => {
+      const call = client(submissionsRouter.updateStatus, authedContext());
+      await expect(
+        call({ id: SUBMISSION_ID, status: 'UNDER_REVIEW' }),
+      ).rejects.toThrow(ORPCError);
+    });
+
+    it('rejects READER role', async () => {
+      mockService.updateStatusAsEditor.mockRejectedValueOnce(
+        new ForbiddenError('Editor or admin role required'),
+      );
+
+      const call = client(submissionsRouter.updateStatus, orgContext('READER'));
+      await expect(
+        call({ id: SUBMISSION_ID, status: 'UNDER_REVIEW' }),
+      ).rejects.toThrow('Editor or admin role required');
+    });
+
+    it('updates status as EDITOR', async () => {
+      const result = {
+        submission: { id: SUBMISSION_ID, status: 'UNDER_REVIEW' },
+        historyEntry: { id: 'h-1' },
+      };
+      mockService.updateStatusAsEditor.mockResolvedValueOnce(result as never);
+
+      const call = client(submissionsRouter.updateStatus, orgContext('EDITOR'));
+      const response = await call({
+        id: SUBMISSION_ID,
+        status: 'UNDER_REVIEW',
+      });
+      expect(response.submission.status).toBe('UNDER_REVIEW');
+    });
+
+    it('maps InvalidStatusTransitionError to BAD_REQUEST', async () => {
+      const { InvalidStatusTransitionError } =
+        await import('../../services/submission.service.js');
+      mockService.updateStatusAsEditor.mockRejectedValueOnce(
+        new InvalidStatusTransitionError('DRAFT', 'ACCEPTED'),
+      );
+
+      const call = client(submissionsRouter.updateStatus, orgContext('EDITOR'));
+      await expect(
+        call({ id: SUBMISSION_ID, status: 'ACCEPTED' }),
+      ).rejects.toThrow('Invalid status transition');
+    });
+
+    it('passes comment when provided', async () => {
+      const result = {
+        submission: { id: SUBMISSION_ID, status: 'REJECTED' },
+        historyEntry: { id: 'h-1' },
+      };
+      mockService.updateStatusAsEditor.mockResolvedValueOnce(result as never);
+
+      const call = client(submissionsRouter.updateStatus, orgContext('ADMIN'));
+      await call({
+        id: SUBMISSION_ID,
+        status: 'REJECTED',
+        comment: 'Not a fit',
+      });
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.updateStatusAsEditor).toHaveBeenCalledWith(
+        expect.anything(),
+        SUBMISSION_ID,
+        'REJECTED',
+        'Not a fit',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /submissions/{id}/history
+  // -------------------------------------------------------------------------
+
+  describe('GET /submissions/{id}/history', () => {
+    it('requires org context', async () => {
+      const call = client(submissionsRouter.history, authedContext());
+      await expect(call({ id: SUBMISSION_ID })).rejects.toThrow(ORPCError);
+    });
+
+    it('returns history for submission', async () => {
+      const history = [
+        { id: 'h-1', fromStatus: null, toStatus: 'DRAFT' },
+        { id: 'h-2', fromStatus: 'DRAFT', toStatus: 'SUBMITTED' },
+      ];
+      mockService.getHistoryWithAccess.mockResolvedValueOnce(history as never);
+
+      const call = client(submissionsRouter.history, orgContext('READER'));
+      const result = await call({ id: SUBMISSION_ID });
+      expect(result).toHaveLength(2);
+    });
+
+    it('maps SubmissionNotFoundError to NOT_FOUND', async () => {
+      const { SubmissionNotFoundError } =
+        await import('../../services/submission.service.js');
+      mockService.getHistoryWithAccess.mockRejectedValueOnce(
+        new SubmissionNotFoundError(SUBMISSION_ID),
+      );
+
+      const call = client(submissionsRouter.history, orgContext('READER'));
+      await expect(call({ id: SUBMISSION_ID })).rejects.toThrow(ORPCError);
+    });
+
+    it('maps ForbiddenError to FORBIDDEN', async () => {
+      mockService.getHistoryWithAccess.mockRejectedValueOnce(
+        new ForbiddenError('You do not have access'),
+      );
+
+      const call = client(submissionsRouter.history, orgContext('READER'));
+      await expect(call({ id: SUBMISSION_ID })).rejects.toThrow(
+        'You do not have access',
+      );
+    });
+  });
+});

--- a/apps/api/src/rest/routers/submissions.ts
+++ b/apps/api/src/rest/routers/submissions.ts
@@ -1,0 +1,188 @@
+import { z } from 'zod';
+import {
+  createSubmissionSchema,
+  updateSubmissionSchema,
+  updateSubmissionStatusSchema,
+  listSubmissionsSchema,
+} from '@colophony/types';
+import { restPaginationQuery } from '@colophony/api-contracts';
+import { submissionService } from '../../services/submission.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { assertEditorOrAdmin } from '../../services/errors.js';
+import { mapServiceError } from '../error-mapper.js';
+import { orgProcedure } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// Query schemas — override page/limit with z.coerce for REST query strings
+// ---------------------------------------------------------------------------
+
+const restListSubmissionsQuery = listSubmissionsSchema
+  .omit({ page: true, limit: true })
+  .merge(restPaginationQuery);
+
+// ---------------------------------------------------------------------------
+// Path param schemas
+// ---------------------------------------------------------------------------
+
+const submissionIdParam = z.object({ id: z.string().uuid() });
+
+// ---------------------------------------------------------------------------
+// Submission routes
+// ---------------------------------------------------------------------------
+
+const mine = orgProcedure
+  .route({ method: 'GET', path: '/submissions/mine' })
+  .input(restListSubmissionsQuery)
+  .handler(async ({ input, context }) => {
+    return submissionService.listBySubmitter(
+      context.dbTx,
+      context.authContext.userId,
+      input,
+    );
+  });
+
+const list = orgProcedure
+  .route({ method: 'GET', path: '/submissions' })
+  .input(restListSubmissionsQuery)
+  .handler(async ({ input, context }) => {
+    try {
+      assertEditorOrAdmin(context.authContext.role);
+      return await submissionService.listAll(context.dbTx, input);
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const create = orgProcedure
+  .route({ method: 'POST', path: '/submissions', successStatus: 201 })
+  .input(createSubmissionSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionService.createWithAudit(
+        toServiceContext(context),
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const get = orgProcedure
+  .route({ method: 'GET', path: '/submissions/{id}' })
+  .input(submissionIdParam)
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionService.getByIdWithAccess(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const update = orgProcedure
+  .route({ method: 'PATCH', path: '/submissions/{id}' })
+  .input(submissionIdParam.merge(updateSubmissionSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    try {
+      return await submissionService.updateAsOwner(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const submit = orgProcedure
+  .route({ method: 'POST', path: '/submissions/{id}/submit' })
+  .input(submissionIdParam)
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionService.submitAsOwner(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const del = orgProcedure
+  .route({ method: 'DELETE', path: '/submissions/{id}' })
+  .input(submissionIdParam)
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionService.deleteAsOwner(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const withdraw = orgProcedure
+  .route({ method: 'POST', path: '/submissions/{id}/withdraw' })
+  .input(submissionIdParam)
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionService.withdrawAsOwner(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const updateStatus = orgProcedure
+  .route({ method: 'PATCH', path: '/submissions/{id}/status' })
+  .input(submissionIdParam.merge(updateSubmissionStatusSchema))
+  .handler(async ({ input, context }) => {
+    const { id, status, comment } = input;
+    try {
+      return await submissionService.updateStatusAsEditor(
+        toServiceContext(context),
+        id,
+        status,
+        comment,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const history = orgProcedure
+  .route({ method: 'GET', path: '/submissions/{id}/history' })
+  .input(submissionIdParam)
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionService.getHistoryWithAccess(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const submissionsRouter = {
+  mine,
+  list,
+  create,
+  get,
+  update,
+  submit,
+  delete: del,
+  withdraw,
+  updateStatus,
+  history,
+};

--- a/apps/api/src/rest/routers/users.spec.ts
+++ b/apps/api/src/rest/routers/users.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ORPCError } from '@orpc/server';
+
+vi.mock('../../services/user.service.js', () => ({
+  userService: {
+    getProfile: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/organization.service.js', () => ({
+  organizationService: {
+    listUserOrganizations: vi.fn(),
+  },
+}));
+
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  users: {},
+  eq: vi.fn(),
+}));
+
+import { userService } from '../../services/user.service.js';
+import { usersRouter } from './users.js';
+import type { RestContext } from '../context.js';
+import { createProcedureClient } from '@orpc/server';
+
+const mockUserService = vi.mocked(userService);
+
+const USER_ID = 'a0000000-0000-4000-a000-000000000001';
+
+function baseContext(): RestContext {
+  return { authContext: null, dbTx: null, audit: vi.fn() };
+}
+
+function authedContext(): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: 'zid-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+    },
+    dbTx: null,
+    audit: vi.fn(),
+  };
+}
+
+function client<T>(procedure: T, context: RestContext) {
+  return createProcedureClient(procedure as any, { context }) as any;
+}
+
+describe('users REST router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /users/me', () => {
+    it('requires authentication', async () => {
+      const call = client(usersRouter.me, baseContext());
+      await expect(call({})).rejects.toThrow(ORPCError);
+    });
+
+    it('returns user profile', async () => {
+      const profile = {
+        id: USER_ID,
+        email: 'test@example.com',
+        emailVerified: true,
+        createdAt: new Date(),
+        organizations: [],
+      };
+      mockUserService.getProfile.mockResolvedValueOnce(profile as never);
+
+      const call = client(usersRouter.me, authedContext());
+      const result = await call({});
+      expect(result.id).toBe(USER_ID);
+      expect(result.email).toBe('test@example.com');
+    });
+
+    it('throws NOT_FOUND when user profile is null', async () => {
+      mockUserService.getProfile.mockResolvedValueOnce(null as never);
+
+      const call = client(usersRouter.me, authedContext());
+      await expect(call({})).rejects.toThrow('User not found');
+    });
+  });
+});

--- a/apps/api/src/rest/routers/users.ts
+++ b/apps/api/src/rest/routers/users.ts
@@ -1,0 +1,25 @@
+import { ORPCError } from '@orpc/server';
+import { userService } from '../../services/user.service.js';
+import { authedProcedure } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// User routes
+// ---------------------------------------------------------------------------
+
+const me = authedProcedure
+  .route({ method: 'GET', path: '/users/me' })
+  .handler(async ({ context }) => {
+    const profile = await userService.getProfile(context.authContext.userId);
+    if (!profile) {
+      throw new ORPCError('NOT_FOUND', { message: 'User not found' });
+    }
+    return profile;
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const usersRouter = {
+  me,
+};

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -59,7 +59,7 @@
 
 - [x] Service layer extraction from tRPC routers — PR 1 (foundation) done 2026-02-17 #94; PR 2 (router refactor) done 2026-02-17 — (architecture doc Track 2)
 - [x] oRPC REST API surface — PR 1: contracts + organizations (replaces ts-rest; done 2026-02-18) — (architecture doc Track 2)
-- [ ] oRPC REST API surface — PR 2: submissions, files, users, API keys contracts + OpenAPI spec endpoint — (DEVLOG 2026-02-18)
+- [x] oRPC REST API surface — PR 2: submissions, files, users, API keys contracts + OpenAPI spec endpoint — (DEVLOG 2026-02-18; done 2026-02-18)
 - [ ] oRPC REST API surface — PR 3: typed client package — (DEVLOG 2026-02-18)
 - [ ] API key scope enforcement on REST endpoints — (DEVLOG 2026-02-18, plan)
 - [ ] Pothos + GraphQL Yoga surface — decision point at Month 3: Pothos vs TypeGraphQL — (architecture doc Track 2, Section 6.6)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,26 @@ Newest entries first.
 
 ---
 
+## 2026-02-18 — oRPC REST API Surface (PR 2: Submissions, Files, Users, API Keys)
+
+### Done
+
+- Created 4 new contract files in `@colophony/api-contracts`: submissions (10 endpoints), files (3), users (1), api-keys (4)
+- Implemented all 18 REST router handlers in `apps/api/src/rest/routers/` using `orgProcedure`/`adminProcedure`/`authedProcedure`
+- Added `OpenAPIReferencePlugin` serving OpenAPI 3.1 spec at `/v1/openapi.json` and Scalar docs at `/v1/docs`
+- Added `/v1/openapi.json` and `/v1/docs` to public route allowlist in auth hook
+- Wrote 47 new tests across 4 spec files (submissions: 36, files: 11, users: 3, api-keys: 11); all 432 tests pass
+- Addressed Codex branch review [P3]: normalized trailing slashes in `isPublicRoute()` so `/v1/docs/` and `/v1/openapi.json/` are correctly treated as public
+
+### Decisions
+
+- `GET /users/me` returns 404 (not null) when profile missing — REST convention differs from tRPC which returns null as 200
+- `submissions.mine` calls `listBySubmitter()` directly; `submissions.list` requires editor/admin role via `assertEditorOrAdmin()`
+- API key endpoints: `list` uses `orgProcedure` (any member), `create`/`revoke`/`delete` use `adminProcedure`
+- Files router uses lazy S3 client pattern (`getS3Client()`/`getEnvConfig()`) to avoid module-load-time initialization in tests
+
+---
+
 ## 2026-02-18 — oRPC REST API Surface (PR 1: Contracts + Organizations)
 
 ### Done

--- a/packages/api-contracts/src/api-keys.ts
+++ b/packages/api-contracts/src/api-keys.ts
@@ -1,0 +1,58 @@
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+import {
+  createApiKeySchema,
+  apiKeyResponseSchema,
+  createApiKeyResponseSchema,
+} from "@colophony/types";
+import { restPaginationQuery } from "./shared.js";
+
+// ---------------------------------------------------------------------------
+// Path param schemas
+// ---------------------------------------------------------------------------
+
+const keyIdParam = z.object({
+  keyId: z.string().uuid(),
+});
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+const paginatedApiKeysSchema = z.object({
+  items: z.array(apiKeyResponseSchema),
+  total: z.number(),
+  page: z.number(),
+  limit: z.number(),
+  totalPages: z.number(),
+});
+
+const deleteResponseSchema = z.object({
+  success: z.literal(true),
+});
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+export const apiKeysContract = {
+  list: oc
+    .route({ method: "GET", path: "/api-keys" })
+    .input(restPaginationQuery)
+    .output(paginatedApiKeysSchema),
+
+  create: oc
+    .route({ method: "POST", path: "/api-keys", successStatus: 201 })
+    .input(createApiKeySchema)
+    .output(createApiKeyResponseSchema),
+
+  revoke: oc
+    .route({ method: "POST", path: "/api-keys/{keyId}/revoke" })
+    .input(keyIdParam)
+    .output(apiKeyResponseSchema),
+
+  delete: oc
+    .route({ method: "DELETE", path: "/api-keys/{keyId}" })
+    .input(keyIdParam)
+    .output(deleteResponseSchema),
+};

--- a/packages/api-contracts/src/files.ts
+++ b/packages/api-contracts/src/files.ts
@@ -1,0 +1,50 @@
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+import { submissionFileSchema } from "@colophony/types";
+
+// ---------------------------------------------------------------------------
+// Path param schemas
+// ---------------------------------------------------------------------------
+
+const submissionIdParam = z.object({
+  submissionId: z.string().uuid(),
+});
+
+const fileIdParam = z.object({
+  fileId: z.string().uuid(),
+});
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+const downloadUrlResponseSchema = z.object({
+  url: z.string(),
+  filename: z.string(),
+  mimeType: z.string(),
+});
+
+const deleteResponseSchema = z.object({
+  success: z.literal(true),
+});
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+export const filesContract = {
+  list: oc
+    .route({ method: "GET", path: "/submissions/{submissionId}/files" })
+    .input(submissionIdParam)
+    .output(z.array(submissionFileSchema)),
+
+  download: oc
+    .route({ method: "GET", path: "/files/{fileId}/download" })
+    .input(fileIdParam)
+    .output(downloadUrlResponseSchema),
+
+  delete: oc
+    .route({ method: "DELETE", path: "/files/{fileId}" })
+    .input(fileIdParam)
+    .output(deleteResponseSchema),
+};

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -4,3 +4,7 @@ export {
   organizationsContract,
   organizationMembersContract,
 } from "./organizations.js";
+export { submissionsContract } from "./submissions.js";
+export { filesContract } from "./files.js";
+export { usersContract } from "./users.js";
+export { apiKeysContract } from "./api-keys.js";

--- a/packages/api-contracts/src/submissions.ts
+++ b/packages/api-contracts/src/submissions.ts
@@ -1,0 +1,110 @@
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+import {
+  submissionSchema,
+  submissionFileSchema,
+  createSubmissionSchema,
+  updateSubmissionSchema,
+  updateSubmissionStatusSchema,
+  listSubmissionsSchema,
+  submissionHistorySchema,
+} from "@colophony/types";
+import { restPaginationQuery } from "./shared.js";
+
+// ---------------------------------------------------------------------------
+// Query schemas — override page/limit with z.coerce for REST query strings
+// ---------------------------------------------------------------------------
+
+const restListSubmissionsQuery = listSubmissionsSchema
+  .omit({ page: true, limit: true })
+  .merge(restPaginationQuery);
+
+// ---------------------------------------------------------------------------
+// Path param schemas
+// ---------------------------------------------------------------------------
+
+const submissionIdParam = z.object({
+  id: z.string().uuid(),
+});
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+const submissionWithDetailsSchema = submissionSchema.extend({
+  files: z.array(submissionFileSchema),
+  submitterEmail: z.string().nullable(),
+});
+
+const paginatedSubmissionsSchema = z.object({
+  items: z.array(submissionSchema),
+  total: z.number(),
+  page: z.number(),
+  limit: z.number(),
+  totalPages: z.number(),
+});
+
+const statusUpdateResponseSchema = z.object({
+  submission: submissionSchema,
+  historyEntry: submissionHistorySchema,
+});
+
+const deleteResponseSchema = z.object({
+  success: z.literal(true),
+});
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+export const submissionsContract = {
+  mine: oc
+    .route({ method: "GET", path: "/submissions/mine" })
+    .input(restListSubmissionsQuery)
+    .output(paginatedSubmissionsSchema),
+
+  list: oc
+    .route({ method: "GET", path: "/submissions" })
+    .input(restListSubmissionsQuery)
+    .output(paginatedSubmissionsSchema),
+
+  create: oc
+    .route({ method: "POST", path: "/submissions", successStatus: 201 })
+    .input(createSubmissionSchema)
+    .output(submissionSchema),
+
+  get: oc
+    .route({ method: "GET", path: "/submissions/{id}" })
+    .input(submissionIdParam)
+    .output(submissionWithDetailsSchema),
+
+  update: oc
+    .route({ method: "PATCH", path: "/submissions/{id}" })
+    .input(submissionIdParam.merge(updateSubmissionSchema))
+    .output(submissionSchema),
+
+  submit: oc
+    .route({ method: "POST", path: "/submissions/{id}/submit" })
+    .input(submissionIdParam)
+    .output(statusUpdateResponseSchema),
+
+  delete: oc
+    .route({ method: "DELETE", path: "/submissions/{id}" })
+    .input(submissionIdParam)
+    .output(deleteResponseSchema),
+
+  withdraw: oc
+    .route({ method: "POST", path: "/submissions/{id}/withdraw" })
+    .input(submissionIdParam)
+    .output(statusUpdateResponseSchema),
+
+  updateStatus: oc
+    .route({ method: "PATCH", path: "/submissions/{id}/status" })
+    .input(submissionIdParam.merge(updateSubmissionStatusSchema))
+    .output(statusUpdateResponseSchema),
+
+  history: oc
+    .route({ method: "GET", path: "/submissions/{id}/history" })
+    .input(submissionIdParam)
+    .output(z.array(submissionHistorySchema)),
+};

--- a/packages/api-contracts/src/users.ts
+++ b/packages/api-contracts/src/users.ts
@@ -1,0 +1,30 @@
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+import { roleSchema } from "@colophony/types";
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+const userProfileSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string(),
+  emailVerified: z.boolean(),
+  createdAt: z.date(),
+  organizations: z.array(
+    z.object({
+      organizationId: z.string().uuid(),
+      name: z.string(),
+      slug: z.string(),
+      role: roleSchema,
+    }),
+  ),
+});
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+export const usersContract = {
+  me: oc.route({ method: "GET", path: "/users/me" }).output(userProfileSchema),
+};


### PR DESCRIPTION
## Summary

- Adds 18 REST endpoints across 4 new router modules: submissions (10), files (3), users (1), api-keys (4)
- Creates corresponding oRPC contract definitions in `@colophony/api-contracts` for typed client generation
- Serves OpenAPI 3.1 spec at `/v1/openapi.json` and Scalar API docs at `/v1/docs` via `OpenAPIReferencePlugin`

## Changes

**Contracts (`packages/api-contracts/src/`):**
- `submissions.ts` — 10 contracts (CRUD, submit, withdraw, status, history)
- `files.ts` — 3 contracts (list by submission, download presigned URL, delete)
- `users.ts` — 1 contract (GET /users/me)
- `api-keys.ts` — 4 contracts (list, create, revoke, delete)

**Routers (`apps/api/src/rest/routers/`):**
- `submissions.ts` — 10 handlers using `orgProcedure`, service layer access-aware methods
- `files.ts` — 3 handlers with lazy S3 client pattern
- `users.ts` — 1 handler using `authedProcedure` (no org context needed)
- `api-keys.ts` — 4 handlers (`list` = `orgProcedure`, mutations = `adminProcedure`)

**Infrastructure:**
- `router.ts` — registers all 4 new routers + `OpenAPIReferencePlugin`
- `auth.ts` — adds `/v1/openapi.json` and `/v1/docs` to public route allowlist; normalizes trailing slashes in `isPublicRoute()`

**Tests:** 49 new tests (47 router + 2 auth trailing-slash), 432 total passing

## Test plan

- [x] All 432 unit tests pass (`pnpm test`)
- [x] Type-check clean (`pnpm type-check`)
- [x] Lint clean (`pnpm lint`)
- [x] branch review — 1 P3 finding addressed (trailing-slash normalization)