### PR TITLE
chore(docs): rewrite testing.md for v2 stack

### DIFF
--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -86,6 +86,38 @@
       {
         "event": "Bash(git commit*)",
         "script": ".claude/hooks/post-commit-devlog.js"
+      },
+      {
+        "event": "Edit(**/*.spec.ts)",
+        "script": ".claude/hooks/post-test-file.js"
+      },
+      {
+        "event": "Write(**/*.spec.ts)",
+        "script": ".claude/hooks/post-test-file.js"
+      },
+      {
+        "event": "Edit(**/*.spec.tsx)",
+        "script": ".claude/hooks/post-test-file.js"
+      },
+      {
+        "event": "Write(**/*.spec.tsx)",
+        "script": ".claude/hooks/post-test-file.js"
+      },
+      {
+        "event": "Edit(**/*.test.ts)",
+        "script": ".claude/hooks/post-test-file.js"
+      },
+      {
+        "event": "Write(**/*.test.ts)",
+        "script": ".claude/hooks/post-test-file.js"
+      },
+      {
+        "event": "Edit(**/e2e/**/*.ts)",
+        "script": ".claude/hooks/post-test-file.js"
+      },
+      {
+        "event": "Write(**/e2e/**/*.ts)",
+        "script": ".claude/hooks/post-test-file.js"
       }
     ]
   }

--- a/.claude/hooks/post-test-file.js
+++ b/.claude/hooks/post-test-file.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+/**
+ * Post-edit hook for test files.
+ * Reminds to update docs/testing.md if test counts, tiers, or running instructions changed.
+ */
+
+console.log('⚠️ Test file modified. If test counts, tiers, or running instructions changed, update docs/testing.md');

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -47,7 +47,7 @@
 
 - [x] Clean up v1 components (`_v1/` directory) — (DEVLOG 2026-02-15; done 2026-02-17)
 - [ ] Consider Playwright tsconfig extending web for E2E type-checking — nice-to-have — (DEVLOG 2026-02-15)
-- [ ] Rewrite `docs/testing.md` for v2 — still references v1 patterns (Prisma, NestJS, old test counts/tiers); Playwright section updated but rest is stale — (DEVLOG 2026-02-18)
+- [x] Rewrite `docs/testing.md` for v2 — still references v1 patterns (Prisma, NestJS, old test counts/tiers); Playwright section updated but rest is stale — (DEVLOG 2026-02-18; done 2026-02-18)
 - [x] Migrate `forwardRef` → ref-as-prop in 19 shadcn/ui components — React 19 deprecation — (DEVLOG 2026-02-16; done 2026-02-17)
 - [x] Migrate `Context.Provider` → `Context` — React 19 deprecation — (DEVLOG 2026-02-16; done 2026-02-17)
 - [x] Refactor OIDC guard `setState` in effects to satisfy `react-hooks/set-state-in-effect` — `callback/page.tsx` — (DEVLOG 2026-02-16; done 2026-02-17)
@@ -64,6 +64,7 @@
 - [x] oRPC REST API surface — PR 3: typed client package — (DEVLOG 2026-02-18; done 2026-02-18)
 - [x] API key scope enforcement on REST + tRPC endpoints — (DEVLOG 2026-02-18, done 2026-02-18)
 - [ ] API key scope enforcement on GraphQL surface — when Pothos/GraphQL Yoga is built — (DEVLOG 2026-02-18)
+- [ ] Stripe webhook: audit raw payload storage for PCI compliance — `stripe.webhook.ts` stores raw event payload in `stripe_webhook_events`; verify no card data leaks through Checkout Session objects — (Codex review 2026-02-18)
 - [x] tRPC `.output()` runtime response validation — all 30 procedures wired with Zod output schemas; 9 new response schemas added — (input validation audit 2026-02-18; done 2026-02-18)
 - [ ] Pothos + GraphQL Yoga surface — decision point at Month 3: Pothos vs TypeGraphQL — (architecture doc Track 2, Section 6.6)
 - [ ] SDK generation (TypeScript, Python) — (architecture doc Track 2)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-18 — Testing Documentation Rewrite for v2
