### PR TITLE
feat(api): typed REST client package (@colophony/api-client)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -60,7 +60,7 @@
 - [x] Service layer extraction from tRPC routers — PR 1 (foundation) done 2026-02-17 #94; PR 2 (router refactor) done 2026-02-17 — (architecture doc Track 2)
 - [x] oRPC REST API surface — PR 1: contracts + organizations (replaces ts-rest; done 2026-02-18) — (architecture doc Track 2)
 - [x] oRPC REST API surface — PR 2: submissions, files, users, API keys contracts + OpenAPI spec endpoint — (DEVLOG 2026-02-18; done 2026-02-18)
-- [ ] oRPC REST API surface — PR 3: typed client package — (DEVLOG 2026-02-18)
+- [x] oRPC REST API surface — PR 3: typed client package — (DEVLOG 2026-02-18; done 2026-02-18)
 - [ ] API key scope enforcement on REST endpoints — (DEVLOG 2026-02-18, plan)
 - [ ] Pothos + GraphQL Yoga surface — decision point at Month 3: Pothos vs TypeGraphQL — (architecture doc Track 2, Section 6.6)
 - [ ] SDK generation (TypeScript, Python) — (architecture doc Track 2)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,27 @@ Newest entries first.
 
 ---
 
+## 2026-02-18 — Typed REST Client Package (@colophony/api-client)
+
+### Done
+
+- Created `@colophony/api-client` workspace package with `createColophonyClient()` and `createSafeColophonyClient()` factory functions
+- Used `OpenAPILink` from `@orpc/openapi-client/fetch` to connect to the server's `OpenAPIHandler`-based REST API
+- Supports bearer token and API key auth, dynamic token/orgId functions (called per-request for refresh/switching)
+- Safe client returns 4-value tuples `[error, data, isDefined, isSuccess]` via `@orpc/client`'s `createSafeClient`
+- Composed contract router in `contract.ts` matching server's `restRouter` structure
+- Exported `ColophonyInputs`/`ColophonyOutputs` type helpers and re-exported `safe`, `isDefinedError`, `ORPCError`
+- Wrote 8 unit tests with mocked fetch verifying all header behaviors and safe tuple shape
+- Addressed Codex diff review P1: applied `JsonifyDates` to client output types so `Date` fields correctly appear as `string` (matching JSON wire format)
+
+### Decisions
+
+- `JsonifiedRouterClient<T>` recursively remaps procedure return types through `JsonifyDates` — inputs left unchanged (oRPC serializes Date inputs automatically)
+- Added `@types/node` as devDep (matching `auth-client` pattern) for global `Request`/`Response` types since library tsconfig only includes `ES2022`
+- `fetch` option typed as `(request: Request) => Promise<Response>` — simplified from oRPC's multi-arg signature since only the Request is needed for testing/custom fetch
+
+---
+
 ## 2026-02-18 — oRPC REST API Surface (PR 2: Submissions, Files, Users, API Keys)
 
 ### Done

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@colophony/api-client",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@colophony/api-contracts": "workspace:*",
+    "@orpc/client": "^1.13.5",
+    "@orpc/contract": "^1.13.5",
+    "@orpc/openapi-client": "^1.13.5"
+  },
+  "devDependencies": {
+    "@colophony/typescript-config": "workspace:*",
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.2",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/api-client/src/client.spec.ts
+++ b/packages/api-client/src/client.spec.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi } from "vitest";
+import { createColophonyClient, createSafeColophonyClient } from "./client.js";
+
+/**
+ * Creates a mock fetch that captures the request and returns a minimal
+ * successful JSON response.
+ */
+function createMockFetch(
+  responseBody: unknown = {
+    items: [],
+    total: 0,
+    page: 1,
+    limit: 20,
+    totalPages: 0,
+  },
+) {
+  const captured: { request: Request }[] = [];
+
+  const mockFetch = vi.fn(async (request: Request) => {
+    captured.push({ request });
+    return new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  return { mockFetch, captured };
+}
+
+function clientOptions(overrides: Record<string, unknown> = {}) {
+  const { mockFetch } = createMockFetch();
+  return {
+    baseUrl: "http://localhost:4000/v1",
+    auth: { type: "bearer" as const, token: "test-token" },
+    fetch: mockFetch,
+    ...overrides,
+  };
+}
+
+describe("createColophonyClient", () => {
+  it("sends Bearer token in Authorization header", async () => {
+    const { mockFetch, captured } = createMockFetch();
+    const client = createColophonyClient({
+      ...clientOptions(),
+      auth: { type: "bearer", token: "my-jwt-token" },
+      fetch: mockFetch,
+    });
+
+    await client.submissions.list({});
+
+    expect(captured.length).toBe(1);
+    expect(captured[0]!.request.headers.get("Authorization")).toBe(
+      "Bearer my-jwt-token",
+    );
+  });
+
+  it("sends API key in X-Api-Key header", async () => {
+    const { mockFetch, captured } = createMockFetch();
+    const client = createColophonyClient({
+      ...clientOptions(),
+      auth: { type: "apiKey", key: "col_live_abc123def456" },
+      fetch: mockFetch,
+    });
+
+    await client.submissions.list({});
+
+    expect(captured.length).toBe(1);
+    expect(captured[0]!.request.headers.get("X-Api-Key")).toBe(
+      "col_live_abc123def456",
+    );
+    expect(captured[0]!.request.headers.get("Authorization")).toBeNull();
+  });
+
+  it("calls dynamic token function per-request", async () => {
+    const { mockFetch, captured } = createMockFetch();
+    let callCount = 0;
+    const tokenFn = vi.fn(async () => {
+      callCount++;
+      return `token-${callCount}`;
+    });
+
+    const client = createColophonyClient({
+      ...clientOptions(),
+      auth: { type: "bearer", token: tokenFn },
+      fetch: mockFetch,
+    });
+
+    await client.submissions.list({});
+    await client.submissions.list({});
+
+    expect(tokenFn).toHaveBeenCalledTimes(2);
+    expect(captured[0]!.request.headers.get("Authorization")).toBe(
+      "Bearer token-1",
+    );
+    expect(captured[1]!.request.headers.get("Authorization")).toBe(
+      "Bearer token-2",
+    );
+  });
+
+  it("sends X-Organization-Id header when orgId is provided", async () => {
+    const { mockFetch, captured } = createMockFetch();
+    const client = createColophonyClient({
+      ...clientOptions(),
+      orgId: "org-uuid-123",
+      fetch: mockFetch,
+    });
+
+    await client.submissions.list({});
+
+    expect(captured[0]!.request.headers.get("X-Organization-Id")).toBe(
+      "org-uuid-123",
+    );
+  });
+
+  it("calls dynamic orgId function per-request", async () => {
+    const { mockFetch, captured } = createMockFetch();
+    let callCount = 0;
+    const orgIdFn = vi.fn(async () => {
+      callCount++;
+      return `org-${callCount}`;
+    });
+
+    const client = createColophonyClient({
+      ...clientOptions(),
+      orgId: orgIdFn,
+      fetch: mockFetch,
+    });
+
+    await client.submissions.list({});
+    await client.submissions.list({});
+
+    expect(orgIdFn).toHaveBeenCalledTimes(2);
+    expect(captured[0]!.request.headers.get("X-Organization-Id")).toBe("org-1");
+    expect(captured[1]!.request.headers.get("X-Organization-Id")).toBe("org-2");
+  });
+
+  it("omits X-Organization-Id header when orgId is not provided", async () => {
+    const { mockFetch, captured } = createMockFetch();
+    const client = createColophonyClient({
+      ...clientOptions(),
+      fetch: mockFetch,
+    });
+
+    await client.submissions.list({});
+
+    expect(captured[0]!.request.headers.get("X-Organization-Id")).toBeNull();
+  });
+});
+
+describe("createSafeColophonyClient", () => {
+  it("returns 4-value success tuple [null, data, false, true]", async () => {
+    const responseBody = {
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 20,
+      totalPages: 0,
+    };
+    const { mockFetch } = createMockFetch(responseBody);
+    const client = createSafeColophonyClient({
+      ...clientOptions(),
+      fetch: mockFetch,
+    });
+
+    const result = await client.submissions.list({});
+    const [error, data, isDefined, isSuccess] = result;
+
+    expect(isSuccess).toBe(true);
+    expect(error).toBeNull();
+    expect(isDefined).toBe(false);
+    expect(data).toEqual(responseBody);
+  });
+
+  it("returns 4-value error tuple on failure", async () => {
+    const mockFetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          code: "UNAUTHORIZED",
+          status: 401,
+          message: "Not authenticated",
+        }),
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+
+    const client = createSafeColophonyClient({
+      ...clientOptions(),
+      fetch: mockFetch,
+    });
+
+    const result = await client.submissions.list({});
+    const [error, data, _isDefined, isSuccess] = result;
+
+    expect(isSuccess).toBe(false);
+    expect(data).toBeUndefined();
+    expect(error).toBeDefined();
+  });
+});

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,0 +1,158 @@
+import { createORPCClient, createSafeClient } from "@orpc/client";
+import { OpenAPILink } from "@orpc/openapi-client/fetch";
+import type { ContractRouterClient } from "@orpc/contract";
+import { colophonyContract } from "./contract.js";
+
+// ---------------------------------------------------------------------------
+// Auth types
+// ---------------------------------------------------------------------------
+
+export type ColophonyBearerAuth = {
+  type: "bearer";
+  token: string | (() => string | Promise<string>);
+};
+
+export type ColophonyApiKeyAuth = {
+  type: "apiKey";
+  key: string;
+};
+
+export type ColophonyAuth = ColophonyBearerAuth | ColophonyApiKeyAuth;
+
+// ---------------------------------------------------------------------------
+// Client options
+// ---------------------------------------------------------------------------
+
+export interface ColophonyClientOptions {
+  /** Base URL of the Colophony API (e.g. "https://api.example.com/v1"). */
+  baseUrl: string;
+  /** Authentication credentials. */
+  auth: ColophonyAuth;
+  /** Organization ID header. String or async function for dynamic switching. */
+  orgId?: string | (() => string | Promise<string>);
+  /**
+   * Custom fetch implementation (useful for testing or server-side usage).
+   * Receives the Request object built by the oRPC link.
+   */
+  fetch?: (request: Request) => Promise<Response>;
+}
+
+// ---------------------------------------------------------------------------
+// Client types
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively converts Date fields to string to reflect JSON serialization.
+ * The REST API returns JSON, so Date schemas become ISO strings on the wire.
+ */
+export type JsonifyDates<T> = T extends Date
+  ? string
+  : T extends Array<infer U>
+    ? Array<JsonifyDates<U>>
+    : T extends object
+      ? { [K in keyof T]: JsonifyDates<T[K]> }
+      : T;
+
+/**
+ * Recursively maps a nested oRPC client so procedure return types have
+ * Date fields replaced with string (reflecting JSON wire format).
+ * Leaves inputs unchanged — oRPC serializes Date inputs automatically.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type JsonifiedRouterClient<T> = T extends (...args: any[]) => Promise<infer R>
+  ? (...args: Parameters<T>) => Promise<JsonifyDates<R>>
+  : { [K in keyof T]: JsonifiedRouterClient<T[K]> };
+
+/** Internal type matching the raw contract (Date outputs). */
+type RawClient = ContractRouterClient<typeof colophonyContract>;
+
+/** Public client type with JSON-accurate output types (dates as strings). */
+export type ColophonyClient = JsonifiedRouterClient<RawClient>;
+
+// ---------------------------------------------------------------------------
+// Header builder
+// ---------------------------------------------------------------------------
+
+async function buildHeaders(
+  options: ColophonyClientOptions,
+): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {};
+
+  // Auth header
+  if (options.auth.type === "bearer") {
+    const token =
+      typeof options.auth.token === "function"
+        ? await options.auth.token()
+        : options.auth.token;
+    headers["Authorization"] = `Bearer ${token}`;
+  } else {
+    headers["X-Api-Key"] = options.auth.key;
+  }
+
+  // Org context header
+  if (options.orgId !== undefined) {
+    const orgId =
+      typeof options.orgId === "function"
+        ? await options.orgId()
+        : options.orgId;
+    headers["X-Organization-Id"] = orgId;
+  }
+
+  return headers;
+}
+
+// ---------------------------------------------------------------------------
+// Factory functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a typed Colophony REST API client.
+ *
+ * @example
+ * ```ts
+ * const client = createColophonyClient({
+ *   baseUrl: "https://api.example.com/v1",
+ *   auth: { type: "bearer", token: () => getAccessToken() },
+ *   orgId: "org-uuid",
+ * });
+ *
+ * const submissions = await client.submissions.list({ page: 1, limit: 10 });
+ * ```
+ */
+export function createColophonyClient(
+  options: ColophonyClientOptions,
+): ColophonyClient {
+  const link = new OpenAPILink(colophonyContract, {
+    url: options.baseUrl,
+    headers: () => buildHeaders(options),
+    ...(options.fetch ? { fetch: (request) => options.fetch!(request) } : {}),
+  });
+
+  return createORPCClient<RawClient>(link) as unknown as ColophonyClient;
+}
+
+/**
+ * Creates a safe Colophony REST API client that returns tuples instead of throwing.
+ *
+ * Each call returns `[error, data, isDefined, isSuccess]`:
+ * - Success: `[null, data, false, true]`
+ * - Defined error (typed ORPCError): `[error, undefined, true, false]`
+ * - Unexpected error: `[error, undefined, false, false]`
+ *
+ * @example
+ * ```ts
+ * const client = createSafeColophonyClient({
+ *   baseUrl: "https://api.example.com/v1",
+ *   auth: { type: "apiKey", key: "col_live_abc123" },
+ * });
+ *
+ * const [error, data, isDefined, isSuccess] = await client.submissions.list({});
+ * if (isSuccess) {
+ *   console.log(data.items);
+ * }
+ * ```
+ */
+export function createSafeColophonyClient(options: ColophonyClientOptions) {
+  const client = createColophonyClient(options);
+  return createSafeClient(client);
+}

