### PR TITLE
feat(api): GraphQL mutations PR 2 — 16 mutations + API key query

### DIFF
--- a/apps/api/src/graphql/builder.ts
+++ b/apps/api/src/graphql/builder.ts
@@ -63,3 +63,6 @@ builder.addScalarType('JSON', JSONScalar);
 
 // Query root — resolvers add fields via builder.queryFields()
 builder.queryType({});
+
+// Mutation root — resolvers add fields via builder.mutationFields()
+builder.mutationType({});

--- a/apps/api/src/graphql/resolvers/api-keys.spec.ts
+++ b/apps/api/src/graphql/resolvers/api-keys.spec.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GraphQLError } from 'graphql';
+import type { GraphQLContext } from '../context.js';
+import type { AuthContext } from '@colophony/types';
+import type { DrizzleDb } from '@colophony/db';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../guards.js', () => ({
+  requireAuth: vi.fn(),
+  requireOrgContext: vi.fn(),
+  requireAdmin: vi.fn(),
+  requireScopes: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../services/context.js', () => ({
+  toServiceContext: vi.fn((ctx: unknown) => ctx),
+}));
+
+vi.mock('../../services/api-key.service.js', () => ({
+  apiKeyService: {
+    list: vi.fn(),
+    create: vi.fn(),
+    revoke: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/submission.service.js', () => ({
+  submissionService: {
+    listAll: vi.fn(),
+    listBySubmitter: vi.fn(),
+    getByIdWithAccess: vi.fn(),
+    getHistoryWithAccess: vi.fn(),
+    createWithAudit: vi.fn(),
+    updateAsOwner: vi.fn(),
+    submitAsOwner: vi.fn(),
+    deleteAsOwner: vi.fn(),
+    withdrawAsOwner: vi.fn(),
+    updateStatusAsEditor: vi.fn(),
+  },
+  SubmissionNotFoundError: class extends Error {
+    name = 'SubmissionNotFoundError';
+  },
+  NotDraftError: class extends Error {
+    name = 'NotDraftError';
+  },
+  InvalidStatusTransitionError: class extends Error {
+    name = 'InvalidStatusTransitionError';
+  },
+  UnscannedFilesError: class extends Error {
+    name = 'UnscannedFilesError';
+  },
+  InfectedFilesError: class extends Error {
+    name = 'InfectedFilesError';
+  },
+}));
+
+vi.mock('../../services/organization.service.js', () => ({
+  organizationService: {
+    listUserOrganizations: vi.fn(),
+    getById: vi.fn(),
+    listMembers: vi.fn(),
+    createWithAudit: vi.fn(),
+    updateWithAudit: vi.fn(),
+    addMemberWithAudit: vi.fn(),
+    removeMemberWithAudit: vi.fn(),
+    updateMemberRoleWithAudit: vi.fn(),
+  },
+  UserNotFoundError: class extends Error {
+    name = 'UserNotFoundError';
+  },
+  LastAdminError: class extends Error {
+    name = 'LastAdminError';
+  },
+}));
+
+vi.mock('../../services/file.service.js', () => ({
+  fileService: { deleteAsOwner: vi.fn() },
+  FileNotFoundError: class extends Error {
+    name = 'FileNotFoundError';
+  },
+  FileNotCleanError: class extends Error {
+    name = 'FileNotCleanError';
+  },
+}));
+
+vi.mock('../../services/errors.js', () => ({
+  assertEditorOrAdmin: vi.fn(),
+  assertOwnerOrEditor: vi.fn(),
+  ForbiddenError: class extends Error {
+    name = 'ForbiddenError';
+  },
+  NotFoundError: class extends Error {
+    name = 'NotFoundError';
+  },
+}));
+
+vi.mock('../error-mapper.js', () => ({
+  mapServiceError: vi.fn((e: unknown) => {
+    throw e;
+  }),
+}));
+
+vi.mock('../../services/scope-check.js', () => ({
+  checkApiKeyScopes: vi.fn().mockReturnValue({ allowed: true }),
+}));
+
+vi.mock('../../services/s3.js', () => ({
+  createS3Client: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: vi.fn().mockReturnValue({
+    S3_ENDPOINT: 'http://localhost:9000',
+    S3_REGION: 'us-east-1',
+    S3_ACCESS_KEY: 'test',
+    S3_SECRET_KEY: 'test',
+    S3_BUCKET: 'submissions',
+    S3_QUARANTINE_BUCKET: 'quarantine',
+  }),
+}));
+
+import { requireOrgContext, requireAdmin, requireScopes } from '../guards.js';
+import { apiKeyService } from '../../services/api-key.service.js';
+
+const mockRequireOrgContext = vi.mocked(requireOrgContext);
+const mockRequireAdmin = vi.mocked(requireAdmin);
+const mockRequireScopes = vi.mocked(requireScopes);
+
+import { schema } from '../schema.js';
+
+function makeCtx(): GraphQLContext {
+  return {
+    authContext: {
+      userId: 'user-1',
+      email: 'admin@example.com',
+      emailVerified: true,
+      authMethod: 'oidc' as const,
+      orgId: 'org-1',
+      role: 'ADMIN' as const,
+    },
+    dbTx: {} as DrizzleDb,
+    audit: vi.fn().mockResolvedValue(undefined),
+    loaders: {} as GraphQLContext['loaders'],
+  };
+}
+
+function makeAdminCtx() {
+  const ctx = makeCtx();
+  return {
+    ...ctx,
+    authContext: ctx.authContext as AuthContext & {
+      orgId: string;
+      role: 'ADMIN';
+    },
+    dbTx: ctx.dbTx as DrizzleDb,
+  };
+}
+
+function getMutationField(name: string) {
+  return schema.getMutationType()!.getFields()[name];
+}
+
+function getQueryField(name: string) {
+  return schema.getQueryType()!.getFields()[name];
+}
+
+describe('API key resolvers — schema', () => {
+  it('registers apiKeys query', () => {
+    expect(getQueryField('apiKeys')).toBeDefined();
+  });
+
+  it('registers all 3 API key mutations', () => {
+    for (const name of ['createApiKey', 'revokeApiKey', 'deleteApiKey']) {
+      expect(getMutationField(name)).toBeDefined();
+    }
+  });
+
+  it('createApiKey has name, scopes, expiresAt args', () => {
+    const argNames = getMutationField('createApiKey').args.map((a) => a.name);
+    expect(argNames).toEqual(
+      expect.arrayContaining(['name', 'scopes', 'expiresAt']),
+    );
+  });
+});
+
+describe('API key mutations — resolver wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireOrgContext.mockReturnValue(makeAdminCtx());
+    mockRequireAdmin.mockReturnValue(makeAdminCtx());
+    mockRequireScopes.mockResolvedValue(undefined);
+  });
+
+  it('createApiKey calls service and audits', async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(apiKeyService.create).mockResolvedValue({
+      id: 'key-1',
+      name: 'CI Key',
+      scopes: ['submissions:read'] as string[],
+      keyPrefix: 'col_live_',
+      plainTextKey: 'col_live_abc',
+      createdAt: new Date(),
+      expiresAt: null,
+      lastUsedAt: null,
+      revokedAt: null,
+    });
+
+    const ctx = makeCtx();
+    const field = getMutationField('createApiKey');
+    const result = await field.resolve!(
+      {},
+      { name: 'CI Key', scopes: ['submissions:read'], expiresAt: null },
+      ctx,
+      {} as never,
+    );
+
+    expect(mockRequireAdmin).toHaveBeenCalled();
+    expect(mockRequireScopes).toHaveBeenCalledWith(
+      expect.anything(),
+      'api-keys:manage',
+    );
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(apiKeyService.create).toHaveBeenCalled();
+    expect(ctx.audit).toHaveBeenCalled();
+    expect((result as { plainTextKey: string }).plainTextKey).toBe(
+      'col_live_abc',
+    );
+  });
+
+  it('revokeApiKey throws NOT_FOUND when null', async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(apiKeyService.revoke).mockResolvedValue(null as never);
+
+    const field = getMutationField('revokeApiKey');
+    await expect(
+      field.resolve!(
+        {},
+        { keyId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' },
+        makeCtx(),
+        {} as never,
+      ),
+    ).rejects.toThrow('API key not found');
+  });
+
+  it('revokeApiKey returns revoked key and audits', async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(apiKeyService.revoke).mockResolvedValue({
+      id: 'key-1',
+      name: 'CI Key',
+      revokedAt: new Date(),
+    });
+
+    const ctx = makeCtx();
+    const field = getMutationField('revokeApiKey');
+    const result = await field.resolve!(
+      {},
+      { keyId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' },
+      ctx,
+      {} as never,
+    );
+
+    expect((result as { name: string }).name).toBe('CI Key');
+    expect(ctx.audit).toHaveBeenCalled();
+  });
+
+  it('deleteApiKey throws NOT_FOUND when null', async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(apiKeyService.delete).mockResolvedValue(null as never);
+
+    const field = getMutationField('deleteApiKey');
+    await expect(
+      field.resolve!(
+        {},
+        { keyId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' },
+        makeCtx(),
+        {} as never,
+      ),
+    ).rejects.toThrow('API key not found');
+  });
+
+  it('deleteApiKey returns success and audits', async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(apiKeyService.delete).mockResolvedValue({ id: 'key-1' });
+
+    const ctx = makeCtx();
+    const field = getMutationField('deleteApiKey');
+    const result = await field.resolve!(
+      {},
+      { keyId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' },
+      ctx,
+      {} as never,
+    );
+
+    expect((result as { success: boolean }).success).toBe(true);
+    expect(ctx.audit).toHaveBeenCalled();
+  });
+
+  it('admin guard failure prevents service call', async () => {
+    mockRequireAdmin.mockImplementation(() => {
+      throw new GraphQLError('Admin role required', {
+        extensions: { code: 'FORBIDDEN' },
+      });
+    });
+
+    const field = getMutationField('createApiKey');
+    await expect(
+      field.resolve!(
+        {},
+        { name: 'X', scopes: ['submissions:read'] },
+        makeCtx(),
+        {} as never,
+      ),
+    ).rejects.toThrow('Admin role required');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(apiKeyService.create).not.toHaveBeenCalled();
+  });
+
+  it('apiKeys query enforces org context + scope', async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(apiKeyService.list).mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 20,
+      totalPages: 0,
+    });
+
+    const field = getQueryField('apiKeys');
+    await field.resolve!({}, { page: 1, limit: 20 }, makeCtx(), {} as never);
+
+    expect(mockRequireOrgContext).toHaveBeenCalled();
+    expect(mockRequireScopes).toHaveBeenCalledWith(
+      expect.anything(),
+      'api-keys:read',
+    );
+  });
+});

