### PR TITLE
docs: form renderer manual QA — devlog and backlog updates

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -108,6 +108,8 @@
 - [ ] GDPR deletion mutation — stubbed with TODO — (DEVLOG 2026-02-15)
 - [ ] GDPR tools finalization from MVP — (architecture doc Track 3)
 - [ ] Org deletion — needs careful cascade handling — (DEVLOG 2026-02-13)
+- [ ] [P3] Form editor: debounce or batch field add/update API calls to avoid 429 rate limiting on rapid edits — (manual QA 2026-02-20)
+- [ ] Form selector UI in submission creation — submitters need a way to select a published form when creating a submission (currently requires DB linkage) — (manual QA 2026-02-20)
 
 ---
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,26 @@ Newest entries first.
 
 ---
 
+## 2026-02-20 — Form Renderer Manual QA (Track 3)
+
+### Done
+
+- Manual end-to-end test of form builder + form renderer flow with dev servers
+- Ran `pnpm db:migrate` to apply form builder schema changes (form_definitions, form_fields, submissions.form_definition_id, submissions.form_data)
+- Created test form with 8 fields across 6 types: Section Header, Short Text (required), Email (required), Number (min/max), Dropdown (3 options, required), Radio (2 options, required), Long Text, Checkbox (required)
+- Published form, created submission, linked to form definition, edited submission
+- Verified: all field types render correctly, required markers display, placeholders work, dropdown/radio options populate from form definition
+- Verified: client-side Zod validation fires on submit — field-specific error messages for all required fields
+- Verified: form data persists on Save Draft and survives page reload (text, number, select, radio, checkbox, textarea all restored)
+- Verified: Submit for Review succeeds — backend validates form data, status transitions DRAFT → SUBMITTED
+
+### Issues Found
+
+- Rate limiting (429) when adding form fields rapidly in editor — operations hit the per-user rate limit; mitigated by pacing, but UX could benefit from debouncing or request batching in the form editor
+- No form selector UI in submission creation — had to link form_definition_id via database; submission creation page has no way to select a published form (already tracked in backlog)
+
+---
+
 ## 2026-02-20 — Form Renderer for Submitters (Track 3)
 
 ### Done


### PR DESCRIPTION
## Summary

- Manual end-to-end QA of form builder + form renderer flow
- Updated devlog with test results and issues found
- Added 2 new backlog items discovered during testing

## Test Results

All form renderer functionality verified working:
- Form creation (8 fields, 6 types), publishing
- Dynamic field rendering in submission edit
- Client-side Zod validation with field-specific errors
- Form data persistence across save/reload
- Submit for Review with backend validation

## Issues Found

- Rate limiting (429) on rapid field adds in editor (P3, backlog)
- No form selector UI in submission creation (backlog)

## Test plan

- [x] Manual QA completed this session — no code changes to verify