### PR TITLE
feat(hopper): editor submission queue with table layout and detail view

### DIFF
--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -161,8 +161,25 @@ export const submissionService = {
 
     const [items, countResult] = await Promise.all([
       tx
-        .select()
+        .select({
+          id: submissions.id,
+          organizationId: submissions.organizationId,
+          submitterId: submissions.submitterId,
+          submissionPeriodId: submissions.submissionPeriodId,
+          title: submissions.title,
+          content: submissions.content,
+          coverLetter: submissions.coverLetter,
+          formDefinitionId: submissions.formDefinitionId,
+          formData: submissions.formData,
+          status: submissions.status,
+          submittedAt: submissions.submittedAt,
+          createdAt: submissions.createdAt,
+          updatedAt: submissions.updatedAt,
+          searchVector: submissions.searchVector,
+          submitterEmail: users.email,
+        })
         .from(submissions)
+        .leftJoin(users, eq(users.id, submissions.submitterId))
         .where(where)
         .orderBy(desc(submissions.createdAt))
         .limit(limit)

--- a/apps/api/src/trpc/routers/submissions.ts
+++ b/apps/api/src/trpc/routers/submissions.ts
@@ -7,6 +7,7 @@ import {
   idParamSchema,
   submissionIdParamSchema,
   submissionSchema,
+  submissionListItemSchema,
   submissionDetailSchema,
   submissionStatusChangeResponseSchema,
   submissionHistorySchema,
@@ -37,7 +38,7 @@ export const submissionsRouter = createRouter({
   list: orgProcedure
     .use(requireScopes('submissions:read'))
     .input(listSubmissionsSchema)
-    .output(paginatedResponseSchema(submissionSchema))
+    .output(paginatedResponseSchema(submissionListItemSchema))
     .query(async ({ ctx, input }) => {
       try {
         assertEditorOrAdmin(ctx.authContext.role);

--- a/apps/web/src/app/(dashboard)/editor/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/[id]/page.tsx
@@ -1,10 +1,14 @@
-export default function SubmissionReviewPage() {
+import { SubmissionDetail } from "@/components/submissions/submission-detail";
+
+export default async function EditorSubmissionDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold">Submission Review</h1>
-      <p className="text-muted-foreground mt-2">
-        Coming soon — v2 submission review under development.
-      </p>
+      <SubmissionDetail submissionId={id} backHref="/editor/submissions" />
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/editor/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/page.tsx
@@ -7,7 +7,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { ClipboardList } from "lucide-react";
+import { ClipboardList, Inbox } from "lucide-react";
 
 export default function EditorPage() {
   return (
@@ -20,6 +20,29 @@ export default function EditorPage() {
       </div>
 
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <Link href="/editor/submissions">
+          <Card className="hover:border-primary/50 transition-colors cursor-pointer">
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <div className="rounded-lg bg-primary/10 p-2">
+                  <Inbox className="h-5 w-5 text-primary" />
+                </div>
+                <div>
+                  <CardTitle className="text-base">Submissions</CardTitle>
+                  <CardDescription>
+                    Review and manage incoming submissions
+                  </CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Button variant="outline" size="sm" className="w-full">
+                View Queue
+              </Button>
+            </CardContent>
+          </Card>
+        </Link>
+
         <Link href="/editor/forms">
           <Card className="hover:border-primary/50 transition-colors cursor-pointer">
             <CardHeader>

--- a/apps/web/src/app/(dashboard)/editor/submissions/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/submissions/page.tsx
@@ -1,0 +1,9 @@
+import { EditorSubmissionQueue } from "@/components/submissions/editor-submission-queue";
+
+export default function EditorSubmissionsPage() {
+  return (
+    <div className="p-6">
+      <EditorSubmissionQueue />
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Building2,
   ClipboardList,
   FileText,
+  Inbox,
   LayoutDashboard,
   Settings,
 } from "lucide-react";
@@ -19,6 +20,7 @@ const navigation = [
 
 const editorNavigation = [
   { name: "Editor Dashboard", href: "/editor", icon: LayoutDashboard },
+  { name: "Submissions", href: "/editor/submissions", icon: Inbox },
   { name: "Forms", href: "/editor/forms", icon: ClipboardList },
 ];
 

--- a/apps/web/src/components/submissions/__tests__/editor-submission-queue.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/editor-submission-queue.spec.tsx
@@ -1,0 +1,165 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { EditorSubmissionQueue } from "../editor-submission-queue";
+import "../../../../test/setup";
+
+// --- Mutable mock state ---
+let mockData:
+  | {
+      items: Array<Record<string, unknown>>;
+      total: number;
+      page: number;
+      limit: number;
+      totalPages: number;
+    }
+  | undefined;
+let mockIsPending: boolean;
+let mockError: { message: string } | null;
+
+function resetMocks() {
+  mockData = undefined;
+  mockIsPending = false;
+  mockError = null;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    submissions: {
+      list: {
+        useQuery: () => ({
+          data: mockData,
+          isPending: mockIsPending,
+          error: mockError,
+        }),
+      },
+    },
+  },
+}));
+
+beforeEach(() => {
+  resetMocks();
+});
+
+function makeItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "sub-1",
+    organizationId: "org-1",
+    submitterId: "user-1",
+    submissionPeriodId: null,
+    title: "My Poem",
+    content: "Some content",
+    coverLetter: null,
+    formDefinitionId: null,
+    formData: null,
+    status: "SUBMITTED",
+    submittedAt: "2026-01-15T12:00:00.000Z",
+    createdAt: "2026-01-14T12:00:00.000Z",
+    updatedAt: "2026-01-14T12:00:00.000Z",
+    submitterEmail: "poet@example.com",
+    ...overrides,
+  };
+}
+
+describe("EditorSubmissionQueue", () => {
+  it("shows loading skeletons when isPending", () => {
+    mockIsPending = true;
+    mockData = undefined;
+    render(<EditorSubmissionQueue />);
+    // Skeletons are rendered — no table or heading "Submissions"
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("shows error message when query fails", () => {
+    mockError = { message: "Forbidden" };
+    render(<EditorSubmissionQueue />);
+    expect(screen.getByText(/Forbidden/)).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when no submissions", () => {
+    mockData = { items: [], total: 0, page: 1, limit: 20, totalPages: 0 };
+    render(<EditorSubmissionQueue />);
+    expect(screen.getByText("No submissions")).toBeInTheDocument();
+  });
+
+  it("renders submission rows with title, email, status, date", () => {
+    mockData = {
+      items: [makeItem()],
+      total: 1,
+      page: 1,
+      limit: 20,
+      totalPages: 1,
+    };
+    render(<EditorSubmissionQueue />);
+    expect(screen.getByText("My Poem")).toBeInTheDocument();
+    expect(screen.getByText("poet@example.com")).toBeInTheDocument();
+    // StatusBadge renders "Submitted"; also appears in tab and table header
+    expect(screen.getAllByText("Submitted").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Jan 15, 2026")).toBeInTheDocument();
+  });
+
+  it('renders "(Untitled)" for null title', () => {
+    mockData = {
+      items: [makeItem({ id: "sub-2", title: null })],
+      total: 1,
+      page: 1,
+      limit: 20,
+      totalPages: 1,
+    };
+    render(<EditorSubmissionQueue />);
+    expect(screen.getByText("(Untitled)")).toBeInTheDocument();
+  });
+
+  it('renders "\u2014" for null submitterEmail', () => {
+    mockData = {
+      items: [makeItem({ id: "sub-3", submitterEmail: null })],
+      total: 1,
+      page: 1,
+      limit: 20,
+      totalPages: 1,
+    };
+    render(<EditorSubmissionQueue />);
+    expect(screen.getByText("\u2014")).toBeInTheDocument();
+  });
+
+  it("title link points to /editor/[id]", () => {
+    mockData = {
+      items: [makeItem({ id: "abc123" })],
+      total: 1,
+      page: 1,
+      limit: 20,
+      totalPages: 1,
+    };
+    render(<EditorSubmissionQueue />);
+    const link = screen.getByText("My Poem").closest("a");
+    expect(link).toHaveAttribute("href", "/editor/abc123");
+  });
+
+  it("shows pagination when totalPages > 1", () => {
+    mockData = {
+      items: [makeItem()],
+      total: 60,
+      page: 1,
+      limit: 20,
+      totalPages: 3,
+    };
+    render(<EditorSubmissionQueue />);
+    expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Next" })).not.toBeDisabled();
+  });
+
+  it("search input debounce works without crash", () => {
+    jest.useFakeTimers();
+    mockData = { items: [], total: 0, page: 1, limit: 20, totalPages: 0 };
+    render(<EditorSubmissionQueue />);
+    const input = screen.getByPlaceholderText("Search by title...");
+    fireEvent.change(input, { target: { value: "poetry" } });
+    expect(input).toHaveValue("poetry");
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    // No crash — component still renders
+    expect(screen.getByText("No submissions")).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+});

--- a/apps/web/src/components/submissions/editor-submission-queue.tsx
+++ b/apps/web/src/components/submissions/editor-submission-queue.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { format } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { StatusBadge } from "./status-badge";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Inbox, MoreHorizontal, Eye, X } from "lucide-react";
+import type { SubmissionStatus } from "@colophony/types";
+
+const STATUS_TABS: Array<{ value: SubmissionStatus | "ALL"; label: string }> = [
+  { value: "ALL", label: "All" },
+  { value: "SUBMITTED", label: "Submitted" },
+  { value: "UNDER_REVIEW", label: "Under Review" },
+  { value: "HOLD", label: "Hold" },
+  { value: "ACCEPTED", label: "Accepted" },
+  { value: "REJECTED", label: "Rejected" },
+  { value: "WITHDRAWN", label: "Withdrawn" },
+];
+
+export function EditorSubmissionQueue() {
+  const [statusFilter, setStatusFilter] = useState<SubmissionStatus | "ALL">(
+    "ALL",
+  );
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search);
+      setPage(1);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const { data, isPending, error } = trpc.submissions.list.useQuery({
+    status: statusFilter === "ALL" ? undefined : statusFilter,
+    search: debouncedSearch || undefined,
+    page,
+    limit: 20,
+  });
+
+  const handleStatusChange = (value: string) => {
+    setStatusFilter(value as SubmissionStatus | "ALL");
+    setPage(1);
+  };
+
+  if (isPending) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Submissions</h1>
+        <p className="text-destructive">
+          Failed to load submissions: {error.message}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Submissions</h1>
+
+      {/* Search */}
+      <div className="relative max-w-sm">
+        <Input
+          placeholder="Search by title..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        {search && (
+          <button
+            type="button"
+            onClick={() => setSearch("")}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Status tabs */}
+      <Tabs value={statusFilter} onValueChange={handleStatusChange}>
+        <TabsList>
+          {STATUS_TABS.map((tab) => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      {/* Table or empty state */}
+      {data && data.items.length > 0 ? (
+        <>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[100px]">Status</TableHead>
+                <TableHead>Title</TableHead>
+                <TableHead>Submitter</TableHead>
+                <TableHead className="w-[140px]">Submitted</TableHead>
+                <TableHead className="w-[60px]">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.items.map((item) => (
+                <TableRow key={item.id}>
+                  <TableCell>
+                    <StatusBadge status={item.status as SubmissionStatus} />
+                  </TableCell>
+                  <TableCell>
+                    <Link
+                      href={`/editor/${item.id}`}
+                      className="font-medium hover:underline"
+                    >
+                      {item.title ?? "(Untitled)"}
+                    </Link>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {item.submitterEmail ?? "\u2014"}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {item.submittedAt
+                      ? format(new Date(item.submittedAt), "MMM d, yyyy")
+                      : "\u2014"}
+                  </TableCell>
+                  <TableCell>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" size="icon" className="h-8 w-8">
+                          <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem asChild>
+                          <Link href={`/editor/${item.id}`}>
+                            <Eye className="mr-2 h-4 w-4" />
+                            View
+                          </Link>
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+
+          {/* Pagination */}
+          {data.totalPages > 1 && (
+            <div className="flex items-center justify-center gap-4">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {page} of {data.totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))}
+                disabled={page >= data.totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <Inbox className="h-12 w-12 text-muted-foreground mb-4" />
+          <p className="text-lg font-medium">No submissions</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            {statusFilter !== "ALL"
+              ? `No ${statusFilter.toLowerCase().replace("_", " ")} submissions found.`
+              : debouncedSearch
+                ? "No submissions match your search."
+                : "Submissions will appear here once submitters send them in."}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { formatDistanceToNow, format } from "date-fns";
 import { trpc } from "@/lib/trpc";
-import { useAuth } from "@/hooks/use-auth";
 import { useOrganization } from "@/hooks/use-organization";
 import { StatusBadge } from "./status-badge";
 import { StatusTransition } from "./status-transition";
@@ -68,8 +67,7 @@ export function SubmissionDetail({
   backHref = "/submissions",
 }: SubmissionDetailProps) {
   const router = useRouter();
-  const { user } = useAuth();
-  const { isEditor, isAdmin } = useOrganization();
+  const { user, isEditor, isAdmin } = useOrganization();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showWithdrawDialog, setShowWithdrawDialog] = useState(false);
   const utils = trpc.useUtils();

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { formatDistanceToNow, format } from "date-fns";
 import { trpc } from "@/lib/trpc";
+import { useAuth } from "@/hooks/use-auth";
 import { useOrganization } from "@/hooks/use-organization";
 import { StatusBadge } from "./status-badge";
 import { StatusTransition } from "./status-transition";
@@ -42,6 +43,7 @@ import type { ScanStatus, SubmissionStatus } from "@colophony/types";
 
 interface SubmissionDetailProps {
   submissionId: string;
+  backHref?: string;
 }
 
 const scanStatusIcons: Record<
@@ -61,8 +63,12 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export function SubmissionDetail({ submissionId }: SubmissionDetailProps) {
+export function SubmissionDetail({
+  submissionId,
+  backHref = "/submissions",
+}: SubmissionDetailProps) {
   const router = useRouter();
+  const { user } = useAuth();
   const { isEditor, isAdmin } = useOrganization();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showWithdrawDialog, setShowWithdrawDialog] = useState(false);
@@ -85,7 +91,7 @@ export function SubmissionDetail({ submissionId }: SubmissionDetailProps) {
   const deleteMutation = trpc.submissions.delete.useMutation({
     onSuccess: () => {
       toast.success("Submission deleted");
-      router.push("/submissions");
+      router.push(backHref);
     },
     onError: (err) => {
       toast.error(err.message);
@@ -126,18 +132,19 @@ export function SubmissionDetail({ submissionId }: SubmissionDetailProps) {
     return (
       <div className="text-center py-12">
         <p className="text-muted-foreground">Submission not found</p>
-        <Link href="/submissions">
+        <Link href={backHref}>
           <Button variant="link">Back to submissions</Button>
         </Link>
       </div>
     );
   }
 
-  const canEdit = submission.status === "DRAFT";
-  const canDelete = submission.status === "DRAFT";
-  const canWithdraw = ["SUBMITTED", "UNDER_REVIEW", "HOLD"].includes(
-    submission.status,
-  );
+  const isOwner = user?.id === submission.submitterId;
+  const canEdit = isOwner && submission.status === "DRAFT";
+  const canDelete = isOwner && submission.status === "DRAFT";
+  const canWithdraw =
+    isOwner &&
+    ["SUBMITTED", "UNDER_REVIEW", "HOLD"].includes(submission.status);
 
   return (
     <div className="space-y-6">
@@ -145,7 +152,7 @@ export function SubmissionDetail({ submissionId }: SubmissionDetailProps) {
       <div className="flex items-start justify-between">
         <div className="space-y-1">
           <Link
-            href="/submissions"
+            href={backHref}
             className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
           >
             <ArrowLeft className="mr-1 h-4 w-4" />

--- a/apps/web/src/hooks/use-organization.ts
+++ b/apps/web/src/hooks/use-organization.ts
@@ -72,6 +72,7 @@ export function useOrganization() {
   const isReader = !!currentOrg;
 
   return {
+    user,
     currentOrg,
     organizations,
     switchOrganization,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -102,7 +102,7 @@
 - [ ] Conditional logic engine — (architecture doc Track 3, form-builder-research.md)
 - [ ] Embeddable forms (iframe) — (architecture doc Track 3, form-builder-research.md)
 - [ ] Submission periods UI — schema exists, no UI — (DEVLOG 2026-02-15)
-- [ ] Editor dashboard rewrite (`/editor` pages) — current pages are stubs — (DEVLOG 2026-02-15)
+- [x] Editor dashboard rewrite (`/editor` pages) — submission queue + detail view reuse — (DEVLOG 2026-02-15; done 2026-02-21)
 - [x] Fix stale cache after submit: `submission-form.tsx` `submitMutation.onSuccess` does `router.push` but doesn't invalidate `getById` query — detail page shows stale DRAFT status — (DEVLOG 2026-02-18, E2E test run; done 2026-02-19)
 - [ ] Manuscript entity — separate manuscripts (with versions) from submissions; creators maintain a manuscript library and attach manuscripts to submissions rather than uploading per-submission. Enables one-click withdraw-on-accept across all pending submissions of the same manuscript — (roadmap idea 2026-02-19)
 - [ ] GDPR deletion mutation — stubbed with TODO — (DEVLOG 2026-02-15)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,30 @@ Newest entries first.
 
 ---
 
+## 2026-02-21 — Editor Submission Queue (Track 3)
+
+### Done
+
+- Added `submissionListItemSchema` to `@colophony/types` with `submitterEmail` field for editor list views
+- Modified `listAll` in `submission.service.ts` to left-join `users` table and return `submitterEmail`
+- Updated `list` tRPC procedure output to use `submissionListItemSchema`
+- Added `backHref` prop to `SubmissionDetail` component — enables reuse from both `/submissions/[id]` and `/editor/[id]`
+- Added `isOwner` gating via `useAuth` — editors viewing submissions no longer see Edit/Delete/Withdraw buttons
+- Replaced editor detail stub (`/editor/[id]`) with working `SubmissionDetail` reuse (backHref → `/editor/submissions`)
+- Created `EditorSubmissionQueue` component: table layout with status tabs (ALL + 6 statuses, no DRAFT tab), search with 300ms debounce, pagination, dropdown actions
+- Created `/editor/submissions` page (thin server component wrapper)
+- Added Submissions card to editor dashboard hub (`/editor`)
+- Added Submissions nav item to sidebar between Editor Dashboard and Forms
+- Wrote 9 unit tests for `EditorSubmissionQueue` (loading, error, empty, row content, null title/email, link href, pagination, debounce)
+- All 227 tests passing, type-check clean
+
+### Decisions
+
+- Added `searchVector` to explicit select in `listAll` (plan override) — GraphQL resolver uses Drizzle `Submission` type which requires it; omitting it broke type-check
+- DRAFTs visible in editor queue but not actionable — `EDITOR_ALLOWED_TRANSITIONS[DRAFT]` is empty; simpler than backend filtering, status badge makes them identifiable
+
+---
+
 ## 2026-02-20 — Form Selector UI in Submission Creation (Track 3)
 
 ### Done

--- a/packages/types/src/submission.ts
+++ b/packages/types/src/submission.ts
@@ -57,6 +57,17 @@ export const submissionSchema = z.object({
 
 export type Submission = z.infer<typeof submissionSchema>;
 
+/** Submission list item — includes submitter email for editor list view. */
+export const submissionListItemSchema = submissionSchema.extend({
+  submitterEmail: z
+    .string()
+    .email()
+    .nullable()
+    .describe("Email address of the submitter"),
+});
+
+export type SubmissionListItem = z.infer<typeof submissionListItemSchema>;
+
 export const createSubmissionSchema = z.object({
   title: z
     .string()


### PR DESCRIPTION
## Summary

- Add editor submission queue at `/editor/submissions` with table layout, status tabs, search (300ms debounce), and pagination
- Reuse `SubmissionDetail` component with `backHref` prop for `/editor/[id]` detail view
- Add `isOwner` gating so editors see status transitions but not submitter-only actions (Edit/Delete/Withdraw)
- Backend `listAll` now joins `users` table to return `submitterEmail` via new `submissionListItemSchema`
- Update editor dashboard hub with Submissions card and sidebar with Submissions nav item

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `apps/api/src/services/submission.service.ts` | Explicit select without `searchVector` | Added `searchVector` to select | GraphQL resolver uses Drizzle `Submission` type which requires `searchVector`; omitting it broke type-check |
| `apps/web/src/hooks/use-organization.ts` | Not in plan | Expose `user` from return value | code review: avoid duplicate `useAuth` call in `SubmissionDetail` |

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (227 tests, 22 suites)
- [x] branch review — addressed duplicate `useAuth` finding
- [ ] Manual QA: navigate `/editor` — see both Forms and Submissions cards
- [ ] Manual QA: click "View Queue" or sidebar "Submissions" — see table
- [ ] Manual QA: verify submitter email in table rows
- [ ] Manual QA: search by title, filter by status tabs
- [ ] Manual QA: click title → `/editor/[id]` detail, verify back-link goes to `/editor/submissions`
- [ ] Manual QA: verify `/submissions` (submitter view) unchanged