--- a/apps/api/src/graphql/resolvers/api-keys.ts
+++ b/apps/api/src/graphql/resolvers/api-keys.ts
@@ -1,0 +1,169 @@
+import { GraphQLError } from 'graphql';
+import {
+  paginationSchema,
+  createApiKeySchema,
+  revokeApiKeySchema,
+  deleteApiKeySchema,
+  AuditActions,
+  AuditResources,
+} from '@colophony/types';
+import { builder } from '../builder.js';
+import { requireOrgContext, requireAdmin, requireScopes } from '../guards.js';
+import { apiKeyService } from '../../services/api-key.service.js';
+import { ApiKeyType } from '../types/api-key.js';
+import {
+  CreateApiKeyPayload,
+  RevokeApiKeyPayload,
+  SuccessPayload,
+} from '../types/payloads.js';
+
+// ---------------------------------------------------------------------------
+// Paginated response type
+// ---------------------------------------------------------------------------
+
+const PaginatedApiKeys = builder
+  .objectRef<{
+    items: {
+      id: string;
+      name: string;
+      scopes: unknown;
+      keyPrefix: string;
+      createdAt: Date;
+      expiresAt: Date | null;
+      lastUsedAt: Date | null;
+      revokedAt: Date | null;
+    }[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }>('PaginatedApiKeys')
+  .implement({
+    fields: (t) => ({
+      items: t.field({ type: [ApiKeyType], resolve: (r) => r.items }),
+      total: t.exposeInt('total'),
+      page: t.exposeInt('page'),
+      limit: t.exposeInt('limit'),
+      totalPages: t.exposeInt('totalPages'),
+    }),
+  });
+
+// ---------------------------------------------------------------------------
+// Query fields
+// ---------------------------------------------------------------------------
+
+builder.queryFields((t) => ({
+  /**
+   * List API keys for the current organization.
+   */
+  apiKeys: t.field({
+    type: PaginatedApiKeys,
+    args: {
+      page: t.arg.int({ required: false, defaultValue: 1 }),
+      limit: t.arg.int({ required: false, defaultValue: 20 }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'api-keys:read');
+      const input = paginationSchema.parse({
+        page: args.page,
+        limit: args.limit,
+      });
+      return apiKeyService.list(orgCtx.dbTx, input);
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mutation fields
+// ---------------------------------------------------------------------------
+
+builder.mutationFields((t) => ({
+  /**
+   * Create a new API key (admin only). Returns the plain text key once.
+   */
+  createApiKey: t.field({
+    type: CreateApiKeyPayload,
+    args: {
+      name: t.arg.string({ required: true }),
+      scopes: t.arg.stringList({ required: true }),
+      expiresAt: t.arg({ type: 'DateTime', required: false }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireAdmin(ctx);
+      await requireScopes(ctx, 'api-keys:manage');
+      const input = createApiKeySchema.parse({
+        name: args.name,
+        scopes: args.scopes,
+        expiresAt: args.expiresAt ?? undefined,
+      });
+      const result = await apiKeyService.create(
+        orgCtx.dbTx,
+        orgCtx.authContext.orgId,
+        orgCtx.authContext.userId,
+        input,
+      );
+      await ctx.audit({
+        action: AuditActions.API_KEY_CREATED,
+        resource: AuditResources.API_KEY,
+        resourceId: result.id,
+        newValue: { name: input.name, scopes: input.scopes },
+      });
+      return result;
+    },
+  }),
+
+  /**
+   * Revoke an API key (admin only).
+   */
+  revokeApiKey: t.field({
+    type: RevokeApiKeyPayload,
+    args: {
+      keyId: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireAdmin(ctx);
+      await requireScopes(ctx, 'api-keys:manage');
+      const { keyId } = revokeApiKeySchema.parse({ keyId: args.keyId });
+      const revoked = await apiKeyService.revoke(orgCtx.dbTx, keyId);
+      if (!revoked) {
+        throw new GraphQLError('API key not found', {
+          extensions: { code: 'NOT_FOUND' },
+        });
+      }
+      await ctx.audit({
+        action: AuditActions.API_KEY_REVOKED,
+        resource: AuditResources.API_KEY,
+        resourceId: revoked.id,
+      });
+      return revoked;
+    },
+  }),
+
+  /**
+   * Delete an API key (admin only).
+   */
+  deleteApiKey: t.field({
+    type: SuccessPayload,
+    args: {
+      keyId: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireAdmin(ctx);
+      await requireScopes(ctx, 'api-keys:manage');
+      const { keyId } = deleteApiKeySchema.parse({ keyId: args.keyId });
+      const deleted = await apiKeyService.delete(orgCtx.dbTx, keyId);
+      if (!deleted) {
+        throw new GraphQLError('API key not found', {
+          extensions: { code: 'NOT_FOUND' },
+        });
+      }
+      await ctx.audit({
+        action: AuditActions.API_KEY_DELETED,
+        resource: AuditResources.API_KEY,
+        resourceId: deleted.id,
+      });
+      return { success: true };
+    },
+  }),
+}));

--- a/apps/api/src/graphql/resolvers/files-mutations.spec.ts
+++ b/apps/api/src/graphql/resolvers/files-mutations.spec.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GraphQLError } from 'graphql';
+import type { GraphQLContext } from '../context.js';
+import type { AuthContext } from '@colophony/types';
+import type { DrizzleDb } from '@colophony/db';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../guards.js', () => ({
+  requireAuth: vi.fn(),
+  requireOrgContext: vi.fn(),
+  requireAdmin: vi.fn(),
+  requireScopes: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../services/context.js', () => ({
+  toServiceContext: vi.fn((ctx: unknown) => ctx),
+}));
+
+vi.mock('../../services/file.service.js', () => ({
+  fileService: { deleteAsOwner: vi.fn() },
+  FileNotFoundError: class extends Error {
+    name = 'FileNotFoundError';
+  },
+  FileNotCleanError: class extends Error {
+    name = 'FileNotCleanError';
+  },
+}));
+
+vi.mock('../../services/submission.service.js', () => ({
+  submissionService: {
+    listAll: vi.fn(),
+    listBySubmitter: vi.fn(),
+    getByIdWithAccess: vi.fn(),
+    getHistoryWithAccess: vi.fn(),
+    createWithAudit: vi.fn(),
+    updateAsOwner: vi.fn(),
+    submitAsOwner: vi.fn(),
+    deleteAsOwner: vi.fn(),
+    withdrawAsOwner: vi.fn(),
+    updateStatusAsEditor: vi.fn(),
+  },
+  SubmissionNotFoundError: class extends Error {
+    name = 'SubmissionNotFoundError';
+  },
+  NotDraftError: class extends Error {
+    name = 'NotDraftError';
+  },
+  InvalidStatusTransitionError: class extends Error {
+    name = 'InvalidStatusTransitionError';
+  },
+  UnscannedFilesError: class extends Error {
+    name = 'UnscannedFilesError';
+  },
+  InfectedFilesError: class extends Error {
+    name = 'InfectedFilesError';
+  },
+}));
+
+vi.mock('../../services/organization.service.js', () => ({
+  organizationService: {
+    listUserOrganizations: vi.fn(),
+    getById: vi.fn(),
+    listMembers: vi.fn(),
+    createWithAudit: vi.fn(),
+    updateWithAudit: vi.fn(),
+    addMemberWithAudit: vi.fn(),
+    removeMemberWithAudit: vi.fn(),
+    updateMemberRoleWithAudit: vi.fn(),
+  },
+  UserNotFoundError: class extends Error {
+    name = 'UserNotFoundError';
+  },
+  LastAdminError: class extends Error {
+    name = 'LastAdminError';
+  },
+}));
+
+vi.mock('../../services/api-key.service.js', () => ({
+  apiKeyService: {
+    list: vi.fn(),
+    create: vi.fn(),
+    revoke: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/errors.js', () => ({
+  assertEditorOrAdmin: vi.fn(),
+  assertOwnerOrEditor: vi.fn(),
+  ForbiddenError: class extends Error {
+    name = 'ForbiddenError';
+  },
+  NotFoundError: class extends Error {
+    name = 'NotFoundError';
+  },
+}));
+
+vi.mock('../error-mapper.js', () => ({
+  mapServiceError: vi.fn((e: unknown) => {
+    throw e;
+  }),
+}));
+
+vi.mock('../../services/scope-check.js', () => ({
+  checkApiKeyScopes: vi.fn().mockReturnValue({ allowed: true }),
+}));
+
+vi.mock('../../services/s3.js', () => ({
+  createS3Client: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: vi.fn().mockReturnValue({
+    S3_ENDPOINT: 'http://localhost:9000',
+    S3_REGION: 'us-east-1',
+    S3_ACCESS_KEY: 'test',
+    S3_SECRET_KEY: 'test',
+    S3_BUCKET: 'submissions',
+    S3_QUARANTINE_BUCKET: 'quarantine',
+  }),
+}));
+
+import { requireOrgContext, requireScopes } from '../guards.js';
+import { fileService } from '../../services/file.service.js';
+import { mapServiceError } from '../error-mapper.js';
+
+const mockRequireOrgContext = vi.mocked(requireOrgContext);
+const mockRequireScopes = vi.mocked(requireScopes);
+
+import { schema } from '../schema.js';
+
+function makeCtx(): GraphQLContext {
+  return {
+    authContext: {
+      userId: 'user-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'oidc' as const,
+      orgId: 'org-1',
+      role: 'EDITOR' as const,
+    },
+    dbTx: {} as DrizzleDb,
+    audit: vi.fn().mockResolvedValue(undefined),
+    loaders: {} as GraphQLContext['loaders'],
+  };
+}
+
+function makeOrgCtx() {
+  const ctx = makeCtx();
+  return {
+    ...ctx,
+    authContext: ctx.authContext as AuthContext & {
+      orgId: string;
+      role: 'ADMIN' | 'EDITOR' | 'READER';
+    },
+    dbTx: ctx.dbTx as DrizzleDb,
+  };
+}
+
+function getMutationField(name: string) {
+  return schema.getMutationType()!.getFields()[name];
+}
+
+describe('File mutations — schema', () => {
+  it('registers deleteFile mutation', () => {
+    const field = getMutationField('deleteFile');
+    expect(field).toBeDefined();
+    expect(field.args.map((a) => a.name)).toContain('fileId');
+  });
+});
+
+describe('File mutations — resolver wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireOrgContext.mockReturnValue(makeOrgCtx());
+    mockRequireScopes.mockResolvedValue(undefined);
+  });
+
+  it('deleteFile calls requireOrgContext + files:write scope + service', async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(fileService.deleteAsOwner).mockResolvedValue({ success: true });
+
+    const field = getMutationField('deleteFile');
+    const result = await field.resolve!(
+      {},
+      { fileId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' },
+      makeCtx(),
+      {} as never,
+    );
+
+    expect(mockRequireOrgContext).toHaveBeenCalled();
+    expect(mockRequireScopes).toHaveBeenCalledWith(
+      expect.anything(),
+      'files:write',
+    );
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(fileService.deleteAsOwner).toHaveBeenCalled();
+    expect((result as { success: boolean }).success).toBe(true);
+  });
+
+  it('deleteFile validates fileId as UUID', async () => {
+    const field = getMutationField('deleteFile');
+    await expect(
+      field.resolve!({}, { fileId: 'not-a-uuid' }, makeCtx(), {} as never),
+    ).rejects.toThrow();
+  });
+
+  it('deleteFile guard failure prevents service call', async () => {
+    mockRequireOrgContext.mockImplementation(() => {
+      throw new GraphQLError('Not authenticated', {
+        extensions: { code: 'UNAUTHENTICATED' },
+      });
+    });
+
+    const field = getMutationField('deleteFile');
+    await expect(
+      field.resolve!(
+        {},
+        { fileId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' },
+        makeCtx(),
+        {} as never,
+      ),
+    ).rejects.toThrow('Not authenticated');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(fileService.deleteAsOwner).not.toHaveBeenCalled();
+  });
+
+  it('deleteFile maps service errors', async () => {
+    const error = new Error('File not found');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(fileService.deleteAsOwner).mockRejectedValue(error);
+
+    const field = getMutationField('deleteFile');
+    await expect(
+      field.resolve!(
+        {},
+        { fileId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' },
+        makeCtx(),
+        {} as never,
+      ),
+    ).rejects.toThrow();
+    expect(mapServiceError).toHaveBeenCalledWith(error);
+  });
+});

--- a/apps/api/src/graphql/resolvers/files.ts
+++ b/apps/api/src/graphql/resolvers/files.ts
@@ -1,0 +1,60 @@
+import { fileIdParamSchema } from '@colophony/types';
+import { builder } from '../builder.js';
+import { requireOrgContext, requireScopes } from '../guards.js';
+import { toServiceContext } from '../../services/context.js';
+import { fileService } from '../../services/file.service.js';
+import { createS3Client } from '../../services/s3.js';
+import { validateEnv } from '../../config/env.js';
+import { mapServiceError } from '../error-mapper.js';
+import { SuccessPayload } from '../types/payloads.js';
+
+// ---------------------------------------------------------------------------
+// Lazy S3 client (same pattern as tRPC files router)
+// ---------------------------------------------------------------------------
+
+let s3ClientInstance: ReturnType<typeof createS3Client> | null = null;
+
+function getS3Client() {
+  if (!s3ClientInstance) {
+    const env = validateEnv();
+    s3ClientInstance = createS3Client(env);
+  }
+  return s3ClientInstance;
+}
+
+function getEnvConfig() {
+  return validateEnv();
+}
+
+// ---------------------------------------------------------------------------
+// Mutation fields
+// ---------------------------------------------------------------------------
+
+builder.mutationFields((t) => ({
+  /**
+   * Delete a file from a DRAFT submission (owner only).
+   */
+  deleteFile: t.field({
+    type: SuccessPayload,
+    args: {
+      fileId: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'files:write');
+      const { fileId } = fileIdParamSchema.parse({ fileId: args.fileId });
+      try {
+        const env = getEnvConfig();
+        return await fileService.deleteAsOwner(
+          toServiceContext(orgCtx),
+          fileId,
+          getS3Client(),
+          env.S3_BUCKET,
+          env.S3_QUARANTINE_BUCKET,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));

--- a/apps/api/src/graphql/resolvers/index.ts
+++ b/apps/api/src/graphql/resolvers/index.ts
@@ -1,5 +1,7 @@
-// Side-effect barrel — importing registers query fields on the builder.
+// Side-effect barrel — importing registers query/mutation fields on the builder.
 import './submissions.js';
 import './organizations.js';
 import './users.js';
 import './audit.js';
+import './api-keys.js';
+import './files.js';

--- a/apps/api/src/graphql/resolvers/organizations-mutations.spec.ts
+++ b/apps/api/src/graphql/resolvers/organizations-mutations.spec.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GraphQLError } from 'graphql';
+import type { GraphQLContext } from '../context.js';
+import type { AuthContext } from '@colophony/types';
+import type { DrizzleDb } from '@colophony/db';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../guards.js', () => ({
+  requireAuth: vi.fn(),
+  requireOrgContext: vi.fn(),
+  requireAdmin: vi.fn(),
+  requireScopes: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../services/context.js', () => ({
+  toServiceContext: vi.fn((ctx: unknown) => ctx),
+}));
+
+vi.mock('../../services/submission.service.js', () => ({
+  submissionService: {
+    listAll: vi.fn(),
+    listBySubmitter: vi.fn(),
+    getByIdWithAccess: vi.fn(),
+    getHistoryWithAccess: vi.fn(),
+    createWithAudit: vi.fn(),
+    updateAsOwner: vi.fn(),
+    submitAsOwner: vi.fn(),
+    deleteAsOwner: vi.fn(),
+    withdrawAsOwner: vi.fn(),
+    updateStatusAsEditor: vi.fn(),
+  },
+  SubmissionNotFoundError: class extends Error {
+    name = 'SubmissionNotFoundError';
+  },
+  NotDraftError: class extends Error {
+    name = 'NotDraftError';
+  },
+  InvalidStatusTransitionError: class extends Error {
+    name = 'InvalidStatusTransitionError';
+  },
+  UnscannedFilesError: class extends Error {
+    name = 'UnscannedFilesError';
+  },
+  InfectedFilesError: class extends Error {
+    name = 'InfectedFilesError';
+  },
+}));
+
+vi.mock('../../services/organization.service.js', () => ({
+  organizationService: {
+    listUserOrganizations: vi.fn(),
+    getById: vi.fn(),
+    listMembers: vi.fn(),
+    createWithAudit: vi.fn(),
+    updateWithAudit: vi.fn(),
+    addMemberWithAudit: vi.fn(),
+    removeMemberWithAudit: vi.fn(),
+    updateMemberRoleWithAudit: vi.fn(),
+  },
+  UserNotFoundError: class extends Error {
+    name = 'UserNotFoundError';
+  },
+  LastAdminError: class extends Error {
+    name = 'LastAdminError';
+  },
+}));
+
+vi.mock('../../services/api-key.service.js', () => ({
+  apiKeyService: {
+    list: vi.fn(),
+    create: vi.fn(),
+    revoke: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/file.service.js', () => ({
+  fileService: { deleteAsOwner: vi.fn() },
+  FileNotFoundError: class extends Error {
+    name = 'FileNotFoundError';
+  },
+  FileNotCleanError: class extends Error {
+    name = 'FileNotCleanError';
+  },
+}));
+
+vi.mock('../../services/errors.js', () => ({
+  assertEditorOrAdmin: vi.fn(),
+  assertOwnerOrEditor: vi.fn(),
+  ForbiddenError: class extends Error {
+    name = 'ForbiddenError';
+  },
+  NotFoundError: class extends Error {
+    name = 'NotFoundError';
+  },
+}));
+
+vi.mock('../error-mapper.js', () => ({
+  mapServiceError: vi.fn((e: unknown) => {
+    throw e;
+  }),
+}));
+
+vi.mock('../../services/scope-check.js', () => ({
+  checkApiKeyScopes: vi.fn().mockReturnValue({ allowed: true }),
+}));
+
+vi.mock('../../services/s3.js', () => ({
+  createS3Client: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: vi.fn().mockReturnValue({
+    S3_ENDPOINT: 'http://localhost:9000',
+    S3_REGION: 'us-east-1',
+    S3_ACCESS_KEY: 'test',
+    S3_SECRET_KEY: 'test',
+    S3_BUCKET: 'submissions',
+    S3_QUARANTINE_BUCKET: 'quarantine',
+  }),
+}));
+
+import { requireAuth, requireAdmin, requireScopes } from '../guards.js';
+import { organizationService } from '../../services/organization.service.js';
+
+const mockRequireAuth = vi.mocked(requireAuth);
+const mockRequireAdmin = vi.mocked(requireAdmin);
+const mockRequireScopes = vi.mocked(requireScopes);
+
+import { schema } from '../schema.js';
+
+function makeCtx(): GraphQLContext {
+  return {
+    authContext: {
+      userId: 'user-1',
+      email: 'admin@example.com',
+      emailVerified: true,
+      authMethod: 'oidc' as const,
+      orgId: 'org-1',
+      role: 'ADMIN' as const,
+    },
+    dbTx: {} as DrizzleDb,
+    audit: vi.fn().mockResolvedValue(undefined),
+    loaders: {} as GraphQLContext['loaders'],
+  };
+}
+
+function makeAuthedCtx() {
+  const ctx = makeCtx();
+  return { ...ctx, authContext: ctx.authContext as AuthContext };
+}
+
+function makeAdminCtx() {
+  const ctx = makeCtx();
+  return {
+    ...ctx,
+    authContext: ctx.authContext as AuthContext & {
+      orgId: string;
+      role: 'ADMIN';
+    },
+    dbTx: ctx.dbTx as DrizzleDb,
+  };
+}
+
+function getMutationField(name: string) {
+  const fields = schema.getMutationType()!.getFields();
+  return fields[name];
+}
+
+describe('Organization mutations — schema', () => {
+  it('registers all 5 organization mutations', () => {
+    const names = [
+      'createOrganization',
+      'updateOrganization',
+      'addOrganizationMember',
+      'removeOrganizationMember',
+      'updateOrganizationMemberRole',
+    ];
+    for (const name of names) {
+      expect(getMutationField(name)).toBeDefined();
+    }
+  });
+
+  it('createOrganization has name and slug args', () => {
+    const field = getMutationField('createOrganization');
+    const argNames = field.args.map((a) => a.name);
+    expect(argNames).toContain('name');
+    expect(argNames).toContain('slug');
+  });
+});
+
+describe('Organization mutations — resolver wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockReturnValue(makeAuthedCtx());
+    mockRequireAdmin.mockReturnValue(makeAdminCtx());
+    mockRequireScopes.mockResolvedValue(undefined);
+  });
+
+  it('createOrganization uses requireAuth and calls createWithAudit', async () => {
+    const result_data = {
+      organization: {
+        id: 'org-new',
+        name: 'New Org',
+        slug: 'new-org',
+        settings: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      membership: {
+        id: 'mem-1',
+        organizationId: 'org-new',
+        userId: 'user-1',
+        role: 'ADMIN' as const,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(organizationService.createWithAudit).mockResolvedValue(
+      result_data,
+    );
+
+    const field = getMutationField('createOrganization');
+    const result = await field.resolve!(
+      {},
+      { name: 'New Org', slug: 'new-org' },
+      makeCtx(),
+      {} as never,
+    );
+
+    expect(mockRequireAuth).toHaveBeenCalled();
+    expect(mockRequireScopes).toHaveBeenCalledWith(
+      expect.anything(),
+      'organizations:write',
+    );
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(organizationService.createWithAudit).toHaveBeenCalled();
+    expect(result).toBe(result_data);
+  });
+
+  it('updateOrganization uses requireAdmin', async () => {
+    const updated = {
+      id: 'org-1',
+      name: 'Updated',
+      slug: 'my-org',
+      settings: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(organizationService.updateWithAudit).mockResolvedValue(updated);
+
+    const field = getMutationField('updateOrganization');
+    await field.resolve!(
+      {},
+      { name: 'Updated', settings: null },
+      makeCtx(),
+      {} as never,
+    );
+
+    expect(mockRequireAdmin).toHaveBeenCalled();
+  });
+
+  it('addOrganizationMember validates email + role via Zod', async () => {
+    const field = getMutationField('addOrganizationMember');
+    // Invalid role should fail Zod validation
+    await expect(
+      field.resolve!(
+        {},
+        { email: 'x@test.com', role: 'SUPERADMIN' },
+        makeCtx(),
+        {} as never,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('removeOrganizationMember validates memberId as UUID', async () => {
+    const field = getMutationField('removeOrganizationMember');
+    await expect(
+      field.resolve!({}, { memberId: 'not-a-uuid' }, makeCtx(), {} as never),
+    ).rejects.toThrow();
+  });
+
+  it('updateOrganizationMemberRole calls service with validated args', async () => {
+    const updated = {
+      id: 'mem-1',
+      organizationId: 'org-1',
+      userId: 'user-2',
+      role: 'EDITOR' as const,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(organizationService.updateMemberRoleWithAudit).mockResolvedValue(
+      updated,
+    );
+
+    const field = getMutationField('updateOrganizationMemberRole');
+    const result = await field.resolve!(
+      {},
+      { memberId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', role: 'EDITOR' },
+      makeCtx(),
+      {} as never,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(organizationService.updateMemberRoleWithAudit).toHaveBeenCalled();
+    expect(result).toBe(updated);
+  });
+
+  it('createOrganization guard failure prevents service call', async () => {
+    mockRequireAuth.mockImplementation(() => {
+      throw new GraphQLError('Not authenticated', {
+        extensions: { code: 'UNAUTHENTICATED' },
+      });
+    });
+
+    const field = getMutationField('createOrganization');
+    await expect(
+      field.resolve!({}, { name: 'X', slug: 'x' }, makeCtx(), {} as never),
+    ).rejects.toThrow('Not authenticated');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(organizationService.createWithAudit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/graphql/resolvers/organizations.ts
+++ b/apps/api/src/graphql/resolvers/organizations.ts
@@ -1,8 +1,26 @@
-import { paginationSchema } from '@colophony/types';
+import {
+  paginationSchema,
+  createOrganizationSchema,
+  updateOrganizationSchema,
+  inviteMemberSchema,
+  updateMemberRoleSchema,
+  memberIdParamSchema,
+} from '@colophony/types';
 import { builder } from '../builder.js';
-import { requireAuth, requireOrgContext, requireScopes } from '../guards.js';
+import {
+  requireAuth,
+  requireOrgContext,
+  requireAdmin,
+  requireScopes,
+} from '../guards.js';
+import { toServiceContext } from '../../services/context.js';
 import { organizationService } from '../../services/organization.service.js';
-import { OrganizationType } from '../types/index.js';
+import { mapServiceError } from '../error-mapper.js';
+import { OrganizationType, OrganizationMemberType } from '../types/index.js';
+import {
+  CreateOrganizationPayload,
+  SuccessPayload,
+} from '../types/payloads.js';
 
 // ---------------------------------------------------------------------------
 // Paginated response types
@@ -120,6 +138,148 @@ builder.queryFields((t) => ({
         limit: args.limit,
       });
       return organizationService.listMembers(orgCtx.dbTx, input);
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mutation fields
+// ---------------------------------------------------------------------------
+
+builder.mutationFields((t) => ({
+  /**
+   * Create a new organization. No org context needed (it doesn't exist yet).
+   */
+  createOrganization: t.field({
+    type: CreateOrganizationPayload,
+    args: {
+      name: t.arg.string({ required: true }),
+      slug: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const authed = requireAuth(ctx);
+      await requireScopes(ctx, 'organizations:write');
+      const input = createOrganizationSchema.parse({
+        name: args.name,
+        slug: args.slug,
+      });
+      try {
+        return await organizationService.createWithAudit(
+          authed.audit,
+          input,
+          authed.authContext.userId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Update the current organization (admin only).
+   */
+  updateOrganization: t.field({
+    type: OrganizationType,
+    args: {
+      name: t.arg.string({ required: false }),
+      settings: t.arg({ type: 'JSON', required: false }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireAdmin(ctx);
+      await requireScopes(ctx, 'organizations:write');
+      const input = updateOrganizationSchema.parse({
+        name: args.name ?? undefined,
+        settings: args.settings ?? undefined,
+      });
+      try {
+        return await organizationService.updateWithAudit(
+          toServiceContext(orgCtx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Add a member to the current organization (admin only).
+   */
+  addOrganizationMember: t.field({
+    type: OrganizationMemberType,
+    args: {
+      email: t.arg.string({ required: true }),
+      role: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireAdmin(ctx);
+      await requireScopes(ctx, 'organizations:write');
+      const { email, role } = inviteMemberSchema.parse({
+        email: args.email,
+        role: args.role,
+      });
+      try {
+        return await organizationService.addMemberWithAudit(
+          toServiceContext(orgCtx),
+          email,
+          role,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Remove a member from the current organization (admin only).
+   */
+  removeOrganizationMember: t.field({
+    type: SuccessPayload,
+    args: {
+      memberId: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireAdmin(ctx);
+      await requireScopes(ctx, 'organizations:write');
+      const { memberId } = memberIdParamSchema.parse({
+        memberId: args.memberId,
+      });
+      try {
+        return await organizationService.removeMemberWithAudit(
+          toServiceContext(orgCtx),
+          memberId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Update a member's role in the current organization (admin only).
+   */
+  updateOrganizationMemberRole: t.field({
+    type: OrganizationMemberType,
+    args: {
+      memberId: t.arg.string({ required: true }),
+      role: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireAdmin(ctx);
+      await requireScopes(ctx, 'organizations:write');
+      const { memberId, role } = updateMemberRoleSchema.parse({
+        memberId: args.memberId,
+        role: args.role,
+      });
+      try {
+        return await organizationService.updateMemberRoleWithAudit(
+          toServiceContext(orgCtx),
+          memberId,
+          role,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
     },
   }),
 }));

--- a/apps/api/src/graphql/resolvers/submissions-mutations.spec.ts
+++ b/apps/api/src/graphql/resolvers/submissions-mutations.spec.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GraphQLError } from 'graphql';
+import type { GraphQLContext } from '../context.js';
+import type { AuthContext } from '@colophony/types';
+import type { DrizzleDb } from '@colophony/db';
+
+// ---------------------------------------------------------------------------
+// Mocks — must mock all services imported by any resolver since schema.ts
+// imports all resolvers as side effects.
+// ---------------------------------------------------------------------------
+
+vi.mock('../guards.js', () => ({
+  requireAuth: vi.fn(),
+  requireOrgContext: vi.fn(),
+  requireAdmin: vi.fn(),
+  requireScopes: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../services/context.js', () => ({
+  toServiceContext: vi.fn((ctx: unknown) => ctx),
+}));
+
+vi.mock('../../services/submission.service.js', () => ({
+  submissionService: {
+    listAll: vi.fn(),
+    listBySubmitter: vi.fn(),
+    getByIdWithAccess: vi.fn(),
+    getHistoryWithAccess: vi.fn(),
+    createWithAudit: vi.fn(),
+    updateAsOwner: vi.fn(),
+    submitAsOwner: vi.fn(),
+    deleteAsOwner: vi.fn(),
+    withdrawAsOwner: vi.fn(),
+    updateStatusAsEditor: vi.fn(),
+  },
+  SubmissionNotFoundError: class extends Error {
+    name = 'SubmissionNotFoundError';
+  },
+  NotDraftError: class extends Error {
+    name = 'NotDraftError';
+  },
+  InvalidStatusTransitionError: class extends Error {
+    name = 'InvalidStatusTransitionError';
+  },
+  UnscannedFilesError: class extends Error {
+    name = 'UnscannedFilesError';
+  },
+  InfectedFilesError: class extends Error {
+    name = 'InfectedFilesError';
+  },
+}));
+
+vi.mock('../../services/errors.js', () => ({
+  assertEditorOrAdmin: vi.fn(),
+  assertOwnerOrEditor: vi.fn(),
+  ForbiddenError: class extends Error {
+    name = 'ForbiddenError';
+  },
+  NotFoundError: class extends Error {
+    name = 'NotFoundError';
+  },
+}));
+
+vi.mock('../../services/file.service.js', () => ({
+  fileService: { deleteAsOwner: vi.fn() },
+  FileNotFoundError: class extends Error {
+    name = 'FileNotFoundError';
+  },
+  FileNotCleanError: class extends Error {
+    name = 'FileNotCleanError';
+  },
+}));
+
+vi.mock('../../services/organization.service.js', () => ({
+  organizationService: {
+    listUserOrganizations: vi.fn(),
+    getById: vi.fn(),
+    listMembers: vi.fn(),
+    createWithAudit: vi.fn(),
+    updateWithAudit: vi.fn(),
+    addMemberWithAudit: vi.fn(),
+    removeMemberWithAudit: vi.fn(),
+    updateMemberRoleWithAudit: vi.fn(),
+  },
+  UserNotFoundError: class extends Error {
+    name = 'UserNotFoundError';
+  },
+  LastAdminError: class extends Error {
+    name = 'LastAdminError';
+  },
+}));
+
+vi.mock('../../services/api-key.service.js', () => ({
+  apiKeyService: {
+    list: vi.fn(),
+    create: vi.fn(),
+    revoke: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../error-mapper.js', () => ({
+  mapServiceError: vi.fn((e: unknown) => {
+    throw e;
+  }),
+}));
+
+vi.mock('../../services/scope-check.js', () => ({
+  checkApiKeyScopes: vi.fn().mockReturnValue({ allowed: true }),
+}));
+
+vi.mock('../../services/s3.js', () => ({
+  createS3Client: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: vi.fn().mockReturnValue({
+    S3_ENDPOINT: 'http://localhost:9000',
+    S3_REGION: 'us-east-1',
+    S3_ACCESS_KEY: 'test',
+    S3_SECRET_KEY: 'test',
+    S3_BUCKET: 'submissions',
+    S3_QUARANTINE_BUCKET: 'quarantine',
+  }),
+}));
+
+import { requireOrgContext, requireScopes } from '../guards.js';
+import { submissionService } from '../../services/submission.service.js';
+import { mapServiceError } from '../error-mapper.js';
+
+const mockRequireOrgContext = vi.mocked(requireOrgContext);
+const mockRequireScopes = vi.mocked(requireScopes);
+
+import { schema } from '../schema.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCtx(): GraphQLContext {
+  return {
+    authContext: {
+      userId: 'user-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'oidc' as const,
+      orgId: 'org-1',
+      role: 'EDITOR' as const,
+    },
+    dbTx: {} as DrizzleDb,
+    audit: vi.fn().mockResolvedValue(undefined),
+    loaders: {} as GraphQLContext['loaders'],
+  };
+}
+
+function makeOrgCtx() {
+  const ctx = makeCtx();
+  return {
+    ...ctx,
+    authContext: ctx.authContext as AuthContext & {
+      orgId: string;
+      role: 'ADMIN' | 'EDITOR' | 'READER';
+    },
+    dbTx: ctx.dbTx as DrizzleDb,
+  };
+}
+
+function getMutationField(name: string) {
+  const mutationType = schema.getMutationType();
+  expect(mutationType).toBeDefined();
+  const fields = mutationType!.getFields();
+  return fields[name];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Submission mutations — schema', () => {
+  it('registers createSubmission mutation', () => {
+    const field = getMutationField('createSubmission');
+    expect(field).toBeDefined();
+    const argNames = field.args.map((a) => a.name);
+    expect(argNames).toContain('title');
+  });
+
+  it('registers updateSubmission mutation', () => {
+    const field = getMutationField('updateSubmission');
+    expect(field).toBeDefined();
+    const argNames = field.args.map((a) => a.name);
+    expect(argNames).toContain('id');
+    expect(argNames).toContain('title');
+  });
+
+  it('registers submitSubmission mutation', () => {
+    const field = getMutationField('submitSubmission');
+    expect(field).toBeDefined();
+    expect(field.args.map((a) => a.name)).toContain('id');
+  });
+
+  it('registers deleteSubmission mutation', () => {
+    const field = getMutationField('deleteSubmission');
+    expect(field).toBeDefined();
+    expect(field.args.map((a) => a.name)).toContain('id');
+  });
+
+  it('registers withdrawSubmission mutation', () => {
+    const field = getMutationField('withdrawSubmission');
+    expect(field).toBeDefined();
+    expect(field.args.map((a) => a.name)).toContain('id');
+  });
+
+  it('registers updateSubmissionStatus mutation', () => {
+    const field = getMutationField('updateSubmissionStatus');
+    expect(field).toBeDefined();
+    const argNames = field.args.map((a) => a.name);
+    expect(argNames).toContain('id');
+    expect(argNames).toContain('status');
+    expect(argNames).toContain('comment');
+  });
+});
+
+describe('Submission mutations — resolver wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireOrgContext.mockReturnValue(makeOrgCtx());
+    mockRequireScopes.mockResolvedValue(undefined);
+  });
+
+  it('createSubmission calls requireOrgContext + service', async () => {
+    const submission = {
+      id: 'sub-1',
+      organizationId: 'org-1',
+      submitterId: 'user-1',
+      submissionPeriodId: null,
+      title: 'Test',
+      content: null,
+      coverLetter: null,
+      status: 'DRAFT' as const,
+      submittedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      searchVector: null,
+    };
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(submissionService.createWithAudit).mockResolvedValue(submission);
+
+    const field = getMutationField('createSubmission');
+    const result = await field.resolve!(
+      {},
+      {
+        title: 'Test',
+        content: null,
+        coverLetter: null,
+        submissionPeriodId: null,
+      },
+      makeCtx(),
+      {} as never,
+    );
+
+    expect(mockRequireOrgContext).toHaveBeenCalled();
+    expect(mockRequireScopes).toHaveBeenCalledWith(
+      expect.anything(),
+      'submissions:write',
+    );
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(submissionService.createWithAudit).toHaveBeenCalled();
+    expect(result).toEqual(submission);
+  });
+
+  it('createSubmission guard failure prevents service call', async () => {
+    mockRequireOrgContext.mockImplementation(() => {
+      throw new GraphQLError('Not authenticated', {
+        extensions: { code: 'UNAUTHENTICATED' },
+      });
+    });
+
+    const field = getMutationField('createSubmission');
+    await expect(
+      field.resolve!({}, { title: 'X' }, makeCtx(), {} as never),
+    ).rejects.toThrow('Not authenticated');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(submissionService.createWithAudit).not.toHaveBeenCalled();
+  });
+
+  it('createSubmission validates input via Zod', async () => {
+    const field = getMutationField('createSubmission');
+    await expect(
+      field.resolve!({}, { title: '' }, makeCtx(), {} as never),
+    ).rejects.toThrow(); // Zod rejects empty title
+  });
+
+  it('updateSubmission validates id as UUID', async () => {
+    const field = getMutationField('updateSubmission');
+    await expect(
+      field.resolve!(
+        {},
+        { id: 'not-a-uuid', title: 'X' },
+        makeCtx(),
+        {} as never,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('deleteSubmission calls deleteAsOwner', async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(submissionService.deleteAsOwner).mockResolvedValue({
+      success: true,
+    });
+
+    const field = getMutationField('deleteSubmission');
+    const result = await field.resolve!(
+      {},
+      { id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' },
+      makeCtx(),
+      {} as never,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(submissionService.deleteAsOwner).toHaveBeenCalled();
+    expect(result).toEqual({ success: true });
+  });
+
+  it('updateSubmissionStatus calls updateStatusAsEditor', async () => {
+    const payload = {
+      submission: {
+        id: 'sub-1',
+        organizationId: 'org-1',
+        submitterId: 'user-1',
+        submissionPeriodId: null,
+        title: 'Test',
+        content: null,
+        coverLetter: null,
+        status: 'UNDER_REVIEW' as const,
+        submittedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        searchVector: null,
+      },
+      historyEntry: {
+        id: 'hist-1',
+        submissionId: 'sub-1',
+        fromStatus: 'SUBMITTED' as const,
+        toStatus: 'UNDER_REVIEW' as const,
+        changedBy: 'user-1',
+        comment: 'test',
+        changedAt: new Date(),
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(submissionService.updateStatusAsEditor).mockResolvedValue(
+      payload,
+    );
+
+    const field = getMutationField('updateSubmissionStatus');
+    const result = await field.resolve!(
+      {},
+      {
+        id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        status: 'UNDER_REVIEW',
+        comment: 'test',
+      },
+      makeCtx(),
+      {} as never,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(submissionService.updateStatusAsEditor).toHaveBeenCalled();
+    expect(result).toBe(payload);
+  });
+
+  it('mapServiceError is called on service failure', async () => {
+    const error = new Error('Service failed');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(submissionService.createWithAudit).mockRejectedValue(error);
+
+    const field = getMutationField('createSubmission');
+    await expect(
+      field.resolve!({}, { title: 'Test' }, makeCtx(), {} as never),
+    ).rejects.toThrow();
+    expect(mapServiceError).toHaveBeenCalledWith(error);
+  });
+});

--- a/apps/api/src/graphql/resolvers/submissions.ts
+++ b/apps/api/src/graphql/resolvers/submissions.ts
@@ -1,5 +1,11 @@
 import type { Submission } from '@colophony/db';
-import { listSubmissionsSchema } from '@colophony/types';
+import {
+  listSubmissionsSchema,
+  createSubmissionSchema,
+  updateSubmissionSchema,
+  updateSubmissionStatusSchema,
+  idParamSchema,
+} from '@colophony/types';
 import { builder } from '../builder.js';
 import { requireOrgContext, requireScopes } from '../guards.js';
 import { toServiceContext } from '../../services/context.js';
@@ -7,6 +13,10 @@ import { assertEditorOrAdmin } from '../../services/errors.js';
 import { submissionService } from '../../services/submission.service.js';
 import { mapServiceError } from '../error-mapper.js';
 import { SubmissionType, SubmissionHistoryType } from '../types/index.js';
+import {
+  SubmissionStatusChangePayload,
+  SuccessPayload,
+} from '../types/payloads.js';
 
 // ---------------------------------------------------------------------------
 // Paginated response types
@@ -135,6 +145,175 @@ builder.queryFields((t) => ({
         return await submissionService.getHistoryWithAccess(
           toServiceContext(orgCtx),
           args.submissionId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mutation fields
+// ---------------------------------------------------------------------------
+
+builder.mutationFields((t) => ({
+  /**
+   * Create a new submission in DRAFT status.
+   */
+  createSubmission: t.field({
+    type: SubmissionType,
+    args: {
+      title: t.arg.string({ required: true }),
+      content: t.arg.string({ required: false }),
+      coverLetter: t.arg.string({ required: false }),
+      submissionPeriodId: t.arg.string({ required: false }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'submissions:write');
+      const input = createSubmissionSchema.parse({
+        title: args.title,
+        content: args.content ?? undefined,
+        coverLetter: args.coverLetter ?? undefined,
+        submissionPeriodId: args.submissionPeriodId ?? undefined,
+      });
+      try {
+        return await submissionService.createWithAudit(
+          toServiceContext(orgCtx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Update a DRAFT submission (owner only).
+   */
+  updateSubmission: t.field({
+    type: SubmissionType,
+    args: {
+      id: t.arg.string({ required: true }),
+      title: t.arg.string({ required: false }),
+      content: t.arg.string({ required: false }),
+      coverLetter: t.arg.string({ required: false }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'submissions:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      const data = updateSubmissionSchema.parse({
+        title: args.title ?? undefined,
+        content: args.content ?? undefined,
+        coverLetter: args.coverLetter ?? undefined,
+      });
+      try {
+        return await submissionService.updateAsOwner(
+          toServiceContext(orgCtx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Submit a DRAFT submission (DRAFT → SUBMITTED, owner only).
+   */
+  submitSubmission: t.field({
+    type: SubmissionStatusChangePayload,
+    args: {
+      id: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'submissions:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await submissionService.submitAsOwner(
+          toServiceContext(orgCtx),
+          id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Delete a DRAFT submission (owner only).
+   */
+  deleteSubmission: t.field({
+    type: SuccessPayload,
+    args: {
+      id: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'submissions:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await submissionService.deleteAsOwner(
+          toServiceContext(orgCtx),
+          id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Withdraw a submission (owner only).
+   */
+  withdrawSubmission: t.field({
+    type: SubmissionStatusChangePayload,
+    args: {
+      id: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'submissions:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await submissionService.withdrawAsOwner(
+          toServiceContext(orgCtx),
+          id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Update submission status (editor/admin transition with comment).
+   */
+  updateSubmissionStatus: t.field({
+    type: SubmissionStatusChangePayload,
+    args: {
+      id: t.arg.string({ required: true }),
+      status: t.arg.string({ required: true }),
+      comment: t.arg.string({ required: false }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'submissions:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      const { status, comment } = updateSubmissionStatusSchema.parse({
+        status: args.status,
+        comment: args.comment ?? undefined,
+      });
+      try {
+        return await submissionService.updateStatusAsEditor(
+          toServiceContext(orgCtx),
+          id,
+          status,
+          comment,
         );
       } catch (e) {
         mapServiceError(e);

--- a/apps/api/src/graphql/types/api-key.ts
+++ b/apps/api/src/graphql/types/api-key.ts
@@ -1,0 +1,28 @@
+import { builder } from '../builder.js';
+
+export const ApiKeyType = builder
+  .objectRef<{
+    id: string;
+    name: string;
+    scopes: unknown;
+    keyPrefix: string;
+    createdAt: Date;
+    expiresAt: Date | null;
+    lastUsedAt: Date | null;
+    revokedAt: Date | null;
+  }>('ApiKey')
+  .implement({
+    fields: (t) => ({
+      id: t.exposeString('id'),
+      name: t.exposeString('name'),
+      scopes: t.expose('scopes', { type: 'JSON' }),
+      keyPrefix: t.exposeString('keyPrefix'),
+      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+      expiresAt: t.expose('expiresAt', { type: 'DateTime', nullable: true }),
+      lastUsedAt: t.expose('lastUsedAt', {
+        type: 'DateTime',
+        nullable: true,
+      }),
+      revokedAt: t.expose('revokedAt', { type: 'DateTime', nullable: true }),
+    }),
+  });

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -5,3 +5,11 @@ export { OrganizationType, OrganizationMemberType } from './organization.js';
 export { SubmissionType, SubmissionHistoryType } from './submission.js';
 export { SubmissionFileType } from './file.js';
 export { AuditEventType } from './audit.js';
+export { ApiKeyType } from './api-key.js';
+export {
+  SubmissionStatusChangePayload,
+  CreateOrganizationPayload,
+  CreateApiKeyPayload,
+  RevokeApiKeyPayload,
+  SuccessPayload,
+} from './payloads.js';

--- a/apps/api/src/graphql/types/payloads.ts
+++ b/apps/api/src/graphql/types/payloads.ts
@@ -1,0 +1,112 @@
+import type {
+  Submission,
+  SubmissionHistoryEntry,
+  Organization,
+  OrganizationMember,
+} from '@colophony/db';
+import { builder } from '../builder.js';
+import { SubmissionType, SubmissionHistoryType } from './submission.js';
+import { OrganizationType, OrganizationMemberType } from './organization.js';
+
+// ---------------------------------------------------------------------------
+// Submission mutation payloads
+// ---------------------------------------------------------------------------
+
+export const SubmissionStatusChangePayload = builder
+  .objectRef<{
+    submission: Submission;
+    historyEntry: SubmissionHistoryEntry;
+  }>('SubmissionStatusChangePayload')
+  .implement({
+    fields: (t) => ({
+      submission: t.field({
+        type: SubmissionType,
+        resolve: (r) => r.submission,
+      }),
+      historyEntry: t.field({
+        type: SubmissionHistoryType,
+        resolve: (r) => r.historyEntry,
+      }),
+    }),
+  });
+
+// ---------------------------------------------------------------------------
+// Organization mutation payloads
+// ---------------------------------------------------------------------------
+
+export const CreateOrganizationPayload = builder
+  .objectRef<{
+    organization: Organization;
+    membership: OrganizationMember;
+  }>('CreateOrganizationPayload')
+  .implement({
+    fields: (t) => ({
+      organization: t.field({
+        type: OrganizationType,
+        resolve: (r) => r.organization,
+      }),
+      membership: t.field({
+        type: OrganizationMemberType,
+        resolve: (r) => r.membership,
+      }),
+    }),
+  });
+
+// ---------------------------------------------------------------------------
+// API key mutation payloads
+// ---------------------------------------------------------------------------
+
+export const CreateApiKeyPayload = builder
+  .objectRef<{
+    id: string;
+    name: string;
+    scopes: unknown;
+    keyPrefix: string;
+    plainTextKey: string;
+    createdAt: Date;
+    expiresAt: Date | null;
+    lastUsedAt: Date | null;
+    revokedAt: Date | null;
+  }>('CreateApiKeyPayload')
+  .implement({
+    fields: (t) => ({
+      id: t.exposeString('id'),
+      name: t.exposeString('name'),
+      scopes: t.expose('scopes', { type: 'JSON' }),
+      keyPrefix: t.exposeString('keyPrefix'),
+      plainTextKey: t.exposeString('plainTextKey'),
+      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+      expiresAt: t.expose('expiresAt', { type: 'DateTime', nullable: true }),
+      lastUsedAt: t.expose('lastUsedAt', {
+        type: 'DateTime',
+        nullable: true,
+      }),
+      revokedAt: t.expose('revokedAt', { type: 'DateTime', nullable: true }),
+    }),
+  });
+
+export const RevokeApiKeyPayload = builder
+  .objectRef<{
+    id: string;
+    name: string;
+    revokedAt: Date | null;
+  }>('RevokeApiKeyPayload')
+  .implement({
+    fields: (t) => ({
+      id: t.exposeString('id'),
+      name: t.exposeString('name'),
+      revokedAt: t.expose('revokedAt', { type: 'DateTime', nullable: true }),
+    }),
+  });
+
+// ---------------------------------------------------------------------------
+// Generic payloads
+// ---------------------------------------------------------------------------
+
+export const SuccessPayload = builder
+  .objectRef<{ success: boolean }>('SuccessPayload')
+  .implement({
+    fields: (t) => ({
+      success: t.exposeBoolean('success'),
+    }),
+  });

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -77,8 +77,8 @@
 - [x] Stripe webhook: audit raw payload storage for PCI compliance — `stripe.webhook.ts` stores raw event payload in `stripe_webhook_events`; verified: Checkout Session events contain amounts/currency/payment_intent ID/metadata only, never card numbers/CVV/cardholder data. Added PCI note comment. — (Codex review 2026-02-18; done 2026-02-19)
 - [x] Stripe webhook: `resourceId` passed to `insert_audit_event()` is Stripe session ID (`cs_...`), not UUID — fails `::uuid` cast in production. Fixed: removed `resourceId` from audit calls (session ID already in `newValue.stripeSessionId`); updated tests to use realistic `cs_test_` IDs. — (DEVLOG 2026-02-19; done 2026-02-19)
 - [x] tRPC `.output()` runtime response validation — all 30 procedures wired with Zod output schemas; 9 new response schemas added — (input validation audit 2026-02-18; done 2026-02-18)
-- [x] Pothos + GraphQL Yoga surface — PR 1: foundation (types, queries, DataLoaders, scope enforcement, Fastify integration) done 2026-02-19; PR 2: mutations pending — (architecture doc Track 2, Section 6.6)
-- [ ] GraphQL mutations (PR 2) — create/update submissions, file operations, org management — (DEVLOG 2026-02-19)
+- [x] Pothos + GraphQL Yoga surface — PR 1: foundation (types, queries, DataLoaders, scope enforcement, Fastify integration) done 2026-02-19; PR 2: mutations done 2026-02-19 — (architecture doc Track 2, Section 6.6)
+- [x] GraphQL mutations (PR 2) — 16 mutations + API key list query, unit tests (36 new tests) — done 2026-02-19
 - [ ] SDK generation (TypeScript, Python) — (architecture doc Track 2)
 - [ ] API documentation — (architecture doc Track 2)
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-19 — GraphQL Mutations PR 2
+
+### Done
+
+- Implemented 16 GraphQL mutations + 1 API key list query for feature parity with tRPC and REST surfaces
+- Submissions (6): createSubmission, updateSubmission, submitSubmission, deleteSubmission, withdrawSubmission, updateSubmissionStatus
+- Organizations (5): createOrganization, updateOrganization, addOrganizationMember, removeOrganizationMember, updateOrganizationMemberRole
+- API Keys (3+1): createApiKey, revokeApiKey, deleteApiKey + apiKeys list query
+- Files (1): deleteFile with lazy S3 client pattern
+- All mutations wire args → Zod validation → service layer → Pothos return types, reusing existing guards, error mapper, and service context
+- 8 new files: 2 type files (payloads.ts, api-key.ts), 2 resolver files (api-keys.ts, files.ts), 4 test files
+- 36 new unit tests covering schema registration, guard enforcement, scope checks, Zod validation, service wiring, and error mapping — all 561 tests pass
+- Addressed Codex plan review finding: all mutation ID args validated via Zod (idParamSchema, fileIdParamSchema, memberIdParamSchema)
+
+### Decisions
+
+- Direct resolver testing via `schema.getMutationType()!.getFields()[name].resolve!()` instead of `graphql()` executor — avoids pnpm graphql module deduplication issue where separate symlinks cause "Cannot use GraphQLSchema from another module or realm"
+- `createOrganization` uses `requireAuth` (not `requireOrgContext`) since no org exists yet — matches tRPC pattern
+- API key mutations use inline audit calls (no `WithAudit` wrapper) — matches tRPC api-keys router pattern
+- Codex plan review: dismissed "superuser pool" concern as false positive (organizations table has no RLS by design)
+
+---
+
 ## 2026-02-19 — GraphQL Surface PR 1 (Pothos + Yoga Foundation)
 
 ### Done


### PR DESCRIPTION
## Summary

- Add 16 GraphQL mutations + 1 API key list query for feature parity with tRPC and REST surfaces
- **Submissions (6):** createSubmission, updateSubmission, submitSubmission, deleteSubmission, withdrawSubmission, updateSubmissionStatus
- **Organizations (5):** createOrganization, updateOrganization, addOrganizationMember, removeOrganizationMember, updateOrganizationMemberRole
- **API Keys (3+1):** createApiKey, revokeApiKey, deleteApiKey + apiKeys list query
- **Files (1):** deleteFile with lazy S3 client pattern
- All mutations wire args → Zod validation → service layer → Pothos return types, reusing existing guards, error mapper, and service context
- 36 new unit tests across 4 test files (561 total tests pass)

## Test plan

- [x] All 561 unit tests pass (`pnpm test`)
- [x] Type-check clean (`pnpm type-check`)
- [x] Lint clean (`pnpm lint`)
- [ ] Manual: start dev server, open GraphiQL at `/graphql`, run a mutation with Bearer auth + X-Organization-Id header
- [ ] Verify schema introspection shows all 16 mutations with correct arg types