### PR TITLE
feat(hopper): submission periods REST + GraphQL API parity

### DIFF
--- a/apps/api/src/graphql/error-mapper.ts
+++ b/apps/api/src/graphql/error-mapper.ts
@@ -24,6 +24,10 @@ import {
   FormInUseError,
   InvalidFormDataError,
 } from '../services/form.service.js';
+import {
+  PeriodNotFoundError,
+  PeriodHasSubmissionsError,
+} from '../services/period.service.js';
 
 type GraphQLErrorCode = string;
 
@@ -52,6 +56,9 @@ const errorCodeMap: [new (...args: never[]) => Error, GraphQLErrorCode][] = [
   [FormHasNoFieldsError, 'BAD_REQUEST'],
   [FormInUseError, 'BAD_REQUEST'],
   [InvalidFormDataError, 'BAD_REQUEST'],
+  // Period errors
+  [PeriodNotFoundError, 'NOT_FOUND'],
+  [PeriodHasSubmissionsError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/graphql/resolvers/index.ts
+++ b/apps/api/src/graphql/resolvers/index.ts
@@ -6,3 +6,4 @@ import './audit.js';
 import './api-keys.js';
 import './files.js';
 import './forms.js';
+import './periods.js';

--- a/apps/api/src/graphql/resolvers/periods.ts
+++ b/apps/api/src/graphql/resolvers/periods.ts
@@ -1,0 +1,241 @@
+import type { SubmissionPeriod } from '@colophony/types';
+import {
+  listSubmissionPeriodsSchema,
+  createSubmissionPeriodSchema,
+  updateSubmissionPeriodSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { builder } from '../builder.js';
+import { requireOrgContext, requireScopes } from '../guards.js';
+import { toServiceContext } from '../../services/context.js';
+import {
+  periodService,
+  PeriodNotFoundError,
+} from '../../services/period.service.js';
+import { mapServiceError } from '../error-mapper.js';
+import { SubmissionPeriodType } from '../types/index.js';
+import { SuccessPayload } from '../types/payloads.js';
+
+// ---------------------------------------------------------------------------
+// Paginated response type
+// ---------------------------------------------------------------------------
+
+const PaginatedSubmissionPeriods = builder
+  .objectRef<{
+    items: SubmissionPeriod[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }>('PaginatedSubmissionPeriods')
+  .implement({
+    fields: (t) => ({
+      items: t.field({
+        type: [SubmissionPeriodType],
+        resolve: (r) => r.items,
+      }),
+      total: t.exposeInt('total'),
+      page: t.exposeInt('page'),
+      limit: t.exposeInt('limit'),
+      totalPages: t.exposeInt('totalPages'),
+    }),
+  });
+
+// ---------------------------------------------------------------------------
+// Query fields
+// ---------------------------------------------------------------------------
+
+builder.queryFields((t) => ({
+  /** List submission periods in the org. */
+  submissionPeriods: t.field({
+    type: PaginatedSubmissionPeriods,
+    description: 'List submission periods in the organization.',
+    args: {
+      status: t.arg.string({
+        required: false,
+        description: 'Filter by computed status (UPCOMING, OPEN, CLOSED).',
+      }),
+      search: t.arg.string({
+        required: false,
+        description: 'Search by name.',
+      }),
+      page: t.arg.int({
+        required: false,
+        defaultValue: 1,
+        description: 'Page number (1-based).',
+      }),
+      limit: t.arg.int({
+        required: false,
+        defaultValue: 20,
+        description: 'Items per page (1-100).',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'periods:read');
+      const input = listSubmissionPeriodsSchema.parse({
+        status: args.status ?? undefined,
+        search: args.search ?? undefined,
+        page: args.page,
+        limit: args.limit,
+      });
+      return periodService.list(orgCtx.dbTx, input);
+    },
+  }),
+
+  /** Get a single submission period by ID. */
+  submissionPeriod: t.field({
+    type: SubmissionPeriodType,
+    nullable: true,
+    description: 'Get a submission period by ID.',
+    args: {
+      id: t.arg.string({
+        required: true,
+        description: 'Submission period ID.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'periods:read');
+      try {
+        const period = await periodService.getById(orgCtx.dbTx, args.id);
+        if (!period) throw new PeriodNotFoundError(args.id);
+        return period;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mutation fields
+// ---------------------------------------------------------------------------
+
+builder.mutationFields((t) => ({
+  /** Create a new submission period. */
+  createSubmissionPeriod: t.field({
+    type: SubmissionPeriodType,
+    description:
+      'Create a new submission period — a time window for accepting submissions.',
+    args: {
+      name: t.arg.string({
+        required: true,
+        description: 'Display name for the period.',
+      }),
+      description: t.arg.string({
+        required: false,
+        description: 'Description of the period.',
+      }),
+      opensAt: t.arg({ type: 'DateTime', required: true }),
+      closesAt: t.arg({ type: 'DateTime', required: true }),
+      fee: t.arg.float({
+        required: false,
+        description: 'Submission fee in cents (omit for free).',
+      }),
+      maxSubmissions: t.arg.int({
+        required: false,
+        description: 'Maximum submissions (omit for unlimited).',
+      }),
+      formDefinitionId: t.arg.string({
+        required: false,
+        description: 'Form definition to link.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'periods:write');
+      const input = createSubmissionPeriodSchema.parse({
+        name: args.name,
+        description: args.description ?? undefined,
+        opensAt: args.opensAt,
+        closesAt: args.closesAt,
+        fee: args.fee ?? undefined,
+        maxSubmissions: args.maxSubmissions ?? undefined,
+        formDefinitionId: args.formDefinitionId ?? undefined,
+      });
+      try {
+        return await periodService.createWithAudit(
+          toServiceContext(orgCtx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Update a submission period. */
+  updateSubmissionPeriod: t.field({
+    type: SubmissionPeriodType,
+    description: 'Update a submission period.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Period ID.' }),
+      name: t.arg.string({ required: false, description: 'New name.' }),
+      description: t.arg.string({
+        required: false,
+        description: 'New description.',
+      }),
+      opensAt: t.arg({ type: 'DateTime', required: false }),
+      closesAt: t.arg({ type: 'DateTime', required: false }),
+      fee: t.arg.float({
+        required: false,
+        description: 'New fee in cents.',
+      }),
+      maxSubmissions: t.arg.int({
+        required: false,
+        description: 'New max submissions.',
+      }),
+      formDefinitionId: t.arg.string({
+        required: false,
+        description: 'Form definition to link (null to unlink).',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'periods:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      const data = updateSubmissionPeriodSchema.parse({
+        name: args.name ?? undefined,
+        description: args.description ?? undefined,
+        opensAt: args.opensAt ?? undefined,
+        closesAt: args.closesAt ?? undefined,
+        fee: args.fee ?? undefined,
+        maxSubmissions: args.maxSubmissions ?? undefined,
+        formDefinitionId: args.formDefinitionId ?? undefined,
+      });
+      try {
+        return await periodService.updateWithAudit(
+          toServiceContext(orgCtx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Delete a submission period. */
+  deleteSubmissionPeriod: t.field({
+    type: SuccessPayload,
+    description:
+      'Delete a submission period. Fails if the period has submissions.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Period ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'periods:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await periodService.deleteWithAudit(
+          toServiceContext(orgCtx),
+          id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));

--- a/apps/api/src/graphql/resolvers/periods.ts
+++ b/apps/api/src/graphql/resolvers/periods.ts
@@ -97,9 +97,10 @@ builder.queryFields((t) => ({
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
       await requireScopes(ctx, 'periods:read');
+      const { id } = idParamSchema.parse({ id: args.id });
       try {
-        const period = await periodService.getById(orgCtx.dbTx, args.id);
-        if (!period) throw new PeriodNotFoundError(args.id);
+        const period = await periodService.getById(orgCtx.dbTx, id);
+        if (!period) throw new PeriodNotFoundError(id);
         return period;
       } catch (e) {
         mapServiceError(e);
@@ -202,7 +203,10 @@ builder.mutationFields((t) => ({
         closesAt: args.closesAt ?? undefined,
         fee: args.fee ?? undefined,
         maxSubmissions: args.maxSubmissions ?? undefined,
-        formDefinitionId: args.formDefinitionId ?? undefined,
+        formDefinitionId:
+          args.formDefinitionId === null
+            ? null
+            : (args.formDefinitionId ?? undefined),
       });
       try {
         return await periodService.updateWithAudit(

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -12,6 +12,7 @@ export {
   FormStatusEnum,
   FormFieldTypeEnum,
 } from './form.js';
+export { SubmissionPeriodType, PeriodStatusEnum } from './period.js';
 export {
   SubmissionStatusChangePayload,
   CreateOrganizationPayload,

--- a/apps/api/src/graphql/types/period.ts
+++ b/apps/api/src/graphql/types/period.ts
@@ -1,0 +1,72 @@
+import type { SubmissionPeriod } from '@colophony/types';
+import { builder } from '../builder.js';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const PeriodStatusEnum = builder.enumType('PeriodStatus', {
+  description: 'Computed status of a submission period based on date range.',
+  values: {
+    UPCOMING: {
+      description: 'Period has not opened yet (opensAt is in the future).',
+    },
+    OPEN: {
+      description:
+        'Period is currently accepting submissions (between opensAt and closesAt).',
+    },
+    CLOSED: {
+      description: 'Period is past its deadline (closesAt is in the past).',
+    },
+  } as const,
+});
+
+// ---------------------------------------------------------------------------
+// Object type
+// ---------------------------------------------------------------------------
+
+export const SubmissionPeriodType = builder
+  .objectRef<SubmissionPeriod>('SubmissionPeriod')
+  .implement({
+    description:
+      'A submission period — a time window during which submissions are accepted.',
+    fields: (t) => ({
+      id: t.exposeString('id', { description: 'Unique identifier.' }),
+      organizationId: t.exposeString('organizationId', {
+        description: 'ID of the owning organization.',
+      }),
+      name: t.exposeString('name', { description: 'Display name.' }),
+      description: t.exposeString('description', {
+        nullable: true,
+        description: 'Optional description.',
+      }),
+      opensAt: t.expose('opensAt', {
+        type: 'DateTime',
+        description: 'When submissions open.',
+      }),
+      closesAt: t.expose('closesAt', {
+        type: 'DateTime',
+        description: 'When submissions close.',
+      }),
+      fee: t.exposeFloat('fee', {
+        nullable: true,
+        description: 'Submission fee in cents (null = free).',
+      }),
+      maxSubmissions: t.exposeInt('maxSubmissions', {
+        nullable: true,
+        description: 'Maximum submissions allowed (null = unlimited).',
+      }),
+      formDefinitionId: t.exposeString('formDefinitionId', {
+        nullable: true,
+        description: 'ID of the linked form definition.',
+      }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the period was created.',
+      }),
+      updatedAt: t.expose('updatedAt', {
+        type: 'DateTime',
+        description: 'When the period was last updated.',
+      }),
+    }),
+  });

--- a/apps/api/src/rest/error-mapper.ts
+++ b/apps/api/src/rest/error-mapper.ts
@@ -24,6 +24,10 @@ import {
   FormInUseError,
   InvalidFormDataError,
 } from '../services/form.service.js';
+import {
+  PeriodNotFoundError,
+  PeriodHasSubmissionsError,
+} from '../services/period.service.js';
 
 type ORPCErrorCode = ConstructorParameters<typeof ORPCError>[0];
 
@@ -52,6 +56,9 @@ const errorCodeMap: [new (...args: never[]) => Error, ORPCErrorCode][] = [
   [FormHasNoFieldsError, 'BAD_REQUEST'],
   [FormInUseError, 'BAD_REQUEST'],
   [InvalidFormDataError, 'BAD_REQUEST'],
+  // Period errors
+  [PeriodNotFoundError, 'NOT_FOUND'],
+  [PeriodHasSubmissionsError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/rest/router.ts
+++ b/apps/api/src/rest/router.ts
@@ -9,6 +9,7 @@ import { usersRouter } from './routers/users.js';
 import { apiKeysRouter } from './routers/api-keys.js';
 import { auditRouter } from './routers/audit.js';
 import { formsRouter } from './routers/forms.js';
+import { periodsRouter } from './routers/periods.js';
 import type { RestContext } from './context.js';
 
 const restRouter = {
@@ -18,6 +19,7 @@ const restRouter = {
   users: usersRouter,
   apiKeys: apiKeysRouter,
   forms: formsRouter,
+  periods: periodsRouter,
   audit: auditRouter,
 };
 
@@ -78,6 +80,11 @@ const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
             name: 'Forms',
             description:
               'Create and manage dynamic form definitions for submission intake. Forms define the fields submitters fill out.',
+          },
+          {
+            name: 'Periods',
+            description:
+              'Manage submission periods — time windows during which submissions are accepted.',
           },
           {
             name: 'Audit',

--- a/apps/api/src/rest/routers/periods.ts
+++ b/apps/api/src/rest/routers/periods.ts
@@ -1,0 +1,146 @@
+import {
+  listSubmissionPeriodsSchema,
+  createSubmissionPeriodSchema,
+  updateSubmissionPeriodSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { restPaginationQuery } from '@colophony/api-contracts';
+import {
+  periodService,
+  PeriodNotFoundError,
+} from '../../services/period.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+import { orgProcedure, requireScopes } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// Query schemas — override page/limit with z.coerce for REST query strings
+// ---------------------------------------------------------------------------
+
+const restListPeriodsQuery = listSubmissionPeriodsSchema
+  .omit({ page: true, limit: true })
+  .merge(restPaginationQuery);
+
+// ---------------------------------------------------------------------------
+// Period routes
+// ---------------------------------------------------------------------------
+
+const list = orgProcedure
+  .use(requireScopes('periods:read'))
+  .route({
+    method: 'GET',
+    path: '/periods',
+    summary: 'List submission periods',
+    description:
+      'Returns a paginated list of submission periods in the organization.',
+    operationId: 'listPeriods',
+    tags: ['Periods'],
+  })
+  .input(restListPeriodsQuery)
+  .handler(async ({ input, context }) => {
+    return periodService.list(context.dbTx, input);
+  });
+
+const create = orgProcedure
+  .use(requireScopes('periods:write'))
+  .route({
+    method: 'POST',
+    path: '/periods',
+    successStatus: 201,
+    summary: 'Create a submission period',
+    description:
+      'Create a new submission period — a time window during which submissions are accepted.',
+    operationId: 'createPeriod',
+    tags: ['Periods'],
+  })
+  .input(createSubmissionPeriodSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await periodService.createWithAudit(
+        toServiceContext(context),
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const get = orgProcedure
+  .use(requireScopes('periods:read'))
+  .route({
+    method: 'GET',
+    path: '/periods/{id}',
+    summary: 'Get a submission period',
+    description: 'Retrieve a submission period by ID.',
+    operationId: 'getPeriod',
+    tags: ['Periods'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const period = await periodService.getById(context.dbTx, input.id);
+      if (!period) throw new PeriodNotFoundError(input.id);
+      return period;
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const update = orgProcedure
+  .use(requireScopes('periods:write'))
+  .route({
+    method: 'PATCH',
+    path: '/periods/{id}',
+    summary: 'Update a submission period',
+    description: 'Update a submission period by ID.',
+    operationId: 'updatePeriod',
+    tags: ['Periods'],
+  })
+  .input(idParamSchema.merge(updateSubmissionPeriodSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    try {
+      return await periodService.updateWithAudit(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const del = orgProcedure
+  .use(requireScopes('periods:write'))
+  .route({
+    method: 'DELETE',
+    path: '/periods/{id}',
+    summary: 'Delete a submission period',
+    description:
+      'Delete a submission period. Fails if the period has submissions.',
+    operationId: 'deletePeriod',
+    tags: ['Periods'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await periodService.deleteWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const periodsRouter = {
+  list,
+  create,
+  get,
+  update,
+  delete: del,
+};

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -102,7 +102,7 @@
 - [ ] Conditional logic engine — (architecture doc Track 3, form-builder-research.md)
 - [ ] Embeddable forms (iframe) — (architecture doc Track 3, form-builder-research.md)
 - [x] Submission periods UI — schema exists, no UI — (DEVLOG 2026-02-15; done 2026-02-21)
-- [ ] Submission periods: REST oRPC router + GraphQL resolvers for parity with forms/submissions — (DEVLOG 2026-02-21, deferred from submission periods PR)
+- [x] Submission periods: REST oRPC router + GraphQL resolvers for parity with forms/submissions — (DEVLOG 2026-02-21, deferred from submission periods PR; done 2026-02-21)
 - [x] Editor dashboard rewrite (`/editor` pages) — submission queue + detail view reuse — (DEVLOG 2026-02-15; done 2026-02-21)
 - [x] Fix stale cache after submit: `submission-form.tsx` `submitMutation.onSuccess` does `router.push` but doesn't invalidate `getById` query — detail page shows stale DRAFT status — (DEVLOG 2026-02-18, E2E test run; done 2026-02-19)
 - [ ] Manuscript entity — separate manuscripts (with versions) from submissions; creators maintain a manuscript library and attach manuscripts to submissions rather than uploading per-submission. Enables one-click withdraw-on-accept across all pending submissions of the same manuscript — (roadmap idea 2026-02-19)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -14,6 +14,8 @@ Newest entries first.
 - Updated REST + GraphQL error mappers with `PeriodNotFoundError` → `NOT_FOUND`, `PeriodHasSubmissionsError` → `BAD_REQUEST`
 - Registered periods router in REST `router.ts` with OpenAPI tag, barrel exports in GraphQL types/resolvers indexes
 - All 663 API tests + type-check + lint passing
+- Smoke tested all 13 endpoints against live dev server: REST (list, list+filter, get, get-not-found, get-invalid-uuid, create, update, delete) and GraphQL (list, list+filter, get, get-not-found, create, update, delete) — all passed
+- Added `periods:read` and `periods:write` scopes to seed API key (was missing from initial seed data)
 
 ### Decisions
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,24 @@ Newest entries first.
 
 ---
 
+## 2026-02-21 — Submission Periods API Parity (Track 3)
+
+### Done
+
+- Added oRPC REST router for submission periods — 5 endpoints (list, create, get, update, delete) with `periods:read`/`periods:write` scope enforcement
+- Added Pothos GraphQL type (`SubmissionPeriodType`, `PeriodStatusEnum`) and resolvers — 2 queries (`submissionPeriods`, `submissionPeriod`), 3 mutations (`createSubmissionPeriod`, `updateSubmissionPeriod`, `deleteSubmissionPeriod`)
+- Added `PaginatedSubmissionPeriods` GraphQL response type following forms pattern
+- Updated REST + GraphQL error mappers with `PeriodNotFoundError` → `NOT_FOUND`, `PeriodHasSubmissionsError` → `BAD_REQUEST`
+- Registered periods router in REST `router.ts` with OpenAPI tag, barrel exports in GraphQL types/resolvers indexes
+- All 663 API tests + type-check + lint passing
+
+### Decisions
+
+- Used `SubmissionPeriod` from `@colophony/types` (not `@colophony/db`) for GraphQL type — service's `mapRow()` coerces `fee` from DB `string` to `number | null`
+- tRPC error mapper already had period errors from previous PR; only REST + GraphQL mappers needed updates
+
+---
+
 ## 2026-02-21 — Submission Periods UI (Track 3)
 
 ### Done

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -378,6 +378,8 @@ async function main() {
         "api-keys:read",
         "payments:read",
         "audit:read",
+        "periods:read",
+        "periods:write",
       ],
     });
 


### PR DESCRIPTION
## Summary

- Add oRPC REST router for submission periods (5 endpoints: list, create, get, update, delete) with `periods:read`/`periods:write` scope enforcement
- Add Pothos GraphQL type (`SubmissionPeriodType`, `PeriodStatusEnum`) and resolvers (2 queries, 3 mutations) with paginated list support
- Update REST + GraphQL error mappers with `PeriodNotFoundError` and `PeriodHasSubmissionsError`
- Register periods router in REST `router.ts` with OpenAPI `Periods` tag, wire barrel exports in GraphQL types/resolvers indexes

Closes the API parity gap — submission periods are now available on all three surfaces (tRPC, REST, GraphQL), matching forms and submissions.

## Test plan

- [x] `pnpm type-check` passes (all packages)
- [x] `pnpm lint` passes (no new warnings)
- [x] `pnpm test` passes (663 tests, no regressions)
- [ ] Start dev server, verify `/v1/docs` shows Periods tag with 5 endpoints
- [ ] Verify `submissionPeriods` query and mutations appear in GraphQL Yoga playground
- [ ] Manual smoke: `curl` REST list/create/get, run a GraphQL query