### PR TITLE
feat(hopper): form selector UI in submission creation

### DIFF
--- a/apps/web/src/components/submissions/__tests__/submission-form.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/submission-form.spec.tsx
@@ -1,14 +1,76 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SubmissionForm } from "../submission-form";
 // Navigation mocks imported to ensure setup.ts runs (registers next/navigation mock)
 import "../../../../test/setup";
+
+// Mock shadcn Select with native HTML elements (Radix Select doesn't work in jsdom)
+jest.mock("@/components/ui/select", () => {
+  const React = require("react");
+  const SelectContext = React.createContext({
+    onValueChange: (_v: string) => {},
+    value: undefined as string | undefined,
+  });
+  return {
+    Select: ({
+      children,
+      onValueChange,
+      value,
+    }: {
+      children: React.ReactNode;
+      onValueChange: (v: string) => void;
+      value?: string;
+    }) => (
+      <SelectContext.Provider value={{ onValueChange, value }}>
+        <div data-testid="mock-select" data-value={value}>
+          {children}
+        </div>
+      </SelectContext.Provider>
+    ),
+    SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+      <button type="button" role="combobox">
+        {children}
+      </button>
+    ),
+    SelectValue: ({ placeholder }: { placeholder?: string }) => (
+      <span>{placeholder}</span>
+    ),
+    SelectContent: ({ children }: { children: React.ReactNode }) => (
+      <div role="listbox">{children}</div>
+    ),
+    SelectItem: ({
+      children,
+      value,
+    }: {
+      children: React.ReactNode;
+      value: string;
+    }) => {
+      const ctx = React.useContext(SelectContext);
+      return (
+        <div
+          role="option"
+          data-value={value}
+          onClick={() => ctx.onValueChange(value)}
+        >
+          {children}
+        </div>
+      );
+    },
+  };
+});
 
 // --- Mutable mock state ---
 let mockExistingSubmission: Record<string, unknown> | undefined;
 let mockIsLoadingSubmission: boolean;
 let mockExistingFiles: Array<Record<string, unknown>> | undefined;
 let mockFormDefinition: Record<string, unknown> | undefined;
+let mockPublishedForms: {
+  items: Array<{ id: string; name: string }>;
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+};
 
 let mockCreateMutateAsync: jest.Mock;
 let mockCreateIsPending: boolean;
@@ -30,6 +92,13 @@ function resetMocks() {
   mockIsLoadingSubmission = false;
   mockExistingFiles = undefined;
   mockFormDefinition = undefined;
+  mockPublishedForms = {
+    items: [],
+    total: 0,
+    page: 1,
+    limit: 100,
+    totalPages: 0,
+  };
 
   mockCreateMutateAsync = jest.fn().mockResolvedValue({ id: "new-sub-1" });
   mockCreateIsPending = false;
@@ -96,6 +165,12 @@ jest.mock("@/lib/trpc", () => ({
           data: mockFormDefinition,
           isPending: false,
           error: null,
+        }),
+      },
+      list: {
+        useQuery: () => ({
+          data: mockPublishedForms,
+          isPending: false,
         }),
       },
     },
@@ -213,7 +288,7 @@ describe("SubmissionForm", () => {
           title: "My Story",
           content: "Once upon a time",
           coverLetter: "Please consider",
-          formData: {},
+          formData: undefined,
         });
       });
     });
