### PR TITLE
fix(api): tusd v2 webhook compat + upload E2E tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test-results/
 playwright-report/
 blob-report/
 *.log
+apps/web/e2e/.zitadel-e2e-config.json
 
 # Next.js
 .next/

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -185,12 +185,13 @@ Workers and queues are started in `main.ts` and closed during graceful shutdown.
 
 ## Quirks
 
-| Quirk                                 | Details                                                                                                                                                                                                                                             |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Zitadel webhook signatures**        | Verify `x-zitadel-signature` header on all webhook payloads. Use shared secret from Zitadel Actions config                                                                                                                                          |
-| **BullMQ Redis password**             | Uses `REDIS_HOST`/`REDIS_PORT`/`REDIS_PASSWORD` (not `REDIS_URL`). Pass password in worker/queue config                                                                                                                                             |
-| **tRPC TS2742 under NodeNext**        | Resolved in tRPC v11. `declaration: true` now works in API tsconfig. Web app still resolves `AppRouter` via source path alias pointing to `src/trpc/client-types.ts` (bundler resolution). All web-facing type exports go through `client-types.ts` |
-| **`@fastify/raw-body` doesn't exist** | Official `@fastify/` scoped package not published on npm. Use `fastify-raw-body` (community package, v5.0.0 for Fastify 5)                                                                                                                          |
+| Quirk                                 | Details                                                                                                                                                                                                                                              |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Zitadel webhook signatures**        | Verify `x-zitadel-signature` header on all webhook payloads. Use shared secret from Zitadel Actions config                                                                                                                                           |
+| **BullMQ Redis password**             | Uses `REDIS_HOST`/`REDIS_PORT`/`REDIS_PASSWORD` (not `REDIS_URL`). Pass password in worker/queue config                                                                                                                                              |
+| **tRPC TS2742 under NodeNext**        | Resolved in tRPC v11. `declaration: true` now works in API tsconfig. Web app still resolves `AppRouter` via source path alias pointing to `src/trpc/client-types.ts` (bundler resolution). All web-facing type exports go through `client-types.ts`  |
+| **`@fastify/raw-body` doesn't exist** | Official `@fastify/` scoped package not published on npm. Use `fastify-raw-body` (community package, v5.0.0 for Fastify 5)                                                                                                                           |
+| **tusd v2 webhook payload format**    | tusd v2.8.0 sends `{ Type: "pre-create"\|"post-finish", Event: { Upload, HTTPRequest } }` instead of v1's `Hook-Name` header + `{ Upload, HTTPRequest }` body. Our handler supports both formats. The `Event` envelope is unwrapped before dispatch. |
 
 ## Version Pins
 

--- a/apps/api/src/webhooks/tusd.webhook.spec.ts
+++ b/apps/api/src/webhooks/tusd.webhook.spec.ts
@@ -151,56 +151,64 @@ const TEST_ENV = {
 
 const SUBMISSION_ID = 'a1111111-1111-1111-a111-111111111111';
 
+/** Build a tusd v2 pre-create webhook payload: { Type, Event: { Upload, HTTPRequest } } */
 function makePreCreateBody(overrides: Record<string, unknown> = {}) {
   return {
-    Upload: {
-      Size: 1024,
-      MetaData: {
-        'submission-id': SUBMISSION_ID,
-        filetype: 'application/pdf',
-        filename: 'poem.pdf',
+    Type: 'pre-create',
+    Event: {
+      Upload: {
+        Size: 1024,
+        MetaData: {
+          'submission-id': SUBMISSION_ID,
+          filetype: 'application/pdf',
+          filename: 'poem.pdf',
+        },
+        ...overrides,
       },
-      ...overrides,
-    },
-    HTTPRequest: {
-      Method: 'POST',
-      URI: '/files/',
-      RemoteAddr: '127.0.0.1',
-      Header: {
-        Authorization: ['Bearer test-token'],
-        'X-Organization-Id': ['org-1'],
-        'X-Test-User-Id': ['user-1'],
+      HTTPRequest: {
+        Method: 'POST',
+        URI: '/files/',
+        RemoteAddr: '127.0.0.1',
+        Header: {
+          Authorization: ['Bearer test-token'],
+          'X-Organization-Id': ['org-1'],
+          'X-Test-User-Id': ['user-1'],
+        },
       },
     },
   };
 }
 
+/** Build a tusd v2 post-finish webhook payload: { Type, Event: { Upload, HTTPRequest } } */
 function makePostFinishBody(overrides: Record<string, unknown> = {}) {
   return {
-    Upload: {
-      ID: 'upload-abc123',
-      Size: 1024,
-      Offset: 1024,
-      MetaData: {
-        'submission-id': SUBMISSION_ID,
-        filetype: 'application/pdf',
-        filename: 'poem.pdf',
+    Type: 'post-finish',
+    Event: {
+      Upload: {
+        ID: 'upload-abc123',
+        Size: 1024,
+        Offset: 1024,
+        MetaData: {
+          'submission-id': SUBMISSION_ID,
+          filetype: 'application/pdf',
+          filename: 'poem.pdf',
+        },
+        Storage: {
+          Key: 'quarantine/upload-abc123',
+          Bucket: 'quarantine',
+          Type: 's3store',
+        },
+        ...overrides,
       },
-      Storage: {
-        Key: 'quarantine/upload-abc123',
-        Bucket: 'quarantine',
-        Type: 's3store',
-      },
-      ...overrides,
-    },
-    HTTPRequest: {
-      Method: 'POST',
-      URI: '/files/upload-abc123',
-      RemoteAddr: '127.0.0.1',
-      Header: {
-        Authorization: ['Bearer test-token'],
-        'X-Organization-Id': ['org-1'],
-        'X-Test-User-Id': ['user-1'],
+      HTTPRequest: {
+        Method: 'POST',
+        URI: '/files/upload-abc123',
+        RemoteAddr: '127.0.0.1',
+        Header: {
+          Authorization: ['Bearer test-token'],
+          'X-Organization-Id': ['org-1'],
+          'X-Test-User-Id': ['user-1'],
+        },
       },
     },
   };
@@ -262,7 +270,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: makePreCreateBody(),
       });
 
@@ -273,14 +281,14 @@ describe('tusd webhook handler', () => {
 
     it('rejects when missing auth', async () => {
       const body = makePreCreateBody();
-      body.HTTPRequest.Header = {
+      body.Event.HTTPRequest.Header = {
         'X-Organization-Id': ['org-1'],
       } as never;
 
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: body,
       });
 
@@ -297,7 +305,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: makePreCreateBody(),
       });
 
@@ -325,7 +333,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: makePreCreateBody(),
       });
 
@@ -361,7 +369,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: makePreCreateBody(),
       });
 
@@ -397,7 +405,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: makePreCreateBody(),
       });
 
@@ -415,7 +423,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: body,
       });
 
@@ -453,7 +461,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'post-finish' },
+        headers: {},
         payload: makePostFinishBody(),
       });
 
@@ -492,7 +500,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'post-finish' },
+        headers: {},
         payload: makePostFinishBody(),
       });
 
@@ -503,14 +511,14 @@ describe('tusd webhook handler', () => {
 
     it('rejects when auth is missing (fail closed)', async () => {
       const body = makePostFinishBody();
-      body.HTTPRequest.Header = {
+      body.Event.HTTPRequest.Header = {
         'X-Organization-Id': ['org-1'],
       } as never;
 
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'post-finish' },
+        headers: {},
         payload: body,
       });
 
@@ -521,7 +529,7 @@ describe('tusd webhook handler', () => {
 
     it('returns 400 when missing org id', async () => {
       const body = makePostFinishBody();
-      body.HTTPRequest.Header = {
+      body.Event.HTTPRequest.Header = {
         Authorization: ['Bearer test-token'],
         'X-Test-User-Id': ['user-1'],
       } as never;
@@ -529,7 +537,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'post-finish' },
+        headers: {},
         payload: body,
       });
 
@@ -560,7 +568,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'post-finish' },
+        headers: {},
         payload: makePostFinishBody(),
       });
 
@@ -590,7 +598,7 @@ describe('tusd webhook handler', () => {
       await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'post-finish' },
+        headers: {},
         payload: makePostFinishBody(),
       });
 
@@ -613,7 +621,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'post-finish' },
+        headers: {},
         payload: makePostFinishBody(),
       });
 
@@ -633,7 +641,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'post-finish' },
+        headers: {},
         payload: makePostFinishBody(),
       });
 
@@ -668,21 +676,24 @@ describe('tusd webhook handler', () => {
 
     function makeApiKeyPreCreateBody() {
       return {
-        Upload: {
-          Size: 1024,
-          MetaData: {
-            'submission-id': SUBMISSION_ID,
-            filetype: 'application/pdf',
-            filename: 'poem.pdf',
+        Type: 'pre-create',
+        Event: {
+          Upload: {
+            Size: 1024,
+            MetaData: {
+              'submission-id': SUBMISSION_ID,
+              filetype: 'application/pdf',
+              filename: 'poem.pdf',
+            },
           },
-        },
-        HTTPRequest: {
-          Method: 'POST',
-          URI: '/files/',
-          RemoteAddr: '127.0.0.1',
-          Header: {
-            'X-Api-Key': ['col_test_abc123'],
-            'X-Organization-Id': ['org-from-header-should-be-ignored'],
+          HTTPRequest: {
+            Method: 'POST',
+            URI: '/files/',
+            RemoteAddr: '127.0.0.1',
+            Header: {
+              'X-Api-Key': ['col_test_abc123'],
+              'X-Organization-Id': ['org-from-header-should-be-ignored'],
+            },
           },
         },
       };
@@ -690,28 +701,31 @@ describe('tusd webhook handler', () => {
 
     function makeApiKeyPostFinishBody() {
       return {
-        Upload: {
-          ID: 'upload-abc123',
-          Size: 1024,
-          Offset: 1024,
-          MetaData: {
-            'submission-id': SUBMISSION_ID,
-            filetype: 'application/pdf',
-            filename: 'poem.pdf',
+        Type: 'post-finish',
+        Event: {
+          Upload: {
+            ID: 'upload-abc123',
+            Size: 1024,
+            Offset: 1024,
+            MetaData: {
+              'submission-id': SUBMISSION_ID,
+              filetype: 'application/pdf',
+              filename: 'poem.pdf',
+            },
+            Storage: {
+              Key: 'quarantine/upload-abc123',
+              Bucket: 'quarantine',
+              Type: 's3store',
+            },
           },
-          Storage: {
-            Key: 'quarantine/upload-abc123',
-            Bucket: 'quarantine',
-            Type: 's3store',
-          },
-        },
-        HTTPRequest: {
-          Method: 'POST',
-          URI: '/files/upload-abc123',
-          RemoteAddr: '127.0.0.1',
-          Header: {
-            'X-Api-Key': ['col_test_abc123'],
-            'X-Organization-Id': ['org-from-header-should-be-ignored'],
+          HTTPRequest: {
+            Method: 'POST',
+            URI: '/files/upload-abc123',
+            RemoteAddr: '127.0.0.1',
+            Header: {
+              'X-Api-Key': ['col_test_abc123'],
+              'X-Organization-Id': ['org-from-header-should-be-ignored'],
+            },
           },
         },
       };
@@ -745,7 +759,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: makeApiKeyPreCreateBody(),
       });
 
@@ -765,7 +779,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: makeApiKeyPreCreateBody(),
       });
 
@@ -787,7 +801,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: makeApiKeyPreCreateBody(),
       });
 
@@ -809,7 +823,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: makeApiKeyPreCreateBody(),
       });
 
@@ -831,7 +845,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: makeApiKeyPreCreateBody(),
       });
 
@@ -853,7 +867,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: makeApiKeyPreCreateBody(),
       });
 
