### PR TITLE
fix: Track 1 QA — RLS bypass, UI cache bugs, org switcher

### DIFF
--- a/.claude/mcp-servers.example.json
+++ b/.claude/mcp-servers.example.json
@@ -69,6 +69,17 @@
         "Can list containers, read logs, inspect health checks, and view stats",
         "Replaces manual 'docker compose logs' and 'docker stats' commands"
       ]
+    },
+    "chrome-devtools": {
+      "description": "Chrome DevTools bridge — browser automation, network inspection, screenshots, console, performance tracing",
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest"],
+      "notes": [
+        "Launch Chrome with: google-chrome --remote-debugging-port=9222",
+        "Chrome 144+ supports automatic connection to existing browser sessions",
+        "26 tools: click, fill, navigate, screenshot, network requests, console messages, performance tracing",
+        "Useful for manual QA assistance — navigate flows, inspect requests, capture issues"
+      ]
     }
   },
   "notes": {

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 # DATABASE
 # =============================================================================
 DATABASE_URL=postgresql://colophony:password@localhost:5432/colophony
+# Application connection (non-superuser, enforces RLS). Falls back to DATABASE_URL if unset.
+DATABASE_APP_URL=postgresql://app_user:app_password@localhost:5432/colophony
 DATABASE_TEST_URL=postgresql://test:test@localhost:5433/colophony_test
 
 # =============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,21 +280,22 @@ pnpm db:reset                 # Drop and recreate with migrations + RLS
 
 Canonical env definition with Zod validation: `apps/api/src/config/env.ts`
 
-| Variable                                                          | Required | Default                     | Used by        |
-| ----------------------------------------------------------------- | -------- | --------------------------- | -------------- |
-| `DATABASE_URL`                                                    | Yes      | —                           | API            |
-| `PORT` / `HOST`                                                   | No       | `4000` / `0.0.0.0`          | API            |
-| `NODE_ENV`                                                        | No       | `development`               | API            |
-| `REDIS_HOST` / `REDIS_PORT` / `REDIS_PASSWORD`                    | No       | `localhost` / `6379` / `""` | API            |
-| `CORS_ORIGIN`                                                     | No       | `http://localhost:3000`     | API            |
-| `ZITADEL_AUTHORITY` / `ZITADEL_CLIENT_ID`                         | Optional | —                           | API            |
-| `ZITADEL_WEBHOOK_SECRET`                                          | Optional | —                           | API            |
-| `CLAMAV_HOST` / `CLAMAV_PORT`                                     | No       | `localhost` / `3310`        | API            |
-| `VIRUS_SCAN_ENABLED`                                              | No       | `true`                      | API            |
-| `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET`                     | Optional | —                           | API            |
-| `NEXT_PUBLIC_API_URL`                                             | No       | `http://localhost:4000`     | Web            |
-| `NEXT_PUBLIC_ZITADEL_AUTHORITY` / `NEXT_PUBLIC_ZITADEL_CLIENT_ID` | —        | —                           | Web            |
-| `API_URL`                                                         | —        | —                           | Web (SSR only) |
+| Variable                                                          | Required | Default                      | Used by        |
+| ----------------------------------------------------------------- | -------- | ---------------------------- | -------------- |
+| `DATABASE_URL`                                                    | Yes      | —                            | API            |
+| `DATABASE_APP_URL`                                                | No       | Falls back to `DATABASE_URL` | API (RLS)      |
+| `PORT` / `HOST`                                                   | No       | `4000` / `0.0.0.0`           | API            |
+| `NODE_ENV`                                                        | No       | `development`                | API            |
+| `REDIS_HOST` / `REDIS_PORT` / `REDIS_PASSWORD`                    | No       | `localhost` / `6379` / `""`  | API            |
+| `CORS_ORIGIN`                                                     | No       | `http://localhost:3000`      | API            |
+| `ZITADEL_AUTHORITY` / `ZITADEL_CLIENT_ID`                         | Optional | —                            | API            |
+| `ZITADEL_WEBHOOK_SECRET`                                          | Optional | —                            | API            |
+| `CLAMAV_HOST` / `CLAMAV_PORT`                                     | No       | `localhost` / `3310`         | API            |
+| `VIRUS_SCAN_ENABLED`                                              | No       | `true`                       | API            |
+| `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET`                     | Optional | —                            | API            |
+| `NEXT_PUBLIC_API_URL`                                             | No       | `http://localhost:4000`      | Web            |
+| `NEXT_PUBLIC_ZITADEL_AUTHORITY` / `NEXT_PUBLIC_ZITADEL_CLIENT_ID` | —        | —                            | Web            |
+| `API_URL`                                                         | —        | —                            | Web (SSR only) |
 
 ---
 

--- a/apps/api/src/hooks/audit.spec.ts
+++ b/apps/api/src/hooks/audit.spec.ts
@@ -40,6 +40,10 @@ vi.mock('@colophony/db', () => ({
     connect: mockPoolConnect,
     query: vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
   },
+  appPool: {
+    connect: mockPoolConnect,
+    query: vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
+  },
   DrizzleDb: {},
 }));
 

