### PR TITLE
chore: dev workflow improvements — .claudeignore, backlog, tmux

### DIFF
--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -182,10 +182,10 @@ Run these commands in parallel:
 docker compose ps --format '{{.Name}}\t{{.Status}}' 2>/dev/null || echo "Docker Compose not running"
 ```
 
-Also check if a Codex review tmux session is active:
+Also check if the Codex review tmux window is available (part of the `colophony` tmux session):
 
 ```bash
-tmux has-session -t codex-review 2>/dev/null && echo "active" || echo "not started"
+tmux list-windows -t colophony -F '#{window_name}' 2>/dev/null | grep -q codex-review && echo "available" || echo "not found (start with: cc)"
 ```
 
 Report which services are up/down. Flag if critical services (postgres, redis) are not running.

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,23 @@
+# Build outputs
+dist/
+.next/
+out/
+build/
+
+# Dependencies
+node_modules/
+
+# Generated types (read source schemas instead)
+**/*.d.ts
+
+# Lock file (large, low signal)
+pnpm-lock.yaml
+
+# Test artifacts
+coverage/
+test-results/
+playwright-report/
+blob-report/
+
+# Turbo cache
+.turbo/

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -226,6 +226,25 @@
 
 ---
 
+## Code Quality
+
+### File Size & Complexity
+
+- [ ] Add soft 500-line guideline to CLAUDE.md — flag files over 500 lines for review during `/codex-review`; not a hard gate, just a review trigger — (dev workflow session 2026-02-20)
+- [ ] Extract `validateFormData` and per-type validators from `form.service.ts` (912 lines) into `form-validation.service.ts` — natural seam between CRUD operations and validation logic — (dev workflow session 2026-02-20)
+
+### Dev Workflow
+
+- [ ] Structured session handoff doc (`session-handoff.md`, gitignored) — `/end-session` writes machine-readable state (branch, status, files touched, decisions made, open questions, next action) alongside DEVLOG narrative; `/start-session` reads handoff first for instant context restoration, falls back to DEVLOG if missing. DEVLOG becomes purely archival/human-readable — (dev workflow session 2026-02-20)
+- [ ] Add decision-surfacing step to plan mode — after exploring code but before writing the plan, explicitly enumerate architectural gray areas and present them with a recommended path and rationale; get user preferences before committing to an approach. Still recommend, just surface the choice — (dev workflow session 2026-02-20)
+- [ ] Integrate Codex plan review into plan mode — run `/codex-review plan` automatically after writing the plan but before ExitPlanMode; adjust plan based on findings, note changes and dismissals with rationale; user sees a Codex-vetted plan at approval time instead of reviewing then manually triggering Codex — (dev workflow session 2026-02-20)
+- [ ] Increase plan specificity standard — plans should include exact file paths, concrete type/prop names, and named test cases with setup and assertions where feasible; specific enough to mechanically verify post-implementation. Update plan mode instructions in CLAUDE.md — (dev workflow session 2026-02-20)
+- [ ] Plan drift detection — after implementation, verify that the delivered code matches the approved plan. Check that specified files exist, export expected symbols, and follow specified patterns. Run as part of `/codex-review branch` or as a standalone `/plan-drift` skill — (dev workflow session 2026-02-20)
+- [ ] Plan override log for drift detection — during implementation, when discoveries require deliberate divergence from the plan, log overrides with rationale (file, what changed, why) in a structured format (e.g., task list metadata or a plan-overrides section in the PR). Drift detection reads the override log and excludes acknowledged divergences, only flagging unlogged drift — (dev workflow session 2026-02-20)
+- [ ] Automatic Codex branch review before PR — run `/codex-review branch` automatically after implementation is complete (all tasks done, tests passing) but before creating the PR; incorporate findings before presenting the PR for user review. Mirrors the plan review integration: user sees a Codex-vetted PR, not a raw first draft — (dev workflow session 2026-02-20)
+
+---
+
 ## Production Deployment Checklist
 
 ### Infrastructure Setup


### PR DESCRIPTION
## Summary
- Add `.claudeignore` to exclude build outputs, generated types, lock file, and test artifacts from Claude Code context (reduces token waste)
- Add Code Quality section to backlog with 9 new items from dev workflow optimization session: file size guidelines, form service extraction, session handoff doc, decision surfacing in plan mode, Codex plan/branch review integration, plan specificity standard, drift detection, and plan override log
- Update `/start-session` skill to check for `codex-review` as a tmux window within the `colophony` session (matches new `cc` alias setup)

## Test plan
- [ ] Verify `.claudeignore` excludes expected paths from Claude Code context
- [ ] Verify `/start-session` correctly detects codex-review tmux window
- [ ] Review backlog items for completeness and accuracy