### PR TITLE
feat(hopper): form renderer for submitters

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-progress": "^1.1.8",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",

--- a/apps/web/src/components/submissions/__tests__/submission-form.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/submission-form.spec.tsx
@@ -8,6 +8,7 @@ import "../../../../test/setup";
 let mockExistingSubmission: Record<string, unknown> | undefined;
 let mockIsLoadingSubmission: boolean;
 let mockExistingFiles: Array<Record<string, unknown>> | undefined;
+let mockFormDefinition: Record<string, unknown> | undefined;
 
 let mockCreateMutateAsync: jest.Mock;
 let mockCreateIsPending: boolean;
@@ -18,6 +19,9 @@ let mockUpdateIsPending: boolean;
 
 let mockSubmitMutateAsync: jest.Mock;
 let mockSubmitIsPending: boolean;
+let mockSubmitOnError:
+  | ((err: { message: string; data?: unknown }) => void)
+  | undefined;
 
 const mockInvalidateGetById = jest.fn();
 
@@ -25,6 +29,7 @@ function resetMocks() {
   mockExistingSubmission = undefined;
   mockIsLoadingSubmission = false;
   mockExistingFiles = undefined;
+  mockFormDefinition = undefined;
 
   mockCreateMutateAsync = jest.fn().mockResolvedValue({ id: "new-sub-1" });
   mockCreateIsPending = false;
@@ -35,6 +40,7 @@ function resetMocks() {
 
   mockSubmitMutateAsync = jest.fn().mockResolvedValue({});
   mockSubmitIsPending = false;
+  mockSubmitOnError = undefined;
 }
 
 jest.mock("@/lib/trpc", () => ({
@@ -68,16 +74,28 @@ jest.mock("@/lib/trpc", () => ({
       },
       submit: {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        useMutation: (_opts: any) => ({
-          mutateAsync: mockSubmitMutateAsync,
-          isPending: mockSubmitIsPending,
-        }),
+        useMutation: (opts: any) => {
+          mockSubmitOnError = opts.onError as typeof mockSubmitOnError;
+          return {
+            mutateAsync: mockSubmitMutateAsync,
+            isPending: mockSubmitIsPending,
+          };
+        },
       },
     },
     files: {
       listBySubmission: {
         useQuery: () => ({
           data: mockExistingFiles,
+        }),
+      },
+    },
+    forms: {
+      getById: {
+        useQuery: () => ({
+          data: mockFormDefinition,
+          isPending: false,
+          error: null,
         }),
       },
     },
@@ -93,6 +111,23 @@ jest.mock("../file-upload", () => ({
     />
   ),
 }));
+
+jest.mock("../form-renderer", () => {
+  const actual = jest.requireActual("../form-renderer");
+  return {
+    ...actual,
+    DynamicFormFields: (props: {
+      formDefinitionId: string;
+      disabled: boolean;
+    }) => (
+      <div
+        data-testid="dynamic-form-fields"
+        data-form-definition-id={props.formDefinitionId}
+        data-disabled={String(props.disabled)}
+      />
+    ),
+  };
+});
 
 const mockToastSuccess = jest.fn();
 const mockToastError = jest.fn();
@@ -178,6 +213,7 @@ describe("SubmissionForm", () => {
           title: "My Story",
           content: "Once upon a time",
           coverLetter: "Please consider",
+          formData: {},
         });
       });
     });
@@ -282,6 +318,7 @@ describe("SubmissionForm", () => {
           title: "Updated Poem",
           content: "Roses are red...",
           coverLetter: "Dear editors,",
+          formData: {},
         });
       });
     });
