### PR TITLE
feat(hopper): form builder backend — schema, service, API endpoints

### DIFF
--- a/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
+++ b/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
@@ -3,6 +3,8 @@ import { globalSetup, getAdminPool, getAppPool } from './helpers/db-setup';
 
 const RLS_TABLES = [
   'organization_members',
+  'form_definitions',
+  'form_fields',
   'submission_periods',
   'submissions',
   'submission_files',
@@ -34,7 +36,7 @@ describe('RLS Infrastructure', () => {
   // No teardown — pools are shared across test files (singleFork mode)
 
   describe('Row-level security enabled', () => {
-    it('should have relrowsecurity = true on all 10 RLS tables', async () => {
+    it('should have relrowsecurity = true on all RLS tables', async () => {
       const admin = getAdminPool();
       const { rows } = await admin.query<{
         relname: string;
@@ -57,7 +59,7 @@ describe('RLS Infrastructure', () => {
       }
     });
 
-    it('should have relforcerowsecurity = true on all 10 RLS tables', async () => {
+    it('should have relforcerowsecurity = true on all RLS tables', async () => {
       const admin = getAdminPool();
       const { rows } = await admin.query<{
         relname: string;
@@ -272,7 +274,12 @@ describe('RLS Infrastructure', () => {
 
     it('direct isolation policies reference current_org_id()', async () => {
       const admin = getAdminPool();
-      const directTables = ['submissions', 'submission_periods', 'payments'];
+      const directTables = [
+        'submissions',
+        'submission_periods',
+        'payments',
+        'form_definitions',
+      ];
       const { rows } = await admin.query<{
         tablename: string;
         qual: string;

--- a/apps/api/src/graphql/error-mapper.ts
+++ b/apps/api/src/graphql/error-mapper.ts
@@ -13,6 +13,16 @@ import {
   InfectedFilesError,
 } from '../services/submission.service.js';
 import { LastAdminError } from '../services/organization.service.js';
+import {
+  FormNotFoundError,
+  FormFieldNotFoundError,
+  FormNotDraftError,
+  FormNotPublishedError,
+  DuplicateFieldKeyError,
+  FormHasNoFieldsError,
+  FormInUseError,
+  InvalidFormDataError,
+} from '../services/form.service.js';
 
 type GraphQLErrorCode = string;
 
@@ -31,6 +41,15 @@ const errorCodeMap: [new (...args: never[]) => Error, GraphQLErrorCode][] = [
   [UnscannedFilesError, 'BAD_REQUEST'],
   [InfectedFilesError, 'BAD_REQUEST'],
   [LastAdminError, 'BAD_REQUEST'],
+  // Form errors
+  [FormNotFoundError, 'NOT_FOUND'],
+  [FormFieldNotFoundError, 'NOT_FOUND'],
+  [FormNotDraftError, 'BAD_REQUEST'],
+  [FormNotPublishedError, 'BAD_REQUEST'],
+  [DuplicateFieldKeyError, 'CONFLICT'],
+  [FormHasNoFieldsError, 'BAD_REQUEST'],
+  [FormInUseError, 'BAD_REQUEST'],
+  [InvalidFormDataError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/graphql/loaders.ts
+++ b/apps/api/src/graphql/loaders.ts
@@ -1,15 +1,23 @@
 import DataLoader from 'dataloader';
+import { asc } from 'drizzle-orm';
 import {
   submissionFiles,
+  formFields,
   users,
   organizationMembers,
   inArray,
   type DrizzleDb,
 } from '@colophony/db';
-import type { SubmissionFile, User, OrganizationMember } from '@colophony/db';
+import type {
+  SubmissionFile,
+  FormField,
+  User,
+  OrganizationMember,
+} from '@colophony/db';
 
 export interface Loaders {
   submissionFiles: DataLoader<string, SubmissionFile[]>;
+  formFields: DataLoader<string, FormField[]>;
   user: DataLoader<string, User | null>;
   orgMembers: DataLoader<string, OrganizationMember[]>;
 }
@@ -43,6 +51,29 @@ export function createLoaders(dbTx: DrizzleDb | null): Loaders {
         return submissionIds.map((id) => grouped.get(id) ?? []);
       },
     ),
+
+    /**
+     * Batch-load form fields by form definition ID.
+     * Returns an array of fields per form (may be empty), ordered by sortOrder.
+     */
+    formFields: new DataLoader<string, FormField[]>(async (formIds) => {
+      if (!dbTx) return formIds.map(() => []);
+
+      const rows = await dbTx
+        .select()
+        .from(formFields)
+        .where(inArray(formFields.formDefinitionId, [...formIds]))
+        .orderBy(asc(formFields.sortOrder));
+
+      const grouped = new Map<string, FormField[]>();
+      for (const row of rows) {
+        const list = grouped.get(row.formDefinitionId) ?? [];
+        list.push(row);
+        grouped.set(row.formDefinitionId, list);
+      }
+
+      return formIds.map((id) => grouped.get(id) ?? []);
+    }),
 
     /**
      * Batch-load users by user ID.

--- a/apps/api/src/graphql/resolvers/forms.spec.ts
+++ b/apps/api/src/graphql/resolvers/forms.spec.ts
@@ -20,6 +20,48 @@ vi.mock('../../services/context.js', () => ({
   toServiceContext: vi.fn((ctx: unknown) => ctx),
 }));
 
+vi.mock('../../services/form.service.js', () => ({
+  formService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    createWithAudit: vi.fn(),
+    updateWithAudit: vi.fn(),
+    publishWithAudit: vi.fn(),
+    archiveWithAudit: vi.fn(),
+    duplicateWithAudit: vi.fn(),
+    deleteWithAudit: vi.fn(),
+    addFieldWithAudit: vi.fn(),
+    updateFieldWithAudit: vi.fn(),
+    removeFieldWithAudit: vi.fn(),
+    reorderFieldsWithAudit: vi.fn(),
+    getFieldsByFormIds: vi.fn(),
+  },
+  FormNotFoundError: class extends Error {
+    name = 'FormNotFoundError';
+  },
+  FormFieldNotFoundError: class extends Error {
+    name = 'FormFieldNotFoundError';
+  },
+  FormNotDraftError: class extends Error {
+    name = 'FormNotDraftError';
+  },
+  FormNotPublishedError: class extends Error {
+    name = 'FormNotPublishedError';
+  },
+  DuplicateFieldKeyError: class extends Error {
+    name = 'DuplicateFieldKeyError';
+  },
+  FormHasNoFieldsError: class extends Error {
+    name = 'FormHasNoFieldsError';
+  },
+  FormInUseError: class extends Error {
+    name = 'FormInUseError';
+  },
+  InvalidFormDataError: class extends Error {
+    name = 'InvalidFormDataError';
+  },
+}));
+
 vi.mock('../../services/submission.service.js', () => ({
   submissionService: {
     listAll: vi.fn(),
@@ -125,7 +167,7 @@ vi.mock('../../config/env.js', () => ({
 }));
 
 import { requireOrgContext, requireScopes } from '../guards.js';
-import { submissionService } from '../../services/submission.service.js';
+import { formService } from '../../services/form.service.js';
 import { mapServiceError } from '../error-mapper.js';
 
 const mockRequireOrgContext = vi.mocked(requireOrgContext);
@@ -136,6 +178,9 @@ import { schema } from '../schema.js';
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+const FORM_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+const FIELD_ID = 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22';
 
 function makeCtx(): GraphQLContext {
   return {
@@ -165,97 +210,128 @@ function makeOrgCtx() {
   };
 }
 
+function getQueryField(name: string) {
+  const queryType = schema.getQueryType();
+  expect(queryType).toBeDefined();
+  return queryType!.getFields()[name];
+}
+
 function getMutationField(name: string) {
   const mutationType = schema.getMutationType();
   expect(mutationType).toBeDefined();
-  const fields = mutationType!.getFields();
-  return fields[name];
+  return mutationType!.getFields()[name];
+}
+
+function makeFormDefinition(overrides: Record<string, unknown> = {}) {
+  return {
+    id: FORM_ID,
+    organizationId: 'org-1',
+    name: 'Test Form',
+    description: null,
+    status: 'DRAFT' as const,
+    version: 1,
+    duplicatedFromId: null,
+    createdBy: 'user-1',
+    publishedAt: null,
+    archivedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeFormField(overrides: Record<string, unknown> = {}) {
+  return {
+    id: FIELD_ID,
+    formDefinitionId: FORM_ID,
+    fieldKey: 'test_field',
+    fieldType: 'text' as const,
+    label: 'Test Field',
+    description: null,
+    placeholder: null,
+    required: false,
+    sortOrder: 0,
+    config: null,
+    conditionalRules: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Tests — schema registration
 // ---------------------------------------------------------------------------
 
-describe('Submission mutations — schema', () => {
-  it('registers createSubmission mutation', () => {
-    const field = getMutationField('createSubmission');
+describe('Form resolvers — schema', () => {
+  it('registers formDefinitions query', () => {
+    const field = getQueryField('formDefinitions');
     expect(field).toBeDefined();
-    const argNames = field.args.map((a) => a.name);
-    expect(argNames).toContain('title');
   });
 
-  it('registers updateSubmission mutation', () => {
-    const field = getMutationField('updateSubmission');
-    expect(field).toBeDefined();
-    const argNames = field.args.map((a) => a.name);
-    expect(argNames).toContain('id');
-    expect(argNames).toContain('title');
-  });
-
-  it('registers submitSubmission mutation', () => {
-    const field = getMutationField('submitSubmission');
+  it('registers formDefinition query', () => {
+    const field = getQueryField('formDefinition');
     expect(field).toBeDefined();
     expect(field.args.map((a) => a.name)).toContain('id');
   });
 
-  it('registers deleteSubmission mutation', () => {
-    const field = getMutationField('deleteSubmission');
+  it('registers createFormDefinition mutation', () => {
+    const field = getMutationField('createFormDefinition');
+    expect(field).toBeDefined();
+    expect(field.args.map((a) => a.name)).toContain('name');
+  });
+
+  it('registers publishFormDefinition mutation', () => {
+    const field = getMutationField('publishFormDefinition');
     expect(field).toBeDefined();
     expect(field.args.map((a) => a.name)).toContain('id');
   });
 
-  it('registers withdrawSubmission mutation', () => {
-    const field = getMutationField('withdrawSubmission');
+  it('registers deleteFormDefinition mutation', () => {
+    const field = getMutationField('deleteFormDefinition');
     expect(field).toBeDefined();
     expect(field.args.map((a) => a.name)).toContain('id');
   });
 
-  it('registers updateSubmissionStatus mutation', () => {
-    const field = getMutationField('updateSubmissionStatus');
+  it('registers addFormField mutation', () => {
+    const field = getMutationField('addFormField');
     expect(field).toBeDefined();
     const argNames = field.args.map((a) => a.name);
-    expect(argNames).toContain('id');
-    expect(argNames).toContain('status');
-    expect(argNames).toContain('comment');
+    expect(argNames).toContain('formId');
+    expect(argNames).toContain('fieldKey');
+    expect(argNames).toContain('fieldType');
+    expect(argNames).toContain('label');
+  });
+
+  it('registers reorderFormFields mutation', () => {
+    const field = getMutationField('reorderFormFields');
+    expect(field).toBeDefined();
+    const argNames = field.args.map((a) => a.name);
+    expect(argNames).toContain('formId');
+    expect(argNames).toContain('fieldIds');
   });
 });
 
-describe('Submission mutations — resolver wiring', () => {
+// ---------------------------------------------------------------------------
+// Tests — resolver wiring
+// ---------------------------------------------------------------------------
+
+describe('Form resolvers — wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequireOrgContext.mockReturnValue(makeOrgCtx());
     mockRequireScopes.mockResolvedValue(undefined);
   });
 
-  it('createSubmission calls requireOrgContext + service', async () => {
-    const submission = {
-      id: 'sub-1',
-      organizationId: 'org-1',
-      submitterId: 'user-1',
-      submissionPeriodId: null,
-      title: 'Test',
-      content: null,
-      coverLetter: null,
-      status: 'DRAFT' as const,
-      formDefinitionId: null,
-      formData: null,
-      submittedAt: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      searchVector: null,
-    };
+  it('createFormDefinition calls requireOrgContext + service', async () => {
+    const form = makeFormDefinition();
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    vi.mocked(submissionService.createWithAudit).mockResolvedValue(submission);
+    vi.mocked(formService.createWithAudit).mockResolvedValue(form);
 
-    const field = getMutationField('createSubmission');
+    const field = getMutationField('createFormDefinition');
     const result = await field.resolve!(
       {},
-      {
-        title: 'Test',
-        content: null,
-        coverLetter: null,
-        submissionPeriodId: null,
-      },
+      { name: 'Test Form' },
       makeCtx(),
       {} as never,
     );
@@ -263,124 +339,106 @@ describe('Submission mutations — resolver wiring', () => {
     expect(mockRequireOrgContext).toHaveBeenCalled();
     expect(mockRequireScopes).toHaveBeenCalledWith(
       expect.anything(),
-      'submissions:write',
+      'forms:write',
     );
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(submissionService.createWithAudit).toHaveBeenCalled();
-    expect(result).toEqual(submission);
+    expect(formService.createWithAudit).toHaveBeenCalled();
+    expect(result).toEqual(form);
   });
 
-  it('createSubmission guard failure prevents service call', async () => {
+  it('createFormDefinition guard failure prevents service call', async () => {
     mockRequireOrgContext.mockImplementation(() => {
       throw new GraphQLError('Not authenticated', {
         extensions: { code: 'UNAUTHENTICATED' },
       });
     });
 
-    const field = getMutationField('createSubmission');
+    const field = getMutationField('createFormDefinition');
     await expect(
-      field.resolve!({}, { title: 'X' }, makeCtx(), {} as never),
+      field.resolve!({}, { name: 'X' }, makeCtx(), {} as never),
     ).rejects.toThrow('Not authenticated');
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(submissionService.createWithAudit).not.toHaveBeenCalled();
+    expect(formService.createWithAudit).not.toHaveBeenCalled();
   });
 
-  it('createSubmission validates input via Zod', async () => {
-    const field = getMutationField('createSubmission');
+  it('createFormDefinition validates input via Zod', async () => {
+    const field = getMutationField('createFormDefinition');
     await expect(
-      field.resolve!({}, { title: '' }, makeCtx(), {} as never),
-    ).rejects.toThrow(); // Zod rejects empty title
+      field.resolve!({}, { name: '' }, makeCtx(), {} as never),
+    ).rejects.toThrow(); // Zod rejects empty name
   });
 
-  it('updateSubmission validates id as UUID', async () => {
-    const field = getMutationField('updateSubmission');
-    await expect(
-      field.resolve!(
-        {},
-        { id: 'not-a-uuid', title: 'X' },
-        makeCtx(),
-        {} as never,
-      ),
-    ).rejects.toThrow();
-  });
-
-  it('deleteSubmission calls deleteAsOwner', async () => {
+  it('deleteFormDefinition calls deleteWithAudit', async () => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    vi.mocked(submissionService.deleteAsOwner).mockResolvedValue({
+    vi.mocked(formService.deleteWithAudit).mockResolvedValue({
       success: true,
     });
 
-    const field = getMutationField('deleteSubmission');
+    const field = getMutationField('deleteFormDefinition');
     const result = await field.resolve!(
       {},
-      { id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' },
+      { id: FORM_ID },
       makeCtx(),
       {} as never,
     );
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(submissionService.deleteAsOwner).toHaveBeenCalled();
+    expect(formService.deleteWithAudit).toHaveBeenCalled();
     expect(result).toEqual({ success: true });
   });
 
-  it('updateSubmissionStatus calls updateStatusAsEditor', async () => {
-    const payload = {
-      submission: {
-        id: 'sub-1',
-        organizationId: 'org-1',
-        submitterId: 'user-1',
-        submissionPeriodId: null,
-        formDefinitionId: null,
-        formData: null,
-        title: 'Test',
-        content: null,
-        coverLetter: null,
-        status: 'UNDER_REVIEW' as const,
-        submittedAt: new Date(),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        searchVector: null,
-      },
-      historyEntry: {
-        id: 'hist-1',
-        submissionId: 'sub-1',
-        fromStatus: 'SUBMITTED' as const,
-        toStatus: 'UNDER_REVIEW' as const,
-        changedBy: 'user-1',
-        comment: 'test',
-        changedAt: new Date(),
-      },
-    };
+  it('publishFormDefinition calls publishWithAudit', async () => {
+    const published = makeFormDefinition({
+      status: 'PUBLISHED',
+      publishedAt: new Date(),
+    });
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    vi.mocked(submissionService.updateStatusAsEditor).mockResolvedValue(
-      payload,
+    vi.mocked(formService.publishWithAudit).mockResolvedValue(published);
+
+    const field = getMutationField('publishFormDefinition');
+    const result = await field.resolve!(
+      {},
+      { id: FORM_ID },
+      makeCtx(),
+      {} as never,
     );
 
-    const field = getMutationField('updateSubmissionStatus');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(formService.publishWithAudit).toHaveBeenCalled();
+    expect(result).toEqual(published);
+  });
+
+  it('addFormField calls addFieldWithAudit', async () => {
+    const formField = makeFormField();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(formService.addFieldWithAudit).mockResolvedValue(formField);
+
+    const field = getMutationField('addFormField');
     const result = await field.resolve!(
       {},
       {
-        id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
-        status: 'UNDER_REVIEW',
-        comment: 'test',
+        formId: FORM_ID,
+        fieldKey: 'test_field',
+        fieldType: 'text',
+        label: 'Test Field',
       },
       makeCtx(),
       {} as never,
     );
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(submissionService.updateStatusAsEditor).toHaveBeenCalled();
-    expect(result).toBe(payload);
+    expect(formService.addFieldWithAudit).toHaveBeenCalled();
+    expect(result).toEqual(formField);
   });
 
   it('mapServiceError is called on service failure', async () => {
     const error = new Error('Service failed');
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    vi.mocked(submissionService.createWithAudit).mockRejectedValue(error);
+    vi.mocked(formService.createWithAudit).mockRejectedValue(error);
 
-    const field = getMutationField('createSubmission');
+    const field = getMutationField('createFormDefinition');
     await expect(
-      field.resolve!({}, { title: 'Test' }, makeCtx(), {} as never),
+      field.resolve!({}, { name: 'Test' }, makeCtx(), {} as never),
     ).rejects.toThrow();
     expect(mapServiceError).toHaveBeenCalledWith(error);
   });

--- a/apps/api/src/graphql/resolvers/forms.ts
+++ b/apps/api/src/graphql/resolvers/forms.ts
@@ -1,0 +1,437 @@
+import type { FormDefinition } from '@colophony/db';
+import {
+  listFormDefinitionsSchema,
+  createFormDefinitionSchema,
+  updateFormDefinitionSchema,
+  createFormFieldSchema,
+  updateFormFieldSchema,
+  reorderFormFieldsSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { builder } from '../builder.js';
+import { requireOrgContext, requireScopes } from '../guards.js';
+import { toServiceContext } from '../../services/context.js';
+import { formService, FormNotFoundError } from '../../services/form.service.js';
+import { mapServiceError } from '../error-mapper.js';
+import { FormDefinitionType, FormFieldObjectType } from '../types/index.js';
+import { SuccessPayload } from '../types/payloads.js';
+
+// ---------------------------------------------------------------------------
+// Paginated response type
+// ---------------------------------------------------------------------------
+
+const PaginatedFormDefinitions = builder
+  .objectRef<{
+    items: FormDefinition[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }>('PaginatedFormDefinitions')
+  .implement({
+    fields: (t) => ({
+      items: t.field({
+        type: [FormDefinitionType],
+        resolve: (r) => r.items,
+      }),
+      total: t.exposeInt('total'),
+      page: t.exposeInt('page'),
+      limit: t.exposeInt('limit'),
+      totalPages: t.exposeInt('totalPages'),
+    }),
+  });
+
+// ---------------------------------------------------------------------------
+// Query fields
+// ---------------------------------------------------------------------------
+
+builder.queryFields((t) => ({
+  /** List form definitions in the org. */
+  formDefinitions: t.field({
+    type: PaginatedFormDefinitions,
+    description: 'List form definitions in the organization.',
+    args: {
+      status: t.arg.string({
+        required: false,
+        description: 'Filter by form status (DRAFT, PUBLISHED, ARCHIVED).',
+      }),
+      search: t.arg.string({
+        required: false,
+        description: 'Search by name.',
+      }),
+      page: t.arg.int({
+        required: false,
+        defaultValue: 1,
+        description: 'Page number (1-based).',
+      }),
+      limit: t.arg.int({
+        required: false,
+        defaultValue: 20,
+        description: 'Items per page (1-100).',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'forms:read');
+      const input = listFormDefinitionsSchema.parse({
+        status: args.status ?? undefined,
+        search: args.search ?? undefined,
+        page: args.page,
+        limit: args.limit,
+      });
+      return formService.list(orgCtx.dbTx, input);
+    },
+  }),
+
+  /** Get a single form definition by ID. */
+  formDefinition: t.field({
+    type: FormDefinitionType,
+    nullable: true,
+    description: 'Get a form definition by ID, including its fields.',
+    args: {
+      id: t.arg.string({
+        required: true,
+        description: 'Form definition ID.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'forms:read');
+      try {
+        const form = await formService.getById(orgCtx.dbTx, args.id);
+        if (!form) throw new FormNotFoundError(args.id);
+        return form;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mutation fields
+// ---------------------------------------------------------------------------
+
+builder.mutationFields((t) => ({
+  /** Create a new form definition in DRAFT status. */
+  createFormDefinition: t.field({
+    type: FormDefinitionType,
+    description: 'Create a new form definition in DRAFT status.',
+    args: {
+      name: t.arg.string({
+        required: true,
+        description: 'Display name for the form.',
+      }),
+      description: t.arg.string({
+        required: false,
+        description: 'Description of the form.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'forms:write');
+      const input = createFormDefinitionSchema.parse({
+        name: args.name,
+        description: args.description ?? undefined,
+      });
+      try {
+        return await formService.createWithAudit(
+          toServiceContext(orgCtx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Update a DRAFT form definition. */
+  updateFormDefinition: t.field({
+    type: FormDefinitionType,
+    description: 'Update a DRAFT form definition.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Form ID.' }),
+      name: t.arg.string({ required: false, description: 'New name.' }),
+      description: t.arg.string({
+        required: false,
+        description: 'New description.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'forms:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      const data = updateFormDefinitionSchema.parse({
+        name: args.name ?? undefined,
+        description: args.description ?? undefined,
+      });
+      try {
+        return await formService.updateWithAudit(
+          toServiceContext(orgCtx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Publish a DRAFT form (DRAFT → PUBLISHED). */
+  publishFormDefinition: t.field({
+    type: FormDefinitionType,
+    description: 'Publish a DRAFT form. Requires at least one field.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Form ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'forms:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await formService.publishWithAudit(toServiceContext(orgCtx), id);
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Archive a PUBLISHED form (PUBLISHED → ARCHIVED). */
+  archiveFormDefinition: t.field({
+    type: FormDefinitionType,
+    description: 'Archive a PUBLISHED form.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Form ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'forms:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await formService.archiveWithAudit(toServiceContext(orgCtx), id);
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Duplicate a form as a new DRAFT. */
+  duplicateFormDefinition: t.field({
+    type: FormDefinitionType,
+    description:
+      'Create a copy of a form (including all fields) as a new DRAFT.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Form ID to copy.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'forms:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        const result = await formService.duplicateWithAudit(
+          toServiceContext(orgCtx),
+          id,
+        );
+        return result;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Delete a DRAFT form. */
+  deleteFormDefinition: t.field({
+    type: SuccessPayload,
+    description:
+      'Delete a DRAFT form. Fails if referenced by periods or submissions.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Form ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'forms:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await formService.deleteWithAudit(toServiceContext(orgCtx), id);
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Add a field to a DRAFT form. */
+  addFormField: t.field({
+    type: FormFieldObjectType,
+    description: 'Add a new field to a DRAFT form definition.',
+    args: {
+      formId: t.arg.string({
+        required: true,
+        description: 'Form definition ID.',
+      }),
+      fieldKey: t.arg.string({
+        required: true,
+        description: 'Machine name for the field.',
+      }),
+      fieldType: t.arg.string({
+        required: true,
+        description: 'Field type (text, textarea, select, etc.).',
+      }),
+      label: t.arg.string({
+        required: true,
+        description: 'Human-readable label.',
+      }),
+      description: t.arg.string({ required: false, description: 'Help text.' }),
+      placeholder: t.arg.string({
+        required: false,
+        description: 'Placeholder text.',
+      }),
+      required: t.arg.boolean({
+        required: false,
+        defaultValue: false,
+        description: 'Whether the field is required.',
+      }),
+      sortOrder: t.arg.int({
+        required: false,
+        description: 'Display order (auto-assigned if omitted).',
+      }),
+      config: t.arg({
+        type: 'JSON',
+        required: false,
+        description: 'Type-specific configuration.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'forms:write');
+      const input = createFormFieldSchema.parse({
+        fieldKey: args.fieldKey,
+        fieldType: args.fieldType,
+        label: args.label,
+        description: args.description ?? undefined,
+        placeholder: args.placeholder ?? undefined,
+        required: args.required ?? false,
+        sortOrder: args.sortOrder ?? undefined,
+        config: (args.config as Record<string, unknown>) ?? undefined,
+      });
+      try {
+        return await formService.addFieldWithAudit(
+          toServiceContext(orgCtx),
+          args.formId,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Update a field in a DRAFT form. */
+  updateFormField: t.field({
+    type: FormFieldObjectType,
+    description: 'Update a field in a DRAFT form definition.',
+    args: {
+      formId: t.arg.string({
+        required: true,
+        description: 'Form definition ID.',
+      }),
+      fieldId: t.arg.string({ required: true, description: 'Field ID.' }),
+      label: t.arg.string({ required: false, description: 'New label.' }),
+      description: t.arg.string({
+        required: false,
+        description: 'New help text.',
+      }),
+      placeholder: t.arg.string({
+        required: false,
+        description: 'New placeholder.',
+      }),
+      required: t.arg.boolean({
+        required: false,
+        description: 'New required state.',
+      }),
+      config: t.arg({
+        type: 'JSON',
+        required: false,
+        description: 'New configuration.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'forms:write');
+      const data = updateFormFieldSchema.parse({
+        label: args.label ?? undefined,
+        description: args.description ?? undefined,
+        placeholder: args.placeholder ?? undefined,
+        required: args.required ?? undefined,
+        config: (args.config as Record<string, unknown>) ?? undefined,
+      });
+      try {
+        return await formService.updateFieldWithAudit(
+          toServiceContext(orgCtx),
+          args.formId,
+          args.fieldId,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Remove a field from a DRAFT form. */
+  removeFormField: t.field({
+    type: FormFieldObjectType,
+    description: 'Remove a field from a DRAFT form definition.',
+    args: {
+      formId: t.arg.string({
+        required: true,
+        description: 'Form definition ID.',
+      }),
+      fieldId: t.arg.string({ required: true, description: 'Field ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'forms:write');
+      try {
+        return await formService.removeFieldWithAudit(
+          toServiceContext(orgCtx),
+          args.formId,
+          args.fieldId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Reorder fields in a DRAFT form. */
+  reorderFormFields: t.field({
+    type: [FormFieldObjectType],
+    description: 'Set the display order of fields in a DRAFT form.',
+    args: {
+      formId: t.arg.string({
+        required: true,
+        description: 'Form definition ID.',
+      }),
+      fieldIds: t.arg.stringList({
+        required: true,
+        description: 'Ordered list of field IDs.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'forms:write');
+      const input = reorderFormFieldsSchema.parse({
+        fieldIds: args.fieldIds,
+      });
+      try {
+        return await formService.reorderFieldsWithAudit(
+          toServiceContext(orgCtx),
+          args.formId,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));

--- a/apps/api/src/graphql/resolvers/index.ts
+++ b/apps/api/src/graphql/resolvers/index.ts
@@ -5,3 +5,4 @@ import './users.js';
 import './audit.js';
 import './api-keys.js';
 import './files.js';
+import './forms.js';

--- a/apps/api/src/graphql/types/form.ts
+++ b/apps/api/src/graphql/types/form.ts
@@ -1,0 +1,151 @@
+import type { FormDefinition, FormField } from '@colophony/db';
+import { builder } from '../builder.js';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const FormStatusEnum = builder.enumType('FormStatus', {
+  description: 'Current status of a form definition.',
+  values: {
+    DRAFT: {
+      description: 'Form is being designed — fields can be added/edited.',
+    },
+    PUBLISHED: {
+      description: 'Form is live — can be linked to submission periods.',
+    },
+    ARCHIVED: {
+      description: 'Form is retired — no longer assignable to new periods.',
+    },
+  } as const,
+});
+
+export const FormFieldTypeEnum = builder.enumType('FormFieldType', {
+  description: 'Type of form field.',
+  values: {
+    text: { description: 'Single-line text input.' },
+    textarea: { description: 'Multi-line text input.' },
+    rich_text: { description: 'Rich text editor (HTML).' },
+    number: { description: 'Numeric input.' },
+    email: { description: 'Email address input.' },
+    url: { description: 'URL input.' },
+    date: { description: 'Date picker.' },
+    select: { description: 'Single-select dropdown.' },
+    multi_select: { description: 'Multi-select dropdown.' },
+    radio: { description: 'Radio button group.' },
+    checkbox: { description: 'Single checkbox (boolean).' },
+    checkbox_group: { description: 'Checkbox group (multiple selection).' },
+    file_upload: { description: 'File upload field.' },
+    section_header: { description: 'Presentational — section heading.' },
+    info_text: { description: 'Presentational — informational text block.' },
+  } as const,
+});
+
+// ---------------------------------------------------------------------------
+// Object types
+// ---------------------------------------------------------------------------
+
+export const FormFieldType = builder
+  .objectRef<FormField>('FormField')
+  .implement({
+    description: 'A field within a form definition.',
+    fields: (t) => ({
+      id: t.exposeString('id', { description: 'Unique identifier.' }),
+      formDefinitionId: t.exposeString('formDefinitionId', {
+        description: 'ID of the parent form definition.',
+      }),
+      fieldKey: t.exposeString('fieldKey', {
+        description: 'Machine name (unique per form).',
+      }),
+      fieldType: t.expose('fieldType', {
+        type: FormFieldTypeEnum,
+        description: 'Type of form field.',
+      }),
+      label: t.exposeString('label', { description: 'Human-readable label.' }),
+      description: t.exposeString('description', {
+        nullable: true,
+        description: 'Help text.',
+      }),
+      placeholder: t.exposeString('placeholder', {
+        nullable: true,
+        description: 'Placeholder text.',
+      }),
+      required: t.exposeBoolean('required', {
+        description: 'Whether this field is required.',
+      }),
+      sortOrder: t.exposeInt('sortOrder', {
+        description: 'Display order within the form.',
+      }),
+      config: t.expose('config', {
+        type: 'JSON',
+        nullable: true,
+        description: 'Type-specific configuration (options, min/max, etc.).',
+      }),
+      conditionalRules: t.expose('conditionalRules', {
+        type: 'JSON',
+        nullable: true,
+        description: 'Conditional display rules (Phase 2).',
+      }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the field was created.',
+      }),
+      updatedAt: t.expose('updatedAt', {
+        type: 'DateTime',
+        description: 'When the field was last updated.',
+      }),
+    }),
+  });
+
+export const FormDefinitionType = builder
+  .objectRef<FormDefinition>('FormDefinition')
+  .implement({
+    description:
+      'A form definition that describes the fields submitters fill out.',
+    fields: (t) => ({
+      id: t.exposeString('id', { description: 'Unique identifier.' }),
+      organizationId: t.exposeString('organizationId', {
+        description: 'ID of the owning organization.',
+      }),
+      name: t.exposeString('name', { description: 'Display name.' }),
+      description: t.exposeString('description', {
+        nullable: true,
+        description: 'Description of the form.',
+      }),
+      status: t.expose('status', {
+        type: FormStatusEnum,
+        description: 'Current lifecycle status.',
+      }),
+      version: t.exposeInt('version', { description: 'Version number.' }),
+      duplicatedFromId: t.exposeString('duplicatedFromId', {
+        nullable: true,
+        description: 'ID of the form this was duplicated from.',
+      }),
+      createdBy: t.exposeString('createdBy', {
+        description: 'ID of the user who created this form.',
+      }),
+      publishedAt: t.expose('publishedAt', {
+        type: 'DateTime',
+        nullable: true,
+        description: 'When the form was published.',
+      }),
+      archivedAt: t.expose('archivedAt', {
+        type: 'DateTime',
+        nullable: true,
+        description: 'When the form was archived.',
+      }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the form was created.',
+      }),
+      updatedAt: t.expose('updatedAt', {
+        type: 'DateTime',
+        description: 'When the form was last updated.',
+      }),
+      fields: t.field({
+        type: [FormFieldType],
+        description: 'Fields in this form, ordered by sortOrder.',
+        resolve: (form, _args, ctx) => ctx.loaders.formFields.load(form.id),
+      }),
+    }),
+  });

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -7,6 +7,12 @@ export { SubmissionFileType } from './file.js';
 export { AuditEventType } from './audit.js';
 export { ApiKeyType } from './api-key.js';
 export {
+  FormDefinitionType,
+  FormFieldType as FormFieldObjectType,
+  FormStatusEnum,
+  FormFieldTypeEnum,
+} from './form.js';
+export {
   SubmissionStatusChangePayload,
   CreateOrganizationPayload,
   CreateApiKeyPayload,

--- a/apps/api/src/graphql/types/submission.ts
+++ b/apps/api/src/graphql/types/submission.ts
@@ -33,6 +33,16 @@ export const SubmissionType = builder
         nullable: true,
         description: 'Optional cover letter.',
       }),
+      formDefinitionId: t.exposeString('formDefinitionId', {
+        nullable: true,
+        description: 'ID of the form definition used for this submission.',
+      }),
+      formData: t.expose('formData', {
+        type: 'JSON',
+        nullable: true,
+        description:
+          'Structured form data keyed by field key (used when form is attached).',
+      }),
       status: t.expose('status', {
         type: SubmissionStatusEnum,
         description: 'Current workflow status.',

--- a/apps/api/src/rest/error-mapper.ts
+++ b/apps/api/src/rest/error-mapper.ts
@@ -13,6 +13,16 @@ import {
   InfectedFilesError,
 } from '../services/submission.service.js';
 import { LastAdminError } from '../services/organization.service.js';
+import {
+  FormNotFoundError,
+  FormFieldNotFoundError,
+  FormNotDraftError,
+  FormNotPublishedError,
+  DuplicateFieldKeyError,
+  FormHasNoFieldsError,
+  FormInUseError,
+  InvalidFormDataError,
+} from '../services/form.service.js';
 
 type ORPCErrorCode = ConstructorParameters<typeof ORPCError>[0];
 
@@ -31,6 +41,15 @@ const errorCodeMap: [new (...args: never[]) => Error, ORPCErrorCode][] = [
   [UnscannedFilesError, 'BAD_REQUEST'],
   [InfectedFilesError, 'BAD_REQUEST'],
   [LastAdminError, 'BAD_REQUEST'],
+  // Form errors
+  [FormNotFoundError, 'NOT_FOUND'],
+  [FormFieldNotFoundError, 'NOT_FOUND'],
+  [FormNotDraftError, 'BAD_REQUEST'],
+  [FormNotPublishedError, 'BAD_REQUEST'],
+  [DuplicateFieldKeyError, 'CONFLICT'],
+  [FormHasNoFieldsError, 'BAD_REQUEST'],
+  [FormInUseError, 'BAD_REQUEST'],
+  [InvalidFormDataError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/rest/router.ts
+++ b/apps/api/src/rest/router.ts
@@ -8,6 +8,7 @@ import { filesRouter } from './routers/files.js';
 import { usersRouter } from './routers/users.js';
 import { apiKeysRouter } from './routers/api-keys.js';
 import { auditRouter } from './routers/audit.js';
+import { formsRouter } from './routers/forms.js';
 import type { RestContext } from './context.js';
 
 const restRouter = {
@@ -16,6 +17,7 @@ const restRouter = {
   files: filesRouter,
   users: usersRouter,
   apiKeys: apiKeysRouter,
+  forms: formsRouter,
   audit: auditRouter,
 };
 
@@ -71,6 +73,11 @@ const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
             name: 'API Keys',
             description:
               'Create and manage organization-scoped API keys for programmatic access.',
+          },
+          {
+            name: 'Forms',
+            description:
+              'Create and manage dynamic form definitions for submission intake. Forms define the fields submitters fill out.',
           },
           {
             name: 'Audit',

--- a/apps/api/src/rest/routers/forms.spec.ts
+++ b/apps/api/src/rest/routers/forms.spec.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ORPCError } from '@orpc/server';
+
+// Mock the form service before importing the router
+vi.mock('../../services/form.service.js', () => ({
+  formService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    createWithAudit: vi.fn(),
+    updateWithAudit: vi.fn(),
+    publishWithAudit: vi.fn(),
+    archiveWithAudit: vi.fn(),
+    duplicateWithAudit: vi.fn(),
+    deleteWithAudit: vi.fn(),
+    addFieldWithAudit: vi.fn(),
+    updateFieldWithAudit: vi.fn(),
+    removeFieldWithAudit: vi.fn(),
+    reorderFieldsWithAudit: vi.fn(),
+    getFieldsByFormIds: vi.fn(),
+  },
+  FormNotFoundError: class FormNotFoundError extends Error {
+    name = 'FormNotFoundError';
+  },
+  FormNotDraftError: class FormNotDraftError extends Error {
+    name = 'FormNotDraftError';
+    constructor() {
+      super('Form must be in DRAFT status');
+    }
+  },
+  FormNotPublishedError: class FormNotPublishedError extends Error {
+    name = 'FormNotPublishedError';
+  },
+  FormHasNoFieldsError: class FormHasNoFieldsError extends Error {
+    name = 'FormHasNoFieldsError';
+    constructor() {
+      super('Form must have at least one field');
+    }
+  },
+  FormInUseError: class FormInUseError extends Error {
+    name = 'FormInUseError';
+    constructor() {
+      super('Form is referenced by periods or submissions');
+    }
+  },
+  DuplicateFieldKeyError: class DuplicateFieldKeyError extends Error {
+    name = 'DuplicateFieldKeyError';
+    constructor() {
+      super('Duplicate field key');
+    }
+  },
+  FormFieldNotFoundError: class FormFieldNotFoundError extends Error {
+    name = 'FormFieldNotFoundError';
+  },
+  InvalidFormDataError: class InvalidFormDataError extends Error {
+    name = 'InvalidFormDataError';
+  },
+}));
+
+vi.mock('../../services/errors.js', async (importOriginal) => {
+  return importOriginal();
+});
+
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  formDefinitions: {},
+  formFields: {},
+  submissions: {},
+  submissionFiles: {},
+  submissionHistory: {},
+  users: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+}));
+
+import { formService } from '../../services/form.service.js';
+import { formsRouter } from './forms.js';
+import type { RestContext } from '../context.js';
+import { createProcedureClient } from '@orpc/server';
+
+const mockService = vi.mocked(formService);
+
+// Deterministic UUIDs for tests
+const USER_ID = 'a0000000-0000-4000-a000-000000000001';
+const ORG_ID = 'b0000000-0000-4000-a000-000000000001';
+const FORM_ID = 'c0000000-0000-4000-a000-000000000001';
+const FIELD_ID = 'd0000000-0000-4000-a000-000000000001';
+
+// ---------------------------------------------------------------------------
+// Context helpers
+// ---------------------------------------------------------------------------
+
+function baseContext(): RestContext {
+  return {
+    authContext: null,
+    dbTx: null,
+    audit: vi.fn(),
+  };
+}
+
+function authedContext(): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: 'zid-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+    },
+    dbTx: null,
+    audit: vi.fn(),
+  };
+}
+
+function orgContext(
+  role: 'ADMIN' | 'EDITOR' | 'READER' = 'EDITOR',
+): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: 'zid-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+      orgId: ORG_ID,
+      role,
+    },
+    dbTx: {} as never,
+    audit: vi.fn(),
+  };
+}
+
+function apiKeyContext(
+  scopes: string[],
+  role: 'ADMIN' | 'EDITOR' | 'READER' = 'EDITOR',
+): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'apikey',
+      apiKeyId: 'k0000000-0000-4000-a000-000000000001',
+      apiKeyScopes: scopes as any,
+      orgId: ORG_ID,
+      role,
+    },
+    dbTx: {} as never,
+    audit: vi.fn(),
+  };
+}
+
+function client<T>(procedure: T, context: RestContext) {
+  return createProcedureClient(procedure as any, { context }) as any;
+}
+
+function makeFormDefinition(overrides: Record<string, unknown> = {}) {
+  return {
+    id: FORM_ID,
+    organizationId: ORG_ID,
+    name: 'Test Form',
+    description: null,
+    status: 'DRAFT',
+    version: 1,
+    duplicatedFromId: null,
+    createdBy: USER_ID,
+    publishedAt: null,
+    archivedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeFormField(overrides: Record<string, unknown> = {}) {
+  return {
+    id: FIELD_ID,
+    formDefinitionId: FORM_ID,
+    fieldKey: 'test_field',
+    fieldType: 'text',
+    label: 'Test Field',
+    description: null,
+    placeholder: null,
+    required: false,
+    sortOrder: 0,
+    config: null,
+    conditionalRules: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('forms REST router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /forms (list)
+  // -------------------------------------------------------------------------
+
+  describe('GET /forms (list)', () => {
+    it('requires authentication', async () => {
+      const call = client(formsRouter.list, baseContext());
+      await expect(call({})).rejects.toThrow(ORPCError);
+    });
+
+    it('requires org context', async () => {
+      const call = client(formsRouter.list, authedContext());
+      await expect(call({})).rejects.toThrow(ORPCError);
+    });
+
+    it('returns paginated form definitions', async () => {
+      const response = {
+        items: [makeFormDefinition()],
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      };
+      mockService.list.mockResolvedValueOnce(response as never);
+
+      const call = client(formsRouter.list, orgContext());
+      const result = await call({ page: 1, limit: 20 });
+      expect(result.items).toHaveLength(1);
+    });
+
+    it('enforces forms:read scope for API keys', async () => {
+      const ctx = apiKeyContext(['submissions:read']);
+      const call = client(formsRouter.list, ctx);
+      await expect(call({ page: 1, limit: 20 })).rejects.toThrow(
+        'Insufficient API key scope',
+      );
+    });
+
+    it('allows forms:read scope', async () => {
+      const response = {
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 0,
+      };
+      mockService.list.mockResolvedValueOnce(response as never);
+
+      const ctx = apiKeyContext(['forms:read']);
+      const call = client(formsRouter.list, ctx);
+      const result = await call({ page: 1, limit: 20 });
+      expect(result.items).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /forms (create)
+  // -------------------------------------------------------------------------
+
+  describe('POST /forms (create)', () => {
+    it('requires org context', async () => {
+      const call = client(formsRouter.create, authedContext());
+      await expect(call({ name: 'Test' })).rejects.toThrow(ORPCError);
+    });
+
+    it('creates a form definition', async () => {
+      const form = makeFormDefinition();
+      mockService.createWithAudit.mockResolvedValueOnce(form as never);
+
+      const call = client(formsRouter.create, orgContext());
+      const result = await call({ name: 'Test Form' });
+      expect(result.id).toBe(FORM_ID);
+    });
+
+    it('enforces forms:write scope', async () => {
+      const ctx = apiKeyContext(['forms:read']);
+      const call = client(formsRouter.create, ctx);
+      await expect(call({ name: 'Test' })).rejects.toThrow(
+        'Insufficient API key scope',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /forms/{id} (get)
+  // -------------------------------------------------------------------------
+
+  describe('GET /forms/{id} (get)', () => {
+    it('returns form with fields', async () => {
+      const form = {
+        ...makeFormDefinition(),
+        fields: [makeFormField()],
+      };
+      mockService.getById.mockResolvedValueOnce(form as never);
+
+      const call = client(formsRouter.get, orgContext());
+      const result = await call({ id: FORM_ID });
+      expect(result.id).toBe(FORM_ID);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /forms/{id}/publish
+  // -------------------------------------------------------------------------
+
+  describe('POST /forms/{id}/publish', () => {
+    it('publishes a draft form', async () => {
+      const published = makeFormDefinition({
+        status: 'PUBLISHED',
+        publishedAt: new Date(),
+      });
+      mockService.publishWithAudit.mockResolvedValueOnce(published as never);
+
+      const call = client(formsRouter.publish, orgContext());
+      const result = await call({ id: FORM_ID });
+      expect(result.status).toBe('PUBLISHED');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // DELETE /forms/{id}
+  // -------------------------------------------------------------------------
+
+  describe('DELETE /forms/{id} (delete)', () => {
+    it('deletes a draft form', async () => {
+      mockService.deleteWithAudit.mockResolvedValueOnce({
+        success: true,
+      } as never);
+
+      const call = client(formsRouter['delete'], orgContext());
+      const result = await call({ id: FORM_ID });
+      expect(result).toEqual({ success: true });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /forms/{id}/fields (addField)
+  // -------------------------------------------------------------------------
+
+  describe('POST /forms/{id}/fields (addField)', () => {
+    it('adds a field to a draft form', async () => {
+      const field = makeFormField();
+      mockService.addFieldWithAudit.mockResolvedValueOnce(field as never);
+
+      const call = client(formsRouter.addField, orgContext());
+      const result = await call({
+        id: FORM_ID,
+        fieldKey: 'test_field',
+        fieldType: 'text',
+        label: 'Test Field',
+      });
+      expect(result.fieldKey).toBe('test_field');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // DELETE /forms/{id}/fields/{fieldId} (removeField)
+  // -------------------------------------------------------------------------
+
+  describe('DELETE /forms/{id}/fields/{fieldId} (removeField)', () => {
+    it('removes a field from a draft form', async () => {
+      const field = makeFormField();
+      mockService.removeFieldWithAudit.mockResolvedValueOnce(field as never);
+
+      const call = client(formsRouter.removeField, orgContext());
+      const result = await call({ id: FORM_ID, fieldId: FIELD_ID });
+      expect(result.id).toBe(FIELD_ID);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // PUT /forms/{id}/fields/order (reorderFields)
+  // -------------------------------------------------------------------------
+
+  describe('PUT /forms/{id}/fields/order (reorderFields)', () => {
+    it('reorders fields', async () => {
+      const fields = [
+        makeFormField({ sortOrder: 0 }),
+        makeFormField({
+          id: 'e0000000-0000-4000-a000-000000000001',
+          sortOrder: 1,
+        }),
+      ];
+      mockService.reorderFieldsWithAudit.mockResolvedValueOnce(fields as never);
+
+      const call = client(formsRouter.reorderFields, orgContext());
+      const result = await call({
+        id: FORM_ID,
+        fieldIds: [FIELD_ID, 'e0000000-0000-4000-a000-000000000001'],
+      });
+      expect(result).toHaveLength(2);
+    });
+  });
+});

--- a/apps/api/src/rest/routers/forms.ts
+++ b/apps/api/src/rest/routers/forms.ts
@@ -1,0 +1,330 @@
+import { z } from 'zod';
+import {
+  createFormDefinitionSchema,
+  updateFormDefinitionSchema,
+  createFormFieldSchema,
+  updateFormFieldSchema,
+  reorderFormFieldsSchema,
+  listFormDefinitionsSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { restPaginationQuery } from '@colophony/api-contracts';
+import { formService, FormNotFoundError } from '../../services/form.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+import { orgProcedure, requireScopes } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// Query schemas — override page/limit with z.coerce for REST query strings
+// ---------------------------------------------------------------------------
+
+const restListFormsQuery = listFormDefinitionsSchema
+  .omit({ page: true, limit: true })
+  .merge(restPaginationQuery);
+
+// ---------------------------------------------------------------------------
+// Path param schemas
+// ---------------------------------------------------------------------------
+
+const formFieldIdParam = z.object({
+  id: z.string().uuid(),
+  fieldId: z.string().uuid(),
+});
+
+// ---------------------------------------------------------------------------
+// Form routes
+// ---------------------------------------------------------------------------
+
+const list = orgProcedure
+  .use(requireScopes('forms:read'))
+  .route({
+    method: 'GET',
+    path: '/forms',
+    summary: 'List form definitions',
+    description:
+      'Returns a paginated list of form definitions in the organization.',
+    operationId: 'listForms',
+    tags: ['Forms'],
+  })
+  .input(restListFormsQuery)
+  .handler(async ({ input, context }) => {
+    return formService.list(context.dbTx, input);
+  });
+
+const create = orgProcedure
+  .use(requireScopes('forms:write'))
+  .route({
+    method: 'POST',
+    path: '/forms',
+    successStatus: 201,
+    summary: 'Create a form definition',
+    description: 'Create a new form definition in DRAFT status.',
+    operationId: 'createForm',
+    tags: ['Forms'],
+  })
+  .input(createFormDefinitionSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await formService.createWithAudit(
+        toServiceContext(context),
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const get = orgProcedure
+  .use(requireScopes('forms:read'))
+  .route({
+    method: 'GET',
+    path: '/forms/{id}',
+    summary: 'Get a form definition',
+    description:
+      'Retrieve a form definition by ID, including its fields ordered by sortOrder.',
+    operationId: 'getForm',
+    tags: ['Forms'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const form = await formService.getById(context.dbTx, input.id);
+      if (!form) throw new FormNotFoundError(input.id);
+      return form;
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const update = orgProcedure
+  .use(requireScopes('forms:write'))
+  .route({
+    method: 'PATCH',
+    path: '/forms/{id}',
+    summary: 'Update a form definition',
+    description: "Update a DRAFT form definition's name or description.",
+    operationId: 'updateForm',
+    tags: ['Forms'],
+  })
+  .input(idParamSchema.merge(updateFormDefinitionSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    try {
+      return await formService.updateWithAudit(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const publish = orgProcedure
+  .use(requireScopes('forms:write'))
+  .route({
+    method: 'POST',
+    path: '/forms/{id}/publish',
+    summary: 'Publish a form',
+    description:
+      'Transition a DRAFT form to PUBLISHED status. Requires at least one field.',
+    operationId: 'publishForm',
+    tags: ['Forms'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await formService.publishWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const archive = orgProcedure
+  .use(requireScopes('forms:write'))
+  .route({
+    method: 'POST',
+    path: '/forms/{id}/archive',
+    summary: 'Archive a form',
+    description: 'Transition a PUBLISHED form to ARCHIVED status.',
+    operationId: 'archiveForm',
+    tags: ['Forms'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await formService.archiveWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const duplicate = orgProcedure
+  .use(requireScopes('forms:write'))
+  .route({
+    method: 'POST',
+    path: '/forms/{id}/duplicate',
+    successStatus: 201,
+    summary: 'Duplicate a form',
+    description:
+      'Create a copy of a form (including all fields) as a new DRAFT.',
+    operationId: 'duplicateForm',
+    tags: ['Forms'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const result = await formService.duplicateWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+      return result;
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const del = orgProcedure
+  .use(requireScopes('forms:write'))
+  .route({
+    method: 'DELETE',
+    path: '/forms/{id}',
+    summary: 'Delete a form',
+    description:
+      'Delete a DRAFT form. Fails if referenced by submission periods or submissions.',
+    operationId: 'deleteForm',
+    tags: ['Forms'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await formService.deleteWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const addField = orgProcedure
+  .use(requireScopes('forms:write'))
+  .route({
+    method: 'POST',
+    path: '/forms/{id}/fields',
+    successStatus: 201,
+    summary: 'Add a field',
+    description: 'Add a new field to a DRAFT form definition.',
+    operationId: 'addFormField',
+    tags: ['Forms'],
+  })
+  .input(idParamSchema.merge(createFormFieldSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...fieldData } = input;
+    try {
+      return await formService.addFieldWithAudit(
+        toServiceContext(context),
+        id,
+        fieldData,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const updateField = orgProcedure
+  .use(requireScopes('forms:write'))
+  .route({
+    method: 'PATCH',
+    path: '/forms/{id}/fields/{fieldId}',
+    summary: 'Update a field',
+    description: 'Update a field in a DRAFT form definition.',
+    operationId: 'updateFormField',
+    tags: ['Forms'],
+  })
+  .input(formFieldIdParam.merge(updateFormFieldSchema))
+  .handler(async ({ input, context }) => {
+    const { id, fieldId, ...data } = input;
+    try {
+      return await formService.updateFieldWithAudit(
+        toServiceContext(context),
+        id,
+        fieldId,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const removeField = orgProcedure
+  .use(requireScopes('forms:write'))
+  .route({
+    method: 'DELETE',
+    path: '/forms/{id}/fields/{fieldId}',
+    summary: 'Remove a field',
+    description: 'Remove a field from a DRAFT form definition.',
+    operationId: 'removeFormField',
+    tags: ['Forms'],
+  })
+  .input(formFieldIdParam)
+  .handler(async ({ input, context }) => {
+    try {
+      return await formService.removeFieldWithAudit(
+        toServiceContext(context),
+        input.id,
+        input.fieldId,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const reorderFields = orgProcedure
+  .use(requireScopes('forms:write'))
+  .route({
+    method: 'PUT',
+    path: '/forms/{id}/fields/order',
+    summary: 'Reorder fields',
+    description: 'Set the display order of fields in a DRAFT form definition.',
+    operationId: 'reorderFormFields',
+    tags: ['Forms'],
+  })
+  .input(idParamSchema.merge(reorderFormFieldsSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    try {
+      return await formService.reorderFieldsWithAudit(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const formsRouter = {
+  list,
+  create,
+  get,
+  update,
+  publish,
+  archive,
+  duplicate,
+  delete: del,
+  addField,
+  updateField,
+  removeField,
+  reorderFields,
+};

--- a/apps/api/src/services/form.service.spec.ts
+++ b/apps/api/src/services/form.service.spec.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Drizzle mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  formDefinitions: {},
+  formFields: {},
+  submissions: {},
+  submissionPeriods: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+  asc: vi.fn(),
+  inArray: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+  asc: vi.fn(),
+  inArray: vi.fn(),
+  count: vi.fn(),
+  ilike: vi.fn(),
+}));
+
+import { formService, FormNotFoundError } from './form.service.js';
+import type { DrizzleDb } from '@colophony/db';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFormWithFields(fieldOverrides: Record<string, unknown>[] = [{}]) {
+  return {
+    id: 'form-1',
+    organizationId: 'org-1',
+    name: 'Test Form',
+    description: null,
+    status: 'PUBLISHED' as const,
+    version: 1,
+    duplicatedFromId: null,
+    createdBy: 'user-1',
+    publishedAt: new Date(),
+    archivedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    fields: fieldOverrides.map((overrides, i) => ({
+      id: `field-${i}`,
+      formDefinitionId: 'form-1',
+      fieldKey: `field_${i}`,
+      fieldType: 'text' as const,
+      label: `Field ${i}`,
+      description: null,
+      placeholder: null,
+      required: false,
+      sortOrder: i,
+      config: null,
+      conditionalRules: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests — validateFormData
+// ---------------------------------------------------------------------------
+
+describe('formService.validateFormData', () => {
+  const mockTx = {} as DrizzleDb;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws FormNotFoundError when form does not exist', async () => {
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(null);
+
+    await expect(
+      formService.validateFormData(mockTx, 'nonexistent', {}),
+    ).rejects.toThrow(FormNotFoundError);
+  });
+
+  it('returns empty errors for valid data', async () => {
+    const form = makeFormWithFields([
+      { fieldKey: 'name', fieldType: 'text', required: false },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      name: 'Test',
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it('validates required fields', async () => {
+    const form = makeFormWithFields([
+      {
+        fieldKey: 'name',
+        fieldType: 'text',
+        label: 'Name',
+        required: true,
+      },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {});
+    expect(errors).toHaveLength(1);
+    expect(errors[0].fieldKey).toBe('name');
+    expect(errors[0].message).toContain('required');
+  });
+
+  it('skips presentational fields', async () => {
+    const form = makeFormWithFields([
+      {
+        fieldKey: 'header',
+        fieldType: 'section_header',
+        required: true,
+      },
+      {
+        fieldKey: 'info',
+        fieldType: 'info_text',
+        required: true,
+      },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {});
+    expect(errors).toEqual([]);
+  });
+
+  it('validates text field type', async () => {
+    const form = makeFormWithFields([
+      { fieldKey: 'name', fieldType: 'text', label: 'Name' },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      name: 123,
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('must be text');
+  });
+
+  it('validates text field minLength', async () => {
+    const form = makeFormWithFields([
+      {
+        fieldKey: 'name',
+        fieldType: 'text',
+        label: 'Name',
+        config: { minLength: 5 },
+      },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      name: 'ab',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('at least 5');
+  });
+
+  it('validates text field maxLength', async () => {
+    const form = makeFormWithFields([
+      {
+        fieldKey: 'name',
+        fieldType: 'text',
+        label: 'Name',
+        config: { maxLength: 3 },
+      },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      name: 'abcdef',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('at most 3');
+  });
+
+  it('validates number field type', async () => {
+    const form = makeFormWithFields([
+      { fieldKey: 'age', fieldType: 'number', label: 'Age' },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      age: 'not-a-number',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('must be a number');
+  });
+
+  it('validates number field min/max', async () => {
+    const form = makeFormWithFields([
+      {
+        fieldKey: 'age',
+        fieldType: 'number',
+        label: 'Age',
+        config: { min: 18, max: 120 },
+      },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      age: 10,
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('at least 18');
+  });
+
+  it('validates email field', async () => {
+    const form = makeFormWithFields([
+      { fieldKey: 'email', fieldType: 'email', label: 'Email' },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      email: 'not-an-email',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('valid email');
+  });
+
+  it('validates url field', async () => {
+    const form = makeFormWithFields([
+      { fieldKey: 'website', fieldType: 'url', label: 'Website' },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      website: 'not-a-url',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('valid URL');
+  });
+
+  it('validates date field', async () => {
+    const form = makeFormWithFields([
+      { fieldKey: 'dob', fieldType: 'date', label: 'Date of Birth' },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      dob: 'not-a-date',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('valid date');
+  });
+
+  it('validates select field options', async () => {
+    const form = makeFormWithFields([
+      {
+        fieldKey: 'genre',
+        fieldType: 'select',
+        label: 'Genre',
+        config: {
+          options: [
+            { label: 'Poetry', value: 'poetry' },
+            { label: 'Fiction', value: 'fiction' },
+          ],
+        },
+      },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      genre: 'non-fiction',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('must be one of');
+  });
+
+  it('validates multi_select field', async () => {
+    const form = makeFormWithFields([
+      {
+        fieldKey: 'tags',
+        fieldType: 'multi_select',
+        label: 'Tags',
+        config: {
+          options: [
+            { label: 'A', value: 'a' },
+            { label: 'B', value: 'b' },
+          ],
+        },
+      },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      tags: ['a', 'invalid'],
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('invalid option');
+  });
+
+  it('validates checkbox field must be boolean', async () => {
+    const form = makeFormWithFields([
+      { fieldKey: 'agree', fieldType: 'checkbox', label: 'Agree' },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      agree: 'yes',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('true or false');
+  });
+
+  it('skips optional empty fields', async () => {
+    const form = makeFormWithFields([
+      {
+        fieldKey: 'bio',
+        fieldType: 'textarea',
+        label: 'Bio',
+        required: false,
+      },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {});
+    expect(errors).toEqual([]);
+  });
+
+  it('validates multiple fields at once', async () => {
+    const form = makeFormWithFields([
+      {
+        fieldKey: 'name',
+        fieldType: 'text',
+        label: 'Name',
+        required: true,
+      },
+      {
+        fieldKey: 'email',
+        fieldType: 'email',
+        label: 'Email',
+        required: true,
+      },
+      {
+        fieldKey: 'age',
+        fieldType: 'number',
+        label: 'Age',
+      },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      age: 'not-a-number',
+    });
+    // name required, email required, age wrong type
+    expect(errors).toHaveLength(3);
+    expect(errors.map((e) => e.fieldKey)).toEqual(
+      expect.arrayContaining(['name', 'email', 'age']),
+    );
+  });
+});

--- a/apps/api/src/services/form.service.ts
+++ b/apps/api/src/services/form.service.ts
@@ -1,0 +1,912 @@
+import {
+  formDefinitions,
+  formFields,
+  submissionPeriods,
+  submissions,
+  eq,
+  and,
+  sql,
+  type DrizzleDb,
+} from '@colophony/db';
+import { desc, asc, ilike, count, inArray } from 'drizzle-orm';
+import { z } from 'zod';
+import type {
+  CreateFormDefinitionInput,
+  UpdateFormDefinitionInput,
+  CreateFormFieldInput,
+  UpdateFormFieldInput,
+  ReorderFormFieldsInput,
+  ListFormDefinitionsInput,
+  FormFieldError,
+} from '@colophony/types';
+import {
+  AuditActions,
+  AuditResources,
+  PRESENTATIONAL_FIELD_TYPES,
+  textFieldConfigSchema,
+  numberFieldConfigSchema,
+  selectFieldConfigSchema,
+  richTextFieldConfigSchema,
+} from '@colophony/types';
+import type { ServiceContext } from './types.js';
+import { assertEditorOrAdmin } from './errors.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class FormNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Form definition "${id}" not found`);
+    this.name = 'FormNotFoundError';
+  }
+}
+
+export class FormFieldNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Form field "${id}" not found`);
+    this.name = 'FormFieldNotFoundError';
+  }
+}
+
+export class FormNotDraftError extends Error {
+  constructor() {
+    super('Form must be in DRAFT status for this operation');
+    this.name = 'FormNotDraftError';
+  }
+}
+
+export class FormNotPublishedError extends Error {
+  constructor() {
+    super('Form must be in PUBLISHED status for this operation');
+    this.name = 'FormNotPublishedError';
+  }
+}
+
+export class DuplicateFieldKeyError extends Error {
+  constructor(key: string) {
+    super(`Field key "${key}" already exists in this form`);
+    this.name = 'DuplicateFieldKeyError';
+  }
+}
+
+export class FormHasNoFieldsError extends Error {
+  constructor() {
+    super('Cannot publish a form with no fields');
+    this.name = 'FormHasNoFieldsError';
+  }
+}
+
+export class FormInUseError extends Error {
+  constructor() {
+    super(
+      'Cannot delete this form because it is referenced by submission periods or submissions',
+    );
+    this.name = 'FormInUseError';
+  }
+}
+
+export class InvalidFormDataError extends Error {
+  readonly fieldErrors: FormFieldError[];
+
+  constructor(fieldErrors: FormFieldError[]) {
+    super('Form data validation failed');
+    this.name = 'InvalidFormDataError';
+    this.fieldErrors = fieldErrors;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getFormForUpdate(tx: DrizzleDb, id: string) {
+  const rows = await tx.execute<{
+    id: string;
+    status: string;
+  }>(sql`SELECT id, status FROM form_definitions WHERE id = ${id} FOR UPDATE`);
+  return rows.rows[0] ?? null;
+}
+
+async function assertDraft(tx: DrizzleDb, id: string) {
+  const form = await getFormForUpdate(tx, id);
+  if (!form) throw new FormNotFoundError(id);
+  if (form.status !== 'DRAFT') throw new FormNotDraftError();
+  return form;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const formService = {
+  // -------------------------------------------------------------------------
+  // List / Get
+  // -------------------------------------------------------------------------
+
+  async list(tx: DrizzleDb, input: ListFormDefinitionsInput) {
+    const { status, search, page, limit } = input;
+    const offset = (page - 1) * limit;
+
+    const conditions = [];
+    if (status) conditions.push(eq(formDefinitions.status, status));
+    if (search) conditions.push(ilike(formDefinitions.name, `%${search}%`));
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const [items, countResult] = await Promise.all([
+      tx
+        .select()
+        .from(formDefinitions)
+        .where(where)
+        .orderBy(desc(formDefinitions.createdAt))
+        .limit(limit)
+        .offset(offset),
+      tx.select({ count: count() }).from(formDefinitions).where(where),
+    ]);
+
+    const total = countResult[0]?.count ?? 0;
+    return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
+  },
+
+  async getById(tx: DrizzleDb, id: string) {
+    const [form] = await tx
+      .select()
+      .from(formDefinitions)
+      .where(eq(formDefinitions.id, id))
+      .limit(1);
+
+    if (!form) return null;
+
+    const fields = await tx
+      .select()
+      .from(formFields)
+      .where(eq(formFields.formDefinitionId, id))
+      .orderBy(asc(formFields.sortOrder));
+
+    return { ...form, fields };
+  },
+
+  // -------------------------------------------------------------------------
+  // Create / Update / Delete
+  // -------------------------------------------------------------------------
+
+  async create(
+    tx: DrizzleDb,
+    input: CreateFormDefinitionInput,
+    orgId: string,
+    userId: string,
+  ) {
+    const [form] = await tx
+      .insert(formDefinitions)
+      .values({
+        organizationId: orgId,
+        name: input.name,
+        description: input.description ?? null,
+        status: 'DRAFT',
+        version: 1,
+        createdBy: userId,
+      })
+      .returning();
+
+    return form;
+  },
+
+  async createWithAudit(svc: ServiceContext, input: CreateFormDefinitionInput) {
+    assertEditorOrAdmin(svc.actor.role);
+    const form = await formService.create(
+      svc.tx,
+      input,
+      svc.actor.orgId,
+      svc.actor.userId,
+    );
+    await svc.audit({
+      action: AuditActions.FORM_CREATED,
+      resource: AuditResources.FORM,
+      resourceId: form.id,
+      newValue: { name: input.name },
+    });
+    return form;
+  },
+
+  async update(tx: DrizzleDb, id: string, input: UpdateFormDefinitionInput) {
+    await assertDraft(tx, id);
+
+    const [updated] = await tx
+      .update(formDefinitions)
+      .set({
+        ...(input.name !== undefined ? { name: input.name } : {}),
+        ...(input.description !== undefined
+          ? { description: input.description }
+          : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(formDefinitions.id, id))
+      .returning();
+
+    return updated ?? null;
+  },
+
+  async updateWithAudit(
+    svc: ServiceContext,
+    id: string,
+    input: UpdateFormDefinitionInput,
+  ) {
+    assertEditorOrAdmin(svc.actor.role);
+    const updated = await formService.update(svc.tx, id, input);
+    if (!updated) throw new FormNotFoundError(id);
+    await svc.audit({
+      action: AuditActions.FORM_UPDATED,
+      resource: AuditResources.FORM,
+      resourceId: id,
+      newValue: input,
+    });
+    return updated;
+  },
+
+  // -------------------------------------------------------------------------
+  // Publish / Archive
+  // -------------------------------------------------------------------------
+
+  async publish(tx: DrizzleDb, id: string) {
+    await assertDraft(tx, id);
+
+    // Check that the form has at least one field
+    const fieldCount = await tx
+      .select({ count: count() })
+      .from(formFields)
+      .where(eq(formFields.formDefinitionId, id));
+
+    if ((fieldCount[0]?.count ?? 0) === 0) throw new FormHasNoFieldsError();
+
+    const [published] = await tx
+      .update(formDefinitions)
+      .set({
+        status: 'PUBLISHED',
+        publishedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(formDefinitions.id, id))
+      .returning();
+
+    return published;
+  },
+
+  async publishWithAudit(svc: ServiceContext, id: string) {
+    assertEditorOrAdmin(svc.actor.role);
+    const published = await formService.publish(svc.tx, id);
+    await svc.audit({
+      action: AuditActions.FORM_PUBLISHED,
+      resource: AuditResources.FORM,
+      resourceId: id,
+    });
+    return published;
+  },
+
+  async archive(tx: DrizzleDb, id: string) {
+    const form = await getFormForUpdate(tx, id);
+    if (!form) throw new FormNotFoundError(id);
+    if (form.status !== 'PUBLISHED') throw new FormNotPublishedError();
+
+    const [archived] = await tx
+      .update(formDefinitions)
+      .set({
+        status: 'ARCHIVED',
+        archivedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(formDefinitions.id, id))
+      .returning();
+
+    return archived;
+  },
+
+  async archiveWithAudit(svc: ServiceContext, id: string) {
+    assertEditorOrAdmin(svc.actor.role);
+    const archived = await formService.archive(svc.tx, id);
+    await svc.audit({
+      action: AuditActions.FORM_ARCHIVED,
+      resource: AuditResources.FORM,
+      resourceId: id,
+    });
+    return archived;
+  },
+
+  // -------------------------------------------------------------------------
+  // Duplicate
+  // -------------------------------------------------------------------------
+
+  async duplicate(tx: DrizzleDb, id: string, orgId: string, userId: string) {
+    const source = await formService.getById(tx, id);
+    if (!source) throw new FormNotFoundError(id);
+
+    const [newForm] = await tx
+      .insert(formDefinitions)
+      .values({
+        organizationId: orgId,
+        name: `${source.name} (copy)`,
+        description: source.description,
+        status: 'DRAFT',
+        version: source.version + 1,
+        duplicatedFromId: source.id,
+        createdBy: userId,
+      })
+      .returning();
+
+    // Copy all fields
+    if (source.fields.length > 0) {
+      await tx.insert(formFields).values(
+        source.fields.map((f) => ({
+          formDefinitionId: newForm.id,
+          fieldKey: f.fieldKey,
+          fieldType: f.fieldType,
+          label: f.label,
+          description: f.description,
+          placeholder: f.placeholder,
+          required: f.required,
+          sortOrder: f.sortOrder,
+          config: f.config,
+          conditionalRules: f.conditionalRules,
+        })),
+      );
+    }
+
+    return formService.getById(tx, newForm.id);
+  },
+
+  async duplicateWithAudit(svc: ServiceContext, id: string) {
+    assertEditorOrAdmin(svc.actor.role);
+    const duplicated = await formService.duplicate(
+      svc.tx,
+      id,
+      svc.actor.orgId,
+      svc.actor.userId,
+    );
+    if (!duplicated) throw new FormNotFoundError(id);
+    await svc.audit({
+      action: AuditActions.FORM_DUPLICATED,
+      resource: AuditResources.FORM,
+      resourceId: duplicated.id,
+      newValue: { sourceFormId: id },
+    });
+    return duplicated;
+  },
+
+  // -------------------------------------------------------------------------
+  // Delete
+  // -------------------------------------------------------------------------
+
+  async delete(tx: DrizzleDb, id: string) {
+    await assertDraft(tx, id);
+
+    // Check if referenced by submission periods or submissions
+    const [periodRefs, submissionRefs] = await Promise.all([
+      tx
+        .select({ count: count() })
+        .from(submissionPeriods)
+        .where(eq(submissionPeriods.formDefinitionId, id)),
+      tx
+        .select({ count: count() })
+        .from(submissions)
+        .where(eq(submissions.formDefinitionId, id)),
+    ]);
+
+    if (
+      (periodRefs[0]?.count ?? 0) > 0 ||
+      (submissionRefs[0]?.count ?? 0) > 0
+    ) {
+      throw new FormInUseError();
+    }
+
+    const [deleted] = await tx
+      .delete(formDefinitions)
+      .where(eq(formDefinitions.id, id))
+      .returning();
+
+    return deleted ?? null;
+  },
+
+  async deleteWithAudit(svc: ServiceContext, id: string) {
+    assertEditorOrAdmin(svc.actor.role);
+    const deleted = await formService.delete(svc.tx, id);
+    if (!deleted) throw new FormNotFoundError(id);
+    await svc.audit({
+      action: AuditActions.FORM_DELETED,
+      resource: AuditResources.FORM,
+      resourceId: id,
+    });
+    return { success: true as const };
+  },
+
+  // -------------------------------------------------------------------------
+  // Field Operations
+  // -------------------------------------------------------------------------
+
+  async addField(tx: DrizzleDb, formId: string, input: CreateFormFieldInput) {
+    await assertDraft(tx, formId);
+
+    // Auto-assign sortOrder if not provided
+    let sortOrder = input.sortOrder;
+    if (sortOrder === undefined) {
+      const maxResult = await tx.execute<{ max_order: number | null }>(
+        sql`SELECT MAX(sort_order) as max_order FROM form_fields WHERE form_definition_id = ${formId}`,
+      );
+      sortOrder = (maxResult.rows[0]?.max_order ?? -1) + 1;
+    }
+
+    const [field] = await tx
+      .insert(formFields)
+      .values({
+        formDefinitionId: formId,
+        fieldKey: input.fieldKey,
+        fieldType: input.fieldType,
+        label: input.label,
+        description: input.description ?? null,
+        placeholder: input.placeholder ?? null,
+        required: input.required ?? false,
+        sortOrder,
+        config: input.config ?? {},
+      })
+      .returning();
+
+    return field;
+  },
+
+  async addFieldWithAudit(
+    svc: ServiceContext,
+    formId: string,
+    input: CreateFormFieldInput,
+  ) {
+    assertEditorOrAdmin(svc.actor.role);
+    try {
+      const field = await formService.addField(svc.tx, formId, input);
+      await svc.audit({
+        action: AuditActions.FORM_FIELD_ADDED,
+        resource: AuditResources.FORM,
+        resourceId: formId,
+        newValue: { fieldId: field.id, fieldKey: input.fieldKey },
+      });
+      return field;
+    } catch (e) {
+      // Map unique constraint violation to DuplicateFieldKeyError
+      if (
+        typeof e === 'object' &&
+        e !== null &&
+        'code' in e &&
+        (e as { code: string }).code === '23505'
+      ) {
+        throw new DuplicateFieldKeyError(input.fieldKey);
+      }
+      throw e;
+    }
+  },
+
+  async updateField(
+    tx: DrizzleDb,
+    formId: string,
+    fieldId: string,
+    input: UpdateFormFieldInput,
+  ) {
+    await assertDraft(tx, formId);
+
+    const [existing] = await tx
+      .select()
+      .from(formFields)
+      .where(
+        and(
+          eq(formFields.id, fieldId),
+          eq(formFields.formDefinitionId, formId),
+        ),
+      )
+      .limit(1);
+
+    if (!existing) throw new FormFieldNotFoundError(fieldId);
+
+    const [updated] = await tx
+      .update(formFields)
+      .set({
+        ...(input.label !== undefined ? { label: input.label } : {}),
+        ...(input.description !== undefined
+          ? { description: input.description }
+          : {}),
+        ...(input.placeholder !== undefined
+          ? { placeholder: input.placeholder }
+          : {}),
+        ...(input.required !== undefined ? { required: input.required } : {}),
+        ...(input.config !== undefined ? { config: input.config } : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(formFields.id, fieldId))
+      .returning();
+
+    return updated ?? null;
+  },
+
+  async updateFieldWithAudit(
+    svc: ServiceContext,
+    formId: string,
+    fieldId: string,
+    input: UpdateFormFieldInput,
+  ) {
+    assertEditorOrAdmin(svc.actor.role);
+    const updated = await formService.updateField(
+      svc.tx,
+      formId,
+      fieldId,
+      input,
+    );
+    if (!updated) throw new FormFieldNotFoundError(fieldId);
+    await svc.audit({
+      action: AuditActions.FORM_FIELD_UPDATED,
+      resource: AuditResources.FORM,
+      resourceId: formId,
+      newValue: { fieldId, ...input },
+    });
+    return updated;
+  },
+
+  async removeField(tx: DrizzleDb, formId: string, fieldId: string) {
+    await assertDraft(tx, formId);
+
+    const [deleted] = await tx
+      .delete(formFields)
+      .where(
+        and(
+          eq(formFields.id, fieldId),
+          eq(formFields.formDefinitionId, formId),
+        ),
+      )
+      .returning();
+
+    if (!deleted) throw new FormFieldNotFoundError(fieldId);
+    return deleted;
+  },
+
+  async removeFieldWithAudit(
+    svc: ServiceContext,
+    formId: string,
+    fieldId: string,
+  ) {
+    assertEditorOrAdmin(svc.actor.role);
+    const removed = await formService.removeField(svc.tx, formId, fieldId);
+    await svc.audit({
+      action: AuditActions.FORM_FIELD_REMOVED,
+      resource: AuditResources.FORM,
+      resourceId: formId,
+      newValue: { fieldId },
+    });
+    return removed;
+  },
+
+  async reorderFields(
+    tx: DrizzleDb,
+    formId: string,
+    input: ReorderFormFieldsInput,
+  ) {
+    await assertDraft(tx, formId);
+
+    // Verify all field IDs belong to this form
+    const existingFields = await tx
+      .select({ id: formFields.id })
+      .from(formFields)
+      .where(eq(formFields.formDefinitionId, formId));
+
+    const existingIds = new Set(existingFields.map((f) => f.id));
+    for (const fieldId of input.fieldIds) {
+      if (!existingIds.has(fieldId)) throw new FormFieldNotFoundError(fieldId);
+    }
+
+    // Bulk update sortOrder
+    for (let i = 0; i < input.fieldIds.length; i++) {
+      await tx
+        .update(formFields)
+        .set({ sortOrder: i, updatedAt: new Date() })
+        .where(eq(formFields.id, input.fieldIds[i]));
+    }
+
+    return tx
+      .select()
+      .from(formFields)
+      .where(eq(formFields.formDefinitionId, formId))
+      .orderBy(asc(formFields.sortOrder));
+  },
+
+  async reorderFieldsWithAudit(
+    svc: ServiceContext,
+    formId: string,
+    input: ReorderFormFieldsInput,
+  ) {
+    assertEditorOrAdmin(svc.actor.role);
+    const fields = await formService.reorderFields(svc.tx, formId, input);
+    await svc.audit({
+      action: AuditActions.FORM_FIELDS_REORDERED,
+      resource: AuditResources.FORM,
+      resourceId: formId,
+      newValue: { fieldIds: input.fieldIds },
+    });
+    return fields;
+  },
+
+  // -------------------------------------------------------------------------
+  // Form Data Validation
+  // -------------------------------------------------------------------------
+
+  /**
+   * Validate submission formData against a published form definition.
+   * Returns field-level errors. Skips presentational fields.
+   */
+  async validateFormData(
+    tx: DrizzleDb,
+    formDefinitionId: string,
+    data: Record<string, unknown>,
+  ): Promise<FormFieldError[]> {
+    const form = await formService.getById(tx, formDefinitionId);
+    if (!form) throw new FormNotFoundError(formDefinitionId);
+
+    const errors: FormFieldError[] = [];
+
+    for (const field of form.fields) {
+      // Skip presentational fields
+      if (PRESENTATIONAL_FIELD_TYPES.includes(field.fieldType)) {
+        continue;
+      }
+
+      const value = data[field.fieldKey];
+
+      // Required check
+      if (
+        field.required &&
+        (value === undefined || value === null || value === '')
+      ) {
+        errors.push({
+          fieldKey: field.fieldKey,
+          message: `${field.label} is required`,
+        });
+        continue;
+      }
+
+      // Skip further validation if value is not provided and not required
+      if (value === undefined || value === null || value === '') continue;
+
+      // Type-specific validation
+      const fieldErrors = validateFieldValue(field, value);
+      errors.push(...fieldErrors);
+    }
+
+    return errors;
+  },
+
+  /**
+   * Batch-load form fields by form definition IDs.
+   * Used by GraphQL DataLoader for N+1 prevention.
+   */
+  async getFieldsByFormIds(tx: DrizzleDb, formIds: string[]) {
+    if (formIds.length === 0)
+      return new Map<string, (typeof formFields.$inferSelect)[]>();
+
+    const rows = await tx
+      .select()
+      .from(formFields)
+      .where(inArray(formFields.formDefinitionId, formIds))
+      .orderBy(asc(formFields.sortOrder));
+
+    const grouped = new Map<string, (typeof formFields.$inferSelect)[]>();
+    for (const row of rows) {
+      const list = grouped.get(row.formDefinitionId) ?? [];
+      list.push(row);
+      grouped.set(row.formDefinitionId, list);
+    }
+
+    return grouped;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Field value validation helpers
+// ---------------------------------------------------------------------------
+
+function validateFieldValue(
+  field: {
+    fieldKey: string;
+    fieldType: string;
+    label: string;
+    config: Record<string, unknown> | null;
+  },
+  value: unknown,
+): FormFieldError[] {
+  const errors: FormFieldError[] = [];
+  const config = field.config ?? {};
+
+  switch (field.fieldType) {
+    case 'text':
+    case 'textarea': {
+      if (typeof value !== 'string') {
+        errors.push({
+          fieldKey: field.fieldKey,
+          message: `${field.label} must be text`,
+        });
+        break;
+      }
+      const parsed = textFieldConfigSchema.safeParse(config);
+      if (parsed.success) {
+        if (
+          parsed.data.minLength !== undefined &&
+          value.length < parsed.data.minLength
+        ) {
+          errors.push({
+            fieldKey: field.fieldKey,
+            message: `${field.label} must be at least ${parsed.data.minLength} characters`,
+          });
+        }
+        if (
+          parsed.data.maxLength !== undefined &&
+          value.length > parsed.data.maxLength
+        ) {
+          errors.push({
+            fieldKey: field.fieldKey,
+            message: `${field.label} must be at most ${parsed.data.maxLength} characters`,
+          });
+        }
+      }
+      break;
+    }
+    case 'rich_text': {
+      if (typeof value !== 'string') {
+        errors.push({
+          fieldKey: field.fieldKey,
+          message: `${field.label} must be text`,
+        });
+        break;
+      }
+      const parsed = richTextFieldConfigSchema.safeParse(config);
+      if (
+        parsed.success &&
+        parsed.data.maxLength !== undefined &&
+        value.length > parsed.data.maxLength
+      ) {
+        errors.push({
+          fieldKey: field.fieldKey,
+          message: `${field.label} must be at most ${parsed.data.maxLength} characters`,
+        });
+      }
+      break;
+    }
+    case 'number': {
+      if (typeof value !== 'number') {
+        errors.push({
+          fieldKey: field.fieldKey,
+          message: `${field.label} must be a number`,
+        });
+        break;
+      }
+      const parsed = numberFieldConfigSchema.safeParse(config);
+      if (parsed.success) {
+        if (parsed.data.min !== undefined && value < parsed.data.min) {
+          errors.push({
+            fieldKey: field.fieldKey,
+            message: `${field.label} must be at least ${parsed.data.min}`,
+          });
+        }
+        if (parsed.data.max !== undefined && value > parsed.data.max) {
+          errors.push({
+            fieldKey: field.fieldKey,
+            message: `${field.label} must be at most ${parsed.data.max}`,
+          });
+        }
+      }
+      break;
+    }
+    case 'email': {
+      if (typeof value !== 'string') {
+        errors.push({
+          fieldKey: field.fieldKey,
+          message: `${field.label} must be text`,
+        });
+        break;
+      }
+      const emailResult = z.string().email().safeParse(value);
+      if (!emailResult.success) {
+        errors.push({
+          fieldKey: field.fieldKey,
+          message: `${field.label} must be a valid email address`,
+        });
+      }
+      break;
+    }
+    case 'url': {
+      if (typeof value !== 'string') {
+        errors.push({
+          fieldKey: field.fieldKey,
+          message: `${field.label} must be text`,
+        });
+        break;
+      }
+      const urlResult = z.string().url().safeParse(value);
+      if (!urlResult.success) {
+        errors.push({
+          fieldKey: field.fieldKey,
+          message: `${field.label} must be a valid URL`,
+        });
+      }
+      break;
+    }
+    case 'date': {
+      if (typeof value !== 'string') {
+        errors.push({
+          fieldKey: field.fieldKey,
+          message: `${field.label} must be a date string`,
+        });
+        break;
+      }
+      const dateResult = z.string().date().safeParse(value);
+      if (!dateResult.success) {
+        errors.push({
+          fieldKey: field.fieldKey,
+          message: `${field.label} must be a valid date (YYYY-MM-DD)`,
+        });
+      }
+      break;
+    }
+    case 'select':
+    case 'radio': {
+      if (typeof value !== 'string') {
+        errors.push({
+          fieldKey: field.fieldKey,
+          message: `${field.label} must be a string`,
+        });
+        break;
+      }
+      const parsed = selectFieldConfigSchema.safeParse(config);
+      if (parsed.success) {
+        const validValues = parsed.data.options.map((o) => o.value);
+        if (!validValues.includes(value)) {
+          errors.push({
+            fieldKey: field.fieldKey,
+            message: `${field.label} must be one of: ${validValues.join(', ')}`,
+          });
+        }
+      }
+      break;
+    }
+    case 'multi_select':
+    case 'checkbox_group': {
+      if (!Array.isArray(value)) {
+        errors.push({
+          fieldKey: field.fieldKey,
+          message: `${field.label} must be an array`,
+        });
+        break;
+      }
+      const parsed = selectFieldConfigSchema.safeParse(config);
+      if (parsed.success) {
+        const validValues = parsed.data.options.map((o) => o.value);
+        for (const v of value) {
+          if (typeof v !== 'string' || !validValues.includes(v)) {
+            errors.push({
+              fieldKey: field.fieldKey,
+              message: `${field.label} contains invalid option: ${String(v)}`,
+            });
+            break;
+          }
+        }
+      }
+      break;
+    }
+    case 'checkbox': {
+      if (typeof value !== 'boolean') {
+        errors.push({
+          fieldKey: field.fieldKey,
+          message: `${field.label} must be true or false`,
+        });
+      }
+      break;
+    }
+    case 'file_upload': {
+      // File upload validation happens at the file upload layer, not here.
+      // We only validate the reference exists.
+      break;
+    }
+  }
+
+  return errors;
+}

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -13,6 +13,16 @@ import {
   InfectedFilesError,
 } from '../services/submission.service.js';
 import { LastAdminError } from '../services/organization.service.js';
+import {
+  FormNotFoundError,
+  FormFieldNotFoundError,
+  FormNotDraftError,
+  FormNotPublishedError,
+  DuplicateFieldKeyError,
+  FormHasNoFieldsError,
+  FormInUseError,
+  InvalidFormDataError,
+} from '../services/form.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -31,6 +41,15 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [UnscannedFilesError, 'BAD_REQUEST'],
   [InfectedFilesError, 'BAD_REQUEST'],
   [LastAdminError, 'BAD_REQUEST'],
+  // Form errors
+  [FormNotFoundError, 'NOT_FOUND'],
+  [FormFieldNotFoundError, 'NOT_FOUND'],
+  [FormNotDraftError, 'BAD_REQUEST'],
+  [FormNotPublishedError, 'BAD_REQUEST'],
+  [DuplicateFieldKeyError, 'CONFLICT'],
+  [FormHasNoFieldsError, 'BAD_REQUEST'],
+  [FormInUseError, 'BAD_REQUEST'],
+  [InvalidFormDataError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -6,6 +6,7 @@ import { submissionsRouter } from './routers/submissions.js';
 import { filesRouter } from './routers/files.js';
 import { apiKeysRouter } from './routers/api-keys.js';
 import { auditRouter } from './routers/audit.js';
+import { formsRouter } from './routers/forms.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -34,6 +35,7 @@ export const appRouter = t.router({
   gdpr: t.router({}),
   consent: t.router({}),
   audit: auditRouter,
+  forms: formsRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/forms.spec.ts
+++ b/apps/api/src/trpc/routers/forms.spec.ts
@@ -1,0 +1,443 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+// Mock the form service before importing the router
+vi.mock('../../services/form.service.js', () => ({
+  formService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    createWithAudit: vi.fn(),
+    updateWithAudit: vi.fn(),
+    publishWithAudit: vi.fn(),
+    archiveWithAudit: vi.fn(),
+    duplicateWithAudit: vi.fn(),
+    deleteWithAudit: vi.fn(),
+    addFieldWithAudit: vi.fn(),
+    updateFieldWithAudit: vi.fn(),
+    removeFieldWithAudit: vi.fn(),
+    reorderFieldsWithAudit: vi.fn(),
+    getFieldsByFormIds: vi.fn(),
+  },
+  FormNotFoundError: class FormNotFoundError extends Error {
+    name = 'FormNotFoundError';
+    constructor(id = 'unknown') {
+      super(`Form "${id}" not found`);
+    }
+  },
+  FormNotDraftError: class FormNotDraftError extends Error {
+    name = 'FormNotDraftError';
+    constructor() {
+      super('Form must be in DRAFT status');
+    }
+  },
+  FormNotPublishedError: class FormNotPublishedError extends Error {
+    name = 'FormNotPublishedError';
+    constructor() {
+      super('Form must be in PUBLISHED status');
+    }
+  },
+  FormHasNoFieldsError: class FormHasNoFieldsError extends Error {
+    name = 'FormHasNoFieldsError';
+    constructor() {
+      super('Form must have at least one field');
+    }
+  },
+  FormInUseError: class FormInUseError extends Error {
+    name = 'FormInUseError';
+    constructor() {
+      super('Form is referenced by periods or submissions');
+    }
+  },
+  DuplicateFieldKeyError: class DuplicateFieldKeyError extends Error {
+    name = 'DuplicateFieldKeyError';
+    constructor() {
+      super('Duplicate field key');
+    }
+  },
+  FormFieldNotFoundError: class FormFieldNotFoundError extends Error {
+    name = 'FormFieldNotFoundError';
+    constructor() {
+      super('Field not found');
+    }
+  },
+  InvalidFormDataError: class InvalidFormDataError extends Error {
+    name = 'InvalidFormDataError';
+    fieldErrors: { fieldKey: string; message: string }[] = [];
+    constructor() {
+      super('Invalid form data');
+    }
+  },
+}));
+
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  organizations: {},
+  organizationMembers: {},
+  users: {},
+  submissions: {},
+  submissionFiles: {},
+  submissionHistory: {},
+  formDefinitions: {},
+  formFields: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+}));
+
+import { formService } from '../../services/form.service.js';
+import { appRouter } from '../router.js';
+import type { TRPCContext } from '../context.js';
+
+const mockService = vi.mocked(formService);
+
+// ---------------------------------------------------------------------------
+// UUID constants
+// ---------------------------------------------------------------------------
+const FORM_ID = 'a1111111-1111-4111-a111-111111111111';
+const FIELD_ID = 'b2222222-2222-4222-b222-222222222222';
+const ORG_ID = 'c3333333-3333-4333-a333-333333333333';
+const USER_ID = 'd4444444-4444-4444-a444-444444444444';
+const ZITADEL_USER_ID = 'e5555555-5555-4555-a555-555555555555';
+
+function makeContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
+  return {
+    authContext: null,
+    dbTx: null,
+    audit: vi.fn(),
+    ...overrides,
+  };
+}
+
+function orgContext(
+  role: 'ADMIN' | 'EDITOR' | 'READER' = 'EDITOR',
+  overrides: Partial<TRPCContext> = {},
+): TRPCContext {
+  const mockTx = {} as never;
+  return makeContext({
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: ZITADEL_USER_ID,
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+      orgId: ORG_ID,
+      role,
+    },
+    dbTx: mockTx,
+    audit: vi.fn(),
+    ...overrides,
+  });
+}
+
+const createCaller = (appRouter as any).createCaller as (
+  ctx: TRPCContext,
+) => any;
+
+function makeFormDefinition(overrides: Record<string, unknown> = {}) {
+  return {
+    id: FORM_ID,
+    organizationId: ORG_ID,
+    name: 'Test Form',
+    description: null,
+    status: 'DRAFT' as const,
+    version: 1,
+    duplicatedFromId: null,
+    createdBy: USER_ID,
+    publishedAt: null,
+    archivedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeFormField(overrides: Record<string, unknown> = {}) {
+  return {
+    id: FIELD_ID,
+    formDefinitionId: FORM_ID,
+    fieldKey: 'test_field',
+    fieldType: 'text' as const,
+    label: 'Test Field',
+    description: null,
+    placeholder: null,
+    required: false,
+    sortOrder: 0,
+    config: null,
+    conditionalRules: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('forms tRPC router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Auth / access control
+  // -------------------------------------------------------------------------
+
+  describe('auth and access', () => {
+    it('list requires authentication', async () => {
+      const caller = createCaller(makeContext());
+      await expect(caller.forms.list({ page: 1, limit: 20 })).rejects.toThrow(
+        TRPCError,
+      );
+    });
+
+    it('create requires org context', async () => {
+      const caller = createCaller(makeContext());
+      await expect(caller.forms.create({ name: 'Test' })).rejects.toThrow(
+        TRPCError,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Queries
+  // -------------------------------------------------------------------------
+
+  describe('list', () => {
+    it('returns paginated form definitions', async () => {
+      const response = {
+        items: [makeFormDefinition()],
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      };
+      mockService.list.mockResolvedValueOnce(response as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.forms.list({ page: 1, limit: 20 });
+      expect(result.items).toHaveLength(1);
+      expect(result.total).toBe(1);
+    });
+  });
+
+  describe('getById', () => {
+    it('returns form with fields', async () => {
+      const form = {
+        ...makeFormDefinition(),
+        fields: [makeFormField()],
+      };
+      mockService.getById.mockResolvedValueOnce(form as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.forms.getById({ id: FORM_ID });
+      expect(result.id).toBe(FORM_ID);
+      expect(result.fields).toHaveLength(1);
+    });
+
+    it('maps FormNotFoundError to NOT_FOUND', async () => {
+      mockService.getById.mockResolvedValueOnce(null as never);
+
+      const caller = createCaller(orgContext());
+      await expect(caller.forms.getById({ id: FORM_ID })).rejects.toThrow(
+        'not found',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Mutations
+  // -------------------------------------------------------------------------
+
+  describe('create', () => {
+    it('creates a form definition', async () => {
+      const form = makeFormDefinition();
+      mockService.createWithAudit.mockResolvedValueOnce(form as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.forms.create({ name: 'Test Form' });
+      expect(result.id).toBe(FORM_ID);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.createWithAudit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tx: expect.anything(),
+          actor: expect.objectContaining({ userId: USER_ID, orgId: ORG_ID }),
+        }),
+        { name: 'Test Form' },
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('updates a DRAFT form', async () => {
+      const updated = makeFormDefinition({ name: 'Updated' });
+      mockService.updateWithAudit.mockResolvedValueOnce(updated as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.forms.update({
+        id: FORM_ID,
+        name: 'Updated',
+      });
+      expect(result.name).toBe('Updated');
+    });
+
+    it('maps FormNotDraftError', async () => {
+      const { FormNotDraftError } =
+        await import('../../services/form.service.js');
+      mockService.updateWithAudit.mockRejectedValueOnce(
+        new FormNotDraftError(),
+      );
+
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.forms.update({ id: FORM_ID, name: 'X' }),
+      ).rejects.toThrow('DRAFT');
+    });
+  });
+
+  describe('publish', () => {
+    it('publishes a form', async () => {
+      const published = makeFormDefinition({
+        status: 'PUBLISHED',
+        publishedAt: new Date(),
+      });
+      mockService.publishWithAudit.mockResolvedValueOnce(published as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.forms.publish({ id: FORM_ID });
+      expect(result.status).toBe('PUBLISHED');
+    });
+
+    it('maps FormHasNoFieldsError', async () => {
+      const { FormHasNoFieldsError } =
+        await import('../../services/form.service.js');
+      mockService.publishWithAudit.mockRejectedValueOnce(
+        new FormHasNoFieldsError(),
+      );
+
+      const caller = createCaller(orgContext());
+      await expect(caller.forms.publish({ id: FORM_ID })).rejects.toThrow(
+        'at least one field',
+      );
+    });
+  });
+
+  describe('archive', () => {
+    it('archives a published form', async () => {
+      const archived = makeFormDefinition({
+        status: 'ARCHIVED',
+        archivedAt: new Date(),
+      });
+      mockService.archiveWithAudit.mockResolvedValueOnce(archived as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.forms.archive({ id: FORM_ID });
+      expect(result.status).toBe('ARCHIVED');
+    });
+  });
+
+  describe('duplicate', () => {
+    it('duplicates a form with fields', async () => {
+      const duplicated = {
+        ...makeFormDefinition({
+          id: 'f0000000-0000-4000-a000-000000000000',
+          duplicatedFromId: FORM_ID,
+        }),
+        fields: [makeFormField()],
+      };
+      mockService.duplicateWithAudit.mockResolvedValueOnce(duplicated as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.forms.duplicate({ id: FORM_ID });
+      expect(result.duplicatedFromId).toBe(FORM_ID);
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes a draft form', async () => {
+      mockService.deleteWithAudit.mockResolvedValueOnce({
+        success: true,
+      } as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.forms.delete({ id: FORM_ID });
+      expect(result).toEqual({ success: true });
+    });
+
+    it('maps FormInUseError', async () => {
+      const { FormInUseError } = await import('../../services/form.service.js');
+      mockService.deleteWithAudit.mockRejectedValueOnce(new FormInUseError());
+
+      const caller = createCaller(orgContext());
+      await expect(caller.forms.delete({ id: FORM_ID })).rejects.toThrow(
+        'referenced',
+      );
+    });
+  });
+
+  describe('addField', () => {
+    it('adds a field to a draft form', async () => {
+      const field = makeFormField();
+      mockService.addFieldWithAudit.mockResolvedValueOnce(field as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.forms.addField({
+        id: FORM_ID,
+        fieldKey: 'test_field',
+        fieldType: 'text',
+        label: 'Test Field',
+      });
+      expect(result.fieldKey).toBe('test_field');
+    });
+
+    it('maps DuplicateFieldKeyError', async () => {
+      const { DuplicateFieldKeyError } =
+        await import('../../services/form.service.js');
+      mockService.addFieldWithAudit.mockRejectedValueOnce(
+        new DuplicateFieldKeyError('test_field'),
+      );
+
+      const caller = createCaller(orgContext());
+      await expect(
+        caller.forms.addField({
+          id: FORM_ID,
+          fieldKey: 'test_field',
+          fieldType: 'text',
+          label: 'Test',
+        }),
+      ).rejects.toThrow('Duplicate');
+    });
+  });
+
+  describe('removeField', () => {
+    it('removes a field from a draft form', async () => {
+      const field = makeFormField();
+      mockService.removeFieldWithAudit.mockResolvedValueOnce(field as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.forms.removeField({
+        id: FORM_ID,
+        fieldId: FIELD_ID,
+      });
+      expect(result.id).toBe(FIELD_ID);
+    });
+  });
+
+  describe('reorderFields', () => {
+    it('reorders fields in a draft form', async () => {
+      const field1 = makeFormField({ sortOrder: 0 });
+      const field2 = makeFormField({
+        id: 'c0000000-0000-4000-a000-000000000000',
+        sortOrder: 1,
+      });
+      mockService.reorderFieldsWithAudit.mockResolvedValueOnce([
+        field1,
+        field2,
+      ] as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.forms.reorderFields({
+        id: FORM_ID,
+        fieldIds: [FIELD_ID, 'c0000000-0000-4000-a000-000000000000'],
+      });
+      expect(result).toHaveLength(2);
+    });
+  });
+});

--- a/apps/api/src/trpc/routers/forms.ts
+++ b/apps/api/src/trpc/routers/forms.ts
@@ -1,0 +1,222 @@
+import { z } from 'zod';
+import {
+  createFormDefinitionSchema,
+  updateFormDefinitionSchema,
+  createFormFieldSchema,
+  updateFormFieldSchema,
+  reorderFormFieldsSchema,
+  listFormDefinitionsSchema,
+  formDefinitionSchema,
+  formDefinitionDetailSchema,
+  formFieldSchema,
+  idParamSchema,
+  successResponseSchema,
+  paginatedResponseSchema,
+} from '@colophony/types';
+import { orgProcedure, createRouter, requireScopes } from '../init.js';
+import { formService } from '../../services/form.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+
+const formIdFieldIdSchema = z.object({
+  id: z.string().uuid(),
+  fieldId: z.string().uuid(),
+});
+
+export const formsRouter = createRouter({
+  /** List form definitions in the org. */
+  list: orgProcedure
+    .use(requireScopes('forms:read'))
+    .input(listFormDefinitionsSchema)
+    .output(paginatedResponseSchema(formDefinitionSchema))
+    .query(async ({ ctx, input }) => {
+      return formService.list(ctx.dbTx, input);
+    }),
+
+  /** Get form definition by ID with fields. */
+  getById: orgProcedure
+    .use(requireScopes('forms:read'))
+    .input(idParamSchema)
+    .output(formDefinitionDetailSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        const form = await formService.getById(ctx.dbTx, input.id);
+        if (!form) {
+          const { FormNotFoundError } =
+            await import('../../services/form.service.js');
+          throw new FormNotFoundError(input.id);
+        }
+        return form;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Create a new DRAFT form definition. */
+  create: orgProcedure
+    .use(requireScopes('forms:write'))
+    .input(createFormDefinitionSchema)
+    .output(formDefinitionSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await formService.createWithAudit(toServiceContext(ctx), input);
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Update a DRAFT form definition. */
+  update: orgProcedure
+    .use(requireScopes('forms:write'))
+    .input(idParamSchema.merge(updateFormDefinitionSchema))
+    .output(formDefinitionSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      try {
+        return await formService.updateWithAudit(
+          toServiceContext(ctx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Publish a DRAFT form (DRAFT → PUBLISHED). */
+  publish: orgProcedure
+    .use(requireScopes('forms:write'))
+    .input(idParamSchema)
+    .output(formDefinitionSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await formService.publishWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Archive a PUBLISHED form (PUBLISHED → ARCHIVED). */
+  archive: orgProcedure
+    .use(requireScopes('forms:write'))
+    .input(idParamSchema)
+    .output(formDefinitionSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await formService.archiveWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Duplicate a form as a new DRAFT. */
+  duplicate: orgProcedure
+    .use(requireScopes('forms:write'))
+    .input(idParamSchema)
+    .output(formDefinitionDetailSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const result = await formService.duplicateWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
+        return result;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Delete a DRAFT form. */
+  delete: orgProcedure
+    .use(requireScopes('forms:write'))
+    .input(idParamSchema)
+    .output(successResponseSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await formService.deleteWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Add a field to a DRAFT form. */
+  addField: orgProcedure
+    .use(requireScopes('forms:write'))
+    .input(idParamSchema.merge(createFormFieldSchema))
+    .output(formFieldSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...fieldData } = input;
+      try {
+        return await formService.addFieldWithAudit(
+          toServiceContext(ctx),
+          id,
+          fieldData,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Update a field in a DRAFT form. */
+  updateField: orgProcedure
+    .use(requireScopes('forms:write'))
+    .input(formIdFieldIdSchema.merge(updateFormFieldSchema))
+    .output(formFieldSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { id, fieldId, ...data } = input;
+      try {
+        return await formService.updateFieldWithAudit(
+          toServiceContext(ctx),
+          id,
+          fieldId,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Remove a field from a DRAFT form. */
+  removeField: orgProcedure
+    .use(requireScopes('forms:write'))
+    .input(formIdFieldIdSchema)
+    .output(formFieldSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await formService.removeFieldWithAudit(
+          toServiceContext(ctx),
+          input.id,
+          input.fieldId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Reorder fields in a DRAFT form. */
+  reorderFields: orgProcedure
+    .use(requireScopes('forms:write'))
+    .input(idParamSchema.merge(reorderFormFieldsSchema))
+    .output(z.array(formFieldSchema))
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      try {
+        return await formService.reorderFieldsWithAudit(
+          toServiceContext(ctx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+});

--- a/apps/api/src/trpc/routers/submissions.spec.ts
+++ b/apps/api/src/trpc/routers/submissions.spec.ts
@@ -152,6 +152,8 @@ function makeSubmissionBase(submitterId = USER_ID) {
     content: 'Roses are red...',
     coverLetter: null,
     status: 'DRAFT' as const,
+    formDefinitionId: null,
+    formData: null,
     submittedAt: null,
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -93,7 +93,9 @@
 
 ### Code
 
-- [ ] Form builder — all 15 field types — (architecture doc Track 3, form-builder-research.md)
+- [x] Form builder backend — DB schema (form_definitions + form_fields), Zod types, service layer, tRPC + REST + GraphQL endpoints, validateFormData, audit constants, API key scopes — (architecture doc Track 3; done 2026-02-20)
+- [ ] Form builder frontend — editor UI for creating/editing form definitions, field drag-and-drop, field config panels — (architecture doc Track 3, form-builder-research.md)
+- [ ] Form builder integration — wire validateFormData into submission create/update flow, replace hardcoded title/content/coverLetter with formData — (architecture doc Track 3, deferred from backend PR 2026-02-20)
 - [ ] Conditional logic engine — (architecture doc Track 3, form-builder-research.md)
 - [ ] Embeddable forms (iframe) — (architecture doc Track 3, form-builder-research.md)
 - [ ] Submission periods UI — schema exists, no UI — (DEVLOG 2026-02-15)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,32 @@ Newest entries first.
 
 ---
 
+## 2026-02-20 — Form Builder Backend (Track 3 Begin)
+
+### Done
+
+- Implemented form builder backend — DB schema, service layer, all 3 API surfaces (tRPC, REST, GraphQL)
+- New DB tables: `form_definitions` (org-scoped, RLS) and `form_fields` (normalized, RLS via subquery through parent)
+- Migration 0011: enums, tables, FKs, indexes, RLS policies, FORCE ROW LEVEL SECURITY, app_user grants
+- Zod types: 15 field types, per-type config schemas, CRUD input schemas, `formFieldErrorSchema`
+- Service layer: full CRUD, field ops (add/update/remove/reorder), `validateFormData` with per-type validation, audit wrappers
+- tRPC: 12 procedures; REST/oRPC: 12 routes with OpenAPI contracts; GraphQL: queries + mutations with DataLoader for fields
+- Added `formDefinitionId` + `formData` columns to submissions and submission_periods (schema-only, no behavioral change)
+- Updated audit constants (10 form actions), API key scopes (`forms:read`, `forms:write`), all 3 error mappers
+- 58 new tests across 4 files (service, tRPC, REST, GraphQL); all 624 tests pass
+- Fixed existing submission test mocks to include new nullable columns
+- Codex branch review: LGTM, no issues
+
+### Decisions
+
+- Forms are org-level, linked to submission periods via FK (many periods can share one form)
+- Published forms are immutable; editing requires duplicating as a new DRAFT
+- Form fields stored in normalized `form_fields` table (not JSONB) for field-level CRUD + DB constraints
+- This PR is schema-only groundwork — submission create/update flow unchanged; behavioral switch to formData in follow-up PR
+- 15 field types include 2 presentational types (`section_header`, `info_text`) skipped during validation
+
+---
+
 ## 2026-02-19 — Track 2 Design Decisions
 
 ### Done

--- a/packages/api-client/src/contract.ts
+++ b/packages/api-client/src/contract.ts
@@ -8,6 +8,7 @@ import {
   filesContract,
   usersContract,
   apiKeysContract,
+  formsContract,
 } from "@colophony/api-contracts";
 
 export const colophonyContract = {
@@ -16,4 +17,5 @@ export const colophonyContract = {
   files: filesContract,
   users: usersContract,
   apiKeys: apiKeysContract,
+  forms: formsContract,
 };

--- a/packages/api-contracts/src/forms.ts
+++ b/packages/api-contracts/src/forms.ts
@@ -1,0 +1,210 @@
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+import {
+  formDefinitionSchema,
+  formDefinitionDetailSchema,
+  formFieldSchema,
+  createFormDefinitionSchema,
+  updateFormDefinitionSchema,
+  createFormFieldSchema,
+  updateFormFieldSchema,
+  reorderFormFieldsSchema,
+  listFormDefinitionsSchema,
+} from "@colophony/types";
+import { restPaginationQuery } from "./shared.js";
+
+// ---------------------------------------------------------------------------
+// Query schemas — override page/limit with z.coerce for REST query strings
+// ---------------------------------------------------------------------------
+
+const restListFormsQuery = listFormDefinitionsSchema
+  .omit({ page: true, limit: true })
+  .merge(restPaginationQuery);
+
+// ---------------------------------------------------------------------------
+// Path param schemas
+// ---------------------------------------------------------------------------
+
+const formIdParam = z.object({
+  id: z.string().uuid(),
+});
+
+const formFieldIdParam = z.object({
+  id: z.string().uuid(),
+  fieldId: z.string().uuid(),
+});
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+const paginatedFormsSchema = z.object({
+  items: z.array(formDefinitionSchema),
+  total: z.number(),
+  page: z.number(),
+  limit: z.number(),
+  totalPages: z.number(),
+});
+
+const deleteResponseSchema = z.object({
+  success: z.literal(true),
+});
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+export const formsContract = {
+  list: oc
+    .route({
+      method: "GET",
+      path: "/forms",
+      summary: "List form definitions",
+      description:
+        "Returns a paginated list of form definitions in the organization.",
+      operationId: "listForms",
+      tags: ["Forms"],
+    })
+    .input(restListFormsQuery)
+    .output(paginatedFormsSchema),
+
+  create: oc
+    .route({
+      method: "POST",
+      path: "/forms",
+      successStatus: 201,
+      summary: "Create a form definition",
+      description: "Create a new form definition in DRAFT status.",
+      operationId: "createForm",
+      tags: ["Forms"],
+    })
+    .input(createFormDefinitionSchema)
+    .output(formDefinitionSchema),
+
+  get: oc
+    .route({
+      method: "GET",
+      path: "/forms/{id}",
+      summary: "Get a form definition",
+      description:
+        "Retrieve a form definition by ID, including its fields ordered by sortOrder.",
+      operationId: "getForm",
+      tags: ["Forms"],
+    })
+    .input(formIdParam)
+    .output(formDefinitionDetailSchema),
+
+  update: oc
+    .route({
+      method: "PATCH",
+      path: "/forms/{id}",
+      summary: "Update a form definition",
+      description: "Update a DRAFT form definition's name or description.",
+      operationId: "updateForm",
+      tags: ["Forms"],
+    })
+    .input(formIdParam.merge(updateFormDefinitionSchema))
+    .output(formDefinitionSchema),
+
+  publish: oc
+    .route({
+      method: "POST",
+      path: "/forms/{id}/publish",
+      summary: "Publish a form",
+      description:
+        "Transition a DRAFT form to PUBLISHED status. Requires at least one field.",
+      operationId: "publishForm",
+      tags: ["Forms"],
+    })
+    .input(formIdParam)
+    .output(formDefinitionSchema),
+
+  archive: oc
+    .route({
+      method: "POST",
+      path: "/forms/{id}/archive",
+      summary: "Archive a form",
+      description: "Transition a PUBLISHED form to ARCHIVED status.",
+      operationId: "archiveForm",
+      tags: ["Forms"],
+    })
+    .input(formIdParam)
+    .output(formDefinitionSchema),
+
+  duplicate: oc
+    .route({
+      method: "POST",
+      path: "/forms/{id}/duplicate",
+      successStatus: 201,
+      summary: "Duplicate a form",
+      description:
+        "Create a copy of a form (including all fields) as a new DRAFT.",
+      operationId: "duplicateForm",
+      tags: ["Forms"],
+    })
+    .input(formIdParam)
+    .output(formDefinitionDetailSchema),
+
+  delete: oc
+    .route({
+      method: "DELETE",
+      path: "/forms/{id}",
+      summary: "Delete a form",
+      description:
+        "Delete a DRAFT form definition. Fails if referenced by submission periods or submissions.",
+      operationId: "deleteForm",
+      tags: ["Forms"],
+    })
+    .input(formIdParam)
+    .output(deleteResponseSchema),
+
+  addField: oc
+    .route({
+      method: "POST",
+      path: "/forms/{id}/fields",
+      successStatus: 201,
+      summary: "Add a field",
+      description: "Add a new field to a DRAFT form definition.",
+      operationId: "addFormField",
+      tags: ["Forms"],
+    })
+    .input(formIdParam.merge(createFormFieldSchema))
+    .output(formFieldSchema),
+
+  updateField: oc
+    .route({
+      method: "PATCH",
+      path: "/forms/{id}/fields/{fieldId}",
+      summary: "Update a field",
+      description: "Update a field in a DRAFT form definition.",
+      operationId: "updateFormField",
+      tags: ["Forms"],
+    })
+    .input(formFieldIdParam.merge(updateFormFieldSchema))
+    .output(formFieldSchema),
+
+  removeField: oc
+    .route({
+      method: "DELETE",
+      path: "/forms/{id}/fields/{fieldId}",
+      summary: "Remove a field",
+      description: "Remove a field from a DRAFT form definition.",
+      operationId: "removeFormField",
+      tags: ["Forms"],
+    })
+    .input(formFieldIdParam)
+    .output(formFieldSchema),
+
+  reorderFields: oc
+    .route({
+      method: "PUT",
+      path: "/forms/{id}/fields/order",
+      summary: "Reorder fields",
+      description:
+        "Set the display order of fields in a DRAFT form definition.",
+      operationId: "reorderFormFields",
+      tags: ["Forms"],
+    })
+    .input(formIdParam.merge(reorderFormFieldsSchema))
+    .output(z.array(formFieldSchema)),
+};

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -8,4 +8,5 @@ export { submissionsContract } from "./submissions.js";
 export { filesContract } from "./files.js";
 export { usersContract } from "./users.js";
 export { apiKeysContract } from "./api-keys.js";
+export { formsContract } from "./forms.js";
 export { restListAuditEventsQuery } from "./audit.js";

--- a/packages/db/migrations/0011_form_definitions.sql
+++ b/packages/db/migrations/0011_form_definitions.sql
@@ -1,0 +1,95 @@
+-- Form builder: form_definitions + form_fields tables
+-- Also adds form_definition_id + form_data columns to submissions and submission_periods
+
+-- Create FormStatus enum
+CREATE TYPE "public"."FormStatus" AS ENUM('DRAFT', 'PUBLISHED', 'ARCHIVED');--> statement-breakpoint
+
+-- Create FormFieldType enum
+CREATE TYPE "public"."FormFieldType" AS ENUM('text', 'textarea', 'rich_text', 'number', 'email', 'url', 'date', 'select', 'multi_select', 'radio', 'checkbox', 'checkbox_group', 'file_upload', 'section_header', 'info_text');--> statement-breakpoint
+
+-- Create form_definitions table
+CREATE TABLE "form_definitions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"description" text,
+	"status" "FormStatus" DEFAULT 'DRAFT' NOT NULL,
+	"version" integer DEFAULT 1 NOT NULL,
+	"duplicated_from_id" uuid,
+	"created_by" uuid NOT NULL,
+	"published_at" timestamp with time zone,
+	"archived_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+
+ALTER TABLE "form_definitions" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+
+-- Create form_fields table
+CREATE TABLE "form_fields" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"form_definition_id" uuid NOT NULL,
+	"field_key" varchar(100) NOT NULL,
+	"field_type" "FormFieldType" NOT NULL,
+	"label" varchar(500) NOT NULL,
+	"description" text,
+	"placeholder" varchar(500),
+	"required" boolean DEFAULT false NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"config" jsonb DEFAULT '{}'::jsonb,
+	"conditional_rules" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+
+ALTER TABLE "form_fields" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+
+-- Add form_definition_id to submission_periods
+ALTER TABLE "submission_periods" ADD COLUMN "form_definition_id" uuid;--> statement-breakpoint
+
+-- Add form_definition_id and form_data to submissions
+ALTER TABLE "submissions" ADD COLUMN "form_definition_id" uuid;--> statement-breakpoint
+ALTER TABLE "submissions" ADD COLUMN "form_data" jsonb;--> statement-breakpoint
+
+-- Foreign keys for form_definitions
+ALTER TABLE "form_definitions" ADD CONSTRAINT "form_definitions_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "form_definitions" ADD CONSTRAINT "form_definitions_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+
+-- Foreign keys for form_fields
+ALTER TABLE "form_fields" ADD CONSTRAINT "form_fields_form_definition_id_form_definitions_id_fk" FOREIGN KEY ("form_definition_id") REFERENCES "public"."form_definitions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+
+-- Foreign keys for submission_periods.form_definition_id
+ALTER TABLE "submission_periods" ADD CONSTRAINT "submission_periods_form_definition_id_form_definitions_id_fk" FOREIGN KEY ("form_definition_id") REFERENCES "public"."form_definitions"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+
+-- Foreign keys for submissions.form_definition_id
+ALTER TABLE "submissions" ADD CONSTRAINT "submissions_form_definition_id_form_definitions_id_fk" FOREIGN KEY ("form_definition_id") REFERENCES "public"."form_definitions"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+
+-- Indexes for form_definitions
+CREATE INDEX "form_definitions_organization_id_idx" ON "form_definitions" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "form_definitions_org_status_idx" ON "form_definitions" USING btree ("organization_id", "status");--> statement-breakpoint
+
+-- Indexes for form_fields
+CREATE INDEX "form_fields_form_definition_id_idx" ON "form_fields" USING btree ("form_definition_id");--> statement-breakpoint
+CREATE INDEX "form_fields_form_sort_idx" ON "form_fields" USING btree ("form_definition_id", "sort_order");--> statement-breakpoint
+CREATE UNIQUE INDEX "form_fields_form_field_key_idx" ON "form_fields" USING btree ("form_definition_id", "field_key");--> statement-breakpoint
+
+-- Indexes for new columns on existing tables
+CREATE INDEX "submission_periods_form_definition_id_idx" ON "submission_periods" USING btree ("form_definition_id");--> statement-breakpoint
+CREATE INDEX "submissions_form_definition_id_idx" ON "submissions" USING btree ("form_definition_id");--> statement-breakpoint
+
+-- RLS policies for form_definitions
+CREATE POLICY "form_definitions_org_isolation" ON "form_definitions" AS PERMISSIVE FOR ALL TO public USING (organization_id = current_org_id());--> statement-breakpoint
+
+-- RLS policies for form_fields (subquery through form_definitions)
+CREATE POLICY "form_fields_org_isolation" ON "form_fields" AS PERMISSIVE FOR ALL TO public USING (form_definition_id IN (
+  SELECT id FROM form_definitions
+  WHERE organization_id = current_org_id()
+));--> statement-breakpoint
+
+-- FORCE ROW LEVEL SECURITY (Drizzle only generates ENABLE, not FORCE)
+ALTER TABLE "form_definitions" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "form_fields" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+
+-- Grant DML permissions to app_user
+GRANT SELECT, INSERT, UPDATE, DELETE ON "form_definitions" TO app_user;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON "form_fields" TO app_user;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1771208876533,
       "tag": "0010_audit_writer_role",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1771400000000,
+      "tag": "0011_form_definitions",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -41,3 +41,27 @@ export const dsarStatusEnum = pgEnum("DsarStatus", [
   "COMPLETED",
   "REJECTED",
 ]);
+
+export const formStatusEnum = pgEnum("FormStatus", [
+  "DRAFT",
+  "PUBLISHED",
+  "ARCHIVED",
+]);
+
+export const formFieldTypeEnum = pgEnum("FormFieldType", [
+  "text",
+  "textarea",
+  "rich_text",
+  "number",
+  "email",
+  "url",
+  "date",
+  "select",
+  "multi_select",
+  "radio",
+  "checkbox",
+  "checkbox_group",
+  "file_upload",
+  "section_header",
+  "info_text",
+]);

--- a/packages/db/src/schema/forms.ts
+++ b/packages/db/src/schema/forms.ts
@@ -1,0 +1,104 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  text,
+  timestamp,
+  integer,
+  boolean,
+  jsonb,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { formStatusEnum, formFieldTypeEnum } from "./enums";
+import { organizations } from "./organizations";
+import { users } from "./users";
+
+// --- form_definitions ---
+
+export const formDefinitions = pgTable(
+  "form_definitions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    name: varchar("name", { length: 255 }).notNull(),
+    description: text("description"),
+    status: formStatusEnum("status").notNull().default("DRAFT"),
+    version: integer("version").notNull().default(1),
+    duplicatedFromId: uuid("duplicated_from_id"),
+    createdBy: uuid("created_by")
+      .notNull()
+      .references(() => users.id, { onDelete: "restrict" }),
+    publishedAt: timestamp("published_at", { withTimezone: true }),
+    archivedAt: timestamp("archived_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("form_definitions_organization_id_idx").on(table.organizationId),
+    index("form_definitions_org_status_idx").on(
+      table.organizationId,
+      table.status,
+    ),
+    pgPolicy("form_definitions_org_isolation", {
+      for: "all",
+      using: sql`organization_id = current_org_id()`,
+    }),
+  ],
+).enableRLS();
+
+// --- form_fields ---
+
+export const formFields = pgTable(
+  "form_fields",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    formDefinitionId: uuid("form_definition_id")
+      .notNull()
+      .references(() => formDefinitions.id, { onDelete: "cascade" }),
+    fieldKey: varchar("field_key", { length: 100 }).notNull(),
+    fieldType: formFieldTypeEnum("field_type").notNull(),
+    label: varchar("label", { length: 500 }).notNull(),
+    description: text("description"),
+    placeholder: varchar("placeholder", { length: 500 }),
+    required: boolean("required").notNull().default(false),
+    sortOrder: integer("sort_order").notNull().default(0),
+    config: jsonb("config").$type<Record<string, unknown>>().default({}),
+    conditionalRules:
+      jsonb("conditional_rules").$type<Record<string, unknown>[]>(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("form_fields_form_definition_id_idx").on(table.formDefinitionId),
+    index("form_fields_form_sort_idx").on(
+      table.formDefinitionId,
+      table.sortOrder,
+    ),
+    uniqueIndex("form_fields_form_field_key_idx").on(
+      table.formDefinitionId,
+      table.fieldKey,
+    ),
+    pgPolicy("form_fields_org_isolation", {
+      for: "all",
+      using: sql`form_definition_id IN (
+        SELECT id FROM form_definitions
+        WHERE organization_id = current_org_id()
+      )`,
+    }),
+  ],
+).enableRLS();

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -2,6 +2,7 @@ export * from "./enums";
 export * from "./organizations";
 export * from "./users";
 export * from "./members";
+export * from "./forms";
 export * from "./submissions";
 export * from "./payments";
 export * from "./audit";

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -2,6 +2,7 @@ import { relations } from "drizzle-orm";
 import { organizations } from "./organizations";
 import { users } from "./users";
 import { organizationMembers } from "./members";
+import { formDefinitions, formFields } from "./forms";
 import {
   submissionPeriods,
   submissions,
@@ -17,6 +18,7 @@ import { apiKeys } from "./api-keys";
 
 export const organizationsRelations = relations(organizations, ({ many }) => ({
   members: many(organizationMembers),
+  formDefinitions: many(formDefinitions),
   submissionPeriods: many(submissionPeriods),
   submissions: many(submissions),
   payments: many(payments),
@@ -30,6 +32,7 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
 
 export const usersRelations = relations(users, ({ many }) => ({
   memberships: many(organizationMembers),
+  formDefinitions: many(formDefinitions),
   submissions: many(submissions),
   auditEvents: many(auditEvents),
   dsarRequests: many(dsarRequests),
@@ -53,6 +56,34 @@ export const organizationMembersRelations = relations(
   }),
 );
 
+// --- form_definitions ---
+
+export const formDefinitionsRelations = relations(
+  formDefinitions,
+  ({ one, many }) => ({
+    organization: one(organizations, {
+      fields: [formDefinitions.organizationId],
+      references: [organizations.id],
+    }),
+    creator: one(users, {
+      fields: [formDefinitions.createdBy],
+      references: [users.id],
+    }),
+    fields: many(formFields),
+    submissionPeriods: many(submissionPeriods),
+    submissions: many(submissions),
+  }),
+);
+
+// --- form_fields ---
+
+export const formFieldsRelations = relations(formFields, ({ one }) => ({
+  formDefinition: one(formDefinitions, {
+    fields: [formFields.formDefinitionId],
+    references: [formDefinitions.id],
+  }),
+}));
+
 // --- submission_periods ---
 
 export const submissionPeriodsRelations = relations(
@@ -61,6 +92,10 @@ export const submissionPeriodsRelations = relations(
     organization: one(organizations, {
       fields: [submissionPeriods.organizationId],
       references: [organizations.id],
+    }),
+    formDefinition: one(formDefinitions, {
+      fields: [submissionPeriods.formDefinitionId],
+      references: [formDefinitions.id],
     }),
     submissions: many(submissions),
   }),
@@ -80,6 +115,10 @@ export const submissionsRelations = relations(submissions, ({ one, many }) => ({
   submissionPeriod: one(submissionPeriods, {
     fields: [submissions.submissionPeriodId],
     references: [submissionPeriods.id],
+  }),
+  formDefinition: one(formDefinitions, {
+    fields: [submissions.formDefinitionId],
+    references: [formDefinitions.id],
   }),
   files: many(submissionFiles),
   history: many(submissionHistory),

--- a/packages/db/src/schema/submissions.ts
+++ b/packages/db/src/schema/submissions.ts
@@ -8,6 +8,7 @@ import {
   integer,
   bigint,
   numeric,
+  jsonb,
   index,
   customType,
 } from "drizzle-orm/pg-core";
@@ -15,6 +16,7 @@ import { sql } from "drizzle-orm";
 import { submissionStatusEnum, scanStatusEnum } from "./enums";
 import { organizations } from "./organizations";
 import { users } from "./users";
+import { formDefinitions } from "./forms";
 
 const tsvector = customType<{ data: string }>({
   dataType() {
@@ -42,6 +44,10 @@ export const submissionPeriods = pgTable(
     closesAt: timestamp("closes_at", { withTimezone: true }).notNull(),
     fee: numeric("fee", { precision: 10, scale: 2 }),
     maxSubmissions: integer("max_submissions"),
+    formDefinitionId: uuid("form_definition_id").references(
+      () => formDefinitions.id,
+      { onDelete: "set null" },
+    ),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
@@ -56,6 +62,9 @@ export const submissionPeriods = pgTable(
       table.organizationId,
       table.opensAt,
       table.closesAt,
+    ),
+    index("submission_periods_form_definition_id_idx").on(
+      table.formDefinitionId,
     ),
     orgIsolationPolicy,
   ],
@@ -77,9 +86,14 @@ export const submissions = pgTable(
       () => submissionPeriods.id,
       { onDelete: "set null" },
     ),
+    formDefinitionId: uuid("form_definition_id").references(
+      () => formDefinitions.id,
+      { onDelete: "set null" },
+    ),
     title: varchar("title", { length: 500 }),
     content: text("content"),
     coverLetter: text("cover_letter"),
+    formData: jsonb("form_data").$type<Record<string, unknown>>(),
     status: submissionStatusEnum("status").notNull().default("DRAFT"),
     submittedAt: timestamp("submitted_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true })
@@ -99,6 +113,7 @@ export const submissions = pgTable(
       table.status,
     ),
     index("submissions_submission_period_id_idx").on(table.submissionPeriodId),
+    index("submissions_form_definition_id_idx").on(table.formDefinitionId),
     index("submissions_org_status_submitted_idx").on(
       table.organizationId,
       table.status,

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -2,6 +2,7 @@ import type { InferSelectModel, InferInsertModel } from "drizzle-orm";
 import type { organizations } from "./schema/organizations";
 import type { users } from "./schema/users";
 import type { organizationMembers } from "./schema/members";
+import type { formDefinitions, formFields } from "./schema/forms";
 import type {
   submissionPeriods,
   submissions,
@@ -19,6 +20,8 @@ import type { zitadelWebhookEvents } from "./schema/webhooks";
 export type Organization = InferSelectModel<typeof organizations>;
 export type User = InferSelectModel<typeof users>;
 export type OrganizationMember = InferSelectModel<typeof organizationMembers>;
+export type FormDefinition = InferSelectModel<typeof formDefinitions>;
+export type FormField = InferSelectModel<typeof formFields>;
 export type SubmissionPeriod = InferSelectModel<typeof submissionPeriods>;
 export type Submission = InferSelectModel<typeof submissions>;
 export type SubmissionFile = InferSelectModel<typeof submissionFiles>;
@@ -39,6 +42,8 @@ export type NewUser = InferInsertModel<typeof users>;
 export type NewOrganizationMember = InferInsertModel<
   typeof organizationMembers
 >;
+export type NewFormDefinition = InferInsertModel<typeof formDefinitions>;
+export type NewFormField = InferInsertModel<typeof formFields>;
 export type NewSubmissionPeriod = InferInsertModel<typeof submissionPeriods>;
 export type NewSubmission = InferInsertModel<typeof submissions>;
 export type NewSubmissionFile = InferInsertModel<typeof submissionFiles>;

--- a/packages/types/src/api-key.ts
+++ b/packages/types/src/api-key.ts
@@ -10,6 +10,8 @@ export const apiKeyScopeSchema = z
     "submissions:write",
     "files:read",
     "files:write",
+    "forms:read",
+    "forms:write",
     "organizations:read",
     "organizations:write",
     "users:read",

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -51,6 +51,18 @@ export const AuditActions = {
   API_KEY_AUTH_FAILED: "API_KEY_AUTH_FAILED",
   API_KEY_SCOPE_DENIED: "API_KEY_SCOPE_DENIED",
 
+  // Form lifecycle
+  FORM_CREATED: "FORM_CREATED",
+  FORM_UPDATED: "FORM_UPDATED",
+  FORM_PUBLISHED: "FORM_PUBLISHED",
+  FORM_ARCHIVED: "FORM_ARCHIVED",
+  FORM_DUPLICATED: "FORM_DUPLICATED",
+  FORM_DELETED: "FORM_DELETED",
+  FORM_FIELD_ADDED: "FORM_FIELD_ADDED",
+  FORM_FIELD_UPDATED: "FORM_FIELD_UPDATED",
+  FORM_FIELD_REMOVED: "FORM_FIELD_REMOVED",
+  FORM_FIELDS_REORDERED: "FORM_FIELDS_REORDERED",
+
   // Payment lifecycle
   PAYMENT_SUCCEEDED: "PAYMENT_SUCCEEDED",
   PAYMENT_EXPIRED: "PAYMENT_EXPIRED",
@@ -67,6 +79,7 @@ export const AuditResources = {
   ORGANIZATION: "organization",
   SUBMISSION: "submission",
   FILE: "file",
+  FORM: "form",
   AUTH: "auth",
   API_KEY: "api_key",
   PAYMENT: "payment",
@@ -156,6 +169,21 @@ export interface ApiKeyAuditParams extends BaseAuditParams {
     | typeof AuditActions.API_KEY_SCOPE_DENIED;
 }
 
+export interface FormAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.FORM;
+  action:
+    | typeof AuditActions.FORM_CREATED
+    | typeof AuditActions.FORM_UPDATED
+    | typeof AuditActions.FORM_PUBLISHED
+    | typeof AuditActions.FORM_ARCHIVED
+    | typeof AuditActions.FORM_DUPLICATED
+    | typeof AuditActions.FORM_DELETED
+    | typeof AuditActions.FORM_FIELD_ADDED
+    | typeof AuditActions.FORM_FIELD_UPDATED
+    | typeof AuditActions.FORM_FIELD_REMOVED
+    | typeof AuditActions.FORM_FIELDS_REORDERED;
+}
+
 export interface PaymentAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.PAYMENT;
   action:
@@ -174,6 +202,7 @@ export type AuditLogParams =
   | OrgAuditParams
   | SubmissionAuditParams
   | FileAuditParams
+  | FormAuditParams
   | AuthAuditParams
   | ApiKeyAuditParams
   | PaymentAuditParams

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -1,0 +1,277 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const formStatusSchema = z
+  .enum(["DRAFT", "PUBLISHED", "ARCHIVED"])
+  .describe("Current status of the form definition");
+
+export type FormStatus = z.infer<typeof formStatusSchema>;
+
+export const formFieldTypeSchema = z
+  .enum([
+    "text",
+    "textarea",
+    "rich_text",
+    "number",
+    "email",
+    "url",
+    "date",
+    "select",
+    "multi_select",
+    "radio",
+    "checkbox",
+    "checkbox_group",
+    "file_upload",
+    "section_header",
+    "info_text",
+  ])
+  .describe("Type of form field");
+
+export type FormFieldType = z.infer<typeof formFieldTypeSchema>;
+
+/** Presentational field types that are not collected as response data. */
+export const PRESENTATIONAL_FIELD_TYPES: FormFieldType[] = [
+  "section_header",
+  "info_text",
+];
+
+// ---------------------------------------------------------------------------
+// Per-type config schemas (for validation in the service layer)
+// ---------------------------------------------------------------------------
+
+export const textFieldConfigSchema = z.object({
+  minLength: z.number().int().min(0).optional(),
+  maxLength: z.number().int().min(1).optional(),
+});
+
+export const numberFieldConfigSchema = z.object({
+  min: z.number().optional(),
+  max: z.number().optional(),
+  step: z.number().optional(),
+});
+
+export const selectOptionSchema = z.object({
+  label: z.string().min(1).max(500),
+  value: z.string().min(1).max(255),
+});
+
+export const selectFieldConfigSchema = z.object({
+  options: z.array(selectOptionSchema).min(1),
+});
+
+export const fileUploadFieldConfigSchema = z.object({
+  allowedMimeTypes: z.array(z.string()).optional(),
+  maxFileSize: z.number().int().min(1).optional(),
+  maxFiles: z.number().int().min(1).optional(),
+});
+
+export const richTextFieldConfigSchema = z.object({
+  maxLength: z.number().int().min(1).optional(),
+});
+
+/** Loose config schema for DB storage — validated per-type in service layer. */
+export const fieldConfigSchema = z
+  .record(z.string(), z.unknown())
+  .default({})
+  .describe("Type-specific configuration for the field");
+
+// ---------------------------------------------------------------------------
+// Form field schema
+// ---------------------------------------------------------------------------
+
+export const formFieldSchema = z.object({
+  id: z.string().uuid().describe("Unique identifier for the field"),
+  formDefinitionId: z
+    .string()
+    .uuid()
+    .describe("ID of the parent form definition"),
+  fieldKey: z
+    .string()
+    .min(1)
+    .max(100)
+    .describe("Machine name for the field (unique per form)"),
+  fieldType: formFieldTypeSchema,
+  label: z.string().min(1).max(500).describe("Human-readable label"),
+  description: z.string().nullable().describe("Help text for the field"),
+  placeholder: z
+    .string()
+    .nullable()
+    .describe("Placeholder text for input fields"),
+  required: z
+    .boolean()
+    .describe("Whether the field is required for submission"),
+  sortOrder: z.number().int().describe("Display order within the form"),
+  config: z
+    .record(z.string(), z.unknown())
+    .nullable()
+    .describe("Type-specific configuration for the field"),
+  conditionalRules: z
+    .array(z.record(z.string(), z.unknown()))
+    .nullable()
+    .describe("Conditional display rules (Phase 2)"),
+  createdAt: z.date().describe("When the field was created"),
+  updatedAt: z.date().describe("When the field was last updated"),
+});
+
+export type FormField = z.infer<typeof formFieldSchema>;
+
+// ---------------------------------------------------------------------------
+// Form definition schemas
+// ---------------------------------------------------------------------------
+
+export const formDefinitionSchema = z.object({
+  id: z.string().uuid().describe("Unique identifier for the form definition"),
+  organizationId: z.string().uuid().describe("ID of the owning organization"),
+  name: z.string().describe("Display name of the form"),
+  description: z.string().nullable().describe("Description of the form"),
+  status: formStatusSchema,
+  version: z.number().int().describe("Version number"),
+  duplicatedFromId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("ID of the form this was duplicated from"),
+  createdBy: z.string().uuid().describe("ID of the user who created the form"),
+  publishedAt: z.date().nullable().describe("When the form was published"),
+  archivedAt: z.date().nullable().describe("When the form was archived"),
+  createdAt: z.date().describe("When the form was created"),
+  updatedAt: z.date().describe("When the form was last updated"),
+});
+
+export type FormDefinition = z.infer<typeof formDefinitionSchema>;
+
+/** Form definition with its fields — returned by getById. */
+export const formDefinitionDetailSchema = formDefinitionSchema.extend({
+  fields: z
+    .array(formFieldSchema)
+    .describe("Fields in this form, ordered by sortOrder"),
+});
+
+export type FormDefinitionDetail = z.infer<typeof formDefinitionDetailSchema>;
+
+// ---------------------------------------------------------------------------
+// CRUD input schemas
+// ---------------------------------------------------------------------------
+
+export const createFormDefinitionSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .describe("Display name for the form (1-255 chars)"),
+  description: z
+    .string()
+    .max(2000)
+    .optional()
+    .describe("Description of the form (max 2,000 chars)"),
+});
+
+export type CreateFormDefinitionInput = z.infer<
+  typeof createFormDefinitionSchema
+>;
+
+export const updateFormDefinitionSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .optional()
+    .describe("New display name"),
+  description: z.string().max(2000).optional().describe("New description"),
+});
+
+export type UpdateFormDefinitionInput = z.infer<
+  typeof updateFormDefinitionSchema
+>;
+
+export const createFormFieldSchema = z.object({
+  fieldKey: z
+    .string()
+    .trim()
+    .min(1)
+    .max(100)
+    .regex(
+      /^[a-z][a-z0-9_]*$/,
+      "Field key must start with a lowercase letter and contain only lowercase letters, numbers, and underscores",
+    )
+    .describe("Machine name for the field"),
+  fieldType: formFieldTypeSchema,
+  label: z.string().trim().min(1).max(500).describe("Human-readable label"),
+  description: z
+    .string()
+    .max(2000)
+    .optional()
+    .describe("Help text for the field"),
+  placeholder: z.string().max(500).optional().describe("Placeholder text"),
+  required: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Whether the field is required"),
+  sortOrder: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Display order (auto-assigned if omitted)"),
+  config: fieldConfigSchema.optional().describe("Type-specific configuration"),
+});
+
+export type CreateFormFieldInput = z.infer<typeof createFormFieldSchema>;
+
+export const updateFormFieldSchema = z.object({
+  label: z.string().trim().min(1).max(500).optional().describe("New label"),
+  description: z.string().max(2000).optional().describe("New help text"),
+  placeholder: z.string().max(500).optional().describe("New placeholder"),
+  required: z.boolean().optional().describe("New required state"),
+  config: fieldConfigSchema.optional().describe("New configuration"),
+});
+
+export type UpdateFormFieldInput = z.infer<typeof updateFormFieldSchema>;
+
+export const reorderFormFieldsSchema = z.object({
+  fieldIds: z
+    .array(z.string().uuid())
+    .min(1)
+    .describe("Ordered list of field IDs"),
+});
+
+export type ReorderFormFieldsInput = z.infer<typeof reorderFormFieldsSchema>;
+
+export const listFormDefinitionsSchema = z.object({
+  status: formStatusSchema.optional().describe("Filter by form status"),
+  search: z
+    .string()
+    .trim()
+    .max(200)
+    .optional()
+    .describe("Search by name (max 200 chars)"),
+  page: z.number().int().min(1).default(1).describe("Page number (1-based)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page (1-100, default 20)"),
+});
+
+export type ListFormDefinitionsInput = z.infer<
+  typeof listFormDefinitionsSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Form data validation error
+// ---------------------------------------------------------------------------
+
+export const formFieldErrorSchema = z.object({
+  fieldKey: z.string().describe("Key of the invalid field"),
+  message: z.string().describe("Validation error message"),
+});
+
+export type FormFieldError = z.infer<typeof formFieldErrorSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,6 +4,7 @@ export * from "./organization";
 export * from "./submission";
 export * from "./payment";
 export * from "./file";
+export * from "./form";
 export * from "./common";
 export * from "./audit";
 export * from "./api-key";

--- a/packages/types/src/submission.ts
+++ b/packages/types/src/submission.ts
@@ -37,6 +37,15 @@ export const submissionSchema = z.object({
   title: z.string().nullable().describe("Title of the submission"),
   content: z.string().nullable().describe("Body content of the submission"),
   coverLetter: z.string().nullable().describe("Optional cover letter"),
+  formDefinitionId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("ID of the form definition used, if applicable"),
+  formData: z
+    .record(z.string(), z.unknown())
+    .nullable()
+    .describe("Structured form data keyed by field key"),
   status: submissionStatusSchema,
   submittedAt: z
     .date()
@@ -70,6 +79,15 @@ export const createSubmissionSchema = z.object({
     .uuid()
     .optional()
     .describe("Submission period to associate with"),
+  formDefinitionId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Form definition to use for structured data"),
+  formData: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe("Structured form data keyed by field key"),
 });
 
 export type CreateSubmissionInput = z.infer<typeof createSubmissionSchema>;
@@ -195,6 +213,11 @@ export const submissionPeriodSchema = z.object({
     .number()
     .nullable()
     .describe("Max submissions allowed (null = unlimited)"),
+  formDefinitionId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("ID of the form definition linked to this period"),
   createdAt: z.date().describe("When the period was created"),
   updatedAt: z.date().describe("When the period was last updated"),
 });


### PR DESCRIPTION
## Summary

- Add `form_definitions` and `form_fields` tables with RLS policies, 15 field types, and full lifecycle (DRAFT → PUBLISHED → ARCHIVED)
- Add `formDefinitionId` and `formData` columns to `submissions` and `submission_periods` (schema-only groundwork — submission flow unchanged)
- Implement form service layer with CRUD, field operations, `validateFormData` (dynamic Zod validation from form definitions), and 8 custom error classes
- Wire all 12 endpoints across tRPC, REST (oRPC + OpenAPI), and GraphQL (Pothos) with scope enforcement and error mapping
- Add Zod types, audit constants, API key scopes (`forms:read`/`forms:write`), oRPC contracts, and typed client bindings
- 58 new tests (service validation, tRPC routing, REST routing, GraphQL resolver wiring) — 624 total pass

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 624 tests pass (58 new)
- [x] branch review — LGTM
- [ ] CI pipeline (type-check, lint, unit tests, RLS tests, Playwright E2E, build)
- [ ] Manual: verify RLS isolation on `form_definitions` and `form_fields` tables
- [ ] Manual: verify FORCE ROW LEVEL SECURITY on both new tables