### PR TITLE
fix(hopper): add idParamSchema validation to all GraphQL resolver ID args

### DIFF
--- a/apps/api/src/graphql/resolvers/audit.ts
+++ b/apps/api/src/graphql/resolvers/audit.ts
@@ -1,6 +1,7 @@
 import { GraphQLError } from 'graphql';
 import {
   listAuditEventsSchema,
+  idParamSchema,
   AuditActions,
   AuditResources,
 } from '@colophony/types';
@@ -133,7 +134,8 @@ builder.queryFields((t) => ({
     resolve: async (_root, args, ctx) => {
       const adminCtx = requireAdmin(ctx);
       await requireScopes(ctx, 'audit:read');
-      const event = await auditService.getById(adminCtx.dbTx, args.id);
+      const { id } = idParamSchema.parse({ id: args.id });
+      const event = await auditService.getById(adminCtx.dbTx, id);
       if (!event) {
         throw new GraphQLError('Audit event not found', {
           extensions: { code: 'NOT_FOUND' },

--- a/apps/api/src/graphql/resolvers/forms.spec.ts
+++ b/apps/api/src/graphql/resolvers/forms.spec.ts
@@ -434,6 +434,86 @@ describe('Form resolvers — wiring', () => {
     expect(result).toEqual(formField);
   });
 
+  it('formDefinition query validates id as UUID', async () => {
+    const field = getQueryField('formDefinition');
+    await expect(
+      field.resolve!({}, { id: 'not-a-uuid' }, makeCtx(), {} as never),
+    ).rejects.toThrow();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(formService.getById).not.toHaveBeenCalled();
+  });
+
+  it('addFormField validates formId as UUID', async () => {
+    const field = getMutationField('addFormField');
+    await expect(
+      field.resolve!(
+        {},
+        { formId: 'not-a-uuid', fieldKey: 'k', fieldType: 'text', label: 'L' },
+        makeCtx(),
+        {} as never,
+      ),
+    ).rejects.toThrow();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(formService.addFieldWithAudit).not.toHaveBeenCalled();
+  });
+
+  it('updateFormField validates formId and fieldId as UUID', async () => {
+    const field = getMutationField('updateFormField');
+    await expect(
+      field.resolve!(
+        {},
+        { formId: 'not-a-uuid', fieldId: FIELD_ID, label: 'X' },
+        makeCtx(),
+        {} as never,
+      ),
+    ).rejects.toThrow();
+    await expect(
+      field.resolve!(
+        {},
+        { formId: FORM_ID, fieldId: 'not-a-uuid', label: 'X' },
+        makeCtx(),
+        {} as never,
+      ),
+    ).rejects.toThrow();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(formService.updateFieldWithAudit).not.toHaveBeenCalled();
+  });
+
+  it('removeFormField validates formId and fieldId as UUID', async () => {
+    const field = getMutationField('removeFormField');
+    await expect(
+      field.resolve!(
+        {},
+        { formId: 'not-a-uuid', fieldId: FIELD_ID },
+        makeCtx(),
+        {} as never,
+      ),
+    ).rejects.toThrow();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(formService.removeFieldWithAudit).not.toHaveBeenCalled();
+  });
+
+  it('reorderFormFields validates formId as UUID', async () => {
+    const field = getMutationField('reorderFormFields');
+    await expect(
+      field.resolve!(
+        {},
+        { formId: 'not-a-uuid', fieldIds: [FIELD_ID] },
+        makeCtx(),
+        {} as never,
+      ),
+    ).rejects.toThrow();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(formService.reorderFieldsWithAudit).not.toHaveBeenCalled();
+  });
+
+  it('auditEvent query validates id as UUID', async () => {
+    const field = getQueryField('auditEvent');
+    await expect(
+      field.resolve!({}, { id: 'not-a-uuid' }, makeCtx(), {} as never),
+    ).rejects.toThrow();
+  });
+
   it('mapServiceError is called on service failure', async () => {
     const error = new Error('Service failed');
     // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/apps/api/src/graphql/resolvers/forms.ts
+++ b/apps/api/src/graphql/resolvers/forms.ts
@@ -97,9 +97,10 @@ builder.queryFields((t) => ({
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
       await requireScopes(ctx, 'forms:read');
+      const { id } = idParamSchema.parse({ id: args.id });
       try {
-        const form = await formService.getById(orgCtx.dbTx, args.id);
-        if (!form) throw new FormNotFoundError(args.id);
+        const form = await formService.getById(orgCtx.dbTx, id);
+        if (!form) throw new FormNotFoundError(id);
         return form;
       } catch (e) {
         mapServiceError(e);
@@ -313,10 +314,11 @@ builder.mutationFields((t) => ({
         sortOrder: args.sortOrder ?? undefined,
         config: (args.config as Record<string, unknown>) ?? undefined,
       });
+      const { id: formId } = idParamSchema.parse({ id: args.formId });
       try {
         return await formService.addFieldWithAudit(
           toServiceContext(orgCtx),
-          args.formId,
+          formId,
           input,
         );
       } catch (e) {
@@ -364,11 +366,13 @@ builder.mutationFields((t) => ({
         required: args.required ?? undefined,
         config: (args.config as Record<string, unknown>) ?? undefined,
       });
+      const { id: formId } = idParamSchema.parse({ id: args.formId });
+      const { id: fieldId } = idParamSchema.parse({ id: args.fieldId });
       try {
         return await formService.updateFieldWithAudit(
           toServiceContext(orgCtx),
-          args.formId,
-          args.fieldId,
+          formId,
+          fieldId,
           data,
         );
       } catch (e) {
@@ -391,11 +395,13 @@ builder.mutationFields((t) => ({
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
       await requireScopes(ctx, 'forms:write');
+      const { id: formId } = idParamSchema.parse({ id: args.formId });
+      const { id: fieldId } = idParamSchema.parse({ id: args.fieldId });
       try {
         return await formService.removeFieldWithAudit(
           toServiceContext(orgCtx),
-          args.formId,
-          args.fieldId,
+          formId,
+          fieldId,
         );
       } catch (e) {
         mapServiceError(e);
@@ -423,10 +429,11 @@ builder.mutationFields((t) => ({
       const input = reorderFormFieldsSchema.parse({
         fieldIds: args.fieldIds,
       });
+      const { id: formId } = idParamSchema.parse({ id: args.formId });
       try {
         return await formService.reorderFieldsWithAudit(
           toServiceContext(orgCtx),
-          args.formId,
+          formId,
           input,
         );
       } catch (e) {

--- a/apps/api/src/graphql/resolvers/submissions-mutations.spec.ts
+++ b/apps/api/src/graphql/resolvers/submissions-mutations.spec.ts
@@ -482,6 +482,31 @@ describe('Submission mutations — resolver wiring', () => {
     expect(result).toEqual(submission);
   });
 
+  it('submission query validates id as UUID', async () => {
+    const queryType = schema.getQueryType();
+    const field = queryType!.getFields()['submission'];
+    await expect(
+      field.resolve!({}, { id: 'not-a-uuid' }, makeCtx(), {} as never),
+    ).rejects.toThrow();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(submissionService.getByIdWithAccess).not.toHaveBeenCalled();
+  });
+
+  it('submissionHistory query validates submissionId as UUID', async () => {
+    const queryType = schema.getQueryType();
+    const field = queryType!.getFields()['submissionHistory'];
+    await expect(
+      field.resolve!(
+        {},
+        { submissionId: 'not-a-uuid' },
+        makeCtx(),
+        {} as never,
+      ),
+    ).rejects.toThrow();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(submissionService.getHistoryWithAccess).not.toHaveBeenCalled();
+  });
+
   it('updateSubmission passes formData to service', async () => {
     const submission = {
       id: 'sub-1',

--- a/apps/api/src/graphql/resolvers/submissions.ts
+++ b/apps/api/src/graphql/resolvers/submissions.ts
@@ -158,10 +158,11 @@ builder.queryFields((t) => ({
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
       await requireScopes(ctx, 'submissions:read');
+      const { id } = idParamSchema.parse({ id: args.id });
       try {
         return await submissionService.getByIdWithAccess(
           toServiceContext(orgCtx),
-          args.id,
+          id,
         );
       } catch (e) {
         mapServiceError(e);
@@ -184,10 +185,13 @@ builder.queryFields((t) => ({
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
       await requireScopes(ctx, 'submissions:read');
+      const { id: submissionId } = idParamSchema.parse({
+        id: args.submissionId,
+      });
       try {
         return await submissionService.getHistoryWithAccess(
           toServiceContext(orgCtx),
-          args.submissionId,
+          submissionId,
         );
       } catch (e) {
         mapServiceError(e);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -98,7 +98,7 @@
 - [x] Form renderer for submitters — render published forms in submission flow — (architecture doc Track 3, form-builder-research.md; done 2026-02-20)
 - [x] Form builder integration — wire validateFormData into submission create/update flow, formData persistence + validation on submit — (architecture doc Track 3, deferred from backend PR 2026-02-20; done 2026-02-20)
 - [x] Add `formDefinitionId` to `createSubmissionPeriodSchema` — done 2026-02-21 as part of submission periods UI PR
-- [ ] [P2] GraphQL forms resolver: add `idParamSchema` validation on raw string args passed to services — (Codex plan review 2026-02-20)
+- [x] [P2] GraphQL resolvers: add `idParamSchema` validation on all raw string ID args passed to services — forms (query + field mutations), submissions (query + history), audit (query) — (Codex plan review 2026-02-20; done 2026-02-21)
 - [ ] Conditional logic engine — (architecture doc Track 3, form-builder-research.md)
 - [ ] Embeddable forms (iframe) — (architecture doc Track 3, form-builder-research.md)
 - [x] Submission periods UI — schema exists, no UI — (DEVLOG 2026-02-15; done 2026-02-21)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,22 @@ Newest entries first.
 
 ---
 
+## 2026-02-21 — GraphQL ID Validation Fix (Track 3)
+
+### Done
+
+- Fixed 9 unvalidated ID usages across 3 GraphQL resolver files — `formDefinition` query, `addFormField`/`updateFormField`/`removeFormField`/`reorderFormFields` mutations (forms.ts), `submission`/`submissionHistory` queries (submissions.ts), `auditEvent` query (audit.ts)
+- All ID args now validated via `idParamSchema.parse()` before passing to service layer, matching the pattern already used by all mutation resolvers
+- Added 8 new unit tests verifying invalid UUIDs are rejected (671 total tests, all passing)
+- Marked [P2] backlog item complete
+
+### Decisions
+
+- Used `idParamSchema` with destructuring alias (e.g., `{ id: formId }`) for non-`id` named parameters rather than creating specialized schemas
+- Added audit resolver test to forms.spec.ts since it already had the required test infrastructure (schema import, guard mocks)
+
+---
+
 ## 2026-02-21 — Submission Periods API Parity (Track 3)
 
 ### Done


### PR DESCRIPTION
## Summary

- Added `idParamSchema.parse()` validation to 9 unvalidated ID usages across 3 GraphQL resolver files
- **forms.ts**: `formDefinition` query, `addFormField`/`updateFormField`/`removeFormField`/`reorderFormFields` mutations
- **submissions.ts**: `submission` query, `submissionHistory` query
- **audit.ts**: `auditEvent` query
- Added 8 new unit tests (671 total, all passing)

All mutation resolvers already had this validation — this closes the gap on query resolvers and form field operations.

## Test plan

- [x] All 671 API unit tests pass
- [x] Type-check passes
- [x] Lint passes (pre-push hooks)
- [x] Invalid UUIDs rejected before reaching service layer (verified by new tests)
- [x] branch review: LGTM, no issues found