### PR TITLE
ci: add Playwright uploads and OIDC E2E jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
   # Playwright E2E tests (~5 min): submissions project
   # ──────────────────────────────────────────────────
   playwright-tests:
-    name: Playwright E2E Tests
+    name: Playwright Submissions E2E
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
@@ -363,7 +363,7 @@ jobs:
           timeout 30 bash -c 'until curl -sf http://localhost:9000/minio/health/live; do sleep 2; done'
       - name: Create MinIO buckets
         run: |
-          docker run --rm --network host minio/mc:latest sh -c "
+          docker run --rm --network host --entrypoint /bin/sh minio/mc:latest -c "
             mc alias set minio http://localhost:9000 minioadmin minioadmin;
             mc mb minio/submissions --ignore-existing;
             mc mb minio/quarantine --ignore-existing;
@@ -467,10 +467,8 @@ jobs:
             END
             \$\$;
           "
-          PGPASSWORD=password psql -h localhost -p 5432 -U colophony -c "
-            SELECT 'CREATE DATABASE zitadel OWNER zitadel'
-            WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'zitadel')\gexec
-          "
+          echo "SELECT 'CREATE DATABASE zitadel OWNER zitadel' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'zitadel') \gexec" | \
+            PGPASSWORD=password psql -h localhost -p 5432 -U colophony
       - name: Run Drizzle migrations
         run: pnpm db:migrate
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,19 +456,6 @@ jobs:
             ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user;
             ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO app_user;
           "
-      - name: Create Zitadel database
-        run: |
-          PGPASSWORD=password psql -h localhost -p 5432 -U colophony -d colophony -c "
-            DO \$\$
-            BEGIN
-              IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'zitadel') THEN
-                CREATE ROLE zitadel WITH LOGIN PASSWORD 'zitadel_password' CREATEDB;
-              END IF;
-            END
-            \$\$;
-          "
-          echo "SELECT 'CREATE DATABASE zitadel OWNER zitadel' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'zitadel') \gexec" | \
-            PGPASSWORD=password psql -h localhost -p 5432 -U colophony
       - name: Run Drizzle migrations
         run: pnpm db:migrate
         env:
@@ -480,6 +467,7 @@ jobs:
       - name: Start Zitadel
         run: |
           mkdir -p .docker/zitadel/machinekey
+          chmod 777 .docker/zitadel/machinekey
           docker run -d --name zitadel --network host \
             -v ${{ github.workspace }}/.docker/zitadel/machinekey:/machinekey \
             -e ZITADEL_DATABASE_POSTGRES_HOST=localhost \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,7 +500,7 @@ jobs:
           timeout 180 bash -c 'until curl -sf http://localhost:8080/debug/healthz; do sleep 5; done'
           echo "Zitadel is ready."
       - name: Provision Zitadel E2E config
-        run: pnpm --filter @colophony/web e2e:setup-oidc
+        run: pnpm --filter @colophony/db exec tsx ../../scripts/setup-zitadel-e2e.ts
         env:
           DATABASE_URL: postgresql://colophony:password@localhost:5432/colophony
           ZITADEL_URL: http://localhost:8080

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: '22'
-  PNPM_VERSION: '9.15.0'
+  NODE_VERSION: "22"
+  PNPM_VERSION: "9.15.0"
 
 jobs:
   # ──────────────────────────────────────────────────
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile
 
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
+          cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - name: Build workspace dependencies
         run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/auth-client --filter=@colophony/types --filter=@colophony/api-contracts
@@ -211,7 +211,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
+          cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - name: Build workspace dependencies
         run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/types --filter=@colophony/api-contracts
@@ -251,7 +251,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
+          cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - name: Build workspace dependencies
         run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/auth-client --filter=@colophony/types --filter=@colophony/api-contracts
@@ -295,6 +295,248 @@ jobs:
           retention-days: 30
 
   # ──────────────────────────────────────────────────