--- a/apps/api/src/hooks/db-context.spec.ts
+++ b/apps/api/src/hooks/db-context.spec.ts
@@ -32,6 +32,10 @@ vi.mock('@colophony/db', () => ({
     connect: mockPoolConnect,
     query: vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
   },
+  appPool: {
+    connect: mockPoolConnect,
+    query: vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
+  },
   DrizzleDb: {},
 }));
 

--- a/apps/api/src/hooks/db-context.ts
+++ b/apps/api/src/hooks/db-context.ts
@@ -1,7 +1,7 @@
 import fp from 'fastify-plugin';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { drizzle } from 'drizzle-orm/node-postgres';
-import { pool, type DrizzleDb } from '@colophony/db';
+import { appPool, type DrizzleDb } from '@colophony/db';
 import type { PoolClient } from 'pg';
 
 declare module 'fastify' {
@@ -39,7 +39,7 @@ export default fp(
         // Only set up transaction if we have an authenticated user
         if (!request.authContext?.userId) return;
 
-        const client = await pool.connect();
+        const client = await appPool.connect();
         clientMap.set(request, client);
 
         await client.query('BEGIN');

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -326,7 +326,7 @@ export function SubmissionDetail({ submissionId }: SubmissionDetailProps) {
                       <div className="flex gap-3">
                         <div className="w-4 h-4 mt-1 rounded-full bg-primary flex-shrink-0" />
                         <div className="space-y-1">
-                          <p className="text-sm">
+                          <span className="text-sm">
                             {event.fromStatus ? (
                               <>
                                 Changed from{" "}
@@ -346,7 +346,7 @@ export function SubmissionDetail({ submissionId }: SubmissionDetailProps) {
                                 </Badge>
                               </>
                             )}
-                          </p>
+                          </span>
                           {event.comment && (
                             <p className="text-sm text-muted-foreground">
                               &ldquo;{event.comment}&rdquo;

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -96,6 +96,7 @@ export function SubmissionDetail({ submissionId }: SubmissionDetailProps) {
     onSuccess: () => {
       toast.success("Submission withdrawn");
       utils.submissions.getById.invalidate({ id: submissionId });
+      utils.submissions.getHistory.invalidate({ submissionId });
     },
     onError: (err) => {
       toast.error(err.message);

--- a/apps/web/src/components/submissions/submission-form.tsx
+++ b/apps/web/src/components/submissions/submission-form.tsx
@@ -106,8 +106,12 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
 
   // Submit mutation (for submitting draft)
   const submitMutation = trpc.submissions.submit.useMutation({
-    onSuccess: () => {
+    onSuccess: async () => {
       toast.success("Submission submitted!");
+      await utils.submissions.getById.invalidate({ id: submissionId! });
+      await utils.submissions.getHistory.invalidate({
+        submissionId: submissionId!,
+      });
       router.push(`/submissions/${submissionId}`);
     },
     onError: (err) => {

--- a/apps/web/src/hooks/use-organization.ts
+++ b/apps/web/src/hooks/use-organization.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { getCurrentOrgId, setCurrentOrgId, trpc } from "@/lib/trpc";
 import { useAuth } from "./use-auth";
 
@@ -29,8 +29,10 @@ export function useOrganization() {
     [user?.organizations],
   );
 
-  // Get current org ID from storage
-  const currentOrgId = typeof window !== "undefined" ? getCurrentOrgId() : null;
+  // Reactive org ID state — initialized from localStorage, updated on switch
+  const [currentOrgId, _setCurrentOrgId] = useState<string | null>(() =>
+    typeof window !== "undefined" ? getCurrentOrgId() : null,
+  );
 
   // Find current organization
   const currentOrg =
@@ -39,7 +41,9 @@ export function useOrganization() {
   // If no current org but user has orgs, select the first one
   useEffect(() => {
     if (isAuthenticated && organizations.length > 0 && !currentOrgId) {
-      setCurrentOrgId(organizations[0].id);
+      const firstId = organizations[0].id;
+      setCurrentOrgId(firstId);
+      _setCurrentOrgId(firstId);
     }
   }, [isAuthenticated, organizations, currentOrgId]);
 
@@ -53,6 +57,7 @@ export function useOrganization() {
       }
 
       setCurrentOrgId(orgId);
+      _setCurrentOrgId(orgId);
 
       // Invalidate queries that depend on org context
       utils.invalidate();

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -54,8 +54,8 @@
 - [x] Webhook integration tests: tusd webhook → file record → BullMQ job with real database — (DEVLOG 2026-02-18; done 2026-02-19)
 - [x] CI: enable `@colophony/web` in type-check, build, and unit-test jobs — excluded during rewrite, rewrite is done — (DEVLOG 2026-02-18; done 2026-02-19)
 - [x] CI: add Playwright submission E2E job (20 tests, needs Postgres service) — (DEVLOG 2026-02-18; done 2026-02-19)
-- [ ] CI: add Playwright uploads E2E job (6 tests, needs tusd + MinIO services) — (DEVLOG 2026-02-19)
-- [ ] CI: add Playwright OIDC E2E job (6 tests, needs Zitadel service) — (DEVLOG 2026-02-19)
+- [x] CI: add Playwright uploads E2E job (6 tests, needs tusd + MinIO services) — (DEVLOG 2026-02-19; done 2026-02-19 PR #115)
+- [x] CI: add Playwright OIDC E2E job (6 tests, needs Zitadel service) — (DEVLOG 2026-02-19; done 2026-02-19 PR #115)
 
 ### Housekeeping
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -37,11 +37,11 @@
 
 ### QA / Testing
 
-- [ ] Manual testing of 4 submission pages with dev server — (DEVLOG 2026-02-15)
+- [x] Manual testing of 4 submission pages with dev server — (DEVLOG 2026-02-15; done 2026-02-19)
 - [x] E2E tests for submission flow — (DEVLOG 2026-02-15; done 2026-02-18 PR pending)
 - [x] E2E tests for upload flow — needs tusd + MinIO in CI — (DEVLOG 2026-02-15; done 2026-02-18)
 - [x] E2E tests for OIDC flow — requires Zitadel instance — (DEVLOG 2026-02-13; done 2026-02-18)
-- [ ] Manual QA of full org management flow with Zitadel + dev services running — (DEVLOG 2026-02-13)
+- [x] Manual QA of full org management flow with Zitadel + dev services running — (DEVLOG 2026-02-13; done 2026-02-19)
 - [ ] Manual QA: webhook freshness/rate-limit/ordering with Docker Compose + Zitadel — (DEVLOG 2026-02-15)
 - [x] Web unit tests: auth hooks (`use-auth`, `use-organization`, `use-slug-check`) — (DEVLOG 2026-02-18; done 2026-02-19)
 - [x] Web unit tests: `ProtectedRoute` rendering states (loading, no org, authenticated, error) — (DEVLOG 2026-02-18; done 2026-02-19)
@@ -101,7 +101,7 @@
 - [ ] Embeddable forms (iframe) — (architecture doc Track 3, form-builder-research.md)
 - [ ] Submission periods UI — schema exists, no UI — (DEVLOG 2026-02-15)
 - [ ] Editor dashboard rewrite (`/editor` pages) — current pages are stubs — (DEVLOG 2026-02-15)
-- [ ] Fix stale cache after submit: `submission-form.tsx` `submitMutation.onSuccess` does `router.push` but doesn't invalidate `getById` query — detail page shows stale DRAFT status — (DEVLOG 2026-02-18, E2E test run)
+- [x] Fix stale cache after submit: `submission-form.tsx` `submitMutation.onSuccess` does `router.push` but doesn't invalidate `getById` query — detail page shows stale DRAFT status — (DEVLOG 2026-02-18, E2E test run; done 2026-02-19)
 - [ ] GDPR deletion mutation — stubbed with TODO — (DEVLOG 2026-02-15)
 - [ ] GDPR tools finalization from MVP — (architecture doc Track 3)
 - [ ] Org deletion — needs careful cascade handling — (DEVLOG 2026-02-13)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,25 @@ Newest entries first.
 
 ---
 
+## 2026-02-19 — Track 1 Manual QA + Bug Fixes
+
+### Done
+
+- Manual QA of submission pages, org management, editor transitions, and auth flow using Chrome DevTools MCP — 8 test scenarios, all passing
+- Fixed RLS bypass in dev: introduced `appPool` using `DATABASE_APP_URL` (non-superuser `app_user`) so request-scoped queries respect row-level security; `pool` (superuser) retained for admin/migration use
+- Fixed React hydration error: `<p>` → `<span>` around Badge components in submission history panel (Badge renders `<div>`, invalid inside `<p>`)
+- Fixed stale status badge after submit: added `getById` + `getHistory` cache invalidation to `submitMutation.onSuccess`
+- Fixed stale withdraw history: added `getHistory` cache invalidation to `withdrawMutation.onSuccess`
+- Fixed org switcher label stale after switch: made `currentOrgId` reactive via `useState` instead of reading localStorage once
+- Fixed Zitadel E2E redirect URI mismatch: `setup-zitadel-e2e.ts` now registers both port 3000 (dev) and configurable E2E port (default 3010) redirect URIs, and updates existing apps on re-run via PUT
+
+### Decisions
+
+- `appPool` falls back to `DATABASE_URL` if `DATABASE_APP_URL` is unset — no breaking change for existing setups
+- No dedicated "Withdrawn" tab on submissions list — withdrawn submissions only appear in "All" tab (acceptable UX)
+
+---
+
 ## 2026-02-19 — Playwright E2E CI Job
 
 ### Done

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -41,6 +41,13 @@ export const submissions = pgTable(
 );
 ```
 
+### Connection Pools (`src/client.ts`)
+
+- **`pool`** — superuser (`colophony`). Used for migrations, admin tasks, and the Drizzle `db` instance.
+- **`appPool`** — non-superuser (`app_user`, `NOBYPASSRLS`). Used by `withRls()` and the `dbContext` hook for all request-scoped queries. Configured via `DATABASE_APP_URL` (falls back to `DATABASE_URL`).
+
+**Always use `appPool` for tenant data queries.** The superuser `pool` bypasses all RLS policies.
+
 ### `withRls()` — RLS transaction helper (`src/context.ts`)
 
 ```typescript

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -2,6 +2,10 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import * as schema from "./schema/index";
 
+/**
+ * Admin pool — superuser connection for migrations, seed, and admin operations.
+ * Uses DATABASE_URL (typically the superuser role).
+ */
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   max: parseInt(process.env.DB_POOL_MAX || "10", 10),
@@ -9,5 +13,17 @@ const pool = new Pool({
   connectionTimeoutMillis: 2000,
 });
 
+/**
+ * Application pool — non-superuser connection for RLS-enforced queries.
+ * Uses DATABASE_APP_URL (app_user role, NOSUPERUSER NOBYPASSRLS).
+ * Falls back to DATABASE_URL for backwards compatibility in dev.
+ */
+const appPool = new Pool({
+  connectionString: process.env.DATABASE_APP_URL || process.env.DATABASE_URL,
+  max: parseInt(process.env.DB_POOL_MAX || "10", 10),
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: 2000,
+});
+
 export const db = drizzle(pool, { schema });
-export { pool };
+export { pool, appPool };

--- a/packages/db/src/context.ts
+++ b/packages/db/src/context.ts
@@ -1,5 +1,5 @@
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
-import { pool } from "./client";
+import { appPool } from "./client";
 
 export type DrizzleDb = NodePgDatabase<Record<string, never>>;
 
@@ -29,7 +29,7 @@ export async function withRls<T>(
   if (ctx.orgId) validateUuid(ctx.orgId, "orgId");
   if (ctx.userId) validateUuid(ctx.userId, "userId");
 
-  const client = await pool.connect();
+  const client = await appPool.connect();
   try {
     await client.query("BEGIN");
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,7 +2,7 @@
 export * from "./schema/index";
 
 // Client
-export { db, pool } from "./client";
+export { db, pool, appPool } from "./client";
 
 // RLS context helper
 export { withRls, type DrizzleDb } from "./context";

--- a/scripts/setup-zitadel-e2e.ts
+++ b/scripts/setup-zitadel-e2e.ts
@@ -31,8 +31,13 @@ const PAT_FILE_PATH =
 
 const E2E_PROJECT_NAME = "colophony-e2e";
 const E2E_APP_NAME = "colophony-e2e-web";
-const E2E_REDIRECT_URI = "http://localhost:3010/auth/callback";
-const E2E_POST_LOGOUT_URI = "http://localhost:3010";
+const E2E_WEB_PORT = process.env.E2E_WEB_PORT || "3010";
+const E2E_REDIRECT_URI = `http://localhost:${E2E_WEB_PORT}/auth/callback`;
+const E2E_POST_LOGOUT_URI = `http://localhost:${E2E_WEB_PORT}`;
+
+// Also allow port 3000 (dev server) so the same Zitadel app works for manual QA
+const DEV_REDIRECT_URI = "http://localhost:3000/auth/callback";
+const DEV_POST_LOGOUT_URI = "http://localhost:3000";
 
 const TEST_USER_EMAIL = "e2e-test@colophony.dev";
 const TEST_USER_PASSWORD = "E2eTestPassword1!";
@@ -175,6 +180,24 @@ async function findOrCreateOidcApp(
   const existing = search.data.result?.find((a) => a.name === E2E_APP_NAME);
   if (existing?.oidcConfig) {
     console.log(`Found existing OIDC app: ${existing.oidcConfig.clientId}`);
+    // Ensure redirect URIs include both E2E and dev ports
+    await zitadelApi(
+      token,
+      `/management/v1/projects/${projectId}/apps/${existing.id}/oidc`,
+      "PUT",
+      {
+        redirectUris: [E2E_REDIRECT_URI, DEV_REDIRECT_URI],
+        postLogoutRedirectUris: [E2E_POST_LOGOUT_URI, DEV_POST_LOGOUT_URI],
+        responseTypes: ["OIDC_RESPONSE_TYPE_CODE"],
+        grantTypes: ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"],
+        appType: "OIDC_APP_TYPE_USER_AGENT",
+        authMethodType: "OIDC_AUTH_METHOD_TYPE_NONE",
+        accessTokenType: "OIDC_TOKEN_TYPE_JWT",
+        accessTokenRoleAssertion: true,
+        devMode: true,
+      },
+    );
+    console.log("Updated OIDC app redirect URIs.");
     return { appId: existing.id, clientId: existing.oidcConfig.clientId };
   }
 
@@ -184,8 +207,8 @@ async function findOrCreateOidcApp(
     clientId: string;
   }>(token, `/management/v1/projects/${projectId}/apps/oidc`, "POST", {
     name: E2E_APP_NAME,
-    redirectUris: [E2E_REDIRECT_URI],
-    postLogoutRedirectUris: [E2E_POST_LOGOUT_URI],
+    redirectUris: [E2E_REDIRECT_URI, DEV_REDIRECT_URI],
+    postLogoutRedirectUris: [E2E_POST_LOGOUT_URI, DEV_POST_LOGOUT_URI],
     responseTypes: ["OIDC_RESPONSE_TYPE_CODE"],
     grantTypes: ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"],
     appType: "OIDC_APP_TYPE_USER_AGENT",


### PR DESCRIPTION
## Summary

- **fix(db):** Enforce RLS by routing app queries through non-superuser `appPool` (`DATABASE_APP_URL` / `app_user`). The `colophony` superuser bypasses all RLS policies — this was causing cross-org data leaks in dev.
- **fix(web):** Fix React hydration error (`<p>` → `<span>` around Badge in history panel), stale status badge after submit (missing cache invalidation), stale withdraw history (missing `getHistory` invalidation), and org switcher button label not updating after switch (non-reactive `currentOrgId`).
- **chore:** Zitadel E2E setup registers both dev (port 3000) and E2E (port 3010) redirect URIs; updates existing apps on re-run.

## Test plan

- [x] All 499 unit tests passing
- [x] Manual QA via Chrome DevTools MCP: 8 scenarios (editor transitions, withdraw, delete, create org, org switch, tab filters, editor dashboard)
- [x] Pre-push hooks pass (type-check + lint)
- [ ] CI pipeline