### PR TITLE
feat(hopper): conditional logic engine for form fields

### DIFF
--- a/apps/api/src/graphql/resolvers/forms.ts
+++ b/apps/api/src/graphql/resolvers/forms.ts
@@ -7,6 +7,7 @@ import {
   updateFormFieldSchema,
   reorderFormFieldsSchema,
   idParamSchema,
+  type ConditionalRule,
 } from '@colophony/types';
 import { builder } from '../builder.js';
 import { requireOrgContext, requireScopes } from '../guards.js';
@@ -355,6 +356,11 @@ builder.mutationFields((t) => ({
         required: false,
         description: 'New configuration.',
       }),
+      conditionalRules: t.arg({
+        type: 'JSON',
+        required: false,
+        description: 'Conditional display rules.',
+      }),
     },
     resolve: async (_root, args, ctx) => {
       const orgCtx = requireOrgContext(ctx);
@@ -365,6 +371,8 @@ builder.mutationFields((t) => ({
         placeholder: args.placeholder ?? undefined,
         required: args.required ?? undefined,
         config: (args.config as Record<string, unknown>) ?? undefined,
+        conditionalRules:
+          (args.conditionalRules as ConditionalRule[] | null) ?? undefined,
       });
       const { id: formId } = idParamSchema.parse({ id: args.formId });
       const { id: fieldId } = idParamSchema.parse({ id: args.fieldId });

--- a/apps/api/src/graphql/resolvers/forms.ts
+++ b/apps/api/src/graphql/resolvers/forms.ts
@@ -372,7 +372,9 @@ builder.mutationFields((t) => ({
         required: args.required ?? undefined,
         config: (args.config as Record<string, unknown>) ?? undefined,
         conditionalRules:
-          (args.conditionalRules as ConditionalRule[] | null) ?? undefined,
+          args.conditionalRules !== undefined
+            ? (args.conditionalRules as ConditionalRule[] | null)
+            : undefined,
       });
       const { id: formId } = idParamSchema.parse({ id: args.formId });
       const { id: fieldId } = idParamSchema.parse({ id: args.fieldId });

--- a/apps/api/src/services/conditional-rules.spec.ts
+++ b/apps/api/src/services/conditional-rules.spec.ts
@@ -1,0 +1,446 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateCondition,
+  evaluateFieldVisibility,
+  getFieldDependencies,
+  type RuleCondition,
+  type ConditionalRule,
+} from '@colophony/types';
+
+// ---------------------------------------------------------------------------
+// evaluateCondition
+// ---------------------------------------------------------------------------
+
+describe('evaluateCondition', () => {
+  describe('AND operator', () => {
+    it('returns true when all conditions are true', () => {
+      const condition: RuleCondition = {
+        operator: 'AND',
+        rules: [
+          { field: 'category', comparator: 'eq', value: 'fiction' },
+          { field: 'length', comparator: 'gt', value: 100 },
+        ],
+      };
+      expect(
+        evaluateCondition(condition, { category: 'fiction', length: 200 }),
+      ).toBe(true);
+    });
+
+    it('returns false when one condition is false', () => {
+      const condition: RuleCondition = {
+        operator: 'AND',
+        rules: [
+          { field: 'category', comparator: 'eq', value: 'fiction' },
+          { field: 'length', comparator: 'gt', value: 100 },
+        ],
+      };
+      expect(
+        evaluateCondition(condition, { category: 'fiction', length: 50 }),
+      ).toBe(false);
+    });
+  });
+
+  describe('OR operator', () => {
+    it('returns true when one condition is true', () => {
+      const condition: RuleCondition = {
+        operator: 'OR',
+        rules: [
+          { field: 'category', comparator: 'eq', value: 'fiction' },
+          { field: 'category', comparator: 'eq', value: 'poetry' },
+        ],
+      };
+      expect(evaluateCondition(condition, { category: 'poetry' })).toBe(true);
+    });
+
+    it('returns false when all conditions are false', () => {
+      const condition: RuleCondition = {
+        operator: 'OR',
+        rules: [
+          { field: 'category', comparator: 'eq', value: 'fiction' },
+          { field: 'category', comparator: 'eq', value: 'poetry' },
+        ],
+      };
+      expect(evaluateCondition(condition, { category: 'nonfiction' })).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('comparators', () => {
+    it('eq — matches equal strings', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'eq', value: 'hello' }],
+      };
+      expect(evaluateCondition(cond, { x: 'hello' })).toBe(true);
+      expect(evaluateCondition(cond, { x: 'world' })).toBe(false);
+    });
+
+    it('neq — matches unequal strings', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'neq', value: 'hello' }],
+      };
+      expect(evaluateCondition(cond, { x: 'world' })).toBe(true);
+      expect(evaluateCondition(cond, { x: 'hello' })).toBe(false);
+    });
+
+    it('gt — numeric greater than', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'gt', value: 10 }],
+      };
+      expect(evaluateCondition(cond, { x: 15 })).toBe(true);
+      expect(evaluateCondition(cond, { x: 10 })).toBe(false);
+      expect(evaluateCondition(cond, { x: 5 })).toBe(false);
+    });
+
+    it('lt — numeric less than', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'lt', value: 10 }],
+      };
+      expect(evaluateCondition(cond, { x: 5 })).toBe(true);
+      expect(evaluateCondition(cond, { x: 10 })).toBe(false);
+    });
+
+    it('gte — numeric greater than or equal', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'gte', value: 10 }],
+      };
+      expect(evaluateCondition(cond, { x: 10 })).toBe(true);
+      expect(evaluateCondition(cond, { x: 9 })).toBe(false);
+    });
+
+    it('lte — numeric less than or equal', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'lte', value: 10 }],
+      };
+      expect(evaluateCondition(cond, { x: 10 })).toBe(true);
+      expect(evaluateCondition(cond, { x: 11 })).toBe(false);
+    });
+
+    it('contains — substring match', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'contains', value: 'ello' }],
+      };
+      expect(evaluateCondition(cond, { x: 'hello world' })).toBe(true);
+      expect(evaluateCondition(cond, { x: 'goodbye' })).toBe(false);
+    });
+
+    it('not_contains — no substring match', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'not_contains', value: 'ello' }],
+      };
+      expect(evaluateCondition(cond, { x: 'goodbye' })).toBe(true);
+      expect(evaluateCondition(cond, { x: 'hello' })).toBe(false);
+    });
+
+    it('starts_with — prefix match', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'starts_with', value: 'hel' }],
+      };
+      expect(evaluateCondition(cond, { x: 'hello' })).toBe(true);
+      expect(evaluateCondition(cond, { x: 'world' })).toBe(false);
+    });
+
+    it('ends_with — suffix match', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'ends_with', value: 'rld' }],
+      };
+      expect(evaluateCondition(cond, { x: 'world' })).toBe(true);
+      expect(evaluateCondition(cond, { x: 'hello' })).toBe(false);
+    });
+
+    it('is_empty — empty values', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'is_empty' }],
+      };
+      expect(evaluateCondition(cond, { x: '' })).toBe(true);
+      expect(evaluateCondition(cond, { x: undefined })).toBe(true);
+      expect(evaluateCondition(cond, {})).toBe(true);
+      expect(evaluateCondition(cond, { x: null })).toBe(true);
+      expect(evaluateCondition(cond, { x: [] })).toBe(true);
+      expect(evaluateCondition(cond, { x: 'hi' })).toBe(false);
+    });
+
+    it('is_not_empty — non-empty values', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'is_not_empty' }],
+      };
+      expect(evaluateCondition(cond, { x: 'hello' })).toBe(true);
+      expect(evaluateCondition(cond, { x: '' })).toBe(false);
+      expect(evaluateCondition(cond, {})).toBe(false);
+    });
+
+    it('in — value in array', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'in', value: ['a', 'b', 'c'] }],
+      };
+      expect(evaluateCondition(cond, { x: 'b' })).toBe(true);
+      expect(evaluateCondition(cond, { x: 'd' })).toBe(false);
+    });
+
+    it('not_in — value not in array', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'not_in', value: ['a', 'b', 'c'] }],
+      };
+      expect(evaluateCondition(cond, { x: 'd' })).toBe(true);
+      expect(evaluateCondition(cond, { x: 'a' })).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles undefined field value gracefully', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'missing', comparator: 'eq', value: 'test' }],
+      };
+      expect(evaluateCondition(cond, {})).toBe(false);
+    });
+
+    it('handles null field value', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'is_empty' }],
+      };
+      expect(evaluateCondition(cond, { x: null })).toBe(true);
+    });
+
+    it('handles numeric comparison with string values', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'gt', value: 5 }],
+      };
+      expect(evaluateCondition(cond, { x: '10' })).toBe(true);
+      expect(evaluateCondition(cond, { x: '3' })).toBe(false);
+    });
+
+    it('handles eq with boolean value', () => {
+      const cond: RuleCondition = {
+        operator: 'AND',
+        rules: [{ field: 'x', comparator: 'eq', value: 'true' }],
+      };
+      expect(evaluateCondition(cond, { x: true })).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateFieldVisibility
+// ---------------------------------------------------------------------------
+
+describe('evaluateFieldVisibility', () => {
+  it('returns visible=true, required=false with no rules', () => {
+    expect(evaluateFieldVisibility(null, {})).toEqual({
+      visible: true,
+      required: false,
+    });
+    expect(evaluateFieldVisibility([], {})).toEqual({
+      visible: true,
+      required: false,
+    });
+    expect(evaluateFieldVisibility(undefined, {})).toEqual({
+      visible: true,
+      required: false,
+    });
+  });
+
+  it('SHOW rule — visible when condition is true', () => {
+    const rules: ConditionalRule[] = [
+      {
+        effect: 'SHOW',
+        condition: {
+          operator: 'AND',
+          rules: [{ field: 'category', comparator: 'eq', value: 'fiction' }],
+        },
+      },
+    ];
+    expect(evaluateFieldVisibility(rules, { category: 'fiction' })).toEqual({
+      visible: true,
+      required: false,
+    });
+  });
+
+  it('SHOW rule — hidden when condition is false', () => {
+    const rules: ConditionalRule[] = [
+      {
+        effect: 'SHOW',
+        condition: {
+          operator: 'AND',
+          rules: [{ field: 'category', comparator: 'eq', value: 'fiction' }],
+        },
+      },
+    ];
+    expect(evaluateFieldVisibility(rules, { category: 'poetry' })).toEqual({
+      visible: false,
+      required: false,
+    });
+  });
+
+  it('HIDE rule — hidden when condition is true', () => {
+    const rules: ConditionalRule[] = [
+      {
+        effect: 'HIDE',
+        condition: {
+          operator: 'AND',
+          rules: [{ field: 'category', comparator: 'eq', value: 'poetry' }],
+        },
+      },
+    ];
+    expect(evaluateFieldVisibility(rules, { category: 'poetry' })).toEqual({
+      visible: false,
+      required: false,
+    });
+  });
+
+  it('HIDE rule — visible when condition is false', () => {
+    const rules: ConditionalRule[] = [
+      {
+        effect: 'HIDE',
+        condition: {
+          operator: 'AND',
+          rules: [{ field: 'category', comparator: 'eq', value: 'poetry' }],
+        },
+      },
+    ];
+    expect(evaluateFieldVisibility(rules, { category: 'fiction' })).toEqual({
+      visible: true,
+      required: false,
+    });
+  });
+
+  it('REQUIRE rule — required when condition is true', () => {
+    const rules: ConditionalRule[] = [
+      {
+        effect: 'REQUIRE',
+        condition: {
+          operator: 'AND',
+          rules: [{ field: 'category', comparator: 'eq', value: 'fiction' }],
+        },
+      },
+    ];
+    expect(evaluateFieldVisibility(rules, { category: 'fiction' })).toEqual({
+      visible: true,
+      required: true,
+    });
+  });
+
+  it('REQUIRE rule — not required when condition is false', () => {
+    const rules: ConditionalRule[] = [
+      {
+        effect: 'REQUIRE',
+        condition: {
+          operator: 'AND',
+          rules: [{ field: 'category', comparator: 'eq', value: 'fiction' }],
+        },
+      },
+    ];
+    expect(evaluateFieldVisibility(rules, { category: 'poetry' })).toEqual({
+      visible: true,
+      required: false,
+    });
+  });
+
+  it('mixed SHOW + REQUIRE rules', () => {
+    const rules: ConditionalRule[] = [
+      {
+        effect: 'SHOW',
+        condition: {
+          operator: 'AND',
+          rules: [{ field: 'category', comparator: 'eq', value: 'fiction' }],
+        },
+      },
+      {
+        effect: 'REQUIRE',
+        condition: {
+          operator: 'AND',
+          rules: [{ field: 'category', comparator: 'eq', value: 'fiction' }],
+        },
+      },
+    ];
+    // Both conditions met
+    expect(evaluateFieldVisibility(rules, { category: 'fiction' })).toEqual({
+      visible: true,
+      required: true,
+    });
+
+    // SHOW condition not met → hidden, REQUIRE overridden by hidden
+    expect(evaluateFieldVisibility(rules, { category: 'poetry' })).toEqual({
+      visible: false,
+      required: false,
+    });
+  });
+
+  it('multiple SHOW/HIDE rules — last wins', () => {
+    const rules: ConditionalRule[] = [
+      {
+        effect: 'SHOW',
+        condition: {
+          operator: 'AND',
+          rules: [{ field: 'a', comparator: 'eq', value: 'yes' }],
+        },
+      },
+      {
+        effect: 'HIDE',
+        condition: {
+          operator: 'AND',
+          rules: [{ field: 'b', comparator: 'eq', value: 'yes' }],
+        },
+      },
+    ];
+    // SHOW passes (a=yes), then HIDE also passes (b=yes) → hidden (last wins)
+    expect(evaluateFieldVisibility(rules, { a: 'yes', b: 'yes' })).toEqual({
+      visible: false,
+      required: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFieldDependencies
+// ---------------------------------------------------------------------------
+
+describe('getFieldDependencies', () => {
+  it('returns empty array for null/undefined/empty rules', () => {
+    expect(getFieldDependencies(null)).toEqual([]);
+    expect(getFieldDependencies(undefined)).toEqual([]);
+    expect(getFieldDependencies([])).toEqual([]);
+  });
+
+  it('extracts unique fieldKeys from rules', () => {
+    const rules: ConditionalRule[] = [
+      {
+        effect: 'SHOW',
+        condition: {
+          operator: 'AND',
+          rules: [
+            { field: 'category', comparator: 'eq', value: 'fiction' },
+            { field: 'category', comparator: 'neq', value: 'poetry' },
+          ],
+        },
+      },
+      {
+        effect: 'REQUIRE',
+        condition: {
+          operator: 'OR',
+          rules: [{ field: 'status', comparator: 'eq', value: 'active' }],
+        },
+      },
+    ];
+    const deps = getFieldDependencies(rules);
+    expect(deps).toHaveLength(2);
+    expect(deps).toContain('category');
+    expect(deps).toContain('status');
+  });
+});

--- a/apps/api/src/services/form.service.spec.ts
+++ b/apps/api/src/services/form.service.spec.ts
@@ -150,6 +150,154 @@ describe('formService.validateFormData', () => {
     expect(errors).toEqual([]);
   });
 
+  // -------------------------------------------------------------------------
+  // Conditional logic tests
+  // -------------------------------------------------------------------------
+
+  it('skips validation for hidden field', async () => {
+    const form = makeFormWithFields([
+      {
+        fieldKey: 'category',
+        fieldType: 'select',
+        label: 'Category',
+        required: false,
+      },
+      {
+        fieldKey: 'genre',
+        fieldType: 'text',
+        label: 'Genre',
+        required: true,
+        conditionalRules: [
+          {
+            effect: 'SHOW',
+            condition: {
+              operator: 'AND',
+              rules: [
+                { field: 'category', comparator: 'eq', value: 'fiction' },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    // Category is "poetry" → genre is hidden → no required error
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      category: 'poetry',
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it('validates visible field normally', async () => {
+    const form = makeFormWithFields([
+      {
+        fieldKey: 'category',
+        fieldType: 'select',
+        label: 'Category',
+        required: false,
+      },
+      {
+        fieldKey: 'genre',
+        fieldType: 'text',
+        label: 'Genre',
+        required: true,
+        conditionalRules: [
+          {
+            effect: 'SHOW',
+            condition: {
+              operator: 'AND',
+              rules: [
+                { field: 'category', comparator: 'eq', value: 'fiction' },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    // Category is "fiction" → genre is visible and required → error
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      category: 'fiction',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].fieldKey).toBe('genre');
+    expect(errors[0].message).toContain('required');
+  });
+
+  it('enforces conditional REQUIRE', async () => {
+    const form = makeFormWithFields([
+      {
+        fieldKey: 'category',
+        fieldType: 'select',
+        label: 'Category',
+        required: false,
+      },
+      {
+        fieldKey: 'genre',
+        fieldType: 'text',
+        label: 'Genre',
+        required: false, // not statically required
+        conditionalRules: [
+          {
+            effect: 'REQUIRE',
+            condition: {
+              operator: 'AND',
+              rules: [
+                { field: 'category', comparator: 'eq', value: 'fiction' },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    // Category is "fiction" → genre is conditionally required → error
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      category: 'fiction',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].fieldKey).toBe('genre');
+    expect(errors[0].message).toContain('required');
+  });
+
+  it('does not enforce REQUIRE when condition is false', async () => {
+    const form = makeFormWithFields([
+      {
+        fieldKey: 'category',
+        fieldType: 'select',
+        label: 'Category',
+        required: false,
+      },
+      {
+        fieldKey: 'genre',
+        fieldType: 'text',
+        label: 'Genre',
+        required: false,
+        conditionalRules: [
+          {
+            effect: 'REQUIRE',
+            condition: {
+              operator: 'AND',
+              rules: [
+                { field: 'category', comparator: 'eq', value: 'fiction' },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+    vi.spyOn(formService, 'getById').mockResolvedValueOnce(form);
+
+    // Category is "poetry" → REQUIRE not triggered → no error
+    const errors = await formService.validateFormData(mockTx, 'form-1', {
+      category: 'poetry',
+    });
+    expect(errors).toEqual([]);
+  });
+
   it('validates multiple fields at once', async () => {
     const form = makeFormWithFields([
       {

--- a/apps/api/src/services/form.service.ts
+++ b/apps/api/src/services/form.service.ts
@@ -22,6 +22,7 @@ import {
   AuditActions,
   AuditResources,
   PRESENTATIONAL_FIELD_TYPES,
+  evaluateFieldVisibility,
 } from '@colophony/types';
 import type { ServiceContext } from './types.js';
 import { assertEditorOrAdmin } from './errors.js';
@@ -510,6 +511,9 @@ export const formService = {
           : {}),
         ...(input.required !== undefined ? { required: input.required } : {}),
         ...(input.config !== undefined ? { config: input.config } : {}),
+        ...(input.conditionalRules !== undefined
+          ? { conditionalRules: input.conditionalRules }
+          : {}),
         updatedAt: new Date(),
       })
       .where(eq(formFields.id, fieldId))
@@ -647,11 +651,19 @@ export const formService = {
         continue;
       }
 
+      // Evaluate conditional visibility
+      const { visible, required: conditionallyRequired } =
+        evaluateFieldVisibility(field.conditionalRules, data);
+
+      // Skip hidden fields entirely — no validation
+      if (!visible) continue;
+
+      const isRequired = field.required || conditionallyRequired;
       const value = data[field.fieldKey];
 
       // Required check
       if (
-        field.required &&
+        isRequired &&
         (value === undefined || value === null || value === '')
       ) {
         errors.push({

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.0.0",

--- a/apps/web/src/components/form-builder/__tests__/field-properties-panel.spec.tsx
+++ b/apps/web/src/components/form-builder/__tests__/field-properties-panel.spec.tsx
@@ -18,12 +18,17 @@ const baseField = {
   updatedAt: new Date(),
 };
 
+const allFields = [
+  { fieldKey: "title", fieldType: "text", label: "Title", config: null },
+];
+
 describe("FieldPropertiesPanel", () => {
   it("renders common fields for any field type", () => {
     const onUpdate = jest.fn();
     render(
       <FieldPropertiesPanel
         field={baseField}
+        allFields={allFields}
         onUpdate={onUpdate}
         isSaving={false}
       />,
@@ -41,6 +46,7 @@ describe("FieldPropertiesPanel", () => {
     render(
       <FieldPropertiesPanel
         field={baseField}
+        allFields={allFields}
         onUpdate={onUpdate}
         isSaving={false}
       />,
@@ -61,6 +67,7 @@ describe("FieldPropertiesPanel", () => {
     render(
       <FieldPropertiesPanel
         field={numberField}
+        allFields={allFields}
         onUpdate={onUpdate}
         isSaving={false}
       />,
@@ -86,6 +93,7 @@ describe("FieldPropertiesPanel", () => {
     render(
       <FieldPropertiesPanel
         field={selectField}
+        allFields={allFields}
         onUpdate={onUpdate}
         isSaving={false}
       />,
@@ -106,6 +114,7 @@ describe("FieldPropertiesPanel", () => {
     render(
       <FieldPropertiesPanel
         field={fileField}
+        allFields={allFields}
         onUpdate={onUpdate}
         isSaving={false}
       />,
@@ -121,6 +130,7 @@ describe("FieldPropertiesPanel", () => {
     render(
       <FieldPropertiesPanel
         field={baseField}
+        allFields={allFields}
         onUpdate={jest.fn()}
         isSaving={true}
       />,
@@ -136,6 +146,7 @@ describe("FieldPropertiesPanel", () => {
     render(
       <FieldPropertiesPanel
         field={baseField}
+        allFields={allFields}
         onUpdate={jest.fn()}
         isSaving={false}
       />,
@@ -153,6 +164,7 @@ describe("FieldPropertiesPanel", () => {
     render(
       <FieldPropertiesPanel
         field={headerField}
+        allFields={allFields}
         onUpdate={jest.fn()}
         isSaving={false}
       />,

--- a/apps/web/src/components/form-builder/field-config/conditional-rules-config.tsx
+++ b/apps/web/src/components/form-builder/field-config/conditional-rules-config.tsx
@@ -1,0 +1,606 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Badge } from "@/components/ui/badge";
+import { Plus, Trash2, X } from "lucide-react";
+import type {
+  ConditionalRule,
+  RuleEffect,
+  RuleComparator,
+  SingleCondition,
+} from "@colophony/types";
+import { PRESENTATIONAL_FIELD_TYPES } from "@colophony/types";
+
+// ---------------------------------------------------------------------------
+// Comparator filtering by field type
+// ---------------------------------------------------------------------------
+
+const COMPARATORS_BY_TYPE: Record<string, RuleComparator[]> = {
+  text: [
+    "eq",
+    "neq",
+    "contains",
+    "not_contains",
+    "starts_with",
+    "ends_with",
+    "is_empty",
+    "is_not_empty",
+  ],
+  textarea: [
+    "eq",
+    "neq",
+    "contains",
+    "not_contains",
+    "starts_with",
+    "ends_with",
+    "is_empty",
+    "is_not_empty",
+  ],
+  rich_text: [
+    "eq",
+    "neq",
+    "contains",
+    "not_contains",
+    "starts_with",
+    "ends_with",
+    "is_empty",
+    "is_not_empty",
+  ],
+  email: [
+    "eq",
+    "neq",
+    "contains",
+    "not_contains",
+    "starts_with",
+    "ends_with",
+    "is_empty",
+    "is_not_empty",
+  ],
+  url: [
+    "eq",
+    "neq",
+    "contains",
+    "not_contains",
+    "starts_with",
+    "ends_with",
+    "is_empty",
+    "is_not_empty",
+  ],
+  number: ["eq", "neq", "gt", "lt", "gte", "lte", "is_empty", "is_not_empty"],
+  select: ["eq", "neq", "in", "not_in", "is_empty", "is_not_empty"],
+  radio: ["eq", "neq", "in", "not_in", "is_empty", "is_not_empty"],
+  multi_select: ["contains", "not_contains", "is_empty", "is_not_empty"],
+  checkbox_group: ["contains", "not_contains", "is_empty", "is_not_empty"],
+  checkbox: ["eq"],
+  date: ["eq", "neq", "gt", "lt", "gte", "lte", "is_empty", "is_not_empty"],
+};
+
+const COMPARATOR_LABELS: Record<RuleComparator, string> = {
+  eq: "equals",
+  neq: "not equals",
+  gt: "greater than",
+  lt: "less than",
+  gte: "at least",
+  lte: "at most",
+  contains: "contains",
+  not_contains: "does not contain",
+  starts_with: "starts with",
+  ends_with: "ends with",
+  is_empty: "is empty",
+  is_not_empty: "is not empty",
+  in: "is one of",
+  not_in: "is not one of",
+};
+
+const EFFECT_LABELS: Record<RuleEffect, string> = {
+  SHOW: "Show",
+  HIDE: "Hide",
+  REQUIRE: "Require",
+};
+
+const UNARY_COMPARATORS: RuleComparator[] = ["is_empty", "is_not_empty"];
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface FieldInfo {
+  fieldKey: string;
+  fieldType: string;
+  label: string;
+  config: Record<string, unknown> | null;
+}
+
+interface ConditionalRulesConfigProps {
+  rules: ConditionalRule[] | null;
+  onChange: (rules: ConditionalRule[] | null) => void;
+  fields: FieldInfo[];
+  currentFieldKey: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getComparators(fieldType: string): RuleComparator[] {
+  return COMPARATORS_BY_TYPE[fieldType] ?? COMPARATORS_BY_TYPE.text;
+}
+
+function getFieldOptions(
+  field: FieldInfo,
+): Array<{ label: string; value: string }> | null {
+  const config = field.config as Record<string, unknown> | null;
+  const options = config?.options as
+    | Array<{ label: string; value: string }>
+    | undefined;
+  if (options && options.length > 0) return options;
+  return null;
+}
+
+function makeEmptyCondition(availableFields: FieldInfo[]): SingleCondition {
+  const firstField = availableFields[0];
+  return {
+    field: firstField?.fieldKey ?? "",
+    comparator: "eq",
+    value: "",
+  };
+}
+
+function makeEmptyRule(availableFields: FieldInfo[]): ConditionalRule {
+  return {
+    effect: "SHOW",
+    condition: {
+      operator: "AND",
+      rules: [makeEmptyCondition(availableFields)],
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ConditionalRulesConfig({
+  rules,
+  onChange,
+  fields,
+  currentFieldKey,
+}: ConditionalRulesConfigProps) {
+  const [enabled, setEnabled] = useState(rules !== null && rules.length > 0);
+
+  const availableFields = fields.filter(
+    (f) =>
+      f.fieldKey !== currentFieldKey &&
+      !PRESENTATIONAL_FIELD_TYPES.includes(
+        f.fieldType as (typeof PRESENTATIONAL_FIELD_TYPES)[number],
+      ),
+  );
+
+  function handleToggle(checked: boolean) {
+    setEnabled(checked);
+    if (checked) {
+      if (!rules || rules.length === 0) {
+        onChange([makeEmptyRule(availableFields)]);
+      }
+    } else {
+      onChange(null);
+    }
+  }
+
+  function updateRule(index: number, updatedRule: ConditionalRule) {
+    const newRules = [...(rules ?? [])];
+    newRules[index] = updatedRule;
+    onChange(newRules);
+  }
+
+  function addRule() {
+    onChange([...(rules ?? []), makeEmptyRule(availableFields)]);
+  }
+
+  function removeRule(index: number) {
+    const newRules = (rules ?? []).filter((_, i) => i !== index);
+    if (newRules.length === 0) {
+      setEnabled(false);
+      onChange(null);
+    } else {
+      onChange(newRules);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <Label className="text-xs">Conditional Logic</Label>
+        <Switch
+          checked={enabled}
+          onCheckedChange={handleToggle}
+          disabled={availableFields.length === 0}
+        />
+      </div>
+
+      {availableFields.length === 0 && (
+        <p className="text-xs text-muted-foreground">
+          Add more fields to the form to use conditional logic.
+        </p>
+      )}
+
+      {enabled && rules && rules.length > 0 && (
+        <div className="space-y-3">
+          {rules.map((rule, ruleIdx) => (
+            <RuleEditor
+              key={ruleIdx}
+              rule={rule}
+              availableFields={availableFields}
+              onUpdate={(updated) => updateRule(ruleIdx, updated)}
+              onRemove={() => removeRule(ruleIdx)}
+              canRemove={rules.length > 1}
+            />
+          ))}
+
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={addRule}
+          >
+            <Plus className="mr-1 h-3 w-3" />
+            Add Rule
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rule editor
+// ---------------------------------------------------------------------------
+
+function RuleEditor({
+  rule,
+  availableFields,
+  onUpdate,
+  onRemove,
+  canRemove,
+}: {
+  rule: ConditionalRule;
+  availableFields: FieldInfo[];
+  onUpdate: (rule: ConditionalRule) => void;
+  onRemove: () => void;
+  canRemove: boolean;
+}) {
+  function updateEffect(effect: RuleEffect) {
+    onUpdate({ ...rule, effect });
+  }
+
+  function updateOperator(operator: "AND" | "OR") {
+    onUpdate({
+      ...rule,
+      condition: { ...rule.condition, operator },
+    });
+  }
+
+  function updateCondition(index: number, condition: SingleCondition) {
+    const newRules = [...rule.condition.rules];
+    newRules[index] = condition;
+    onUpdate({
+      ...rule,
+      condition: { ...rule.condition, rules: newRules },
+    });
+  }
+
+  function addCondition() {
+    onUpdate({
+      ...rule,
+      condition: {
+        ...rule.condition,
+        rules: [...rule.condition.rules, makeEmptyCondition(availableFields)],
+      },
+    });
+  }
+
+  function removeCondition(index: number) {
+    const newRules = rule.condition.rules.filter((_, i) => i !== index);
+    if (newRules.length === 0) return; // must have at least 1
+    onUpdate({
+      ...rule,
+      condition: { ...rule.condition, rules: newRules },
+    });
+  }
+
+  return (
+    <div className="rounded-lg border p-3 space-y-2">
+      <div className="flex items-center gap-2">
+        <Select
+          value={rule.effect}
+          onValueChange={(v) => updateEffect(v as RuleEffect)}
+        >
+          <SelectTrigger className="w-24 h-7 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {(["SHOW", "HIDE", "REQUIRE"] as RuleEffect[]).map((e) => (
+              <SelectItem key={e} value={e}>
+                {EFFECT_LABELS[e]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <span className="text-xs text-muted-foreground">this field when:</span>
+        <div className="flex-1" />
+        {canRemove && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0"
+            onClick={onRemove}
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        )}
+      </div>
+
+      {rule.condition.rules.map((cond, condIdx) => (
+        <div key={condIdx}>
+          {condIdx > 0 && (
+            <div className="flex items-center gap-2 py-1">
+              <Separator className="flex-1" />
+              <button
+                type="button"
+                className="text-[10px] font-medium px-1.5 py-0.5 rounded-sm hover:bg-muted"
+                onClick={() =>
+                  updateOperator(
+                    rule.condition.operator === "AND" ? "OR" : "AND",
+                  )
+                }
+              >
+                <Badge variant="secondary" className="text-[10px]">
+                  {rule.condition.operator}
+                </Badge>
+              </button>
+              <Separator className="flex-1" />
+            </div>
+          )}
+          <ConditionEditor
+            condition={cond}
+            availableFields={availableFields}
+            onUpdate={(updated) => updateCondition(condIdx, updated)}
+            onRemove={() => removeCondition(condIdx)}
+            canRemove={rule.condition.rules.length > 1}
+          />
+        </div>
+      ))}
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="text-xs h-6"
+        onClick={addCondition}
+      >
+        <Plus className="mr-1 h-3 w-3" />
+        Add condition
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Condition editor
+// ---------------------------------------------------------------------------
+
+function ConditionEditor({
+  condition,
+  availableFields,
+  onUpdate,
+  onRemove,
+  canRemove,
+}: {
+  condition: SingleCondition;
+  availableFields: FieldInfo[];
+  onUpdate: (condition: SingleCondition) => void;
+  onRemove: () => void;
+  canRemove: boolean;
+}) {
+  const selectedField = availableFields.find(
+    (f) => f.fieldKey === condition.field,
+  );
+  const fieldType = selectedField?.fieldType ?? "text";
+  const comparators = getComparators(fieldType);
+  const isUnary = UNARY_COMPARATORS.includes(condition.comparator);
+  const fieldOptions = selectedField ? getFieldOptions(selectedField) : null;
+  const isSelectComparator =
+    condition.comparator === "in" || condition.comparator === "not_in";
+
+  function handleFieldChange(fieldKey: string) {
+    const newField = availableFields.find((f) => f.fieldKey === fieldKey);
+    const newType = newField?.fieldType ?? "text";
+    const newComparators = getComparators(newType);
+    const comparator = newComparators.includes(condition.comparator)
+      ? condition.comparator
+      : newComparators[0];
+    onUpdate({
+      field: fieldKey,
+      comparator,
+      value: UNARY_COMPARATORS.includes(comparator) ? undefined : "",
+    });
+  }
+
+  function handleComparatorChange(comparator: RuleComparator) {
+    if (UNARY_COMPARATORS.includes(comparator)) {
+      onUpdate({ ...condition, comparator, value: undefined });
+    } else if (comparator === "in" || comparator === "not_in") {
+      onUpdate({
+        ...condition,
+        comparator,
+        value: Array.isArray(condition.value) ? condition.value : [],
+      });
+    } else {
+      onUpdate({
+        ...condition,
+        comparator,
+        value: typeof condition.value === "string" ? condition.value : "",
+      });
+    }
+  }
+
+  return (
+    <div className="flex items-start gap-1.5">
+      {/* Field selector */}
+      <Select value={condition.field} onValueChange={handleFieldChange}>
+        <SelectTrigger className="w-28 h-7 text-xs">
+          <SelectValue placeholder="Field" />
+        </SelectTrigger>
+        <SelectContent>
+          {availableFields.map((f) => (
+            <SelectItem key={f.fieldKey} value={f.fieldKey}>
+              {f.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {/* Comparator selector */}
+      <Select
+        value={condition.comparator}
+        onValueChange={(v) => handleComparatorChange(v as RuleComparator)}
+      >
+        <SelectTrigger className="w-28 h-7 text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {comparators.map((c) => (
+            <SelectItem key={c} value={c}>
+              {COMPARATOR_LABELS[c]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {/* Value input */}
+      {!isUnary && (
+        <>
+          {fieldType === "checkbox" ? (
+            <Select
+              value={String(condition.value ?? "true")}
+              onValueChange={(v) => onUpdate({ ...condition, value: v })}
+            >
+              <SelectTrigger className="w-20 h-7 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="true">Yes</SelectItem>
+                <SelectItem value="false">No</SelectItem>
+              </SelectContent>
+            </Select>
+          ) : isSelectComparator && fieldOptions ? (
+            <MultiValueSelect
+              options={fieldOptions}
+              value={Array.isArray(condition.value) ? condition.value : []}
+              onChange={(vals) => onUpdate({ ...condition, value: vals })}
+            />
+          ) : fieldOptions &&
+            (condition.comparator === "eq" ||
+              condition.comparator === "neq") ? (
+            <Select
+              value={String(condition.value ?? "")}
+              onValueChange={(v) => onUpdate({ ...condition, value: v })}
+            >
+              <SelectTrigger className="flex-1 h-7 text-xs">
+                <SelectValue placeholder="Value" />
+              </SelectTrigger>
+              <SelectContent>
+                {fieldOptions.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <Input
+              type={fieldType === "number" ? "number" : "text"}
+              className="flex-1 h-7 text-xs"
+              placeholder="Value"
+              value={String(condition.value ?? "")}
+              onChange={(e) =>
+                onUpdate({
+                  ...condition,
+                  value:
+                    fieldType === "number"
+                      ? e.target.value
+                        ? Number(e.target.value)
+                        : ""
+                      : e.target.value,
+                })
+              }
+            />
+          )}
+        </>
+      )}
+
+      {canRemove && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0 shrink-0"
+          onClick={onRemove}
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Multi-value select (for in/not_in comparators)
+// ---------------------------------------------------------------------------
+
+function MultiValueSelect({
+  options,
+  value,
+  onChange,
+}: {
+  options: Array<{ label: string; value: string }>;
+  value: string[];
+  onChange: (value: string[]) => void;
+}) {
+  function toggle(optValue: string) {
+    if (value.includes(optValue)) {
+      onChange(value.filter((v) => v !== optValue));
+    } else {
+      onChange([...value, optValue]);
+    }
+  }
+
+  return (
+    <div className="flex-1 flex flex-wrap gap-1">
+      {options.map((opt) => (
+        <Badge
+          key={opt.value}
+          variant={value.includes(opt.value) ? "default" : "outline"}
+          className="cursor-pointer text-[10px] py-0"
+          onClick={() => toggle(opt.value)}
+        >
+          {opt.label}
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/form-builder/field-config/conditional-rules-config.tsx
+++ b/apps/web/src/components/form-builder/field-config/conditional-rules-config.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -178,7 +178,15 @@ export function ConditionalRulesConfig({
   fields,
   currentFieldKey,
 }: ConditionalRulesConfigProps) {
+  // Local state for responsive editing — synced from props on field change
+  const [localRules, setLocalRules] = useState<ConditionalRule[] | null>(rules);
   const [enabled, setEnabled] = useState(rules !== null && rules.length > 0);
+
+  // Sync from props when the selected field changes (currentFieldKey drives this)
+  useEffect(() => {
+    setLocalRules(rules);
+    setEnabled(rules !== null && rules.length > 0);
+  }, [currentFieldKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const availableFields = fields.filter(
     (f) =>
@@ -188,34 +196,42 @@ export function ConditionalRulesConfig({
       ),
   );
 
+  const commit = useCallback(
+    (newRules: ConditionalRule[] | null) => {
+      setLocalRules(newRules);
+      onChange(newRules);
+    },
+    [onChange],
+  );
+
   function handleToggle(checked: boolean) {
     setEnabled(checked);
     if (checked) {
-      if (!rules || rules.length === 0) {
-        onChange([makeEmptyRule(availableFields)]);
+      if (!localRules || localRules.length === 0) {
+        commit([makeEmptyRule(availableFields)]);
       }
     } else {
-      onChange(null);
+      commit(null);
     }
   }
 
   function updateRule(index: number, updatedRule: ConditionalRule) {
-    const newRules = [...(rules ?? [])];
+    const newRules = [...(localRules ?? [])];
     newRules[index] = updatedRule;
-    onChange(newRules);
+    commit(newRules);
   }
 
   function addRule() {
-    onChange([...(rules ?? []), makeEmptyRule(availableFields)]);
+    commit([...(localRules ?? []), makeEmptyRule(availableFields)]);
   }
 
   function removeRule(index: number) {
-    const newRules = (rules ?? []).filter((_, i) => i !== index);
+    const newRules = (localRules ?? []).filter((_, i) => i !== index);
     if (newRules.length === 0) {
       setEnabled(false);
-      onChange(null);
+      commit(null);
     } else {
-      onChange(newRules);
+      commit(newRules);
     }
   }
 
@@ -226,26 +242,26 @@ export function ConditionalRulesConfig({
         <Switch
           checked={enabled}
           onCheckedChange={handleToggle}
-          disabled={availableFields.length === 0}
+          disabled={!enabled && availableFields.length === 0}
         />
       </div>
 
-      {availableFields.length === 0 && (
+      {!enabled && availableFields.length === 0 && (
         <p className="text-xs text-muted-foreground">
           Add more fields to the form to use conditional logic.
         </p>
       )}
 
-      {enabled && rules && rules.length > 0 && (
+      {enabled && localRules && localRules.length > 0 && (
         <div className="space-y-3">
-          {rules.map((rule, ruleIdx) => (
+          {localRules.map((rule, ruleIdx) => (
             <RuleEditor
               key={ruleIdx}
               rule={rule}
               availableFields={availableFields}
               onUpdate={(updated) => updateRule(ruleIdx, updated)}
               onRemove={() => removeRule(ruleIdx)}
-              canRemove={rules.length > 1}
+              canRemove={localRules.length > 1}
             />
           ))}
 

--- a/apps/web/src/components/form-builder/field-properties-panel.tsx
+++ b/apps/web/src/components/form-builder/field-properties-panel.tsx
@@ -11,22 +11,37 @@ import { TextConfig } from "./field-config/text-config";
 import { NumberConfig } from "./field-config/number-config";
 import { SelectConfig } from "./field-config/select-config";
 import { FileUploadConfig } from "./field-config/file-upload-config";
+import { ConditionalRulesConfig } from "./field-config/conditional-rules-config";
 import { FIELD_TYPE_META } from "./field-type-meta";
 import { Loader2, Check } from "lucide-react";
-import type { FormFieldType, UpdateFormFieldInput } from "@colophony/types";
+import type {
+  FormFieldType,
+  UpdateFormFieldInput,
+  ConditionalRule,
+} from "@colophony/types";
 
 interface PropertiesField {
   id: string;
+  fieldKey: string;
   fieldType: FormFieldType;
   label: string;
   description: string | null;
   placeholder: string | null;
   required: boolean;
   config: Record<string, unknown> | null;
+  conditionalRules: ConditionalRule[] | null;
+}
+
+interface AllFieldInfo {
+  fieldKey: string;
+  fieldType: string;
+  label: string;
+  config: Record<string, unknown> | null;
 }
 
 interface FieldPropertiesPanelProps {
   field: PropertiesField;
+  allFields: AllFieldInfo[];
   onUpdate: (fieldId: string, data: UpdateFormFieldInput) => void;
   isSaving: boolean;
 }
@@ -43,6 +58,7 @@ const SELECT_TYPES = [
 
 export function FieldPropertiesPanel({
   field,
+  allFields,
   onUpdate,
   isSaving,
 }: FieldPropertiesPanelProps) {
@@ -120,6 +136,10 @@ export function FieldPropertiesPanel({
   function handleConfigChange(newConfig: Record<string, unknown>) {
     setConfig(newConfig);
     debouncedSave({ config: newConfig });
+  }
+
+  function handleConditionalRulesChange(newRules: ConditionalRule[] | null) {
+    debouncedSave({ conditionalRules: newRules });
   }
 
   const meta = FIELD_TYPE_META[field.fieldType];
@@ -232,6 +252,20 @@ export function FieldPropertiesPanel({
             </div>
           </>
         )}
+
+        {/* Conditional logic */}
+        <Separator />
+        <div className="space-y-3">
+          <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+            Conditions
+          </h3>
+          <ConditionalRulesConfig
+            rules={field.conditionalRules}
+            onChange={handleConditionalRulesChange}
+            fields={allFields}
+            currentFieldKey={field.fieldKey}
+          />
+        </div>
       </div>
     </ScrollArea>
   );

--- a/apps/web/src/components/form-builder/form-editor.tsx
+++ b/apps/web/src/components/form-builder/form-editor.tsx
@@ -293,6 +293,7 @@ export function FormEditor({ formId }: FormEditorProps) {
               {selectedField ? (
                 <FieldPropertiesPanel
                   field={selectedField}
+                  allFields={form.fields}
                   onUpdate={handleUpdateField}
                   isSaving={updateField.isPending}
                 />

--- a/apps/web/src/components/form-builder/form-preview.tsx
+++ b/apps/web/src/components/form-builder/form-preview.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useCallback } from "react";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -13,7 +14,8 @@ import {
 } from "@/components/ui/select";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
-import type { FormFieldType } from "@colophony/types";
+import { useConditionalFields } from "@/hooks/use-conditional-fields";
+import type { FormFieldType, ConditionalRule } from "@colophony/types";
 
 interface PreviewFieldData {
   id: string;
@@ -24,6 +26,7 @@ interface PreviewFieldData {
   placeholder: string | null;
   required: boolean;
   config: Record<string, unknown> | null;
+  conditionalRules?: ConditionalRule[] | null;
 }
 
 interface FormPreviewProps {
@@ -34,7 +37,15 @@ interface FormPreviewProps {
   };
 }
 
-function PreviewField({ field }: { field: PreviewFieldData }) {
+function PreviewField({
+  field,
+  value,
+  onChange,
+}: {
+  field: PreviewFieldData;
+  value?: unknown;
+  onChange?: (value: unknown) => void;
+}) {
   const config = (field.config ?? {}) as Record<string, unknown>;
   const options =
     (config.options as Array<{ label: string; value: string }>) ?? [];
@@ -69,7 +80,12 @@ function PreviewField({ field }: { field: PreviewFieldData }) {
           {field.description && (
             <p className="text-xs text-muted-foreground">{field.description}</p>
           )}
-          <Textarea placeholder={field.placeholder ?? ""} disabled rows={4} />
+          <Textarea
+            placeholder={field.placeholder ?? ""}
+            rows={4}
+            value={(value as string) ?? ""}
+            onChange={(e) => onChange?.(e.target.value)}
+          />
         </div>
       );
 
@@ -83,7 +99,10 @@ function PreviewField({ field }: { field: PreviewFieldData }) {
           {field.description && (
             <p className="text-xs text-muted-foreground">{field.description}</p>
           )}
-          <Select disabled>
+          <Select
+            value={(value as string) ?? ""}
+            onValueChange={(v) => onChange?.(v)}
+          >
             <SelectTrigger>
               <SelectValue placeholder={field.placeholder ?? "Select..."} />
             </SelectTrigger>
@@ -111,7 +130,12 @@ function PreviewField({ field }: { field: PreviewFieldData }) {
           <div className="space-y-2">
             {options.map((opt) => (
               <div key={opt.value} className="flex items-center gap-2">
-                <input type="radio" name={field.fieldKey} disabled />
+                <input
+                  type="radio"
+                  name={field.fieldKey}
+                  checked={(value as string) === opt.value}
+                  onChange={() => onChange?.(opt.value)}
+                />
                 <Label className="font-normal">{opt.label}</Label>
               </div>
             ))}
@@ -122,7 +146,10 @@ function PreviewField({ field }: { field: PreviewFieldData }) {
     case "checkbox":
       return (
         <div className="flex items-center gap-2">
-          <Checkbox disabled />
+          <Checkbox
+            checked={!!value}
+            onCheckedChange={(checked) => onChange?.(checked === true)}
+          />
           <Label className="font-normal">
             {field.label}
             {field.required && <span className="text-destructive ml-1">*</span>}
@@ -191,7 +218,8 @@ function PreviewField({ field }: { field: PreviewFieldData }) {
                       : "text"
             }
             placeholder={field.placeholder ?? ""}
-            disabled
+            value={(value as string) ?? ""}
+            onChange={(e) => onChange?.(e.target.value)}
           />
         </div>
       );
@@ -199,6 +227,19 @@ function PreviewField({ field }: { field: PreviewFieldData }) {
 }
 
 export function FormPreview({ form }: FormPreviewProps) {
+  const [previewValues, setPreviewValues] = useState<Record<string, unknown>>(
+    {},
+  );
+
+  const handlePreviewChange = useCallback(
+    (fieldKey: string, value: unknown) => {
+      setPreviewValues((prev) => ({ ...prev, [fieldKey]: value }));
+    },
+    [],
+  );
+
+  const visibilityMap = useConditionalFields(form.fields, previewValues);
+
   return (
     <ScrollArea className="flex-1">
       <div className="max-w-2xl mx-auto p-6 space-y-6">
@@ -210,9 +251,22 @@ export function FormPreview({ form }: FormPreviewProps) {
         </div>
         <Separator />
         <div className="space-y-6">
-          {form.fields.map((field) => (
-            <PreviewField key={field.id} field={field} />
-          ))}
+          {form.fields.map((field) => {
+            const vis = visibilityMap.get(field.fieldKey);
+            if (vis && !vis.visible) return null;
+
+            const effectiveRequired =
+              field.required || (vis?.required ?? false);
+
+            return (
+              <PreviewField
+                key={field.id}
+                field={{ ...field, required: effectiveRequired }}
+                value={previewValues[field.fieldKey]}
+                onChange={(val) => handlePreviewChange(field.fieldKey, val)}
+              />
+            );
+          })}
         </div>
         {form.fields.length === 0 && (
           <p className="text-center text-muted-foreground py-12">

--- a/apps/web/src/components/submissions/form-renderer/build-form-schema.ts
+++ b/apps/web/src/components/submissions/form-renderer/build-form-schema.ts
@@ -5,6 +5,8 @@ import {
   selectFieldConfigSchema,
   richTextFieldConfigSchema,
   PRESENTATIONAL_FIELD_TYPES,
+  evaluateFieldVisibility,
+  type ConditionalRule,
 } from "@colophony/types";
 
 // ---------------------------------------------------------------------------
@@ -19,6 +21,7 @@ export interface FormFieldForRenderer {
   placeholder: string | null;
   required: boolean;
   config: Record<string, unknown> | null;
+  conditionalRules?: ConditionalRule[] | null;
 }
 
 export interface FormSchemaResult {
@@ -219,6 +222,45 @@ export function buildFormFieldsSchema(
 
   for (const field of fields) {
     const schema = buildFieldSchema(field);
+    if (schema === null) continue;
+
+    shape[field.fieldKey] = schema;
+    defaultValues[field.fieldKey] = getDefaultValue(field);
+  }
+
+  return {
+    schema: z.object(shape),
+    defaultValues,
+  };
+}
+
+/**
+ * Build a Zod schema that accounts for conditional visibility.
+ * Hidden fields get optional schemas; REQUIRE-affected fields get required schemas.
+ */
+export function buildConditionalFormSchema(
+  fields: FormFieldForRenderer[],
+  formValues: Record<string, unknown>,
+): FormSchemaResult {
+  const shape: Record<string, z.ZodTypeAny> = {};
+  const defaultValues: Record<string, unknown> = {};
+
+  for (const field of fields) {
+    const { visible, required: conditionallyRequired } =
+      evaluateFieldVisibility(field.conditionalRules ?? null, formValues);
+
+    // Hidden fields: make optional so they don't block validation
+    if (!visible) {
+      const schema = buildFieldSchema({ ...field, required: false });
+      if (schema === null) continue;
+      shape[field.fieldKey] = schema.optional();
+      defaultValues[field.fieldKey] = getDefaultValue(field);
+      continue;
+    }
+
+    // Visible fields: respect conditional required override
+    const effectiveRequired = field.required || conditionallyRequired;
+    const schema = buildFieldSchema({ ...field, required: effectiveRequired });
     if (schema === null) continue;
 
     shape[field.fieldKey] = schema;

--- a/apps/web/src/components/submissions/form-renderer/dynamic-form-fields.tsx
+++ b/apps/web/src/components/submissions/form-renderer/dynamic-form-fields.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { trpc } from "@/lib/trpc";
+import { useFormContext } from "react-hook-form";
+import { useConditionalFields } from "@/hooks/use-conditional-fields";
 import {
   Card,
   CardContent,
@@ -54,11 +56,41 @@ export function DynamicFormFields({
     );
   }
 
+  // Get live form values for conditional evaluation
+  const formCtx = useFormContext();
+  const watchedFormData = formCtx?.watch("formData") as
+    | Record<string, unknown>
+    | undefined;
+
   if (!formDefinition) return null;
 
   const fields = [...formDefinition.fields].sort(
     (a, b) => a.sortOrder - b.sortOrder,
   ) as FormFieldForRenderer[];
+
+  return (
+    <ConditionalFieldRenderer
+      formDefinition={formDefinition}
+      fields={fields}
+      formValues={watchedFormData ?? {}}
+      disabled={disabled}
+    />
+  );
+}
+
+/** Inner component to use the hook unconditionally. */
+function ConditionalFieldRenderer({
+  formDefinition,
+  fields,
+  formValues,
+  disabled,
+}: {
+  formDefinition: { name: string; description: string | null };
+  fields: FormFieldForRenderer[];
+  formValues: Record<string, unknown>;
+  disabled: boolean;
+}) {
+  const visibilityMap = useConditionalFields(fields, formValues);
 
   return (
     <Card>
@@ -69,13 +101,23 @@ export function DynamicFormFields({
         )}
       </CardHeader>
       <CardContent className="space-y-6">
-        {fields.map((field) => (
-          <DynamicFormField
-            key={field.fieldKey}
-            field={field}
-            disabled={disabled}
-          />
-        ))}
+        {fields.map((field) => {
+          const vis = visibilityMap.get(field.fieldKey);
+          if (vis && !vis.visible) return null;
+
+          const effectiveField =
+            vis?.required && !field.required
+              ? { ...field, required: true }
+              : field;
+
+          return (
+            <DynamicFormField
+              key={field.fieldKey}
+              field={effectiveField}
+              disabled={disabled}
+            />
+          );
+        })}
       </CardContent>
     </Card>
   );

--- a/apps/web/src/components/submissions/form-renderer/dynamic-form-fields.tsx
+++ b/apps/web/src/components/submissions/form-renderer/dynamic-form-fields.tsx
@@ -30,6 +30,12 @@ export function DynamicFormFields({
     error,
   } = trpc.forms.getById.useQuery({ id: formDefinitionId });
 
+  // Must call hooks before any early returns (rules of hooks)
+  const formCtx = useFormContext();
+  const watchedFormData = formCtx?.watch("formData") as
+    | Record<string, unknown>
+    | undefined;
+
   if (isPending) {
     return (
       <Card>
@@ -55,12 +61,6 @@ export function DynamicFormFields({
       </Alert>
     );
   }
-
-  // Get live form values for conditional evaluation
-  const formCtx = useFormContext();
-  const watchedFormData = formCtx?.watch("formData") as
-    | Record<string, unknown>
-    | undefined;
 
   if (!formDefinition) return null;
 

--- a/apps/web/src/components/submissions/form-renderer/index.ts
+++ b/apps/web/src/components/submissions/form-renderer/index.ts
@@ -1,6 +1,7 @@
 export { DynamicFormFields } from "./dynamic-form-fields";
 export {
   buildFormFieldsSchema,
+  buildConditionalFormSchema,
   type FormFieldForRenderer,
   type FormSchemaResult,
 } from "./build-form-schema";

--- a/apps/web/src/components/submissions/submission-form.tsx
+++ b/apps/web/src/components/submissions/submission-form.tsx
@@ -9,6 +9,7 @@ import { trpc } from "@/lib/trpc";
 import {
   DynamicFormFields,
   buildFormFieldsSchema,
+  buildConditionalFormSchema,
   mapFieldErrorsToForm,
 } from "./form-renderer";
 import { Button } from "@/components/ui/button";
@@ -90,21 +91,27 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
     { enabled: !!formDefinitionId },
   );
 
-  // Build dynamic schema from form definition fields
-  const { schema: formDataSchema, defaultValues: formDataDefaults } = useMemo(
+  // Build static default values from form definition
+  const { defaultValues: formDataDefaults } = useMemo(
     () =>
       formDefinition
         ? buildFormFieldsSchema(formDefinition.fields)
         : { schema: z.object({}), defaultValues: {} },
     [formDefinition],
   );
-  const fullSchema = useMemo(
-    () => formSchema.extend({ formData: formDataSchema }),
-    [formDataSchema],
+
+  // Use a ref to hold the latest full schema so the resolver always validates
+  // against the current conditional visibility state without re-creating useForm.
+  const schemaRef = useRef(
+    formSchema.extend({ formData: z.object({}).passthrough() }),
   );
 
   const form = useForm({
-    resolver: zodResolver(fullSchema),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolver: async (values: any, context: any, options: any) => {
+      const resolver = zodResolver(schemaRef.current);
+      return resolver(values, context, options);
+    },
     defaultValues: {
       title: "",
       content: "",
@@ -112,6 +119,24 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
       formData: formDataDefaults,
     },
   });
+
+  // Watch formData to reactively rebuild the conditional validation schema
+  const watchedFormData = form.watch("formData") as Record<string, unknown>;
+
+  // Rebuild schema reactively when form values change conditional visibility
+  useEffect(() => {
+    if (!formDefinition) {
+      schemaRef.current = formSchema.extend({
+        formData: z.object({}).passthrough(),
+      });
+      return;
+    }
+    const { schema: conditionalSchema } = buildConditionalFormSchema(
+      formDefinition.fields,
+      watchedFormData ?? {},
+    );
+    schemaRef.current = formSchema.extend({ formData: conditionalSchema });
+  }, [formDefinition, watchedFormData]);
 
   // Populate form when editing (re-runs when formDefinition loads to apply defaults)
   useEffect(() => {

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+
+import { cn } from "@/lib/utils";
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/apps/web/src/hooks/use-conditional-fields.ts
+++ b/apps/web/src/hooks/use-conditional-fields.ts
@@ -1,0 +1,24 @@
+import { useMemo } from "react";
+import { evaluateFieldVisibility } from "@colophony/types";
+import type { ConditionalRule } from "@colophony/types";
+
+interface FieldWithRules {
+  fieldKey: string;
+  conditionalRules?: ConditionalRule[] | null | undefined;
+}
+
+export function useConditionalFields(
+  fields: FieldWithRules[],
+  formValues: Record<string, unknown>,
+): Map<string, { visible: boolean; required: boolean }> {
+  return useMemo(() => {
+    const result = new Map<string, { visible: boolean; required: boolean }>();
+    for (const field of fields) {
+      result.set(
+        field.fieldKey,
+        evaluateFieldVisibility(field.conditionalRules, formValues),
+      );
+    }
+    return result;
+  }, [fields, formValues]);
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -99,7 +99,7 @@
 - [x] Form builder integration — wire validateFormData into submission create/update flow, formData persistence + validation on submit — (architecture doc Track 3, deferred from backend PR 2026-02-20; done 2026-02-20)
 - [x] Add `formDefinitionId` to `createSubmissionPeriodSchema` — done 2026-02-21 as part of submission periods UI PR
 - [x] [P2] GraphQL resolvers: add `idParamSchema` validation on all raw string ID args passed to services — forms (query + field mutations), submissions (query + history), audit (query) — (Codex plan review 2026-02-20; done 2026-02-21)
-- [ ] Conditional logic engine — (architecture doc Track 3, form-builder-research.md)
+- [x] Conditional logic engine — (architecture doc Track 3, form-builder-research.md; done 2026-02-21)
 - [ ] Embeddable forms (iframe) — (architecture doc Track 3, form-builder-research.md)
 - [x] Submission periods UI — schema exists, no UI — (DEVLOG 2026-02-15; done 2026-02-21)
 - [x] Submission periods: REST oRPC router + GraphQL resolvers for parity with forms/submissions — (DEVLOG 2026-02-21, deferred from submission periods PR; done 2026-02-21)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-21 — Conditional Logic Engine (Track 3)
+
+### Done
+
+- Implemented conditional logic engine for form fields — SHOW, HIDE, REQUIRE effects with AND/OR grouping and 14 comparators (eq, neq, gt, lt, gte, lte, contains, not_contains, starts_with, ends_with, is_empty, is_not_empty, in, not_in)
+- Created shared types, Zod schemas, and pure evaluation functions (`evaluateCondition`, `evaluateFieldVisibility`, `getFieldDependencies`) in `@colophony/types`
+- Backend: `validateFormData` now evaluates conditional visibility — hidden fields skip validation entirely, REQUIRE effect enforces conditional requirement
+- Backend: `updateField` supports `conditionalRules` in set spread; GraphQL `updateFormField` mutation gets new `conditionalRules` arg
+- Frontend: rule builder UI in field properties panel with comparator filtering by field type, multi-value select for in/not_in, interactive condition editor
+- Frontend: `useConditionalFields` hook + `buildConditionalFormSchema` for reactive conditional visibility in form renderer
+- Frontend: form preview now interactive (not disabled) so editors can test conditional logic in preview mode
+- Frontend: reactive schema rebuild in `submission-form.tsx` via ref-based resolver pattern — Zod schema updates as conditional visibility changes
+- 37 new tests: 33 evaluation engine unit tests + 4 form service validation integration tests (all 708 tests passing)
+- Full type-check clean across all 11 packages
+
+### Decisions
+
+- Used inline `ConditionalRuleJson` type in DB schema to avoid circular dependency between `@colophony/db` and `@colophony/types` (plan override: DB schema was planned as no-change but needed type annotation update for cross-package type safety)
+- Ref-based resolver pattern in `submission-form.tsx` — react-hook-form doesn't reactively update resolvers, so `schemaRef.current` holds the latest conditional schema and the resolver closure reads from it
+- Form preview fields made interactive (not just disabled) so editors can test conditional rules visually before publishing
+
+---
+
 ## 2026-02-21 — GraphQL ID Validation Fix (Track 3)
 
 ### Done

--- a/packages/db/src/schema/forms.ts
+++ b/packages/db/src/schema/forms.ts
@@ -13,6 +13,34 @@ import {
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import { formStatusEnum, formFieldTypeEnum } from "./enums";
+
+/** Inline type for conditional rules JSONB column — mirrors ConditionalRule from @colophony/types. */
+export type RuleComparatorJson =
+  | "eq"
+  | "neq"
+  | "gt"
+  | "lt"
+  | "gte"
+  | "lte"
+  | "contains"
+  | "not_contains"
+  | "starts_with"
+  | "ends_with"
+  | "is_empty"
+  | "is_not_empty"
+  | "in"
+  | "not_in";
+export interface ConditionalRuleJson {
+  effect: "SHOW" | "HIDE" | "REQUIRE";
+  condition: {
+    operator: "AND" | "OR";
+    rules: Array<{
+      field: string;
+      comparator: RuleComparatorJson;
+      value?: string | number | boolean | string[];
+    }>;
+  };
+}
 import { organizations } from "./organizations";
 import { users } from "./users";
 
@@ -73,8 +101,7 @@ export const formFields = pgTable(
     required: boolean("required").notNull().default(false),
     sortOrder: integer("sort_order").notNull().default(0),
     config: jsonb("config").$type<Record<string, unknown>>().default({}),
-    conditionalRules:
-      jsonb("conditional_rules").$type<Record<string, unknown>[]>(),
+    conditionalRules: jsonb("conditional_rules").$type<ConditionalRuleJson[]>(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),

--- a/packages/types/src/conditional-rules.ts
+++ b/packages/types/src/conditional-rules.ts
@@ -1,0 +1,232 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+export const ruleComparatorSchema = z.enum([
+  "eq",
+  "neq",
+  "gt",
+  "lt",
+  "gte",
+  "lte",
+  "contains",
+  "not_contains",
+  "starts_with",
+  "ends_with",
+  "is_empty",
+  "is_not_empty",
+  "in",
+  "not_in",
+]);
+export type RuleComparator = z.infer<typeof ruleComparatorSchema>;
+
+export const ruleEffectSchema = z.enum(["SHOW", "HIDE", "REQUIRE"]);
+export type RuleEffect = z.infer<typeof ruleEffectSchema>;
+
+export const singleConditionSchema = z.object({
+  field: z.string().min(1),
+  comparator: ruleComparatorSchema,
+  value: z
+    .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
+    .optional(),
+});
+export type SingleCondition = z.infer<typeof singleConditionSchema>;
+
+export const ruleConditionSchema = z.object({
+  operator: z.enum(["AND", "OR"]),
+  rules: z.array(singleConditionSchema).min(1),
+});
+export type RuleCondition = z.infer<typeof ruleConditionSchema>;
+
+export const conditionalRuleSchema = z.object({
+  effect: ruleEffectSchema,
+  condition: ruleConditionSchema,
+});
+export type ConditionalRule = z.infer<typeof conditionalRuleSchema>;
+
+export const conditionalRulesSchema = z.array(conditionalRuleSchema);
+export type ConditionalRules = z.infer<typeof conditionalRulesSchema>;
+
+// ---------------------------------------------------------------------------
+// Evaluation engine
+// ---------------------------------------------------------------------------
+
+type FormValues = Record<string, unknown>;
+
+function toComparableString(val: unknown): string {
+  if (val === null || val === undefined) return "";
+  return String(val);
+}
+
+function toComparableNumber(val: unknown): number | null {
+  if (val === null || val === undefined || val === "") return null;
+  const n = Number(val);
+  return Number.isNaN(n) ? null : n;
+}
+
+function isEmpty(val: unknown): boolean {
+  if (val === null || val === undefined) return true;
+  if (typeof val === "string") return val === "";
+  if (Array.isArray(val)) return val.length === 0;
+  return false;
+}
+
+function evaluateSingleCondition(
+  condition: SingleCondition,
+  formValues: FormValues,
+): boolean {
+  const fieldValue = formValues[condition.field];
+  const { comparator, value: conditionValue } = condition;
+
+  switch (comparator) {
+    case "is_empty":
+      return isEmpty(fieldValue);
+    case "is_not_empty":
+      return !isEmpty(fieldValue);
+
+    case "eq":
+      return (
+        toComparableString(fieldValue) === toComparableString(conditionValue)
+      );
+    case "neq":
+      return (
+        toComparableString(fieldValue) !== toComparableString(conditionValue)
+      );
+
+    case "gt": {
+      const a = toComparableNumber(fieldValue);
+      const b = toComparableNumber(conditionValue);
+      return a !== null && b !== null && a > b;
+    }
+    case "lt": {
+      const a = toComparableNumber(fieldValue);
+      const b = toComparableNumber(conditionValue);
+      return a !== null && b !== null && a < b;
+    }
+    case "gte": {
+      const a = toComparableNumber(fieldValue);
+      const b = toComparableNumber(conditionValue);
+      return a !== null && b !== null && a >= b;
+    }
+    case "lte": {
+      const a = toComparableNumber(fieldValue);
+      const b = toComparableNumber(conditionValue);
+      return a !== null && b !== null && a <= b;
+    }
+
+    case "contains":
+      return toComparableString(fieldValue).includes(
+        toComparableString(conditionValue),
+      );
+    case "not_contains":
+      return !toComparableString(fieldValue).includes(
+        toComparableString(conditionValue),
+      );
+    case "starts_with":
+      return toComparableString(fieldValue).startsWith(
+        toComparableString(conditionValue),
+      );
+    case "ends_with":
+      return toComparableString(fieldValue).endsWith(
+        toComparableString(conditionValue),
+      );
+
+    case "in": {
+      const arr = Array.isArray(conditionValue) ? conditionValue : [];
+      const fv = toComparableString(fieldValue);
+      return arr.some((v) => toComparableString(v) === fv);
+    }
+    case "not_in": {
+      const arr = Array.isArray(conditionValue) ? conditionValue : [];
+      const fv = toComparableString(fieldValue);
+      return !arr.some((v) => toComparableString(v) === fv);
+    }
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Evaluate a rule condition (AND/OR group of single conditions) against form values.
+ */
+export function evaluateCondition(
+  condition: RuleCondition,
+  formValues: FormValues,
+): boolean {
+  const { operator, rules } = condition;
+
+  if (operator === "AND") {
+    return rules.every((rule) => evaluateSingleCondition(rule, formValues));
+  }
+  // OR
+  return rules.some((rule) => evaluateSingleCondition(rule, formValues));
+}
+
+/**
+ * Evaluate all conditional rules for a field and return its visibility and required state.
+ *
+ * - No rules → `{ visible: true, required: false }` (base required comes from field.required)
+ * - SHOW rule: visible when condition is true
+ * - HIDE rule: visible when condition is false (i.e., hidden when true)
+ * - REQUIRE rule: conditionally required when condition is true
+ * - Multiple SHOW/HIDE rules: last one wins
+ * - REQUIRE is additive (any matching REQUIRE → required)
+ */
+export function evaluateFieldVisibility(
+  rules: ConditionalRule[] | null | undefined,
+  formValues: FormValues,
+): { visible: boolean; required: boolean } {
+  if (!rules || rules.length === 0) {
+    return { visible: true, required: false };
+  }
+
+  let visible = true;
+  let required = false;
+  let hasVisibilityRule = false;
+
+  for (const rule of rules) {
+    const conditionMet = evaluateCondition(rule.condition, formValues);
+
+    switch (rule.effect) {
+      case "SHOW":
+        hasVisibilityRule = true;
+        visible = conditionMet;
+        break;
+      case "HIDE":
+        hasVisibilityRule = true;
+        visible = !conditionMet;
+        break;
+      case "REQUIRE":
+        if (conditionMet) required = true;
+        break;
+    }
+  }
+
+  // If there are visibility rules and the field is hidden, it can't be required
+  if (hasVisibilityRule && !visible) {
+    required = false;
+  }
+
+  return { visible, required };
+}
+
+/**
+ * Extract the fieldKeys that a field's rules depend on.
+ * Used for dependency graph optimization in the renderer.
+ */
+export function getFieldDependencies(
+  rules: ConditionalRule[] | null | undefined,
+): string[] {
+  if (!rules || rules.length === 0) return [];
+
+  const keys = new Set<string>();
+  for (const rule of rules) {
+    for (const condition of rule.condition.rules) {
+      keys.add(condition.field);
+    }
+  }
+  return Array.from(keys);
+}

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { conditionalRulesSchema } from "./conditional-rules";
 
 // ---------------------------------------------------------------------------
 // Enums
@@ -108,10 +109,9 @@ export const formFieldSchema = z.object({
     .record(z.string(), z.unknown())
     .nullable()
     .describe("Type-specific configuration for the field"),
-  conditionalRules: z
-    .array(z.record(z.string(), z.unknown()))
+  conditionalRules: conditionalRulesSchema
     .nullable()
-    .describe("Conditional display rules (Phase 2)"),
+    .describe("Conditional display rules"),
   createdAt: z.date().describe("When the field was created"),
   updatedAt: z.date().describe("When the field was last updated"),
 });
@@ -230,6 +230,10 @@ export const updateFormFieldSchema = z.object({
   placeholder: z.string().max(500).optional().describe("New placeholder"),
   required: z.boolean().optional().describe("New required state"),
   config: fieldConfigSchema.optional().describe("New configuration"),
+  conditionalRules: conditionalRulesSchema
+    .nullable()
+    .optional()
+    .describe("Conditional display rules"),
 });
 
 export type UpdateFormFieldInput = z.infer<typeof updateFormFieldSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,6 +5,7 @@ export * from "./submission";
 export * from "./payment";
 export * from "./file";
 export * from "./form";
+export * from "./conditional-rules";
 export * from "./common";
 export * from "./audit";
 export * from "./api-key";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-switch':
+        specifier: ^1.2.6
+        version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2331,6 +2334,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-tabs@1.1.13':
@@ -8772,6 +8788,21 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a conditional logic engine that evaluates SHOW/HIDE/REQUIRE rules against form field values
- Implements a rule builder UI in the form editor's field properties panel with comparator filtering by field type
- Integrates conditional visibility into the form renderer (submission form + builder preview) with reactive schema rebuilding
- Backend validates conditional rules server-side, skipping hidden fields and enforcing conditional REQUIRE

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `packages/db/src/schema/forms.ts` | Should NOT change | Added inline `ConditionalRuleJson` type + `$type<>()` annotation | Avoids circular dep between db and types packages; ensures type-safe JSONB column |
| `apps/web/src/components/submissions/form-renderer/build-form-schema.ts` | Hidden fields excluded from schema | Hidden fields included as optional | Safer for form state preservation; prevents data loss on visibility toggle |
| `apps/web/src/components/submissions/submission-form.tsx` | Stable visibility-state comparison | Direct `useEffect` on `watchedFormData` | Simpler implementation; React's built-in batching prevents infinite loops in practice |

## Test plan

- [x] 708/708 unit tests pass (including 33 new evaluation engine tests + 4 new service integration tests)
- [x] Type-check clean across all 11 packages
- [x] ESLint passes (0 errors)
- [ ] Manual: Create form with conditional SHOW rule, verify field appears/disappears in preview
- [ ] Manual: Submit form with hidden required field, verify no validation error
- [ ] Manual: Test REQUIRE rule — field becomes required only when condition is met
- [ ] Manual: Clear conditional rules via GraphQL mutation (null payload)