--- a/packages/api-client/src/contract.ts
+++ b/packages/api-client/src/contract.ts
@@ -1,0 +1,19 @@
+/**
+ * Composed contract router matching the server's REST router structure.
+ * @see apps/api/src/rest/router.ts (lines 11-17)
+ */
+import {
+  organizationsContract,
+  submissionsContract,
+  filesContract,
+  usersContract,
+  apiKeysContract,
+} from "@colophony/api-contracts";
+
+export const colophonyContract = {
+  organizations: organizationsContract,
+  submissions: submissionsContract,
+  files: filesContract,
+  users: usersContract,
+  apiKeys: apiKeysContract,
+};

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,0 +1,23 @@
+// Factory functions and client types
+export { createColophonyClient, createSafeColophonyClient } from "./client.js";
+export type {
+  ColophonyAuth,
+  ColophonyBearerAuth,
+  ColophonyApiKeyAuth,
+  ColophonyClientOptions,
+  ColophonyClient,
+  JsonifyDates,
+} from "./client.js";
+
+// Contract router (for advanced use / custom link configuration)
+export { colophonyContract } from "./contract.js";
+
+// Type helpers
+export type {
+  ColophonyInputs,
+  ColophonyOutputs,
+  RestPaginationQuery,
+} from "./types.js";
+
+// Re-exports from @orpc/client for error handling
+export { safe, isDefinedError, ORPCError } from "@orpc/client";

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -1,0 +1,26 @@
+import type {
+  InferContractRouterInputs,
+  InferContractRouterOutputs,
+} from "@orpc/contract";
+import type { JsonifyDates } from "./client.js";
+import type { colophonyContract } from "./contract.js";
+
+/** Inferred input types for every procedure in the contract. */
+export type ColophonyInputs = InferContractRouterInputs<
+  typeof colophonyContract
+>;
+
+/** Raw output types from the contract (Date fields). */
+type RawOutputs = InferContractRouterOutputs<typeof colophonyContract>;
+
+/**
+ * Inferred output types with JSON-accurate date fields (string, not Date).
+ * Recursively applied so nested objects reflect the wire format.
+ */
+export type ColophonyOutputs = {
+  [K in keyof RawOutputs]: {
+    [P in keyof RawOutputs[K]]: JsonifyDates<RawOutputs[K][P]>;
+  };
+};
+
+export type { RestPaginationQuery } from "@colophony/api-contracts";

