### PR TITLE
docs(api): API documentation — Zod, oRPC, GraphQL, Scalar, export scripts

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -88,11 +88,11 @@ User lifecycle events are synced from Zitadel to the local DB via webhooks.
 
 ## API Surfaces
 
-| Surface     | Audience              | Status                                      | Auth               |
-| ----------- | --------------------- | ------------------------------------------- | ------------------ |
-| **tRPC**    | Internal web frontend | **Built**                                   | Zitadel OIDC token |
-| **REST**    | Public API, Zapier    | **PR 1 done** (oRPC)                        | API key or OIDC    |
-| **GraphQL** | Power users           | **PR 1 done** (Pothos + Yoga, queries only) | API key or OIDC    |
+| Surface     | Audience              | Status                                         | Auth               |
+| ----------- | --------------------- | ---------------------------------------------- | ------------------ |
+| **tRPC**    | Internal web frontend | **Built**                                      | Zitadel OIDC token |
+| **REST**    | Public API, Zapier    | **Built** (oRPC + OpenAPI 3.1 at `/v1/docs`)   | API key or OIDC    |
+| **GraphQL** | Power users           | **Built** (Pothos + Yoga, queries + mutations) | API key or OIDC    |
 
 All surfaces share the same service layer and Zod schemas from `@colophony/types`.
 
@@ -198,6 +198,7 @@ Workers and queues are started in `main.ts` and closed during graceful shutdown.
 | **`@fastify/raw-body` doesn't exist**  | Official `@fastify/` scoped package not published on npm. Use `fastify-raw-body` (community package, v5.0.0 for Fastify 5)                                                                                                                                      |
 | **tusd v2 webhook payload format**     | tusd v2.8.0 sends `{ Type: "pre-create"\|"post-finish", Event: { Upload, HTTPRequest } }` instead of v1's `Hook-Name` header + `{ Upload, HTTPRequest }` body. Our handler supports both formats. The `Event` envelope is unwrapped before dispatch.            |
 | **Fastify 5 preHandler short-circuit** | To stop request processing in a `preHandler` hook, you MUST `return reply.status(N).send(...)`. Using `void reply.send(); return;` does NOT work — Fastify still runs the handler, causing `ERR_HTTP_HEADERS_SENT` crash. This bit us in webhook rate limiters. |
+| **oRPC OpenAPI needs Zod 4 converter** | `OpenAPIReferencePlugin` requires explicit `schemaConverters: [new ZodToJsonSchemaConverter()]` from `@orpc/zod/zod4`. Without it, all schemas become `{}` and routes with path params throw 500. The default `@orpc/zod` export is Zod 3 only.                 |
 
 ## Version Pins
 