+
+### Done
+
+- Full rewrite of `docs/testing.md` — removed all v1 patterns (Prisma, NestJS, Express, supertest, API E2E tier)
+- Updated to 5 tiers, ~660 tests: API unit (36 files/~478), package unit (4/~38), web unit (4/~35), RLS integration (8/~89), Playwright E2E (3/20)
+- Rewrote Test Architecture section: Fastify `app.inject()` + `vi.mock()` pattern, Jest for web unit only, dual-pool Drizzle RLS pattern, Playwright auth strategy
+- Updated Critical Test Cases with real code examples from `rls-direct-isolation.test.ts` and `stripe.webhook.spec.ts`
+- Replaced 5 v1 quirks with 8 v2 quirks (Jest/Vitest split, `pnpm test` scope, manual `globalSetup()`, Drizzle migrate workaround, Playwright env, dedicated E2E ports, Turborepo build deps, `singleFork: true`)
+- Removed v1 historical sections: "E2E False-Positive Audit", "Production Bugs Found During Testing"
+- Added `.claude/hooks/post-test-file.js` staleness prevention hook — fires on `*.spec.ts`, `*.spec.tsx`, `*.test.ts`, `e2e/**/*.ts` edits, reminds to update `docs/testing.md`
+- Registered hook in `.claude/hooks/hooks.json` (8 new PostToolUse entries)
+- Added Stripe raw payload PCI compliance concern to backlog (Codex review finding, out of scope for testing.md)
+- Codex plan review: 4 findings — tier count inconsistency (fixed), web test count (fixed), run tests for counts (adopted), Stripe PCI concern (tracked in backlog)
+
+### Decisions
+
+- Test counts use `~` prefix since they shift frequently — doc encourages `pnpm test` for exact numbers
+- Kept Playwright section mostly intact (recently written, already v2-accurate)
+- Inline single-field Zod schemas (`{ id: uuid }`) intentionally kept inline — discussed with David, no backlog item needed
+
+---
+
 ## 2026-02-18 — Playwright E2E Tests for Submission Flow
 
 ### Done

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,14 +1,14 @@
 # Testing Guide
 
 Comprehensive testing reference for the Colophony platform.
-For architecture details, see [docs/architecture.md](./architecture.md).
+For architecture details, see [docs/architecture-v2-planning.md](./architecture-v2-planning.md).
 
 ---
 
 ## Running Tests
 
 ```bash
-# Unit tests (308 tests: 191 API + 117 Web, 26 suites)
+# Unit tests — API + packages (~516 tests, 40 suites)
 pnpm test
 
 # Watch mode
@@ -17,61 +17,62 @@ pnpm test:watch
 # Coverage report
 pnpm test:cov
 
-# RLS integration tests (70 tests, requires postgres-test container)
+# Web unit tests — Jest (35 tests, 4 suites)
+pnpm --filter @colophony/web test
+
+# RLS integration tests (~89 tests, requires postgres-test container)
 pnpm --filter @colophony/api test:rls
 
-# API E2E tests (65 tests, requires docker-compose up)
-pnpm test:e2e
-
-# Playwright browser E2E tests (19 tests, requires dev servers)
+# Playwright browser E2E tests (20 tests, requires dev servers)
 pnpm --filter @colophony/web test:e2e
 
 # Playwright interactive UI mode
 pnpm --filter @colophony/web test:e2e:ui
 ```
 
-**Prerequisites for E2E tests:**
+**Prerequisites:**
 
-- PostgreSQL test DB: `docker-compose up postgres-test`
-- Redis: `docker-compose up redis`
+- PostgreSQL test DB: `docker compose up -d postgres-test` (RLS tests)
 - For Playwright: `npx playwright install` (first time only, downloads Chromium)
-- For Playwright: dev servers running (`pnpm dev`) or auto-started by `playwright.config.ts`
+- For Playwright: `pnpm db:seed` (seed data required for read-only tests)
+- Dev servers auto-started by `playwright.config.ts` — or run `pnpm dev` manually
 
 ---
 
 ## Current Test Status
 
-**462 tests passing** across 5 tiers:
+**~660 tests passing** across 5 tiers:
 
-| Tier                   | Count | Suites | Location                                 |
-| ---------------------- | ----- | ------ | ---------------------------------------- |
-| API unit tests         | 191   | 13     | `apps/api/test/unit/`                    |
-| Web unit tests         | 117   | 13     | `apps/web/src/**/__tests__/`             |
-| RLS integration tests  | 70    | 6      | `apps/api/src/__tests__/rls/`            |
-| API E2E tests          | 65    | 5      | `apps/api/test/e2e/` + `app.e2e-spec.ts` |
-| Playwright browser E2E | 20    | 3      | `apps/web/e2e/`                          |
+| Tier                   | Files | Tests | Runner          | Location                      |
+| ---------------------- | ----- | ----- | --------------- | ----------------------------- |
+| API unit tests         | 36    | ~478  | Vitest          | `apps/api/src/**/*.spec.ts`   |
+| Package unit tests     | 4     | ~38   | Vitest          | `packages/*/src/**/*.spec.ts` |
+| Web unit tests         | 4     | ~35   | Jest + jsdom    | `apps/web/src/**/*.spec.*`    |
+| RLS integration tests  | 8     | ~89   | Vitest (custom) | `apps/api/src/__tests__/rls/` |
+| Playwright browser E2E | 3     | 20    | Playwright      | `apps/web/e2e/`               |
 
