### PR TITLE
fix(web): create-org-form tests + enable web in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-      - name: Type check (scoped — web app excluded during rewrite)
-        run: pnpm turbo run type-check --filter=@colophony/db --filter=@colophony/auth-client --filter=@colophony/api-contracts --filter=@colophony/api
+      - name: Type check
+        run: pnpm turbo run type-check --filter=@colophony/db --filter=@colophony/auth-client --filter=@colophony/api-contracts --filter=@colophony/api --filter=@colophony/web
 
       - name: Audit dependencies
         run: pnpm audit --audit-level=high
@@ -103,8 +103,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build workspace dependencies
         run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/auth-client --filter=@colophony/types --filter=@colophony/api-contracts
-      - name: Run unit tests (scoped — web app excluded during rewrite)
-        run: pnpm --filter @colophony/db test && pnpm --filter @colophony/auth-client test && pnpm --filter @colophony/api test
+      - name: Run unit tests
+        run: pnpm --filter @colophony/db test && pnpm --filter @colophony/auth-client test && pnpm --filter @colophony/api test && pnpm --filter @colophony/web test
 
   # ──────────────────────────────────────────────────
   # API E2E tests (~5 min): needs Postgres + Redis
@@ -239,5 +239,5 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - name: Build packages (scoped — web app excluded during rewrite)
-        run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/auth-client --filter=@colophony/api-contracts --filter=@colophony/api --filter=@colophony/types
+      - name: Build packages
+        run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/auth-client --filter=@colophony/api-contracts --filter=@colophony/api --filter=@colophony/types --filter=@colophony/web

--- a/apps/web/src/components/organizations/__tests__/create-org-form.spec.tsx
+++ b/apps/web/src/components/organizations/__tests__/create-org-form.spec.tsx
@@ -7,6 +7,7 @@ import { mockPush } from "../../../../test/setup";
 let mockIsChecking = false;
 let mockIsAvailable: boolean | null = null;
 let mockHasOrganizations = false;
+let mockDebouncedSlug = "";
 const mockMutate = jest.fn();
 const mockInvalidate = jest.fn();
 
@@ -15,7 +16,7 @@ jest.mock("@/hooks/use-slug-check", () => ({
     return {
       isChecking: mockIsChecking,
       isAvailable: mockIsAvailable,
-      debouncedSlug: slug,
+      debouncedSlug: mockDebouncedSlug,
     };
   },
 }));

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -48,11 +48,11 @@
 - [x] Web unit tests: form components (org creation) — (DEVLOG 2026-02-18; done 2026-02-19)
 - [x] Web unit tests: layout components with data states (user menu, sidebar, org switcher) — (DEVLOG 2026-02-18; done 2026-02-19)
 - [x] Web unit tests: `SubmissionForm` + `FileUpload` — complex component with 5 tRPC queries/mutations, deferred from org/layout test PR — (DEVLOG 2026-02-19; done 2026-02-19)
-- [ ] Fix `create-org-form.spec.tsx` broken mocks — `mockDebouncedSlug` referenced in `beforeEach` but never declared; `slug` used in `useSlugCheck` mock factory instead of `_slug` parameter. All 7 tests fail. — (discovered 2026-02-19)
+- [x] Fix `create-org-form.spec.tsx` broken mocks — `mockDebouncedSlug` referenced in `beforeEach` but never declared; `slug` used in `useSlugCheck` mock factory instead of `_slug` parameter. All 7 tests fail. — (discovered 2026-02-19; done 2026-02-19)
 - [x] Webhook integration tests: Stripe webhook → DB → side-effects with real database — (DEVLOG 2026-02-18; done 2026-02-19)
 - [x] Webhook integration tests: Zitadel webhook → user sync → DB with real database — (DEVLOG 2026-02-18; done 2026-02-19)
 - [x] Webhook integration tests: tusd webhook → file record → BullMQ job with real database — (DEVLOG 2026-02-18; done 2026-02-19)
-- [ ] CI: enable `@colophony/web` in type-check, build, and unit-test jobs — excluded during rewrite, rewrite is done — (DEVLOG 2026-02-18)
+- [x] CI: enable `@colophony/web` in type-check, build, and unit-test jobs — excluded during rewrite, rewrite is done — (DEVLOG 2026-02-18; done 2026-02-19)
 - [ ] CI: add Playwright submission E2E job (20 tests, needs Postgres + Redis services) — (DEVLOG 2026-02-18)
 
 ### Housekeeping

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,20 @@ Newest entries first.
 
 ---
 
+## 2026-02-19 — Fix create-org-form Tests + Enable Web in CI
+
+### Done
+
+- Fixed 2 bugs in `create-org-form.spec.tsx`: missing `mockDebouncedSlug` declaration and undefined `slug` reference in `useSlugCheck` mock factory — all 7 tests now pass
+- Enabled `@colophony/web` in 3 CI jobs (type-check, unit-tests, build) — removed "excluded during rewrite" exclusions now that v2 rewrite is complete
+- All 130 web unit tests passing, including the 7 previously broken create-org-form tests
+
+### Decisions
+
+- Deferred Playwright CI job to separate PR — needs Postgres + Redis service containers, API + web dev servers via `webServer` config
+
+---
+
 ## 2026-02-19 — SubmissionForm + FileUpload Unit Tests
 
 ### Done


### PR DESCRIPTION
## Summary

- Fix 2 bugs in `create-org-form.spec.tsx` that caused all 7 tests to fail: missing `mockDebouncedSlug` declaration and undefined `slug` reference in `useSlugCheck` mock factory
- Enable `@colophony/web` in 3 CI jobs (type-check, unit-tests, build) — the v2 rewrite is complete, no longer needs exclusion
- All 130 web unit tests passing locally

## Test plan

- [x] `pnpm --filter @colophony/web test` — 130 tests pass (including 7 previously broken)
- [ ] CI passes with web enabled in quality, unit-tests, and build jobs