### PR TITLE
fix(hopper): hide Editor Actions card when no transitions available

### DIFF
--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -38,7 +38,11 @@ import {
   AlertCircle,
   Loader2,
 } from "lucide-react";
-import type { ScanStatus, SubmissionStatus } from "@colophony/types";
+import {
+  EDITOR_ALLOWED_TRANSITIONS,
+  type ScanStatus,
+  type SubmissionStatus,
+} from "@colophony/types";
 
 interface SubmissionDetailProps {
   submissionId: string;
@@ -198,22 +202,24 @@ export function SubmissionDetail({
       </div>
 
       {/* Editor status transitions */}
-      {(isEditor || isAdmin) && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Editor Actions</CardTitle>
-            <CardDescription>
-              Change the status of this submission
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <StatusTransition
-              submissionId={submissionId}
-              currentStatus={submission.status as SubmissionStatus}
-            />
-          </CardContent>
-        </Card>
-      )}
+      {(isEditor || isAdmin) &&
+        EDITOR_ALLOWED_TRANSITIONS[submission.status as SubmissionStatus]
+          ?.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Editor Actions</CardTitle>
+              <CardDescription>
+                Change the status of this submission
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <StatusTransition
+                submissionId={submissionId}
+                currentStatus={submission.status as SubmissionStatus}
+              />
+            </CardContent>
+          </Card>
+        )}
 
       {/* Content */}
       <div className="grid gap-6 md:grid-cols-3">

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -20,11 +20,14 @@ Newest entries first.
 - Added Submissions nav item to sidebar between Editor Dashboard and Forms
 - Wrote 9 unit tests for `EditorSubmissionQueue` (loading, error, empty, row content, null title/email, link href, pagination, debounce)
 - All 227 tests passing, type-check clean
+- Manual QA of editor submission queue via Chrome DevTools MCP — all 7 checks passed (page load, search, filtering, pagination, detail view, sidebar nav, submitter view regression)
+- Fixed empty Editor Actions card for terminal statuses — card now checks `EDITOR_ALLOWED_TRANSITIONS` before rendering, hides entirely when no transitions available (was showing header with empty body for WITHDRAWN/etc.)
 
 ### Decisions
 
 - Added `searchVector` to explicit select in `listAll` (plan override) — GraphQL resolver uses Drizzle `Submission` type which requires it; omitting it broke type-check
 - DRAFTs visible in editor queue but not actionable — `EDITOR_ALLOWED_TRANSITIONS[DRAFT]` is empty; simpler than backend filtering, status badge makes them identifiable
+- Hide Editor Actions card entirely when no transitions available (vs showing empty card with header only) — cleaner UX, avoids misleading "Change the status" text with no controls
 
 ---
 


### PR DESCRIPTION
## Summary

- Hide the "Editor Actions" card entirely on submission detail when no status transitions are available (e.g., WITHDRAWN, DRAFT)
- Previously the card rendered its header ("Change the status of this submission") with an empty body, which was misleading
- Checks `EDITOR_ALLOWED_TRANSITIONS` in the parent component before rendering the card wrapper

## Test plan

- [x] Manual QA: WITHDRAWN submission no longer shows Editor Actions card
- [x] Manual QA: UNDER_REVIEW submission still shows Accept/Reject/Hold buttons
- [x] Manual QA: Submitter view unchanged (no regressions)
- [x] Type-check passes
- [x] branch review: LGTM