-**Unit test breakdown (API):**
+> Counts use `~` prefix because they shift as tests are added. Run `pnpm test` to get exact numbers.
 
-- `audit.service.spec.ts` — 13 tests
-- `gdpr.service.spec.ts` — 17 tests
-- `retention.service.spec.ts` — 14 tests
-- `outbox.service.spec.ts` — 14 tests
-- `virus-scan.service.spec.ts`
-- `email.service.spec.ts`
-- `payments.service.spec.ts`
-- `auth.service.spec.ts`
-- `submission-workflow.spec.ts`
-- `file-utils.spec.ts`
-- `rate-limit.service.spec.ts`
+**API unit test coverage areas:**
 
-**API E2E test breakdown:**
+- Config: `env.spec.ts`
+- Hooks: `auth`, `audit`, `db-context`, `org-context`, `rate-limit` (2 files)
+- Server: `main.spec.ts`
+- Queues: `file-scan.queue.spec.ts`
+- REST: `error-mapper`, `require-scopes`, 6 routers
+- Services: 7 service specs
+- tRPC: `error-mapper`, 6 router specs
+- Webhooks: `stripe`, `tusd`, `zitadel`
+- Workers: `file-scan.worker.spec.ts`
 
-- `auth.e2e-spec.ts` — 15 tests (register, login, refresh, logout, me)
-- `submissions.e2e-spec.ts` — 28 tests (CRUD, status transitions, cross-org isolation)
-- `gdpr.e2e-spec.ts` — 15 tests (consent, DSAR, export, deletion)
-- `payments.e2e-spec.ts` — 6 tests (Stripe not configured, auth checks)
-- `app.e2e-spec.ts` — 1 test (health check)
+**Package unit tests:**
+
+- `@colophony/auth-client`: `jwks.spec.ts`, `types.spec.ts`, `webhook-signature.spec.ts`
+- `@colophony/api-client`: `client.spec.ts`
+
+**Web unit tests:**
+
+- `use-file-upload.spec.ts`, `use-organization.spec.tsx`, `trpc.spec.ts`, `utils.spec.ts`
 
 **Playwright E2E test breakdown:**
 
@@ -94,59 +95,122 @@ pnpm --filter @colophony/web test:e2e:ui
 
 ## Test Architecture
 
-### Unit Tests
+### API Unit Tests
 
-**API unit tests** (`apps/api/test/unit/`):
+**Location:** `apps/api/src/**/*.spec.ts` (co-located with source)
 
-- Mock all external dependencies (Prisma, Redis, BullMQ, Stripe, email)
-- Test business logic in isolation
-- Uses Jest with NestJS `@nestjs/testing` for DI
+**Config:** `apps/api/vitest.config.ts` — `globals: false` (explicit imports required), excludes `src/__tests__/rls/`.
 