--- a/apps/api/src/graphql/resolvers/api-keys.ts
+++ b/apps/api/src/graphql/resolvers/api-keys.ts
@@ -58,9 +58,18 @@ builder.queryFields((t) => ({
    */
   apiKeys: t.field({
     type: PaginatedApiKeys,
+    description: 'List API keys for the current organization.',
     args: {
-      page: t.arg.int({ required: false, defaultValue: 1 }),
-      limit: t.arg.int({ required: false, defaultValue: 20 }),
+      page: t.arg.int({
+        required: false,
+        defaultValue: 1,
+        description: 'Page number (1-based).',
+      }),
+      limit: t.arg.int({
+        required: false,
+        defaultValue: 20,
+        description: 'Items per page (1-100).',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
@@ -84,10 +93,22 @@ builder.mutationFields((t) => ({
    */
   createApiKey: t.field({
     type: CreateApiKeyPayload,
+    description:
+      'Create a new API key. The plain-text key is returned only once. Requires ADMIN role.',
     args: {
-      name: t.arg.string({ required: true }),
-      scopes: t.arg.stringList({ required: true }),
-      expiresAt: t.arg({ type: 'DateTime', required: false }),
+      name: t.arg.string({
+        required: true,
+        description: 'Human-readable name for the key.',
+      }),
+      scopes: t.arg.stringList({
+        required: true,
+        description: 'Permission scopes to grant.',
+      }),
+      expiresAt: t.arg({
+        type: 'DateTime',
+        required: false,
+        description: 'Optional expiration date.',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireAdmin(ctx);
@@ -118,8 +139,13 @@ builder.mutationFields((t) => ({
    */
   revokeApiKey: t.field({
     type: RevokeApiKeyPayload,
+    description:
+      'Revoke an active API key, preventing further use. Requires ADMIN role.',
     args: {
-      keyId: t.arg.string({ required: true }),
+      keyId: t.arg.string({
+        required: true,
+        description: 'ID of the API key to revoke.',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireAdmin(ctx);
@@ -145,8 +171,12 @@ builder.mutationFields((t) => ({
    */
   deleteApiKey: t.field({
     type: SuccessPayload,
+    description: 'Permanently delete an API key record. Requires ADMIN role.',
     args: {
-      keyId: t.arg.string({ required: true }),
+      keyId: t.arg.string({
+        required: true,
+        description: 'ID of the API key to delete.',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireAdmin(ctx);

--- a/apps/api/src/graphql/resolvers/audit.ts
+++ b/apps/api/src/graphql/resolvers/audit.ts
@@ -58,15 +58,45 @@ builder.queryFields((t) => ({
    */
   auditEvents: t.field({
     type: PaginatedAuditEvents,
+    description:
+      'List audit events for the current organization. Requires ADMIN role.',
     args: {
-      action: t.arg.string({ required: false }),
-      resource: t.arg.string({ required: false }),
-      actorId: t.arg.string({ required: false }),
-      resourceId: t.arg.string({ required: false }),
-      from: t.arg({ type: 'DateTime', required: false }),
-      to: t.arg({ type: 'DateTime', required: false }),
-      page: t.arg.int({ required: false, defaultValue: 1 }),
-      limit: t.arg.int({ required: false, defaultValue: 20 }),
+      action: t.arg.string({
+        required: false,
+        description: 'Filter by audit action (e.g. ORG_CREATED).',
+      }),
+      resource: t.arg.string({
+        required: false,
+        description: 'Filter by resource type (e.g. organization).',
+      }),
+      actorId: t.arg.string({
+        required: false,
+        description: 'Filter by the user who performed the action.',
+      }),
+      resourceId: t.arg.string({
+        required: false,
+        description: 'Filter by the affected resource ID.',
+      }),
+      from: t.arg({
+        type: 'DateTime',
+        required: false,
+        description: 'Start of date range.',
+      }),
+      to: t.arg({
+        type: 'DateTime',
+        required: false,
+        description: 'End of date range.',
+      }),
+      page: t.arg.int({
+        required: false,
+        defaultValue: 1,
+        description: 'Page number (1-based).',
+      }),
+      limit: t.arg.int({
+        required: false,
+        defaultValue: 20,
+        description: 'Items per page (1-100).',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const adminCtx = requireAdmin(ctx);
@@ -96,8 +126,9 @@ builder.queryFields((t) => ({
   auditEvent: t.field({
     type: AuditEventType,
     nullable: true,
+    description: 'Get a single audit event by ID. Requires ADMIN role.',
     args: {
-      id: t.arg.string({ required: true }),
+      id: t.arg.string({ required: true, description: 'Audit event ID.' }),
     },
     resolve: async (_root, args, ctx) => {
       const adminCtx = requireAdmin(ctx);

--- a/apps/api/src/graphql/resolvers/files.ts
+++ b/apps/api/src/graphql/resolvers/files.ts
@@ -36,8 +36,13 @@ builder.mutationFields((t) => ({
    */
   deleteFile: t.field({
     type: SuccessPayload,
+    description:
+      'Delete a file from a DRAFT submission. Only the submission owner can delete.',
     args: {
-      fileId: t.arg.string({ required: true }),
+      fileId: t.arg.string({
+        required: true,
+        description: 'ID of the file to delete.',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);

--- a/apps/api/src/graphql/resolvers/organizations.ts
+++ b/apps/api/src/graphql/resolvers/organizations.ts
@@ -99,6 +99,8 @@ builder.queryFields((t) => ({
    */
   myOrganizations: t.field({
     type: [UserOrganizationType],
+    description:
+      "List the current user's organizations (cross-org, no org context needed).",
     resolve: async (_root, _args, ctx) => {
       const authed = requireAuth(ctx);
       await requireScopes(ctx, 'organizations:read');
@@ -114,6 +116,8 @@ builder.queryFields((t) => ({
   organization: t.field({
     type: OrganizationType,
     nullable: true,
+    description:
+      'Get the current organization (requires X-Organization-Id header).',
     resolve: async (_root, _args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
       await requireScopes(ctx, 'organizations:read');
@@ -126,9 +130,18 @@ builder.queryFields((t) => ({
    */
   organizationMembers: t.field({
     type: PaginatedOrganizationMembers,
+    description: 'List members of the current organization.',
     args: {
-      page: t.arg.int({ required: false, defaultValue: 1 }),
-      limit: t.arg.int({ required: false, defaultValue: 20 }),
+      page: t.arg.int({
+        required: false,
+        defaultValue: 1,
+        description: 'Page number (1-based).',
+      }),
+      limit: t.arg.int({
+        required: false,
+        defaultValue: 20,
+        description: 'Items per page (1-100).',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
@@ -152,9 +165,18 @@ builder.mutationFields((t) => ({
    */
   createOrganization: t.field({
     type: CreateOrganizationPayload,
+    description:
+      'Create a new organization. The caller becomes the first ADMIN.',
     args: {
-      name: t.arg.string({ required: true }),
-      slug: t.arg.string({ required: true }),
+      name: t.arg.string({
+        required: true,
+        description: 'Display name of the organization.',
+      }),
+      slug: t.arg.string({
+        required: true,
+        description:
+          'URL-friendly identifier (3-63 chars, lowercase alphanumeric with hyphens).',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const authed = requireAuth(ctx);
@@ -180,9 +202,15 @@ builder.mutationFields((t) => ({
    */
   updateOrganization: t.field({
     type: OrganizationType,
+    description:
+      "Update the current organization's name or settings. Requires ADMIN role.",
     args: {
-      name: t.arg.string({ required: false }),
-      settings: t.arg({ type: 'JSON', required: false }),
+      name: t.arg.string({ required: false, description: 'New display name.' }),
+      settings: t.arg({
+        type: 'JSON',
+        required: false,
+        description: 'Organization settings as key-value pairs.',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireAdmin(ctx);
@@ -207,9 +235,17 @@ builder.mutationFields((t) => ({
    */
   addOrganizationMember: t.field({
     type: OrganizationMemberType,
+    description:
+      'Add a member to the current organization by email. Requires ADMIN role.',
     args: {
-      email: t.arg.string({ required: true }),
-      role: t.arg.string({ required: true }),
+      email: t.arg.string({
+        required: true,
+        description: 'Email address of the user to invite.',
+      }),
+      role: t.arg.string({
+        required: true,
+        description: 'Role to assign (ADMIN, EDITOR, or READER).',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireAdmin(ctx);
@@ -235,8 +271,13 @@ builder.mutationFields((t) => ({
    */
   removeOrganizationMember: t.field({
     type: SuccessPayload,
+    description:
+      'Remove a member from the current organization. Requires ADMIN role.',
     args: {
-      memberId: t.arg.string({ required: true }),
+      memberId: t.arg.string({
+        required: true,
+        description: 'ID of the membership record to remove.',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireAdmin(ctx);
@@ -260,9 +301,17 @@ builder.mutationFields((t) => ({
    */
   updateOrganizationMemberRole: t.field({
     type: OrganizationMemberType,
+    description:
+      "Change a member's role in the current organization. Requires ADMIN role.",
     args: {
-      memberId: t.arg.string({ required: true }),
-      role: t.arg.string({ required: true }),
+      memberId: t.arg.string({
+        required: true,
+        description: 'ID of the membership record to update.',
+      }),
+      role: t.arg.string({
+        required: true,
+        description: 'New role (ADMIN, EDITOR, or READER).',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireAdmin(ctx);

--- a/apps/api/src/graphql/resolvers/submissions.ts
+++ b/apps/api/src/graphql/resolvers/submissions.ts
@@ -51,12 +51,31 @@ builder.queryFields((t) => ({
    */
   submissions: t.field({
     type: PaginatedSubmissions,
+    description:
+      'List all submissions in the organization. Requires EDITOR or ADMIN role.',
     args: {
-      status: t.arg.string({ required: false }),
-      submissionPeriodId: t.arg.string({ required: false }),
-      search: t.arg.string({ required: false }),
-      page: t.arg.int({ required: false, defaultValue: 1 }),
-      limit: t.arg.int({ required: false, defaultValue: 20 }),
+      status: t.arg.string({
+        required: false,
+        description: 'Filter by submission status.',
+      }),
+      submissionPeriodId: t.arg.string({
+        required: false,
+        description: 'Filter by submission period.',
+      }),
+      search: t.arg.string({
+        required: false,
+        description: 'Full-text search query.',
+      }),
+      page: t.arg.int({
+        required: false,
+        defaultValue: 1,
+        description: 'Page number (1-based).',
+      }),
+      limit: t.arg.int({
+        required: false,
+        defaultValue: 20,
+        description: 'Items per page (1-100).',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
@@ -82,12 +101,30 @@ builder.queryFields((t) => ({
    */
   mySubmissions: t.field({
     type: PaginatedSubmissions,
+    description: "List the current user's own submissions.",
     args: {
-      status: t.arg.string({ required: false }),
-      submissionPeriodId: t.arg.string({ required: false }),
-      search: t.arg.string({ required: false }),
-      page: t.arg.int({ required: false, defaultValue: 1 }),
-      limit: t.arg.int({ required: false, defaultValue: 20 }),
+      status: t.arg.string({
+        required: false,
+        description: 'Filter by submission status.',
+      }),
+      submissionPeriodId: t.arg.string({
+        required: false,
+        description: 'Filter by submission period.',
+      }),
+      search: t.arg.string({
+        required: false,
+        description: 'Full-text search query.',
+      }),
+      page: t.arg.int({
+        required: false,
+        defaultValue: 1,
+        description: 'Page number (1-based).',
+      }),
+      limit: t.arg.int({
+        required: false,
+        defaultValue: 20,
+        description: 'Items per page (1-100).',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
@@ -113,8 +150,10 @@ builder.queryFields((t) => ({
   submission: t.field({
     type: SubmissionType,
     nullable: true,
+    description:
+      'Get a single submission by ID. Editors can view any; submitters can view their own.',
     args: {
-      id: t.arg.string({ required: true }),
+      id: t.arg.string({ required: true, description: 'Submission ID.' }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
@@ -135,8 +174,12 @@ builder.queryFields((t) => ({
    */
   submissionHistory: t.field({
     type: [SubmissionHistoryType],
+    description: 'Get the full status change history for a submission.',
     args: {
-      submissionId: t.arg.string({ required: true }),
+      submissionId: t.arg.string({
+        required: true,
+        description: 'Submission ID.',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
@@ -163,11 +206,21 @@ builder.mutationFields((t) => ({
    */
   createSubmission: t.field({
     type: SubmissionType,
+    description: 'Create a new submission in DRAFT status.',
     args: {
-      title: t.arg.string({ required: true }),
-      content: t.arg.string({ required: false }),
-      coverLetter: t.arg.string({ required: false }),
-      submissionPeriodId: t.arg.string({ required: false }),
+      title: t.arg.string({
+        required: true,
+        description: 'Title of the submission.',
+      }),
+      content: t.arg.string({ required: false, description: 'Body content.' }),
+      coverLetter: t.arg.string({
+        required: false,
+        description: 'Optional cover letter.',
+      }),
+      submissionPeriodId: t.arg.string({
+        required: false,
+        description: 'Submission period to associate with.',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
@@ -194,11 +247,18 @@ builder.mutationFields((t) => ({
    */
   updateSubmission: t.field({
     type: SubmissionType,
+    description: 'Update a DRAFT submission. Only the submitter can update.',
     args: {
-      id: t.arg.string({ required: true }),
-      title: t.arg.string({ required: false }),
-      content: t.arg.string({ required: false }),
-      coverLetter: t.arg.string({ required: false }),
+      id: t.arg.string({ required: true, description: 'Submission ID.' }),
+      title: t.arg.string({ required: false, description: 'New title.' }),
+      content: t.arg.string({
+        required: false,
+        description: 'New body content.',
+      }),
+      coverLetter: t.arg.string({
+        required: false,
+        description: 'New cover letter.',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
@@ -226,8 +286,10 @@ builder.mutationFields((t) => ({
    */
   submitSubmission: t.field({
     type: SubmissionStatusChangePayload,
+    description:
+      'Submit a DRAFT (DRAFT → SUBMITTED). Only the submitter can submit.',
     args: {
-      id: t.arg.string({ required: true }),
+      id: t.arg.string({ required: true, description: 'Submission ID.' }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
@@ -249,8 +311,10 @@ builder.mutationFields((t) => ({
    */
   deleteSubmission: t.field({
     type: SuccessPayload,
+    description:
+      'Delete a DRAFT submission and its files. Only the submitter can delete.',
     args: {
-      id: t.arg.string({ required: true }),
+      id: t.arg.string({ required: true, description: 'Submission ID.' }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
@@ -272,8 +336,10 @@ builder.mutationFields((t) => ({
    */
   withdrawSubmission: t.field({
     type: SubmissionStatusChangePayload,
+    description:
+      'Withdraw a submission from consideration. Only the submitter can withdraw.',
     args: {
-      id: t.arg.string({ required: true }),
+      id: t.arg.string({ required: true, description: 'Submission ID.' }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
@@ -295,10 +361,18 @@ builder.mutationFields((t) => ({
    */
   updateSubmissionStatus: t.field({
     type: SubmissionStatusChangePayload,
+    description:
+      "Transition a submission's status. Requires EDITOR or ADMIN role. Invalid transitions are rejected.",
     args: {
-      id: t.arg.string({ required: true }),
-      status: t.arg.string({ required: true }),
-      comment: t.arg.string({ required: false }),
+      id: t.arg.string({ required: true, description: 'Submission ID.' }),
+      status: t.arg.string({
+        required: true,
+        description: 'Target status (e.g. UNDER_REVIEW, ACCEPTED).',
+      }),
+      comment: t.arg.string({
+        required: false,
+        description: 'Optional comment explaining the decision.',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);

--- a/apps/api/src/graphql/resolvers/users.ts
+++ b/apps/api/src/graphql/resolvers/users.ts
@@ -56,6 +56,8 @@ builder.queryFields((t) => ({
   me: t.field({
     type: UserProfileType,
     nullable: true,
+    description:
+      "Get the current user's profile with organization memberships.",
     resolve: async (_root, _args, ctx) => {
       const authed = requireAuth(ctx);
       await requireScopes(ctx, 'users:read');

--- a/apps/api/src/graphql/types/api-key.ts
+++ b/apps/api/src/graphql/types/api-key.ts
@@ -12,17 +12,35 @@ export const ApiKeyType = builder
     revokedAt: Date | null;
   }>('ApiKey')
   .implement({
+    description: 'An organization-scoped API key for programmatic access.',
     fields: (t) => ({
-      id: t.exposeString('id'),
-      name: t.exposeString('name'),
-      scopes: t.expose('scopes', { type: 'JSON' }),
-      keyPrefix: t.exposeString('keyPrefix'),
-      createdAt: t.expose('createdAt', { type: 'DateTime' }),
-      expiresAt: t.expose('expiresAt', { type: 'DateTime', nullable: true }),
+      id: t.exposeString('id', { description: 'Unique identifier.' }),
+      name: t.exposeString('name', { description: 'Human-readable name.' }),
+      scopes: t.expose('scopes', {
+        type: 'JSON',
+        description: 'Granted permission scopes.',
+      }),
+      keyPrefix: t.exposeString('keyPrefix', {
+        description: 'First characters of the key for identification.',
+      }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the key was created.',
+      }),
+      expiresAt: t.expose('expiresAt', {
+        type: 'DateTime',
+        nullable: true,
+        description: 'When the key expires (null = never).',
+      }),
       lastUsedAt: t.expose('lastUsedAt', {
         type: 'DateTime',
         nullable: true,
+        description: 'When the key was last used for authentication.',
       }),
-      revokedAt: t.expose('revokedAt', { type: 'DateTime', nullable: true }),
+      revokedAt: t.expose('revokedAt', {
+        type: 'DateTime',
+        nullable: true,
+        description: 'When the key was revoked (null = active).',
+      }),
     }),
   });

--- a/apps/api/src/graphql/types/audit.ts
+++ b/apps/api/src/graphql/types/audit.ts
@@ -21,19 +21,56 @@ export const AuditEventType = builder
     createdAt: Date;
   }>('AuditEvent')
   .implement({
+    description: 'An immutable record of a security-relevant action.',
     fields: (t) => ({
-      id: t.exposeString('id'),
-      actorId: t.exposeString('actorId', { nullable: true }),
-      action: t.exposeString('action'),
-      resource: t.exposeString('resource'),
-      resourceId: t.exposeString('resourceId', { nullable: true }),
-      oldValue: t.expose('oldValue', { type: 'JSON', nullable: true }),
-      newValue: t.expose('newValue', { type: 'JSON', nullable: true }),
-      ipAddress: t.exposeString('ipAddress', { nullable: true }),
-      userAgent: t.exposeString('userAgent', { nullable: true }),
-      requestId: t.exposeString('requestId', { nullable: true }),
-      method: t.exposeString('method', { nullable: true }),
-      route: t.exposeString('route', { nullable: true }),
-      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+      id: t.exposeString('id', { description: 'Unique identifier.' }),
+      actorId: t.exposeString('actorId', {
+        nullable: true,
+        description: 'ID of the user who performed the action.',
+      }),
+      action: t.exposeString('action', {
+        description: 'Action that was performed (e.g. ORG_CREATED).',
+      }),
+      resource: t.exposeString('resource', {
+        description: 'Resource type affected (e.g. organization).',
+      }),
+      resourceId: t.exposeString('resourceId', {
+        nullable: true,
+        description: 'ID of the affected resource.',
+      }),
+      oldValue: t.expose('oldValue', {
+        type: 'JSON',
+        nullable: true,
+        description: 'Previous state before the change.',
+      }),
+      newValue: t.expose('newValue', {
+        type: 'JSON',
+        nullable: true,
+        description: 'New state after the change.',
+      }),
+      ipAddress: t.exposeString('ipAddress', {
+        nullable: true,
+        description: 'IP address of the request.',
+      }),
+      userAgent: t.exposeString('userAgent', {
+        nullable: true,
+        description: 'User-Agent header from the request.',
+      }),
+      requestId: t.exposeString('requestId', {
+        nullable: true,
+        description: 'Correlation ID for the request.',
+      }),
+      method: t.exposeString('method', {
+        nullable: true,
+        description: 'HTTP method of the request.',
+      }),
+      route: t.exposeString('route', {
+        nullable: true,
+        description: 'API route that was called.',
+      }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the event was recorded.',
+      }),
     }),
   });

--- a/apps/api/src/graphql/types/enums.ts
+++ b/apps/api/src/graphql/types/enums.ts
@@ -1,21 +1,43 @@
 import { builder } from '../builder.js';
 
 export const SubmissionStatusEnum = builder.enumType('SubmissionStatus', {
-  values: [
-    'DRAFT',
-    'SUBMITTED',
-    'UNDER_REVIEW',
-    'ACCEPTED',
-    'REJECTED',
-    'HOLD',
-    'WITHDRAWN',
-  ] as const,
+  description: 'Current status of a submission in the editorial workflow.',
+  values: {
+    DRAFT: {
+      description:
+        'Initial state — submission is being prepared by the author.',
+    },
+    SUBMITTED: { description: 'Author has submitted for review.' },
+    UNDER_REVIEW: {
+      description: 'Editors are actively reviewing the submission.',
+    },
+    ACCEPTED: { description: 'Submission has been accepted for publication.' },
+    REJECTED: { description: 'Submission has been declined.' },
+    HOLD: { description: 'Temporarily set aside for later consideration.' },
+    WITHDRAWN: { description: 'Author has withdrawn the submission.' },
+  } as const,
 });
 
 export const ScanStatusEnum = builder.enumType('ScanStatus', {
-  values: ['PENDING', 'SCANNING', 'CLEAN', 'INFECTED', 'FAILED'] as const,
+  description: 'Virus scan status for an uploaded file.',
+  values: {
+    PENDING: { description: 'File is queued for scanning.' },
+    SCANNING: { description: 'Scan is in progress.' },
+    CLEAN: { description: 'No threats detected — file is safe to download.' },
+    INFECTED: { description: 'Threat detected — file has been quarantined.' },
+    FAILED: {
+      description: 'Scan failed — file is blocked until retry succeeds.',
+    },
+  } as const,
 });
 
 export const RoleEnum = builder.enumType('Role', {
-  values: ['ADMIN', 'EDITOR', 'READER'] as const,
+  description: 'Member role within an organization.',
+  values: {
+    ADMIN: {
+      description: 'Full access — can manage members, settings, and API keys.',
+    },
+    EDITOR: { description: 'Can review and manage submissions.' },
+    READER: { description: 'Read-only access to submissions and files.' },
+  } as const,
 });

--- a/apps/api/src/graphql/types/file.ts
+++ b/apps/api/src/graphql/types/file.ts
@@ -5,18 +5,35 @@ import { ScanStatusEnum } from './enums.js';
 export const SubmissionFileType = builder
   .objectRef<SubmissionFile>('SubmissionFile')
   .implement({
+    description:
+      'A file attached to a submission (document, image, audio, or video).',
     fields: (t) => ({
-      id: t.exposeString('id'),
-      submissionId: t.exposeString('submissionId'),
-      filename: t.exposeString('filename'),
-      mimeType: t.exposeString('mimeType'),
-      size: t.exposeInt('size'),
-      storageKey: t.exposeString('storageKey'),
-      scanStatus: t.expose('scanStatus', { type: ScanStatusEnum }),
+      id: t.exposeString('id', { description: 'Unique identifier.' }),
+      submissionId: t.exposeString('submissionId', {
+        description: 'ID of the parent submission.',
+      }),
+      filename: t.exposeString('filename', {
+        description: 'Original filename as uploaded.',
+      }),
+      mimeType: t.exposeString('mimeType', {
+        description: 'MIME type (e.g. application/pdf).',
+      }),
+      size: t.exposeInt('size', { description: 'File size in bytes.' }),
+      storageKey: t.exposeString('storageKey', {
+        description: 'Object storage key.',
+      }),
+      scanStatus: t.expose('scanStatus', {
+        type: ScanStatusEnum,
+        description: 'Virus scan status.',
+      }),
       scannedAt: t.expose('scannedAt', {
         type: 'DateTime',
         nullable: true,
+        description: 'When the virus scan completed.',
       }),
-      uploadedAt: t.expose('uploadedAt', { type: 'DateTime' }),
+      uploadedAt: t.expose('uploadedAt', {
+        type: 'DateTime',
+        description: 'When the file was uploaded.',
+      }),
     }),
   });

--- a/apps/api/src/graphql/types/organization.ts
+++ b/apps/api/src/graphql/types/organization.ts
@@ -6,15 +6,30 @@ import { UserType } from './user.js';
 export const OrganizationType = builder
   .objectRef<Organization>('Organization')
   .implement({
+    description:
+      'A literary magazine organization — the top-level tenant in Colophony.',
     fields: (t) => ({
-      id: t.exposeString('id'),
-      name: t.exposeString('name'),
-      slug: t.exposeString('slug'),
-      settings: t.expose('settings', { type: 'JSON', nullable: true }),
-      createdAt: t.expose('createdAt', { type: 'DateTime' }),
-      updatedAt: t.expose('updatedAt', { type: 'DateTime' }),
+      id: t.exposeString('id', { description: 'Unique identifier.' }),
+      name: t.exposeString('name', {
+        description: 'Display name of the organization.',
+      }),
+      slug: t.exposeString('slug', { description: 'URL-friendly identifier.' }),
+      settings: t.expose('settings', {
+        type: 'JSON',
+        nullable: true,
+        description: 'Organization-specific settings.',
+      }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the organization was created.',
+      }),
+      updatedAt: t.expose('updatedAt', {
+        type: 'DateTime',
+        description: 'When the organization was last updated.',
+      }),
       members: t.field({
         type: [OrganizationMemberType],
+        description: 'Members of this organization.',
         resolve: (org, _args, ctx) => ctx.loaders.orgMembers.load(org.id),
       }),
     }),
@@ -23,15 +38,28 @@ export const OrganizationType = builder
 export const OrganizationMemberType = builder
   .objectRef<OrganizationMember>('OrganizationMember')
   .implement({
+    description:
+      'A membership record linking a user to an organization with a role.',
     fields: (t) => ({
-      id: t.exposeString('id'),
-      organizationId: t.exposeString('organizationId'),
-      userId: t.exposeString('userId'),
-      role: t.expose('role', { type: RoleEnum }),
-      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+      id: t.exposeString('id', { description: 'Membership record ID.' }),
+      organizationId: t.exposeString('organizationId', {
+        description: 'ID of the organization.',
+      }),
+      userId: t.exposeString('userId', {
+        description: 'ID of the member user.',
+      }),
+      role: t.expose('role', {
+        type: RoleEnum,
+        description: 'Role within the organization.',
+      }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the member was added.',
+      }),
       user: t.field({
         type: UserType,
         nullable: true,
+        description: 'The user associated with this membership.',
         resolve: (member, _args, ctx) => ctx.loaders.user.load(member.userId),
       }),
     }),

--- a/apps/api/src/graphql/types/payloads.ts
+++ b/apps/api/src/graphql/types/payloads.ts
@@ -18,13 +18,16 @@ export const SubmissionStatusChangePayload = builder
     historyEntry: SubmissionHistoryEntry;
   }>('SubmissionStatusChangePayload')
   .implement({
+    description: 'Result of a submission status transition.',
     fields: (t) => ({
       submission: t.field({
         type: SubmissionType,
+        description: 'The submission after the status change.',
         resolve: (r) => r.submission,
       }),
       historyEntry: t.field({
         type: SubmissionHistoryType,
+        description: 'The history entry recording this transition.',
         resolve: (r) => r.historyEntry,
       }),
     }),
@@ -40,13 +43,16 @@ export const CreateOrganizationPayload = builder
     membership: OrganizationMember;
   }>('CreateOrganizationPayload')
   .implement({
+    description: 'Result of creating a new organization.',
     fields: (t) => ({
       organization: t.field({
         type: OrganizationType,
+        description: 'The newly created organization.',
         resolve: (r) => r.organization,
       }),
       membership: t.field({
         type: OrganizationMemberType,
+        description: "The creator's membership record.",
         resolve: (r) => r.membership,
       }),
     }),
@@ -69,19 +75,40 @@ export const CreateApiKeyPayload = builder
     revokedAt: Date | null;
   }>('CreateApiKeyPayload')
   .implement({
+    description:
+      'Result of creating a new API key. The plain-text key is shown only once.',
     fields: (t) => ({
-      id: t.exposeString('id'),
-      name: t.exposeString('name'),
-      scopes: t.expose('scopes', { type: 'JSON' }),
-      keyPrefix: t.exposeString('keyPrefix'),
-      plainTextKey: t.exposeString('plainTextKey'),
-      createdAt: t.expose('createdAt', { type: 'DateTime' }),
-      expiresAt: t.expose('expiresAt', { type: 'DateTime', nullable: true }),
+      id: t.exposeString('id', { description: 'Unique identifier.' }),
+      name: t.exposeString('name', { description: 'Human-readable name.' }),
+      scopes: t.expose('scopes', {
+        type: 'JSON',
+        description: 'Granted permission scopes.',
+      }),
+      keyPrefix: t.exposeString('keyPrefix', {
+        description: 'First characters for identification.',
+      }),
+      plainTextKey: t.exposeString('plainTextKey', {
+        description: 'The full API key — shown only once, never stored.',
+      }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the key was created.',
+      }),
+      expiresAt: t.expose('expiresAt', {
+        type: 'DateTime',
+        nullable: true,
+        description: 'When the key expires.',
+      }),
       lastUsedAt: t.expose('lastUsedAt', {
         type: 'DateTime',
         nullable: true,
+        description: 'When the key was last used.',
       }),
-      revokedAt: t.expose('revokedAt', { type: 'DateTime', nullable: true }),
+      revokedAt: t.expose('revokedAt', {
+        type: 'DateTime',
+        nullable: true,
+        description: 'When the key was revoked.',
+      }),
     }),
   });
 
@@ -92,10 +119,15 @@ export const RevokeApiKeyPayload = builder
     revokedAt: Date | null;
   }>('RevokeApiKeyPayload')
   .implement({
+    description: 'Result of revoking an API key.',
     fields: (t) => ({
-      id: t.exposeString('id'),
-      name: t.exposeString('name'),
-      revokedAt: t.expose('revokedAt', { type: 'DateTime', nullable: true }),
+      id: t.exposeString('id', { description: 'API key ID.' }),
+      name: t.exposeString('name', { description: 'Human-readable name.' }),
+      revokedAt: t.expose('revokedAt', {
+        type: 'DateTime',
+        nullable: true,
+        description: 'When the key was revoked.',
+      }),
     }),
   });
 
@@ -106,7 +138,11 @@ export const RevokeApiKeyPayload = builder
 export const SuccessPayload = builder
   .objectRef<{ success: boolean }>('SuccessPayload')
   .implement({
+    description:
+      "Generic success response for mutations that don't return a resource.",
     fields: (t) => ({
-      success: t.exposeBoolean('success'),
+      success: t.exposeBoolean('success', {
+        description: 'Always true on success.',
+      }),
     }),
   });

--- a/apps/api/src/graphql/types/submission.ts
+++ b/apps/api/src/graphql/types/submission.ts
@@ -7,31 +7,60 @@ import { UserType } from './user.js';
 export const SubmissionType = builder
   .objectRef<Submission>('Submission')
   .implement({
+    description:
+      'A literary submission (manuscript, poem, story, etc.) under review.',
     fields: (t) => ({
-      id: t.exposeString('id'),
-      organizationId: t.exposeString('organizationId'),
-      submitterId: t.exposeString('submitterId'),
+      id: t.exposeString('id', { description: 'Unique identifier.' }),
+      organizationId: t.exposeString('organizationId', {
+        description: 'ID of the owning organization.',
+      }),
+      submitterId: t.exposeString('submitterId', {
+        description: 'ID of the user who created this submission.',
+      }),
       submissionPeriodId: t.exposeString('submissionPeriodId', {
         nullable: true,
+        description: 'ID of the associated submission period, if any.',
       }),
-      title: t.exposeString('title', { nullable: true }),
-      content: t.exposeString('content', { nullable: true }),
-      coverLetter: t.exposeString('coverLetter', { nullable: true }),
-      status: t.expose('status', { type: SubmissionStatusEnum }),
+      title: t.exposeString('title', {
+        nullable: true,
+        description: 'Title of the submission.',
+      }),
+      content: t.exposeString('content', {
+        nullable: true,
+        description: 'Body content of the submission.',
+      }),
+      coverLetter: t.exposeString('coverLetter', {
+        nullable: true,
+        description: 'Optional cover letter.',
+      }),
+      status: t.expose('status', {
+        type: SubmissionStatusEnum,
+        description: 'Current workflow status.',
+      }),
       submittedAt: t.expose('submittedAt', {
         type: 'DateTime',
         nullable: true,
+        description:
+          'When the submission was formally submitted (null if still a draft).',
       }),
-      createdAt: t.expose('createdAt', { type: 'DateTime' }),
-      updatedAt: t.expose('updatedAt', { type: 'DateTime' }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the submission was created.',
+      }),
+      updatedAt: t.expose('updatedAt', {
+        type: 'DateTime',
+        description: 'When the submission was last updated.',
+      }),
       files: t.field({
         type: [SubmissionFileType],
+        description: 'Files attached to this submission.',
         resolve: (submission, _args, ctx) =>
           ctx.loaders.submissionFiles.load(submission.id),
       }),
       submitter: t.field({
         type: UserType,
         nullable: true,
+        description: 'The user who created this submission.',
         resolve: (submission, _args, ctx) =>
           ctx.loaders.user.load(submission.submitterId),
       }),
@@ -41,16 +70,32 @@ export const SubmissionType = builder
 export const SubmissionHistoryType = builder
   .objectRef<SubmissionHistoryEntry>('SubmissionHistory')
   .implement({
+    description: "A record of a status change in a submission's workflow.",
     fields: (t) => ({
-      id: t.exposeString('id'),
-      submissionId: t.exposeString('submissionId'),
+      id: t.exposeString('id', { description: 'History entry ID.' }),
+      submissionId: t.exposeString('submissionId', {
+        description: 'ID of the submission.',
+      }),
       fromStatus: t.expose('fromStatus', {
         type: SubmissionStatusEnum,
         nullable: true,
+        description: 'Previous status (null for initial creation).',
       }),
-      toStatus: t.expose('toStatus', { type: SubmissionStatusEnum }),
-      changedBy: t.exposeString('changedBy', { nullable: true }),
-      comment: t.exposeString('comment', { nullable: true }),
-      changedAt: t.expose('changedAt', { type: 'DateTime' }),
+      toStatus: t.expose('toStatus', {
+        type: SubmissionStatusEnum,
+        description: 'New status after the transition.',
+      }),
+      changedBy: t.exposeString('changedBy', {
+        nullable: true,
+        description: 'ID of the user who made the change.',
+      }),
+      comment: t.exposeString('comment', {
+        nullable: true,
+        description: 'Optional comment explaining the change.',
+      }),
+      changedAt: t.expose('changedAt', {
+        type: 'DateTime',
+        description: 'When the status change occurred.',
+      }),
     }),
   });

--- a/apps/api/src/graphql/types/user.ts
+++ b/apps/api/src/graphql/types/user.ts
@@ -2,11 +2,20 @@ import type { User } from '@colophony/db';
 import { builder } from '../builder.js';
 
 export const UserType = builder.objectRef<User>('User').implement({
+  description: 'A Colophony user account, synced from Zitadel.',
   fields: (t) => ({
-    id: t.exposeString('id'),
-    email: t.exposeString('email'),
-    emailVerified: t.exposeBoolean('emailVerified'),
-    createdAt: t.expose('createdAt', { type: 'DateTime' }),
-    updatedAt: t.expose('updatedAt', { type: 'DateTime' }),
+    id: t.exposeString('id', { description: 'Unique identifier.' }),
+    email: t.exposeString('email', { description: 'Primary email address.' }),
+    emailVerified: t.exposeBoolean('emailVerified', {
+      description: 'Whether the email has been verified.',
+    }),
+    createdAt: t.expose('createdAt', {
+      type: 'DateTime',
+      description: 'When the account was created.',
+    }),
+    updatedAt: t.expose('updatedAt', {
+      type: 'DateTime',
+      description: 'When the account was last updated.',
+    }),
   }),
 });

--- a/apps/api/src/rest/router.ts
+++ b/apps/api/src/rest/router.ts
@@ -27,9 +27,59 @@ const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
         info: {
           title: 'Colophony API',
           version: '2.0.0',
-          description: 'REST API for the Colophony literary magazine platform.',
+          description:
+            'REST API for Colophony, the open-source infrastructure suite for literary magazines. ' +
+            'Covers submission intake, review pipelines, file management, and organization administration.\n\n' +
+            '## Authentication\n\n' +
+            'All endpoints require authentication via one of:\n' +
+            '- **Bearer token** — Zitadel OIDC access token in the `Authorization` header\n' +
+            '- **API key** — Organization-scoped key in the `X-Api-Key` header\n\n' +
+            'Most endpoints also require the `X-Organization-Id` header to set the organization context.',
+          contact: {
+            name: 'Colophony',
+            url: 'https://github.com/colophony/colophony',
+          },
+          license: {
+            name: 'MIT',
+          },
         },
-        servers: [{ url: '/v1' }],
+        servers: [{ url: '/v1', description: 'Current version' }],
+        tags: [
+          {
+            name: 'Organizations',
+            description:
+              'Manage organizations and their members. Organizations are the top-level tenant in Colophony.',
+          },
+          {
+            name: 'Submissions',
+            description:
+              'Create, review, and manage literary submissions through the editorial workflow.',
+          },
+          {
+            name: 'Files',
+            description:
+              'List, download, and delete files attached to submissions. Uploads use the tus protocol.',
+          },
+          {
+            name: 'Users',
+            description:
+              'User profile and account information. User lifecycle is managed via Zitadel.',
+          },
+          {
+            name: 'API Keys',
+            description:
+              'Create and manage organization-scoped API keys for programmatic access.',
+          },
+          {
+            name: 'Audit',
+            description:
+              'Query the audit log for security and compliance. Admin-only.',
+          },
+        ],
+        externalDocs: {
+          description: 'Colophony source code and documentation',
+          url: 'https://github.com/colophony/colophony',
+        },
       },
     }),
   ],

--- a/apps/api/src/rest/router.ts
+++ b/apps/api/src/rest/router.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { OpenAPIHandler } from '@orpc/openapi/fastify';
 import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins';
+import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4';
 import { organizationsRouter } from './routers/organizations.js';
 import { submissionsRouter } from './routers/submissions.js';
 import { filesRouter } from './routers/files.js';
@@ -21,6 +22,7 @@ const restRouter = {
 const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
   plugins: [
     new OpenAPIReferencePlugin({
+      schemaConverters: [new ZodToJsonSchemaConverter()],
       specPath: '/openapi.json',
       docsPath: '/docs',
       specGenerateOptions: {

--- a/apps/api/src/rest/routers/api-keys.ts
+++ b/apps/api/src/rest/routers/api-keys.ts
@@ -21,7 +21,15 @@ const keyIdParam = z.object({ keyId: z.string().uuid() });
 
 const list = orgProcedure
   .use(requireScopes('api-keys:read'))
-  .route({ method: 'GET', path: '/api-keys' })
+  .route({
+    method: 'GET',
+    path: '/api-keys',
+    summary: 'List API keys',
+    description:
+      'Returns all API keys for the current organization. Key values are masked.',
+    operationId: 'listApiKeys',
+    tags: ['API Keys'],
+  })
   .input(restPaginationQuery)
   .handler(async ({ input, context }) => {
     return apiKeyService.list(context.dbTx, input);
@@ -29,7 +37,16 @@ const list = orgProcedure
 
 const create = adminProcedure
   .use(requireScopes('api-keys:manage'))
-  .route({ method: 'POST', path: '/api-keys', successStatus: 201 })
+  .route({
+    method: 'POST',
+    path: '/api-keys',
+    successStatus: 201,
+    summary: 'Create an API key',
+    description:
+      'Create a new API key for the organization. The plain-text key is returned only once. Requires ADMIN role.',
+    operationId: 'createApiKey',
+    tags: ['API Keys'],
+  })
   .input(createApiKeySchema)
   .handler(async ({ input, context }) => {
     const result = await apiKeyService.create(
@@ -49,7 +66,15 @@ const create = adminProcedure
 
 const revoke = adminProcedure
   .use(requireScopes('api-keys:manage'))
-  .route({ method: 'POST', path: '/api-keys/{keyId}/revoke' })
+  .route({
+    method: 'POST',
+    path: '/api-keys/{keyId}/revoke',
+    summary: 'Revoke an API key',
+    description:
+      'Revoke an API key so it can no longer be used for authentication. Requires ADMIN role.',
+    operationId: 'revokeApiKey',
+    tags: ['API Keys'],
+  })
   .input(keyIdParam)
   .handler(async ({ input, context }) => {
     const revoked = await apiKeyService.revoke(context.dbTx, input.keyId);
@@ -66,7 +91,14 @@ const revoke = adminProcedure
 
 const del = adminProcedure
   .use(requireScopes('api-keys:manage'))
-  .route({ method: 'DELETE', path: '/api-keys/{keyId}' })
+  .route({
+    method: 'DELETE',
+    path: '/api-keys/{keyId}',
+    summary: 'Delete an API key',
+    description: 'Permanently delete an API key. Requires ADMIN role.',
+    operationId: 'deleteApiKey',
+    tags: ['API Keys'],
+  })
   .input(keyIdParam)
   .handler(async ({ input, context }) => {
     const deleted = await apiKeyService.delete(context.dbTx, input.keyId);

--- a/apps/api/src/rest/routers/audit.ts
+++ b/apps/api/src/rest/routers/audit.ts
@@ -10,7 +10,15 @@ import { adminProcedure, requireScopes } from '../context.js';
 
 const list = adminProcedure
   .use(requireScopes('audit:read'))
-  .route({ method: 'GET', path: '/audit-events' })
+  .route({
+    method: 'GET',
+    path: '/audit-events',
+    summary: 'List audit events',
+    description:
+      'Returns a paginated, filterable list of audit events for the current organization. Requires ADMIN role.',
+    operationId: 'listAuditEvents',
+    tags: ['Audit'],
+  })
   .input(restListAuditEventsQuery)
   .handler(async ({ input, context }) => {
     const result = await auditService.list(context.dbTx, input);
@@ -23,7 +31,15 @@ const list = adminProcedure
 
 const getById = adminProcedure
   .use(requireScopes('audit:read'))
-  .route({ method: 'GET', path: '/audit-events/{id}' })
+  .route({
+    method: 'GET',
+    path: '/audit-events/{id}',
+    summary: 'Get an audit event',
+    description:
+      'Retrieve a single audit event by its ID. Requires ADMIN role.',
+    operationId: 'getAuditEvent',
+    tags: ['Audit'],
+  })
   .input(idParamSchema)
   .handler(async ({ input, context }) => {
     const event = await auditService.getById(context.dbTx, input.id);

--- a/apps/api/src/rest/routers/files.ts
+++ b/apps/api/src/rest/routers/files.ts
@@ -27,7 +27,14 @@ function getEnvConfig() {
 
 const list = orgProcedure
   .use(requireScopes('files:read'))
-  .route({ method: 'GET', path: '/submissions/{submissionId}/files' })
+  .route({
+    method: 'GET',
+    path: '/submissions/{submissionId}/files',
+    summary: 'List submission files',
+    description: 'Returns all files attached to a submission.',
+    operationId: 'listSubmissionFiles',
+    tags: ['Files'],
+  })
   .input(submissionIdParamSchema)
   .handler(async ({ input, context }) => {
     try {
@@ -42,7 +49,15 @@ const list = orgProcedure
 
 const download = orgProcedure
   .use(requireScopes('files:read'))
-  .route({ method: 'GET', path: '/files/{fileId}/download' })
+  .route({
+    method: 'GET',
+    path: '/files/{fileId}/download',
+    summary: 'Get file download URL',
+    description:
+      'Returns a pre-signed download URL for a file. Only available for files with CLEAN scan status.',
+    operationId: 'getFileDownloadUrl',
+    tags: ['Files'],
+  })
   .input(fileIdParamSchema)
   .handler(async ({ input, context }) => {
     try {
@@ -60,7 +75,15 @@ const download = orgProcedure
 
 const del = orgProcedure
   .use(requireScopes('files:write'))
-  .route({ method: 'DELETE', path: '/files/{fileId}' })
+  .route({
+    method: 'DELETE',
+    path: '/files/{fileId}',
+    summary: 'Delete a file',
+    description:
+      'Delete a file from a submission. Only allowed while the submission is in DRAFT status.',
+    operationId: 'deleteFile',
+    tags: ['Files'],
+  })
   .input(fileIdParamSchema)
   .handler(async ({ input, context }) => {
     try {

--- a/apps/api/src/rest/routers/organizations.ts
+++ b/apps/api/src/rest/routers/organizations.ts
@@ -48,7 +48,15 @@ function assertOrgIdMatch(pathOrgId: string, contextOrgId: string): void {
 
 const membersList = orgProcedure
   .use(requireScopes('organizations:read'))
-  .route({ method: 'GET', path: '/organizations/{orgId}/members' })
+  .route({
+    method: 'GET',
+    path: '/organizations/{orgId}/members',
+    summary: 'List organization members',
+    description:
+      'Returns a paginated list of members for the specified organization.',
+    operationId: 'listOrganizationMembers',
+    tags: ['Organizations'],
+  })
   .input(orgIdParam.merge(restPaginationQuery))
   .handler(async ({ input, context }) => {
     assertOrgIdMatch(input.orgId, context.authContext.orgId);
@@ -64,6 +72,11 @@ const membersAdd = adminProcedure
     method: 'POST',
     path: '/organizations/{orgId}/members',
     successStatus: 201,
+    summary: 'Add a member',
+    description:
+      'Invite a user to the organization by email. The user must already have an account. Requires ADMIN role.',
+    operationId: 'addOrganizationMember',
+    tags: ['Organizations'],
   })
   .input(orgIdParam.merge(inviteMemberSchema))
   .handler(async ({ input, context }) => {
@@ -84,6 +97,10 @@ const membersRemove = adminProcedure
   .route({
     method: 'DELETE',
     path: '/organizations/{orgId}/members/{memberId}',
+    summary: 'Remove a member',
+    description: 'Remove a member from the organization. Requires ADMIN role.',
+    operationId: 'removeOrganizationMember',
+    tags: ['Organizations'],
   })
   .input(memberIdParam)
   .handler(async ({ context, input }) => {
@@ -103,6 +120,11 @@ const membersUpdateRole = adminProcedure
   .route({
     method: 'PATCH',
     path: '/organizations/{orgId}/members/{memberId}',
+    summary: 'Update member role',
+    description:
+      "Change a member's role within the organization. Requires ADMIN role.",
+    operationId: 'updateOrganizationMemberRole',
+    tags: ['Organizations'],
   })
   .input(memberIdParam.merge(z.object({ role: roleSchema })))
   .handler(async ({ context, input }) => {
@@ -124,7 +146,15 @@ const membersUpdateRole = adminProcedure
 
 const orgsList = authedProcedure
   .use(requireScopes('organizations:read'))
-  .route({ method: 'GET', path: '/organizations' })
+  .route({
+    method: 'GET',
+    path: '/organizations',
+    summary: 'List organizations',
+    description:
+      'Returns all organizations the authenticated user is a member of.',
+    operationId: 'listOrganizations',
+    tags: ['Organizations'],
+  })
   .handler(async ({ context }) => {
     return organizationService.listUserOrganizations(
       context.authContext.userId,
@@ -133,7 +163,16 @@ const orgsList = authedProcedure
 
 const orgsCreate = authedProcedure
   .use(requireScopes('organizations:write'))
-  .route({ method: 'POST', path: '/organizations', successStatus: 201 })
+  .route({
+    method: 'POST',
+    path: '/organizations',
+    successStatus: 201,
+    summary: 'Create an organization',
+    description:
+      'Create a new organization. The authenticated user becomes the first ADMIN member.',
+    operationId: 'createOrganization',
+    tags: ['Organizations'],
+  })
   .input(createOrganizationSchema)
   .handler(async ({ context, input }) => {
     const available = await organizationService.isSlugAvailable(input.slug);
@@ -156,7 +195,15 @@ const orgsCreate = authedProcedure
 
 const orgsCheckSlug = authedProcedure
   .use(requireScopes('organizations:read'))
-  .route({ method: 'GET', path: '/organizations/check-slug' })
+  .route({
+    method: 'GET',
+    path: '/organizations/check-slug',
+    summary: 'Check slug availability',
+    description:
+      'Check whether a slug is available for use when creating an organization.',
+    operationId: 'checkSlugAvailability',
+    tags: ['Organizations'],
+  })
   .input(checkSlugSchema)
   .handler(async ({ input }) => {
     const available = await organizationService.isSlugAvailable(input.slug);
@@ -165,7 +212,14 @@ const orgsCheckSlug = authedProcedure
 
 const orgsGet = orgProcedure
   .use(requireScopes('organizations:read'))
-  .route({ method: 'GET', path: '/organizations/{orgId}' })
+  .route({
+    method: 'GET',
+    path: '/organizations/{orgId}',
+    summary: 'Get an organization',
+    description: 'Retrieve a single organization by its ID.',
+    operationId: 'getOrganization',
+    tags: ['Organizations'],
+  })
   .input(orgIdParam)
   .handler(async ({ input, context }) => {
     assertOrgIdMatch(input.orgId, context.authContext.orgId);
@@ -181,7 +235,15 @@ const orgsGet = orgProcedure
 
 const orgsUpdate = adminProcedure
   .use(requireScopes('organizations:write'))
-  .route({ method: 'PATCH', path: '/organizations/{orgId}' })
+  .route({
+    method: 'PATCH',
+    path: '/organizations/{orgId}',
+    summary: 'Update an organization',
+    description:
+      "Update an organization's name or settings. Requires ADMIN role.",
+    operationId: 'updateOrganization',
+    tags: ['Organizations'],
+  })
   .input(orgIdParam.merge(updateOrganizationSchema))
   .handler(async ({ context, input }) => {
     assertOrgIdMatch(input.orgId, context.authContext.orgId);

--- a/apps/api/src/rest/routers/submissions.ts
+++ b/apps/api/src/rest/routers/submissions.ts
@@ -26,7 +26,15 @@ const restListSubmissionsQuery = listSubmissionsSchema
 
 const mine = orgProcedure
   .use(requireScopes('submissions:read'))
-  .route({ method: 'GET', path: '/submissions/mine' })
+  .route({
+    method: 'GET',
+    path: '/submissions/mine',
+    summary: 'List my submissions',
+    description:
+      'Returns submissions created by the authenticated user in the current organization.',
+    operationId: 'listMySubmissions',
+    tags: ['Submissions'],
+  })
   .input(restListSubmissionsQuery)
   .handler(async ({ input, context }) => {
     return submissionService.listBySubmitter(
@@ -38,7 +46,15 @@ const mine = orgProcedure
 
 const list = orgProcedure
   .use(requireScopes('submissions:read'))
-  .route({ method: 'GET', path: '/submissions' })
+  .route({
+    method: 'GET',
+    path: '/submissions',
+    summary: 'List all submissions',
+    description:
+      'Returns all submissions in the organization. Requires EDITOR or ADMIN role.',
+    operationId: 'listSubmissions',
+    tags: ['Submissions'],
+  })
   .input(restListSubmissionsQuery)
   .handler(async ({ input, context }) => {
     try {
@@ -51,7 +67,15 @@ const list = orgProcedure
 
 const create = orgProcedure
   .use(requireScopes('submissions:write'))
-  .route({ method: 'POST', path: '/submissions', successStatus: 201 })
+  .route({
+    method: 'POST',
+    path: '/submissions',
+    successStatus: 201,
+    summary: 'Create a submission',
+    description: 'Create a new submission in DRAFT status.',
+    operationId: 'createSubmission',
+    tags: ['Submissions'],
+  })
   .input(createSubmissionSchema)
   .handler(async ({ input, context }) => {
     try {
@@ -66,7 +90,15 @@ const create = orgProcedure
 
 const get = orgProcedure
   .use(requireScopes('submissions:read'))
-  .route({ method: 'GET', path: '/submissions/{id}' })
+  .route({
+    method: 'GET',
+    path: '/submissions/{id}',
+    summary: 'Get a submission',
+    description:
+      'Retrieve a single submission by ID, including attached files and submitter email.',
+    operationId: 'getSubmission',
+    tags: ['Submissions'],
+  })
   .input(idParamSchema)
   .handler(async ({ input, context }) => {
     try {
@@ -81,7 +113,15 @@ const get = orgProcedure
 
 const update = orgProcedure
   .use(requireScopes('submissions:write'))
-  .route({ method: 'PATCH', path: '/submissions/{id}' })
+  .route({
+    method: 'PATCH',
+    path: '/submissions/{id}',
+    summary: 'Update a submission',
+    description:
+      "Update a submission's title, content, or cover letter. Only allowed while in DRAFT status.",
+    operationId: 'updateSubmission',
+    tags: ['Submissions'],
+  })
   .input(idParamSchema.merge(updateSubmissionSchema))
   .handler(async ({ input, context }) => {
     const { id, ...data } = input;
@@ -98,7 +138,15 @@ const update = orgProcedure
 
 const submit = orgProcedure
   .use(requireScopes('submissions:write'))
-  .route({ method: 'POST', path: '/submissions/{id}/submit' })
+  .route({
+    method: 'POST',
+    path: '/submissions/{id}/submit',
+    summary: 'Submit a submission',
+    description:
+      'Transition a DRAFT submission to SUBMITTED status. Validates that all files have passed virus scanning.',
+    operationId: 'submitSubmission',
+    tags: ['Submissions'],
+  })
   .input(idParamSchema)
   .handler(async ({ input, context }) => {
     try {
@@ -113,7 +161,15 @@ const submit = orgProcedure
 
 const del = orgProcedure
   .use(requireScopes('submissions:write'))
-  .route({ method: 'DELETE', path: '/submissions/{id}' })
+  .route({
+    method: 'DELETE',
+    path: '/submissions/{id}',
+    summary: 'Delete a submission',
+    description:
+      'Permanently delete a DRAFT submission and its attached files.',
+    operationId: 'deleteSubmission',
+    tags: ['Submissions'],
+  })
   .input(idParamSchema)
   .handler(async ({ input, context }) => {
     try {
@@ -128,7 +184,15 @@ const del = orgProcedure
 
 const withdraw = orgProcedure
   .use(requireScopes('submissions:write'))
-  .route({ method: 'POST', path: '/submissions/{id}/withdraw' })
+  .route({
+    method: 'POST',
+    path: '/submissions/{id}/withdraw',
+    summary: 'Withdraw a submission',
+    description:
+      'Withdraw a submission from consideration. Allowed from DRAFT, SUBMITTED, UNDER_REVIEW, or HOLD status.',
+    operationId: 'withdrawSubmission',
+    tags: ['Submissions'],
+  })
   .input(idParamSchema)
   .handler(async ({ input, context }) => {
     try {
@@ -143,7 +207,15 @@ const withdraw = orgProcedure
 
 const updateStatus = orgProcedure
   .use(requireScopes('submissions:write'))
-  .route({ method: 'PATCH', path: '/submissions/{id}/status' })
+  .route({
+    method: 'PATCH',
+    path: '/submissions/{id}/status',
+    summary: 'Update submission status',
+    description:
+      'Transition a submission to a new status. Requires EDITOR or ADMIN role. Valid transitions depend on current status.',
+    operationId: 'updateSubmissionStatus',
+    tags: ['Submissions'],
+  })
   .input(idParamSchema.merge(updateSubmissionStatusSchema))
   .handler(async ({ input, context }) => {
     const { id, status, comment } = input;
@@ -161,7 +233,14 @@ const updateStatus = orgProcedure
 
 const history = orgProcedure
   .use(requireScopes('submissions:read'))
-  .route({ method: 'GET', path: '/submissions/{id}/history' })
+  .route({
+    method: 'GET',
+    path: '/submissions/{id}/history',
+    summary: 'Get submission history',
+    description: 'Returns the status change history for a submission.',
+    operationId: 'getSubmissionHistory',
+    tags: ['Submissions'],
+  })
   .input(idParamSchema)
   .handler(async ({ input, context }) => {
     try {

--- a/apps/api/src/rest/routers/users.ts
+++ b/apps/api/src/rest/routers/users.ts
@@ -8,7 +8,15 @@ import { authedProcedure, requireScopes } from '../context.js';
 
 const me = authedProcedure
   .use(requireScopes('users:read'))
-  .route({ method: 'GET', path: '/users/me' })
+  .route({
+    method: 'GET',
+    path: '/users/me',
+    summary: 'Get current user profile',
+    description:
+      "Returns the authenticated user's profile including organization memberships.",
+    operationId: 'getCurrentUser',
+    tags: ['Users'],
+  })
   .handler(async ({ context }) => {
     const profile = await userService.getProfile(context.authContext.userId);
     if (!profile) {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -80,7 +80,7 @@
 - [x] Pothos + GraphQL Yoga surface — PR 1: foundation (types, queries, DataLoaders, scope enforcement, Fastify integration) done 2026-02-19; PR 2: mutations done 2026-02-19 — (architecture doc Track 2, Section 6.6)
 - [x] GraphQL mutations (PR 2) — 16 mutations + API key list query, unit tests (36 new tests) — done 2026-02-19
 - [ ] SDK generation (TypeScript, Python) — (architecture doc Track 2)
-- [ ] API documentation — (architecture doc Track 2)
+- [x] API documentation — Zod descriptions, oRPC metadata, GraphQL Pothos descriptions, Scalar UI, export scripts — (architecture doc Track 2; done 2026-02-19)
 
 ### Design Decisions
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-19 — API Documentation (Track 2 Completion)
+
+### Done
+
+- Added `.describe()` to all Zod schema fields across 8 type files (`packages/types/src/`) — propagates to OpenAPI property descriptions
+- Added oRPC route metadata (summary, description, operationId, tags) to all 30 server-side REST router routes across 5 files
+- Added oRPC contract metadata to all ~23 contract routes in `packages/api-contracts/src/` (mirroring server routers)
+- Enhanced Scalar docs UI config: info block, tag descriptions, contact, license, externalDocs
+- Added GraphQL Pothos descriptions to all types, fields, enum values, query/mutation resolvers, and arguments
+- Created `scripts/export-openapi.ts` and `scripts/export-schema.ts` export scripts
+- Exported `sdks/openapi.json` (21 paths, 29 operations) and `sdks/schema.graphql`
+- Fixed OpenAPI spec generation 500 error: `OpenAPIReferencePlugin` had no schema converters registered — all Zod schemas converted to `{}`. Added `ZodToJsonSchemaConverter` from `@orpc/zod/zod4`
+- Discovered server-side routers (not contracts) are the source for `OpenAPIReferencePlugin` spec generation — added metadata to all server routers
+- Codex branch review: LGTM, no findings
+
+### Decisions
+
+- OpenAPI spec export uses fetch-based approach (requires running dev server) — `@orpc/server` doesn't expose a programmatic `generateOpenAPI()` from server routers
+- SDK generation (TypeScript, Python) deferred — no external consumers yet
+- `@orpc/zod/zod4` is the correct import for Zod 4 schema converter (the default `@orpc/zod` export checks `!("_zod" in schema)` which fails for Zod 4)
+
+---
+
 ## 2026-02-19 — GraphQL Mutations PR 2
 
 ### Done

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "db:studio": "pnpm --filter @colophony/db studio",
     "db:seed": "pnpm --filter @colophony/db seed",
     "db:reset": "bash scripts/db-reset.sh",
+    "sdk:export-spec": "pnpm --filter @colophony/api exec tsx ../../scripts/export-openapi.ts",
+    "sdk:export-schema": "pnpm --filter @colophony/api exec tsx ../../scripts/export-schema.ts",
     "clean": "turbo run clean && rm -rf node_modules",
     "prepare": "husky"
   },

--- a/packages/api-contracts/src/api-keys.ts
+++ b/packages/api-contracts/src/api-keys.ts
@@ -37,22 +37,54 @@ const deleteResponseSchema = z.object({
 
 export const apiKeysContract = {
   list: oc
-    .route({ method: "GET", path: "/api-keys" })
+    .route({
+      method: "GET",
+      path: "/api-keys",
+      summary: "List API keys",
+      description:
+        "Returns a paginated list of API keys for the current organization.",
+      operationId: "listApiKeys",
+      tags: ["API Keys"],
+    })
     .input(restPaginationQuery)
     .output(paginatedApiKeysSchema),
 
   create: oc
-    .route({ method: "POST", path: "/api-keys", successStatus: 201 })
+    .route({
+      method: "POST",
+      path: "/api-keys",
+      successStatus: 201,
+      summary: "Create an API key",
+      description:
+        "Generate a new API key with specified scopes. The plain-text key is returned only once. Requires ADMIN role.",
+      operationId: "createApiKey",
+      tags: ["API Keys"],
+    })
     .input(createApiKeySchema)
     .output(createApiKeyResponseSchema),
 
   revoke: oc
-    .route({ method: "POST", path: "/api-keys/{keyId}/revoke" })
+    .route({
+      method: "POST",
+      path: "/api-keys/{keyId}/revoke",
+      summary: "Revoke an API key",
+      description:
+        "Revoke an active API key, preventing further use. Requires ADMIN role.",
+      operationId: "revokeApiKey",
+      tags: ["API Keys"],
+    })
     .input(keyIdParam)
     .output(apiKeyResponseSchema),
 
   delete: oc
-    .route({ method: "DELETE", path: "/api-keys/{keyId}" })
+    .route({
+      method: "DELETE",
+      path: "/api-keys/{keyId}",
+      summary: "Delete an API key",
+      description: "Permanently delete an API key record. Requires ADMIN role.",
+      operationId: "deleteApiKey",
+      tags: ["API Keys"],
+    })
     .input(keyIdParam)
     .output(deleteResponseSchema),
 };

--- a/packages/api-contracts/src/files.ts
+++ b/packages/api-contracts/src/files.ts
@@ -34,17 +34,40 @@ const deleteResponseSchema = z.object({
 
 export const filesContract = {
   list: oc
-    .route({ method: "GET", path: "/submissions/{submissionId}/files" })
+    .route({
+      method: "GET",
+      path: "/submissions/{submissionId}/files",
+      summary: "List submission files",
+      description: "Returns all files attached to a submission.",
+      operationId: "listSubmissionFiles",
+      tags: ["Files"],
+    })
     .input(submissionIdParam)
     .output(z.array(submissionFileSchema)),
 
   download: oc
-    .route({ method: "GET", path: "/files/{fileId}/download" })
+    .route({
+      method: "GET",
+      path: "/files/{fileId}/download",
+      summary: "Get download URL",
+      description:
+        "Generate a pre-signed download URL for a file. Only available for files with CLEAN scan status.",
+      operationId: "getFileDownloadUrl",
+      tags: ["Files"],
+    })
     .input(fileIdParam)
     .output(downloadUrlResponseSchema),
 
   delete: oc
-    .route({ method: "DELETE", path: "/files/{fileId}" })
+    .route({
+      method: "DELETE",
+      path: "/files/{fileId}",
+      summary: "Delete a file",
+      description:
+        "Delete a file from a DRAFT submission. Only the submission owner can delete files.",
+      operationId: "deleteFile",
+      tags: ["Files"],
+    })
     .input(fileIdParam)
     .output(deleteResponseSchema),
 };

--- a/packages/api-contracts/src/organizations.ts
+++ b/packages/api-contracts/src/organizations.ts
@@ -84,7 +84,15 @@ const memberIdParam = z.object({
 
 export const organizationMembersContract = {
   list: oc
-    .route({ method: "GET", path: "/organizations/{orgId}/members" })
+    .route({
+      method: "GET",
+      path: "/organizations/{orgId}/members",
+      summary: "List organization members",
+      description:
+        "Returns a paginated list of members for the specified organization.",
+      operationId: "listOrganizationMembers",
+      tags: ["Organizations"],
+    })
     .input(orgIdParam.merge(restPaginationQuery))
     .output(paginatedMembersSchema),
 
@@ -93,6 +101,11 @@ export const organizationMembersContract = {
       method: "POST",
       path: "/organizations/{orgId}/members",
       successStatus: 201,
+      summary: "Add a member",
+      description:
+        "Invite a user to the organization by email. The user must already have an account. Requires ADMIN role.",
+      operationId: "addOrganizationMember",
+      tags: ["Organizations"],
     })
     .input(orgIdParam.merge(inviteMemberSchema))
     .output(memberMutationResponseSchema),
@@ -101,6 +114,11 @@ export const organizationMembersContract = {
     .route({
       method: "DELETE",
       path: "/organizations/{orgId}/members/{memberId}",
+      summary: "Remove a member",
+      description:
+        "Remove a member from the organization. Requires ADMIN role.",
+      operationId: "removeOrganizationMember",
+      tags: ["Organizations"],
     })
     .input(memberIdParam)
     .output(memberRemovedSchema),
@@ -109,6 +127,11 @@ export const organizationMembersContract = {
     .route({
       method: "PATCH",
       path: "/organizations/{orgId}/members/{memberId}",
+      summary: "Update member role",
+      description:
+        "Change a member's role within the organization. Requires ADMIN role.",
+      operationId: "updateOrganizationMemberRole",
+      tags: ["Organizations"],
     })
     .input(memberIdParam.merge(updateMemberRoleSchema.omit({ memberId: true })))
     .output(memberMutationResponseSchema),
@@ -116,26 +139,66 @@ export const organizationMembersContract = {
 
 export const organizationsContract = {
   list: oc
-    .route({ method: "GET", path: "/organizations" })
+    .route({
+      method: "GET",
+      path: "/organizations",
+      summary: "List organizations",
+      description:
+        "Returns all organizations the authenticated user is a member of.",
+      operationId: "listOrganizations",
+      tags: ["Organizations"],
+    })
     .output(z.array(orgListItemSchema)),
 
   create: oc
-    .route({ method: "POST", path: "/organizations", successStatus: 201 })
+    .route({
+      method: "POST",
+      path: "/organizations",
+      successStatus: 201,
+      summary: "Create an organization",
+      description:
+        "Create a new organization. The authenticated user becomes the first ADMIN member.",
+      operationId: "createOrganization",
+      tags: ["Organizations"],
+    })
     .input(createOrganizationSchema)
     .output(createOrgResponseSchema),
 
   checkSlug: oc
-    .route({ method: "GET", path: "/organizations/check-slug" })
+    .route({
+      method: "GET",
+      path: "/organizations/check-slug",
+      summary: "Check slug availability",
+      description:
+        "Check whether a slug is available for use when creating an organization.",
+      operationId: "checkSlugAvailability",
+      tags: ["Organizations"],
+    })
     .input(checkSlugSchema)
     .output(checkSlugResponseSchema),
 
   get: oc
-    .route({ method: "GET", path: "/organizations/{orgId}" })
+    .route({
+      method: "GET",
+      path: "/organizations/{orgId}",
+      summary: "Get an organization",
+      description: "Retrieve a single organization by its ID.",
+      operationId: "getOrganization",
+      tags: ["Organizations"],
+    })
     .input(orgIdParam)
     .output(organizationSchema),
 
   update: oc
-    .route({ method: "PATCH", path: "/organizations/{orgId}" })
+    .route({
+      method: "PATCH",
+      path: "/organizations/{orgId}",
+      summary: "Update an organization",
+      description:
+        "Update an organization's name or settings. Requires ADMIN role.",
+      operationId: "updateOrganization",
+      tags: ["Organizations"],
+    })
     .input(orgIdParam.merge(updateOrganizationSchema))
     .output(organizationSchema),
 

--- a/packages/api-contracts/src/shared.ts
+++ b/packages/api-contracts/src/shared.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
  * All REST error responses follow this shape.
  */
 export const apiErrorSchema = z.object({
-  error: z.string(),
-  message: z.string(),
+  error: z.string().describe("Machine-readable error code"),
+  message: z.string().describe("Human-readable error description"),
 });
 
 /**
@@ -14,8 +14,19 @@ export const apiErrorSchema = z.object({
  * Uses `z.coerce.number()` because REST query params arrive as strings.
  */
 export const restPaginationQuery = z.object({
-  page: z.coerce.number().int().min(1).default(1),
-  limit: z.coerce.number().int().min(1).max(100).default(20),
+  page: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .default(1)
+    .describe("Page number (1-based)"),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page (1-100, default 20)"),
 });
 
 export type RestPaginationQuery = z.infer<typeof restPaginationQuery>;

--- a/packages/api-contracts/src/submissions.ts
+++ b/packages/api-contracts/src/submissions.ts
@@ -59,52 +59,132 @@ const deleteResponseSchema = z.object({
 
 export const submissionsContract = {
   mine: oc
-    .route({ method: "GET", path: "/submissions/mine" })
+    .route({
+      method: "GET",
+      path: "/submissions/mine",
+      summary: "List my submissions",
+      description:
+        "Returns a paginated list of the authenticated user's own submissions.",
+      operationId: "listMySubmissions",
+      tags: ["Submissions"],
+    })
     .input(restListSubmissionsQuery)
     .output(paginatedSubmissionsSchema),
 
   list: oc
-    .route({ method: "GET", path: "/submissions" })
+    .route({
+      method: "GET",
+      path: "/submissions",
+      summary: "List all submissions",
+      description:
+        "Returns a paginated list of all submissions in the organization. Requires EDITOR or ADMIN role.",
+      operationId: "listSubmissions",
+      tags: ["Submissions"],
+    })
     .input(restListSubmissionsQuery)
     .output(paginatedSubmissionsSchema),
 
   create: oc
-    .route({ method: "POST", path: "/submissions", successStatus: 201 })
+    .route({
+      method: "POST",
+      path: "/submissions",
+      successStatus: 201,
+      summary: "Create a submission",
+      description:
+        "Create a new submission in DRAFT status. Attach files separately via the Files endpoints.",
+      operationId: "createSubmission",
+      tags: ["Submissions"],
+    })
     .input(createSubmissionSchema)
     .output(submissionSchema),
 
   get: oc
-    .route({ method: "GET", path: "/submissions/{id}" })
+    .route({
+      method: "GET",
+      path: "/submissions/{id}",
+      summary: "Get a submission",
+      description:
+        "Retrieve a single submission with its attached files. Editors/admins can view any submission; submitters can view their own.",
+      operationId: "getSubmission",
+      tags: ["Submissions"],
+    })
     .input(submissionIdParam)
     .output(submissionWithDetailsSchema),
 
   update: oc
-    .route({ method: "PATCH", path: "/submissions/{id}" })
+    .route({
+      method: "PATCH",
+      path: "/submissions/{id}",
+      summary: "Update a submission",
+      description:
+        "Update a DRAFT submission's title, content, or cover letter. Only the submitter can update.",
+      operationId: "updateSubmission",
+      tags: ["Submissions"],
+    })
     .input(submissionIdParam.merge(updateSubmissionSchema))
     .output(submissionSchema),
 
   submit: oc
-    .route({ method: "POST", path: "/submissions/{id}/submit" })
+    .route({
+      method: "POST",
+      path: "/submissions/{id}/submit",
+      summary: "Submit a draft",
+      description:
+        "Transition a DRAFT submission to SUBMITTED status. Only the submitter can submit.",
+      operationId: "submitSubmission",
+      tags: ["Submissions"],
+    })
     .input(submissionIdParam)
     .output(statusUpdateResponseSchema),
 
   delete: oc
-    .route({ method: "DELETE", path: "/submissions/{id}" })
+    .route({
+      method: "DELETE",
+      path: "/submissions/{id}",
+      summary: "Delete a submission",
+      description:
+        "Delete a DRAFT submission and its attached files. Only the submitter can delete.",
+      operationId: "deleteSubmission",
+      tags: ["Submissions"],
+    })
     .input(submissionIdParam)
     .output(deleteResponseSchema),
 
   withdraw: oc
-    .route({ method: "POST", path: "/submissions/{id}/withdraw" })
+    .route({
+      method: "POST",
+      path: "/submissions/{id}/withdraw",
+      summary: "Withdraw a submission",
+      description:
+        "Withdraw a submission from consideration. Only the submitter can withdraw.",
+      operationId: "withdrawSubmission",
+      tags: ["Submissions"],
+    })
     .input(submissionIdParam)
     .output(statusUpdateResponseSchema),
 
   updateStatus: oc
-    .route({ method: "PATCH", path: "/submissions/{id}/status" })
+    .route({
+      method: "PATCH",
+      path: "/submissions/{id}/status",
+      summary: "Update submission status",
+      description:
+        "Transition a submission's status (e.g. SUBMITTED → UNDER_REVIEW). Requires EDITOR or ADMIN role. Invalid transitions are rejected.",
+      operationId: "updateSubmissionStatus",
+      tags: ["Submissions"],
+    })
     .input(submissionIdParam.merge(updateSubmissionStatusSchema))
     .output(statusUpdateResponseSchema),
 
   history: oc
-    .route({ method: "GET", path: "/submissions/{id}/history" })
+    .route({
+      method: "GET",
+      path: "/submissions/{id}/history",
+      summary: "Get submission history",
+      description: "Retrieve the full status change history for a submission.",
+      operationId: "getSubmissionHistory",
+      tags: ["Submissions"],
+    })
     .input(submissionIdParam)
     .output(z.array(submissionHistorySchema)),
 };

--- a/packages/api-contracts/src/users.ts
+++ b/packages/api-contracts/src/users.ts
@@ -26,5 +26,15 @@ const userProfileSchema = z.object({
 // ---------------------------------------------------------------------------
 
 export const usersContract = {
-  me: oc.route({ method: "GET", path: "/users/me" }).output(userProfileSchema),
+  me: oc
+    .route({
+      method: "GET",
+      path: "/users/me",
+      summary: "Get current user profile",
+      description:
+        "Returns the authenticated user's profile including their organization memberships.",
+      operationId: "getCurrentUser",
+      tags: ["Users"],
+    })
+    .output(userProfileSchema),
 };

--- a/packages/types/src/api-key.ts
+++ b/packages/types/src/api-key.ts
@@ -4,20 +4,22 @@ import { z } from "zod";
 // API Key Scopes — enforced by requireScopes middleware on REST + tRPC
 // ---------------------------------------------------------------------------
 
-export const apiKeyScopeSchema = z.enum([
-  "submissions:read",
-  "submissions:write",
-  "files:read",
-  "files:write",
-  "organizations:read",
-  "organizations:write",
-  "users:read",
-  "api-keys:read",
-  "api-keys:manage",
-  "payments:read",
-  "webhooks:manage",
-  "audit:read",
-]);
+export const apiKeyScopeSchema = z
+  .enum([
+    "submissions:read",
+    "submissions:write",
+    "files:read",
+    "files:write",
+    "organizations:read",
+    "organizations:write",
+    "users:read",
+    "api-keys:read",
+    "api-keys:manage",
+    "payments:read",
+    "webhooks:manage",
+    "audit:read",
+  ])
+  .describe("Permission scope for the API key");
 
 export type ApiKeyScope = z.infer<typeof apiKeyScopeSchema>;
 
@@ -26,19 +28,30 @@ export type ApiKeyScope = z.infer<typeof apiKeyScopeSchema>;
 // ---------------------------------------------------------------------------
 
 export const createApiKeySchema = z.object({
-  name: z.string().trim().min(1).max(255),
-  scopes: z.array(apiKeyScopeSchema).min(1),
-  expiresAt: z.coerce.date().optional(),
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .describe("Human-readable name for the API key"),
+  scopes: z
+    .array(apiKeyScopeSchema)
+    .min(1)
+    .describe("Permission scopes to grant (at least one)"),
+  expiresAt: z.coerce
+    .date()
+    .optional()
+    .describe("Optional expiration date (ISO-8601)"),
 });
 
 export type CreateApiKeyInput = z.infer<typeof createApiKeySchema>;
 
 export const revokeApiKeySchema = z.object({
-  keyId: z.string().uuid(),
+  keyId: z.string().uuid().describe("ID of the API key to revoke"),
 });
 
 export const deleteApiKeySchema = z.object({
-  keyId: z.string().uuid(),
+  keyId: z.string().uuid().describe("ID of the API key to delete"),
 });
 
 // ---------------------------------------------------------------------------
@@ -46,30 +59,45 @@ export const deleteApiKeySchema = z.object({
 // ---------------------------------------------------------------------------
 
 export const apiKeyResponseSchema = z.object({
-  id: z.string().uuid(),
-  name: z.string(),
-  scopes: z.array(apiKeyScopeSchema),
-  keyPrefix: z.string(),
-  createdAt: z.date(),
-  expiresAt: z.date().nullable(),
-  lastUsedAt: z.date().nullable(),
-  revokedAt: z.date().nullable(),
+  id: z.string().uuid().describe("Unique identifier for the API key"),
+  name: z.string().describe("Human-readable name"),
+  scopes: z.array(apiKeyScopeSchema).describe("Granted permission scopes"),
+  keyPrefix: z
+    .string()
+    .describe(
+      "First characters of the key for identification (e.g. col_live_abc...)",
+    ),
+  createdAt: z.date().describe("When the key was created"),
+  expiresAt: z
+    .date()
+    .nullable()
+    .describe("When the key expires (null = never)"),
+  lastUsedAt: z
+    .date()
+    .nullable()
+    .describe("When the key was last used for authentication"),
+  revokedAt: z
+    .date()
+    .nullable()
+    .describe("When the key was revoked (null = active)"),
 });
 
 export type ApiKeyResponse = z.infer<typeof apiKeyResponseSchema>;
 
 /** Returned from `apiKeys.revoke` — subset of key metadata with revokedAt. */
 export const revokeApiKeyResponseSchema = z.object({
-  id: z.string().uuid(),
-  name: z.string(),
-  revokedAt: z.date().nullable(),
+  id: z.string().uuid().describe("API key ID"),
+  name: z.string().describe("Human-readable name"),
+  revokedAt: z.date().nullable().describe("When the key was revoked"),
 });
 
 export type RevokeApiKeyResponse = z.infer<typeof revokeApiKeyResponseSchema>;
 
 /** Only returned once on creation — plainTextKey is shown once, never stored. */
 export const createApiKeyResponseSchema = apiKeyResponseSchema.extend({
-  plainTextKey: z.string(),
+  plainTextKey: z
+    .string()
+    .describe("The full API key — shown only once, never stored"),
 });
 
 export type CreateApiKeyResponse = z.infer<typeof createApiKeyResponseSchema>;

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -185,33 +185,66 @@ export type AuditLogParams =
 
 /** List/filter input schema for audit events. */
 export const listAuditEventsSchema = z.object({
-  action: z.nativeEnum(AuditActions).optional(),
-  resource: z.nativeEnum(AuditResources).optional(),
-  actorId: z.string().uuid().optional(),
-  resourceId: z.string().uuid().optional(),
-  from: z.coerce.date().optional(),
-  to: z.coerce.date().optional(),
-  page: z.number().int().min(1).default(1),
-  limit: z.number().int().min(1).max(100).default(20),
+  action: z
+    .nativeEnum(AuditActions)
+    .optional()
+    .describe("Filter by audit action (e.g. ORG_CREATED)"),
+  resource: z
+    .nativeEnum(AuditResources)
+    .optional()
+    .describe("Filter by resource type (e.g. organization)"),
+  actorId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Filter by the user who performed the action"),
+  resourceId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Filter by the affected resource ID"),
+  from: z.coerce.date().optional().describe("Start of date range (ISO-8601)"),
+  to: z.coerce.date().optional().describe("End of date range (ISO-8601)"),
+  page: z.number().int().min(1).default(1).describe("Page number (1-based)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page (1-100, default 20)"),
 });
 
 export type ListAuditEventsInput = z.infer<typeof listAuditEventsSchema>;
 
 /** Single audit event response schema. */
 export const auditEventResponseSchema = z.object({
-  id: z.string().uuid(),
-  action: z.string(),
-  resource: z.string(),
-  resourceId: z.string().uuid().nullable(),
-  actorId: z.string().uuid().nullable(),
-  oldValue: z.unknown().nullable(),
-  newValue: z.unknown().nullable(),
-  ipAddress: z.string().nullable(),
-  userAgent: z.string().nullable(),
-  requestId: z.string().nullable(),
-  method: z.string().nullable(),
-  route: z.string().nullable(),
-  createdAt: z.date(),
+  id: z.string().uuid().describe("Unique identifier for the audit event"),
+  action: z.string().describe("Action that was performed (e.g. ORG_CREATED)"),
+  resource: z
+    .string()
+    .describe("Resource type that was affected (e.g. organization)"),
+  resourceId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("ID of the affected resource"),
+  actorId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("ID of the user who performed the action"),
+  oldValue: z.unknown().nullable().describe("Previous state before the change"),
+  newValue: z.unknown().nullable().describe("New state after the change"),
+  ipAddress: z.string().nullable().describe("IP address of the request"),
+  userAgent: z
+    .string()
+    .nullable()
+    .describe("User-Agent header from the request"),
+  requestId: z.string().nullable().describe("Correlation ID for the request"),
+  method: z.string().nullable().describe("HTTP method of the request"),
+  route: z.string().nullable().describe("API route that was called"),
+  createdAt: z.date().describe("When the audit event was recorded"),
 });
 
 export type AuditEventResponse = z.infer<typeof auditEventResponseSchema>;

--- a/packages/types/src/common.ts
+++ b/packages/types/src/common.ts
@@ -1,19 +1,25 @@
 import { z } from "zod";
 
 export const paginationSchema = z.object({
-  page: z.number().int().min(1).default(1),
-  limit: z.number().int().min(1).max(100).default(20),
+  page: z.number().int().min(1).default(1).describe("Page number (1-based)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page (1-100, default 20)"),
 });
 
 export type PaginationInput = z.infer<typeof paginationSchema>;
 
 export const paginatedResponseSchema = <T extends z.ZodType>(itemSchema: T) =>
   z.object({
-    items: z.array(itemSchema),
-    total: z.number(),
-    page: z.number(),
-    limit: z.number(),
-    totalPages: z.number(),
+    items: z.array(itemSchema).describe("Items on the current page"),
+    total: z.number().describe("Total number of items across all pages"),
+    page: z.number().describe("Current page number"),
+    limit: z.number().describe("Items per page"),
+    totalPages: z.number().describe("Total number of pages"),
   });
 
 export type PaginatedResponse<T> = {
@@ -25,7 +31,7 @@ export type PaginatedResponse<T> = {
 };
 
 export const successResponseSchema = z.object({
-  success: z.literal(true),
+  success: z.literal(true).describe("Always true on success"),
 });
 
 export type SuccessResponse = z.infer<typeof successResponseSchema>;
@@ -36,25 +42,29 @@ export const uuidSchema = z.string().uuid();
 // Reusable ID param schemas for API surfaces (tRPC, REST, GraphQL)
 // ---------------------------------------------------------------------------
 
-export const idParamSchema = z.object({ id: z.string().uuid() });
+export const idParamSchema = z.object({
+  id: z.string().uuid().describe("Resource UUID"),
+});
 export type IdParam = z.infer<typeof idParamSchema>;
 
-export const fileIdParamSchema = z.object({ fileId: z.string().uuid() });
+export const fileIdParamSchema = z.object({
+  fileId: z.string().uuid().describe("File UUID"),
+});
 export type FileIdParam = z.infer<typeof fileIdParamSchema>;
 
 export const submissionIdParamSchema = z.object({
-  submissionId: z.string().uuid(),
+  submissionId: z.string().uuid().describe("Submission UUID"),
 });
 export type SubmissionIdParam = z.infer<typeof submissionIdParamSchema>;
 
 export const memberIdParamSchema = z.object({
-  memberId: z.string().uuid(),
+  memberId: z.string().uuid().describe("Membership record UUID"),
 });
 export type MemberIdParam = z.infer<typeof memberIdParamSchema>;
 
 export const dateRangeSchema = z.object({
-  from: z.date().optional(),
-  to: z.date().optional(),
+  from: z.date().optional().describe("Start of date range (ISO-8601)"),
+  to: z.date().optional().describe("End of date range (ISO-8601)"),
 });
 
 export type DateRange = z.infer<typeof dateRangeSchema>;

--- a/packages/types/src/file.ts
+++ b/packages/types/src/file.ts
@@ -1,12 +1,8 @@
 import { z } from "zod";
 
-export const scanStatusSchema = z.enum([
-  "PENDING",
-  "SCANNING",
-  "CLEAN",
-  "INFECTED",
-  "FAILED",
-]);
+export const scanStatusSchema = z
+  .enum(["PENDING", "SCANNING", "CLEAN", "INFECTED", "FAILED"])
+  .describe("Virus scan status for an uploaded file");
 
 export type ScanStatus = z.infer<typeof scanStatusSchema>;
 
@@ -54,24 +50,30 @@ export const MAX_TOTAL_UPLOAD_SIZE = 200 * 1024 * 1024;
 export const MAX_FILES_PER_SUBMISSION = 10;
 
 export const submissionFileSchema = z.object({
-  id: z.string().uuid(),
-  submissionId: z.string().uuid(),
-  filename: z.string(),
-  mimeType: z.string(),
-  size: z.number(),
-  storageKey: z.string(),
+  id: z.string().uuid().describe("Unique identifier for the file"),
+  submissionId: z
+    .string()
+    .uuid()
+    .describe("ID of the submission this file belongs to"),
+  filename: z.string().describe("Original filename as uploaded"),
+  mimeType: z.string().describe("MIME type of the file (e.g. application/pdf)"),
+  size: z.number().describe("File size in bytes"),
+  storageKey: z.string().describe("Object storage key"),
   scanStatus: scanStatusSchema,
-  scannedAt: z.date().nullable(),
-  uploadedAt: z.date(),
+  scannedAt: z.date().nullable().describe("When the virus scan completed"),
+  uploadedAt: z.date().describe("When the file was uploaded"),
 });
 
 export type SubmissionFile = z.infer<typeof submissionFileSchema>;
 
 /** Response from `files.getDownloadUrl`. */
 export const downloadUrlResponseSchema = z.object({
-  url: z.string().url(),
-  filename: z.string(),
-  mimeType: z.string(),
+  url: z
+    .string()
+    .url()
+    .describe("Pre-signed download URL (expires in minutes)"),
+  filename: z.string().describe("Original filename"),
+  mimeType: z.string().describe("MIME type of the file"),
 });
 
 export type DownloadUrlResponse = z.infer<typeof downloadUrlResponseSchema>;
@@ -81,10 +83,22 @@ export type DownloadUrlResponse = z.infer<typeof downloadUrlResponseSchema>;
  * Client provides metadata, server returns upload URL.
  */
 export const initiateUploadSchema = z.object({
-  submissionId: z.string().uuid(),
-  filename: z.string().min(1).max(255),
-  mimeType: z.string(),
-  size: z.number().int().positive().max(MAX_FILE_SIZE),
+  submissionId: z
+    .string()
+    .uuid()
+    .describe("ID of the submission to attach the file to"),
+  filename: z
+    .string()
+    .min(1)
+    .max(255)
+    .describe("Original filename (1-255 chars)"),
+  mimeType: z.string().describe("MIME type of the file"),
+  size: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_FILE_SIZE)
+    .describe("File size in bytes (max 50MB)"),
 });
 
 export type InitiateUploadInput = z.infer<typeof initiateUploadSchema>;
@@ -94,9 +108,9 @@ export type InitiateUploadInput = z.infer<typeof initiateUploadSchema>;
  * Contains the tus upload URL and file ID.
  */
 export const initiateUploadResponseSchema = z.object({
-  fileId: z.string().uuid(),
-  uploadUrl: z.string().url(),
-  expiresAt: z.date(),
+  fileId: z.string().uuid().describe("ID assigned to the new file record"),
+  uploadUrl: z.string().url().describe("tus upload endpoint URL"),
+  expiresAt: z.date().describe("When the upload URL expires"),
 });
 
 export type InitiateUploadResponse = z.infer<

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
 export const organizationSchema = z.object({
-  id: z.string().uuid(),
-  name: z.string(),
-  slug: z.string(),
-  settings: z.record(z.string(), z.unknown()),
-  createdAt: z.date(),
-  updatedAt: z.date(),
+  id: z.string().uuid().describe("Unique identifier for the organization"),
+  name: z.string().describe("Display name of the organization"),
+  slug: z.string().describe("URL-friendly identifier for the organization"),
+  settings: z
+    .record(z.string(), z.unknown())
+    .describe("Organization-specific settings as key-value pairs"),
+  createdAt: z.date().describe("When the organization was created"),
+  updatedAt: z.date().describe("When the organization was last updated"),
 });
 
 export type Organization = z.infer<typeof organizationSchema>;
@@ -15,20 +17,36 @@ export const slugSchema = z
   .string()
   .min(3)
   .max(63)
-  .regex(/^[a-z0-9-]+$/, "Slug must be lowercase alphanumeric with hyphens");
+  .regex(/^[a-z0-9-]+$/, "Slug must be lowercase alphanumeric with hyphens")
+  .describe(
+    "URL-friendly identifier (3-63 chars, lowercase alphanumeric with hyphens)",
+  );
 
-export const checkSlugSchema = z.object({ slug: slugSchema });
+export const checkSlugSchema = z.object({
+  slug: slugSchema.describe("Slug to check availability for"),
+});
 export type CheckSlugInput = z.infer<typeof checkSlugSchema>;
 
 export const createOrganizationSchema = z.object({
-  name: z.string().trim().min(1).max(255),
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .describe("Display name of the organization"),
   slug: slugSchema,
 });
 
 export type CreateOrganizationInput = z.infer<typeof createOrganizationSchema>;
 
 export const updateOrganizationSchema = z.object({
-  name: z.string().trim().min(1).max(255).optional(),
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .optional()
+    .describe("New display name"),
   settings: z
     .record(
       z.string().max(100),
@@ -37,29 +55,32 @@ export const updateOrganizationSchema = z.object({
     .refine((obj) => Object.keys(obj).length <= 50, {
       message: "Settings limited to 50 keys",
     })
-    .optional(),
+    .optional()
+    .describe("Organization settings (max 50 keys)"),
 });
 
 export type UpdateOrganizationInput = z.infer<typeof updateOrganizationSchema>;
 
-export const roleSchema = z.enum(["ADMIN", "EDITOR", "READER"]);
+export const roleSchema = z
+  .enum(["ADMIN", "EDITOR", "READER"])
+  .describe("Member role within an organization");
 export type Role = z.infer<typeof roleSchema>;
 
 export const organizationMemberSchema = z.object({
-  id: z.string().uuid(),
-  userId: z.string().uuid(),
-  email: z.string().email(),
+  id: z.string().uuid().describe("Membership record ID"),
+  userId: z.string().uuid().describe("ID of the member user"),
+  email: z.string().email().describe("Email address of the member"),
   role: roleSchema,
-  createdAt: z.date(),
+  createdAt: z.date().describe("When the member was added"),
 });
 
 export type OrganizationMember = z.infer<typeof organizationMemberSchema>;
 
 /** Shape returned by `listUserOrganizations()` (uses `organizationId`, not `id`). */
 export const userOrganizationSchema = z.object({
-  organizationId: z.string().uuid(),
-  name: z.string(),
-  slug: z.string(),
+  organizationId: z.string().uuid().describe("ID of the organization"),
+  name: z.string().describe("Display name of the organization"),
+  slug: z.string().describe("URL-friendly identifier"),
   role: roleSchema,
 });
 
@@ -67,22 +88,24 @@ export type UserOrganization = z.infer<typeof userOrganizationSchema>;
 
 /** Slug availability check response. */
 export const slugAvailabilitySchema = z.object({
-  available: z.boolean(),
+  available: z.boolean().describe("Whether the slug is available for use"),
 });
 
 export type SlugAvailability = z.infer<typeof slugAvailabilitySchema>;
 
 /** Response from `organizations.create` — org + creator membership. */
 export const createOrganizationResponseSchema = z.object({
-  organization: organizationSchema,
-  membership: z.object({
-    id: z.string().uuid(),
-    organizationId: z.string().uuid(),
-    userId: z.string().uuid(),
-    role: roleSchema,
-    createdAt: z.date(),
-    updatedAt: z.date(),
-  }),
+  organization: organizationSchema.describe("The newly created organization"),
+  membership: z
+    .object({
+      id: z.string().uuid().describe("Membership record ID"),
+      organizationId: z.string().uuid().describe("ID of the organization"),
+      userId: z.string().uuid().describe("ID of the creator user"),
+      role: roleSchema,
+      createdAt: z.date().describe("When the membership was created"),
+      updatedAt: z.date().describe("When the membership was last updated"),
+    })
+    .describe("The creator's membership in the new organization"),
 });
 
 export type CreateOrganizationResponse = z.infer<
@@ -94,12 +117,12 @@ export type CreateOrganizationResponse = z.infer<
  * which has `email` from JOIN and lacks `organizationId`/`updatedAt`.
  */
 export const organizationMemberMutationResponseSchema = z.object({
-  id: z.string().uuid(),
-  organizationId: z.string().uuid(),
-  userId: z.string().uuid(),
+  id: z.string().uuid().describe("Membership record ID"),
+  organizationId: z.string().uuid().describe("ID of the organization"),
+  userId: z.string().uuid().describe("ID of the member user"),
   role: roleSchema,
-  createdAt: z.date(),
-  updatedAt: z.date(),
+  createdAt: z.date().describe("When the membership was created"),
+  updatedAt: z.date().describe("When the membership was last updated"),
 });
 
 export type OrganizationMemberMutationResponse = z.infer<
@@ -107,15 +130,15 @@ export type OrganizationMemberMutationResponse = z.infer<
 >;
 
 export const inviteMemberSchema = z.object({
-  email: z.string().email(),
-  role: roleSchema,
+  email: z.string().email().describe("Email address of the user to invite"),
+  role: roleSchema.describe("Role to assign to the new member"),
 });
 
 export type InviteMemberInput = z.infer<typeof inviteMemberSchema>;
 
 export const updateMemberRoleSchema = z.object({
-  memberId: z.string().uuid(),
-  role: roleSchema,
+  memberId: z.string().uuid().describe("ID of the membership record to update"),
+  role: roleSchema.describe("New role for the member"),
 });
 
 export type UpdateMemberRoleInput = z.infer<typeof updateMemberRoleSchema>;

--- a/packages/types/src/submission.ts
+++ b/packages/types/src/submission.ts
@@ -1,15 +1,17 @@
 import { z } from "zod";
 import { scanStatusSchema, submissionFileSchema } from "./file";
 
-export const submissionStatusSchema = z.enum([
-  "DRAFT",
-  "SUBMITTED",
-  "UNDER_REVIEW",
-  "ACCEPTED",
-  "REJECTED",
-  "HOLD",
-  "WITHDRAWN",
-]);
+export const submissionStatusSchema = z
+  .enum([
+    "DRAFT",
+    "SUBMITTED",
+    "UNDER_REVIEW",
+    "ACCEPTED",
+    "REJECTED",
+    "HOLD",
+    "WITHDRAWN",
+  ])
+  .describe("Current status in the submission workflow");
 
 export type SubmissionStatus = z.infer<typeof submissionStatusSchema>;
 
@@ -18,34 +20,70 @@ export { scanStatusSchema };
 export type { ScanStatus } from "./file";
 
 export const submissionSchema = z.object({
-  id: z.string().uuid(),
-  organizationId: z.string().uuid(),
-  submitterId: z.string().uuid(),
-  submissionPeriodId: z.string().uuid().nullable(),
-  title: z.string().nullable(),
-  content: z.string().nullable(),
-  coverLetter: z.string().nullable(),
+  id: z.string().uuid().describe("Unique identifier for the submission"),
+  organizationId: z
+    .string()
+    .uuid()
+    .describe("ID of the organization this submission belongs to"),
+  submitterId: z
+    .string()
+    .uuid()
+    .describe("ID of the user who created the submission"),
+  submissionPeriodId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("ID of the submission period, if applicable"),
+  title: z.string().nullable().describe("Title of the submission"),
+  content: z.string().nullable().describe("Body content of the submission"),
+  coverLetter: z.string().nullable().describe("Optional cover letter"),
   status: submissionStatusSchema,
-  submittedAt: z.date().nullable(),
-  createdAt: z.date(),
-  updatedAt: z.date(),
+  submittedAt: z
+    .date()
+    .nullable()
+    .describe("When the submission was formally submitted"),
+  createdAt: z.date().describe("When the submission was created"),
+  updatedAt: z.date().describe("When the submission was last updated"),
 });
 
 export type Submission = z.infer<typeof submissionSchema>;
 
 export const createSubmissionSchema = z.object({
-  title: z.string().trim().min(1).max(500),
-  content: z.string().max(50000).optional(),
-  coverLetter: z.string().max(10000).optional(),
-  submissionPeriodId: z.string().uuid().optional(),
+  title: z
+    .string()
+    .trim()
+    .min(1)
+    .max(500)
+    .describe("Title of the submission (1-500 chars)"),
+  content: z
+    .string()
+    .max(50000)
+    .optional()
+    .describe("Body content (max 50,000 chars)"),
+  coverLetter: z
+    .string()
+    .max(10000)
+    .optional()
+    .describe("Optional cover letter (max 10,000 chars)"),
+  submissionPeriodId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Submission period to associate with"),
 });
 
 export type CreateSubmissionInput = z.infer<typeof createSubmissionSchema>;
 
 export const updateSubmissionSchema = z.object({
-  title: z.string().trim().min(1).max(500).optional(),
-  content: z.string().max(50000).optional(),
-  coverLetter: z.string().max(10000).optional(),
+  title: z
+    .string()
+    .trim()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("New title for the submission"),
+  content: z.string().max(50000).optional().describe("New body content"),
+  coverLetter: z.string().max(10000).optional().describe("New cover letter"),
 });
 
 export type UpdateSubmissionInput = z.infer<typeof updateSubmissionSchema>;
@@ -54,29 +92,48 @@ export type UpdateSubmissionInput = z.infer<typeof updateSubmissionSchema>;
 export { submissionFileSchema, type SubmissionFile } from "./file";
 
 export const submissionHistorySchema = z.object({
-  id: z.string().uuid(),
-  submissionId: z.string().uuid(),
-  fromStatus: submissionStatusSchema.nullable(),
-  toStatus: submissionStatusSchema,
-  changedBy: z.string().uuid().nullable(),
-  comment: z.string().nullable(),
-  changedAt: z.date(),
+  id: z.string().uuid().describe("History entry ID"),
+  submissionId: z.string().uuid().describe("ID of the submission"),
+  fromStatus: submissionStatusSchema
+    .nullable()
+    .describe("Previous status (null for initial creation)"),
+  toStatus: submissionStatusSchema.describe("New status after the transition"),
+  changedBy: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("ID of the user who made the change"),
+  comment: z
+    .string()
+    .nullable()
+    .describe("Optional comment explaining the status change"),
+  changedAt: z.date().describe("When the status change occurred"),
 });
 
 export type SubmissionHistory = z.infer<typeof submissionHistorySchema>;
 
 /** Submission detail — includes files and submitter email (for `getById`). */
 export const submissionDetailSchema = submissionSchema.extend({
-  files: z.array(submissionFileSchema),
-  submitterEmail: z.string().email().nullable(),
+  files: z
+    .array(submissionFileSchema)
+    .describe("Files attached to this submission"),
+  submitterEmail: z
+    .string()
+    .email()
+    .nullable()
+    .describe("Email address of the submitter"),
 });
 
 export type SubmissionDetail = z.infer<typeof submissionDetailSchema>;
 
 /** Response from status-change mutations (submit, withdraw, updateStatus). */
 export const submissionStatusChangeResponseSchema = z.object({
-  submission: submissionSchema,
-  historyEntry: submissionHistorySchema,
+  submission: submissionSchema.describe(
+    "The submission after the status change",
+  ),
+  historyEntry: submissionHistorySchema.describe(
+    "The history entry for this transition",
+  ),
 });
 
 export type SubmissionStatusChangeResponse = z.infer<
@@ -84,8 +141,12 @@ export type SubmissionStatusChangeResponse = z.infer<
 >;
 
 export const updateSubmissionStatusSchema = z.object({
-  status: submissionStatusSchema,
-  comment: z.string().max(1000).optional(),
+  status: submissionStatusSchema.describe("Target status for the transition"),
+  comment: z
+    .string()
+    .max(1000)
+    .optional()
+    .describe("Optional comment for the status change (max 1,000 chars)"),
 });
 
 export type UpdateSubmissionStatusInput = z.infer<
@@ -93,37 +154,77 @@ export type UpdateSubmissionStatusInput = z.infer<
 >;
 
 export const listSubmissionsSchema = z.object({
-  status: submissionStatusSchema.optional(),
-  submissionPeriodId: z.string().uuid().optional(),
-  search: z.string().trim().max(200).optional(),
-  page: z.number().int().min(1).default(1),
-  limit: z.number().int().min(1).max(100).default(20),
+  status: submissionStatusSchema
+    .optional()
+    .describe("Filter by submission status"),
+  submissionPeriodId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Filter by submission period"),
+  search: z
+    .string()
+    .trim()
+    .max(200)
+    .optional()
+    .describe("Full-text search query (max 200 chars)"),
+  page: z.number().int().min(1).default(1).describe("Page number (1-based)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page (1-100, default 20)"),
 });
 
 export type ListSubmissionsInput = z.infer<typeof listSubmissionsSchema>;
 
 export const submissionPeriodSchema = z.object({
-  id: z.string().uuid(),
-  organizationId: z.string().uuid(),
-  name: z.string(),
-  description: z.string().nullable(),
-  opensAt: z.date(),
-  closesAt: z.date(),
-  fee: z.number().nullable(),
-  maxSubmissions: z.number().nullable(),
-  createdAt: z.date(),
-  updatedAt: z.date(),
+  id: z.string().uuid().describe("Unique identifier for the submission period"),
+  organizationId: z.string().uuid().describe("ID of the owning organization"),
+  name: z.string().describe("Display name of the period"),
+  description: z
+    .string()
+    .nullable()
+    .describe("Optional description of the period"),
+  opensAt: z.date().describe("When submissions open"),
+  closesAt: z.date().describe("When submissions close"),
+  fee: z.number().nullable().describe("Submission fee in cents (null = free)"),
+  maxSubmissions: z
+    .number()
+    .nullable()
+    .describe("Max submissions allowed (null = unlimited)"),
+  createdAt: z.date().describe("When the period was created"),
+  updatedAt: z.date().describe("When the period was last updated"),
 });
 
 export type SubmissionPeriod = z.infer<typeof submissionPeriodSchema>;
 
 export const createSubmissionPeriodSchema = z.object({
-  name: z.string().min(1).max(255),
-  description: z.string().max(2000).optional(),
-  opensAt: z.date(),
-  closesAt: z.date(),
-  fee: z.number().min(0).optional(),
-  maxSubmissions: z.number().int().min(1).optional(),
+  name: z
+    .string()
+    .min(1)
+    .max(255)
+    .describe("Display name for the submission period"),
+  description: z
+    .string()
+    .max(2000)
+    .optional()
+    .describe("Description of the period (max 2,000 chars)"),
+  opensAt: z.date().describe("When submissions open (ISO-8601)"),
+  closesAt: z.date().describe("When submissions close (ISO-8601)"),
+  fee: z
+    .number()
+    .min(0)
+    .optional()
+    .describe("Submission fee in cents (omit for free)"),
+  maxSubmissions: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe("Maximum number of submissions (omit for unlimited)"),
 });
 
 export type CreateSubmissionPeriodInput = z.infer<

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -1,34 +1,40 @@
 import { z } from "zod";
 
 export const userSchema = z.object({
-  id: z.string().uuid(),
-  email: z.string().email(),
-  emailVerified: z.boolean(),
-  createdAt: z.date(),
-  updatedAt: z.date(),
+  id: z.string().uuid().describe("Unique identifier for the user"),
+  email: z.string().email().describe("Primary email address"),
+  emailVerified: z
+    .boolean()
+    .describe("Whether the email has been verified via Zitadel"),
+  createdAt: z.date().describe("When the user account was created"),
+  updatedAt: z.date().describe("When the user account was last updated"),
 });
 
 export type User = z.infer<typeof userSchema>;
 
 export const updateUserSchema = z.object({
-  email: z.string().email().optional(),
+  email: z.string().email().optional().describe("New email address"),
 });
 
 export type UpdateUserInput = z.infer<typeof updateUserSchema>;
 
 export const userProfileSchema = z.object({
-  id: z.string().uuid(),
-  email: z.string().email(),
-  emailVerified: z.boolean(),
-  createdAt: z.date(),
-  organizations: z.array(
-    z.object({
-      id: z.string().uuid(),
-      name: z.string(),
-      slug: z.string(),
-      role: z.enum(["ADMIN", "EDITOR", "READER"]),
-    }),
-  ),
+  id: z.string().uuid().describe("Unique identifier for the user"),
+  email: z.string().email().describe("Primary email address"),
+  emailVerified: z.boolean().describe("Whether the email has been verified"),
+  createdAt: z.date().describe("When the user account was created"),
+  organizations: z
+    .array(
+      z.object({
+        id: z.string().uuid().describe("Organization ID"),
+        name: z.string().describe("Organization name"),
+        slug: z.string().describe("Organization slug"),
+        role: z
+          .enum(["ADMIN", "EDITOR", "READER"])
+          .describe("User's role in this organization"),
+      }),
+    )
+    .describe("Organizations the user belongs to"),
 });
 
 export type UserProfile = z.infer<typeof userProfileSchema>;

--- a/scripts/export-openapi.ts
+++ b/scripts/export-openapi.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env tsx
+/**
+ * Export the OpenAPI 3.1 specification from the running API server.
+ *
+ * Requires the dev server to be running (`pnpm dev`).
+ *
+ * Usage:
+ *   pnpm sdk:export-spec
+ *   npx tsx scripts/export-openapi.ts [base-url]
+ *
+ * Output: sdks/openapi.json
+ */
+
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+
+const baseUrl = process.argv[2] ?? "http://localhost:4000";
+
+async function main() {
+  const url = `${baseUrl}/v1/openapi.json`;
+  console.log(`Fetching OpenAPI spec from ${url}...`);
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch OpenAPI spec: ${res.status} ${res.statusText}`,
+    );
+  }
+
+  const spec = (await res.json()) as Record<string, unknown>;
+
+  const outPath = resolve(
+    dirname(new URL(import.meta.url).pathname),
+    "../sdks/openapi.json",
+  );
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, JSON.stringify(spec, null, 2) + "\n");
+  console.log(`OpenAPI spec written to ${outPath}`);
+}
+
+main().catch((err) => {
+  console.error(
+    "Error: Could not fetch OpenAPI spec. Is the dev server running? (pnpm dev)",
+  );
+  console.error(err.message);
+  process.exit(1);
+});

--- a/scripts/export-schema.ts
+++ b/scripts/export-schema.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env tsx
+/**
+ * Export the GraphQL SDL schema from the Pothos builder.
+ *
+ * Usage:
+ *   pnpm sdk:export-schema
+ *   npx tsx scripts/export-schema.ts
+ *
+ * Output: sdks/schema.graphql
+ */
+
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { printSchema } from "graphql";
+import { schema } from "../apps/api/src/graphql/schema.js";
+
+const sdl = printSchema(schema);
+
+const outPath = resolve(
+  dirname(new URL(import.meta.url).pathname),
+  "../sdks/schema.graphql",
+);
+mkdirSync(dirname(outPath), { recursive: true });
+writeFileSync(outPath, sdl + "\n");
+console.log(`GraphQL schema written to ${outPath}`);

--- a/sdks/openapi.json
+++ b/sdks/openapi.json
@@ -1,0 +1,1689 @@
+{
+  "servers": [
+    {
+      "url": "/v1",
+      "description": "Current version"
+    }
+  ],
+  "info": {
+    "title": "Colophony API",
+    "version": "2.0.0",
+    "description": "REST API for Colophony, the open-source infrastructure suite for literary magazines. Covers submission intake, review pipelines, file management, and organization administration.\n\n## Authentication\n\nAll endpoints require authentication via one of:\n- **Bearer token** \u2014 Zitadel OIDC access token in the `Authorization` header\n- **API key** \u2014 Organization-scoped key in the `X-Api-Key` header\n\nMost endpoints also require the `X-Organization-Id` header to set the organization context.",
+    "contact": {
+      "name": "Colophony",
+      "url": "https://github.com/colophony/colophony"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "tags": [
+    {
+      "name": "Organizations",
+      "description": "Manage organizations and their members. Organizations are the top-level tenant in Colophony."
+    },
+    {
+      "name": "Submissions",
+      "description": "Create, review, and manage literary submissions through the editorial workflow."
+    },
+    {
+      "name": "Files",
+      "description": "List, download, and delete files attached to submissions. Uploads use the tus protocol."
+    },
+    {
+      "name": "Users",
+      "description": "User profile and account information. User lifecycle is managed via Zitadel."
+    },
+    {
+      "name": "API Keys",
+      "description": "Create and manage organization-scoped API keys for programmatic access."
+    },
+    {
+      "name": "Audit",
+      "description": "Query the audit log for security and compliance. Admin-only."
+    }
+  ],
+  "externalDocs": {
+    "description": "Colophony source code and documentation",
+    "url": "https://github.com/colophony/colophony"
+  },
+  "openapi": "3.1.1",
+  "paths": {
+    "/organizations": {
+      "get": {
+        "operationId": "listOrganizations",
+        "summary": "List organizations",
+        "description": "Returns all organizations the authenticated user is a member of.",
+        "tags": ["Organizations"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createOrganization",
+        "summary": "Create an organization",
+        "description": "Create a new organization. The authenticated user becomes the first ADMIN member.",
+        "tags": ["Organizations"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "description": "Display name of the organization"
+                  },
+                  "slug": {
+                    "type": "string",
+                    "minLength": 3,
+                    "maxLength": 63,
+                    "pattern": "^[a-z0-9-]+$",
+                    "description": "URL-friendly identifier (3-63 chars, lowercase alphanumeric with hyphens)"
+                  }
+                },
+                "required": ["name", "slug"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/check-slug": {
+      "get": {
+        "operationId": "checkSlugAvailability",
+        "summary": "Check slug availability",
+        "description": "Check whether a slug is available for use when creating an organization.",
+        "tags": ["Organizations"],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 63,
+              "pattern": "^[a-z0-9-]+$",
+              "description": "Slug to check availability for"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{orgId}": {
+      "get": {
+        "operationId": "getOrganization",
+        "summary": "Get an organization",
+        "description": "Retrieve a single organization by its ID.",
+        "tags": ["Organizations"],
+        "parameters": [
+          {
+            "name": "orgId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateOrganization",
+        "summary": "Update an organization",
+        "description": "Update an organization's name or settings. Requires ADMIN role.",
+        "tags": ["Organizations"],
+        "parameters": [
+          {
+            "name": "orgId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "description": "New display name"
+                  },
+                  "settings": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string",
+                      "maxLength": 100
+                    },
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "maxLength": 10000
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "description": "Organization settings (max 50 keys)"
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{orgId}/members": {
+      "get": {
+        "operationId": "listOrganizationMembers",
+        "summary": "List organization members",
+        "description": "Returns a paginated list of members for the specified organization.",
+        "tags": ["Organizations"],
+        "parameters": [
+          {
+            "name": "orgId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991,
+              "default": 1,
+              "description": "Page number (1-based)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Items per page (1-100, default 20)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "addOrganizationMember",
+        "summary": "Add a member",
+        "description": "Invite a user to the organization by email. The user must already have an account. Requires ADMIN role.",
+        "tags": ["Organizations"],
+        "parameters": [
+          {
+            "name": "orgId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email address of the user to invite"
+                  },
+                  "role": {
+                    "enum": ["ADMIN", "EDITOR", "READER"],
+                    "description": "Role to assign to the new member"
+                  }
+                },
+                "required": ["email", "role"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{orgId}/members/{memberId}": {
+      "delete": {
+        "operationId": "removeOrganizationMember",
+        "summary": "Remove a member",
+        "description": "Remove a member from the organization. Requires ADMIN role.",
+        "tags": ["Organizations"],
+        "parameters": [
+          {
+            "name": "orgId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "memberId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "required": []
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateOrganizationMemberRole",
+        "summary": "Update member role",
+        "description": "Change a member's role within the organization. Requires ADMIN role.",
+        "tags": ["Organizations"],
+        "parameters": [
+          {
+            "name": "orgId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "memberId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "role": {
+                    "enum": ["ADMIN", "EDITOR", "READER"],
+                    "description": "Member role within an organization"
+                  }
+                },
+                "required": ["role"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submissions/mine": {
+      "get": {
+        "operationId": "listMySubmissions",
+        "summary": "List my submissions",
+        "description": "Returns submissions created by the authenticated user in the current organization.",
+        "tags": ["Submissions"],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "DRAFT",
+                "SUBMITTED",
+                "UNDER_REVIEW",
+                "ACCEPTED",
+                "REJECTED",
+                "HOLD",
+                "WITHDRAWN"
+              ],
+              "description": "Filter by submission status"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "submissionPeriodId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by submission period"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "maxLength": 200,
+              "description": "Full-text search query (max 200 chars)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991,
+              "default": 1,
+              "description": "Page number (1-based)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Items per page (1-100, default 20)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submissions": {
+      "get": {
+        "operationId": "listSubmissions",
+        "summary": "List all submissions",
+        "description": "Returns all submissions in the organization. Requires EDITOR or ADMIN role.",
+        "tags": ["Submissions"],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "DRAFT",
+                "SUBMITTED",
+                "UNDER_REVIEW",
+                "ACCEPTED",
+                "REJECTED",
+                "HOLD",
+                "WITHDRAWN"
+              ],
+              "description": "Filter by submission status"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "submissionPeriodId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by submission period"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "maxLength": 200,
+              "description": "Full-text search query (max 200 chars)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991,
+              "default": 1,
+              "description": "Page number (1-based)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Items per page (1-100, default 20)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createSubmission",
+        "summary": "Create a submission",
+        "description": "Create a new submission in DRAFT status.",
+        "tags": ["Submissions"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500,
+                    "description": "Title of the submission (1-500 chars)"
+                  },
+                  "content": {
+                    "type": "string",
+                    "maxLength": 50000,
+                    "description": "Body content (max 50,000 chars)"
+                  },
+                  "coverLetter": {
+                    "type": "string",
+                    "maxLength": 10000,
+                    "description": "Optional cover letter (max 10,000 chars)"
+                  },
+                  "submissionPeriodId": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Submission period to associate with"
+                  }
+                },
+                "required": ["title"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submissions/{id}": {
+      "get": {
+        "operationId": "getSubmission",
+        "summary": "Get a submission",
+        "description": "Retrieve a single submission by ID, including attached files and submitter email.",
+        "tags": ["Submissions"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Resource UUID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateSubmission",
+        "summary": "Update a submission",
+        "description": "Update a submission's title, content, or cover letter. Only allowed while in DRAFT status.",
+        "tags": ["Submissions"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Resource UUID"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500,
+                    "description": "New title for the submission"
+                  },
+                  "content": {
+                    "type": "string",
+                    "maxLength": 50000,
+                    "description": "New body content"
+                  },
+                  "coverLetter": {
+                    "type": "string",
+                    "maxLength": 10000,
+                    "description": "New cover letter"
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteSubmission",
+        "summary": "Delete a submission",
+        "description": "Permanently delete a DRAFT submission and its attached files.",
+        "tags": ["Submissions"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Resource UUID"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "required": []
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submissions/{id}/submit": {
+      "post": {
+        "operationId": "submitSubmission",
+        "summary": "Submit a submission",
+        "description": "Transition a DRAFT submission to SUBMITTED status. Validates that all files have passed virus scanning.",
+        "tags": ["Submissions"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Resource UUID"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "required": []
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submissions/{id}/withdraw": {
+      "post": {
+        "operationId": "withdrawSubmission",
+        "summary": "Withdraw a submission",
+        "description": "Withdraw a submission from consideration. Allowed from DRAFT, SUBMITTED, UNDER_REVIEW, or HOLD status.",
+        "tags": ["Submissions"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Resource UUID"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "required": []
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submissions/{id}/status": {
+      "patch": {
+        "operationId": "updateSubmissionStatus",
+        "summary": "Update submission status",
+        "description": "Transition a submission to a new status. Requires EDITOR or ADMIN role. Valid transitions depend on current status.",
+        "tags": ["Submissions"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Resource UUID"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "enum": [
+                      "DRAFT",
+                      "SUBMITTED",
+                      "UNDER_REVIEW",
+                      "ACCEPTED",
+                      "REJECTED",
+                      "HOLD",
+                      "WITHDRAWN"
+                    ],
+                    "description": "Target status for the transition"
+                  },
+                  "comment": {
+                    "type": "string",
+                    "maxLength": 1000,
+                    "description": "Optional comment for the status change (max 1,000 chars)"
+                  }
+                },
+                "required": ["status"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submissions/{id}/history": {
+      "get": {
+        "operationId": "getSubmissionHistory",
+        "summary": "Get submission history",
+        "description": "Returns the status change history for a submission.",
+        "tags": ["Submissions"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Resource UUID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submissions/{submissionId}/files": {
+      "get": {
+        "operationId": "listSubmissionFiles",
+        "summary": "List submission files",
+        "description": "Returns all files attached to a submission.",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "submissionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Submission UUID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/files/{fileId}/download": {
+      "get": {
+        "operationId": "getFileDownloadUrl",
+        "summary": "Get file download URL",
+        "description": "Returns a pre-signed download URL for a file. Only available for files with CLEAN scan status.",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "File UUID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/files/{fileId}": {
+      "delete": {
+        "operationId": "deleteFile",
+        "summary": "Delete a file",
+        "description": "Delete a file from a submission. Only allowed while the submission is in DRAFT status.",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "File UUID"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "required": []
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/me": {
+      "get": {
+        "operationId": "getCurrentUser",
+        "summary": "Get current user profile",
+        "description": "Returns the authenticated user's profile including organization memberships.",
+        "tags": ["Users"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api-keys": {
+      "get": {
+        "operationId": "listApiKeys",
+        "summary": "List API keys",
+        "description": "Returns all API keys for the current organization. Key values are masked.",
+        "tags": ["API Keys"],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991,
+              "default": 1,
+              "description": "Page number (1-based)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Items per page (1-100, default 20)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createApiKey",
+        "summary": "Create an API key",
+        "description": "Create a new API key for the organization. The plain-text key is returned only once. Requires ADMIN role.",
+        "tags": ["API Keys"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "description": "Human-readable name for the API key"
+                  },
+                  "scopes": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "enum": [
+                        "submissions:read",
+                        "submissions:write",
+                        "files:read",
+                        "files:write",
+                        "organizations:read",
+                        "organizations:write",
+                        "users:read",
+                        "api-keys:read",
+                        "api-keys:manage",
+                        "payments:read",
+                        "webhooks:manage",
+                        "audit:read"
+                      ],
+                      "description": "Permission scope for the API key"
+                    },
+                    "description": "Permission scopes to grant (at least one)"
+                  },
+                  "expiresAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "x-native-type": "date",
+                    "description": "Optional expiration date (ISO-8601)"
+                  }
+                },
+                "required": ["name", "scopes"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api-keys/{keyId}/revoke": {
+      "post": {
+        "operationId": "revokeApiKey",
+        "summary": "Revoke an API key",
+        "description": "Revoke an API key so it can no longer be used for authentication. Requires ADMIN role.",
+        "tags": ["API Keys"],
+        "parameters": [
+          {
+            "name": "keyId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "required": []
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api-keys/{keyId}": {
+      "delete": {
+        "operationId": "deleteApiKey",
+        "summary": "Delete an API key",
+        "description": "Permanently delete an API key. Requires ADMIN role.",
+        "tags": ["API Keys"],
+        "parameters": [
+          {
+            "name": "keyId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "required": []
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/audit-events": {
+      "get": {
+        "operationId": "listAuditEvents",
+        "summary": "List audit events",
+        "description": "Returns a paginated, filterable list of audit events for the current organization. Requires ADMIN role.",
+        "tags": ["Audit"],
+        "parameters": [
+          {
+            "name": "action",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "USER_CREATED",
+                "USER_UPDATED",
+                "USER_DEACTIVATED",
+                "USER_REACTIVATED",
+                "USER_REMOVED",
+                "USER_EMAIL_VERIFIED",
+                "ORG_CREATED",
+                "ORG_UPDATED",
+                "ORG_DELETED",
+                "ORG_MEMBER_ADDED",
+                "ORG_MEMBER_REMOVED",
+                "ORG_MEMBER_ROLE_CHANGED",
+                "SUBMISSION_CREATED",
+                "SUBMISSION_UPDATED",
+                "SUBMISSION_SUBMITTED",
+                "SUBMISSION_STATUS_CHANGED",
+                "SUBMISSION_DELETED",
+                "SUBMISSION_WITHDRAWN",
+                "FILE_UPLOADED",
+                "FILE_DELETED",
+                "FILE_SCAN_CLEAN",
+                "FILE_SCAN_INFECTED",
+                "FILE_SCAN_FAILED",
+                "AUTH_TOKEN_INVALID",
+                "AUTH_TOKEN_EXPIRED",
+                "AUTH_USER_NOT_PROVISIONED",
+                "AUTH_USER_DEACTIVATED",
+                "API_KEY_CREATED",
+                "API_KEY_REVOKED",
+                "API_KEY_DELETED",
+                "API_KEY_AUTH_SUCCESS",
+                "API_KEY_AUTH_FAILED",
+                "API_KEY_SCOPE_DENIED",
+                "PAYMENT_SUCCEEDED",
+                "PAYMENT_EXPIRED",
+                "AUDIT_ACCESSED"
+              ],
+              "description": "Filter by audit action (e.g. ORG_CREATED)"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "resource",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "user",
+                "organization",
+                "submission",
+                "file",
+                "auth",
+                "api_key",
+                "payment",
+                "audit"
+              ],
+              "description": "Filter by resource type (e.g. organization)"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "actorId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by the user who performed the action"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "resourceId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by the affected resource ID"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "x-native-type": "date",
+              "description": "Start of date range (ISO-8601)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "x-native-type": "date",
+              "description": "End of date range (ISO-8601)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991,
+              "default": 1,
+              "description": "Page number (1-based)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Items per page (1-100, default 20)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/audit-events/{id}": {
+      "get": {
+        "operationId": "getAuditEvent",
+        "summary": "Get an audit event",
+        "description": "Retrieve a single audit event by its ID. Requires ADMIN role.",
+        "tags": ["Audit"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Resource UUID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/sdks/schema.graphql
+++ b/sdks/schema.graphql
@@ -1,0 +1,685 @@
+"""An organization-scoped API key for programmatic access."""
+type ApiKey {
+  """When the key was created."""
+  createdAt: DateTime
+
+  """When the key expires (null = never)."""
+  expiresAt: DateTime
+
+  """Unique identifier."""
+  id: String
+
+  """First characters of the key for identification."""
+  keyPrefix: String
+
+  """When the key was last used for authentication."""
+  lastUsedAt: DateTime
+
+  """Human-readable name."""
+  name: String
+
+  """When the key was revoked (null = active)."""
+  revokedAt: DateTime
+
+  """Granted permission scopes."""
+  scopes: JSON
+}
+
+"""An immutable record of a security-relevant action."""
+type AuditEvent {
+  """Action that was performed (e.g. ORG_CREATED)."""
+  action: String
+
+  """ID of the user who performed the action."""
+  actorId: String
+
+  """When the event was recorded."""
+  createdAt: DateTime
+
+  """Unique identifier."""
+  id: String
+
+  """IP address of the request."""
+  ipAddress: String
+
+  """HTTP method of the request."""
+  method: String
+
+  """New state after the change."""
+  newValue: JSON
+
+  """Previous state before the change."""
+  oldValue: JSON
+
+  """Correlation ID for the request."""
+  requestId: String
+
+  """Resource type affected (e.g. organization)."""
+  resource: String
+
+  """ID of the affected resource."""
+  resourceId: String
+
+  """API route that was called."""
+  route: String
+
+  """User-Agent header from the request."""
+  userAgent: String
+}
+
+"""
+Result of creating a new API key. The plain-text key is shown only once.
+"""
+type CreateApiKeyPayload {
+  """When the key was created."""
+  createdAt: DateTime
+
+  """When the key expires."""
+  expiresAt: DateTime
+
+  """Unique identifier."""
+  id: String
+
+  """First characters for identification."""
+  keyPrefix: String
+
+  """When the key was last used."""
+  lastUsedAt: DateTime
+
+  """Human-readable name."""
+  name: String
+
+  """The full API key — shown only once, never stored."""
+  plainTextKey: String
+
+  """When the key was revoked."""
+  revokedAt: DateTime
+
+  """Granted permission scopes."""
+  scopes: JSON
+}
+
+"""Result of creating a new organization."""
+type CreateOrganizationPayload {
+  """The creator's membership record."""
+  membership: OrganizationMember
+
+  """The newly created organization."""
+  organization: Organization
+}
+
+"""ISO-8601 date-time string"""
+scalar DateTime
+
+"""Arbitrary JSON value"""
+scalar JSON
+
+type Mutation {
+  """
+  Add a member to the current organization by email. Requires ADMIN role.
+  """
+  addOrganizationMember(
+    """Email address of the user to invite."""
+    email: String!
+
+    """Role to assign (ADMIN, EDITOR, or READER)."""
+    role: String!
+  ): OrganizationMember
+
+  """
+  Create a new API key. The plain-text key is returned only once. Requires ADMIN role.
+  """
+  createApiKey(
+    """Optional expiration date."""
+    expiresAt: DateTime
+
+    """Human-readable name for the key."""
+    name: String!
+
+    """Permission scopes to grant."""
+    scopes: [String!]!
+  ): CreateApiKeyPayload
+
+  """Create a new organization. The caller becomes the first ADMIN."""
+  createOrganization(
+    """Display name of the organization."""
+    name: String!
+
+    """
+    URL-friendly identifier (3-63 chars, lowercase alphanumeric with hyphens).
+    """
+    slug: String!
+  ): CreateOrganizationPayload
+
+  """Create a new submission in DRAFT status."""
+  createSubmission(
+    """Body content."""
+    content: String
+
+    """Optional cover letter."""
+    coverLetter: String
+
+    """Submission period to associate with."""
+    submissionPeriodId: String
+
+    """Title of the submission."""
+    title: String!
+  ): Submission
+
+  """Permanently delete an API key record. Requires ADMIN role."""
+  deleteApiKey(
+    """ID of the API key to delete."""
+    keyId: String!
+  ): SuccessPayload
+
+  """
+  Delete a file from a DRAFT submission. Only the submission owner can delete.
+  """
+  deleteFile(
+    """ID of the file to delete."""
+    fileId: String!
+  ): SuccessPayload
+
+  """
+  Delete a DRAFT submission and its files. Only the submitter can delete.
+  """
+  deleteSubmission(
+    """Submission ID."""
+    id: String!
+  ): SuccessPayload
+
+  """Remove a member from the current organization. Requires ADMIN role."""
+  removeOrganizationMember(
+    """ID of the membership record to remove."""
+    memberId: String!
+  ): SuccessPayload
+
+  """Revoke an active API key, preventing further use. Requires ADMIN role."""
+  revokeApiKey(
+    """ID of the API key to revoke."""
+    keyId: String!
+  ): RevokeApiKeyPayload
+
+  """Submit a DRAFT (DRAFT → SUBMITTED). Only the submitter can submit."""
+  submitSubmission(
+    """Submission ID."""
+    id: String!
+  ): SubmissionStatusChangePayload
+
+  """
+  Update the current organization's name or settings. Requires ADMIN role.
+  """
+  updateOrganization(
+    """New display name."""
+    name: String
+
+    """Organization settings as key-value pairs."""
+    settings: JSON
+  ): Organization
+
+  """
+  Change a member's role in the current organization. Requires ADMIN role.
+  """
+  updateOrganizationMemberRole(
+    """ID of the membership record to update."""
+    memberId: String!
+
+    """New role (ADMIN, EDITOR, or READER)."""
+    role: String!
+  ): OrganizationMember
+
+  """Update a DRAFT submission. Only the submitter can update."""
+  updateSubmission(
+    """New body content."""
+    content: String
+
+    """New cover letter."""
+    coverLetter: String
+
+    """Submission ID."""
+    id: String!
+
+    """New title."""
+    title: String
+  ): Submission
+
+  """
+  Transition a submission's status. Requires EDITOR or ADMIN role. Invalid transitions are rejected.
+  """
+  updateSubmissionStatus(
+    """Optional comment explaining the decision."""
+    comment: String
+
+    """Submission ID."""
+    id: String!
+
+    """Target status (e.g. UNDER_REVIEW, ACCEPTED)."""
+    status: String!
+  ): SubmissionStatusChangePayload
+
+  """
+  Withdraw a submission from consideration. Only the submitter can withdraw.
+  """
+  withdrawSubmission(
+    """Submission ID."""
+    id: String!
+  ): SubmissionStatusChangePayload
+}
+
+type OrgMemberWithEmail {
+  createdAt: DateTime
+  email: String
+  id: String
+  role: String
+  userId: String
+}
+
+"""A literary magazine organization — the top-level tenant in Colophony."""
+type Organization {
+  """When the organization was created."""
+  createdAt: DateTime
+
+  """Unique identifier."""
+  id: String
+
+  """Members of this organization."""
+  members: [OrganizationMember!]
+
+  """Display name of the organization."""
+  name: String
+
+  """Organization-specific settings."""
+  settings: JSON
+
+  """URL-friendly identifier."""
+  slug: String
+
+  """When the organization was last updated."""
+  updatedAt: DateTime
+}
+
+"""A membership record linking a user to an organization with a role."""
+type OrganizationMember {
+  """When the member was added."""
+  createdAt: DateTime
+
+  """Membership record ID."""
+  id: String
+
+  """ID of the organization."""
+  organizationId: String
+
+  """Role within the organization."""
+  role: Role
+
+  """The user associated with this membership."""
+  user: User
+
+  """ID of the member user."""
+  userId: String
+}
+
+type PaginatedApiKeys {
+  items: [ApiKey!]
+  limit: Int
+  page: Int
+  total: Int
+  totalPages: Int
+}
+
+type PaginatedAuditEvents {
+  items: [AuditEvent!]
+  limit: Int
+  page: Int
+  total: Int
+  totalPages: Int
+}
+
+type PaginatedOrganizationMembers {
+  items: [OrgMemberWithEmail!]
+  limit: Int
+  page: Int
+  total: Int
+  totalPages: Int
+}
+
+type PaginatedSubmissions {
+  items: [Submission!]
+  limit: Int
+  page: Int
+  total: Int
+  totalPages: Int
+}
+
+type Query {
+  """List API keys for the current organization."""
+  apiKeys(
+    """Items per page (1-100)."""
+    limit: Int = 20
+
+    """Page number (1-based)."""
+    page: Int = 1
+  ): PaginatedApiKeys
+
+  """Get a single audit event by ID. Requires ADMIN role."""
+  auditEvent(
+    """Audit event ID."""
+    id: String!
+  ): AuditEvent
+
+  """List audit events for the current organization. Requires ADMIN role."""
+  auditEvents(
+    """Filter by audit action (e.g. ORG_CREATED)."""
+    action: String
+
+    """Filter by the user who performed the action."""
+    actorId: String
+
+    """Start of date range."""
+    from: DateTime
+
+    """Items per page (1-100)."""
+    limit: Int = 20
+
+    """Page number (1-based)."""
+    page: Int = 1
+
+    """Filter by resource type (e.g. organization)."""
+    resource: String
+
+    """Filter by the affected resource ID."""
+    resourceId: String
+
+    """End of date range."""
+    to: DateTime
+  ): PaginatedAuditEvents
+
+  """Get the current user's profile with organization memberships."""
+  me: UserProfile
+
+  """
+  List the current user's organizations (cross-org, no org context needed).
+  """
+  myOrganizations: [UserOrganization!]
+
+  """List the current user's own submissions."""
+  mySubmissions(
+    """Items per page (1-100)."""
+    limit: Int = 20
+
+    """Page number (1-based)."""
+    page: Int = 1
+
+    """Full-text search query."""
+    search: String
+
+    """Filter by submission status."""
+    status: String
+
+    """Filter by submission period."""
+    submissionPeriodId: String
+  ): PaginatedSubmissions
+
+  """Get the current organization (requires X-Organization-Id header)."""
+  organization: Organization
+
+  """List members of the current organization."""
+  organizationMembers(
+    """Items per page (1-100)."""
+    limit: Int = 20
+
+    """Page number (1-based)."""
+    page: Int = 1
+  ): PaginatedOrganizationMembers
+
+  """
+  Get a single submission by ID. Editors can view any; submitters can view their own.
+  """
+  submission(
+    """Submission ID."""
+    id: String!
+  ): Submission
+
+  """Get the full status change history for a submission."""
+  submissionHistory(
+    """Submission ID."""
+    submissionId: String!
+  ): [SubmissionHistory!]
+
+  """
+  List all submissions in the organization. Requires EDITOR or ADMIN role.
+  """
+  submissions(
+    """Items per page (1-100)."""
+    limit: Int = 20
+
+    """Page number (1-based)."""
+    page: Int = 1
+
+    """Full-text search query."""
+    search: String
+
+    """Filter by submission status."""
+    status: String
+
+    """Filter by submission period."""
+    submissionPeriodId: String
+  ): PaginatedSubmissions
+}
+
+"""Result of revoking an API key."""
+type RevokeApiKeyPayload {
+  """API key ID."""
+  id: String
+
+  """Human-readable name."""
+  name: String
+
+  """When the key was revoked."""
+  revokedAt: DateTime
+}
+
+"""Member role within an organization."""
+enum Role {
+  """Full access — can manage members, settings, and API keys."""
+  ADMIN
+
+  """Can review and manage submissions."""
+  EDITOR
+
+  """Read-only access to submissions and files."""
+  READER
+}
+
+"""Virus scan status for an uploaded file."""
+enum ScanStatus {
+  """No threats detected — file is safe to download."""
+  CLEAN
+
+  """Scan failed — file is blocked until retry succeeds."""
+  FAILED
+
+  """Threat detected — file has been quarantined."""
+  INFECTED
+
+  """File is queued for scanning."""
+  PENDING
+
+  """Scan is in progress."""
+  SCANNING
+}
+
+"""A literary submission (manuscript, poem, story, etc.) under review."""
+type Submission {
+  """Body content of the submission."""
+  content: String
+
+  """Optional cover letter."""
+  coverLetter: String
+
+  """When the submission was created."""
+  createdAt: DateTime
+
+  """Files attached to this submission."""
+  files: [SubmissionFile!]
+
+  """Unique identifier."""
+  id: String
+
+  """ID of the owning organization."""
+  organizationId: String
+
+  """Current workflow status."""
+  status: SubmissionStatus
+
+  """ID of the associated submission period, if any."""
+  submissionPeriodId: String
+
+  """When the submission was formally submitted (null if still a draft)."""
+  submittedAt: DateTime
+
+  """The user who created this submission."""
+  submitter: User
+
+  """ID of the user who created this submission."""
+  submitterId: String
+
+  """Title of the submission."""
+  title: String
+
+  """When the submission was last updated."""
+  updatedAt: DateTime
+}
+
+"""A file attached to a submission (document, image, audio, or video)."""
+type SubmissionFile {
+  """Original filename as uploaded."""
+  filename: String
+
+  """Unique identifier."""
+  id: String
+
+  """MIME type (e.g. application/pdf)."""
+  mimeType: String
+
+  """Virus scan status."""
+  scanStatus: ScanStatus
+
+  """When the virus scan completed."""
+  scannedAt: DateTime
+
+  """File size in bytes."""
+  size: Int
+
+  """Object storage key."""
+  storageKey: String
+
+  """ID of the parent submission."""
+  submissionId: String
+
+  """When the file was uploaded."""
+  uploadedAt: DateTime
+}
+
+"""A record of a status change in a submission's workflow."""
+type SubmissionHistory {
+  """When the status change occurred."""
+  changedAt: DateTime
+
+  """ID of the user who made the change."""
+  changedBy: String
+
+  """Optional comment explaining the change."""
+  comment: String
+
+  """Previous status (null for initial creation)."""
+  fromStatus: SubmissionStatus
+
+  """History entry ID."""
+  id: String
+
+  """ID of the submission."""
+  submissionId: String
+
+  """New status after the transition."""
+  toStatus: SubmissionStatus
+}
+
+"""Current status of a submission in the editorial workflow."""
+enum SubmissionStatus {
+  """Submission has been accepted for publication."""
+  ACCEPTED
+
+  """Initial state — submission is being prepared by the author."""
+  DRAFT
+
+  """Temporarily set aside for later consideration."""
+  HOLD
+
+  """Submission has been declined."""
+  REJECTED
+
+  """Author has submitted for review."""
+  SUBMITTED
+
+  """Editors are actively reviewing the submission."""
+  UNDER_REVIEW
+
+  """Author has withdrawn the submission."""
+  WITHDRAWN
+}
+
+"""Result of a submission status transition."""
+type SubmissionStatusChangePayload {
+  """The history entry recording this transition."""
+  historyEntry: SubmissionHistory
+
+  """The submission after the status change."""
+  submission: Submission
+}
+
+"""Generic success response for mutations that don't return a resource."""
+type SuccessPayload {
+  """Always true on success."""
+  success: Boolean
+}
+
+"""A Colophony user account, synced from Zitadel."""
+type User {
+  """When the account was created."""
+  createdAt: DateTime
+
+  """Primary email address."""
+  email: String
+
+  """Whether the email has been verified."""
+  emailVerified: Boolean
+
+  """Unique identifier."""
+  id: String
+
+  """When the account was last updated."""
+  updatedAt: DateTime
+}
+
+type UserOrganization {
+  name: String
+  organizationId: String
+  role: String
+  slug: String
+}
+
+type UserProfile {
+  createdAt: DateTime
+  email: String
+  emailVerified: Boolean
+  id: String
+  organizations: [UserProfileOrganization!]
+}
+
+type UserProfileOrganization {
+  id: String
+  name: String
+  role: String
+  slug: String
+}


### PR DESCRIPTION
## Summary

- Added `.describe()` to all Zod schema fields across 8 type files — propagates to OpenAPI property descriptions
- Added oRPC route metadata (summary, description, operationId, tags) to all 30 server-side REST router routes and ~23 contract routes
- Enhanced Scalar docs UI at `/v1/docs` with info block, tag descriptions, contact, license
- Added GraphQL Pothos descriptions to all types, fields, enum values, query/mutation resolvers, and arguments
- Fixed OpenAPI spec generation bug: registered `ZodToJsonSchemaConverter` from `@orpc/zod/zod4` (without it, all schemas become `{}` and routes with path params throw 500)
- Created export scripts (`scripts/export-openapi.ts`, `scripts/export-schema.ts`) and exported `sdks/openapi.json` (21 paths, 29 ops) + `sdks/schema.graphql`

Completes the API documentation item in Track 2. SDK generation deferred (no external consumers yet).

## Test plan

- [x] `pnpm type-check` — all 11 projects pass
- [x] `pnpm test` — all tests pass (descriptions are additive)
- [x] Verified `/v1/openapi.json` returns spec with 21 paths, 29 operations, all with summaries/tags/operationIds
- [x] Verified `/v1/docs` shows organized Scalar UI with tag groups
- [x] branch review: LGTM, no findings