### PR TITLE
feat(web): Playwright E2E tests for submission flow

### DIFF
--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -1,0 +1,27 @@
+/**
+ * Playwright global setup — validates seed data exists before running tests.
+ */
+
+import { getOrgBySlug, getUserByEmail, disconnectDb } from "./helpers/db";
+
+export default async function globalSetup() {
+  const org = await getOrgBySlug("quarterly-review");
+  if (!org) {
+    await disconnectDb();
+    throw new Error(
+      'E2E prerequisite failed: seed org "quarterly-review" not found.\n' +
+        "Run `pnpm db:seed` to populate seed data before running E2E tests.",
+    );
+  }
+
+  const user = await getUserByEmail("writer@example.com");
+  if (!user) {
+    await disconnectDb();
+    throw new Error(
+      'E2E prerequisite failed: seed user "writer@example.com" not found.\n' +
+        "Run `pnpm db:seed` to populate seed data before running E2E tests.",
+    );
+  }
+
+  await disconnectDb();
+}

--- a/apps/web/e2e/global-teardown.ts
+++ b/apps/web/e2e/global-teardown.ts
@@ -1,0 +1,9 @@
+/**
+ * Playwright global teardown — disconnects the DB pool.
+ */
+
+import { disconnectDb } from "./helpers/db";
+
+export default async function globalTeardown() {
+  await disconnectDb();
+}

--- a/apps/web/e2e/helpers/auth.ts
+++ b/apps/web/e2e/helpers/auth.ts
@@ -1,0 +1,78 @@
+/**
+ * Auth injection helper for Playwright E2E tests.
+ *
+ * Injects a fake OIDC user into localStorage (satisfies frontend ProtectedRoute
+ * and useAuth checks) and intercepts tRPC requests to swap the fake Bearer token
+ * for a real API key header (satisfies API auth).
+ *
+ * This uses the real API key auth path — no API code changes needed.
+ */
+
+import type { Page } from "@playwright/test";
+
+const OIDC_AUTHORITY = "http://test-idp:8080";
+const OIDC_CLIENT_ID = "test-client";
+const OIDC_STORAGE_KEY = `oidc.user:${OIDC_AUTHORITY}:${OIDC_CLIENT_ID}`;
+
+interface InjectAuthOptions {
+  page: Page;
+  orgId: string;
+  apiKey: string;
+  userProfile: {
+    sub: string;
+    email: string;
+    name: string;
+  };
+}
+
+/**
+ * Inject fake OIDC auth state and API key route interception.
+ *
+ * Must be called BEFORE navigating to any page. Sets up:
+ * 1. localStorage entries for OIDC user + currentOrgId (via addInitScript)
+ * 2. Route interception to swap Authorization header for X-Api-Key on tRPC calls
+ */
+export async function injectAuth({
+  page,
+  orgId,
+  apiKey,
+  userProfile,
+}: InjectAuthOptions): Promise<void> {
+  // 1. Inject OIDC user + org context into localStorage before any page JS runs
+  await page.addInitScript(
+    ({ storageKey, orgId, userProfile }) => {
+      const expiresAt = Math.floor(Date.now() / 1000) + 3600; // 1 hour ahead
+
+      const oidcUser = {
+        access_token: "e2e-fake-token",
+        token_type: "Bearer",
+        expires_at: expiresAt,
+        scope: "openid profile email offline_access",
+        profile: {
+          sub: userProfile.sub,
+          email: userProfile.email,
+          name: userProfile.name,
+          email_verified: true,
+        },
+      };
+
+      localStorage.setItem(storageKey, JSON.stringify(oidcUser));
+      localStorage.setItem("currentOrgId", orgId);
+    },
+    { storageKey: OIDC_STORAGE_KEY, orgId, userProfile },
+  );
+
+  // 2. Intercept tRPC requests: remove fake Bearer token, add real API key
+  await page.route("**/trpc/**", async (route) => {
+    const request = route.request();
+    const headers = { ...request.headers() };
+
+    // Remove the fake OIDC Bearer token
+    delete headers["authorization"];
+
+    // Add the real API key
+    headers["x-api-key"] = apiKey;
+
+    await route.continue({ headers });
+  });
+}

--- a/apps/web/e2e/helpers/db.ts
+++ b/apps/web/e2e/helpers/db.ts
@@ -5,10 +5,18 @@
  * to bypass RLS for creating test orgs, memberships, and other fixtures.
  */
 
+import { randomBytes, createHash } from "crypto";
 import { Pool } from "pg";
 import { drizzle } from "drizzle-orm/node-postgres";
-import { eq } from "drizzle-orm";
-import { organizations, users, organizationMembers } from "@colophony/db";
+import { eq, and, lte, gte } from "drizzle-orm";
+import {
+  organizations,
+  users,
+  organizationMembers,
+  apiKeys,
+  submissions,
+  submissionPeriods,
+} from "@colophony/db";
 
 const DATABASE_URL =
   process.env.DATABASE_URL ||