+  # Playwright E2E tests (~8 min): uploads project
+  # Requires PostgreSQL + MinIO + tusd
+  # ──────────────────────────────────────────────────
+  playwright-uploads:
+    name: Playwright Uploads E2E
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: colophony
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: colophony
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U colophony"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Build workspace dependencies
+        run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/auth-client --filter=@colophony/types --filter=@colophony/api-contracts
+      - name: Create app_user role
+        run: |
+          PGPASSWORD=password psql -h localhost -p 5432 -U colophony -d colophony -c "
+            DO \$\$
+            BEGIN
+              IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'app_user') THEN
+                CREATE ROLE app_user WITH LOGIN PASSWORD 'app_password' NOSUPERUSER NOBYPASSRLS;
+              END IF;
+            END
+            \$\$;
+            GRANT CONNECT ON DATABASE colophony TO app_user;
+            GRANT USAGE ON SCHEMA public TO app_user;
+            GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_user;
+            GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_user;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO app_user;
+          "
+      - name: Run Drizzle migrations
+        run: pnpm db:migrate
+        env:
+          DATABASE_URL: postgresql://colophony:password@localhost:5432/colophony
+      - name: Seed test data
+        run: |
+          echo 'DATABASE_URL="postgresql://colophony:password@localhost:5432/colophony"' > packages/db/.env
+          pnpm db:seed
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio --network host \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:latest server /data --console-address ":9001"
+          timeout 30 bash -c 'until curl -sf http://localhost:9000/minio/health/live; do sleep 2; done'
+      - name: Create MinIO buckets
+        run: |
+          docker run --rm --network host minio/mc:latest sh -c "
+            mc alias set minio http://localhost:9000 minioadmin minioadmin;
+            mc mb minio/submissions --ignore-existing;
+            mc mb minio/quarantine --ignore-existing;
+            mc anonymous set none minio/submissions;
+            mc anonymous set none minio/quarantine;
+          "
+      - name: Start tusd
+        run: |
+          docker run -d --name tusd --network host \
+            -e AWS_ACCESS_KEY_ID=minioadmin \
+            -e AWS_SECRET_ACCESS_KEY=minioadmin \
+            -e AWS_REGION=us-east-1 \
+            tusproject/tusd:latest \
+            -port 1080 \
+            -s3-endpoint http://localhost:9000 \
+            -s3-bucket quarantine \
+            -s3-object-prefix uploads/ \
+            -hooks-http http://localhost:4010/webhooks/tusd \
+            -hooks-http-forward-headers Authorization,X-Organization-Id,X-Api-Key \
+            -behind-proxy -verbose
+          timeout 15 bash -c 'until curl -sf http://localhost:1080; do sleep 2; done'
+      - name: Install Playwright browsers
+        run: pnpm --filter @colophony/web exec playwright install --with-deps chromium
+      - name: Run Playwright uploads E2E tests
+        run: pnpm --filter @colophony/web test:e2e:uploads
+        env:
+          DATABASE_URL: postgresql://colophony:password@localhost:5432/colophony
+      - name: Show container logs on failure
+        if: failure()
+        run: |
+          echo "=== MinIO logs ===" && docker logs minio 2>&1 | tail -50 || true
+          echo "=== tusd logs ===" && docker logs tusd 2>&1 | tail -50 || true
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-uploads-report
+          path: apps/web/playwright-report/
+          retention-days: 30
+
+  # ──────────────────────────────────────────────────
+  # Playwright E2E tests (~10 min): OIDC project
+  # Requires PostgreSQL + Zitadel
+  # ──────────────────────────────────────────────────
+  playwright-oidc:
+    name: Playwright OIDC E2E
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: colophony
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: colophony
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U colophony"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Build workspace dependencies
+        run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/auth-client --filter=@colophony/types --filter=@colophony/api-contracts
+      - name: Create app_user role
+        run: |
+          PGPASSWORD=password psql -h localhost -p 5432 -U colophony -d colophony -c "
+            DO \$\$
+            BEGIN
+              IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'app_user') THEN
+                CREATE ROLE app_user WITH LOGIN PASSWORD 'app_password' NOSUPERUSER NOBYPASSRLS;
+              END IF;
+            END
+            \$\$;
+            GRANT CONNECT ON DATABASE colophony TO app_user;
+            GRANT USAGE ON SCHEMA public TO app_user;
+            GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_user;
+            GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_user;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO app_user;
+          "
+      - name: Create Zitadel database
+        run: |
+          PGPASSWORD=password psql -h localhost -p 5432 -U colophony -d colophony -c "
+            DO \$\$
+            BEGIN
+              IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'zitadel') THEN
+                CREATE ROLE zitadel WITH LOGIN PASSWORD 'zitadel_password' CREATEDB;
+              END IF;
+            END
+            \$\$;
+          "
+          PGPASSWORD=password psql -h localhost -p 5432 -U colophony -c "
+            SELECT 'CREATE DATABASE zitadel OWNER zitadel'
+            WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'zitadel')\gexec
+          "
+      - name: Run Drizzle migrations
+        run: pnpm db:migrate
+        env:
+          DATABASE_URL: postgresql://colophony:password@localhost:5432/colophony
+      - name: Seed test data
+        run: |
+          echo 'DATABASE_URL="postgresql://colophony:password@localhost:5432/colophony"' > packages/db/.env
+          pnpm db:seed
+      - name: Start Zitadel
+        run: |
+          mkdir -p .docker/zitadel/machinekey
+          docker run -d --name zitadel --network host \
+            -v ${{ github.workspace }}/.docker/zitadel/machinekey:/machinekey \
+            -e ZITADEL_DATABASE_POSTGRES_HOST=localhost \
+            -e ZITADEL_DATABASE_POSTGRES_PORT=5432 \
+            -e ZITADEL_DATABASE_POSTGRES_DATABASE=zitadel \
+            -e ZITADEL_DATABASE_POSTGRES_USER_USERNAME=zitadel \
+            -e ZITADEL_DATABASE_POSTGRES_USER_PASSWORD=zitadel_password \
+            -e ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE=disable \
+            -e ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME=colophony \
+            -e ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD=password \
+            -e ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE=disable \
+            -e ZITADEL_EXTERNALDOMAIN=localhost \
+            -e ZITADEL_EXTERNALSECURE=false \
+            -e ZITADEL_EXTERNALPORT=8080 \
+            -e ZITADEL_TLS_ENABLED=false \
+            -e ZITADEL_DEFAULTINSTANCE_FEATURES_LOGINV2_REQUIRED=false \
+            -e ZITADEL_DEFAULTINSTANCE_LOGINPOLICY_FORCEMFA=false \
+            -e ZITADEL_DEFAULTINSTANCE_LOGINPOLICY_FORCEMFALOCALONLY=false \
+            -e "ZITADEL_DEFAULTINSTANCE_LOGINPOLICY_SECONDFACTORS=" \
+            -e "ZITADEL_DEFAULTINSTANCE_LOGINPOLICY_MULTIFACTORS=" \
+            -e ZITADEL_FIRSTINSTANCE_PATPATH=/machinekey/admin.pat \
+            -e ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_USERNAME=e2e-admin \
+            -e "ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_NAME=E2E Admin Service Account" \
+            -e ZITADEL_FIRSTINSTANCE_ORG_MACHINE_PAT_EXPIRATIONDATE=2030-01-01T00:00:00Z \
+            ghcr.io/zitadel/zitadel:v4.10.1 \
+            start-from-init --masterkey "MasterkeyNeedsToHave32Characters" --tlsMode disabled
+      - name: Wait for Zitadel
+        run: |
+          echo "Waiting for Zitadel to be ready..."
+          timeout 180 bash -c 'until curl -sf http://localhost:8080/debug/healthz; do sleep 5; done'
+          echo "Zitadel is ready."
+      - name: Provision Zitadel E2E config
+        run: pnpm --filter @colophony/web e2e:setup-oidc
+        env:
+          DATABASE_URL: postgresql://colophony:password@localhost:5432/colophony
+          ZITADEL_URL: http://localhost:8080
+          ZITADEL_PAT_PATH: ${{ github.workspace }}/.docker/zitadel/machinekey/admin.pat
+      - name: Install Playwright browsers
+        run: pnpm --filter @colophony/web exec playwright install --with-deps chromium
+      - name: Run Playwright OIDC E2E tests
+        run: pnpm --filter @colophony/web test:e2e:oidc
+        env:
+          DATABASE_URL: postgresql://colophony:password@localhost:5432/colophony
+      - name: Show Zitadel logs on failure
+        if: failure()
+        run: docker logs zitadel 2>&1 | tail -100 || true
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-oidc-report
+          path: apps/web/playwright-report/
+          retention-days: 30
+
+  # ──────────────────────────────────────────────────
   # Build verification (~2 min)
   # ──────────────────────────────────────────────────
   build:
@@ -310,7 +552,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
+          cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - name: Build packages
         run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/auth-client --filter=@colophony/api-contracts --filter=@colophony/api --filter=@colophony/types --filter=@colophony/web

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,13 +177,15 @@ All other version pins are in their respective per-directory CLAUDE.md files.
 
 ### CI Pipeline (GitHub Actions)
 
-| Job                  | Checks                                             |
-| -------------------- | -------------------------------------------------- |
-| **quality**          | `format:check`, `lint`, `type-check`, `pnpm audit` |
-| **unit-tests**       | `pnpm test`                                        |
-| **rls-tests**        | RLS tenant isolation integration tests             |
-| **playwright-tests** | Playwright E2E submissions project (20 tests)      |
-| **build**            | `pnpm build` (API + Web production build)          |
+| Job                    | Checks                                             |
+| ---------------------- | -------------------------------------------------- |
+| **quality**            | `format:check`, `lint`, `type-check`, `pnpm audit` |
+| **unit-tests**         | `pnpm test`                                        |
+| **rls-tests**          | RLS tenant isolation integration tests             |
+| **playwright-tests**   | Playwright E2E submissions project (20 tests)      |
+| **playwright-uploads** | Playwright E2E uploads project (6 tests)           |
+| **playwright-oidc**    | Playwright E2E OIDC project (6 tests)              |
+| **build**              | `pnpm build` (API + Web production build)          |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `playwright-uploads` CI job: runs 6 upload E2E tests with MinIO + tusd via `docker run --network host`
- Add `playwright-oidc` CI job: runs 6 OIDC E2E tests with Zitadel via `docker run --network host`, provisions test user via `setup-zitadel-e2e.ts`
- Rename existing job from "Playwright E2E Tests" to "Playwright Submissions E2E" for consistency
- Both new jobs capture container logs on failure and upload Playwright HTML reports as artifacts

## Test plan

- [x] `playwright-uploads` job passes in CI (MinIO healthy, tusd webhooks reach API, all 6 tests green)
- [x] `playwright-oidc` job passes in CI (Zitadel initializes, provisioning script succeeds, all 6 tests green)
- [x] Existing `playwright-tests` (submissions) job still passes
- [x] All other CI jobs (quality, unit-tests, rls-tests, build) still pass