@@ -887,7 +901,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'post-finish' },
+        headers: {},
         payload: makeApiKeyPostFinishBody(),
       });
 
@@ -911,7 +925,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'post-finish' },
+        headers: {},
         payload: makeApiKeyPostFinishBody(),
       });
 
@@ -926,7 +940,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'post-finish' },
+        headers: {},
         payload: makeApiKeyPostFinishBody(),
       });
 
@@ -941,7 +955,18 @@ describe('tusd webhook handler', () => {
   // -------------------------------------------------------------------------
 
   describe('unknown hook', () => {
-    it('returns 200 for unknown hook name', async () => {
+    it('returns 200 for unknown hook type (v2 format)', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: {},
+        payload: { Type: 'post-create', Event: {} },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('returns 200 for unknown hook name (v1 format)', async () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
@@ -964,7 +989,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: makePreCreateBody(),
       });
 
@@ -979,7 +1004,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: makePreCreateBody(),
       });
 
@@ -1018,7 +1043,7 @@ describe('tusd webhook handler', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/webhooks/tusd',
-        headers: { 'hook-name': 'pre-create' },
+        headers: {},
         payload: makePreCreateBody(),
       });
 

--- a/apps/api/src/webhooks/tusd.webhook.spec.ts
+++ b/apps/api/src/webhooks/tusd.webhook.spec.ts
@@ -96,6 +96,16 @@ vi.mock('../services/s3.js', () => ({
   deleteS3Object: (...args: unknown[]) => mockDeleteS3Object(...args),
 }));
 
+// Mock API key service
+const mockVerifyKey = vi.fn();
+const mockTouchLastUsed = vi.fn();
+vi.mock('../services/api-key.service.js', () => ({
+  apiKeyService: {
+    verifyKey: (...args: unknown[]) => mockVerifyKey(...args),
+    touchLastUsed: (...args: unknown[]) => mockTouchLastUsed(...args),
+  },
+}));
+
 // Mock auth-client
 vi.mock('@colophony/auth-client', () => ({
   createJwksVerifier: vi.fn(),
@@ -216,6 +226,7 @@ describe('tusd webhook handler', () => {
     // Restore default: below rate limit
     mockRedisEval.mockResolvedValue([1, 60000]);
     mockRedisQuit.mockResolvedValue('OK');
+    mockVerifyKey.mockResolvedValue(null);
   });
 
   // -------------------------------------------------------------------------
@@ -627,6 +638,301 @@ describe('tusd webhook handler', () => {
       });
 
       expect(response.statusCode).toBe(500);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // API key auth
+  // -------------------------------------------------------------------------
+
+  describe('API key auth', () => {
+    const VALID_API_KEY_RESULT = {
+      apiKey: {
+        id: 'key-1',
+        organizationId: 'org-from-key',
+        createdBy: 'user-1',
+        name: 'test-key',
+        scopes: ['files:read', 'files:write'],
+        expiresAt: null,
+        revokedAt: null,
+        lastUsedAt: null,
+        createdAt: new Date(),
+      },
+      creator: {
+        id: 'user-1',
+        email: 'test@example.com',
+        emailVerified: true,
+        deletedAt: null,
+      },
+    };
+
+    function makeApiKeyPreCreateBody() {
+      return {
+        Upload: {
+          Size: 1024,
+          MetaData: {
+            'submission-id': SUBMISSION_ID,
+            filetype: 'application/pdf',
+            filename: 'poem.pdf',
+          },
+        },
+        HTTPRequest: {
+          Method: 'POST',
+          URI: '/files/',
+          RemoteAddr: '127.0.0.1',
+          Header: {
+            'X-Api-Key': ['col_test_abc123'],
+            'X-Organization-Id': ['org-from-header-should-be-ignored'],
+          },
+        },
+      };
+    }
+
+    function makeApiKeyPostFinishBody() {
+      return {
+        Upload: {
+          ID: 'upload-abc123',
+          Size: 1024,
+          Offset: 1024,
+          MetaData: {
+            'submission-id': SUBMISSION_ID,
+            filetype: 'application/pdf',
+            filename: 'poem.pdf',
+          },
+          Storage: {
+            Key: 'quarantine/upload-abc123',
+            Bucket: 'quarantine',
+            Type: 's3store',
+          },
+        },
+        HTTPRequest: {
+          Method: 'POST',
+          URI: '/files/upload-abc123',
+          RemoteAddr: '127.0.0.1',
+          Header: {
+            'X-Api-Key': ['col_test_abc123'],
+            'X-Organization-Id': ['org-from-header-should-be-ignored'],
+          },
+        },
+      };
+    }
+
+    it('pre-create: allows upload with valid API key', async () => {
+      mockVerifyKey.mockResolvedValueOnce(VALID_API_KEY_RESULT);
+      mockWithRls.mockImplementation(
+        async (_ctx: unknown, fn: (tx: unknown) => Promise<void>) => {
+          const mockTx = {
+            select: () => ({
+              from: () => ({
+                where: () => ({
+                  limit: () =>
+                    Promise.resolve([
+                      {
+                        id: SUBMISSION_ID,
+                        status: 'DRAFT',
+                        submitterId: 'user-1',
+                      },
+                    ]),
+                }),
+              }),
+            }),
+          };
+          return fn(mockTx);
+        },
+      );
+      mockFileService.validateLimits.mockResolvedValueOnce(undefined);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: makeApiKeyPreCreateBody(),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.RejectUpload).toBeUndefined();
+      // Verify org comes from key, not header
+      expect(mockWithRls).toHaveBeenCalledWith(
+        expect.objectContaining({ orgId: 'org-from-key', userId: 'user-1' }),
+        expect.any(Function),
+      );
+    });
+
+    it('pre-create: rejects invalid API key', async () => {
+      mockVerifyKey.mockResolvedValueOnce(null);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: makeApiKeyPreCreateBody(),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.RejectUpload).toBe(true);
+      expect(body.HTTPResponse.Body).toContain('invalid_key');
+    });
+
+    it('pre-create: rejects expired API key', async () => {
+      mockVerifyKey.mockResolvedValueOnce({
+        ...VALID_API_KEY_RESULT,
+        apiKey: {
+          ...VALID_API_KEY_RESULT.apiKey,
+          expiresAt: new Date('2020-01-01'),
+        },
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: makeApiKeyPreCreateBody(),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.RejectUpload).toBe(true);
+      expect(body.HTTPResponse.Body).toContain('key_expired');
+    });
+
+    it('pre-create: rejects revoked API key', async () => {
+      mockVerifyKey.mockResolvedValueOnce({
+        ...VALID_API_KEY_RESULT,
+        apiKey: {
+          ...VALID_API_KEY_RESULT.apiKey,
+          revokedAt: new Date(),
+        },
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: makeApiKeyPreCreateBody(),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.RejectUpload).toBe(true);
+      expect(body.HTTPResponse.Body).toContain('key_revoked');
+    });
+
+    it('pre-create: rejects when creator is deactivated', async () => {
+      mockVerifyKey.mockResolvedValueOnce({
+        ...VALID_API_KEY_RESULT,
+        creator: {
+          ...VALID_API_KEY_RESULT.creator,
+          deletedAt: new Date(),
+        },
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: makeApiKeyPreCreateBody(),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.RejectUpload).toBe(true);
+      expect(body.HTTPResponse.Body).toContain('creator_deactivated');
+    });
+
+    it('pre-create: rejects API key without files:write scope', async () => {
+      mockVerifyKey.mockResolvedValueOnce({
+        ...VALID_API_KEY_RESULT,
+        apiKey: {
+          ...VALID_API_KEY_RESULT.apiKey,
+          scopes: ['files:read'],
+        },
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'pre-create' },
+        payload: makeApiKeyPreCreateBody(),
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload);
+      expect(body.RejectUpload).toBe(true);
+      expect(body.HTTPResponse.Body).toContain('insufficient_scopes');
+    });
+
+    it('post-finish: creates file record with valid API key', async () => {
+      mockVerifyKey.mockResolvedValueOnce(VALID_API_KEY_RESULT);
+      mockWithRls.mockImplementation(
+        async (_ctx: unknown, fn: (tx: unknown) => Promise<void>) => {
+          return fn({});
+        },
+      );
+      mockFileService.getByStorageKey.mockResolvedValueOnce(null as never);
+      mockFileService.create.mockResolvedValueOnce({
+        id: 'file-1',
+        submissionId: SUBMISSION_ID,
+        filename: 'poem.pdf',
+        mimeType: 'application/pdf',
+        size: 1024,
+        storageKey: 'quarantine/upload-abc123',
+        scanStatus: 'PENDING',
+        scannedAt: null,
+        uploadedAt: new Date(),
+      } as never);
+      mockAuditService.log.mockResolvedValueOnce(undefined);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'post-finish' },
+        payload: makeApiKeyPostFinishBody(),
+      });
+
+      expect(response.statusCode).toBe(200);
+      // Verify org comes from key, not header
+      expect(mockWithRls).toHaveBeenCalledWith(
+        expect.objectContaining({ orgId: 'org-from-key', userId: 'user-1' }),
+        expect.any(Function),
+      );
+    });
+
+    it('post-finish: rejects API key without files:write scope', async () => {
+      mockVerifyKey.mockResolvedValueOnce({
+        ...VALID_API_KEY_RESULT,
+        apiKey: {
+          ...VALID_API_KEY_RESULT.apiKey,
+          scopes: ['files:read'],
+        },
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'post-finish' },
+        payload: makeApiKeyPostFinishBody(),
+      });
+
+      expect(response.statusCode).toBe(403);
+      const body = JSON.parse(response.payload);
+      expect(body.error).toBe('insufficient_scopes');
+    });
+
+    it('post-finish: rejects invalid API key', async () => {
+      mockVerifyKey.mockResolvedValueOnce(null);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/tusd',
+        headers: { 'hook-name': 'post-finish' },
+        payload: makeApiKeyPostFinishBody(),
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.payload);
+      expect(body.error).toBe('invalid_key');
     });
   });
 

--- a/apps/api/src/webhooks/tusd.webhook.ts
+++ b/apps/api/src/webhooks/tusd.webhook.ts
@@ -168,7 +168,20 @@ export async function registerTusdWebhooks(
       request: FastifyRequest,
       reply: FastifyReply,
     ) {
-      const hookName = request.headers['hook-name'] as string | undefined;
+      // tusd v2 sends { Type: "pre-create"|"post-finish"|..., Event: { Upload, HTTPRequest } }
+      // tusd v1 sent the hook name as a Hook-Name header and Upload/HTTPRequest at top level.
+      // Support both formats for compatibility.
+      const body = request.body as Record<string, unknown>;
+      let hookName: string | undefined;
+
+      if (body && typeof body.Type === 'string' && body.Event) {
+        // tusd v2 format: unwrap Event into request body for handler functions
+        hookName = body.Type;
+        (request as unknown as { body: unknown }).body = body.Event;
+      } else {
+        // tusd v1 format: hook name in header, Upload/HTTPRequest at top level
+        hookName = request.headers['hook-name'] as string | undefined;
+      }
 
       if (hookName === 'pre-create') {
         return handlePreCreate(request, reply);

--- a/apps/api/src/webhooks/tusd.webhook.ts
+++ b/apps/api/src/webhooks/tusd.webhook.ts
@@ -272,10 +272,7 @@ export async function registerTusdWebhooks(
         return;
       }
       // Scope check: require files:write for upload
-      if (
-        !apiKey.scopes ||
-        !(apiKey.scopes as string[]).includes('files:write')
-      ) {
+      if (!apiKey.scopes || !apiKey.scopes.includes('files:write')) {
         await reply.status(200).send(rejectUpload(403, 'insufficient_scopes'));
         return;
       }
@@ -443,10 +440,7 @@ export async function registerTusdWebhooks(
         return reply.status(401).send({ error: 'creator_deactivated' });
       }
       // Scope check: require files:write for post-finish
-      if (
-        !apiKey.scopes ||
-        !(apiKey.scopes as string[]).includes('files:write')
-      ) {
+      if (!apiKey.scopes || !apiKey.scopes.includes('files:write')) {
         return reply.status(403).send({ error: 'insufficient_scopes' });
       }
       userId = creator.id;

--- a/apps/api/src/webhooks/tusd.webhook.ts
+++ b/apps/api/src/webhooks/tusd.webhook.ts
@@ -12,6 +12,7 @@ import {
 } from '@colophony/types';
 import type { TusdPreCreateResponse } from '@colophony/types';
 import type { Env } from '../config/env.js';
+import { apiKeyService } from '../services/api-key.service.js';
 import { fileService } from '../services/file.service.js';
 import { auditService } from '../services/audit.service.js';
 import { enqueueFileScan } from '../queues/file-scan.queue.js';
@@ -198,26 +199,26 @@ export async function registerTusdWebhooks(
     const metadata = Upload.MetaData ?? {};
     const forwardedHeaders = HTTPRequest.Header;
 
-    // Extract auth token from forwarded headers
+    // Extract auth from forwarded headers
     const authHeader = getForwardedHeader(forwardedHeaders, 'Authorization');
-    const orgId = getForwardedHeader(forwardedHeaders, 'X-Organization-Id');
-
-    if (!authHeader || !orgId) {
-      await reply.status(200).send(rejectUpload(401, 'missing_auth_or_org'));
-      return;
-    }
-
-    const match = /^Bearer\s+(\S+)$/i.exec(authHeader);
-    if (!match) {
-      await reply.status(200).send(rejectUpload(401, 'invalid_auth_header'));
-      return;
-    }
+    const apiKeyHeader = getForwardedHeader(forwardedHeaders, 'X-Api-Key');
+    let orgId = getForwardedHeader(forwardedHeaders, 'X-Organization-Id');
 
     // Validate token and resolve local user UUID
     let userId: string;
-    if (verifyToken) {
+
+    const bearerMatch = authHeader
+      ? /^Bearer\s+(\S+)$/i.exec(authHeader)
+      : null;
+
+    if (verifyToken && bearerMatch) {
+      // OIDC token auth (interactive users)
+      if (!orgId) {
+        await reply.status(200).send(rejectUpload(401, 'missing_auth_or_org'));
+        return;
+      }
       try {
-        const { payload } = await verifyToken(match[1]);
+        const { payload } = await verifyToken(bearerMatch[1]);
         if (!payload.sub) {
           await reply.status(200).send(rejectUpload(401, 'missing_sub_claim'));
           return;
@@ -237,8 +238,46 @@ export async function registerTusdWebhooks(
           .send(rejectUpload(401, 'token_validation_failed'));
         return;
       }
+    } else if (apiKeyHeader) {
+      // API key auth (programmatic consumers)
+      const result = await apiKeyService.verifyKey(apiKeyHeader);
+      if (!result) {
+        await reply.status(200).send(rejectUpload(401, 'invalid_key'));
+        return;
+      }
+      const { apiKey, creator } = result;
+      if (apiKey.expiresAt && apiKey.expiresAt < new Date()) {
+        await reply.status(200).send(rejectUpload(401, 'key_expired'));
+        return;
+      }
+      if (apiKey.revokedAt) {
+        await reply.status(200).send(rejectUpload(401, 'key_revoked'));
+        return;
+      }
+      if (creator.deletedAt) {
+        await reply.status(200).send(rejectUpload(401, 'creator_deactivated'));
+        return;
+      }
+      // Scope check: require files:write for upload
+      if (
+        !apiKey.scopes ||
+        !(apiKey.scopes as string[]).includes('files:write')
+      ) {
+        await reply.status(200).send(rejectUpload(403, 'insufficient_scopes'));
+        return;
+      }
+      userId = creator.id;
+      // CRITICAL: Use org from the key, NOT from the forwarded X-Organization-Id
+      // header. This mirrors auth.ts and prevents tenant isolation bypass.
+      orgId = apiKey.organizationId;
+      // Fire-and-forget: update lastUsedAt (mirrors auth.ts)
+      void apiKeyService.touchLastUsed(apiKey.id);
     } else if (env.NODE_ENV === 'test') {
       // Test mode: extract from forwarded test headers
+      if (!orgId) {
+        await reply.status(200).send(rejectUpload(401, 'missing_auth_or_org'));
+        return;
+      }
       const testUserId = getForwardedHeader(forwardedHeaders, 'X-Test-User-Id');
       if (!testUserId) {
         await reply.status(200).send(rejectUpload(401, 'no_auth_configured'));
@@ -247,6 +286,11 @@ export async function registerTusdWebhooks(
       userId = testUserId;
     } else {
       await reply.status(200).send(rejectUpload(401, 'no_auth_configured'));
+      return;
+    }
+
+    if (!orgId) {
+      await reply.status(200).send(rejectUpload(401, 'missing_auth_or_org'));
       return;
     }
 
@@ -338,24 +382,25 @@ export async function registerTusdWebhooks(
     const metadata = Upload.MetaData ?? {};
     const forwardedHeaders = HTTPRequest.Header;
 
-    const orgId = getForwardedHeader(forwardedHeaders, 'X-Organization-Id');
+    let orgId = getForwardedHeader(forwardedHeaders, 'X-Organization-Id');
     const authHeader = getForwardedHeader(forwardedHeaders, 'Authorization');
-
-    if (!orgId) {
-      request.log.error('Post-finish webhook missing X-Organization-Id');
-      return reply.status(400).send({ error: 'missing_org_id' });
-    }
+    const apiKeyHeader = getForwardedHeader(forwardedHeaders, 'X-Api-Key');
 
     // Resolve userId from forwarded auth — fail closed if auth is invalid
     let userId: string;
-    if (verifyToken && authHeader) {
-      const match = /^Bearer\s+(\S+)$/i.exec(authHeader);
-      if (!match) {
-        request.log.warn('Post-finish: invalid auth header format');
-        return reply.status(401).send({ error: 'invalid_auth_header' });
+
+    const bearerMatch = authHeader
+      ? /^Bearer\s+(\S+)$/i.exec(authHeader)
+      : null;
+
+    if (verifyToken && bearerMatch) {
+      // OIDC token auth
+      if (!orgId) {
+        request.log.error('Post-finish webhook missing X-Organization-Id');
+        return reply.status(400).send({ error: 'missing_org_id' });
       }
       try {
-        const { payload } = await verifyToken(match[1]);
+        const { payload } = await verifyToken(bearerMatch[1]);
         if (!payload.sub) {
           return reply.status(401).send({ error: 'missing_sub_claim' });
         }
@@ -368,7 +413,39 @@ export async function registerTusdWebhooks(
         request.log.warn('Post-finish: token validation failed');
         return reply.status(401).send({ error: 'token_validation_failed' });
       }
+    } else if (apiKeyHeader) {
+      // API key auth (programmatic consumers)
+      const result = await apiKeyService.verifyKey(apiKeyHeader);
+      if (!result) {
+        return reply.status(401).send({ error: 'invalid_key' });
+      }
+      const { apiKey, creator } = result;
+      if (apiKey.expiresAt && apiKey.expiresAt < new Date()) {
+        return reply.status(401).send({ error: 'key_expired' });
+      }
+      if (apiKey.revokedAt) {
+        return reply.status(401).send({ error: 'key_revoked' });
+      }
+      if (creator.deletedAt) {
+        return reply.status(401).send({ error: 'creator_deactivated' });
+      }
+      // Scope check: require files:write for post-finish
+      if (
+        !apiKey.scopes ||
+        !(apiKey.scopes as string[]).includes('files:write')
+      ) {
+        return reply.status(403).send({ error: 'insufficient_scopes' });
+      }
+      userId = creator.id;
+      // CRITICAL: Use org from the key, NOT from the forwarded header
+      orgId = apiKey.organizationId;
+      // Fire-and-forget: update lastUsedAt (mirrors auth.ts)
+      void apiKeyService.touchLastUsed(apiKey.id);
     } else if (env.NODE_ENV === 'test') {
+      if (!orgId) {
+        request.log.error('Post-finish webhook missing X-Organization-Id');
+        return reply.status(400).send({ error: 'missing_org_id' });
+      }
       const testUserId = getForwardedHeader(forwardedHeaders, 'X-Test-User-Id');
       if (!testUserId) {
         return reply.status(401).send({ error: 'no_auth_configured' });
@@ -377,6 +454,11 @@ export async function registerTusdWebhooks(
     } else {
       request.log.warn('Post-finish: no auth available');
       return reply.status(401).send({ error: 'no_auth_configured' });
+    }
+
+    if (!orgId) {
+      request.log.error('Post-finish webhook missing org context');
+      return reply.status(400).send({ error: 'missing_org_id' });
     }
 
     const submissionId = metadata['submission-id'] ?? metadata['submissionId'];

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -5,12 +5,45 @@
  * 1. Seed data exists (all projects)
  * 2. tusd + MinIO reachable (uploads project)
  * 3. Zitadel reachable + config exists (oidc project)
+ *
+ * NOTE: Playwright passes ALL configured projects to globalSetup, even when
+ * `--project` filters the run. We parse process.argv to detect which project
+ * was actually requested, falling back to "all" if no --project flag is found.
  */
 
 import { existsSync } from "fs";
 import { resolve } from "path";
-import type { FullConfig } from "@playwright/test";
 import { getOrgBySlug, getUserByEmail, disconnectDb } from "./helpers/db";
+
+/**
+ * Determine which projects are being run by checking process.argv.
+ * Playwright doesn't filter FullConfig.projects for globalSetup,
+ * so we parse the CLI args directly.
+ */
+function getRequestedProjects(): Set<string> {
+  const args = process.argv;
+  const projects = new Set<string>();
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--project" && args[i + 1]) {
+      projects.add(args[i + 1]);
+    }
+    // Handle --project=name format
+    const match = args[i]?.match(/^--project=(.+)$/);
+    if (match) {
+      projects.add(match[1]);
+    }
+  }
+
+  // If no --project flag, all projects will run
+  if (projects.size === 0) {
+    projects.add("submissions");
+    projects.add("uploads");
+    projects.add("oidc");
+  }
+
+  return projects;
+}
 
 async function isReachable(url: string, timeoutMs = 5000): Promise<boolean> {
   try {
@@ -24,9 +57,8 @@ async function isReachable(url: string, timeoutMs = 5000): Promise<boolean> {
   }
 }
 
-export default async function globalSetup(config: FullConfig) {
-  // Determine which projects are being run
-  const projectNames = config.projects.map((p) => p.name);
+export default async function globalSetup() {
+  const requestedProjects = getRequestedProjects();
 
   // 1. Seed data validation (required by all projects)
   const org = await getOrgBySlug("quarterly-review");
@@ -48,7 +80,7 @@ export default async function globalSetup(config: FullConfig) {
   }
 
   // 2. Upload infrastructure health check
-  if (projectNames.includes("uploads")) {
+  if (requestedProjects.has("uploads")) {
     const tusdOk = await isReachable("http://localhost:1080");
     if (!tusdOk) {
       await disconnectDb();
@@ -71,7 +103,7 @@ export default async function globalSetup(config: FullConfig) {
   }
 
   // 3. OIDC infrastructure health check
-  if (projectNames.includes("oidc")) {
+  if (requestedProjects.has("oidc")) {
     const zitadelOk = await isReachable("http://localhost:8080/debug/healthz");
     if (!zitadelOk) {
       await disconnectDb();

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -1,10 +1,34 @@
 /**
- * Playwright global setup — validates seed data exists before running tests.
+ * Playwright global setup — validates seed data and infrastructure health.
+ *
+ * Checks:
+ * 1. Seed data exists (all projects)
+ * 2. tusd + MinIO reachable (uploads project)
+ * 3. Zitadel reachable + config exists (oidc project)
  */
 
+import { existsSync } from "fs";
+import { resolve } from "path";
+import type { FullConfig } from "@playwright/test";
 import { getOrgBySlug, getUserByEmail, disconnectDb } from "./helpers/db";
 
-export default async function globalSetup() {
+async function isReachable(url: string, timeoutMs = 5000): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(timer);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export default async function globalSetup(config: FullConfig) {
+  // Determine which projects are being run
+  const projectNames = config.projects.map((p) => p.name);
+
+  // 1. Seed data validation (required by all projects)
   const org = await getOrgBySlug("quarterly-review");
   if (!org) {
     await disconnectDb();
@@ -21,6 +45,50 @@ export default async function globalSetup() {
       'E2E prerequisite failed: seed user "writer@example.com" not found.\n' +
         "Run `pnpm db:seed` to populate seed data before running E2E tests.",
     );
+  }
+
+  // 2. Upload infrastructure health check
+  if (projectNames.includes("uploads")) {
+    const tusdOk = await isReachable("http://localhost:1080");
+    if (!tusdOk) {
+      await disconnectDb();
+      throw new Error(
+        "E2E prerequisite failed: tusd not reachable at http://localhost:1080.\n" +
+          "Run `docker compose -f docker-compose.yml -f docker-compose.e2e.yml up tusd minio minio-setup -d`",
+      );
+    }
+
+    const minioOk = await isReachable(
+      "http://localhost:9000/minio/health/live",
+    );
+    if (!minioOk) {
+      await disconnectDb();
+      throw new Error(
+        "E2E prerequisite failed: MinIO not reachable at http://localhost:9000.\n" +
+          "Run `docker compose -f docker-compose.yml -f docker-compose.e2e.yml up minio minio-setup -d`",
+      );
+    }
+  }
+
+  // 3. OIDC infrastructure health check
+  if (projectNames.includes("oidc")) {
+    const zitadelOk = await isReachable("http://localhost:8080/debug/healthz");
+    if (!zitadelOk) {
+      await disconnectDb();
+      throw new Error(
+        "E2E prerequisite failed: Zitadel not reachable at http://localhost:8080.\n" +
+          "Run `docker compose --profile auth up -d`",
+      );
+    }
+
+    const configPath = resolve(__dirname, ".zitadel-e2e-config.json");
+    if (!existsSync(configPath)) {
+      await disconnectDb();
+      throw new Error(
+        "E2E prerequisite failed: .zitadel-e2e-config.json not found.\n" +
+          "Run `pnpm --filter @colophony/web e2e:setup-oidc` to provision Zitadel test data.",
+      );
+    }
   }
 
   await disconnectDb();

--- a/apps/web/e2e/helpers/oidc-fixtures.ts
+++ b/apps/web/e2e/helpers/oidc-fixtures.ts
@@ -1,0 +1,101 @@
+/**
+ * OIDC test fixtures for Playwright E2E tests.
+ *
+ * These fixtures use a real Zitadel instance (no fake auth injection).
+ * Tests authenticate by filling the actual Zitadel login form.
+ *
+ * Prerequisites:
+ * - Zitadel running via `docker compose --profile auth up -d`
+ * - E2E provisioning via `pnpm --filter @colophony/web e2e:setup-oidc`
+ * - OIDC_E2E=true environment variable
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+import { test as base, expect, type Page, devices } from "@playwright/test";
+
+interface OidcConfig {
+  authority: string;
+  clientId: string;
+  testUserEmail: string;
+  testUserPassword: string;
+  testUserId: string;
+  testOrgId: string;
+}
+
+/**
+ * Load Zitadel E2E config from the generated JSON file.
+ */
+function loadOidcConfig(): OidcConfig {
+  const configPath = resolve(__dirname, "../.zitadel-e2e-config.json");
+  if (!existsSync(configPath)) {
+    throw new Error(
+      "OIDC E2E config not found. Run `pnpm --filter @colophony/web e2e:setup-oidc` first.",
+    );
+  }
+  return JSON.parse(readFileSync(configPath, "utf-8")) as OidcConfig;
+}
+
+/**
+ * Fill the Zitadel login form and submit.
+ *
+ * Zitadel v4.x login UI uses a two-step form:
+ * 1. Enter login name (email) → click Next
+ * 2. Enter password → click Next
+ */
+export async function loginViaZitadel(
+  page: Page,
+  email: string,
+  password: string,
+): Promise<void> {
+  // Step 1: Enter email
+  const loginInput = page.locator(
+    'input[name="loginName"], input[autocomplete="username"]',
+  );
+  await loginInput.waitFor({ state: "visible", timeout: 15_000 });
+  await loginInput.fill(email);
+
+  // Click Next (first step)
+  await page.getByRole("button", { name: /next/i }).click();
+
+  // Step 2: Enter password
+  const passwordInput = page.locator(
+    'input[name="password"], input[type="password"]',
+  );
+  await passwordInput.waitFor({ state: "visible", timeout: 10_000 });
+  await passwordInput.fill(password);
+
+  // Click Next (second step — submits login)
+  await page.getByRole("button", { name: /next/i }).click();
+
+  // Wait for redirect back to app
+  await page.waitForURL(/localhost:3010/, { timeout: 15_000 });
+}
+
+/**
+ * Extended Playwright test with OIDC fixtures.
+ *
+ * Fixtures:
+ * - `oidcConfig` — loaded Zitadel E2E configuration
+ * - `unauthPage` — clean Page with no auth state
+ */
+export const test = base.extend<{
+  oidcConfig: OidcConfig;
+  unauthPage: Page;
+}>({
+  oidcConfig: async ({}, use) => {
+    await use(loadOidcConfig());
+  },
+
+  unauthPage: async ({ browser, baseURL }, use) => {
+    const context = await browser.newContext({
+      ...devices["Desktop Chrome"],
+      baseURL: baseURL ?? undefined,
+    });
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
+});
+
+export { expect };

--- a/apps/web/e2e/helpers/upload.ts
+++ b/apps/web/e2e/helpers/upload.ts
@@ -1,0 +1,121 @@
+/**
+ * Upload-specific E2E test helpers.
+ *
+ * Provides utilities for file upload tests that interact with tusd + MinIO:
+ * - Test file generation
+ * - DB queries for file assertions
+ * - tus request interception to swap Bearer→API key
+ */
+
+import type { Page } from "@playwright/test";
+import { Pool } from "pg";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { eq } from "drizzle-orm";
+import { submissionFiles } from "@colophony/db";
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgresql://colophony:password@localhost:5432/colophony";
+
+let pool: Pool | null = null;
+
+function getPool(): Pool {
+  if (!pool) {
+    pool = new Pool({
+      connectionString: DATABASE_URL,
+      max: 3,
+      idleTimeoutMillis: 5000,
+    });
+  }
+  return pool;
+}
+
+function getDb() {
+  return drizzle(getPool());
+}
+
+/**
+ * Create a test file buffer for use with Playwright's `setInputFiles`.
+ */
+export function createTestFile(
+  name: string,
+  mimeType: string,
+  sizeKB: number = 1,
+): { name: string; mimeType: string; buffer: Buffer } {
+  const buffer = Buffer.alloc(sizeKB * 1024, "a");
+  return { name, mimeType, buffer };
+}
+
+/**
+ * Query files associated with a submission from the database.
+ */
+export async function getFilesBySubmissionId(submissionId: string): Promise<
+  Array<{
+    id: string;
+    filename: string;
+    mimeType: string;
+    size: number;
+    scanStatus: string;
+    storageKey: string;
+  }>
+> {
+  const db = getDb();
+  return db
+    .select({
+      id: submissionFiles.id,
+      filename: submissionFiles.filename,
+      mimeType: submissionFiles.mimeType,
+      size: submissionFiles.size,
+      scanStatus: submissionFiles.scanStatus,
+      storageKey: submissionFiles.storageKey,
+    })
+    .from(submissionFiles)
+    .where(eq(submissionFiles.submissionId, submissionId));
+}
+
+/**
+ * Delete all files associated with a submission (test cleanup).
+ */
+export async function deleteFilesBySubmissionId(
+  submissionId: string,
+): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(submissionFiles)
+    .where(eq(submissionFiles.submissionId, submissionId))
+    .catch(() => {
+      // Ignore if already deleted
+    });
+}
+
+/**
+ * Disconnect the upload helper's DB pool.
+ */
+export async function disconnectUploadDb(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}
+
+/**
+ * Set up tus request interception to swap Bearer token for API key.
+ *
+ * Mirrors the tRPC interception pattern in auth.ts — intercepts all
+ * requests to tusd (localhost:1080) and replaces the Authorization
+ * header with X-Api-Key.
+ */
+export async function setupTusAuth(page: Page, apiKey: string): Promise<void> {
+  await page.route("**/localhost:1080/**", async (route) => {
+    const request = route.request();
+    const headers = { ...request.headers() };
+
+    // Remove the fake OIDC Bearer token
+    delete headers["authorization"];
+
+    // Add the real API key
+    headers["x-api-key"] = apiKey;
+
+    await route.continue({ headers });
+  });
+}

--- a/apps/web/e2e/oidc/auth-guard.spec.ts
+++ b/apps/web/e2e/oidc/auth-guard.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * E2E tests for auth guard behavior with real Zitadel instance.
+ *
+ * Prerequisites:
+ * - Zitadel running via `docker compose --profile auth up -d`
+ * - E2E provisioning via `pnpm --filter @colophony/web e2e:setup-oidc`
+ * - OIDC_E2E=true environment variable
+ */
+
+import { test, expect } from "../helpers/oidc-fixtures";
+
+test.describe("Auth Guard", () => {
+  test("protected routes redirect to login", async ({
+    unauthPage,
+    oidcConfig,
+  }) => {
+    // Test multiple protected routes
+    const protectedRoutes = ["/submissions", "/submissions/new"];
+
+    for (const route of protectedRoutes) {
+      await unauthPage.goto(route);
+      await unauthPage.waitForURL(/localhost:8080/, { timeout: 15_000 });
+      expect(unauthPage.url()).toContain(
+        oidcConfig.authority.replace("http://", ""),
+      );
+
+      // Navigate back to a neutral page before testing the next route
+      await unauthPage.goto("about:blank");
+    }
+  });
+
+  test("callback error shows retry UI", async ({ unauthPage }) => {
+    // Navigate directly to callback without OIDC params — should show error
+    await unauthPage.goto("/auth/callback");
+
+    // Should show "Authentication Error" heading
+    await expect(
+      unauthPage.getByRole("heading", { name: "Authentication Error" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Should show "Try again" link
+    await expect(unauthPage.getByText("Try again")).toBeVisible();
+  });
+});

--- a/apps/web/e2e/oidc/login.spec.ts
+++ b/apps/web/e2e/oidc/login.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * E2E tests for OIDC login flow with real Zitadel instance.
+ *
+ * Prerequisites:
+ * - Zitadel running via `docker compose --profile auth up -d`
+ * - E2E provisioning via `pnpm --filter @colophony/web e2e:setup-oidc`
+ * - OIDC_E2E=true environment variable
+ */
+
+import { test, expect, loginViaZitadel } from "../helpers/oidc-fixtures";
+
+test.describe("OIDC Login Flow", () => {
+  test("unauthenticated access redirects to Zitadel", async ({
+    unauthPage,
+    oidcConfig,
+  }) => {
+    await unauthPage.goto("/submissions");
+
+    // Should redirect to Zitadel login page
+    await unauthPage.waitForURL(/localhost:8080/, { timeout: 15_000 });
+    expect(unauthPage.url()).toContain(
+      oidcConfig.authority.replace("http://", ""),
+    );
+  });
+
+  test("completes login and reaches dashboard", async ({
+    unauthPage,
+    oidcConfig,
+  }) => {
+    await unauthPage.goto("/submissions");
+
+    // Wait for Zitadel redirect
+    await unauthPage.waitForURL(/localhost:8080/, { timeout: 15_000 });
+
+    // Complete login
+    await loginViaZitadel(
+      unauthPage,
+      oidcConfig.testUserEmail,
+      oidcConfig.testUserPassword,
+    );
+
+    // Should be redirected back to the app
+    await expect(unauthPage).toHaveURL(/\/submissions|\//, {
+      timeout: 15_000,
+    });
+
+    // Authenticated UI should be visible (e.g., heading or user menu)
+    await expect(
+      unauthPage.getByRole("heading", { name: /submissions/i }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("preserves return path after login", async ({
+    unauthPage,
+    oidcConfig,
+  }) => {
+    // Navigate to a specific protected route
+    await unauthPage.goto("/submissions/new");
+
+    // Wait for Zitadel redirect
+    await unauthPage.waitForURL(/localhost:8080/, { timeout: 15_000 });
+
+    // Complete login
+    await loginViaZitadel(
+      unauthPage,
+      oidcConfig.testUserEmail,
+      oidcConfig.testUserPassword,
+    );
+
+    // Should be redirected back to the original path
+    await expect(unauthPage).toHaveURL(/\/submissions\/new/, {
+      timeout: 15_000,
+    });
+  });
+
+  test("logout clears session", async ({ unauthPage, oidcConfig }) => {
+    // First, login
+    await unauthPage.goto("/submissions");
+    await unauthPage.waitForURL(/localhost:8080/, { timeout: 15_000 });
+    await loginViaZitadel(
+      unauthPage,
+      oidcConfig.testUserEmail,
+      oidcConfig.testUserPassword,
+    );
+
+    // Wait for authenticated state
+    await expect(unauthPage).toHaveURL(/\/submissions|\//, {
+      timeout: 15_000,
+    });
+
+    // Click logout (look for common logout patterns)
+    const logoutButton = unauthPage.getByRole("button", {
+      name: /log\s*out|sign\s*out/i,
+    });
+    if (await logoutButton.isVisible()) {
+      await logoutButton.click();
+    } else {
+      // Try user menu dropdown first
+      const userMenu = unauthPage.getByRole("button", {
+        name: /user|account|profile/i,
+      });
+      if (await userMenu.isVisible()) {
+        await userMenu.click();
+        await unauthPage
+          .getByRole("menuitem", { name: /log\s*out|sign\s*out/i })
+          .click();
+      }
+    }
+
+    // Navigate to a protected route — should redirect to login again
+    await unauthPage.goto("/submissions");
+    await unauthPage.waitForURL(/localhost:8080/, { timeout: 15_000 });
+  });
+});

--- a/apps/web/e2e/uploads/file-upload.spec.ts
+++ b/apps/web/e2e/uploads/file-upload.spec.ts
@@ -13,6 +13,8 @@ import { test, expect } from "../helpers/fixtures";
 import {
   createSubmission,
   deleteSubmission,
+  getOrgBySlug,
+  getUserByEmail,
   getOpenSubmissionPeriod,
 } from "../helpers/db";
 import {
@@ -25,13 +27,21 @@ import {
 
 test.describe("File Upload (/submissions/:id — edit mode)", () => {
   let submissionId: string;
+  let orgId: string;
 
-  test.beforeAll(async ({ seedOrg, seedUser }) => {
-    // Create a DRAFT submission for upload tests
-    const period = await getOpenSubmissionPeriod(seedOrg.id);
+  test.beforeAll(async () => {
+    // Look up seed data directly (fixtures not available in beforeAll)
+    const org = await getOrgBySlug("quarterly-review");
+    if (!org) throw new Error("Seed org not found");
+    orgId = org.id;
+
+    const user = await getUserByEmail("writer@example.com");
+    if (!user) throw new Error("Seed user not found");
+
+    const period = await getOpenSubmissionPeriod(org.id);
     const submission = await createSubmission({
-      orgId: seedOrg.id,
-      submitterId: seedUser.id,
+      orgId: org.id,
+      submitterId: user.id,
       submissionPeriodId: period?.id,
       title: "E2E Upload Test Submission",
       status: "DRAFT",
@@ -40,14 +50,18 @@ test.describe("File Upload (/submissions/:id — edit mode)", () => {
   });
 
   test.afterAll(async () => {
-    await deleteFilesBySubmissionId(submissionId);
-    await deleteSubmission(submissionId);
+    if (submissionId) {
+      await deleteFilesBySubmissionId(submissionId);
+      await deleteSubmission(submissionId);
+    }
     await disconnectUploadDb();
   });
 
   test.afterEach(async () => {
     // Clean up files between tests to avoid file count limit issues
-    await deleteFilesBySubmissionId(submissionId);
+    if (submissionId) {
+      await deleteFilesBySubmissionId(submissionId);
+    }
   });
 
   test("uploads a file and shows it in file list", async ({
@@ -147,7 +161,10 @@ test.describe("File Upload (/submissions/:id — edit mode)", () => {
       buffer: testFile.buffer,
     });
 
-    // Wait for it to appear
+    // Wait for it to appear in uploaded files
+    await expect(authedPage.getByText("Uploaded files")).toBeVisible({
+      timeout: 15_000,
+    });
     await expect(authedPage.getByText("to-delete.txt")).toBeVisible({
       timeout: 15_000,
     });
@@ -218,7 +235,10 @@ test.describe("File Upload (/submissions/:id — edit mode)", () => {
       { name: file2.name, mimeType: file2.mimeType, buffer: file2.buffer },
     ]);
 
-    // Both files should appear with Clean badge
+    // Wait for both files to appear in the "Uploaded files" section (not just "Uploading")
+    await expect(authedPage.getByText("Uploaded files")).toBeVisible({
+      timeout: 15_000,
+    });
     await expect(authedPage.getByText("poem-1.txt")).toBeVisible({
       timeout: 15_000,
     });

--- a/apps/web/e2e/uploads/file-upload.spec.ts
+++ b/apps/web/e2e/uploads/file-upload.spec.ts
@@ -27,13 +27,11 @@ import {
 
 test.describe("File Upload (/submissions/:id — edit mode)", () => {
   let submissionId: string;
-  let orgId: string;
 
   test.beforeAll(async () => {
     // Look up seed data directly (fixtures not available in beforeAll)
     const org = await getOrgBySlug("quarterly-review");
     if (!org) throw new Error("Seed org not found");
-    orgId = org.id;
 
     const user = await getUserByEmail("writer@example.com");
     if (!user) throw new Error("Seed user not found");

--- a/apps/web/e2e/uploads/file-upload.spec.ts
+++ b/apps/web/e2e/uploads/file-upload.spec.ts
@@ -1,0 +1,235 @@
+/**
+ * E2E tests for file upload flow.
+ *
+ * Prerequisites:
+ * - tusd + MinIO running (docker-compose.e2e.yml)
+ * - pnpm db:seed
+ *
+ * Auth strategy: uses existing authedPage fixture (fake OIDC + API key
+ * interception for tRPC), plus setupTusAuth for tus upload interception.
+ */
+
+import { test, expect } from "../helpers/fixtures";
+import {
+  createSubmission,
+  deleteSubmission,
+  getOpenSubmissionPeriod,
+} from "../helpers/db";
+import {
+  createTestFile,
+  getFilesBySubmissionId,
+  deleteFilesBySubmissionId,
+  setupTusAuth,
+  disconnectUploadDb,
+} from "../helpers/upload";
+
+test.describe("File Upload (/submissions/:id — edit mode)", () => {
+  let submissionId: string;
+
+  test.beforeAll(async ({ seedOrg, seedUser }) => {
+    // Create a DRAFT submission for upload tests
+    const period = await getOpenSubmissionPeriod(seedOrg.id);
+    const submission = await createSubmission({
+      orgId: seedOrg.id,
+      submitterId: seedUser.id,
+      submissionPeriodId: period?.id,
+      title: "E2E Upload Test Submission",
+      status: "DRAFT",
+    });
+    submissionId = submission.id;
+  });
+
+  test.afterAll(async () => {
+    await deleteFilesBySubmissionId(submissionId);
+    await deleteSubmission(submissionId);
+    await disconnectUploadDb();
+  });
+
+  test.afterEach(async () => {
+    // Clean up files between tests to avoid file count limit issues
+    await deleteFilesBySubmissionId(submissionId);
+  });
+
+  test("uploads a file and shows it in file list", async ({
+    authedPage,
+    testApiKey,
+  }) => {
+    await setupTusAuth(authedPage, testApiKey.plainKey);
+    await authedPage.goto(`/submissions/${submissionId}`);
+
+    // Click Edit to enter edit mode
+    await authedPage.getByRole("button", { name: /edit/i }).click();
+
+    // Upload a text file via the hidden file input
+    const testFile = createTestFile("test-poem.txt", "text/plain", 1);
+    const fileInput = authedPage.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: testFile.name,
+      mimeType: testFile.mimeType,
+      buffer: testFile.buffer,
+    });
+
+    // Wait for file to appear in "Uploaded files" section with Clean badge
+    await expect(authedPage.getByText("Uploaded files")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(authedPage.getByText("test-poem.txt")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(authedPage.getByText("Clean")).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("shows upload progress indicator", async ({
+    authedPage,
+    testApiKey,
+  }) => {
+    await setupTusAuth(authedPage, testApiKey.plainKey);
+    await authedPage.goto(`/submissions/${submissionId}`);
+    await authedPage.getByRole("button", { name: /edit/i }).click();
+
+    // Upload a slightly larger file to increase chance of catching progress
+    const testFile = createTestFile("larger-file.txt", "text/plain", 10);
+    const fileInput = authedPage.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: testFile.name,
+      mimeType: testFile.mimeType,
+      buffer: testFile.buffer,
+    });
+
+    // File should eventually appear as uploaded (may complete too fast for progress bar)
+    await expect(authedPage.getByText("larger-file.txt")).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("uploaded file has CLEAN scan status in database", async ({
+    authedPage,
+    testApiKey,
+  }) => {
+    await setupTusAuth(authedPage, testApiKey.plainKey);
+    await authedPage.goto(`/submissions/${submissionId}`);
+    await authedPage.getByRole("button", { name: /edit/i }).click();
+
+    const testFile = createTestFile("scan-test.txt", "text/plain", 1);
+    const fileInput = authedPage.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: testFile.name,
+      mimeType: testFile.mimeType,
+      buffer: testFile.buffer,
+    });
+
+    // Wait for UI to show the file
+    await expect(authedPage.getByText("Clean")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Verify in DB (VIRUS_SCAN_ENABLED=false → marked CLEAN immediately)
+    const files = await getFilesBySubmissionId(submissionId);
+    expect(files.length).toBeGreaterThanOrEqual(1);
+    const uploaded = files.find((f) => f.filename === "scan-test.txt");
+    expect(uploaded).toBeDefined();
+    expect(uploaded!.scanStatus).toBe("CLEAN");
+  });
+
+  test("can delete an uploaded file", async ({ authedPage, testApiKey }) => {
+    await setupTusAuth(authedPage, testApiKey.plainKey);
+    await authedPage.goto(`/submissions/${submissionId}`);
+    await authedPage.getByRole("button", { name: /edit/i }).click();
+
+    // Upload a file first
+    const testFile = createTestFile("to-delete.txt", "text/plain", 1);
+    const fileInput = authedPage.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: testFile.name,
+      mimeType: testFile.mimeType,
+      buffer: testFile.buffer,
+    });
+
+    // Wait for it to appear
+    await expect(authedPage.getByText("to-delete.txt")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(authedPage.getByText("Clean")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Find and click the delete button (X icon) for this file
+    const fileRow = authedPage
+      .locator(".border.rounded-lg")
+      .filter({ hasText: "to-delete.txt" });
+    await fileRow.getByRole("button").click();
+
+    // File should disappear from the UI
+    await expect(authedPage.getByText("to-delete.txt")).not.toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Verify in DB
+    const files = await getFilesBySubmissionId(submissionId);
+    const deleted = files.find((f) => f.filename === "to-delete.txt");
+    expect(deleted).toBeUndefined();
+  });
+
+  test("rejects invalid MIME type (client-side)", async ({
+    authedPage,
+    testApiKey,
+  }) => {
+    await setupTusAuth(authedPage, testApiKey.plainKey);
+    await authedPage.goto(`/submissions/${submissionId}`);
+    await authedPage.getByRole("button", { name: /edit/i }).click();
+
+    // Try to upload an .exe file — client-side validation should catch this
+    const testFile = createTestFile(
+      "malicious.exe",
+      "application/x-msdownload",
+      1,
+    );
+    const fileInput = authedPage.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: testFile.name,
+      mimeType: testFile.mimeType,
+      buffer: testFile.buffer,
+    });
+
+    // Should show error message
+    await expect(authedPage.getByText(/not allowed/i)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // No file should be created in DB
+    const files = await getFilesBySubmissionId(submissionId);
+    const exe = files.find((f) => f.filename === "malicious.exe");
+    expect(exe).toBeUndefined();
+  });
+
+  test("uploads multiple files", async ({ authedPage, testApiKey }) => {
+    await setupTusAuth(authedPage, testApiKey.plainKey);
+    await authedPage.goto(`/submissions/${submissionId}`);
+    await authedPage.getByRole("button", { name: /edit/i }).click();
+
+    const file1 = createTestFile("poem-1.txt", "text/plain", 1);
+    const file2 = createTestFile("poem-2.txt", "text/plain", 1);
+
+    const fileInput = authedPage.locator('input[type="file"]');
+    await fileInput.setInputFiles([
+      { name: file1.name, mimeType: file1.mimeType, buffer: file1.buffer },
+      { name: file2.name, mimeType: file2.mimeType, buffer: file2.buffer },
+    ]);
+
+    // Both files should appear with Clean badge
+    await expect(authedPage.getByText("poem-1.txt")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(authedPage.getByText("poem-2.txt")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Verify in DB
+    const files = await getFilesBySubmissionId(submissionId);
+    const names = files.map((f) => f.filename);
+    expect(names).toContain("poem-1.txt");
+    expect(names).toContain("poem-2.txt");
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,8 +11,12 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
-    "test:e2e": "playwright test",
+    "test:e2e": "playwright test --project submissions",
+    "test:e2e:uploads": "playwright test --project uploads",
+    "test:e2e:oidc": "OIDC_E2E=true playwright test --project oidc",
+    "test:e2e:all": "OIDC_E2E=true playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "e2e:setup-oidc": "tsx ../../scripts/setup-zitadel-e2e.ts",
     "clean": "rm -rf .next"
   },
   "dependencies": {

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from "fs";
 import { resolve } from "path";
 import dotenv from "dotenv";
 import { defineConfig, devices } from "@playwright/test";
@@ -5,15 +6,10 @@ import { defineConfig, devices } from "@playwright/test";
 /**
  * Playwright configuration for browser E2E tests.
  *
- * Prerequisites:
- * - docker-compose up (PostgreSQL)
- * - pnpm db:migrate && pnpm db:seed
- *
- * The webServer config starts both the API and Web dev servers automatically.
- *
- * Auth strategy: Fake OIDC user injected into localStorage (satisfies frontend
- * auth checks), tRPC requests intercepted to swap Bearer token for API key
- * (satisfies API auth). No Zitadel instance required.
+ * Three projects:
+ * - submissions: existing tests (fake OIDC + API key interception, no external services)
+ * - uploads: requires tusd + MinIO (docker-compose.e2e.yml)
+ * - oidc: requires Zitadel (docker-compose --profile auth)
  *
  * IMPORTANT: Playwright's webServer.env replaces process.env entirely for child
  * processes. We must load .env files and spread process.env to ensure DATABASE_URL
@@ -26,13 +22,31 @@ dotenv.config({ path: resolve(__dirname, ".env.local") });
 
 /**
  * E2E servers run on dedicated ports (4010/3010) so they never collide with
- * dev servers on the default ports (4000/3000). This means:
- * - `pnpm dev` can stay running while you run E2E tests
- * - Stale E2E servers from a previous run don't block the next run
- * - No need for `reuseExistingServer` hacks on the web server
+ * dev servers on the default ports (4000/3000).
  */
 const E2E_API_PORT = 4010;
 const E2E_WEB_PORT = 3010;
+
+/**
+ * When OIDC_E2E=true, load real Zitadel config for OIDC project tests.
+ * Otherwise, use fake values for submissions/uploads projects.
+ */
+const isOidcE2e = process.env.OIDC_E2E === "true";
+
+let oidcAuthority = "http://test-idp:8080";
+let oidcClientId = "test-client";
+
+if (isOidcE2e) {
+  const configPath = resolve(__dirname, "e2e/.zitadel-e2e-config.json");
+  if (existsSync(configPath)) {
+    const config = JSON.parse(readFileSync(configPath, "utf-8")) as {
+      authority: string;
+      clientId: string;
+    };
+    oidcAuthority = config.authority;
+    oidcClientId = config.clientId;
+  }
+}
 
 export default defineConfig({
   testDir: "./e2e",
@@ -55,7 +69,18 @@ export default defineConfig({
 
   projects: [
     {
-      name: "chromium",
+      name: "submissions",
+      testDir: "./e2e/submissions",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "uploads",
+      testDir: "./e2e/uploads",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "oidc",
+      testDir: "./e2e/oidc",
       use: { ...devices["Desktop Chrome"] },
     },
   ],
@@ -72,9 +97,13 @@ export default defineConfig({
         PORT: String(E2E_API_PORT),
         CORS_ORIGIN: `http://localhost:${E2E_WEB_PORT}`,
         VIRUS_SCAN_ENABLED: "false",
-        // Raise rate limits for E2E: 20 tests × ~5 requests each can exceed default 60/min
+        // Raise rate limits for E2E: tests × ~5 requests each can exceed default 60/min
         RATE_LIMIT_DEFAULT_MAX: "1000",
         RATE_LIMIT_AUTH_MAX: "1000",
+        ...(isOidcE2e && {
+          ZITADEL_AUTHORITY: oidcAuthority,
+          ZITADEL_CLIENT_ID: oidcClientId,
+        }),
       },
     },
     {
@@ -90,8 +119,9 @@ export default defineConfig({
         ...process.env,
         PORT: String(E2E_WEB_PORT),
         NEXT_PUBLIC_API_URL: `http://localhost:${E2E_API_PORT}`,
-        NEXT_PUBLIC_ZITADEL_AUTHORITY: "http://test-idp:8080",
-        NEXT_PUBLIC_ZITADEL_CLIENT_ID: "test-client",
+        NEXT_PUBLIC_ZITADEL_AUTHORITY: oidcAuthority,
+        NEXT_PUBLIC_ZITADEL_CLIENT_ID: oidcClientId,
+        NEXT_PUBLIC_TUS_URL: "http://localhost:1080/files/",
       },
     },
   ],

--- a/apps/web/src/components/submissions/file-upload.tsx
+++ b/apps/web/src/components/submissions/file-upload.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { trpc } from "@/lib/trpc";
 import { useFileUpload, type UploadingFile } from "@/hooks/use-file-upload";
 import { Button } from "@/components/ui/button";
@@ -177,8 +177,30 @@ function ExistingFileItem({
 
 export function FileUpload({ submissionId, disabled }: FileUploadProps) {
   const inputRef = useRef<HTMLInputElement>(null);
+  // Track whether uploads are in "processing" state (waiting for post-finish
+  // webhook to create the file record). Used by refetchInterval below.
+  const hasProcessingUploadsRef = useRef(false);
 
-  // Poll while any file is still being scanned
+  const deleteMutation = trpc.files.delete.useMutation();
+  const utils = trpc.useUtils();
+
+  const { uploads, uploadFiles, removeUpload, cancelUpload } = useFileUpload({
+    submissionId,
+    onUploadComplete: () => {
+      utils.files.listBySubmission.invalidate({ submissionId });
+    },
+  });
+
+  // Keep ref in sync with upload state so the query's refetchInterval
+  // can read it without stale closures.
+  useEffect(() => {
+    hasProcessingUploadsRef.current = uploads.some(
+      (u) => u.status === "processing",
+    );
+  }, [uploads]);
+
+  // Poll while any file is still being scanned OR while uploads are waiting
+  // for the post-finish webhook to create their DB records.
   const { data: existingFiles, isPending: isLoading } =
     trpc.files.listBySubmission.useQuery(
       { submissionId },
@@ -190,20 +212,25 @@ export function FileUpload({ submissionId, disabled }: FileUploadProps) {
           const hasPending = files?.some(
             (f) => f.scanStatus === "PENDING" || f.scanStatus === "SCANNING",
           );
-          return hasPending ? 3000 : false;
+          return hasPending || hasProcessingUploadsRef.current ? 3000 : false;
         },
       },
     );
 
-  const deleteMutation = trpc.files.delete.useMutation();
-  const utils = trpc.useUtils();
-
-  const { uploads, uploadFiles, removeUpload, cancelUpload } = useFileUpload({
-    submissionId,
-    onUploadComplete: () => {
-      utils.files.listBySubmission.invalidate({ submissionId });
-    },
-  });
+  // Auto-remove "processing" upload items once their file record appears
+  // in the DB query results (i.e., the post-finish webhook has completed).
+  useEffect(() => {
+    if (!existingFiles) return;
+    const existingNames = new Set(existingFiles.map((f) => f.filename));
+    for (const upload of uploads) {
+      if (
+        upload.status === "processing" &&
+        existingNames.has(upload.file.name)
+      ) {
+        removeUpload(upload.id);
+      }
+    }
+  }, [existingFiles, uploads, removeUpload]);
 
   const handleFileSelect = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/web/src/hooks/__tests__/use-file-upload.spec.ts
+++ b/apps/web/src/hooks/__tests__/use-file-upload.spec.ts
@@ -104,6 +104,7 @@ describe("useFileUpload", () => {
   });
 
   it("should handle upload success", async () => {
+    jest.useFakeTimers();
     const { result } = renderHook(() => useFileUpload(defaultOptions));
     const file = new File(["content"], "test.pdf", {
       type: "application/pdf",
@@ -119,10 +120,19 @@ describe("useFileUpload", () => {
 
     expect(result.current.uploads[0].status).toBe("processing");
     expect(result.current.uploads[0].scanStatus).toBe("PENDING");
+
+    // Invalidation is delayed to allow post-finish webhook to complete
+    expect(mockInvalidateFiles).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(1500);
+    });
+
     expect(mockInvalidateFiles).toHaveBeenCalledWith({
       submissionId: "sub-123",
     });
     expect(defaultOptions.onUploadComplete).toHaveBeenCalled();
+    jest.useRealTimers();
   });
 
   it("should handle upload error", async () => {

--- a/apps/web/src/hooks/use-file-upload.ts
+++ b/apps/web/src/hooks/use-file-upload.ts
@@ -170,9 +170,17 @@ export function useFileUpload({
               scanStatus: "PENDING",
             });
             tusInstances.current.delete(uploadId);
-            // Invalidate file queries to pick up the new file
-            utils.files.listBySubmission.invalidate({ submissionId });
-            onUploadComplete?.(uploadId);
+            // The post-finish webhook creates the file record asynchronously
+            // after tusd reports the upload complete. Delay the first
+            // invalidation to give the webhook time to process, then retry
+            // in case the first attempt was still too early.
+            setTimeout(() => {
+              utils.files.listBySubmission.invalidate({ submissionId });
+              onUploadComplete?.(uploadId);
+            }, 1500);
+            setTimeout(() => {
+              utils.files.listBySubmission.invalidate({ submissionId });
+            }, 4000);
           },
           onError: (error) => {
             const message = mapTusError(error);

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -10,6 +10,8 @@
 services:
   tusd:
     command:
+      - -port
+      - "1080"
       - -s3-endpoint
       - http://minio:9000
       - -s3-bucket

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,24 @@
+# Docker Compose override for E2E tests requiring tusd + MinIO.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.e2e.yml up tusd minio minio-setup -d
+#
+# Overrides:
+# - tusd webhook URL points to E2E API port (4010)
+# - tusd forwards X-Api-Key header (for API key auth in E2E tests)
+
+services:
+  tusd:
+    command:
+      - -s3-endpoint
+      - http://minio:9000
+      - -s3-bucket
+      - quarantine
+      - -s3-object-prefix
+      - uploads/
+      - -hooks-http
+      - http://host.docker.internal:4010/webhooks/tusd
+      - -hooks-http-forward-headers
+      - Authorization,X-Organization-Id,X-Api-Key
+      - -behind-proxy
+      - -verbose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,8 @@ services:
       AWS_SECRET_ACCESS_KEY: minioadmin
       AWS_REGION: us-east-1
     command:
+      - -port
+      - "1080"
       - -s3-endpoint
       - http://minio:9000
       - -s3-bucket

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -38,7 +38,7 @@
 
 - [ ] Manual testing of 4 submission pages with dev server — (DEVLOG 2026-02-15)
 - [x] E2E tests for submission flow — (DEVLOG 2026-02-15; done 2026-02-18 PR pending)
-- [ ] E2E tests for upload flow — needs tusd + MinIO in CI — (DEVLOG 2026-02-15)
+- [x] E2E tests for upload flow — needs tusd + MinIO in CI — (DEVLOG 2026-02-15; done 2026-02-18)
 - [ ] E2E tests for OIDC flow — requires Zitadel instance — (DEVLOG 2026-02-13)
 - [ ] Manual QA of full org management flow with Zitadel + dev services running — (DEVLOG 2026-02-13)
 - [ ] Manual QA: webhook freshness/rate-limit/ordering with Docker Compose + Zitadel — (DEVLOG 2026-02-15)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-18 — Upload E2E Tests: tusd v2 Compatibility Fix
+
+### Done
+
+- Debugged and fixed all 6 upload E2E tests (previously all failing due to tusd v2 payload format change)
+- Root cause: tusd v2.8.0 changed webhook payload from `{ Upload, HTTPRequest }` + `Hook-Name` header to `{ Type, Event: { Upload, HTTPRequest } }` — our handler only supported v1 format, so all webhooks fell through to "Unhandled tusd hook"
+- Added v2 payload detection and unwrapping in `tusd.webhook.ts` (backward-compatible with v1)
+- Fixed UI race condition: `onSuccess` fired before post-finish webhook created DB record — added delayed invalidation (1.5s + 4s retry) and polling during "processing" state in `file-upload.tsx`
+- Updated all 29 tusd webhook unit tests to use v2 payload format
+- Updated `use-file-upload.spec.ts` for delayed invalidation (fake timers)
+- Fixed multi-file upload E2E test: wait for "Uploaded files" section before DB assertion
+- Added tusd port (`-port 1080`) to docker-compose.yml and docker-compose.e2e.yml
+- Updated `global-setup.ts` with upload infrastructure health checks (tusd + MinIO)
+- Final results: 6/6 upload E2E, 20/20 submission E2E, 534+ unit tests, type-check clean
+
+### Decisions
+
+- Support both tusd v1 and v2 webhook payload formats for backward compatibility
+- Use delayed invalidation (setTimeout) rather than websocket/SSE for webhook completion notification — simpler, sufficient for the use case
+- Use ref-based polling bridge (`hasProcessingUploadsRef`) to avoid React hook ordering issues between `useFileUpload` and `useQuery`
+
+---
+
 ## 2026-02-18 — Testing Documentation Rewrite for v2
 
 ### Done

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,8 +23,17 @@ pnpm --filter @colophony/web test
 # RLS integration tests (~89 tests, requires postgres-test container)
 pnpm --filter @colophony/api test:rls
 
-# Playwright browser E2E tests (20 tests, requires dev servers)
+# Playwright browser E2E — submissions only (20 tests, requires dev servers)
 pnpm --filter @colophony/web test:e2e
+
+# Playwright — upload flow (6 tests, requires tusd + MinIO)
+pnpm --filter @colophony/web test:e2e:uploads
+
+# Playwright — OIDC flow (6 tests, requires Zitadel)
+pnpm --filter @colophony/web test:e2e:oidc
+
+# Playwright — all projects
+pnpm --filter @colophony/web test:e2e:all
 
 # Playwright interactive UI mode
 pnpm --filter @colophony/web test:e2e:ui
@@ -49,7 +58,7 @@ pnpm --filter @colophony/web test:e2e:ui
 | Package unit tests     | 4     | ~38   | Vitest          | `packages/*/src/**/*.spec.ts` |
 | Web unit tests         | 4     | ~35   | Jest + jsdom    | `apps/web/src/**/*.spec.*`    |
 | RLS integration tests  | 8     | ~89   | Vitest (custom) | `apps/api/src/__tests__/rls/` |
-| Playwright browser E2E | 3     | 20    | Playwright      | `apps/web/e2e/`               |
+| Playwright browser E2E | 6     | ~32   | Playwright      | `apps/web/e2e/`               |
 
 > Counts use `~` prefix because they shift as tests are added. Run `pnpm test` to get exact numbers.
 
@@ -79,6 +88,9 @@ pnpm --filter @colophony/web test:e2e:ui
 - `submissions/submission-list.spec.ts` — 7 tests (heading, new button, status tabs, seed data, navigation, submitted filter, rejected empty state)
 - `submissions/submission-create.spec.ts` — 5 tests (form fields, validation, title-only draft, full draft, appears in list)
 - `submissions/submission-detail.spec.ts` — 8 tests (detail view, edit/delete buttons, pre-filled edit, save changes, submit flow, withdraw flow, delete confirmation)
+- `uploads/file-upload.spec.ts` — 6 tests (upload + list, progress, DB scan status, delete, MIME reject, multi-file)
+- `oidc/login.spec.ts` — 4 tests (redirect to Zitadel, login flow, return path, logout)
+- `oidc/auth-guard.spec.ts` — 2 tests (protected route redirect, callback error UI)
 
 ---
 
@@ -235,7 +247,38 @@ pnpm --filter @colophony/web test:e2e    # Auto-starts API + Web dev servers
 pnpm --filter @colophony/web test:e2e:ui # Interactive UI mode
 ```
 
-The `playwright.config.ts` `webServer` config auto-starts API (port 4010) and Web (port 3010) dev servers on dedicated E2E ports. No Zitadel, MinIO, or Redis required (`VIRUS_SCAN_ENABLED=false` in API webServer env).
+The `playwright.config.ts` `webServer` config auto-starts API (port 4010) and Web (port 3010) dev servers on dedicated E2E ports. The `submissions` project requires no Zitadel, MinIO, or Redis (`VIRUS_SCAN_ENABLED=false` in API webServer env).
+
+#### Upload E2E Tests (uploads project)
+
+Requires tusd + MinIO for real file upload flow:
+
+```bash
+# Start tusd + MinIO with E2E overrides (webhook→port 4010, forwards X-Api-Key)
+docker compose -f docker-compose.yml -f docker-compose.e2e.yml up tusd minio minio-setup -d
+
+# Run upload tests
+pnpm --filter @colophony/web test:e2e:uploads
+```
+
+Auth strategy: API key interception on tus requests (same pattern as tRPC). The tusd webhook validates API keys via `X-Api-Key` forwarded header.
+
+#### OIDC E2E Tests (oidc project)
+
+Requires a real Zitadel instance for actual OIDC login flow:
+
+```bash
+# Start Zitadel
+docker compose --profile auth up -d
+
+# Provision Zitadel project, OIDC app, and test user (idempotent)
+pnpm --filter @colophony/web e2e:setup-oidc
+
+# Run OIDC tests
+pnpm --filter @colophony/web test:e2e:oidc
+```
+
+The setup script creates a Zitadel project, OIDC app (Authorization Code + PKCE), and test user, then inserts the user into the Colophony DB. Config is written to `apps/web/e2e/.zitadel-e2e-config.json` (gitignored).
 
 **CI environment variables:**
 

--- a/scripts/setup-zitadel-e2e.ts
+++ b/scripts/setup-zitadel-e2e.ts
@@ -1,0 +1,428 @@
+/**
+ * Zitadel E2E provisioning script.
+ *
+ * Automates Zitadel setup for OIDC E2E tests:
+ * 1. Wait for Zitadel health
+ * 2. Authenticate via service user or admin PAT
+ * 3. Create/find project + OIDC app
+ * 4. Create/find test user
+ * 5. Insert user into Colophony DB + add org membership
+ * 6. Write config to apps/web/e2e/.zitadel-e2e-config.json
+ *
+ * Idempotent: checks for existing resources before creating.
+ *
+ * Usage:
+ *   tsx scripts/setup-zitadel-e2e.ts
+ */
+
+import { writeFileSync } from "fs";
+import { resolve } from "path";
+import { Pool } from "pg";
+
+const ZITADEL_URL = process.env.ZITADEL_URL || "http://localhost:8080";
+const MASTERKEY =
+  process.env.ZITADEL_MASTERKEY || "MasterkeyNeedsToHave32Characters";
+const DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgresql://colophony:password@localhost:5432/colophony";
+
+const E2E_PROJECT_NAME = "colophony-e2e";
+const E2E_APP_NAME = "colophony-e2e-web";
+const E2E_REDIRECT_URI = "http://localhost:3010/auth/callback";
+const E2E_POST_LOGOUT_URI = "http://localhost:3010";
+
+const TEST_USER_EMAIL = "e2e-test@colophony.dev";
+const TEST_USER_PASSWORD = "E2eTestPassword1!";
+const TEST_USER_FIRST = "E2E";
+const TEST_USER_LAST = "TestUser";
+
+const CONFIG_OUTPUT = resolve(
+  __dirname,
+  "../apps/web/e2e/.zitadel-e2e-config.json",
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function waitForHealth(
+  maxRetries = 30,
+  intervalMs = 2000,
+): Promise<void> {
+  console.log(`Waiting for Zitadel at ${ZITADEL_URL}...`);
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const res = await fetch(`${ZITADEL_URL}/debug/healthz`);
+      if (res.ok) {
+        console.log("Zitadel is healthy.");
+        return;
+      }
+    } catch {
+      // Not ready yet
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`Zitadel not healthy after ${maxRetries * intervalMs}ms`);
+}
+
+/**
+ * Get an admin access token.
+ *
+ * Zitadel `start-from-init` creates a default admin user (zitadel-admin@zitadel.localhost).
+ * We authenticate via the management API's machine user PAT or via the admin API.
+ *
+ * For simplicity in local dev, we use the Admin API with the default admin credentials.
+ * The exact mechanism depends on Zitadel version — we try PAT first, then password grant.
+ */
+async function getAdminToken(): Promise<string> {
+  // Try 1: Use the system API with masterkey (simplest for start-from-init)
+  // Zitadel system API accepts masterkey as Bearer token for system-level operations
+  // But management API needs a proper OIDC token. Let's create a PAT via system API.
+
+  // First, list instances to find the default instance
+  const instanceRes = await fetch(
+    `${ZITADEL_URL}/system/v1/instances/_search`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${MASTERKEY}`,
+      },
+      body: JSON.stringify({ query: { limit: 1 } }),
+    },
+  );
+
+  if (!instanceRes.ok) {
+    throw new Error(
+      `Failed to list Zitadel instances: ${instanceRes.status} ${await instanceRes.text()}`,
+    );
+  }
+
+  // For management API calls, we need a valid access token.
+  // Strategy: find the default IAM admin user via system API, then create a PAT.
+  const instanceData = (await instanceRes.json()) as {
+    result?: Array<{ id: string }>;
+  };
+  if (!instanceData.result?.length) {
+    throw new Error("No Zitadel instances found");
+  }
+
+  // Find the default admin user (created by start-from-init)
+  const usersRes = await fetch(`${ZITADEL_URL}/management/v1/users/_search`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      // Zitadel accepts masterkey as Bearer token for the default instance
+      Authorization: `Bearer ${MASTERKEY}`,
+      "x-zitadel-orgid": "0", // IAM org
+    },
+    body: JSON.stringify({
+      queries: [
+        {
+          emailQuery: {
+            emailAddress: "zitadel-admin@zitadel.localhost",
+            method: "TEXT_QUERY_METHOD_EQUALS",
+          },
+        },
+      ],
+    }),
+  });
+
+  if (!usersRes.ok) {
+    // Fallback: try password grant with the Zitadel Console client_id
+    // The Console app is always created by start-from-init
+    const tokenRes = await fetch(`${ZITADEL_URL}/oauth/v2/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "password",
+        client_id: "zitadel-console", // Default Console app client ID
+        username: "zitadel-admin@zitadel.localhost",
+        password: "Password1!",
+        scope: "openid urn:zitadel:iam:org:project:id:zitadel:aud",
+      }),
+    });
+
+    if (!tokenRes.ok) {
+      const body = await tokenRes.text();
+      throw new Error(
+        `Failed to get admin token: ${tokenRes.status} ${body}\n` +
+          "Ensure Zitadel was started with `start-from-init` and default admin credentials.",
+      );
+    }
+
+    const tokenData = (await tokenRes.json()) as { access_token: string };
+    return tokenData.access_token;
+  }
+
+  // Use masterkey directly for management API (works when Zitadel accepts it)
+  return MASTERKEY;
+}
+
+interface ApiResponse<T> {
+  ok: boolean;
+  status: number;
+  data: T;
+}
+
+async function zitadelApi<T>(
+  token: string,
+  path: string,
+  method: string = "POST",
+  body?: unknown,
+): Promise<ApiResponse<T>> {
+  const res = await fetch(`${ZITADEL_URL}${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  const data = (await res.json().catch(() => ({}))) as T;
+  return { ok: res.ok, status: res.status, data };
+}
+
+// ---------------------------------------------------------------------------
+// Provisioning
+// ---------------------------------------------------------------------------
+
+async function findOrCreateProject(token: string): Promise<string> {
+  // Search for existing project
+  const search = await zitadelApi<{
+    result?: Array<{ id: string; name: string }>;
+  }>(token, "/management/v1/projects/_search", "POST", {
+    queries: [
+      {
+        nameQuery: {
+          name: E2E_PROJECT_NAME,
+          method: "TEXT_QUERY_METHOD_EQUALS",
+        },
+      },
+    ],
+  });
+
+  if (search.ok && search.data.result?.length) {
+    console.log(`Found existing project: ${search.data.result[0].id}`);
+    return search.data.result[0].id;
+  }
+
+  // Create project
+  const create = await zitadelApi<{ id: string }>(
+    token,
+    "/management/v1/projects",
+    "POST",
+    { name: E2E_PROJECT_NAME },
+  );
+
+  if (!create.ok) {
+    throw new Error(`Failed to create project: ${JSON.stringify(create.data)}`);
+  }
+
+  console.log(`Created project: ${create.data.id}`);
+  return create.data.id;
+}
+
+async function findOrCreateOidcApp(
+  token: string,
+  projectId: string,
+): Promise<{ appId: string; clientId: string }> {
+  // Search for existing app
+  const search = await zitadelApi<{
+    result?: Array<{
+      id: string;
+      name: string;
+      oidcConfig?: { clientId: string };
+    }>;
+  }>(token, `/management/v1/projects/${projectId}/apps/_search`, "POST", {});
+
+  const existing = search.data.result?.find((a) => a.name === E2E_APP_NAME);
+  if (existing?.oidcConfig) {
+    console.log(`Found existing OIDC app: ${existing.oidcConfig.clientId}`);
+    return { appId: existing.id, clientId: existing.oidcConfig.clientId };
+  }
+
+  // Create OIDC app
+  const create = await zitadelApi<{
+    appId: string;
+    clientId: string;
+  }>(token, `/management/v1/projects/${projectId}/apps/oidc`, "POST", {
+    name: E2E_APP_NAME,
+    redirectUris: [E2E_REDIRECT_URI],
+    postLogoutRedirectUris: [E2E_POST_LOGOUT_URI],
+    responseTypes: ["OIDC_RESPONSE_TYPE_CODE"],
+    grantTypes: ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"],
+    appType: "OIDC_APP_TYPE_USER_AGENT",
+    authMethodType: "OIDC_AUTH_METHOD_TYPE_NONE", // PKCE (no client secret)
+    devMode: true, // Allow http redirects in dev
+  });
+
+  if (!create.ok) {
+    throw new Error(
+      `Failed to create OIDC app: ${JSON.stringify(create.data)}`,
+    );
+  }
+
+  console.log(`Created OIDC app: ${create.data.clientId}`);
+  return { appId: create.data.appId, clientId: create.data.clientId };
+}
+
+async function findOrCreateUser(token: string): Promise<string> {
+  // Search for existing user
+  const search = await zitadelApi<{
+    result?: Array<{ userId: string }>;
+  }>(token, "/v2/users", "POST", {
+    queries: [
+      {
+        emailQuery: {
+          emailAddress: TEST_USER_EMAIL,
+          method: "TEXT_QUERY_METHOD_EQUALS",
+        },
+      },
+    ],
+  });
+
+  if (search.ok && search.data.result?.length) {
+    console.log(`Found existing user: ${search.data.result[0].userId}`);
+    return search.data.result[0].userId;
+  }
+
+  // Create human user
+  const create = await zitadelApi<{ userId: string }>(
+    token,
+    "/v2/users/human",
+    "POST",
+    {
+      username: TEST_USER_EMAIL,
+      profile: {
+        givenName: TEST_USER_FIRST,
+        familyName: TEST_USER_LAST,
+      },
+      email: {
+        email: TEST_USER_EMAIL,
+        isVerified: true,
+      },
+      password: {
+        password: TEST_USER_PASSWORD,
+        changeRequired: false,
+      },
+    },
+  );
+
+  if (!create.ok) {
+    throw new Error(`Failed to create user: ${JSON.stringify(create.data)}`);
+  }
+
+  console.log(`Created user: ${create.data.userId}`);
+  return create.data.userId;
+}
+
+async function ensureColophonyUser(
+  zitadelUserId: string,
+): Promise<{ userId: string; orgId: string }> {
+  const pool = new Pool({ connectionString: DATABASE_URL, max: 2 });
+
+  try {
+    // Check if user already exists
+    const existing = await pool.query<{ id: string }>(
+      "SELECT id FROM users WHERE zitadel_user_id = $1",
+      [zitadelUserId],
+    );
+
+    let userId: string;
+    if (existing.rows.length > 0) {
+      userId = existing.rows[0].id;
+      console.log(`Found existing Colophony user: ${userId}`);
+    } else {
+      const insert = await pool.query<{ id: string }>(
+        "INSERT INTO users (email, zitadel_user_id) VALUES ($1, $2) RETURNING id",
+        [TEST_USER_EMAIL, zitadelUserId],
+      );
+      userId = insert.rows[0].id;
+      console.log(`Created Colophony user: ${userId}`);
+    }
+
+    // Find or use the seed org
+    const orgResult = await pool.query<{ id: string }>(
+      "SELECT id FROM organizations WHERE slug = 'quarterly-review' LIMIT 1",
+    );
+
+    if (orgResult.rows.length === 0) {
+      throw new Error(
+        'Seed org "quarterly-review" not found. Run `pnpm db:seed` first.',
+      );
+    }
+
+    const orgId = orgResult.rows[0].id;
+
+    // Add membership if not exists
+    const memberExists = await pool.query(
+      "SELECT 1 FROM organization_members WHERE organization_id = $1 AND user_id = $2",
+      [orgId, userId],
+    );
+
+    if (memberExists.rows.length === 0) {
+      await pool.query(
+        "INSERT INTO organization_members (organization_id, user_id, role) VALUES ($1, $2, $3)",
+        [orgId, userId, "ADMIN"],
+      );
+      console.log(`Added user to org ${orgId} as ADMIN`);
+    }
+
+    return { userId, orgId };
+  } finally {
+    await pool.end();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log("=== Zitadel E2E Setup ===\n");
+
+  // 1. Wait for Zitadel
+  await waitForHealth();
+
+  // 2. Get admin token
+  console.log("\nAuthenticating as admin...");
+  const token = await getAdminToken();
+
+  // 3. Create project
+  console.log("\nSetting up project...");
+  const projectId = await findOrCreateProject(token);
+
+  // 4. Create OIDC app
+  console.log("\nSetting up OIDC app...");
+  const { clientId } = await findOrCreateOidcApp(token, projectId);
+
+  // 5. Create test user in Zitadel
+  console.log("\nSetting up test user...");
+  const zitadelUserId = await findOrCreateUser(token);
+
+  // 6. Insert into Colophony DB
+  console.log("\nSyncing to Colophony DB...");
+  const { userId, orgId } = await ensureColophonyUser(zitadelUserId);
+
+  // 7. Write config file
+  const config = {
+    authority: ZITADEL_URL,
+    clientId,
+    projectId,
+    testUserEmail: TEST_USER_EMAIL,
+    testUserPassword: TEST_USER_PASSWORD,
+    testUserId: userId,
+    testOrgId: orgId,
+    zitadelUserId,
+  };
+
+  writeFileSync(CONFIG_OUTPUT, JSON.stringify(config, null, 2) + "\n");
+  console.log(`\nConfig written to: ${CONFIG_OUTPUT}`);
+  console.log("\n=== Setup complete ===");
+}
+
+main().catch((err) => {
+  console.error("\nSetup failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Fixed tusd v2.8.0 webhook payload format incompatibility — root cause of all upload E2E test failures. The handler now detects and unwraps the v2 `{ Type, Event }` envelope while maintaining backward compatibility with v1.
- Fixed UI race condition where `onSuccess` fired before post-finish webhook created the DB record — added delayed invalidation and polling during "processing" upload state.
- Updated all 29 tusd webhook unit tests to use v2 payload format.
- All 6 upload E2E tests pass, all 20 submission E2E tests pass (no regression), 534+ unit tests pass, type-check clean.

## Test plan
- [x] `pnpm test` — all unit tests pass (534+)
- [x] `pnpm type-check` — clean across all packages
- [x] `pnpm --filter @colophony/web test:e2e` — 20/20 submission E2E pass
- [x] `pnpm --filter @colophony/web test:e2e:uploads` — 6/6 upload E2E pass
- [ ] CI pipeline passes