-**Web unit tests** (`apps/web/src/**/__tests__/`):
+**Pattern:** Fastify instances + `vi.mock()` for all external dependencies (Drizzle DB, Redis, BullMQ, Stripe, email). Tests use `app.inject()` (Fastify's built-in test helper) — no supertest.
 
-- Co-located with source files
-- Uses Jest + React Testing Library + `@testing-library/react-hooks`
-- Mock tRPC client and browser APIs (localStorage)
-- Test components, hooks, and utility functions
+```typescript
+// Representative pattern from auth.spec.ts
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import authPlugin from "./auth.js";
 
-### API E2E Tests
+// Mock external deps with vi.mock
+vi.mock("@colophony/db", () => ({
+  db: { query: { users: { findFirst: vi.fn() } } },
+  eq: vi.fn((_col: unknown, val: unknown) => val),
+  users: { zitadelUserId: "zitadel_user_id" },
+  pool: { query: vi.fn().mockResolvedValue({ rows: [{ "?column?": 1 }] }) },
+}));
 
-**Test app module** (`test/e2e-app.module.ts`):
+describe("auth plugin", () => {
+  let app: FastifyInstance;
 
-- Mirrors `AppModule` but excludes `JobsModule` (BullMQ)
-- A `MockJobsModule` provides a no-op `VirusScanService` globally
-- All real modules (auth, storage, GDPR, audit, etc.) are loaded
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(authPlugin, {
+      env: {
+        /* test env */
+      },
+    });
+    app.get("/protected", async (request) => ({
+      authContext: request.authContext,
+    }));
+  });
 
-**Superuser DB connection rationale:**
-E2E tests use the superuser (`test:test`) for the Prisma singleton because `createContext()` needs to query `organization_members` but RLS requires `current_org` to be set first (chicken-and-egg). RLS isolation is verified separately in unit/integration tests using the dual-client pattern.
+  afterAll(async () => {
+    await app.close();
+  });
 
-**CI environment variables:**
+  it("returns 401 when no auth header", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/protected",
+    });
+    expect(response.statusCode).toBe(401);
+  });
+});
+```
 
-| Variable            | Purpose                                                  | CI Value                                                           |
-| ------------------- | -------------------------------------------------------- | ------------------------------------------------------------------ |
-| `DATABASE_TEST_URL` | Superuser connection (test setup, main Prisma singleton) | `postgresql://test:test@localhost:5433/colophony_test`             |
-| `DATABASE_APP_URL`  | Non-superuser connection (RLS E2E test)                  | `postgresql://app_user:app_password@localhost:5433/colophony_test` |
-| `REDIS_URL`         | Redis for BullMQ, sessions, rate limits                  | `redis://localhost:6379`                                           |
+Key differences from v1: no NestJS `@nestjs/testing` or DI — Fastify plugins are registered directly. No supertest — `app.inject()` is built in. Explicit Vitest imports (no `globals: true`).
 
-**Important:** `DATABASE_APP_URL` must be separate from `DATABASE_TEST_URL`. The RLS E2E test (`getAppPrisma()`) uses `DATABASE_APP_URL` to connect as `app_user` (non-superuser). If it falls back to `DATABASE_TEST_URL`, both clients are superuser and RLS is silently bypassed.
+### Web Unit Tests
 
-**Execution model:**
+**Location:** `apps/web/src/**/*.spec.ts` / `.spec.tsx` (co-located with source)
 
-- Sequential: `--runInBand` required — suites share PostgreSQL and Redis
-- `--forceExit` required — Redis/Prisma connections persist after tests
-- Database + Redis cleaned between each test via `cleanDatabase()` (DB truncate + `FLUSHDB`)
-- Rate limits disabled: `RATE_LIMIT_DEFAULT_MAX=10000` and `RATE_LIMIT_AUTH_MAX=10000` in `e2e-setup.ts`
+**Config:** `apps/web/jest.config.ts` — Jest + ts-jest + jsdom. Not yet migrated to Vitest.
 
-**Test helpers** (`test/e2e-helpers.ts`):
+**Pattern:**
 
-- `createTestApp()` — bootstraps NestJS app from `E2eAppModule`
-- `registerUser()` — registers + auto-verifies email
-- `trpcMutation()` / `trpcQuery()` — typed HTTP calls to tRPC
-- `cleanDatabase()` — truncates all tables + flushes Redis
+- Mocks `next/navigation` (`useRouter`, `useSearchParams`, `usePathname`)
+- Mocks tRPC client via `@/lib/trpc` module mock
+- Mocks `@colophony/types` schema exports
+- Uses React Testing Library (`@testing-library/react`)
+- `moduleNameMapper` resolves `@/*` path aliases and cross-package imports
 
-**Test factories** (`test/utils/factories/`):
+### RLS Integration Tests
 
-- `createOrg()`, `createUser()`, `createSubmission()` — direct DB inserts via admin Prisma
+**Location:** `apps/api/src/__tests__/rls/` (8 test files, ~89 tests)
+
+Uses the **dual-pool pattern** with Drizzle ORM + raw `pg` pools to test actual PostgreSQL RLS enforcement:
+
+```typescript
+// Admin pool (superuser) — bypasses RLS for test data setup/teardown
+const adminPool = new Pool({
+  connectionString: "postgresql://test:test@localhost:5433/colophony_test",
+});
+
+// App pool (NOSUPERUSER NOBYPASSRLS) — RLS-enforced queries
+const appPool = new Pool({
+  connectionString:
+    "postgresql://app_user:app_password@localhost:5433/colophony_test",
+});
+```
+
+**Test files:**
+
+| File                             | Tests | Coverage                                                     |
+| -------------------------------- | ----- | ------------------------------------------------------------ |
+| `rls-infrastructure.test.ts`     | 14    | FORCE RLS, role security, GUC functions, policy existence    |
+| `rls-direct-isolation.test.ts`   | 12    | submissions, submission_periods, payments, org_members       |
+| `rls-indirect-isolation.test.ts` | 8     | submission_files, submission_history (subquery policies)     |
+| `rls-nullable-isolation.test.ts` | 9     | audit_events, retention_policies, user_consents              |
+| `rls-write-prevention.test.ts`   | 12    | Cross-org INSERT/UPDATE/DELETE with SQLSTATE 42501           |
+| `rls-no-context.test.ts`         | 15    | Empty context behavior (0 rows strict, global-only nullable) |
+| `organization-service.test.ts`   | —     | Org service operations under RLS                             |
+| `audit-write-path.test.ts`       | —     | Audit write path under RLS                                   |
+
+**Config:** `apps/api/vitest.config.rls.ts` — `singleFork: true` (sequential execution, shared pools), `fileParallelism: false`.
+
+**Running:**
+
+```bash
+# Requires postgres-test container
+docker compose up -d postgres-test
+pnpm --filter @colophony/api test:rls
+```
+
+**Key design:**
+
+- Dedicated Vitest config — excluded from default `pnpm test` to avoid failures without Docker
+- `globalSetup()` (called manually in `beforeAll`) creates `app_user` role portably (works in CI and locally)
+- `withTestRls()` helper sets `app.current_org`/`app.user_id` via `set_config` inside a transaction
+- Faker-based factories (`createTwoOrgScenario`) prevent collision errors in watch mode
+- `DATABASE_URL` overridden in vitest config to point at `app_user` connection — exercises real RLS on `@colophony/db` shared exports
 
 ### Playwright Browser E2E Tests
 
@@ -165,58 +229,22 @@ E2E tests use the superuser (`test:test`) for the Prisma singleton because `crea
 
 ```bash
 npx playwright install                    # First time (downloads Chromium)
-docker-compose up -d                      # PostgreSQL required
+docker compose up -d                      # PostgreSQL required
 pnpm db:seed                              # Seed data required
 pnpm --filter @colophony/web test:e2e    # Auto-starts API + Web dev servers
 pnpm --filter @colophony/web test:e2e:ui # Interactive UI mode
 ```
 
-The `playwright.config.ts` `webServer` config auto-starts API (reuses existing) and Web (always fresh — test OIDC env vars must match `injectAuth` storage key) dev servers. No Zitadel, MinIO, or Redis required (`VIRUS_SCAN_ENABLED=false` in API webServer env).
+The `playwright.config.ts` `webServer` config auto-starts API (port 4010) and Web (port 3010) dev servers on dedicated E2E ports. No Zitadel, MinIO, or Redis required (`VIRUS_SCAN_ENABLED=false` in API webServer env).
 
-### RLS Integration Tests
+**CI environment variables:**
 
-**Location:** `apps/api/src/__tests__/rls/` (6 test files, 70 tests)
+| Variable            | Purpose                              | CI Value                                                           |
+| ------------------- | ------------------------------------ | ------------------------------------------------------------------ |
+| `DATABASE_TEST_URL` | Superuser connection (test setup)    | `postgresql://test:test@localhost:5433/colophony_test`             |
+| `DATABASE_APP_URL`  | Non-superuser connection (RLS tests) | `postgresql://app_user:app_password@localhost:5433/colophony_test` |
 
-Uses the **dual-client pattern** with Drizzle ORM + raw `pg` pools to test actual PostgreSQL RLS enforcement:
-
-```typescript
-// Admin pool (superuser) - for test data setup/teardown (bypasses RLS)
-const adminPool = new Pool({
-  connectionString: "postgresql://test:test@localhost:5433/colophony_test",
-});
-
-// App pool (non-superuser, NOSUPERUSER NOBYPASSRLS) - for RLS-enforced queries
-const appPool = new Pool({
-  connectionString:
-    "postgresql://app_user:app_password@localhost:5433/colophony_test",
-});
-```
-
-**Test files:**
-
-| File                             | Tests | Coverage                                                     |
-| -------------------------------- | ----- | ------------------------------------------------------------ |
-| `rls-infrastructure.test.ts`     | 14    | FORCE RLS, role security, GUC functions, policy existence    |
-| `rls-direct-isolation.test.ts`   | 12    | submissions, submission_periods, payments, org_members       |
-| `rls-indirect-isolation.test.ts` | 8     | submission_files, submission_history (subquery policies)     |
-| `rls-nullable-isolation.test.ts` | 9     | audit_events, retention_policies, user_consents              |
-| `rls-write-prevention.test.ts`   | 12    | Cross-org INSERT/UPDATE/DELETE with SQLSTATE 42501           |
-| `rls-no-context.test.ts`         | 15    | Empty context behavior (0 rows strict, global-only nullable) |
-
-**Running:**
-
-```bash
-# Requires postgres-test container
-docker compose up -d postgres-test
-pnpm --filter @colophony/api test:rls
-```
-
-**Key design:**
-
-- Dedicated `vitest.config.rls.ts` with `singleFork: true` (sequential execution, shared pools)
-- Excluded from default `pnpm test` to avoid failures without Docker
-- `globalSetup()` creates `app_user` role portably (works in CI and locally)
-- Faker-based factories prevent collision errors in watch mode
+**Important:** `DATABASE_APP_URL` must be separate from `DATABASE_TEST_URL`. RLS tests connect as `app_user` (non-superuser, NOBYPASSRLS). If it falls back to `DATABASE_TEST_URL`, both clients are superuser and RLS is silently bypassed.
 
 ---
 
@@ -225,56 +253,84 @@ pnpm --filter @colophony/api test:rls
 ### 1. Multi-Tenancy Isolation
 
 ```typescript
-import { createContextHelpers } from "@colophony/db";
+// From rls-direct-isolation.test.ts
+import { describe, it, expect, beforeAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { globalSetup } from "./helpers/db-setup";
+import { truncateAllTables } from "./helpers/cleanup";
+import { withTestRls } from "./helpers/rls-context";
+import { createTwoOrgScenario, type TwoOrgScenario } from "./helpers/factories";
+import { submissions } from "@colophony/db";
 
-it("should prevent cross-org data leakage", async () => {
-  // Setup with admin client (bypasses RLS)
-  const org1 = await createOrg();
-  const org2 = await createOrg();
-  const submission1 = await createSubmission({ orgId: org1.id });
-  const submission2 = await createSubmission({ orgId: org2.id });
+let scenario: TwoOrgScenario;
 
-  // Test with app client (enforces RLS)
-  const { withOrgContext } = createContextHelpers(appPrisma);
-  const results = await withOrgContext(org1.id, user1.id, async (tx) => {
-    return tx.submission.findMany();
+beforeAll(async () => {
+  await globalSetup();
+  await truncateAllTables();
+  scenario = await createTwoOrgScenario();
+});
+
+it("org A context sees only org A submissions", async () => {
+  const rows = await withTestRls(
+    { orgId: scenario.orgA.id, userId: scenario.userA.id },
+    (tx) => tx.select().from(submissions),
+  );
+  expect(rows).toHaveLength(1);
+  expect(rows[0].id).toBe(scenario.submissionA.id);
+});
+
+it("org A context cannot find org B submission by ID", async () => {
+  const rows = await withTestRls(
+    { orgId: scenario.orgA.id, userId: scenario.userA.id },
+    (tx) =>
+      tx
+        .select()
+        .from(submissions)
+        .where(eq(submissions.id, scenario.submissionB.id)),
+  );
+  expect(rows).toHaveLength(0);
+});
+```
+
+### 2. Stripe Webhook Idempotency
+
+```typescript
+// From stripe.webhook.spec.ts — simplified
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+
+describe("idempotency", () => {
+  it("skips already-processed event (processed=true)", async () => {
+    // Mock DB to return processed=true for the event
+    mockClientQuery.mockImplementation((sqlStr: string) => {
+      if (typeof sqlStr === "string" && sqlStr.includes("SELECT processed")) {
+        return { rows: [{ processed: true }] };
+      }
+      return { rows: [] };
+    });
+
+    const response = await sendWebhook(app);
+    expect(response.statusCode).toBe(200);
+    expect(response.json().status).toBe("already_processed");
+    // Business logic not executed
+    expect(mockTxInsert).not.toHaveBeenCalled();
+    expect(mockAuditLog).not.toHaveBeenCalled();
   });
 
-  expect(results).toHaveLength(1);
-  expect(results[0].id).toBe(submission1.id);
-});
-```
+  it("reprocesses partially-processed event (crash recovery)", async () => {
+    // INSERT ON CONFLICT DO NOTHING (existing), SELECT returns processed=false
+    mockClientQuery.mockImplementation((sqlStr: string) => {
+      if (typeof sqlStr === "string" && sqlStr.includes("SELECT processed")) {
+        return { rows: [{ processed: false }] };
+      }
+      return { rows: [] };
+    });
 
-### 2. Payment Idempotency
-
-```typescript
-it("should handle duplicate webhook events", async () => {
-  const event = { id: "evt_123", type: "checkout.session.completed" };
-
-  await webhookHandler.handle(event);
-  await webhookHandler.handle(event); // Duplicate
-
-  const payments = await findPayments({ eventId: event.id });
-  expect(payments).toHaveLength(1); // Only one payment created
-});
-```
-
-### 3. GDPR Export/Erasure
-
-```typescript
-it("should export all user data", async () => {
-  const user = await createUser();
-  await createSubmissions(user.id, 5);
-
-  const zipPath = await gdprService.exportUserData(user.id);
-  const archive = await unzip(zipPath);
-
-  expect(archive).toContainFiles([
-    "profile.json",
-    "submissions.json",
-    "payments.json",
-    "audit-log.json",
-  ]);
+    const response = await sendWebhook(app);
+    expect(response.statusCode).toBe(200);
+    expect(response.json().status).toBe("processed");
+    expect(mockTxInsert).toHaveBeenCalled(); // Crash recovery: reprocess
+  });
 });
 ```
 
@@ -282,91 +338,34 @@ it("should export all user data", async () => {
 
 ## Known Test Quirks
 
-### tRPC v10.45 Zod Errors Return 400
+### Web uses Jest, not Vitest
 
-Input validation (Zod) errors return `BAD_REQUEST` (400). Tests assert `toBe(400)` with `BAD_REQUEST` error code.
+Web unit tests (`apps/web`) use Jest + ts-jest + jsdom. The rest of the codebase uses Vitest. Migration planned but not yet done. Web tests use `jest.mock()` / `jest.fn()`, not `vi.mock()` / `vi.fn()`.
 
-### NestJS 10.4 Express 4 Path Syntax
+### `pnpm test` excludes web tests
 
-`setGlobalPrefix` exclude pattern must use `trpc/(.*)` (Express 4), not `trpc/*path` (Express 5).
+The root `pnpm test` only runs API and package Vitest tests. Web tests run separately via `pnpm --filter @colophony/web test` because they use a different runner (Jest). In CI, web tests are currently commented out during the Vitest migration.
 
-### TrpcController URL Stripping
+### RLS tests call `globalSetup()` manually in `beforeAll`
 
-The `@Controller('trpc')` prefix must be manually stripped from `req.url` before passing to tRPC middleware — NestJS controllers don't strip prefixes like Express sub-routers.
+There is no Vitest-level `globalSetup` in `vitest.config.rls.ts`. Instead, each RLS test file calls `await globalSetup()` in its `beforeAll` block. This is because the setup creates the `app_user` role and runs migrations, which needs the admin pool — and Vitest global setup files don't share the test process's module scope.
 
-### `--forceExit` Required
+### Drizzle `migrate()` workaround
 
-Redis/Prisma connections persist after tests complete. `--forceExit` is standard for NestJS E2E tests.
+RLS test `globalSetup()` applies migrations by reading `_journal.json` and executing SQL files manually rather than using `drizzle-kit migrate`. This avoids the drizzle-kit TUI prompt that blocks automation.
 
-### TanStack Query v4 `isLoading` with Disabled Queries
+### Playwright `webServer.env` replaces `process.env`
 
-In TanStack Query v4, `isLoading` is `true` even when the query is disabled (`enabled: false`). The fix in `use-auth.ts` checks `fetchStatus !== 'idle'` instead.
+Playwright's `webServer.env` config **replaces** (not merges) the child process environment. The config must load `.env` files via `dotenv` and spread `...process.env` to ensure `DATABASE_URL` and other vars reach dev servers.
 
----
+### Dedicated E2E ports
 
-## E2E False-Positive Audit
+Playwright tests use separate ports (API: 4010, Web: 3010) to avoid conflicting with the development servers (API: 4000, Web: 3000). Configured in `apps/web/playwright.config.ts`.
 
-All 5 priorities from the false-positive audit have been resolved:
+### Turborepo `^build` dependency
 
-### Priority 1: Tightened Status Code Assertions
+Vitest resolves workspace packages via `exports` field pointing to `dist/`. CI must run `pnpm build` for dependency packages (`@colophony/db`, `@colophony/types`, `@colophony/auth-client`, `@colophony/api-client`) before running tests.
 
-tRPC Zod validation assertions check `toBe(400)` with `BAD_REQUEST` error code.
+### RLS `singleFork: true` requirement
 
-| File               | Test               | Assertion                   |
-| ------------------ | ------------------ | --------------------------- |
-| `auth.e2e-spec.ts` | invalid email      | `toBe(400)` + `BAD_REQUEST` |
-| `auth.e2e-spec.ts` | short password     | `toBe(400)` + `BAD_REQUEST` |
-| `gdpr.e2e-spec.ts` | wrong confirmation | `toBe(400)` + `BAD_REQUEST` |
-
-### Priority 2: Fixed Multi-Status Acceptance in Payments
-
-- `payments.e2e-spec.ts:134` — now `toBe(500)` with `/not initialized/i`
-- `payments.e2e-spec.ts:65` — restored to `toBe(412)` (router throws `PRECONDITION_FAILED`)
-
-### Priority 3: RLS E2E Coverage
-
-Added test using `getAppPrisma()` (non-superuser) to verify RLS blocks cross-org reads at the database level.
-
-### Priority 4: Strengthened GDPR Assertions
-
-- DSAR `dueAt` verified as 30-31 days from now
-- Consent grant verifies audit trail entry in database
-
-### Priority 5: Expanded Submission State Machine Coverage
-
-Added negative tests for invalid transitions:
-
-- `DRAFT` → `ACCEPTED` (invalid)
-- `REJECTED` → `UNDER_REVIEW` (invalid)
-- `ACCEPTED` → `DRAFT` (invalid)
-
----
-
-## Production Bugs Found During Testing
-
-### API E2E Test Phase
-
-1. **tRPC routing broken** — `trpc/*path` in `main.ts` used Express 5 syntax. Fixed to `trpc/(.*)`.
-2. **tRPC 404 on all procedures** — `TrpcController` wasn't stripping `/trpc` prefix from `req.url`.
-3. **Circular dependency** — `StorageModule` → `VirusScanService` → `JobsModule` circular import via barrel exports. Fixed barrel export order.
-4. **GdprModule not global** — `GdprService` wasn't available to other modules. Added `@Global()`.
-
-### Playwright E2E Phase
-
-1. **Circular dependency in JobsModule** — `jobs.module` ↔ `storage` barrel exports. Fixed by extracting queue constants to `modules/jobs/constants.ts`.
-2. **API auth.me flattening mismatch** — Endpoint flattened `memberships` but frontend expected nested Prisma structure. Fixed by returning raw `user.memberships`.
-3. **Auth loading state with disabled query** — TanStack Query v4 `isLoading` true when disabled. Fixed with `fetchStatus !== 'idle'` check.
-4. **Unit test import paths stale** — Queue constants moved to `constants.ts` but unit tests still imported from `jobs.module`. Fixed imports.
-
-### Beta Deployment Phase
-
-1. **`.gitignore` missing `.env.prod`** — Secrets file exposure risk.
-2. **Docker Compose env_file vs --env-file** — `env_file:` only sets container runtime env, not YAML `${VAR}` substitution.
-3. **`init-prod.sh` shebang incompatible with Alpine** — `#!/bin/bash` → `#!/bin/sh`.
-4. **`npx prisma` downloading Prisma 7.x** — npm resolution, not pnpm. Fixed with direct binary path.
-5. **Prisma schema engine OpenSSL mismatch** — Added `openssl` to Alpine `apk add`.
-6. **Prisma client "did not initialize yet"** — `pnpm deploy --prod` misses generated client files. Added `cp -r` step.
-7. **Prisma query engine OpenSSL 1.1 vs 3.x** — Added `apk add openssl` before `prisma generate`.
-8. **Redis ECONNREFUSED in BullMQ** — Missing `REDIS_HOST`/`REDIS_PORT`/`REDIS_PASSWORD` env vars.
-9. **Stale database credentials** — Old PostgreSQL volume. Resolved with `docker compose down -v`.
-10. **Port conflict** — Default port 8080 in use. Made configurable via `HTTP_PORT`.
+RLS tests use `singleFork: true` + `fileParallelism: false` because test files share database pools and rely on sequential `set_config` + `COMMIT`/`ROLLBACK` within transactions. Parallel execution would cause GUC context bleed between tests.


### PR DESCRIPTION
## Summary

- Full rewrite of `docs/testing.md` — removed all v1 patterns (Prisma, NestJS, Express, supertest, API E2E tier) and updated to v2 stack (Drizzle, Fastify 5, Vitest)
- Updated to 5 tiers, ~660 tests across API unit, package unit, web unit (Jest), RLS integration, and Playwright E2E
- Added `.claude/hooks/post-test-file.js` staleness prevention hook — fires when test files are modified, reminds to update `docs/testing.md`
- Added Stripe raw payload PCI compliance concern to backlog (code review finding)

## Test plan

- [x] Grep rewritten doc for `Prisma`, `NestJS`, `Express` — no stale references (NestJS only in "differences from v1" note)
- [x] `Jest` appears only in web unit test sections
- [x] `hooks.json` validates as JSON
- [x] Pre-push hooks pass (type-check + lint)