@@ -430,10 +505,10 @@ describe("SubmissionForm", () => {
   describe("dynamic form fields", () => {
     it("renders DynamicFormFields when submission has formDefinitionId", () => {
       mockExistingSubmission = makeDraftSubmission({
-        formDefinitionId: "form-def-1",
+        formDefinitionId: "00000000-0000-4000-8000-000000000001",
       });
       mockFormDefinition = {
-        id: "form-def-1",
+        id: "00000000-0000-4000-8000-000000000001",
         name: "Poetry Submission Form",
         description: "Standard poetry form",
         fields: [
@@ -456,7 +531,7 @@ describe("SubmissionForm", () => {
       expect(dynamicFields).toBeInTheDocument();
       expect(dynamicFields).toHaveAttribute(
         "data-form-definition-id",
-        "form-def-1",
+        "00000000-0000-4000-8000-000000000001",
       );
       expect(dynamicFields).toHaveAttribute("data-disabled", "false");
     });
@@ -472,11 +547,11 @@ describe("SubmissionForm", () => {
 
     it("passes formData in update mutation", async () => {
       mockExistingSubmission = makeDraftSubmission({
-        formDefinitionId: "form-def-1",
+        formDefinitionId: "00000000-0000-4000-8000-000000000001",
         formData: { bio: "A poet" },
       });
       mockFormDefinition = {
-        id: "form-def-1",
+        id: "00000000-0000-4000-8000-000000000001",
         name: "Form",
         description: null,
         fields: [
@@ -510,10 +585,10 @@ describe("SubmissionForm", () => {
 
     it("maps field errors from submit rejection to form fields", () => {
       mockExistingSubmission = makeDraftSubmission({
-        formDefinitionId: "form-def-1",
+        formDefinitionId: "00000000-0000-4000-8000-000000000001",
       });
       mockFormDefinition = {
-        id: "form-def-1",
+        id: "00000000-0000-4000-8000-000000000001",
         name: "Form",
         description: null,
         fields: [],
@@ -534,6 +609,154 @@ describe("SubmissionForm", () => {
 
       // Generic error should not be shown (mapFieldErrorsToForm returns true)
       expect(screen.queryByText("Validation failed")).not.toBeInTheDocument();
+    });
+  });
+
+  // --- Form selector (create mode) ---
+  describe("form selector", () => {
+    it("renders form selector card with published forms in create mode", () => {
+      mockPublishedForms = {
+        items: [
+          { id: "form-1", name: "Poetry Form" },
+          { id: "form-2", name: "Fiction Form" },
+        ],
+        total: 2,
+        page: 1,
+        limit: 100,
+        totalPages: 1,
+      };
+
+      render(<SubmissionForm mode="create" />);
+
+      // Card title renders
+      expect(screen.getByText("Submission Form")).toBeInTheDocument();
+      // Options are rendered (mock Select renders them directly)
+      expect(screen.getByText("Poetry Form")).toBeInTheDocument();
+      expect(screen.getByText("Fiction Form")).toBeInTheDocument();
+      // None option rendered
+      expect(screen.getByRole("option", { name: "None" })).toBeInTheDocument();
+    });
+
+    it("does not render form selector in edit mode", () => {
+      mockExistingSubmission = makeDraftSubmission();
+
+      render(<SubmissionForm mode="edit" submissionId="sub-1" />);
+
+      expect(screen.queryByText("Submission Form")).not.toBeInTheDocument();
+    });
+
+    it("shows DynamicFormFields when a form is selected in create mode", async () => {
+      mockPublishedForms = {
+        items: [
+          { id: "00000000-0000-4000-8000-000000000001", name: "Poetry Form" },
+        ],
+        total: 1,
+        page: 1,
+        limit: 100,
+        totalPages: 1,
+      };
+      mockFormDefinition = {
+        id: "00000000-0000-4000-8000-000000000001",
+        name: "Poetry Form",
+        description: null,
+        fields: [
+          {
+            fieldKey: "bio",
+            fieldType: "text",
+            label: "Bio",
+            description: null,
+            placeholder: null,
+            required: true,
+            sortOrder: 0,
+            config: null,
+          },
+        ],
+      };
+
+      render(<SubmissionForm mode="create" />);
+
+      // Click the form option (mock Select calls onValueChange directly)
+      fireEvent.click(screen.getByRole("option", { name: "Poetry Form" }));
+
+      await waitFor(() => {
+        const dynamicFields = screen.getByTestId("dynamic-form-fields");
+        expect(dynamicFields).toBeInTheDocument();
+        expect(dynamicFields).toHaveAttribute(
+          "data-form-definition-id",
+          "00000000-0000-4000-8000-000000000001",
+        );
+      });
+    });
+
+    it("includes formDefinitionId in create mutation when form selected", async () => {
+      mockPublishedForms = {
+        items: [
+          { id: "00000000-0000-4000-8000-000000000001", name: "Poetry Form" },
+        ],
+        total: 1,
+        page: 1,
+        limit: 100,
+        totalPages: 1,
+      };
+      mockFormDefinition = {
+        id: "00000000-0000-4000-8000-000000000001",
+        name: "Poetry Form",
+        description: null,
+        fields: [],
+      };
+
+      const user = userEvent.setup();
+      render(<SubmissionForm mode="create" />);
+
+      // Select the form option
+      fireEvent.click(screen.getByRole("option", { name: "Poetry Form" }));
+
+      // Fill title
+      await user.type(
+        screen.getByPlaceholderText("Enter submission title"),
+        "My Poem",
+      );
+
+      await user.click(screen.getByRole("button", { name: "Create Draft" }));
+
+      await waitFor(() => {
+        expect(mockCreateMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: "My Poem",
+            formDefinitionId: "00000000-0000-4000-8000-000000000001",
+          }),
+        );
+      });
+    });
+
+    it("omits formDefinitionId when no form selected", async () => {
+      mockPublishedForms = {
+        items: [
+          { id: "00000000-0000-4000-8000-000000000001", name: "Poetry Form" },
+        ],
+        total: 1,
+        page: 1,
+        limit: 100,
+        totalPages: 1,
+      };
+
+      const user = userEvent.setup();
+      render(<SubmissionForm mode="create" />);
+
+      // Fill title without selecting a form
+      await user.type(
+        screen.getByPlaceholderText("Enter submission title"),
+        "My Story",
+      );
+
+      await user.click(screen.getByRole("button", { name: "Create Draft" }));
+
+      await waitFor(() => {
+        expect(mockCreateMutateAsync).toHaveBeenCalled();
+        const callArgs = mockCreateMutateAsync.mock.calls[0][0];
+        expect(callArgs.title).toBe("My Story");
+        expect(callArgs).not.toHaveProperty("formDefinitionId");
+      });
     });
   });
 });

--- a/apps/web/src/components/submissions/__tests__/submission-form.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/submission-form.spec.tsx
@@ -6,8 +6,10 @@ import "../../../../test/setup";
 
 // Mock shadcn Select with native HTML elements (Radix Select doesn't work in jsdom)
 jest.mock("@/components/ui/select", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const React = require("react");
   const SelectContext = React.createContext({
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onValueChange: (_v: string) => {},
     value: undefined as string | undefined,
   });
@@ -28,6 +30,7 @@ jest.mock("@/components/ui/select", () => {
       </SelectContext.Provider>
     ),
     SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+      // eslint-disable-next-line jsx-a11y/role-has-required-aria-props
       <button type="button" role="combobox">
         {children}
       </button>

--- a/apps/web/src/components/submissions/submission-form.tsx
+++ b/apps/web/src/components/submissions/submission-form.tsx
@@ -31,6 +31,13 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { FileUpload } from "./file-upload";
 import { toast } from "sonner";
@@ -40,6 +47,7 @@ const formSchema = z.object({
   title: z.string().min(1, "Title is required").max(500),
   content: z.string().max(50000).optional(),
   coverLetter: z.string().max(10000).optional(),
+  formDefinitionId: z.string().uuid().optional().or(z.literal("__none__")),
 });
 
 interface SubmissionFormProps {
@@ -50,6 +58,7 @@ interface SubmissionFormProps {
 export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
+  const [selectedFormId, setSelectedFormId] = useState<string | undefined>();
   const utils = trpc.useUtils();
 
   // Fetch existing submission for edit mode
@@ -65,8 +74,17 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
     { enabled: mode === "edit" && !!submissionId },
   );
 
-  // Fetch form definition when submission has one
-  const formDefinitionId = existingSubmission?.formDefinitionId;
+  // Fetch published forms for create-mode selector
+  const { data: publishedForms } = trpc.forms.list.useQuery(
+    { status: "PUBLISHED", limit: 100 },
+    { enabled: mode === "create" },
+  );
+
+  // Determine active formDefinitionId: from state in create mode, from submission in edit mode
+  const formDefinitionId =
+    mode === "edit" ? existingSubmission?.formDefinitionId : selectedFormId;
+
+  // Fetch form definition when one is active
   const { data: formDefinition } = trpc.forms.getById.useQuery(
     { id: formDefinitionId ?? "" },
     { enabled: !!formDefinitionId },
@@ -109,6 +127,13 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
       });
     }
   }, [existingSubmission, mode, form, formDefinition, formDataDefaults]);
+
+  // Reset formData defaults when a different form is selected in create mode
+  useEffect(() => {
+    if (mode === "create" && formDefinition) {
+      form.setValue("formData", formDataDefaults, { shouldValidate: false });
+    }
+  }, [formDefinition, formDataDefaults, mode, form]);
 
   // Create mutation
   const createMutation = trpc.submissions.create.useMutation({
@@ -153,10 +178,15 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const onSubmit = async (data: any) => {
     setError(null);
-    const { formData, ...rest } = data;
+    const { formData, formDefinitionId: selectedId, ...rest } = data;
+    const hasForm = selectedId && selectedId !== "__none__";
 
     if (mode === "create") {
-      await createMutation.mutateAsync({ ...rest, formData });
+      await createMutation.mutateAsync({
+        ...rest,
+        ...(hasForm ? { formDefinitionId: selectedId } : {}),
+        formData: hasForm ? formData : undefined,
+      });
     } else if (submissionId) {
       // v2: flattened input — { id, ...data } instead of { id, data }
       await updateMutation.mutateAsync({
@@ -249,6 +279,55 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
 
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          {mode === "create" && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Submission Form</CardTitle>
+                <CardDescription>
+                  Select the form for this submission, if applicable
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <FormField
+                  control={form.control}
+                  name="formDefinitionId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Form</FormLabel>
+                      <Select
+                        onValueChange={(value) => {
+                          field.onChange(value);
+                          setSelectedFormId(
+                            value === "__none__" ? undefined : value,
+                          );
+                        }}
+                        value={field.value ?? "__none__"}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="None (no form)" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="__none__">None</SelectItem>
+                          {publishedForms?.items.map((f) => (
+                            <SelectItem key={f.id} value={f.id}>
+                              {f.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Choose a published form to include additional fields
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </CardContent>
+            </Card>
+          )}
+
           <Card>
             <CardHeader>
               <CardTitle>Submission Details</CardTitle>

--- a/apps/web/src/components/submissions/submission-form.tsx
+++ b/apps/web/src/components/submissions/submission-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -128,12 +128,17 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
     }
   }, [existingSubmission, mode, form, formDefinition, formDataDefaults]);
 
-  // Reset formData defaults when a different form is selected in create mode
+  // Reset formData defaults when a different form is selected in create mode.
+  // Track previous selection to avoid resetting on background query refetches.
+  const prevSelectedFormRef = useRef<string | undefined>(undefined);
   useEffect(() => {
-    if (mode === "create" && formDefinition) {
-      form.setValue("formData", formDataDefaults, { shouldValidate: false });
+    if (mode === "create" && selectedFormId !== prevSelectedFormRef.current) {
+      prevSelectedFormRef.current = selectedFormId;
+      if (formDefinition) {
+        form.setValue("formData", formDataDefaults, { shouldValidate: false });
+      }
     }
-  }, [formDefinition, formDataDefaults, mode, form]);
+  }, [formDefinition, formDataDefaults, mode, form, selectedFormId]);
 
   // Create mutation
   const createMutation = trpc.submissions.create.useMutation({

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -109,7 +109,7 @@
 - [ ] GDPR tools finalization from MVP — (architecture doc Track 3)
 - [ ] Org deletion — needs careful cascade handling — (DEVLOG 2026-02-13)
 - [ ] [P3] Form editor: debounce or batch field add/update API calls to avoid 429 rate limiting on rapid edits — (manual QA 2026-02-20)
-- [ ] Form selector UI in submission creation — submitters need a way to select a published form when creating a submission (currently requires DB linkage) — (manual QA 2026-02-20)
+- [x] Form selector UI in submission creation — submitters need a way to select a published form when creating a submission (currently requires DB linkage) — (manual QA 2026-02-20; done 2026-02-20)
 
 ---
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,27 @@ Newest entries first.
 
 ---
 
+## 2026-02-20 — Form Selector UI in Submission Creation (Track 3)
+
+### Done
+
+- Implemented form selector dropdown in `submission-form.tsx` for create mode — submitters can now select a published form when starting a new submission
+- Added `formDefinitionId` to local Zod schema with `__none__` sentinel (Radix Select rejects empty string values)
+- Added `publishedForms` tRPC query (create mode only, fetches published forms)
+- Used `useState` for selectedFormId to break circular dependency (useForm → schema → formDefinition → formDefinitionId → form.watch)
+- Strips sentinel and conditionally includes `formDefinitionId`/`formData` in create mutation
+- Added 5 new test cases for form selector behavior (render, edit mode exclusion, DynamicFormFields on selection, mutation with/without form)
+- Mocked Radix Select with React context for jsdom compatibility (Radix Select doesn't work in jsdom)
+- All 22 tests passing, type-check clean
+
+### Decisions
+
+- `useState` over `form.watch()` for selectedFormId: avoids circular hook dependency without restructuring the component
+- `__none__` sentinel value: Radix Select cannot have an empty-string `SelectItem` value; stripped before API call
+- Mocked `@/components/ui/select` in tests: Radix UI portals + pointer events are incompatible with jsdom; React context passes `onValueChange` through shadcn's `FormControl`
+
+---
+
 ## 2026-02-20 — Form Renderer Manual QA (Track 3)
 
 ### Done


### PR DESCRIPTION
## Summary

- Add a Select dropdown for published forms in the create-submission flow so submitters can choose a form when starting a new submission
- When a form is selected, the existing `DynamicFormFields` renderer appears with the form's fields; switching forms or selecting "None" updates accordingly
- Backend already supports `formDefinitionId` end-to-end — this is a frontend-only change

## Changes

- `apps/web/src/components/submissions/submission-form.tsx` — form selector card, published forms query, `selectedFormId` state, sentinel stripping, formData reset with refetch guard
- `apps/web/src/components/submissions/__tests__/submission-form.spec.tsx` — 5 new test cases, Radix Select mock, `forms.list` mock

## Plan Overrides

| File | Planned | Actual | Rationale |
| --- | --- | --- | --- |
| `submission-form.tsx` | `form.watch("formDefinitionId")` for create-mode ID | `useState` for `selectedFormId` | Circular hook dependency: useForm needs schema, schema needs formDefinition, formDefinition needs formDefinitionId from watch |

## Test plan

- [x] 22 unit tests passing (17 existing + 5 new)
- [x] Type-check clean
- [x] ESLint clean (0 errors)
- [ ] Manual QA: `/submissions/new` — form selector renders, switching works, create with/without form