--- a/packages/api-client/tsconfig.build.json
+++ b/packages/api-client/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@colophony/typescript-config/library.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/api-client/vitest.config.ts
+++ b/packages/api-client/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.{test,spec}.ts"],
+    globals: false,
+    testTimeout: 30_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,34 @@ importers:
         specifier: ^5.7.2
         version: 5.9.3
 
+  packages/api-client:
+    dependencies:
+      '@colophony/api-contracts':
+        specifier: workspace:*
+        version: link:../api-contracts
+      '@orpc/client':
+        specifier: ^1.13.5
+        version: 1.13.5
+      '@orpc/contract':
+        specifier: ^1.13.5
+        version: 1.13.5
+      '@orpc/openapi-client':
+        specifier: ^1.13.5
+        version: 1.13.5
+    devDependencies:
+      '@colophony/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.2.3)(jiti@1.21.7)(jsdom@20.0.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/api-contracts:
     dependencies:
       '@colophony/types':


### PR DESCRIPTION
## Summary

- New `@colophony/api-client` workspace package providing typed REST API client via `@orpc/openapi-client`
- `createColophonyClient()` factory with bearer/API key auth, dynamic token/orgId functions, and custom fetch support
- `createSafeColophonyClient()` variant returning `[error, data, isDefined, isSuccess]` tuples
- `JsonifyDates` applied to output types so `Date` fields correctly appear as `string` (matching JSON wire format)
- 8 unit tests verifying header injection, dynamic auth, org context, and safe tuple shape

## Test plan

- [x] `pnpm --filter @colophony/api-client test` — 8/8 tests pass
- [x] `pnpm --filter @colophony/api-client build` — compiles cleanly
- [x] `pnpm type-check` — monorepo-wide 11/11 packages pass
- [x] `pnpm build` — full turbo build succeeds
- [ ] CI pipeline validates all of the above