@@ -120,4 +128,158 @@ export async function deleteUser(userId: string): Promise<void> {
     .catch(() => {
       // Ignore if already deleted
     });
+}
+
+/**
+ * Look up an organization by slug.
+ */
+export async function getOrgBySlug(
+  slug: string,
+): Promise<{ id: string; name: string; slug: string } | null> {
+  const db = getDb();
+  const [row] = await db
+    .select({
+      id: organizations.id,
+      name: organizations.name,
+      slug: organizations.slug,
+    })
+    .from(organizations)
+    .where(eq(organizations.slug, slug))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Create a user for testing.
+ */
+export async function createUser(data: {
+  email: string;
+  zitadelUserId: string;
+}): Promise<{ id: string; email: string }> {
+  const db = getDb();
+  const [row] = await db
+    .insert(users)
+    .values({
+      email: data.email,
+      zitadelUserId: data.zitadelUserId,
+    })
+    .returning({
+      id: users.id,
+      email: users.email,
+    });
+  return row;
+}
+
+/**
+ * Create an API key for testing.
+ * Returns the plain key for use in test auth headers.
+ */
+export async function createApiKey(data: {
+  orgId: string;
+  userId: string;
+  scopes: string[];
+  name?: string;
+}): Promise<{ id: string; plainKey: string }> {
+  const db = getDb();
+  const rawKey = randomBytes(32).toString("hex");
+  const plainKey = `col_test_${rawKey}`;
+  const keyHash = createHash("sha256").update(plainKey).digest("hex");
+  const keyPrefix = plainKey.slice(0, 12);
+
+  const [row] = await db
+    .insert(apiKeys)
+    .values({
+      organizationId: data.orgId,
+      createdBy: data.userId,
+      name: data.name ?? `e2e-test-key-${Date.now()}`,
+      keyHash,
+      keyPrefix,
+      scopes: data.scopes,
+    })
+    .returning({
+      id: apiKeys.id,
+    });
+
+  return { id: row.id, plainKey };
+}
+
+/**
+ * Delete an API key by ID.
+ */
+export async function deleteApiKey(keyId: string): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(apiKeys)
+    .where(eq(apiKeys.id, keyId))
+    .catch(() => {
+      // Ignore if already deleted
+    });
+}
+
+/**
+ * Create a submission for testing.
+ */
+export async function createSubmission(data: {
+  orgId: string;
+  submitterId: string;
+  submissionPeriodId?: string;
+  title: string;
+  content?: string;
+  coverLetter?: string;
+  status?: string;
+}): Promise<{ id: string }> {
+  const db = getDb();
+  const [row] = await db
+    .insert(submissions)
+    .values({
+      organizationId: data.orgId,
+      submitterId: data.submitterId,
+      submissionPeriodId: data.submissionPeriodId ?? null,
+      title: data.title,
+      content: data.content ?? null,
+      coverLetter: data.coverLetter ?? null,
+      status: (data.status as "DRAFT") ?? "DRAFT",
+    })
+    .returning({
+      id: submissions.id,
+    });
+  return row;
+}
+
+/**
+ * Delete a submission by ID.
+ */
+export async function deleteSubmission(submissionId: string): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(submissions)
+    .where(eq(submissions.id, submissionId))
+    .catch(() => {
+      // Ignore if already deleted
+    });
+}
+
+/**
+ * Find an open submission period for an org (now between opensAt and closesAt).
+ */
+export async function getOpenSubmissionPeriod(
+  orgId: string,
+): Promise<{ id: string; name: string } | null> {
+  const db = getDb();
+  const now = new Date();
+  const [row] = await db
+    .select({
+      id: submissionPeriods.id,
+      name: submissionPeriods.name,
+    })
+    .from(submissionPeriods)
+    .where(
+      and(
+        eq(submissionPeriods.organizationId, orgId),
+        lte(submissionPeriods.opensAt, now),
+        gte(submissionPeriods.closesAt, now),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
 }

--- a/apps/web/e2e/helpers/fixtures.ts
+++ b/apps/web/e2e/helpers/fixtures.ts
@@ -1,0 +1,111 @@
+/**
+ * Custom Playwright test fixtures for E2E tests.
+ *
+ * Provides authenticated page context with seed data lookups and
+ * API key management. Each test gets a fresh API key that is
+ * cleaned up after the test.
+ */
+
+import { test as base, expect } from "@playwright/test";
+import { injectAuth } from "./auth";
+import { getOrgBySlug, getUserByEmail, createApiKey, deleteApiKey } from "./db";
+
+/** All scopes needed for submission flow E2E tests */
+const E2E_SCOPES = [
+  "submissions:read",
+  "submissions:write",
+  "files:read",
+  "files:write",
+  "users:read",
+  "organizations:read",
+];
+
+interface SeedOrg {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+interface SeedUser {
+  id: string;
+  email: string;
+}
+
+interface TestApiKey {
+  id: string;
+  plainKey: string;
+}
+
+type Fixtures = {
+  seedOrg: SeedOrg;
+  seedUser: SeedUser;
+  testApiKey: TestApiKey;
+  authedPage: ReturnType<typeof base.extend> extends infer T ? never : never;
+};
+
+/**
+ * Extended Playwright test with auth fixtures.
+ *
+ * Fixtures:
+ * - `seedOrg` — the "quarterly-review" seed org
+ * - `seedUser` — the "writer@example.com" seed user
+ * - `testApiKey` — a fresh API key for the seed user (cleaned up after test)
+ * - `authedPage` — a Page with auth injected (OIDC + API key interception)
+ */
+export const test = base.extend<{
+  seedOrg: SeedOrg;
+  seedUser: SeedUser;
+  testApiKey: TestApiKey;
+  authedPage: ReturnType<(typeof base)["page"]> extends infer T ? T : never;
+}>({
+  seedOrg: async ({}, use) => {
+    const org = await getOrgBySlug("quarterly-review");
+    if (!org) {
+      throw new Error(
+        'Seed org "quarterly-review" not found. Run `pnpm db:seed` first.',
+      );
+    }
+    await use(org);
+  },
+
+  seedUser: async ({}, use) => {
+    const user = await getUserByEmail("writer@example.com");
+    if (!user) {
+      throw new Error(
+        'Seed user "writer@example.com" not found. Run `pnpm db:seed` first.',
+      );
+    }
+    await use(user);
+  },
+
+  testApiKey: async ({ seedOrg, seedUser }, use) => {
+    const key = await createApiKey({
+      orgId: seedOrg.id,
+      userId: seedUser.id,
+      scopes: E2E_SCOPES,
+      name: `e2e-test-${Date.now()}`,
+    });
+
+    await use(key);
+
+    // Cleanup
+    await deleteApiKey(key.id);
+  },
+
+  authedPage: async ({ page, seedOrg, seedUser, testApiKey }, use) => {
+    await injectAuth({
+      page,
+      orgId: seedOrg.id,
+      apiKey: testApiKey.plainKey,
+      userProfile: {
+        sub: `seed-zitadel-writer-001`,
+        email: seedUser.email,
+        name: "Test Writer",
+      },
+    });
+
+    await use(page);
+  },
+});
+
+export { expect };

--- a/apps/web/e2e/helpers/fixtures.ts
+++ b/apps/web/e2e/helpers/fixtures.ts
@@ -6,7 +6,7 @@
  * cleaned up after the test.
  */
 
-import { test as base, expect } from "@playwright/test";
+import { test as base, expect, type Page } from "@playwright/test";
 import { injectAuth } from "./auth";
 import { getOrgBySlug, getUserByEmail, createApiKey, deleteApiKey } from "./db";
 
@@ -36,13 +36,6 @@ interface TestApiKey {
   plainKey: string;
 }
 
-type Fixtures = {
-  seedOrg: SeedOrg;
-  seedUser: SeedUser;
-  testApiKey: TestApiKey;
-  authedPage: ReturnType<typeof base.extend> extends infer T ? never : never;
-};
-
 /**
  * Extended Playwright test with auth fixtures.
  *
@@ -56,7 +49,7 @@ export const test = base.extend<{
   seedOrg: SeedOrg;
   seedUser: SeedUser;
   testApiKey: TestApiKey;
-  authedPage: ReturnType<(typeof base)["page"]> extends infer T ? T : never;
+  authedPage: Page;
 }>({
   seedOrg: async ({}, use) => {
     const org = await getOrgBySlug("quarterly-review");

--- a/apps/web/e2e/submissions/submission-create.spec.ts
+++ b/apps/web/e2e/submissions/submission-create.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from "../helpers/fixtures";
+import { deleteSubmission } from "../helpers/db";
+
+test.describe("Submission Create (/submissions/new)", () => {
+  const createdIds: string[] = [];
+
+  test.afterEach(async () => {
+    // Clean up any submissions created during tests
+    for (const id of createdIds) {
+      await deleteSubmission(id);
+    }
+    createdIds.length = 0;
+  });
+
+  test("displays form with title, content, and cover letter fields", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto("/submissions/new");
+
+    await expect(
+      authedPage.getByRole("heading", { name: "New Submission" }),
+    ).toBeVisible();
+    await expect(authedPage.getByLabel("Title *")).toBeVisible();
+    await expect(authedPage.getByLabel("Content")).toBeVisible();
+    await expect(authedPage.getByLabel("Cover Letter")).toBeVisible();
+  });
+
+  test("title is required — empty submit shows validation error", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto("/submissions/new");
+
+    // Click Create Draft without filling any fields
+    await authedPage.getByRole("button", { name: "Create Draft" }).click();
+
+    // Should show validation error
+    await expect(authedPage.getByText("Title is required")).toBeVisible();
+  });
+
+  test("creates draft with title only and redirects to detail page", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto("/submissions/new");
+
+    await authedPage.getByLabel("Title *").fill("E2E Test: Title Only Draft");
+    await authedPage.getByRole("button", { name: "Create Draft" }).click();
+
+    // Should redirect to detail page
+    await expect(authedPage).toHaveURL(/\/submissions\/[a-f0-9-]+$/, {
+      timeout: 10_000,
+    });
+
+    // Extract submission ID from URL for cleanup
+    const url = authedPage.url();
+    const id = url.split("/submissions/")[1];
+    if (id) createdIds.push(id);
+
+    // Detail page should show the title
+    await expect(
+      authedPage.getByRole("heading", { name: "E2E Test: Title Only Draft" }),
+    ).toBeVisible();
+  });
+
+  test("creates draft with all fields and redirects to detail page", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto("/submissions/new");
+
+    await authedPage.getByLabel("Title *").fill("E2E Test: Full Draft");
+    await authedPage
+      .getByLabel("Content")
+      .fill("This is the content of the submission.");
+    await authedPage
+      .getByLabel("Cover Letter")
+      .fill("Dear editors, please consider this piece.");
+
+    await authedPage.getByRole("button", { name: "Create Draft" }).click();
+
+    // Should redirect to detail page
+    await expect(authedPage).toHaveURL(/\/submissions\/[a-f0-9-]+$/, {
+      timeout: 10_000,
+    });
+
+    const url = authedPage.url();
+    const id = url.split("/submissions/")[1];
+    if (id) createdIds.push(id);
+
+    await expect(
+      authedPage.getByRole("heading", { name: "E2E Test: Full Draft" }),
+    ).toBeVisible();
+  });
+
+  test("new submission appears in the list", async ({ authedPage }) => {
+    await authedPage.goto("/submissions/new");
+
+    const title = `E2E Test: List Check ${Date.now()}`;
+    await authedPage.getByLabel("Title *").fill(title);
+    await authedPage.getByRole("button", { name: "Create Draft" }).click();
+
+    // Wait for redirect to detail page
+    await expect(authedPage).toHaveURL(/\/submissions\/[a-f0-9-]+$/, {
+      timeout: 10_000,
+    });
+
+    const url = authedPage.url();
+    const id = url.split("/submissions/")[1];
+    if (id) createdIds.push(id);
+
+    // Navigate to list and verify the new submission appears
+    await authedPage.goto("/submissions");
+    await expect(authedPage.getByText(title)).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/apps/web/e2e/submissions/submission-detail.spec.ts
+++ b/apps/web/e2e/submissions/submission-detail.spec.ts
@@ -1,0 +1,234 @@
+import { test, expect } from "../helpers/fixtures";
+import {
+  createSubmission,
+  deleteSubmission,
+  getOpenSubmissionPeriod,
+} from "../helpers/db";
+
+test.describe("Submission Detail & Edit", () => {
+  let draftId: string;
+  let submitTestId: string;
+  let deleteTestId: string;
+
+  test.beforeAll(async () => {
+    // We need seed org/user IDs — look them up directly
+    const { getOrgBySlug, getUserByEmail } = await import("../helpers/db");
+    const org = await getOrgBySlug("quarterly-review");
+    const user = await getUserByEmail("writer@example.com");
+    if (!org || !user) throw new Error("Seed data not found");
+
+    const period = await getOpenSubmissionPeriod(org.id);
+
+    // Create test submissions for this describe block
+    const draft = await createSubmission({
+      orgId: org.id,
+      submitterId: user.id,
+      submissionPeriodId: period?.id,
+      title: "E2E Detail: View Test",
+      content: "Content for the detail view test.",
+      coverLetter: "Cover letter for editors.",
+    });
+    draftId = draft.id;
+
+    const submitTest = await createSubmission({
+      orgId: org.id,
+      submitterId: user.id,
+      submissionPeriodId: period?.id,
+      title: "E2E Detail: Submit Flow",
+      content: "Content for the submit flow test.",
+    });
+    submitTestId = submitTest.id;
+
+    const deleteTest = await createSubmission({
+      orgId: org.id,
+      submitterId: user.id,
+      submissionPeriodId: period?.id,
+      title: "E2E Detail: Delete Test",
+    });
+    deleteTestId = deleteTest.id;
+  });
+
+  test.afterAll(async () => {
+    // Clean up — ignore errors if already deleted by tests
+    await deleteSubmission(draftId).catch(() => {});
+    await deleteSubmission(submitTestId).catch(() => {});
+    await deleteSubmission(deleteTestId).catch(() => {});
+  });
+
+  test("displays submission title and DRAFT status badge", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto(`/submissions/${draftId}`);
+
+    await expect(
+      authedPage.getByRole("heading", { name: "E2E Detail: View Test" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Status badge should show DRAFT
+    await expect(authedPage.getByText("DRAFT")).toBeVisible();
+  });
+
+  test("shows Edit and Delete buttons for DRAFT submission", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto(`/submissions/${draftId}`);
+
+    await expect(
+      authedPage.getByRole("heading", { name: "E2E Detail: View Test" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    await expect(authedPage.getByRole("link", { name: /Edit/ })).toBeVisible();
+    await expect(
+      authedPage.getByRole("button", { name: /Delete/ }),
+    ).toBeVisible();
+  });
+
+  test("edit page loads with pre-filled form fields", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto(`/submissions/${draftId}/edit`);
+
+    // Wait for form to load with existing data
+    await expect(authedPage.getByLabel("Title *")).toHaveValue(
+      "E2E Detail: View Test",
+      { timeout: 10_000 },
+    );
+    await expect(authedPage.getByLabel("Content")).toHaveValue(
+      "Content for the detail view test.",
+    );
+    await expect(authedPage.getByLabel("Cover Letter")).toHaveValue(
+      "Cover letter for editors.",
+    );
+  });
+
+  test("save draft changes updates the title", async ({ authedPage }) => {
+    await authedPage.goto(`/submissions/${draftId}/edit`);
+
+    // Wait for form to load
+    await expect(authedPage.getByLabel("Title *")).toHaveValue(
+      "E2E Detail: View Test",
+      { timeout: 10_000 },
+    );
+
+    // Update the title
+    await authedPage.getByLabel("Title *").clear();
+    await authedPage
+      .getByLabel("Title *")
+      .fill("E2E Detail: View Test (Updated)");
+    await authedPage.getByRole("button", { name: "Save Draft" }).click();
+
+    // Should show success toast
+    await expect(authedPage.getByText("Submission saved")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Navigate to detail page and verify updated title
+    await authedPage.goto(`/submissions/${draftId}`);
+    await expect(
+      authedPage.getByRole("heading", {
+        name: "E2E Detail: View Test (Updated)",
+      }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("Submit for Review transitions DRAFT to SUBMITTED", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto(`/submissions/${submitTestId}/edit`);
+
+    // Wait for form to load
+    await expect(authedPage.getByLabel("Title *")).toHaveValue(
+      "E2E Detail: Submit Flow",
+      { timeout: 10_000 },
+    );
+
+    // Click Submit for Review
+    await authedPage.getByRole("button", { name: "Submit for Review" }).click();
+
+    // Should redirect to detail page
+    await expect(authedPage).toHaveURL(
+      new RegExp(`/submissions/${submitTestId}$`),
+      { timeout: 10_000 },
+    );
+
+    // Status should now be SUBMITTED
+    await expect(authedPage.getByText("SUBMITTED")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("SUBMITTED submission shows Withdraw button, no Edit button", async ({
+    authedPage,
+  }) => {
+    // submitTestId was submitted in the previous test
+    await authedPage.goto(`/submissions/${submitTestId}`);
+
+    await expect(
+      authedPage.getByRole("heading", { name: "E2E Detail: Submit Flow" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Withdraw should be visible, Edit should not
+    await expect(
+      authedPage.getByRole("button", { name: "Withdraw" }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("link", { name: /Edit/ }),
+    ).not.toBeVisible();
+  });
+
+  test("withdraw dialog changes status to WITHDRAWN", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto(`/submissions/${submitTestId}`);
+
+    await expect(
+      authedPage.getByRole("heading", { name: "E2E Detail: Submit Flow" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Click Withdraw
+    await authedPage.getByRole("button", { name: "Withdraw" }).click();
+
+    // Confirmation dialog should appear
+    await expect(authedPage.getByText("Withdraw submission?")).toBeVisible();
+
+    // Confirm withdrawal
+    await authedPage.getByRole("button", { name: "Withdraw" }).last().click();
+
+    // Should show success toast
+    await expect(authedPage.getByText("Submission withdrawn")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Status should now be WITHDRAWN
+    await expect(authedPage.getByText("WITHDRAWN")).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("delete confirmation dialog deletes the submission", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto(`/submissions/${deleteTestId}`);
+
+    await expect(
+      authedPage.getByRole("heading", { name: "E2E Detail: Delete Test" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Click Delete
+    await authedPage.getByRole("button", { name: /Delete/ }).click();
+
+    // Confirmation dialog should appear
+    await expect(authedPage.getByText("Delete submission?")).toBeVisible();
+
+    // Confirm deletion
+    await authedPage
+      .getByRole("button", { name: /Delete/ })
+      .last()
+      .click();
+
+    // Should redirect to submissions list
+    await expect(authedPage).toHaveURL(/\/submissions$/, {
+      timeout: 10_000,
+    });
+  });
+});

--- a/apps/web/e2e/submissions/submission-list.spec.ts
+++ b/apps/web/e2e/submissions/submission-list.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from "../helpers/fixtures";
+
+test.describe("Submission List (/submissions)", () => {
+  test("displays My Submissions heading", async ({ authedPage }) => {
+    await authedPage.goto("/submissions");
+    await expect(
+      authedPage.getByRole("heading", { name: "My Submissions" }),
+    ).toBeVisible();
+  });
+
+  test("shows New Submission button", async ({ authedPage }) => {
+    await authedPage.goto("/submissions");
+    await expect(
+      authedPage.getByRole("link", { name: /New Submission/ }),
+    ).toBeVisible();
+  });
+
+  test("renders status filter tabs", async ({ authedPage }) => {
+    await authedPage.goto("/submissions");
+    await expect(authedPage.getByRole("tab", { name: "All" })).toBeVisible();
+    await expect(authedPage.getByRole("tab", { name: "Drafts" })).toBeVisible();
+    await expect(
+      authedPage.getByRole("tab", { name: "Submitted" }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("tab", { name: "Under Review" }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("tab", { name: "Accepted" }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("tab", { name: "Rejected" }),
+    ).toBeVisible();
+  });
+
+  test("shows seed submissions in the list", async ({ authedPage }) => {
+    await authedPage.goto("/submissions");
+
+    // Wait for submissions to load (skeleton disappears)
+    await expect(
+      authedPage.getByText("The Weight of Small Things"),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Verify other seed submissions are visible
+    await expect(authedPage.getByText("Cartography of Absence")).toBeVisible();
+    await expect(
+      authedPage.getByText("Field Notes on Disappearing"),
+    ).toBeVisible();
+  });
+
+  test("New Submission button navigates to /submissions/new", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto("/submissions");
+    await authedPage.getByRole("link", { name: /New Submission/ }).click();
+    await expect(authedPage).toHaveURL(/\/submissions\/new/);
+  });
+
+  test("filter by Submitted tab shows only submitted items", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto("/submissions");
+
+    // Wait for list to load
+    await expect(
+      authedPage.getByText("The Weight of Small Things"),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Click Submitted tab
+    await authedPage.getByRole("tab", { name: "Submitted" }).click();
+
+    // "The Weight of Small Things" is SUBMITTED — should be visible
+    await expect(
+      authedPage.getByText("The Weight of Small Things"),
+    ).toBeVisible();
+
+    // UNDER_REVIEW and ACCEPTED should not be visible
+    await expect(
+      authedPage.getByText("Cartography of Absence"),
+    ).not.toBeVisible();
+    await expect(
+      authedPage.getByText("Field Notes on Disappearing"),
+    ).not.toBeVisible();
+  });
+
+  test("filter by Rejected tab shows empty state", async ({ authedPage }) => {
+    await authedPage.goto("/submissions");
+
+    // Wait for list to load first
+    await expect(
+      authedPage.getByText("The Weight of Small Things"),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Click Rejected tab
+    await authedPage.getByRole("tab", { name: "Rejected" }).click();
+
+    // Should show empty state message
+    await expect(authedPage.getByText("No submissions")).toBeVisible();
+  });
+});

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -26,6 +26,14 @@ const eslintConfig = [
       "no-restricted-imports": "off",
     },
   },
+  {
+    files: ["e2e/**/*.ts"],
+    rules: {
+      // Playwright fixture `use()` callback triggers false positives
+      "react-hooks/rules-of-hooks": "off",
+      "no-restricted-imports": "off",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -4,10 +4,14 @@ import { defineConfig, devices } from "@playwright/test";
  * Playwright configuration for browser E2E tests.
  *
  * Prerequisites:
- * - docker-compose up (PostgreSQL, Redis)
- * - pnpm db:generate && pnpm db:push
+ * - docker-compose up (PostgreSQL)
+ * - pnpm db:migrate && pnpm db:seed
  *
  * The webServer config starts both the API and Web dev servers automatically.
+ *
+ * Auth strategy: Fake OIDC user injected into localStorage (satisfies frontend
+ * auth checks), tRPC requests intercepted to swap Bearer token for API key
+ * (satisfies API auth). No Zitadel instance required.
  */
 export default defineConfig({
   testDir: "./e2e",
@@ -17,6 +21,9 @@ export default defineConfig({
   workers: 1, // Single worker to avoid DB conflicts
   reporter: process.env.CI ? "github" : "html",
   timeout: 30_000,
+
+  globalSetup: "./e2e/global-setup.ts",
+  globalTeardown: "./e2e/global-teardown.ts",
 
   use: {
     baseURL: "http://localhost:3000",
@@ -35,10 +42,13 @@ export default defineConfig({
   webServer: [
     {
       command: "pnpm --filter @colophony/api dev",
-      url: "http://localhost:4000/trpc/auth.me",
+      url: "http://localhost:4000/health",
       reuseExistingServer: !process.env.CI,
       timeout: 60_000,
       cwd: "../..",
+      env: {
+        VIRUS_SCAN_ENABLED: "false",
+      },
     },
     {
       command: "pnpm --filter @colophony/web dev",
@@ -46,6 +56,10 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
       timeout: 60_000,
       cwd: "../..",
+      env: {
+        NEXT_PUBLIC_ZITADEL_AUTHORITY: "http://test-idp:8080",
+        NEXT_PUBLIC_ZITADEL_CLIENT_ID: "test-client",
+      },
     },
   ],
 });

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -53,7 +53,10 @@ export default defineConfig({
     {
       command: "pnpm --filter @colophony/web dev",
       url: "http://localhost:3000",
-      reuseExistingServer: !process.env.CI,
+      // Always start fresh — reusing a server started without the test OIDC
+      // env vars causes an auth storage key mismatch (injectAuth writes to a
+      // key derived from NEXT_PUBLIC_ZITADEL_AUTHORITY/CLIENT_ID).
+      reuseExistingServer: false,
       timeout: 60_000,
       cwd: "../..",
       env: {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -37,7 +37,7 @@
 ### QA / Testing
 
 - [ ] Manual testing of 4 submission pages with dev server — (DEVLOG 2026-02-15)
-- [ ] E2E tests for submission flow — (DEVLOG 2026-02-15)
+- [x] E2E tests for submission flow — (DEVLOG 2026-02-15; done 2026-02-18 PR pending)
 - [ ] E2E tests for upload flow — needs tusd + MinIO in CI — (DEVLOG 2026-02-15)
 - [ ] E2E tests for OIDC flow — requires Zitadel instance — (DEVLOG 2026-02-13)
 - [ ] Manual QA of full org management flow with Zitadel + dev services running — (DEVLOG 2026-02-13)
@@ -47,6 +47,7 @@
 
 - [x] Clean up v1 components (`_v1/` directory) — (DEVLOG 2026-02-15; done 2026-02-17)
 - [ ] Consider Playwright tsconfig extending web for E2E type-checking — nice-to-have — (DEVLOG 2026-02-15)
+- [ ] Rewrite `docs/testing.md` for v2 — still references v1 patterns (Prisma, NestJS, old test counts/tiers); Playwright section updated but rest is stale — (DEVLOG 2026-02-18)
 - [x] Migrate `forwardRef` → ref-as-prop in 19 shadcn/ui components — React 19 deprecation — (DEVLOG 2026-02-16; done 2026-02-17)
 - [x] Migrate `Context.Provider` → `Context` — React 19 deprecation — (DEVLOG 2026-02-16; done 2026-02-17)
 - [x] Refactor OIDC guard `setState` in effects to satisfy `react-hooks/set-state-in-effect` — `callback/page.tsx` — (DEVLOG 2026-02-16; done 2026-02-17)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,26 @@ Newest entries first.
 
 ---
 
+## 2026-02-18 — Playwright E2E Tests for Submission Flow
+
+### Done
+
+- Implemented Playwright browser E2E tests for the 4 submission pages (`/submissions`, `/submissions/new`, `/submissions/[id]`, `/submissions/[id]/edit`) — 20 tests across 3 spec files
+- Auth strategy: fake OIDC user injected into localStorage via `addInitScript()` + `page.route()` interception swapping Bearer token for API key on tRPC requests — no Zitadel instance needed
+- Created `e2e/helpers/auth.ts` (OIDC + API key injection), `e2e/helpers/fixtures.ts` (custom Playwright `test` with `seedOrg`, `seedUser`, `testApiKey`, `authedPage` fixtures), `e2e/helpers/db.ts` extensions (7 new helpers: `getOrgBySlug`, `createUser`, `createApiKey`, `deleteApiKey`, `createSubmission`, `deleteSubmission`, `getOpenSubmissionPeriod`)
+- Created `e2e/global-setup.ts` (validates seed data exists) and `e2e/global-teardown.ts` (disconnects DB pool)
+- Updated `playwright.config.ts`: `globalSetup`/`globalTeardown`, fake OIDC env vars on web webServer, `VIRUS_SCAN_ENABLED=false` on API webServer, health check URL changed from `/trpc/auth.me` to `/health`
+- Codex branch review: 1 finding (P2) — `reuseExistingServer` on web webServer can cause OIDC storage key mismatch when local dev server is already running with different env vars. Fixed: set `reuseExistingServer: false` for web server.
+- All 489 unit tests pass, type-check clean
+
+### Decisions
+
+- API key auth + OIDC state injection approach avoids Zitadel dependency for E2E while exercising the real API key auth path (no API code changes)
+- Always start fresh web server for E2E (`reuseExistingServer: false`) to prevent OIDC storage key mismatch
+- Seed data used for read-only tests; mutation tests create fresh data via DB helpers and clean up after
+
+---
+
 ## 2026-02-18 — Seed Data Script
 
 ### Done

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,7 +49,7 @@ pnpm --filter @colophony/web test:e2e:ui
 | Web unit tests         | 117   | 13     | `apps/web/src/**/__tests__/`             |
 | RLS integration tests  | 70    | 6      | `apps/api/src/__tests__/rls/`            |
 | API E2E tests          | 65    | 5      | `apps/api/test/e2e/` + `app.e2e-spec.ts` |
-| Playwright browser E2E | 19    | 3      | `apps/web/e2e/`                          |
+| Playwright browser E2E | 20    | 3      | `apps/web/e2e/`                          |
 
 **Unit test breakdown (API):**
 
@@ -75,9 +75,9 @@ pnpm --filter @colophony/web test:e2e:ui
 
 **Playwright E2E test breakdown:**
 
-- `auth.spec.ts` — 7 tests (login, register, verify, protected routes, logout)
-- `submissions.spec.ts` — 7 tests (create, edit, list, filter, submit, non-draft alert)
-- `editor.spec.ts` — 5 tests (dashboard, filters, review, status change, pagination)
+- `submissions/submission-list.spec.ts` — 7 tests (heading, new button, status tabs, seed data, navigation, submitted filter, rejected empty state)
+- `submissions/submission-create.spec.ts` — 5 tests (form fields, validation, title-only draft, full draft, appears in list)
+- `submissions/submission-detail.spec.ts` — 8 tests (detail view, edit/delete buttons, pre-filled edit, save changes, submit flow, withdraw flow, delete confirmation)
 
 ---
 
@@ -154,21 +154,24 @@ E2E tests use the superuser (`test:test`) for the Prisma singleton because `crea
 
 **Architecture:**
 
-- Test data setup uses superuser `PrismaClient` (`e2e/helpers/db.ts`) for direct DB operations
-- User registration uses tRPC API calls (`e2e/helpers/api-client.ts`) to avoid password hashing in test code
-- `loginAsBrowser()` sets tokens directly in localStorage (fast) — only login form test uses `loginViaForm()`
-- API helper retries on 429 with backoff (reads `retryAfter` from response body)
-- Strict selectors: `getByRole('heading', ...)`, `{ exact: true }`, `main` scoping
+- **Auth strategy:** Fake OIDC user injected into `localStorage` via `addInitScript()` (satisfies `ProtectedRoute`/`useAuth` checks), then `page.route()` intercepts tRPC requests to swap the fake Bearer token for a real API key header (`X-Api-Key`). This exercises the real API key auth path — no Zitadel instance needed.
+- **Fixtures** (`e2e/helpers/fixtures.ts`): Custom Playwright `test` provides `seedOrg`, `seedUser`, `testApiKey` (created per test, cleaned up after), and `authedPage` (page with auth injected).
+- **DB helpers** (`e2e/helpers/db.ts`): Superuser Drizzle pool for direct DB operations — org/user lookups, API key/submission CRUD for test setup/teardown.
+- **Global setup** (`e2e/global-setup.ts`): Validates seed data exists before any tests run. Requires `pnpm db:seed`.
+- **Seed data:** Read-only tests use seed data directly; mutation tests create fresh data via DB helpers and clean up after.
+- Strict selectors: `getByRole('heading', ...)`, `getByLabel()`, `getByRole('button', ...)`, `getByRole('tab', ...)`
 
 **Running:**
 
 ```bash
 npx playwright install                    # First time (downloads Chromium)
-pnpm --filter @colophony/web test:e2e    # Requires docker-compose up + dev servers
+docker-compose up -d                      # PostgreSQL required
+pnpm db:seed                              # Seed data required
+pnpm --filter @colophony/web test:e2e    # Auto-starts API + Web dev servers
 pnpm --filter @colophony/web test:e2e:ui # Interactive UI mode
 ```
 
-The `playwright.config.ts` `webServer` config can auto-start API and Web dev servers, or reuse already-running ones (`reuseExistingServer: true` in dev).
+The `playwright.config.ts` `webServer` config auto-starts API (reuses existing) and Web (always fresh — test OIDC env vars must match `injectAuth` storage key) dev servers. No Zitadel, MinIO, or Redis required (`VIRUS_SCAN_ENABLED=false` in API webServer env).
 
 ### RLS Integration Tests
 


### PR DESCRIPTION
## Summary

- Add 20 Playwright browser E2E tests covering the 4 submission pages (`/submissions`, `/submissions/new`, `/submissions/[id]`, `/submissions/[id]/edit`)
- Auth strategy: fake OIDC user in localStorage + route interception swapping Bearer token for API key — no Zitadel dependency
- Custom fixtures (`seedOrg`, `seedUser`, `testApiKey`, `authedPage`), DB helpers, global setup/teardown
- ESLint config updated to disable `react-hooks/rules-of-hooks` for e2e files (Playwright `use()` callback false positive)

## Test plan

- [ ] `pnpm test` — unit tests pass (489/489)
- [ ] `pnpm type-check` — type-check clean
- [ ] `pnpm lint` — lint clean (only pre-existing warning)
- [ ] `pnpm --filter @colophony/web test:e2e` — all 20 Playwright tests pass (requires `docker-compose up` + `pnpm db:seed`)

## Code review

- branch review: 1 finding (P2) addressed — `reuseExistingServer` on web webServer set to `false` to prevent OIDC storage key mismatch