@@ -386,6 +423,117 @@ describe("SubmissionForm", () => {
       expect(
         screen.getByRole("button", { name: "Submit for Review" }),
       ).toBeInTheDocument();
+    });
+  });
+
+  // --- Dynamic form fields ---
+  describe("dynamic form fields", () => {
+    it("renders DynamicFormFields when submission has formDefinitionId", () => {
+      mockExistingSubmission = makeDraftSubmission({
+        formDefinitionId: "form-def-1",
+      });
+      mockFormDefinition = {
+        id: "form-def-1",
+        name: "Poetry Submission Form",
+        description: "Standard poetry form",
+        fields: [
+          {
+            fieldKey: "bio",
+            fieldType: "text",
+            label: "Bio",
+            description: null,
+            placeholder: null,
+            required: true,
+            sortOrder: 0,
+            config: null,
+          },
+        ],
+      };
+
+      render(<SubmissionForm mode="edit" submissionId="sub-1" />);
+
+      const dynamicFields = screen.getByTestId("dynamic-form-fields");
+      expect(dynamicFields).toBeInTheDocument();
+      expect(dynamicFields).toHaveAttribute(
+        "data-form-definition-id",
+        "form-def-1",
+      );
+      expect(dynamicFields).toHaveAttribute("data-disabled", "false");
+    });
+
+    it("does not render DynamicFormFields when no formDefinitionId", () => {
+      mockExistingSubmission = makeDraftSubmission();
+      render(<SubmissionForm mode="edit" submissionId="sub-1" />);
+
+      expect(
+        screen.queryByTestId("dynamic-form-fields"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("passes formData in update mutation", async () => {
+      mockExistingSubmission = makeDraftSubmission({
+        formDefinitionId: "form-def-1",
+        formData: { bio: "A poet" },
+      });
+      mockFormDefinition = {
+        id: "form-def-1",
+        name: "Form",
+        description: null,
+        fields: [
+          {
+            fieldKey: "bio",
+            fieldType: "text",
+            label: "Bio",
+            description: null,
+            placeholder: null,
+            required: false,
+            sortOrder: 0,
+            config: null,
+          },
+        ],
+      };
+
+      const user = userEvent.setup();
+      render(<SubmissionForm mode="edit" submissionId="sub-1" />);
+
+      await user.click(screen.getByRole("button", { name: "Save Draft" }));
+
+      await waitFor(() => {
+        expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: "sub-1",
+            formData: expect.objectContaining({ bio: "A poet" }),
+          }),
+        );
+      });
+    });
+
+    it("maps field errors from submit rejection to form fields", () => {
+      mockExistingSubmission = makeDraftSubmission({
+        formDefinitionId: "form-def-1",
+      });
+      mockFormDefinition = {
+        id: "form-def-1",
+        name: "Form",
+        description: null,
+        fields: [],
+      };
+
+      render(<SubmissionForm mode="edit" submissionId="sub-1" />);
+
+      // Simulate submit mutation onError with field errors
+      const fieldErrorResponse = {
+        message: "Validation failed",
+        data: {
+          fieldErrors: [{ fieldKey: "bio", message: "Bio is too short" }],
+        },
+      };
+
+      // The onError should map field errors instead of setting generic error
+      mockSubmitOnError?.(fieldErrorResponse);
+
+      // Generic error should not be shown (mapFieldErrorsToForm returns true)
+      expect(screen.queryByText("Validation failed")).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/components/submissions/form-renderer/__tests__/build-form-schema.spec.ts
+++ b/apps/web/src/components/submissions/form-renderer/__tests__/build-form-schema.spec.ts
@@ -106,6 +106,24 @@ describe("buildFormFieldsSchema", () => {
     expect(schema.safeParse({ age: 50 }).success).toBe(true);
   });
 
+  it("required number field rejects empty string (not coerced to 0)", () => {
+    const { schema } = buildFormFieldsSchema([
+      makeField({
+        fieldKey: "count",
+        fieldType: "number",
+        label: "Count",
+        required: true,
+      }),
+    ]);
+
+    // Empty string should NOT coerce to 0 and pass — it should fail
+    expect(schema.safeParse({ count: "" }).success).toBe(false);
+    expect(schema.safeParse({ count: undefined }).success).toBe(false);
+    // Actual numbers should work
+    expect(schema.safeParse({ count: 0 }).success).toBe(true);
+    expect(schema.safeParse({ count: 42 }).success).toBe(true);
+  });
+
   it("select field validates against options", () => {
     const { schema } = buildFormFieldsSchema([
       makeField({

--- a/apps/web/src/components/submissions/form-renderer/__tests__/build-form-schema.spec.ts
+++ b/apps/web/src/components/submissions/form-renderer/__tests__/build-form-schema.spec.ts
@@ -1,0 +1,271 @@
+import {
+  buildFormFieldsSchema,
+  type FormFieldForRenderer,
+} from "../build-form-schema";
+
+function makeField(
+  overrides: Partial<FormFieldForRenderer> & {
+    fieldKey: string;
+    fieldType: string;
+  },
+): FormFieldForRenderer {
+  return {
+    label: "Test Field",
+    description: null,
+    placeholder: null,
+    required: false,
+    config: null,
+    ...overrides,
+  };
+}
+
+describe("buildFormFieldsSchema", () => {
+  it("required text field with minLength/maxLength", () => {
+    const { schema } = buildFormFieldsSchema([
+      makeField({
+        fieldKey: "bio",
+        fieldType: "text",
+        label: "Bio",
+        required: true,
+        config: { minLength: 5, maxLength: 100 },
+      }),
+    ]);
+
+    expect(schema.safeParse({ bio: "" }).success).toBe(false);
+    expect(schema.safeParse({ bio: "abc" }).success).toBe(false);
+    expect(schema.safeParse({ bio: "hello world" }).success).toBe(true);
+  });
+
+  it("optional text field accepts empty string", () => {
+    const { schema } = buildFormFieldsSchema([
+      makeField({ fieldKey: "bio", fieldType: "text", required: false }),
+    ]);
+
+    expect(schema.safeParse({ bio: "" }).success).toBe(true);
+    expect(schema.safeParse({ bio: undefined }).success).toBe(true);
+    expect(schema.safeParse({}).success).toBe(true);
+  });
+
+  it("email field validates email format", () => {
+    const { schema } = buildFormFieldsSchema([
+      makeField({
+        fieldKey: "email",
+        fieldType: "email",
+        label: "Email",
+        required: true,
+      }),
+    ]);
+
+    expect(schema.safeParse({ email: "not-an-email" }).success).toBe(false);
+    expect(schema.safeParse({ email: "test@example.com" }).success).toBe(true);
+  });
+
+  it("url field validates URL format", () => {
+    const { schema } = buildFormFieldsSchema([
+      makeField({
+        fieldKey: "website",
+        fieldType: "url",
+        label: "Website",
+        required: true,
+      }),
+    ]);
+
+    expect(schema.safeParse({ website: "not-a-url" }).success).toBe(false);
+    expect(schema.safeParse({ website: "https://example.com" }).success).toBe(
+      true,
+    );
+  });
+
+  it("date field validates YYYY-MM-DD", () => {
+    const { schema } = buildFormFieldsSchema([
+      makeField({
+        fieldKey: "dob",
+        fieldType: "date",
+        label: "Date",
+        required: true,
+      }),
+    ]);
+
+    expect(schema.safeParse({ dob: "Jan 1" }).success).toBe(false);
+    expect(schema.safeParse({ dob: "2026-01-15" }).success).toBe(true);
+  });
+
+  it("number field with min/max", () => {
+    const { schema } = buildFormFieldsSchema([
+      makeField({
+        fieldKey: "age",
+        fieldType: "number",
+        label: "Age",
+        required: true,
+        config: { min: 0, max: 100 },
+      }),
+    ]);
+
+    expect(schema.safeParse({ age: -1 }).success).toBe(false);
+    expect(schema.safeParse({ age: 101 }).success).toBe(false);
+    expect(schema.safeParse({ age: 50 }).success).toBe(true);
+  });
+
+  it("select field validates against options", () => {
+    const { schema } = buildFormFieldsSchema([
+      makeField({
+        fieldKey: "genre",
+        fieldType: "select",
+        label: "Genre",
+        required: true,
+        config: {
+          options: [
+            { label: "A", value: "a" },
+            { label: "B", value: "b" },
+          ],
+        },
+      }),
+    ]);
+
+    expect(schema.safeParse({ genre: "c" }).success).toBe(false);
+    expect(schema.safeParse({ genre: "a" }).success).toBe(true);
+  });
+
+  it("multi_select as string array", () => {
+    const { schema } = buildFormFieldsSchema([
+      makeField({
+        fieldKey: "tags",
+        fieldType: "multi_select",
+        label: "Tags",
+        required: false,
+        config: {
+          options: [
+            { label: "A", value: "a" },
+            { label: "B", value: "b" },
+            { label: "C", value: "c" },
+          ],
+        },
+      }),
+    ]);
+
+    // Non-array should fail
+    expect(schema.safeParse({ tags: "a" }).success).toBe(false);
+    expect(schema.safeParse({ tags: ["a", "b"] }).success).toBe(true);
+  });
+
+  it("checkbox as boolean", () => {
+    const { schema } = buildFormFieldsSchema([
+      makeField({
+        fieldKey: "agree",
+        fieldType: "checkbox",
+        label: "Agree",
+        required: true,
+      }),
+    ]);
+
+    // Backend required check only rejects undefined/null/"", not false
+    expect(schema.safeParse({ agree: undefined }).success).toBe(false);
+    expect(schema.safeParse({ agree: true }).success).toBe(true);
+    expect(schema.safeParse({ agree: false }).success).toBe(true);
+  });
+
+  it("skips presentational fields", () => {
+    const { schema, defaultValues } = buildFormFieldsSchema([
+      makeField({
+        fieldKey: "header_1",
+        fieldType: "section_header",
+        label: "Section",
+      }),
+      makeField({
+        fieldKey: "info_1",
+        fieldType: "info_text",
+        label: "Info",
+      }),
+    ]);
+
+    expect(Object.keys(schema.shape)).toHaveLength(0);
+    expect(Object.keys(defaultValues)).toHaveLength(0);
+  });
+
+  it("skips file_upload", () => {
+    const { schema, defaultValues } = buildFormFieldsSchema([
+      makeField({
+        fieldKey: "upload",
+        fieldType: "file_upload",
+        label: "Upload",
+      }),
+    ]);
+
+    expect(Object.keys(schema.shape)).toHaveLength(0);
+    expect(Object.keys(defaultValues)).toHaveLength(0);
+  });
+
+  it("returns correct default values", () => {
+    const { defaultValues } = buildFormFieldsSchema([
+      makeField({ fieldKey: "name", fieldType: "text" }),
+      makeField({ fieldKey: "agree", fieldType: "checkbox" }),
+      makeField({
+        fieldKey: "tags",
+        fieldType: "multi_select",
+        config: { options: [{ label: "A", value: "a" }] },
+      }),
+      makeField({ fieldKey: "age", fieldType: "number" }),
+    ]);
+
+    expect(defaultValues).toEqual({
+      name: "",
+      agree: false,
+      tags: [],
+      age: undefined,
+    });
+  });
+
+  it("rich_text only supports maxLength (no minLength)", () => {
+    const { schema } = buildFormFieldsSchema([
+      makeField({
+        fieldKey: "body",
+        fieldType: "rich_text",
+        label: "Body",
+        required: true,
+        config: { maxLength: 500 },
+      }),
+    ]);
+
+    // Short string should pass (no minLength from config)
+    expect(schema.safeParse({ body: "hi" }).success).toBe(true);
+    // Over maxLength should fail
+    expect(schema.safeParse({ body: "x".repeat(501) }).success).toBe(false);
+    // Empty required should fail
+    expect(schema.safeParse({ body: "" }).success).toBe(false);
+  });
+
+  it("radio field validates against options", () => {
+    const { schema } = buildFormFieldsSchema([
+      makeField({
+        fieldKey: "color",
+        fieldType: "radio",
+        label: "Color",
+        required: true,
+        config: {
+          options: [
+            { label: "Red", value: "red" },
+            { label: "Blue", value: "blue" },
+          ],
+        },
+      }),
+    ]);
+
+    expect(schema.safeParse({ color: "green" }).success).toBe(false);
+    expect(schema.safeParse({ color: "red" }).success).toBe(true);
+  });
+
+  it("optional number field converts empty string to undefined", () => {
+    const { schema } = buildFormFieldsSchema([
+      makeField({
+        fieldKey: "count",
+        fieldType: "number",
+        label: "Count",
+        required: false,
+      }),
+    ]);
+
+    expect(schema.safeParse({ count: "" }).success).toBe(true);
+    expect(schema.safeParse({ count: undefined }).success).toBe(true);
+    expect(schema.safeParse({ count: 42 }).success).toBe(true);
+  });
+});

--- a/apps/web/src/components/submissions/form-renderer/__tests__/dynamic-form-field.spec.tsx
+++ b/apps/web/src/components/submissions/form-renderer/__tests__/dynamic-form-field.spec.tsx
@@ -1,0 +1,277 @@
+import { render, screen } from "@testing-library/react";
+import { useForm, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { DynamicFormField } from "../dynamic-form-field";
+import type { FormFieldForRenderer } from "../build-form-schema";
+import "../../../../../test/setup";
+
+function makeField(
+  overrides: Partial<FormFieldForRenderer> & {
+    fieldKey: string;
+    fieldType: string;
+  },
+): FormFieldForRenderer {
+  return {
+    label: "Test Field",
+    description: null,
+    placeholder: null,
+    required: false,
+    config: null,
+    ...overrides,
+  };
+}
+
+// Wrapper that provides FormProvider context with a formData schema
+function FormWrapper({
+  children,
+  schema,
+  defaultValues,
+}: {
+  children: React.ReactNode;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  schema?: z.ZodObject<any>;
+  defaultValues?: Record<string, unknown>;
+}) {
+  const formSchema = z.object({
+    formData: schema ?? z.object({}),
+  });
+  const form = useForm({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      formData: defaultValues ?? {},
+    },
+  });
+
+  return <FormProvider {...form}>{children}</FormProvider>;
+}
+
+describe("DynamicFormField", () => {
+  it("renders text input with label and required asterisk", () => {
+    const field = makeField({
+      fieldKey: "name",
+      fieldType: "text",
+      label: "Full Name",
+      required: true,
+      placeholder: "Enter name",
+    });
+
+    render(
+      <FormWrapper
+        schema={z.object({ name: z.string() })}
+        defaultValues={{ name: "" }}
+      >
+        <DynamicFormField field={field} disabled={false} />
+      </FormWrapper>,
+    );
+
+    expect(screen.getByText("Full Name")).toBeInTheDocument();
+    expect(screen.getByText("*")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Enter name")).toBeInTheDocument();
+  });
+
+  it("renders textarea for textarea type", () => {
+    const field = makeField({
+      fieldKey: "bio",
+      fieldType: "textarea",
+      label: "Biography",
+    });
+
+    render(
+      <FormWrapper
+        schema={z.object({ bio: z.string() })}
+        defaultValues={{ bio: "" }}
+      >
+        <DynamicFormField field={field} disabled={false} />
+      </FormWrapper>,
+    );
+
+    expect(screen.getByText("Biography")).toBeInTheDocument();
+    const textarea = document.querySelector("textarea");
+    expect(textarea).toBeInTheDocument();
+  });
+
+  it("renders select with options", () => {
+    const field = makeField({
+      fieldKey: "genre",
+      fieldType: "select",
+      label: "Genre",
+      config: {
+        options: [
+          { label: "Fiction", value: "fiction" },
+          { label: "Poetry", value: "poetry" },
+          { label: "Nonfiction", value: "nonfiction" },
+        ],
+      },
+    });
+
+    render(
+      <FormWrapper
+        schema={z.object({ genre: z.string().optional() })}
+        defaultValues={{ genre: "" }}
+      >
+        <DynamicFormField field={field} disabled={false} />
+      </FormWrapper>,
+    );
+
+    expect(screen.getByText("Genre")).toBeInTheDocument();
+    // Select trigger should be present
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("renders radio group with options", () => {
+    const field = makeField({
+      fieldKey: "color",
+      fieldType: "radio",
+      label: "Favorite Color",
+      config: {
+        options: [
+          { label: "Red", value: "red" },
+          { label: "Blue", value: "blue" },
+          { label: "Green", value: "green" },
+        ],
+      },
+    });
+
+    render(
+      <FormWrapper
+        schema={z.object({ color: z.string().optional() })}
+        defaultValues={{ color: "" }}
+      >
+        <DynamicFormField field={field} disabled={false} />
+      </FormWrapper>,
+    );
+
+    expect(screen.getByText("Favorite Color")).toBeInTheDocument();
+    expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+    expect(screen.getByText("Red")).toBeInTheDocument();
+    expect(screen.getByText("Blue")).toBeInTheDocument();
+    expect(screen.getByText("Green")).toBeInTheDocument();
+  });
+
+  it("renders checkbox", () => {
+    const field = makeField({
+      fieldKey: "agree",
+      fieldType: "checkbox",
+      label: "I agree to the terms",
+    });
+
+    render(
+      <FormWrapper
+        schema={z.object({ agree: z.boolean() })}
+        defaultValues={{ agree: false }}
+      >
+        <DynamicFormField field={field} disabled={false} />
+      </FormWrapper>,
+    );
+
+    expect(screen.getByText("I agree to the terms")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+  });
+
+  it("renders checkbox group for multi_select", () => {
+    const field = makeField({
+      fieldKey: "tags",
+      fieldType: "multi_select",
+      label: "Tags",
+      config: {
+        options: [
+          { label: "Tag A", value: "a" },
+          { label: "Tag B", value: "b" },
+        ],
+      },
+    });
+
+    render(
+      <FormWrapper
+        schema={z.object({ tags: z.array(z.string()) })}
+        defaultValues={{ tags: [] }}
+      >
+        <DynamicFormField field={field} disabled={false} />
+      </FormWrapper>,
+    );
+
+    expect(screen.getByText("Tags")).toBeInTheDocument();
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(2);
+    expect(screen.getByText("Tag A")).toBeInTheDocument();
+    expect(screen.getByText("Tag B")).toBeInTheDocument();
+  });
+
+  it("renders section_header as heading", () => {
+    const field = makeField({
+      fieldKey: "section_1",
+      fieldType: "section_header",
+      label: "About You",
+      description: "Tell us about yourself",
+    });
+
+    render(
+      <FormWrapper>
+        <DynamicFormField field={field} disabled={false} />
+      </FormWrapper>,
+    );
+
+    const heading = screen.getByText("About You");
+    expect(heading.tagName).toBe("H3");
+    expect(screen.getByText("Tell us about yourself")).toBeInTheDocument();
+  });
+
+  it("renders info_text as info block", () => {
+    const field = makeField({
+      fieldKey: "info_1",
+      fieldType: "info_text",
+      label: "Important notice",
+      description: "Please read carefully before proceeding",
+    });
+
+    render(
+      <FormWrapper>
+        <DynamicFormField field={field} disabled={false} />
+      </FormWrapper>,
+    );
+
+    expect(
+      screen.getByText("Please read carefully before proceeding"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders file_upload placeholder", () => {
+    const field = makeField({
+      fieldKey: "manuscript",
+      fieldType: "file_upload",
+      label: "Manuscript",
+    });
+
+    render(
+      <FormWrapper>
+        <DynamicFormField field={field} disabled={false} />
+      </FormWrapper>,
+    );
+
+    expect(
+      screen.getByText("File uploads are handled in the Files section below."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders disabled inputs when disabled", () => {
+    const field = makeField({
+      fieldKey: "name",
+      fieldType: "text",
+      label: "Name",
+      placeholder: "Enter name",
+    });
+
+    render(
+      <FormWrapper
+        schema={z.object({ name: z.string() })}
+        defaultValues={{ name: "" }}
+      >
+        <DynamicFormField field={field} disabled={true} />
+      </FormWrapper>,
+    );
+
+    const input = screen.getByPlaceholderText("Enter name");
+    expect(input).toBeDisabled();
+  });
+});

--- a/apps/web/src/components/submissions/form-renderer/__tests__/map-field-errors.spec.ts
+++ b/apps/web/src/components/submissions/form-renderer/__tests__/map-field-errors.spec.ts
@@ -1,0 +1,79 @@
+import { extractFieldErrors, mapFieldErrorsToForm } from "../map-field-errors";
+
+describe("extractFieldErrors", () => {
+  it("extracts fieldErrors from TRPCClientError shape", () => {
+    const error = {
+      data: {
+        fieldErrors: [{ fieldKey: "bio", message: "Too short" }],
+      },
+    };
+
+    expect(extractFieldErrors(error)).toEqual([
+      { fieldKey: "bio", message: "Too short" },
+    ]);
+  });
+
+  it("returns null when no fieldErrors", () => {
+    const error = { data: { code: "BAD_REQUEST" } };
+    expect(extractFieldErrors(error)).toBeNull();
+  });
+
+  it("returns null for null/undefined error", () => {
+    expect(extractFieldErrors(null)).toBeNull();
+    expect(extractFieldErrors(undefined)).toBeNull();
+  });
+});
+
+describe("mapFieldErrorsToForm", () => {
+  it("maps fieldErrors to setError calls", () => {
+    const setError = jest.fn();
+    const error = {
+      data: {
+        fieldErrors: [{ fieldKey: "bio", message: "Too short" }],
+      },
+    };
+
+    const result = mapFieldErrorsToForm(error, setError);
+
+    expect(result).toBe(true);
+    expect(setError).toHaveBeenCalledWith("formData.bio", {
+      message: "Too short",
+    });
+  });
+
+  it("returns false when no fieldErrors", () => {
+    const setError = jest.fn();
+    const error = { message: "Something went wrong" };
+
+    const result = mapFieldErrorsToForm(error, setError);
+
+    expect(result).toBe(false);
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it("handles multiple field errors", () => {
+    const setError = jest.fn();
+    const error = {
+      data: {
+        fieldErrors: [
+          { fieldKey: "bio", message: "Too short" },
+          { fieldKey: "email", message: "Invalid email" },
+          { fieldKey: "age", message: "Must be positive" },
+        ],
+      },
+    };
+
+    const result = mapFieldErrorsToForm(error, setError);
+
+    expect(result).toBe(true);
+    expect(setError).toHaveBeenCalledTimes(3);
+  });
+
+  it("handles null/undefined error", () => {
+    const setError = jest.fn();
+
+    expect(mapFieldErrorsToForm(null, setError)).toBe(false);
+    expect(mapFieldErrorsToForm(undefined, setError)).toBe(false);
+    expect(setError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/submissions/form-renderer/build-form-schema.ts
+++ b/apps/web/src/components/submissions/form-renderer/build-form-schema.ts
@@ -1,0 +1,228 @@
+import { z } from "zod";
+import {
+  textFieldConfigSchema,
+  numberFieldConfigSchema,
+  selectFieldConfigSchema,
+  richTextFieldConfigSchema,
+  PRESENTATIONAL_FIELD_TYPES,
+} from "@colophony/types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FormFieldForRenderer {
+  fieldKey: string;
+  fieldType: string;
+  label: string;
+  description: string | null;
+  placeholder: string | null;
+  required: boolean;
+  config: Record<string, unknown> | null;
+}
+
+export interface FormSchemaResult {
+  schema: z.ZodObject<Record<string, z.ZodTypeAny>>;
+  defaultValues: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Schema builder
+// ---------------------------------------------------------------------------
+
+function buildFieldSchema(field: FormFieldForRenderer): z.ZodTypeAny | null {
+  const config = field.config ?? {};
+
+  switch (field.fieldType) {
+    case "text":
+    case "textarea": {
+      let s = z.string();
+      const parsed = textFieldConfigSchema.safeParse(config);
+      if (parsed.success) {
+        if (parsed.data.minLength !== undefined) {
+          s = s.min(
+            parsed.data.minLength,
+            `${field.label} must be at least ${parsed.data.minLength} characters`,
+          );
+        }
+        if (parsed.data.maxLength !== undefined) {
+          s = s.max(
+            parsed.data.maxLength,
+            `${field.label} must be at most ${parsed.data.maxLength} characters`,
+          );
+        }
+      }
+      if (field.required) {
+        return s.min(1, `${field.label} is required`);
+      }
+      return s.optional().or(z.literal(""));
+    }
+
+    case "rich_text": {
+      let s = z.string();
+      const parsed = richTextFieldConfigSchema.safeParse(config);
+      if (parsed.success && parsed.data.maxLength !== undefined) {
+        s = s.max(
+          parsed.data.maxLength,
+          `${field.label} must be at most ${parsed.data.maxLength} characters`,
+        );
+      }
+      if (field.required) {
+        return s.min(1, `${field.label} is required`);
+      }
+      return s.optional().or(z.literal(""));
+    }
+
+    case "email": {
+      const s = z
+        .string()
+        .email(`${field.label} must be a valid email address`);
+      if (field.required) {
+        return s.min(1, `${field.label} is required`);
+      }
+      return s.optional().or(z.literal(""));
+    }
+
+    case "url": {
+      const s = z.string().url(`${field.label} must be a valid URL`);
+      if (field.required) {
+        return s.min(1, `${field.label} is required`);
+      }
+      return s.optional().or(z.literal(""));
+    }
+
+    case "date": {
+      const s = z
+        .string()
+        .date(`${field.label} must be a valid date (YYYY-MM-DD)`);
+      if (field.required) {
+        return s.min(1, `${field.label} is required`);
+      }
+      return s.optional().or(z.literal(""));
+    }
+
+    case "number": {
+      let s = z.coerce.number({
+        error: `${field.label} must be a number`,
+      });
+      const parsed = numberFieldConfigSchema.safeParse(config);
+      if (parsed.success) {
+        if (parsed.data.min !== undefined) {
+          s = s.min(
+            parsed.data.min,
+            `${field.label} must be at least ${parsed.data.min}`,
+          );
+        }
+        if (parsed.data.max !== undefined) {
+          s = s.max(
+            parsed.data.max,
+            `${field.label} must be at most ${parsed.data.max}`,
+          );
+        }
+      }
+      if (field.required) {
+        return s;
+      }
+      return z.preprocess(
+        (val) => (val === "" || val === undefined ? undefined : val),
+        s.optional(),
+      );
+    }
+
+    case "select":
+    case "radio": {
+      const parsed = selectFieldConfigSchema.safeParse(config);
+      if (parsed.success && parsed.data.options.length > 0) {
+        const values = parsed.data.options.map((o) => o.value);
+        const s = z.enum(values as [string, ...string[]]);
+        if (field.required) {
+          return s;
+        }
+        return s.optional().or(z.literal(""));
+      }
+      return field.required
+        ? z.string().min(1, `${field.label} is required`)
+        : z.string().optional().or(z.literal(""));
+    }
+
+    case "multi_select":
+    case "checkbox_group": {
+      const parsed = selectFieldConfigSchema.safeParse(config);
+      const validValues = parsed.success
+        ? parsed.data.options.map((o) => o.value)
+        : [];
+      const s = z
+        .array(z.string())
+        .refine(
+          (arr) =>
+            validValues.length === 0 ||
+            arr.every((v) => validValues.includes(v)),
+          { message: `${field.label} contains invalid option(s)` },
+        );
+      if (field.required) {
+        return s.refine((arr) => arr.length > 0, {
+          message: `${field.label} is required`,
+        });
+      }
+      return s.optional();
+    }
+
+    case "checkbox": {
+      return z.boolean();
+    }
+
+    case "file_upload":
+      return null;
+
+    default: {
+      if (
+        PRESENTATIONAL_FIELD_TYPES.includes(
+          field.fieldType as (typeof PRESENTATIONAL_FIELD_TYPES)[number],
+        )
+      ) {
+        return null;
+      }
+      return field.required
+        ? z.string().min(1, `${field.label} is required`)
+        : z.string().optional().or(z.literal(""));
+    }
+  }
+}
+
+function getDefaultValue(field: FormFieldForRenderer): unknown {
+  switch (field.fieldType) {
+    case "checkbox":
+      return false;
+    case "multi_select":
+    case "checkbox_group":
+      return [];
+    case "number":
+      return undefined;
+    default:
+      return "";
+  }
+}
+
+/**
+ * Build a Zod schema and default values from a list of form field definitions.
+ * Presentational fields and file_upload are skipped.
+ */
+export function buildFormFieldsSchema(
+  fields: FormFieldForRenderer[],
+): FormSchemaResult {
+  const shape: Record<string, z.ZodTypeAny> = {};
+  const defaultValues: Record<string, unknown> = {};
+
+  for (const field of fields) {
+    const schema = buildFieldSchema(field);
+    if (schema === null) continue;
+
+    shape[field.fieldKey] = schema;
+    defaultValues[field.fieldKey] = getDefaultValue(field);
+  }
+
+  return {
+    schema: z.object(shape),
+    defaultValues,
+  };
+}

--- a/apps/web/src/components/submissions/form-renderer/build-form-schema.ts
+++ b/apps/web/src/components/submissions/form-renderer/build-form-schema.ts
@@ -121,7 +121,11 @@ function buildFieldSchema(field: FormFieldForRenderer): z.ZodTypeAny | null {
         }
       }
       if (field.required) {
-        return s;
+        // Reject empty strings before coercion — z.coerce.number() turns "" into 0
+        return z.preprocess((val) => {
+          if (val === "" || val === undefined || val === null) return NaN; // NaN fails z.coerce.number()
+          return val;
+        }, s);
       }
       return z.preprocess(
         (val) => (val === "" || val === undefined ? undefined : val),

--- a/apps/web/src/components/submissions/form-renderer/dynamic-form-field.tsx
+++ b/apps/web/src/components/submissions/form-renderer/dynamic-form-field.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useFormContext } from "react-hook-form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Separator } from "@/components/ui/separator";
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import type { FormFieldForRenderer } from "./build-form-schema";
+
+interface DynamicFormFieldProps {
+  field: FormFieldForRenderer;
+  disabled: boolean;
+}
+
+export function DynamicFormField({ field, disabled }: DynamicFormFieldProps) {
+  const form = useFormContext();
+  const config = (field.config ?? {}) as Record<string, unknown>;
+  const options =
+    (config.options as Array<{ label: string; value: string }>) ?? [];
+
+  switch (field.fieldType) {
+    case "section_header":
+      return (
+        <div className="pt-4">
+          <h3 className="text-lg font-semibold">{field.label}</h3>
+          {field.description && (
+            <p className="text-sm text-muted-foreground">{field.description}</p>
+          )}
+          <Separator className="mt-2" />
+        </div>
+      );
+
+    case "info_text":
+      return (
+        <div className="rounded-lg bg-muted p-3 text-sm text-muted-foreground">
+          {field.description ?? field.label}
+        </div>
+      );
+
+    case "textarea":
+    case "rich_text":
+      return (
+        <FormField
+          control={form.control}
+          name={`formData.${field.fieldKey}`}
+          render={({ field: formField }) => (
+            <FormItem>
+              <FormLabel>
+                {field.label}
+                {field.required && (
+                  <span className="text-destructive ml-1">*</span>
+                )}
+              </FormLabel>
+              {field.description && (
+                <FormDescription>{field.description}</FormDescription>
+              )}
+              <FormControl>
+                <Textarea
+                  placeholder={field.placeholder ?? ""}
+                  disabled={disabled}
+                  rows={4}
+                  {...formField}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      );
+
+    case "select":
+      return (
+        <FormField
+          control={form.control}
+          name={`formData.${field.fieldKey}`}
+          render={({ field: formField }) => (
+            <FormItem>
+              <FormLabel>
+                {field.label}
+                {field.required && (
+                  <span className="text-destructive ml-1">*</span>
+                )}
+              </FormLabel>
+              {field.description && (
+                <FormDescription>{field.description}</FormDescription>
+              )}
+              <Select
+                onValueChange={formField.onChange}
+                value={formField.value}
+                disabled={disabled}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue
+                      placeholder={field.placeholder ?? "Select..."}
+                    />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {options.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      );
+
+    case "radio":
+      return (
+        <FormField
+          control={form.control}
+          name={`formData.${field.fieldKey}`}
+          render={({ field: formField }) => (
+            <FormItem>
+              <FormLabel>
+                {field.label}
+                {field.required && (
+                  <span className="text-destructive ml-1">*</span>
+                )}
+              </FormLabel>
+              {field.description && (
+                <FormDescription>{field.description}</FormDescription>
+              )}
+              <FormControl>
+                <RadioGroup
+                  onValueChange={formField.onChange}
+                  value={formField.value}
+                  disabled={disabled}
+                  className="space-y-2"
+                >
+                  {options.map((opt) => (
+                    <div key={opt.value} className="flex items-center gap-2">
+                      <RadioGroupItem
+                        value={opt.value}
+                        id={`${field.fieldKey}-${opt.value}`}
+                      />
+                      <Label
+                        htmlFor={`${field.fieldKey}-${opt.value}`}
+                        className="font-normal"
+                      >
+                        {opt.label}
+                      </Label>
+                    </div>
+                  ))}
+                </RadioGroup>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      );
+
+    case "checkbox":
+      return (
+        <FormField
+          control={form.control}
+          name={`formData.${field.fieldKey}`}
+          render={({ field: formField }) => (
+            <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+              <FormControl>
+                <Checkbox
+                  checked={formField.value}
+                  onCheckedChange={formField.onChange}
+                  disabled={disabled}
+                />
+              </FormControl>
+              <div className="space-y-1 leading-none">
+                <FormLabel className="font-normal">
+                  {field.label}
+                  {field.required && (
+                    <span className="text-destructive ml-1">*</span>
+                  )}
+                </FormLabel>
+                {field.description && (
+                  <FormDescription>{field.description}</FormDescription>
+                )}
+              </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      );
+
+    case "multi_select":
+    case "checkbox_group":
+      return (
+        <FormField
+          control={form.control}
+          name={`formData.${field.fieldKey}`}
+          render={({ field: formField }) => (
+            <FormItem>
+              <FormLabel>
+                {field.label}
+                {field.required && (
+                  <span className="text-destructive ml-1">*</span>
+                )}
+              </FormLabel>
+              {field.description && (
+                <FormDescription>{field.description}</FormDescription>
+              )}
+              <div className="space-y-2">
+                {options.map((opt) => {
+                  const values: string[] = formField.value ?? [];
+                  return (
+                    <div key={opt.value} className="flex items-center gap-2">
+                      <Checkbox
+                        checked={values.includes(opt.value)}
+                        onCheckedChange={(checked) => {
+                          const next = checked
+                            ? [...values, opt.value]
+                            : values.filter((v: string) => v !== opt.value);
+                          formField.onChange(next);
+                        }}
+                        disabled={disabled}
+                      />
+                      <Label className="font-normal">{opt.label}</Label>
+                    </div>
+                  );
+                })}
+              </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      );
+
+    case "file_upload":
+      return (
+        <div className="space-y-1.5">
+          <Label>
+            {field.label}
+            {field.required && <span className="text-destructive ml-1">*</span>}
+          </Label>
+          {field.description && (
+            <p className="text-xs text-muted-foreground">{field.description}</p>
+          )}
+          <p className="text-sm text-muted-foreground">
+            File uploads are handled in the Files section below.
+          </p>
+        </div>
+      );
+
+    default: {
+      const inputType =
+        field.fieldType === "number"
+          ? "number"
+          : field.fieldType === "email"
+            ? "email"
+            : field.fieldType === "url"
+              ? "url"
+              : field.fieldType === "date"
+                ? "date"
+                : "text";
+
+      return (
+        <FormField
+          control={form.control}
+          name={`formData.${field.fieldKey}`}
+          render={({ field: formField }) => (
+            <FormItem>
+              <FormLabel>
+                {field.label}
+                {field.required && (
+                  <span className="text-destructive ml-1">*</span>
+                )}
+              </FormLabel>
+              {field.description && (
+                <FormDescription>{field.description}</FormDescription>
+              )}
+              <FormControl>
+                <Input
+                  type={inputType}
+                  placeholder={field.placeholder ?? ""}
+                  disabled={disabled}
+                  {...formField}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      );
+    }
+  }
+}

--- a/apps/web/src/components/submissions/form-renderer/dynamic-form-fields.tsx
+++ b/apps/web/src/components/submissions/form-renderer/dynamic-form-fields.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { trpc } from "@/lib/trpc";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { DynamicFormField } from "./dynamic-form-field";
+import type { FormFieldForRenderer } from "./build-form-schema";
+
+interface DynamicFormFieldsProps {
+  formDefinitionId: string;
+  disabled: boolean;
+}
+
+export function DynamicFormFields({
+  formDefinitionId,
+  disabled,
+}: DynamicFormFieldsProps) {
+  const {
+    data: formDefinition,
+    isPending,
+    error,
+  } = trpc.forms.getById.useQuery({ id: formDefinitionId });
+
+  if (isPending) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-72 mt-1" />
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>
+          Failed to load form: {error.message}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!formDefinition) return null;
+
+  const fields = [...formDefinition.fields].sort(
+    (a, b) => a.sortOrder - b.sortOrder,
+  ) as FormFieldForRenderer[];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{formDefinition.name}</CardTitle>
+        {formDefinition.description && (
+          <CardDescription>{formDefinition.description}</CardDescription>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {fields.map((field) => (
+          <DynamicFormField
+            key={field.fieldKey}
+            field={field}
+            disabled={disabled}
+          />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/submissions/form-renderer/index.ts
+++ b/apps/web/src/components/submissions/form-renderer/index.ts
@@ -1,0 +1,7 @@
+export { DynamicFormFields } from "./dynamic-form-fields";
+export {
+  buildFormFieldsSchema,
+  type FormFieldForRenderer,
+  type FormSchemaResult,
+} from "./build-form-schema";
+export { mapFieldErrorsToForm } from "./map-field-errors";

--- a/apps/web/src/components/submissions/form-renderer/map-field-errors.ts
+++ b/apps/web/src/components/submissions/form-renderer/map-field-errors.ts
@@ -1,0 +1,46 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SetErrorFn = (name: any, error: { message: string }) => void;
+
+interface FieldError {
+  fieldKey: string;
+  message: string;
+}
+
+/**
+ * Extract field errors from a TRPCClientError.
+ * The error formatter in `apps/api/src/trpc/init.ts` surfaces fieldErrors
+ * at `error.data.fieldErrors` as `Array<{ fieldKey, message }>`.
+ */
+export function extractFieldErrors(error: unknown): FieldError[] | null {
+  if (
+    error &&
+    typeof error === "object" &&
+    "data" in error &&
+    error.data &&
+    typeof error.data === "object" &&
+    "fieldErrors" in error.data &&
+    Array.isArray(error.data.fieldErrors)
+  ) {
+    return error.data.fieldErrors as FieldError[];
+  }
+  return null;
+}
+
+/**
+ * Map backend field validation errors to react-hook-form errors.
+ * Calls `setError('formData.${fieldKey}', { message })` for each error.
+ * Returns true if field errors were found and mapped, false otherwise.
+ */
+export function mapFieldErrorsToForm(
+  error: unknown,
+  setError: SetErrorFn,
+): boolean {
+  const fieldErrors = extractFieldErrors(error);
+  if (!fieldErrors || fieldErrors.length === 0) return false;
+
+  for (const { fieldKey, message } of fieldErrors) {
+    setError(`formData.${fieldKey}`, { message });
+  }
+
+  return true;
+}

--- a/apps/web/src/components/submissions/submission-form.tsx
+++ b/apps/web/src/components/submissions/submission-form.tsx
@@ -102,7 +102,10 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
         title: existingSubmission.title ?? "",
         content: existingSubmission.content ?? "",
         coverLetter: existingSubmission.coverLetter ?? "",
-        formData: existingSubmission.formData ?? formDataDefaults,
+        formData: {
+          ...formDataDefaults,
+          ...(existingSubmission.formData as Record<string, unknown> | null),
+        },
       });
     }
   }, [existingSubmission, mode, form, formDefinition, formDataDefaults]);

--- a/apps/web/src/components/submissions/submission-form.tsx
+++ b/apps/web/src/components/submissions/submission-form.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { trpc } from "@/lib/trpc";
+import {
+  DynamicFormFields,
+  buildFormFieldsSchema,
+  mapFieldErrorsToForm,
+} from "./form-renderer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -37,8 +42,6 @@ const formSchema = z.object({
   coverLetter: z.string().max(10000).optional(),
 });
 
-type FormData = z.infer<typeof formSchema>;
-
 interface SubmissionFormProps {
   mode: "create" | "edit";
   submissionId?: string;
@@ -62,25 +65,47 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
     { enabled: mode === "edit" && !!submissionId },
   );
 
-  const form = useForm<FormData>({
-    resolver: zodResolver(formSchema),
+  // Fetch form definition when submission has one
+  const formDefinitionId = existingSubmission?.formDefinitionId;
+  const { data: formDefinition } = trpc.forms.getById.useQuery(
+    { id: formDefinitionId ?? "" },
+    { enabled: !!formDefinitionId },
+  );
+
+  // Build dynamic schema from form definition fields
+  const { schema: formDataSchema, defaultValues: formDataDefaults } = useMemo(
+    () =>
+      formDefinition
+        ? buildFormFieldsSchema(formDefinition.fields)
+        : { schema: z.object({}), defaultValues: {} },
+    [formDefinition],
+  );
+  const fullSchema = useMemo(
+    () => formSchema.extend({ formData: formDataSchema }),
+    [formDataSchema],
+  );
+
+  const form = useForm({
+    resolver: zodResolver(fullSchema),
     defaultValues: {
       title: "",
       content: "",
       coverLetter: "",
+      formData: formDataDefaults,
     },
   });
 
-  // Populate form when editing
+  // Populate form when editing (re-runs when formDefinition loads to apply defaults)
   useEffect(() => {
     if (existingSubmission && mode === "edit") {
       form.reset({
         title: existingSubmission.title ?? "",
         content: existingSubmission.content ?? "",
         coverLetter: existingSubmission.coverLetter ?? "",
+        formData: existingSubmission.formData ?? formDataDefaults,
       });
     }
-  }, [existingSubmission, mode, form]);
+  }, [existingSubmission, mode, form, formDefinition, formDataDefaults]);
 
   // Create mutation
   const createMutation = trpc.submissions.create.useMutation({
@@ -115,20 +140,26 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
       router.push(`/submissions/${submissionId}`);
     },
     onError: (err) => {
-      setError(err.message);
+      // Map field-level validation errors to form fields; fall back to generic error
+      if (!mapFieldErrorsToForm(err, form.setError)) {
+        setError(err.message);
+      }
     },
   });
 
-  const onSubmit = async (data: FormData) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const onSubmit = async (data: any) => {
     setError(null);
+    const { formData, ...rest } = data;
 
     if (mode === "create") {
-      await createMutation.mutateAsync(data);
+      await createMutation.mutateAsync({ ...rest, formData });
     } else if (submissionId) {
       // v2: flattened input — { id, ...data } instead of { id, data }
       await updateMutation.mutateAsync({
         id: submissionId,
-        ...data,
+        ...rest,
+        formData,
       });
     }
   };
@@ -142,9 +173,11 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
 
     // Save changes first (v2: flattened input)
     const data = form.getValues();
+    const { formData, ...rest } = data;
     await updateMutation.mutateAsync({
       id: submissionId,
-      ...data,
+      ...rest,
+      formData,
     });
 
     // Check for pending/infected files
@@ -162,7 +195,7 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
       return;
     }
 
-    // Submit
+    // Submit (field errors mapped in onError callback)
     await submitMutation.mutateAsync({ id: submissionId });
   };
 
@@ -281,6 +314,14 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
               />
             </CardContent>
           </Card>
+
+          {/* Dynamic form fields — shown when submission links to a form */}
+          {formDefinitionId && (
+            <DynamicFormFields
+              formDefinitionId={formDefinitionId}
+              disabled={!canEdit}
+            />
+          )}
 
           {/* File upload - only shown after creation */}
           {mode === "edit" && submissionId && (

--- a/apps/web/src/components/ui/radio-group.tsx
+++ b/apps/web/src/components/ui/radio-group.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import * as React from "react";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { Circle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const RadioGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn("grid gap-2", className)}
+      {...props}
+      ref={ref}
+    />
+  );
+});
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+        <Circle className="h-3.5 w-3.5 fill-primary" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+});
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -95,7 +95,7 @@
 
 - [x] Form builder backend — DB schema (form_definitions + form_fields), Zod types, service layer, tRPC + REST + GraphQL endpoints, validateFormData, audit constants, API key scopes — (architecture doc Track 3; done 2026-02-20)
 - [x] Form builder frontend — editor UI for creating/editing form definitions, field drag-and-drop, field config panels — (architecture doc Track 3, form-builder-research.md; done 2026-02-20)
-- [ ] Form renderer for submitters — render published forms in submission flow — (architecture doc Track 3, form-builder-research.md)
+- [x] Form renderer for submitters — render published forms in submission flow — (architecture doc Track 3, form-builder-research.md; done 2026-02-20)
 - [x] Form builder integration — wire validateFormData into submission create/update flow, formData persistence + validation on submit — (architecture doc Track 3, deferred from backend PR 2026-02-20; done 2026-02-20)
 - [ ] Add `formDefinitionId` to `createSubmissionPeriodSchema` — deferred, no active consumer yet — (DEVLOG 2026-02-20)
 - [ ] [P2] GraphQL forms resolver: add `idParamSchema` validation on raw string args passed to services — (Codex plan review 2026-02-20)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,28 @@ Newest entries first.
 
 ---
 
+## 2026-02-20 — Form Renderer for Submitters (Track 3)
+
+### Done
+
+- Implemented form renderer — 6 new files, 1 modified, 4 test files (~1,580 lines)
+- `buildFormFieldsSchema()`: pure function building Zod schemas from form field definitions, mirroring backend `validateFieldValue()` rules exactly
+- `DynamicFormField`: switch-case component rendering 15 field types (text, textarea, rich_text, email, url, date, number, select, radio, checkbox, multi_select, checkbox_group, section_header, info_text, file_upload)
+- `DynamicFormFields`: container fetching form definition via tRPC with skeleton/error states
+- `mapFieldErrorsToForm()`: maps TRPCClientError `fieldErrors` to react-hook-form `setError()` calls
+- Integrated into `submission-form.tsx`: dynamic Zod schema via `useMemo`, `formData` as nested object in parent form, persistence on save, backend error mapping on submit
+- Added shadcn RadioGroup component
+- 32 new tests + 4 updated existing tests (212 total passing), type-check clean
+
+### Decisions
+
+- Single `DynamicFormField` with switch-case (mirrors `form-preview.tsx` pattern) — extract per-type files if conditional logic (Phase 2) pushes past 500 lines
+- `formData` as nested object in parent react-hook-form schema — single form instance, unified validation and submit
+- Zod 4 uses `error` option instead of `invalid_type_error` for `z.coerce.number()`
+- `SetErrorFn` type alias instead of `UseFormSetError<FieldValues>` — avoids TS narrowing mismatch
+
+---
+
 ## 2026-02-20 — Dev Workflow Improvements Part 2
 
 ### Done

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       '@radix-ui/react-progress':
         specifier: ^1.1.8
         version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.3.8
+        version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.10
         version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2236,6 +2239,19 @@ packages:
 
   '@radix-ui/react-progress@1.1.8':
     resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8647,6 +8663,24 @@ snapshots:
     dependencies:
       '@radix-ui/react-context': 1.1.3(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:


### PR DESCRIPTION
## Summary

- When a submission is linked to a published form definition, the submission form now dynamically renders all form fields, validates client-side with Zod schemas mirroring the backend, persists `formData` on save, and maps backend validation errors to inline form field errors on submit
- Added `buildFormFieldsSchema()` pure function that builds Zod schemas from field definitions (15 field types)
- Added `DynamicFormField` switch-case renderer and `DynamicFormFields` container component
- Added `mapFieldErrorsToForm()` utility for TRPCClientError field error mapping
- Integrated into `submission-form.tsx` with dynamic schema via `useMemo`, formData persistence, and error mapping

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `map-field-errors.ts` | `UseFormSetError<FieldValues>` parameter type | `SetErrorFn` type alias with `any` name | TS narrowing mismatch: caller's `setError` has a narrower type than `UseFormSetError<FieldValues>` |
| `build-form-schema.ts` | `z.coerce.number()` directly for required numbers | `z.preprocess` wrapping `z.coerce.number()` | code review: `z.coerce.number()` coerces `""` to `0`, silently accepting blank required fields |
| `submission-form.tsx` | `existingSubmission.formData ?? formDataDefaults` | `{ ...formDataDefaults, ...existingSubmission.formData }` | code review: `??` only falls through on null/undefined, empty `{}` drops defaults |
| `submission-form.spec.tsx` | Assert mapped field error message renders in DOM | Assert generic error is absent (setError called but stub div doesn't render inline errors) | DynamicFormFields is mocked as stub div in parent tests; field-level error rendering tested in `dynamic-form-field.spec.tsx` |

## Test plan

- [x] 213 unit tests passing (32 new + 1 Codex fix test, 21 suites)
- [x] Type check clean (`tsc --noEmit`)
- [x] Pre-push hooks pass (type-check + lint)
- [ ] Manual test: create form in editor, publish, create submission linked to form, verify dynamic fields render and validate correctly
- [ ] Manual test: save draft with formData, reload, verify formData persists
- [ ] Manual test: submit with invalid formData, verify backend field errors appear inline