### PR TITLE
feat(hopper): form builder editor UI — list, editor, preview

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,9 @@
   },
   "dependencies": {
     "@colophony/types": "workspace:*",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/apps/web/src/app/(dashboard)/editor/forms/[formId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/forms/[formId]/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { use } from "react";
+import { FormEditor } from "@/components/form-builder/form-editor";
+
+export default function FormEditorPage({
+  params,
+}: {
+  params: Promise<{ formId: string }>;
+}) {
+  const { formId } = use(params);
+
+  return (
+    <div className="h-[calc(100vh-3.5rem)]">
+      <FormEditor formId={formId} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/editor/forms/new/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/forms/new/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { createFormDefinitionSchema } from "@colophony/types";
+import type { CreateFormDefinitionInput } from "@colophony/types";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+export default function NewFormPage() {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+
+  const form = useForm<CreateFormDefinitionInput>({
+    resolver: zodResolver(createFormDefinitionSchema),
+    defaultValues: {
+      name: "",
+      description: "",
+    },
+  });
+
+  const createMutation = trpc.forms.create.useMutation({
+    onSuccess: (data) => {
+      toast.success("Form created");
+      router.push(`/editor/forms/${data.id}`);
+    },
+    onError: (err) => {
+      setError(err.message);
+    },
+  });
+
+  function onSubmit(values: CreateFormDefinitionInput) {
+    setError(null);
+    createMutation.mutate(values);
+  }
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto">
+      <Card>
+        <CardHeader>
+          <CardTitle>Create Form</CardTitle>
+          <CardDescription>
+            Start with a name and description. You&apos;ll add fields in the
+            editor.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="e.g. Poetry Submission Form"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      The name displayed to submitters.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Instructions or context for submitters..."
+                        rows={3}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Optional instructions shown at the top of the form.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => router.back()}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={createMutation.isPending}>
+                  {createMutation.isPending && (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  )}
+                  Create Form
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/editor/forms/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/forms/page.tsx
@@ -1,0 +1,9 @@
+import { FormList } from "@/components/form-builder/form-list";
+
+export default function FormsPage() {
+  return (
+    <div className="p-6">
+      <FormList />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/editor/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/page.tsx
@@ -1,10 +1,48 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ClipboardList } from "lucide-react";
+
 export default function EditorPage() {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">Editor Dashboard</h1>
-      <p className="text-muted-foreground mt-2">
-        Coming soon — v2 editorial review dashboard under development.
-      </p>
+    <div className="p-6 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Editor Dashboard</h1>
+        <p className="text-muted-foreground mt-1">
+          Manage your publication&apos;s submission process.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <Link href="/editor/forms">
+          <Card className="hover:border-primary/50 transition-colors cursor-pointer">
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <div className="rounded-lg bg-primary/10 p-2">
+                  <ClipboardList className="h-5 w-5 text-primary" />
+                </div>
+                <div>
+                  <CardTitle className="text-base">Forms</CardTitle>
+                  <CardDescription>
+                    Build and manage submission forms
+                  </CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Button variant="outline" size="sm" className="w-full">
+                Manage Forms
+              </Button>
+            </CardContent>
+          </Card>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/form-builder/__tests__/field-properties-panel.spec.tsx
+++ b/apps/web/src/components/form-builder/__tests__/field-properties-panel.spec.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { FieldPropertiesPanel } from "../field-properties-panel";
 import "../../../../test/setup";
 

--- a/apps/web/src/components/form-builder/__tests__/field-properties-panel.spec.tsx
+++ b/apps/web/src/components/form-builder/__tests__/field-properties-panel.spec.tsx
@@ -1,0 +1,164 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FieldPropertiesPanel } from "../field-properties-panel";
+import "../../../../test/setup";
+
+const baseField = {
+  id: "field-1",
+  formDefinitionId: "form-1",
+  fieldKey: "title",
+  fieldType: "text" as const,
+  label: "Title",
+  description: "Enter your title",
+  placeholder: "My Title",
+  required: true,
+  sortOrder: 0,
+  config: { minLength: 5, maxLength: 100 },
+  conditionalRules: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe("FieldPropertiesPanel", () => {
+  it("renders common fields for any field type", () => {
+    const onUpdate = jest.fn();
+    render(
+      <FieldPropertiesPanel
+        field={baseField}
+        onUpdate={onUpdate}
+        isSaving={false}
+      />,
+    );
+
+    expect(screen.getByText("Field Properties")).toBeInTheDocument();
+    expect(screen.getByLabelText("Label")).toHaveValue("Title");
+    expect(screen.getByLabelText("Help Text")).toHaveValue("Enter your title");
+    expect(screen.getByLabelText("Placeholder")).toHaveValue("My Title");
+    expect(screen.getByLabelText("Required")).toBeChecked();
+  });
+
+  it("renders text config for text field type", () => {
+    const onUpdate = jest.fn();
+    render(
+      <FieldPropertiesPanel
+        field={baseField}
+        onUpdate={onUpdate}
+        isSaving={false}
+      />,
+    );
+
+    expect(screen.getByText("Type Settings")).toBeInTheDocument();
+    expect(screen.getByLabelText("Min Length")).toHaveValue(5);
+    expect(screen.getByLabelText("Max Length")).toHaveValue(100);
+  });
+
+  it("renders number config for number field type", () => {
+    const onUpdate = jest.fn();
+    const numberField = {
+      ...baseField,
+      fieldType: "number" as const,
+      config: { min: 0, max: 100, step: 1 },
+    };
+    render(
+      <FieldPropertiesPanel
+        field={numberField}
+        onUpdate={onUpdate}
+        isSaving={false}
+      />,
+    );
+
+    expect(screen.getByLabelText("Minimum")).toHaveValue(0);
+    expect(screen.getByLabelText("Maximum")).toHaveValue(100);
+    expect(screen.getByLabelText("Step")).toHaveValue(1);
+  });
+
+  it("renders select config for select field type", () => {
+    const onUpdate = jest.fn();
+    const selectField = {
+      ...baseField,
+      fieldType: "select" as const,
+      config: {
+        options: [
+          { label: "Option A", value: "option_a" },
+          { label: "Option B", value: "option_b" },
+        ],
+      },
+    };
+    render(
+      <FieldPropertiesPanel
+        field={selectField}
+        onUpdate={onUpdate}
+        isSaving={false}
+      />,
+    );
+
+    expect(screen.getByText("Options")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Option A")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Option B")).toBeInTheDocument();
+  });
+
+  it("renders file upload config for file_upload field type", () => {
+    const onUpdate = jest.fn();
+    const fileField = {
+      ...baseField,
+      fieldType: "file_upload" as const,
+      config: { maxFiles: 3, maxFileSize: 10485760 },
+    };
+    render(
+      <FieldPropertiesPanel
+        field={fileField}
+        onUpdate={onUpdate}
+        isSaving={false}
+      />,
+    );
+
+    expect(screen.getByLabelText("Max Files")).toHaveValue(3);
+    expect(screen.getByLabelText("Max File Size (bytes)")).toHaveValue(
+      10485760,
+    );
+  });
+
+  it("shows saving indicator", () => {
+    render(
+      <FieldPropertiesPanel
+        field={baseField}
+        onUpdate={jest.fn()}
+        isSaving={true}
+      />,
+    );
+
+    // The "Saving..." indicator is shown based on internal state, not isSaving directly.
+    // After a change triggers debounced save, it shows "Saving..."
+    // Here we just verify the panel renders without error when isSaving is true.
+    expect(screen.getByText("Field Properties")).toBeInTheDocument();
+  });
+
+  it("displays the field type icon and label", () => {
+    render(
+      <FieldPropertiesPanel
+        field={baseField}
+        onUpdate={jest.fn()}
+        isSaving={false}
+      />,
+    );
+
+    expect(screen.getByText("Short Text")).toBeInTheDocument();
+  });
+
+  it("does not render type settings for section_header", () => {
+    const headerField = {
+      ...baseField,
+      fieldType: "section_header" as const,
+      config: null,
+    };
+    render(
+      <FieldPropertiesPanel
+        field={headerField}
+        onUpdate={jest.fn()}
+        isSaving={false}
+      />,
+    );
+
+    expect(screen.queryByText("Type Settings")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/form-builder/__tests__/form-editor.spec.tsx
+++ b/apps/web/src/components/form-builder/__tests__/form-editor.spec.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { FormEditor } from "../form-editor";
 import "../../../../test/setup";
 

--- a/apps/web/src/components/form-builder/__tests__/form-editor.spec.tsx
+++ b/apps/web/src/components/form-builder/__tests__/form-editor.spec.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FormEditor } from "../form-editor";
+import "../../../../test/setup";
+
+// --- Mutable mock state ---
+let mockForm: Record<string, unknown> | undefined;
+let mockIsLoading: boolean;
+let mockError: { message: string } | null;
+let mockSelectedFieldId: string | null;
+let mockIsPreviewMode: boolean;
+let mockAddField: jest.Mock;
+let mockSetSelectedFieldId: jest.Mock;
+let mockTogglePreview: jest.Mock;
+let mockPublishMutate: jest.Mock;
+let mockRemoveFieldMutate: jest.Mock;
+let mockReorderFieldsMutate: jest.Mock;
+let mockUpdateFieldMutate: jest.Mock;
+
+function resetMocks() {
+  mockIsLoading = false;
+  mockError = null;
+  mockSelectedFieldId = null;
+  mockIsPreviewMode = false;
+  mockAddField = jest.fn();
+  mockSetSelectedFieldId = jest.fn();
+  mockTogglePreview = jest.fn();
+  mockPublishMutate = jest.fn();
+  mockRemoveFieldMutate = jest.fn();
+  mockReorderFieldsMutate = jest.fn();
+  mockUpdateFieldMutate = jest.fn();
+  mockForm = {
+    id: "form-1",
+    name: "Test Form",
+    description: "A test form",
+    status: "DRAFT",
+    version: 1,
+    fields: [
+      {
+        id: "field-1",
+        formDefinitionId: "form-1",
+        fieldKey: "title",
+        fieldType: "text",
+        label: "Title",
+        description: null,
+        placeholder: null,
+        required: true,
+        sortOrder: 0,
+        config: null,
+        conditionalRules: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "field-2",
+        formDefinitionId: "form-1",
+        fieldKey: "bio",
+        fieldType: "textarea",
+        label: "Bio",
+        description: "Tell us about yourself",
+        placeholder: null,
+        required: false,
+        sortOrder: 1,
+        config: null,
+        conditionalRules: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+    organizationId: "org-1",
+    duplicatedFromId: null,
+    createdBy: "user-1",
+    publishedAt: null,
+    archivedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+jest.mock("@/hooks/use-form-builder", () => ({
+  useFormBuilder: () => ({
+    form: mockForm,
+    isLoading: mockIsLoading,
+    error: mockError,
+    selectedFieldId: mockSelectedFieldId,
+    setSelectedFieldId: mockSetSelectedFieldId,
+    isPreviewMode: mockIsPreviewMode,
+    togglePreview: mockTogglePreview,
+    addField: mockAddField,
+    updateForm: { mutate: jest.fn(), isPending: false },
+    publishForm: { mutate: mockPublishMutate, isPending: false },
+    archiveForm: { mutate: jest.fn(), isPending: false },
+    duplicateForm: { mutate: jest.fn(), isPending: false },
+    deleteForm: { mutate: jest.fn(), isPending: false },
+    updateField: { mutate: mockUpdateFieldMutate, isPending: false },
+    removeField: { mutate: mockRemoveFieldMutate, isPending: false },
+    reorderFields: { mutate: mockReorderFieldsMutate, isPending: false },
+  }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+describe("FormEditor", () => {
+  beforeEach(() => {
+    resetMocks();
+  });
+
+  it("renders 3-column layout with palette, canvas, and properties", () => {
+    render(<FormEditor formId="form-1" />);
+    expect(screen.getByText("Add Field")).toBeInTheDocument();
+    expect(screen.getByText("Title")).toBeInTheDocument();
+    expect(screen.getByText("Bio")).toBeInTheDocument();
+    expect(
+      screen.getByText("Select a field to edit its properties"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders form name and status in header", () => {
+    render(<FormEditor formId="form-1" />);
+    expect(screen.getByText("Test Form")).toBeInTheDocument();
+    expect(screen.getByText("Draft")).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton when loading", () => {
+    mockIsLoading = true;
+    mockForm = undefined;
+    render(<FormEditor formId="form-1" />);
+    expect(screen.queryByText("Add Field")).not.toBeInTheDocument();
+  });
+
+  it("renders error state when form not found", () => {
+    mockForm = undefined;
+    mockError = { message: "Not found" };
+    render(<FormEditor formId="form-1" />);
+    expect(screen.getByText("Not found")).toBeInTheDocument();
+    expect(screen.getByText("Back to Forms")).toBeInTheDocument();
+  });
+
+  it("shows publish button for draft forms", () => {
+    render(<FormEditor formId="form-1" />);
+    expect(screen.getByText("Publish")).toBeInTheDocument();
+  });
+
+  it("shows read-only notice for published forms", () => {
+    mockForm = { ...mockForm, status: "PUBLISHED" };
+    render(<FormEditor formId="form-1" />);
+    expect(
+      screen.getByText(/This form is published and cannot be edited/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders preview toggle button", () => {
+    render(<FormEditor formId="form-1" />);
+    expect(screen.getByText("Preview")).toBeInTheDocument();
+  });
+
+  it("renders palette field types", () => {
+    render(<FormEditor formId="form-1" />);
+    // Palette has the field type buttons — "Short Text" may appear in both palette and canvas
+    expect(screen.getAllByText("Short Text").length).toBeGreaterThanOrEqual(1);
+    // These only appear in the palette (not used in the mock fields)
+    expect(screen.getByText("Dropdown")).toBeInTheDocument();
+    expect(screen.getByText("File Upload")).toBeInTheDocument();
+  });
+
+  it("shows properties panel when field is selected", () => {
+    mockSelectedFieldId = "field-1";
+    render(<FormEditor formId="form-1" />);
+    expect(screen.getByText("Field Properties")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/form-builder/__tests__/form-list.spec.tsx
+++ b/apps/web/src/components/form-builder/__tests__/form-list.spec.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, screen } from "@testing-library/react";
 import { FormList } from "../form-list";
 import "../../../../test/setup";
 

--- a/apps/web/src/components/form-builder/__tests__/form-list.spec.tsx
+++ b/apps/web/src/components/form-builder/__tests__/form-list.spec.tsx
@@ -1,0 +1,168 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FormList } from "../form-list";
+import "../../../../test/setup";
+
+// --- Mutable mock state ---
+let mockListData:
+  | {
+      items: Array<Record<string, unknown>>;
+      total: number;
+      page: number;
+      limit: number;
+      totalPages: number;
+    }
+  | undefined;
+let mockIsLoading: boolean;
+let mockError: { message: string } | null;
+let mockPublishMutate: jest.Mock;
+let mockArchiveMutate: jest.Mock;
+let mockDuplicateMutate: jest.Mock;
+let mockDeleteMutate: jest.Mock;
+
+function resetMocks() {
+  mockIsLoading = false;
+  mockError = null;
+  mockListData = undefined;
+  mockPublishMutate = jest.fn();
+  mockArchiveMutate = jest.fn();
+  mockDuplicateMutate = jest.fn();
+  mockDeleteMutate = jest.fn();
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    useUtils: () => ({
+      forms: { list: { invalidate: jest.fn() } },
+    }),
+    forms: {
+      list: {
+        useQuery: () => ({
+          data: mockListData,
+          isPending: mockIsLoading,
+          error: mockError,
+        }),
+      },
+      publish: {
+        useMutation: () => ({
+          mutate: mockPublishMutate,
+          isPending: false,
+        }),
+      },
+      archive: {
+        useMutation: () => ({
+          mutate: mockArchiveMutate,
+          isPending: false,
+        }),
+      },
+      duplicate: {
+        useMutation: () => ({
+          mutate: mockDuplicateMutate,
+          isPending: false,
+        }),
+      },
+      delete: {
+        useMutation: () => ({
+          mutate: mockDeleteMutate,
+          isPending: false,
+        }),
+      },
+    },
+  },
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const sampleForm = {
+  id: "form-1",
+  name: "Poetry Submission",
+  description: "Submit your poems",
+  status: "DRAFT",
+  version: 1,
+  createdAt: "2026-01-15T00:00:00Z",
+  updatedAt: "2026-01-16T00:00:00Z",
+};
+
+describe("FormList", () => {
+  beforeEach(() => {
+    resetMocks();
+  });
+
+  it("renders loading skeletons when loading", () => {
+    mockIsLoading = true;
+    render(<FormList />);
+    // Skeletons are rendered — no form cards visible
+    expect(screen.queryByText("Poetry Submission")).not.toBeInTheDocument();
+    expect(screen.getByText("Forms")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no forms", () => {
+    mockListData = { items: [], total: 0, page: 1, limit: 12, totalPages: 0 };
+    render(<FormList />);
+    expect(screen.getByText("No forms")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Create your first form to start collecting submissions.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders form cards when data is present", () => {
+    mockListData = {
+      items: [sampleForm],
+      total: 1,
+      page: 1,
+      limit: 12,
+      totalPages: 1,
+    };
+    render(<FormList />);
+    expect(screen.getByText("Poetry Submission")).toBeInTheDocument();
+    expect(screen.getByText("Draft")).toBeInTheDocument();
+  });
+
+  it("renders error state", () => {
+    mockError = { message: "Network error" };
+    render(<FormList />);
+    expect(
+      screen.getByText("Failed to load forms: Network error"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders status filter tabs", () => {
+    mockListData = { items: [], total: 0, page: 1, limit: 12, totalPages: 0 };
+    render(<FormList />);
+    expect(screen.getByText("All")).toBeInTheDocument();
+    expect(screen.getByText("Drafts")).toBeInTheDocument();
+    expect(screen.getByText("Published")).toBeInTheDocument();
+    expect(screen.getByText("Archived")).toBeInTheDocument();
+  });
+
+  it("renders search input", () => {
+    mockListData = { items: [], total: 0, page: 1, limit: 12, totalPages: 0 };
+    render(<FormList />);
+    expect(screen.getByPlaceholderText("Search forms...")).toBeInTheDocument();
+  });
+
+  it("renders new form button linking to create page", () => {
+    mockListData = { items: [], total: 0, page: 1, limit: 12, totalPages: 0 };
+    render(<FormList />);
+    const newButton = screen.getByText("New Form");
+    expect(newButton.closest("a")).toHaveAttribute("href", "/editor/forms/new");
+  });
+
+  it("renders pagination when multiple pages", () => {
+    mockListData = {
+      items: [sampleForm],
+      total: 25,
+      page: 1,
+      limit: 12,
+      totalPages: 3,
+    };
+    render(<FormList />);
+    expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+    expect(screen.getByText("Previous")).toBeDisabled();
+    expect(screen.getByText("Next")).not.toBeDisabled();
+  });
+});

--- a/apps/web/src/components/form-builder/__tests__/select-config.spec.tsx
+++ b/apps/web/src/components/form-builder/__tests__/select-config.spec.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SelectConfig } from "../field-config/select-config";
+import "../../../../test/setup";
+
+describe("SelectConfig", () => {
+  it("renders existing options", () => {
+    const onChange = jest.fn();
+    const config = {
+      options: [
+        { label: "Poetry", value: "poetry" },
+        { label: "Fiction", value: "fiction" },
+      ],
+    };
+
+    render(<SelectConfig config={config} onChange={onChange} />);
+
+    expect(screen.getByDisplayValue("Poetry")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Fiction")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("poetry")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("fiction")).toBeInTheDocument();
+  });
+
+  it("adds a new option with auto-generated value", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const config = { options: [] as Array<{ label: string; value: string }> };
+
+    render(<SelectConfig config={config} onChange={onChange} />);
+
+    const input = screen.getByPlaceholderText("New option label");
+    await user.type(input, "New Genre");
+    await user.click(screen.getByText("Add"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      options: [{ label: "New Genre", value: "new_genre" }],
+    });
+  });
+
+  it("adds option on Enter key", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const config = { options: [] as Array<{ label: string; value: string }> };
+
+    render(<SelectConfig config={config} onChange={onChange} />);
+
+    const input = screen.getByPlaceholderText("New option label");
+    await user.type(input, "Test Option{enter}");
+
+    expect(onChange).toHaveBeenCalledWith({
+      options: [{ label: "Test Option", value: "test_option" }],
+    });
+  });
+
+  it("removes an option", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const config = {
+      options: [
+        { label: "Keep", value: "keep" },
+        { label: "Remove", value: "remove" },
+      ],
+    };
+
+    render(<SelectConfig config={config} onChange={onChange} />);
+
+    const removeButtons = screen.getAllByLabelText("Remove option");
+    await user.click(removeButtons[1]);
+
+    expect(onChange).toHaveBeenCalledWith({
+      options: [{ label: "Keep", value: "keep" }],
+    });
+  });
+
+  it("updates an option label on change", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const config = {
+      options: [{ label: "Original", value: "original" }],
+    };
+
+    render(<SelectConfig config={config} onChange={onChange} />);
+
+    const labelInput = screen.getByDisplayValue("Original");
+    // Type a character — onChange fires with the appended value
+    await user.type(labelInput, "X");
+
+    expect(onChange).toHaveBeenCalled();
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(lastCall.options[0].label).toBe("OriginalX");
+    expect(lastCall.options[0].value).toBe("original");
+  });
+
+  it("disables add button when input is empty", () => {
+    const onChange = jest.fn();
+    render(<SelectConfig config={{ options: [] }} onChange={onChange} />);
+
+    expect(screen.getByText("Add")).toBeDisabled();
+  });
+
+  it("renders empty options list initially", () => {
+    const onChange = jest.fn();
+    render(<SelectConfig config={{}} onChange={onChange} />);
+
+    expect(screen.getByText("Options")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Remove option")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/form-builder/field-config/file-upload-config.tsx
+++ b/apps/web/src/components/form-builder/field-config/file-upload-config.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface FileUploadConfigProps {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+}
+
+export function FileUploadConfig({ config, onChange }: FileUploadConfigProps) {
+  const allowedMimeTypes =
+    (config.allowedMimeTypes as string[] | undefined) ?? [];
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label htmlFor="maxFiles" className="text-xs">
+          Max Files
+        </Label>
+        <Input
+          id="maxFiles"
+          type="number"
+          min={1}
+          value={(config.maxFiles as number) ?? ""}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              maxFiles: e.target.value ? Number(e.target.value) : undefined,
+            })
+          }
+          placeholder="No limit"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="maxFileSize" className="text-xs">
+          Max File Size (bytes)
+        </Label>
+        <Input
+          id="maxFileSize"
+          type="number"
+          min={1}
+          value={(config.maxFileSize as number) ?? ""}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              maxFileSize: e.target.value ? Number(e.target.value) : undefined,
+            })
+          }
+          placeholder="No limit"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="allowedMimeTypes" className="text-xs">
+          Allowed MIME Types
+        </Label>
+        <Input
+          id="allowedMimeTypes"
+          value={allowedMimeTypes.join(", ")}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              allowedMimeTypes: e.target.value
+                ? e.target.value
+                    .split(",")
+                    .map((s) => s.trim())
+                    .filter(Boolean)
+                : undefined,
+            })
+          }
+          placeholder="e.g. application/pdf, image/png"
+        />
+        <p className="text-xs text-muted-foreground">
+          Comma-separated list. Leave empty to allow all types.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/form-builder/field-config/number-config.tsx
+++ b/apps/web/src/components/form-builder/field-config/number-config.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface NumberConfigProps {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+}
+
+export function NumberConfig({ config, onChange }: NumberConfigProps) {
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label htmlFor="min" className="text-xs">
+          Minimum
+        </Label>
+        <Input
+          id="min"
+          type="number"
+          value={(config.min as number) ?? ""}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              min: e.target.value ? Number(e.target.value) : undefined,
+            })
+          }
+          placeholder="No minimum"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="max" className="text-xs">
+          Maximum
+        </Label>
+        <Input
+          id="max"
+          type="number"
+          value={(config.max as number) ?? ""}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              max: e.target.value ? Number(e.target.value) : undefined,
+            })
+          }
+          placeholder="No maximum"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="step" className="text-xs">
+          Step
+        </Label>
+        <Input
+          id="step"
+          type="number"
+          min={0}
+          value={(config.step as number) ?? ""}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              step: e.target.value ? Number(e.target.value) : undefined,
+            })
+          }
+          placeholder="Any"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/form-builder/field-config/select-config.tsx
+++ b/apps/web/src/components/form-builder/field-config/select-config.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Plus, Trash2 } from "lucide-react";
+
+interface SelectOption {
+  label: string;
+  value: string;
+}
+
+interface SelectConfigProps {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function SelectConfig({ config, onChange }: SelectConfigProps) {
+  const options = (config.options as SelectOption[] | undefined) ?? [];
+  const [newLabel, setNewLabel] = useState("");
+
+  function addOption() {
+    const label = newLabel.trim();
+    if (!label) return;
+    const value = slugify(label);
+    if (!value) return;
+    onChange({
+      ...config,
+      options: [...options, { label, value }],
+    });
+    setNewLabel("");
+  }
+
+  function removeOption(index: number) {
+    onChange({
+      ...config,
+      options: options.filter((_, i) => i !== index),
+    });
+  }
+
+  function updateOption(index: number, field: "label" | "value", val: string) {
+    const updated = options.map((opt, i) =>
+      i === index ? { ...opt, [field]: val } : opt,
+    );
+    onChange({ ...config, options: updated });
+  }
+
+  return (
+    <div className="space-y-3">
+      <Label className="text-xs">Options</Label>
+      <div className="space-y-2">
+        {options.map((option, index) => (
+          <div key={index} className="flex items-center gap-2">
+            <Input
+              value={option.label}
+              onChange={(e) => updateOption(index, "label", e.target.value)}
+              placeholder="Label"
+              className="flex-1"
+            />
+            <Input
+              value={option.value}
+              onChange={(e) => updateOption(index, "value", e.target.value)}
+              placeholder="Value"
+              className="flex-1"
+            />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+              onClick={() => removeOption(index)}
+              aria-label="Remove option"
+            >
+              <Trash2 className="h-3 w-3" />
+            </Button>
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center gap-2">
+        <Input
+          value={newLabel}
+          onChange={(e) => setNewLabel(e.target.value)}
+          placeholder="New option label"
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              addOption();
+            }
+          }}
+        />
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={addOption}
+          disabled={!newLabel.trim()}
+        >
+          <Plus className="mr-1 h-3 w-3" />
+          Add
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/form-builder/field-config/text-config.tsx
+++ b/apps/web/src/components/form-builder/field-config/text-config.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface TextConfigProps {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+}
+
+export function TextConfig({ config, onChange }: TextConfigProps) {
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label htmlFor="minLength" className="text-xs">
+          Min Length
+        </Label>
+        <Input
+          id="minLength"
+          type="number"
+          min={0}
+          value={(config.minLength as number) ?? ""}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              minLength: e.target.value ? Number(e.target.value) : undefined,
+            })
+          }
+          placeholder="No minimum"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="maxLength" className="text-xs">
+          Max Length
+        </Label>
+        <Input
+          id="maxLength"
+          type="number"
+          min={1}
+          value={(config.maxLength as number) ?? ""}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              maxLength: e.target.value ? Number(e.target.value) : undefined,
+            })
+          }
+          placeholder="No maximum"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/form-builder/field-palette.tsx
+++ b/apps/web/src/components/form-builder/field-palette.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { FIELD_CATEGORIES, FIELD_TYPE_META } from "./field-type-meta";
+import type { FormFieldType } from "@colophony/types";
+
+interface FieldPaletteProps {
+  onAddField: (type: FormFieldType) => void;
+  disabled?: boolean;
+}
+
+export function FieldPalette({ onAddField, disabled }: FieldPaletteProps) {
+  return (
+    <ScrollArea className="h-full">
+      <div className="p-4 space-y-6">
+        <h2 className="font-semibold text-sm">Add Field</h2>
+        {FIELD_CATEGORIES.map((category) => {
+          const fields = (
+            Object.entries(FIELD_TYPE_META) as Array<
+              [FormFieldType, (typeof FIELD_TYPE_META)[FormFieldType]]
+            >
+          ).filter(([, meta]) => meta.category === category.key);
+
+          if (fields.length === 0) return null;
+
+          return (
+            <div key={category.key} className="space-y-2">
+              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                {category.label}
+              </h3>
+              <div className="grid grid-cols-1 gap-1">
+                {fields.map(([type, meta]) => (
+                  <Button
+                    key={type}
+                    variant="ghost"
+                    size="sm"
+                    className="justify-start h-9"
+                    disabled={disabled}
+                    onClick={() => onAddField(type)}
+                  >
+                    <meta.icon className="mr-2 h-4 w-4 text-muted-foreground" />
+                    {meta.label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/apps/web/src/components/form-builder/field-properties-panel.tsx
+++ b/apps/web/src/components/form-builder/field-properties-panel.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { TextConfig } from "./field-config/text-config";
+import { NumberConfig } from "./field-config/number-config";
+import { SelectConfig } from "./field-config/select-config";
+import { FileUploadConfig } from "./field-config/file-upload-config";
+import { FIELD_TYPE_META } from "./field-type-meta";
+import { Loader2, Check } from "lucide-react";
+import type { FormFieldType, UpdateFormFieldInput } from "@colophony/types";
+
+interface PropertiesField {
+  id: string;
+  fieldType: FormFieldType;
+  label: string;
+  description: string | null;
+  placeholder: string | null;
+  required: boolean;
+  config: Record<string, unknown> | null;
+}
+
+interface FieldPropertiesPanelProps {
+  field: PropertiesField;
+  onUpdate: (fieldId: string, data: UpdateFormFieldInput) => void;
+  isSaving: boolean;
+}
+
+type SaveStatus = "idle" | "saving" | "saved";
+
+const TEXT_TYPES = ["text", "textarea", "rich_text", "email", "url"] as const;
+const SELECT_TYPES = [
+  "select",
+  "multi_select",
+  "radio",
+  "checkbox_group",
+] as const;
+
+export function FieldPropertiesPanel({
+  field,
+  onUpdate,
+  isSaving,
+}: FieldPropertiesPanelProps) {
+  const [label, setLabel] = useState(field.label);
+  const [description, setDescription] = useState(field.description ?? "");
+  const [placeholder, setPlaceholder] = useState(field.placeholder ?? "");
+  const [required, setRequired] = useState(field.required);
+  const [config, setConfig] = useState<Record<string, unknown>>(
+    field.config ?? {},
+  );
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fieldIdRef = useRef(field.id);
+
+  // Reset local state when selected field changes
+  useEffect(() => {
+    if (fieldIdRef.current !== field.id) {
+      fieldIdRef.current = field.id;
+      setLabel(field.label);
+      setDescription(field.description ?? "");
+      setPlaceholder(field.placeholder ?? "");
+      setRequired(field.required);
+      setConfig(field.config ?? {});
+      setSaveStatus("idle");
+    }
+  }, [field]);
+
+  const debouncedSave = useCallback(
+    (data: UpdateFormFieldInput) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      setSaveStatus("saving");
+      debounceRef.current = setTimeout(() => {
+        onUpdate(field.id, data);
+      }, 500);
+    },
+    [field.id, onUpdate],
+  );
+
+  // Track save completion
+  useEffect(() => {
+    if (!isSaving && saveStatus === "saving") {
+      setSaveStatus("saved");
+      const timer = setTimeout(() => setSaveStatus("idle"), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [isSaving, saveStatus]);
+
+  // Cleanup debounce on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  function handleLabelChange(value: string) {
+    setLabel(value);
+    debouncedSave({ label: value });
+  }
+
+  function handleDescriptionChange(value: string) {
+    setDescription(value);
+    debouncedSave({ description: value });
+  }
+
+  function handlePlaceholderChange(value: string) {
+    setPlaceholder(value);
+    debouncedSave({ placeholder: value });
+  }
+
+  function handleRequiredChange(checked: boolean) {
+    setRequired(checked);
+    debouncedSave({ required: checked });
+  }
+
+  function handleConfigChange(newConfig: Record<string, unknown>) {
+    setConfig(newConfig);
+    debouncedSave({ config: newConfig });
+  }
+
+  const meta = FIELD_TYPE_META[field.fieldType];
+
+  function renderTypeConfig() {
+    if ((TEXT_TYPES as readonly string[]).includes(field.fieldType)) {
+      return <TextConfig config={config} onChange={handleConfigChange} />;
+    }
+    if (field.fieldType === "number") {
+      return <NumberConfig config={config} onChange={handleConfigChange} />;
+    }
+    if ((SELECT_TYPES as readonly string[]).includes(field.fieldType)) {
+      return <SelectConfig config={config} onChange={handleConfigChange} />;
+    }
+    if (field.fieldType === "file_upload") {
+      return <FileUploadConfig config={config} onChange={handleConfigChange} />;
+    }
+    return null;
+  }
+
+  return (
+    <ScrollArea className="h-full">
+      <div className="p-4 space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="font-semibold text-sm">Field Properties</h2>
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            {saveStatus === "saving" && (
+              <>
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Saving...
+              </>
+            )}
+            {saveStatus === "saved" && (
+              <>
+                <Check className="h-3 w-3" />
+                Saved
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <meta.icon className="h-4 w-4" />
+          {meta.label}
+        </div>
+
+        <Separator />
+
+        {/* Common fields */}
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="field-label" className="text-xs">
+              Label
+            </Label>
+            <Input
+              id="field-label"
+              value={label}
+              onChange={(e) => handleLabelChange(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="field-description" className="text-xs">
+              Help Text
+            </Label>
+            <Textarea
+              id="field-description"
+              value={description}
+              onChange={(e) => handleDescriptionChange(e.target.value)}
+              rows={2}
+              placeholder="Optional help text for submitters"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="field-placeholder" className="text-xs">
+              Placeholder
+            </Label>
+            <Input
+              id="field-placeholder"
+              value={placeholder}
+              onChange={(e) => handlePlaceholderChange(e.target.value)}
+              placeholder="Optional placeholder text"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="field-required"
+              checked={required}
+              onCheckedChange={(checked) =>
+                handleRequiredChange(checked === true)
+              }
+            />
+            <Label htmlFor="field-required" className="text-xs cursor-pointer">
+              Required
+            </Label>
+          </div>
+        </div>
+
+        {/* Type-specific config */}
+        {renderTypeConfig() && (
+          <>
+            <Separator />
+            <div className="space-y-3">
+              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Type Settings
+              </h3>
+              {renderTypeConfig()}
+            </div>
+          </>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/apps/web/src/components/form-builder/field-type-meta.ts
+++ b/apps/web/src/components/form-builder/field-type-meta.ts
@@ -1,0 +1,63 @@
+import {
+  Type,
+  AlignLeft,
+  FileText,
+  Hash,
+  Mail,
+  Link,
+  Calendar,
+  ChevronDown,
+  List,
+  Circle,
+  CheckSquare,
+  ListChecks,
+  Upload,
+  Heading,
+  Info,
+} from "lucide-react";
+import type { FormFieldType } from "@colophony/types";
+import type { LucideIcon } from "lucide-react";
+
+export interface FieldTypeMeta {
+  icon: LucideIcon;
+  label: string;
+  category: FieldCategory;
+}
+
+export type FieldCategory = "text" | "choice" | "media" | "layout";
+
+export const FIELD_CATEGORIES: Array<{
+  key: FieldCategory;
+  label: string;
+}> = [
+  { key: "text", label: "Text & Numbers" },
+  { key: "choice", label: "Choice" },
+  { key: "media", label: "Media" },
+  { key: "layout", label: "Layout" },
+];
+
+export const FIELD_TYPE_META: Record<FormFieldType, FieldTypeMeta> = {
+  text: { icon: Type, label: "Short Text", category: "text" },
+  textarea: { icon: AlignLeft, label: "Long Text", category: "text" },
+  rich_text: { icon: FileText, label: "Rich Text", category: "text" },
+  number: { icon: Hash, label: "Number", category: "text" },
+  email: { icon: Mail, label: "Email", category: "text" },
+  url: { icon: Link, label: "URL", category: "text" },
+  date: { icon: Calendar, label: "Date", category: "text" },
+  select: { icon: ChevronDown, label: "Dropdown", category: "choice" },
+  multi_select: { icon: List, label: "Multi Select", category: "choice" },
+  radio: { icon: Circle, label: "Radio", category: "choice" },
+  checkbox: { icon: CheckSquare, label: "Checkbox", category: "choice" },
+  checkbox_group: {
+    icon: ListChecks,
+    label: "Checkbox Group",
+    category: "choice",
+  },
+  file_upload: { icon: Upload, label: "File Upload", category: "media" },
+  section_header: {
+    icon: Heading,
+    label: "Section Header",
+    category: "layout",
+  },
+  info_text: { icon: Info, label: "Info Text", category: "layout" },
+};

--- a/apps/web/src/components/form-builder/form-canvas.tsx
+++ b/apps/web/src/components/form-builder/form-canvas.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { SortableFieldItem } from "./sortable-field-item";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { LayoutList } from "lucide-react";
+import type { FormFieldType } from "@colophony/types";
+
+interface CanvasField {
+  id: string;
+  fieldKey: string;
+  fieldType: FormFieldType;
+  label: string;
+  description: string | null;
+  placeholder: string | null;
+  required: boolean;
+  sortOrder: number;
+  config: Record<string, unknown> | null;
+}
+
+interface FormCanvasProps {
+  fields: CanvasField[];
+  selectedFieldId: string | null;
+  onSelectField: (id: string) => void;
+  onRemoveField: (id: string) => void;
+  onReorder: (fieldIds: string[]) => void;
+}
+
+export function FormCanvas({
+  fields,
+  selectedFieldId,
+  onSelectField,
+  onRemoveField,
+  onReorder,
+}: FormCanvasProps) {
+  const fieldIds = fields.map((f) => f.id);
+
+  function handleMoveUp(index: number) {
+    if (index === 0) return;
+    const newIds = [...fieldIds];
+    [newIds[index - 1], newIds[index]] = [newIds[index], newIds[index - 1]];
+    onReorder(newIds);
+  }
+
+  function handleMoveDown(index: number) {
+    if (index === fieldIds.length - 1) return;
+    const newIds = [...fieldIds];
+    [newIds[index], newIds[index + 1]] = [newIds[index + 1], newIds[index]];
+    onReorder(newIds);
+  }
+
+  if (fields.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center border rounded-lg bg-muted/30">
+        <div className="text-center py-12">
+          <LayoutList className="mx-auto h-12 w-12 text-muted-foreground" />
+          <h3 className="mt-4 text-lg font-semibold">No fields yet</h3>
+          <p className="text-sm text-muted-foreground">
+            Click a field type in the palette to add it.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="flex-1 border rounded-lg bg-muted/30">
+      <div className="p-4 space-y-2">
+        <SortableContext
+          items={fieldIds}
+          strategy={verticalListSortingStrategy}
+        >
+          {fields.map((field, index) => (
+            <SortableFieldItem
+              key={field.id}
+              field={field}
+              isSelected={field.id === selectedFieldId}
+              isFirst={index === 0}
+              isLast={index === fields.length - 1}
+              onSelect={() => onSelectField(field.id)}
+              onRemove={() => onRemoveField(field.id)}
+              onMoveUp={() => handleMoveUp(index)}
+              onMoveDown={() => handleMoveDown(index)}
+            />
+          ))}
+        </SortableContext>
+      </div>
+    </ScrollArea>
+  );
+}

--- a/apps/web/src/components/form-builder/form-card.tsx
+++ b/apps/web/src/components/form-builder/form-card.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import Link from "next/link";
+import { formatDistanceToNow } from "date-fns";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { FormStatusBadge } from "./form-status-badge";
+import {
+  MoreHorizontal,
+  Copy,
+  Archive,
+  Trash2,
+  Send,
+  Pencil,
+} from "lucide-react";
+import type { FormStatus } from "@colophony/types";
+
+interface FormCardProps {
+  form: {
+    id: string;
+    name: string;
+    description: string | null;
+    status: FormStatus;
+    version: number;
+    createdAt: Date | string;
+    updatedAt: Date | string;
+  };
+  fieldCount?: number;
+  onPublish?: (id: string) => void;
+  onArchive?: (id: string) => void;
+  onDuplicate?: (id: string) => void;
+  onDelete?: (id: string) => void;
+}
+
+export function FormCard({
+  form,
+  fieldCount,
+  onPublish,
+  onArchive,
+  onDuplicate,
+  onDelete,
+}: FormCardProps) {
+  return (
+    <Card className="hover:border-primary/50 transition-colors">
+      <CardHeader className="pb-2">
+        <div className="flex items-start justify-between gap-2">
+          <Link href={`/editor/forms/${form.id}`} className="flex-1 min-w-0">
+            <CardTitle className="text-base line-clamp-2 hover:underline cursor-pointer">
+              {form.name}
+            </CardTitle>
+          </Link>
+          <div className="flex items-center gap-2 shrink-0">
+            <FormStatusBadge status={form.status} />
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <MoreHorizontal className="h-4 w-4" />
+                  <span className="sr-only">Actions</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem asChild>
+                  <Link href={`/editor/forms/${form.id}`}>
+                    <Pencil className="mr-2 h-4 w-4" />
+                    Edit
+                  </Link>
+                </DropdownMenuItem>
+                {form.status === "DRAFT" && onPublish && (
+                  <DropdownMenuItem onClick={() => onPublish(form.id)}>
+                    <Send className="mr-2 h-4 w-4" />
+                    Publish
+                  </DropdownMenuItem>
+                )}
+                {form.status === "PUBLISHED" && onArchive && (
+                  <DropdownMenuItem onClick={() => onArchive(form.id)}>
+                    <Archive className="mr-2 h-4 w-4" />
+                    Archive
+                  </DropdownMenuItem>
+                )}
+                {onDuplicate && (
+                  <DropdownMenuItem onClick={() => onDuplicate(form.id)}>
+                    <Copy className="mr-2 h-4 w-4" />
+                    Duplicate
+                  </DropdownMenuItem>
+                )}
+                {form.status === "DRAFT" && onDelete && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      className="text-destructive"
+                      onClick={() => onDelete(form.id)}
+                    >
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      Delete
+                    </DropdownMenuItem>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {form.description && (
+          <p className="text-sm text-muted-foreground line-clamp-2 mb-2">
+            {form.description}
+          </p>
+        )}
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          {fieldCount !== undefined && (
+            <span>
+              {fieldCount} {fieldCount === 1 ? "field" : "fields"}
+            </span>
+          )}
+          <span>v{form.version}</span>
+          <span>
+            Updated{" "}
+            {formatDistanceToNow(new Date(form.updatedAt), {
+              addSuffix: true,
+            })}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/form-builder/form-editor.tsx
+++ b/apps/web/src/components/form-builder/form-editor.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import { useFormBuilder } from "@/hooks/use-form-builder";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { FormStatusBadge } from "./form-status-badge";
+import { FieldPalette } from "./field-palette";
+import { FormCanvas } from "./form-canvas";
+import { FieldPropertiesPanel } from "./field-properties-panel";
+import { FormPreview } from "./form-preview";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Send,
+  Archive,
+  Copy,
+  Trash2,
+  Eye,
+  EyeOff,
+  ArrowLeft,
+  Loader2,
+} from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import type { UpdateFormFieldInput } from "@colophony/types";
+
+interface FormEditorProps {
+  formId: string;
+}
+
+export function FormEditor({ formId }: FormEditorProps) {
+  const router = useRouter();
+  const {
+    form,
+    isLoading,
+    error,
+    selectedFieldId,
+    setSelectedFieldId,
+    isPreviewMode,
+    togglePreview,
+    addField,
+    updateForm,
+    publishForm,
+    archiveForm,
+    duplicateForm,
+    deleteForm,
+    updateField,
+    removeField,
+    reorderFields,
+  } = useFormBuilder(formId);
+
+  const [editingName, setEditingName] = useState(false);
+  const [nameValue, setNameValue] = useState("");
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id || !form) return;
+
+      const fieldIds = form.fields.map((f) => f.id);
+      const oldIndex = fieldIds.indexOf(active.id as string);
+      const newIndex = fieldIds.indexOf(over.id as string);
+
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const newIds = [...fieldIds];
+      const [removed] = newIds.splice(oldIndex, 1);
+      newIds.splice(newIndex, 0, removed);
+
+      reorderFields.mutate({ id: formId, fieldIds: newIds });
+    },
+    [form, formId, reorderFields],
+  );
+
+  const handleUpdateField = useCallback(
+    (fieldId: string, data: UpdateFormFieldInput) => {
+      updateField.mutate({ id: formId, fieldId, ...data });
+    },
+    [formId, updateField],
+  );
+
+  const handleNameSave = useCallback(() => {
+    const trimmed = nameValue.trim();
+    if (trimmed && trimmed !== form?.name) {
+      updateForm.mutate({ id: formId, name: trimmed });
+    }
+    setEditingName(false);
+  }, [nameValue, form?.name, formId, updateForm]);
+
+  const handleDelete = useCallback(() => {
+    deleteForm.mutate(
+      { id: formId },
+      {
+        onSuccess: () => {
+          toast.success("Form deleted");
+          router.push("/editor/forms");
+        },
+      },
+    );
+  }, [formId, deleteForm, router]);
+
+  if (isLoading) {
+    return (
+      <div className="h-full p-6 space-y-4">
+        <Skeleton className="h-10 w-64" />
+        <div className="flex gap-4 h-[calc(100vh-12rem)]">
+          <Skeleton className="w-56 h-full" />
+          <Skeleton className="flex-1 h-full" />
+          <Skeleton className="w-72 h-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !form) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-destructive">{error?.message ?? "Form not found"}</p>
+        <Link href="/editor/forms">
+          <Button variant="outline" className="mt-4">
+            Back to Forms
+          </Button>
+        </Link>
+      </div>
+    );
+  }
+
+  const canEdit = form.status === "DRAFT";
+  const selectedField = form.fields.find((f) => f.id === selectedFieldId);
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Header bar */}
+      <div className="flex items-center gap-3 border-b px-4 py-2 shrink-0">
+        <Link
+          href="/editor/forms"
+          className="text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Link>
+
+        {editingName && canEdit ? (
+          <Input
+            value={nameValue}
+            onChange={(e) => setNameValue(e.target.value)}
+            onBlur={handleNameSave}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleNameSave();
+              if (e.key === "Escape") setEditingName(false);
+            }}
+            className="max-w-xs h-8 text-sm font-semibold"
+            autoFocus
+          />
+        ) : (
+          <button
+            className="text-sm font-semibold hover:underline"
+            onClick={() => {
+              if (!canEdit) return;
+              setNameValue(form.name);
+              setEditingName(true);
+            }}
+          >
+            {form.name}
+          </button>
+        )}
+
+        <FormStatusBadge status={form.status} />
+
+        <div className="flex-1" />
+
+        <Button variant="outline" size="sm" onClick={togglePreview}>
+          {isPreviewMode ? (
+            <EyeOff className="mr-1 h-3 w-3" />
+          ) : (
+            <Eye className="mr-1 h-3 w-3" />
+          )}
+          {isPreviewMode ? "Editor" : "Preview"}
+        </Button>
+
+        {canEdit && (
+          <Button
+            size="sm"
+            onClick={() => publishForm.mutate({ id: formId })}
+            disabled={publishForm.isPending}
+          >
+            {publishForm.isPending ? (
+              <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+            ) : (
+              <Send className="mr-1 h-3 w-3" />
+            )}
+            Publish
+          </Button>
+        )}
+
+        {form.status === "PUBLISHED" && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => archiveForm.mutate({ id: formId })}
+            disabled={archiveForm.isPending}
+          >
+            <Archive className="mr-1 h-3 w-3" />
+            Archive
+          </Button>
+        )}
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => duplicateForm.mutate({ id: formId })}
+          disabled={duplicateForm.isPending}
+        >
+          <Copy className="mr-1 h-3 w-3" />
+          Duplicate
+        </Button>
+
+        {canEdit && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-destructive"
+            onClick={handleDelete}
+            disabled={deleteForm.isPending}
+          >
+            <Trash2 className="mr-1 h-3 w-3" />
+            Delete
+          </Button>
+        )}
+      </div>
+
+      {/* Main content */}
+      {isPreviewMode ? (
+        <FormPreview form={form} />
+      ) : (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <div className="flex flex-1 min-h-0">
+            {/* Left: Palette */}
+            <div className="w-56 border-r shrink-0">
+              <FieldPalette onAddField={addField} disabled={!canEdit} />
+            </div>
+
+            {/* Center: Canvas */}
+            <div className="flex-1 flex flex-col p-4">
+              {!canEdit && (
+                <div className="mb-3 rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground">
+                  This form is {form.status.toLowerCase()} and cannot be edited.
+                  Duplicate it to make changes.
+                </div>
+              )}
+              <FormCanvas
+                fields={form.fields}
+                selectedFieldId={selectedFieldId}
+                onSelectField={setSelectedFieldId}
+                onRemoveField={(fieldId) =>
+                  removeField.mutate({ id: formId, fieldId })
+                }
+                onReorder={(fieldIds) =>
+                  reorderFields.mutate({ id: formId, fieldIds })
+                }
+              />
+            </div>
+
+            {/* Right: Properties */}
+            <div className="w-72 border-l shrink-0">
+              {selectedField ? (
+                <FieldPropertiesPanel
+                  field={selectedField}
+                  onUpdate={handleUpdateField}
+                  isSaving={updateField.isPending}
+                />
+              ) : (
+                <div className="flex items-center justify-center h-full text-sm text-muted-foreground p-4 text-center">
+                  Select a field to edit its properties
+                </div>
+              )}
+            </div>
+          </div>
+        </DndContext>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/form-builder/form-editor.tsx
+++ b/apps/web/src/components/form-builder/form-editor.tsx
@@ -74,6 +74,7 @@ export function FormEditor({ formId }: FormEditorProps) {
     (event: DragEndEvent) => {
       const { active, over } = event;
       if (!over || active.id === over.id || !form) return;
+      if (form.status !== "DRAFT") return;
 
       const fieldIds = form.fields.map((f) => f.id);
       const oldIndex = fieldIds.indexOf(active.id as string);
@@ -273,11 +274,16 @@ export function FormEditor({ formId }: FormEditorProps) {
                 fields={form.fields}
                 selectedFieldId={selectedFieldId}
                 onSelectField={setSelectedFieldId}
-                onRemoveField={(fieldId) =>
-                  removeField.mutate({ id: formId, fieldId })
+                onRemoveField={
+                  canEdit
+                    ? (fieldId) => removeField.mutate({ id: formId, fieldId })
+                    : () => {}
                 }
-                onReorder={(fieldIds) =>
-                  reorderFields.mutate({ id: formId, fieldIds })
+                onReorder={
+                  canEdit
+                    ? (fieldIds) =>
+                        reorderFields.mutate({ id: formId, fieldIds })
+                    : () => {}
                 }
               />
             </div>

--- a/apps/web/src/components/form-builder/form-list.tsx
+++ b/apps/web/src/components/form-builder/form-list.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+import { FormCard } from "./form-card";
+import { Plus, FileText, Search } from "lucide-react";
+import { toast } from "sonner";
+import type { FormStatus } from "@colophony/types";
+
+const statusTabs: Array<{ value: FormStatus | "ALL"; label: string }> = [
+  { value: "ALL", label: "All" },
+  { value: "DRAFT", label: "Drafts" },
+  { value: "PUBLISHED", label: "Published" },
+  { value: "ARCHIVED", label: "Archived" },
+];
+
+export function FormList() {
+  const [statusFilter, setStatusFilter] = useState<FormStatus | "ALL">("ALL");
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const limit = 12;
+  const utils = trpc.useUtils();
+
+  const {
+    data,
+    isPending: isLoading,
+    error,
+  } = trpc.forms.list.useQuery({
+    status: statusFilter === "ALL" ? undefined : statusFilter,
+    search: search || undefined,
+    page,
+    limit,
+  });
+
+  const publishMutation = trpc.forms.publish.useMutation({
+    onSuccess: () => {
+      utils.forms.list.invalidate();
+      toast.success("Form published");
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const archiveMutation = trpc.forms.archive.useMutation({
+    onSuccess: () => {
+      utils.forms.list.invalidate();
+      toast.success("Form archived");
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const duplicateMutation = trpc.forms.duplicate.useMutation({
+    onSuccess: () => {
+      utils.forms.list.invalidate();
+      toast.success("Form duplicated");
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const deleteMutation = trpc.forms.delete.useMutation({
+    onSuccess: () => {
+      utils.forms.list.invalidate();
+      toast.success("Form deleted");
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  if (error) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-destructive">
+          Failed to load forms: {error.message}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Forms</h1>
+          <p className="text-muted-foreground">
+            Create and manage submission forms
+          </p>
+        </div>
+        <Link href="/editor/forms/new">
+          <Button>
+            <Plus className="mr-2 h-4 w-4" />
+            New Form
+          </Button>
+        </Link>
+      </div>
+
+      {/* Filters */}
+      <div className="flex items-center gap-4">
+        <Tabs
+          value={statusFilter}
+          onValueChange={(v) => {
+            setStatusFilter(v as FormStatus | "ALL");
+            setPage(1);
+          }}
+        >
+          <TabsList>
+            {statusTabs.map((tab) => (
+              <TabsTrigger key={tab.value} value={tab.value}>
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+        <div className="relative flex-1 max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search forms..."
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(1);
+            }}
+            className="pl-9"
+          />
+        </div>
+      </div>
+
+      {/* Loading state */}
+      {isLoading && (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-36" />
+          ))}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && data?.items.length === 0 && (
+        <div className="text-center py-12 border rounded-lg">
+          <FileText className="mx-auto h-12 w-12 text-muted-foreground" />
+          <h3 className="mt-4 text-lg font-semibold">No forms</h3>
+          <p className="text-muted-foreground">
+            {search
+              ? "No forms match your search."
+              : statusFilter === "ALL"
+                ? "Create your first form to start collecting submissions."
+                : `No ${statusFilter.toLowerCase()} forms.`}
+          </p>
+          {statusFilter === "ALL" && !search && (
+            <Link href="/editor/forms/new">
+              <Button className="mt-4">
+                <Plus className="mr-2 h-4 w-4" />
+                Create your first form
+              </Button>
+            </Link>
+          )}
+        </div>
+      )}
+
+      {/* Forms grid */}
+      {!isLoading && data && data.items.length > 0 && (
+        <>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {data.items.map((form) => (
+              <FormCard
+                key={form.id}
+                form={form}
+                onPublish={(id) => publishMutation.mutate({ id })}
+                onArchive={(id) => archiveMutation.mutate({ id })}
+                onDuplicate={(id) => duplicateMutation.mutate({ id })}
+                onDelete={(id) => deleteMutation.mutate({ id })}
+              />
+            ))}
+          </div>
+
+          {/* Pagination */}
+          {data.totalPages > 1 && (
+            <div className="flex justify-center gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+              >
+                Previous
+              </Button>
+              <span className="flex items-center px-4 text-sm text-muted-foreground">
+                Page {page} of {data.totalPages}
+              </span>
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))}
+                disabled={page === data.totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/form-builder/form-preview.tsx
+++ b/apps/web/src/components/form-builder/form-preview.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { FIELD_TYPE_META } from "./field-type-meta";
+import type { FormFieldType } from "@colophony/types";
+
+interface PreviewFieldData {
+  id: string;
+  fieldKey: string;
+  fieldType: FormFieldType;
+  label: string;
+  description: string | null;
+  placeholder: string | null;
+  required: boolean;
+  config: Record<string, unknown> | null;
+}
+
+interface FormPreviewProps {
+  form: {
+    name: string;
+    description: string | null;
+    fields: PreviewFieldData[];
+  };
+}
+
+function PreviewField({ field }: { field: PreviewFieldData }) {
+  const config = (field.config ?? {}) as Record<string, unknown>;
+  const options =
+    (config.options as Array<{ label: string; value: string }>) ?? [];
+
+  switch (field.fieldType) {
+    case "section_header":
+      return (
+        <div className="pt-4">
+          <h3 className="text-lg font-semibold">{field.label}</h3>
+          {field.description && (
+            <p className="text-sm text-muted-foreground">{field.description}</p>
+          )}
+          <Separator className="mt-2" />
+        </div>
+      );
+
+    case "info_text":
+      return (
+        <div className="rounded-lg bg-muted p-3 text-sm">
+          {field.description ?? field.label}
+        </div>
+      );
+
+    case "textarea":
+    case "rich_text":
+      return (
+        <div className="space-y-1.5">
+          <Label>
+            {field.label}
+            {field.required && <span className="text-destructive ml-1">*</span>}
+          </Label>
+          {field.description && (
+            <p className="text-xs text-muted-foreground">{field.description}</p>
+          )}
+          <Textarea placeholder={field.placeholder ?? ""} disabled rows={4} />
+        </div>
+      );
+
+    case "select":
+      return (
+        <div className="space-y-1.5">
+          <Label>
+            {field.label}
+            {field.required && <span className="text-destructive ml-1">*</span>}
+          </Label>
+          {field.description && (
+            <p className="text-xs text-muted-foreground">{field.description}</p>
+          )}
+          <Select disabled>
+            <SelectTrigger>
+              <SelectValue placeholder={field.placeholder ?? "Select..."} />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      );
+
+    case "radio":
+      return (
+        <div className="space-y-1.5">
+          <Label>
+            {field.label}
+            {field.required && <span className="text-destructive ml-1">*</span>}
+          </Label>
+          {field.description && (
+            <p className="text-xs text-muted-foreground">{field.description}</p>
+          )}
+          <div className="space-y-2">
+            {options.map((opt) => (
+              <div key={opt.value} className="flex items-center gap-2">
+                <input type="radio" name={field.fieldKey} disabled />
+                <Label className="font-normal">{opt.label}</Label>
+              </div>
+            ))}
+          </div>
+        </div>
+      );
+
+    case "checkbox":
+      return (
+        <div className="flex items-center gap-2">
+          <Checkbox disabled />
+          <Label className="font-normal">
+            {field.label}
+            {field.required && <span className="text-destructive ml-1">*</span>}
+          </Label>
+        </div>
+      );
+
+    case "checkbox_group":
+    case "multi_select":
+      return (
+        <div className="space-y-1.5">
+          <Label>
+            {field.label}
+            {field.required && <span className="text-destructive ml-1">*</span>}
+          </Label>
+          {field.description && (
+            <p className="text-xs text-muted-foreground">{field.description}</p>
+          )}
+          <div className="space-y-2">
+            {options.map((opt) => (
+              <div key={opt.value} className="flex items-center gap-2">
+                <Checkbox disabled />
+                <Label className="font-normal">{opt.label}</Label>
+              </div>
+            ))}
+          </div>
+        </div>
+      );
+
+    case "file_upload":
+      return (
+        <div className="space-y-1.5">
+          <Label>
+            {field.label}
+            {field.required && <span className="text-destructive ml-1">*</span>}
+          </Label>
+          {field.description && (
+            <p className="text-xs text-muted-foreground">{field.description}</p>
+          )}
+          <div className="border-2 border-dashed rounded-lg p-6 text-center text-sm text-muted-foreground">
+            Drag and drop files here, or click to browse
+          </div>
+        </div>
+      );
+
+    default:
+      return (
+        <div className="space-y-1.5">
+          <Label>
+            {field.label}
+            {field.required && <span className="text-destructive ml-1">*</span>}
+          </Label>
+          {field.description && (
+            <p className="text-xs text-muted-foreground">{field.description}</p>
+          )}
+          <Input
+            type={
+              field.fieldType === "number"
+                ? "number"
+                : field.fieldType === "email"
+                  ? "email"
+                  : field.fieldType === "url"
+                    ? "url"
+                    : field.fieldType === "date"
+                      ? "date"
+                      : "text"
+            }
+            placeholder={field.placeholder ?? ""}
+            disabled
+          />
+        </div>
+      );
+  }
+}
+
+export function FormPreview({ form }: FormPreviewProps) {
+  return (
+    <ScrollArea className="flex-1">
+      <div className="max-w-2xl mx-auto p-6 space-y-6">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold">{form.name}</h1>
+          {form.description && (
+            <p className="text-muted-foreground">{form.description}</p>
+          )}
+        </div>
+        <Separator />
+        <div className="space-y-6">
+          {form.fields.map((field) => (
+            <PreviewField key={field.id} field={field} />
+          ))}
+        </div>
+        {form.fields.length === 0 && (
+          <p className="text-center text-muted-foreground py-12">
+            No fields to preview. Add fields in the editor.
+          </p>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/apps/web/src/components/form-builder/form-preview.tsx
+++ b/apps/web/src/components/form-builder/form-preview.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/components/ui/select";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
-import { FIELD_TYPE_META } from "./field-type-meta";
 import type { FormFieldType } from "@colophony/types";
 
 interface PreviewFieldData {

--- a/apps/web/src/components/form-builder/form-status-badge.tsx
+++ b/apps/web/src/components/form-builder/form-status-badge.tsx
@@ -1,0 +1,35 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { FormStatus } from "@colophony/types";
+
+const statusConfig: Record<FormStatus, { label: string; className: string }> = {
+  DRAFT: {
+    label: "Draft",
+    className: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+  },
+  PUBLISHED: {
+    label: "Published",
+    className:
+      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  },
+  ARCHIVED: {
+    label: "Archived",
+    className:
+      "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
+  },
+};
+
+interface FormStatusBadgeProps {
+  status: FormStatus;
+  className?: string;
+}
+
+export function FormStatusBadge({ status, className }: FormStatusBadgeProps) {
+  const config = statusConfig[status];
+
+  return (
+    <Badge variant="secondary" className={cn(config.className, className)}>
+      {config.label}
+    </Badge>
+  );
+}

--- a/apps/web/src/components/form-builder/sortable-field-item.tsx
+++ b/apps/web/src/components/form-builder/sortable-field-item.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Button } from "@/components/ui/button";
+import { FIELD_TYPE_META } from "./field-type-meta";
+import {
+  GripVertical,
+  Trash2,
+  ChevronUp,
+  ChevronDown,
+  Asterisk,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { FormFieldType } from "@colophony/types";
+
+interface SortableField {
+  id: string;
+  fieldType: FormFieldType;
+  label: string;
+  required: boolean;
+}
+
+interface SortableFieldItemProps {
+  field: SortableField;
+  isSelected: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+  onSelect: () => void;
+  onRemove: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+}
+
+export function SortableFieldItem({
+  field,
+  isSelected,
+  isFirst,
+  isLast,
+  onSelect,
+  onRemove,
+  onMoveUp,
+  onMoveDown,
+}: SortableFieldItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: field.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const meta = FIELD_TYPE_META[field.fieldType];
+  const Icon = meta.icon;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "flex items-center gap-2 rounded-lg border p-3 bg-background transition-colors",
+        isSelected && "ring-2 ring-primary border-primary",
+        isDragging && "opacity-50",
+      )}
+    >
+      <button
+        className="cursor-grab touch-none text-muted-foreground hover:text-foreground"
+        aria-label="Drag to reorder"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+
+      <button
+        className="flex-1 flex items-center gap-2 text-left min-w-0"
+        onClick={onSelect}
+        type="button"
+      >
+        <Icon className="h-4 w-4 text-muted-foreground shrink-0" />
+        <span className="text-sm font-medium truncate">{field.label}</span>
+        {field.required && (
+          <Asterisk className="h-3 w-3 text-destructive shrink-0" />
+        )}
+        <span className="text-xs text-muted-foreground shrink-0">
+          {meta.label}
+        </span>
+      </button>
+
+      <div className="flex items-center gap-0.5 shrink-0">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          disabled={isFirst}
+          onClick={onMoveUp}
+          aria-label="Move up"
+        >
+          <ChevronUp className="h-3 w-3" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          disabled={isLast}
+          onClick={onMoveDown}
+          aria-label="Move down"
+        >
+          <ChevronDown className="h-3 w-3" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 text-muted-foreground hover:text-destructive"
+          onClick={onRemove}
+          aria-label="Remove field"
+        >
+          <Trash2 className="h-3 w-3" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/__tests__/sidebar.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/sidebar.spec.tsx
@@ -111,4 +111,47 @@ describe("Sidebar", () => {
     render(<Sidebar />);
     expect(screen.getByText("Editor")).toBeInTheDocument();
   });
+
+  it("should show Forms link when isEditor", () => {
+    mockIsEditor = true;
+    render(<Sidebar />);
+    expect(screen.getByText("Forms")).toBeInTheDocument();
+    const formsLink = screen.getByText("Forms").closest("a");
+    expect(formsLink).toHaveAttribute("href", "/editor/forms");
+  });
+
+  it("should not highlight Editor Dashboard when on /editor/forms", () => {
+    mockIsEditor = true;
+    mockPathname = "/editor/forms";
+    render(<Sidebar />);
+
+    const dashboardLink = screen.getByText("Editor Dashboard").closest("a");
+    // /editor uses exact match — should NOT be active on /editor/forms
+    expect(dashboardLink?.className).not.toMatch(/(?:^|\s)bg-accent(?:\s|$)/);
+
+    const formsLink = screen.getByText("Forms").closest("a");
+    // /editor/forms uses startsWith — should be active
+    expect(formsLink?.className).toMatch(/(?:^|\s)bg-accent(?:\s|$)/);
+  });
+
+  it("should highlight Editor Dashboard only on exact /editor path", () => {
+    mockIsEditor = true;
+    mockPathname = "/editor";
+    render(<Sidebar />);
+
+    const dashboardLink = screen.getByText("Editor Dashboard").closest("a");
+    expect(dashboardLink?.className).toMatch(/(?:^|\s)bg-accent(?:\s|$)/);
+  });
+
+  it("should highlight Forms on sub-routes like /editor/forms/new", () => {
+    mockIsEditor = true;
+    mockPathname = "/editor/forms/new";
+    render(<Sidebar />);
+
+    const formsLink = screen.getByText("Forms").closest("a");
+    expect(formsLink?.className).toMatch(/(?:^|\s)bg-accent(?:\s|$)/);
+
+    const dashboardLink = screen.getByText("Editor Dashboard").closest("a");
+    expect(dashboardLink?.className).not.toMatch(/(?:^|\s)bg-accent(?:\s|$)/);
+  });
 });

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -4,7 +4,13 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { useOrganization } from "@/hooks/use-organization";
-import { Building2, FileText, LayoutDashboard, Settings } from "lucide-react";
+import {
+  Building2,
+  ClipboardList,
+  FileText,
+  LayoutDashboard,
+  Settings,
+} from "lucide-react";
 
 const navigation = [
   { name: "My Submissions", href: "/submissions", icon: FileText },
@@ -13,6 +19,7 @@ const navigation = [
 
 const editorNavigation = [
   { name: "Editor Dashboard", href: "/editor", icon: LayoutDashboard },
+  { name: "Forms", href: "/editor/forms", icon: ClipboardList },
 ];
 
 const adminNavigation = [
@@ -22,6 +29,11 @@ const adminNavigation = [
     icon: Building2,
   },
 ];
+
+function isActiveLink(pathname: string, href: string): boolean {
+  if (href === "/editor") return pathname === "/editor";
+  return pathname.startsWith(href);
+}
 
 export function Sidebar() {
   const pathname = usePathname();
@@ -40,7 +52,7 @@ export function Sidebar() {
       <nav className="flex-1 space-y-1 p-2">
         {/* Main navigation */}
         {navigation.map((item) => {
-          const isActive = pathname.startsWith(item.href);
+          const isActive = isActiveLink(pathname, item.href);
           return (
             <Link
               key={item.name}
@@ -66,7 +78,7 @@ export function Sidebar() {
               Editor
             </p>
             {editorNavigation.map((item) => {
-              const isActive = pathname.startsWith(item.href);
+              const isActive = isActiveLink(pathname, item.href);
               return (
                 <Link
                   key={item.name}
@@ -94,7 +106,7 @@ export function Sidebar() {
               Admin
             </p>
             {adminNavigation.map((item) => {
-              const isActive = pathname.startsWith(item.href);
+              const isActive = isActiveLink(pathname, item.href);
               return (
                 <Link
                   key={item.name}

--- a/apps/web/src/hooks/__tests__/use-form-builder.spec.ts
+++ b/apps/web/src/hooks/__tests__/use-form-builder.spec.ts
@@ -131,13 +131,14 @@ describe("useFormBuilder", () => {
     expect(result.current.selectedFieldId).toBeNull();
   });
 
-  it("addField calls mutation with generated key and label", () => {
+  it("addField derives key from max existing suffix to avoid collisions", () => {
     const { result } = renderHook(() => useFormBuilder("form-1"));
 
     act(() => {
       result.current.addField("text");
     });
 
+    // text_1 already exists, so next suffix is max(1) + 1 = 2
     expect(mockMutate).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "form-1",
@@ -149,7 +150,7 @@ describe("useFormBuilder", () => {
     );
   });
 
-  it("addField uses base label when no existing fields of that type", () => {
+  it("addField uses suffix 1 when no existing fields of that type", () => {
     const { result } = renderHook(() => useFormBuilder("form-1"));
 
     act(() => {
@@ -161,6 +162,31 @@ describe("useFormBuilder", () => {
         fieldKey: "number_1",
         fieldType: "number",
         label: "Number",
+      }),
+    );
+  });
+
+  it("addField avoids key collision after deletion (max suffix logic)", () => {
+    // Simulate: text_1 deleted, only text_3 remains
+    mockFormData = {
+      id: "form-1",
+      name: "Test Form",
+      fields: [
+        { id: "f3", fieldType: "text", fieldKey: "text_3", label: "Text 3" },
+      ],
+    };
+    const { result } = renderHook(() => useFormBuilder("form-1"));
+
+    act(() => {
+      result.current.addField("text");
+    });
+
+    // Should use max(3) + 1 = 4, not count(1) + 1 = 2
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fieldKey: "text_4",
+        fieldType: "text",
+        label: "Text 4",
       }),
     );
   });

--- a/apps/web/src/hooks/__tests__/use-form-builder.spec.ts
+++ b/apps/web/src/hooks/__tests__/use-form-builder.spec.ts
@@ -1,0 +1,196 @@
+import { renderHook, act } from "@testing-library/react";
+import "../../../test/setup";
+
+// --- Mutable mock state ---
+let mockFormData: Record<string, unknown> | undefined;
+let mockIsLoading: boolean;
+let mockError: { message: string } | null;
+
+const mockInvalidateGetById = jest.fn();
+const mockInvalidateList = jest.fn();
+const mockMutate = jest.fn();
+
+function resetMocks() {
+  mockIsLoading = false;
+  mockError = null;
+  mockFormData = {
+    id: "form-1",
+    name: "Test Form",
+    fields: [
+      { id: "f1", fieldType: "text", fieldKey: "text_1", label: "Text" },
+      {
+        id: "f2",
+        fieldType: "textarea",
+        fieldKey: "textarea_1",
+        label: "Textarea",
+      },
+    ],
+  };
+  mockInvalidateGetById.mockClear();
+  mockInvalidateList.mockClear();
+  mockMutate.mockClear();
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    useUtils: () => ({
+      forms: {
+        getById: { invalidate: mockInvalidateGetById },
+        list: { invalidate: mockInvalidateList },
+      },
+    }),
+    forms: {
+      getById: {
+        useQuery: () => ({
+          data: mockFormData,
+          isPending: mockIsLoading,
+          error: mockError,
+        }),
+      },
+      update: {
+        useMutation: () => ({ mutate: mockMutate, isPending: false }),
+      },
+      publish: {
+        useMutation: () => ({ mutate: mockMutate, isPending: false }),
+      },
+      archive: {
+        useMutation: () => ({ mutate: mockMutate, isPending: false }),
+      },
+      duplicate: {
+        useMutation: () => ({ mutate: mockMutate, isPending: false }),
+      },
+      delete: {
+        useMutation: () => ({ mutate: mockMutate, isPending: false }),
+      },
+      addField: {
+        useMutation: () => ({ mutate: mockMutate, isPending: false }),
+      },
+      updateField: {
+        useMutation: () => ({ mutate: mockMutate, isPending: false }),
+      },
+      removeField: {
+        useMutation: () => ({ mutate: mockMutate, isPending: false }),
+      },
+      reorderFields: {
+        useMutation: () => ({ mutate: mockMutate, isPending: false }),
+      },
+    },
+  },
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+// Must import after mocks are set up
+import { useFormBuilder } from "../use-form-builder";
+
+describe("useFormBuilder", () => {
+  beforeEach(() => {
+    resetMocks();
+  });
+
+  it("returns form data and loading state", () => {
+    const { result } = renderHook(() => useFormBuilder("form-1"));
+
+    expect(result.current.form).toBeDefined();
+    expect(result.current.form?.name).toBe("Test Form");
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("initializes selection state to null", () => {
+    const { result } = renderHook(() => useFormBuilder("form-1"));
+
+    expect(result.current.selectedFieldId).toBeNull();
+    expect(result.current.isPreviewMode).toBe(false);
+  });
+
+  it("allows setting selectedFieldId", () => {
+    const { result } = renderHook(() => useFormBuilder("form-1"));
+
+    act(() => {
+      result.current.setSelectedFieldId("f1");
+    });
+
+    expect(result.current.selectedFieldId).toBe("f1");
+  });
+
+  it("togglePreview toggles mode and clears selection", () => {
+    const { result } = renderHook(() => useFormBuilder("form-1"));
+
+    act(() => {
+      result.current.setSelectedFieldId("f1");
+    });
+    expect(result.current.selectedFieldId).toBe("f1");
+
+    act(() => {
+      result.current.togglePreview();
+    });
+
+    expect(result.current.isPreviewMode).toBe(true);
+    expect(result.current.selectedFieldId).toBeNull();
+  });
+
+  it("addField calls mutation with generated key and label", () => {
+    const { result } = renderHook(() => useFormBuilder("form-1"));
+
+    act(() => {
+      result.current.addField("text");
+    });
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "form-1",
+        fieldKey: "text_2",
+        fieldType: "text",
+        label: "Text 2",
+        sortOrder: 2,
+      }),
+    );
+  });
+
+  it("addField uses base label when no existing fields of that type", () => {
+    const { result } = renderHook(() => useFormBuilder("form-1"));
+
+    act(() => {
+      result.current.addField("number");
+    });
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fieldKey: "number_1",
+        fieldType: "number",
+        label: "Number",
+      }),
+    );
+  });
+
+  it("returns loading state correctly", () => {
+    mockIsLoading = true;
+    mockFormData = undefined;
+    const { result } = renderHook(() => useFormBuilder("form-1"));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.form).toBeUndefined();
+  });
+
+  it("returns error state correctly", () => {
+    mockError = { message: "Not found" };
+    const { result } = renderHook(() => useFormBuilder("form-1"));
+
+    expect(result.current.error).toEqual({ message: "Not found" });
+  });
+
+  it("provides mutation objects", () => {
+    const { result } = renderHook(() => useFormBuilder("form-1"));
+
+    expect(result.current.updateForm).toBeDefined();
+    expect(result.current.publishForm).toBeDefined();
+    expect(result.current.archiveForm).toBeDefined();
+    expect(result.current.duplicateForm).toBeDefined();
+    expect(result.current.deleteForm).toBeDefined();
+    expect(result.current.updateField).toBeDefined();
+    expect(result.current.removeField).toBeDefined();
+    expect(result.current.reorderFields).toBeDefined();
+  });
+});

--- a/apps/web/src/hooks/use-form-builder.ts
+++ b/apps/web/src/hooks/use-form-builder.ts
@@ -80,11 +80,19 @@ export function useFormBuilder(formId: string) {
   const addField = useCallback(
     (fieldType: FormFieldType) => {
       const fields = formQuery.data?.fields ?? [];
-      const typeCount = fields.filter((f) => f.fieldType === fieldType).length;
-      const fieldKey = `${fieldType}_${typeCount + 1}`;
+      const prefix = `${fieldType}_`;
+      // Derive next suffix from max existing suffix to avoid collisions after deletions
+      const maxSuffix = fields
+        .filter((f) => f.fieldKey.startsWith(prefix))
+        .reduce((max, f) => {
+          const num = parseInt(f.fieldKey.slice(prefix.length), 10);
+          return Number.isNaN(num) ? max : Math.max(max, num);
+        }, 0);
+      const nextNum = maxSuffix + 1;
+      const fieldKey = `${prefix}${nextNum}`;
       const label =
         fieldType.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()) +
-        (typeCount > 0 ? ` ${typeCount + 1}` : "");
+        (nextNum > 1 ? ` ${nextNum}` : "");
 
       addFieldMutation.mutate({
         id: formId,

--- a/apps/web/src/hooks/use-form-builder.ts
+++ b/apps/web/src/hooks/use-form-builder.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { trpc } from "@/lib/trpc";
+import { toast } from "sonner";
+import type { FormFieldType } from "@colophony/types";
+
+export function useFormBuilder(formId: string) {
+  const [selectedFieldId, setSelectedFieldId] = useState<string | null>(null);
+  const [isPreviewMode, setIsPreviewMode] = useState(false);
+
+  const utils = trpc.useUtils();
+
+  const formQuery = trpc.forms.getById.useQuery({ id: formId });
+
+  const invalidateForm = useCallback(() => {
+    utils.forms.getById.invalidate({ id: formId });
+    utils.forms.list.invalidate();
+  }, [utils, formId]);
+
+  const updateFormMutation = trpc.forms.update.useMutation({
+    onSuccess: () => invalidateForm(),
+    onError: (err) => toast.error(err.message),
+  });
+
+  const publishMutation = trpc.forms.publish.useMutation({
+    onSuccess: () => {
+      invalidateForm();
+      toast.success("Form published");
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const archiveMutation = trpc.forms.archive.useMutation({
+    onSuccess: () => {
+      invalidateForm();
+      toast.success("Form archived");
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const duplicateMutation = trpc.forms.duplicate.useMutation({
+    onSuccess: () => {
+      invalidateForm();
+      toast.success("Form duplicated");
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const deleteMutation = trpc.forms.delete.useMutation({
+    onError: (err) => toast.error(err.message),
+  });
+
+  const addFieldMutation = trpc.forms.addField.useMutation({
+    onSuccess: (newField) => {
+      invalidateForm();
+      setSelectedFieldId(newField.id);
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const updateFieldMutation = trpc.forms.updateField.useMutation({
+    onSuccess: () => invalidateForm(),
+    onError: (err) => toast.error(err.message),
+  });
+
+  const removeFieldMutation = trpc.forms.removeField.useMutation({
+    onSuccess: (removed) => {
+      if (selectedFieldId === removed.id) setSelectedFieldId(null);
+      invalidateForm();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const reorderFieldsMutation = trpc.forms.reorderFields.useMutation({
+    onSuccess: () => invalidateForm(),
+    onError: (err) => toast.error(err.message),
+  });
+
+  const addField = useCallback(
+    (fieldType: FormFieldType) => {
+      const fields = formQuery.data?.fields ?? [];
+      const typeCount = fields.filter((f) => f.fieldType === fieldType).length;
+      const fieldKey = `${fieldType}_${typeCount + 1}`;
+      const label =
+        fieldType.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()) +
+        (typeCount > 0 ? ` ${typeCount + 1}` : "");
+
+      addFieldMutation.mutate({
+        id: formId,
+        fieldKey,
+        fieldType,
+        label,
+        sortOrder: fields.length,
+      });
+    },
+    [formId, formQuery.data?.fields, addFieldMutation],
+  );
+
+  const togglePreview = useCallback(() => {
+    setIsPreviewMode((prev) => !prev);
+    setSelectedFieldId(null);
+  }, []);
+
+  return {
+    form: formQuery.data,
+    isLoading: formQuery.isPending,
+    error: formQuery.error,
+    selectedFieldId,
+    setSelectedFieldId,
+    isPreviewMode,
+    togglePreview,
+    addField,
+    updateForm: updateFormMutation,
+    publishForm: publishMutation,
+    archiveForm: archiveMutation,
+    duplicateForm: duplicateMutation,
+    deleteForm: deleteMutation,
+    addFieldMutation,
+    updateField: updateFieldMutation,
+    removeField: removeFieldMutation,
+    reorderFields: reorderFieldsMutation,
+  };
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -94,9 +94,11 @@
 ### Code
 
 - [x] Form builder backend — DB schema (form_definitions + form_fields), Zod types, service layer, tRPC + REST + GraphQL endpoints, validateFormData, audit constants, API key scopes — (architecture doc Track 3; done 2026-02-20)
-- [ ] Form builder frontend — editor UI for creating/editing form definitions, field drag-and-drop, field config panels — (architecture doc Track 3, form-builder-research.md)
+- [x] Form builder frontend — editor UI for creating/editing form definitions, field drag-and-drop, field config panels — (architecture doc Track 3, form-builder-research.md; done 2026-02-20)
+- [ ] Form renderer for submitters — render published forms in submission flow — (architecture doc Track 3, form-builder-research.md)
 - [x] Form builder integration — wire validateFormData into submission create/update flow, formData persistence + validation on submit — (architecture doc Track 3, deferred from backend PR 2026-02-20; done 2026-02-20)
 - [ ] Add `formDefinitionId` to `createSubmissionPeriodSchema` — deferred, no active consumer yet — (DEVLOG 2026-02-20)
+- [ ] [P2] GraphQL forms resolver: add `idParamSchema` validation on raw string args passed to services — (Codex plan review 2026-02-20)
 - [ ] Conditional logic engine — (architecture doc Track 3, form-builder-research.md)
 - [ ] Embeddable forms (iframe) — (architecture doc Track 3, form-builder-research.md)
 - [ ] Submission periods UI — schema exists, no UI — (DEVLOG 2026-02-15)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,31 @@ Newest entries first.
 
 ---
 
+## 2026-02-20 — Form Builder Editor UI (Track 3)
+
+### Done
+
+- Implemented form builder editor UI — 24 new files, 4 modified (~3,050 lines)
+- Form list page: paginated grid with status tabs, search, create link, lifecycle actions (publish/archive/duplicate/delete)
+- Form editor page: 3-column layout — field palette (click-to-add), sortable canvas (dnd-kit), properties panel (debounced auto-save)
+- 4 field config editors: text/textarea/rich_text/email/url, number, select/multi_select/radio/checkbox_group, file_upload
+- Form preview mode (toggle replaces editor, renders approximate submitter view)
+- `useFormBuilder` hook: selection state + tRPC mutation wrappers with cache invalidation
+- Sidebar: added "Forms" link under Editor section, fixed active-link collision (`/editor` exact match, sub-routes use `startsWith`)
+- Updated editor dashboard stub with card linking to forms
+- 58 new tests across 6 files (form list, form editor, properties panel, select config, hook, sidebar)
+- Installed `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`
+- Codex branch review: 3 findings, all addressed — P1 fieldKey collision after deletions (max-suffix logic), P2 drag reorder on non-draft forms (status guard), P2 remove button on non-draft forms (canEdit guard)
+
+### Decisions
+
+- Click-to-add from palette (not drag-from-palette) — avoids multi-container DndContext complexity
+- Local interface types in components rather than strict Zod types — tRPC serializes Date fields as strings; components don't use date fields
+- TanStack Query cache as source of truth — no local form data duplication; hook manages only UI state (selection, preview mode)
+- Individual field operations (each add/update/remove is one API call, matching backend design)
+
+---
+
 ## 2026-02-20 — Form Builder Integration (Track 3)
 
 ### Done

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,15 @@ importers:
       '@colophony/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.4))
@@ -820,6 +829,28 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -7272,6 +7303,31 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
     optional: true
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@drizzle-team/brocli@0.10.2': {}
 


### PR DESCRIPTION
## Summary

- **Form list page** — paginated grid with status tabs (All/Drafts/Published/Archived), search, create CTA, lifecycle actions (publish/archive/duplicate/delete)
- **Form editor page** — 3-column layout: field palette (click-to-add), sortable canvas (dnd-kit drag-and-drop + keyboard reorder), properties panel (debounced 500ms auto-save)
- **Field config editors** — text/textarea/rich_text/email/url (min/max length), number (min/max/step), select/multi_select/radio/checkbox_group (editable options list), file_upload (maxFiles/maxFileSize/allowedMimeTypes)
- **Form preview** — toggle replaces editor with approximate submitter view
- **`useFormBuilder` hook** — selection state + tRPC mutation wrappers with cache invalidation
- **Sidebar** — added "Forms" link under Editor section, fixed active-link collision (`/editor` exact match, sub-routes use `startsWith`)
- **Editor dashboard** — replaced stub with card linking to forms management
- **58 new tests** across 6 files (form list, form editor, field properties panel, select config, hook, sidebar)
- **Dependencies** — `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`

### code review findings addressed

1. **[P1] fieldKey collision after deletions** — Changed from count-based to max-suffix-based generation (prevents `text_2` collision when `text_1` deleted and `text_2` exists)
2. **[P2] Drag reorder on non-draft forms** — Added status guard in `handleDragEnd`
3. **[P2] Remove button on non-draft forms** — Gated `onRemoveField`/`onReorder` callbacks on `canEdit`

## Test plan

- [ ] `pnpm --filter @colophony/web test` — 176 tests pass (58 new)
- [ ] `pnpm type-check` — passes across all packages
- [ ] `pnpm lint` — 0 errors (8 pre-existing warnings)
- [ ] Manual test: create form → add fields of various types → configure → reorder → preview → publish → duplicate → archive