### PR TITLE
feat: Overmind process manager + Docker profile wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,8 @@ Thumbs.db
 # Docker bind mounts (Zitadel PAT, etc.)
 .docker/
 
+# Overmind
+.overmind.sock
+
 # Session handoff (machine-readable, not for version control)
 session-handoff.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ Domain-specific quirks are in per-directory CLAUDE.md files. Cross-cutting quirk
 | **`drizzle-kit generate` TUI blocks automation**      | Interactive prompts (rename vs create) use a TUI that ignores piped stdin. Write manual migrations in non-interactive shells; snapshot files may need regeneration interactively                                                                                                                           |
 | **Playwright `webServer.env` replaces `process.env`** | `webServer.env` **replaces** (not merges) the child process environment. Must load `.env` files via `dotenv` and spread `...process.env` to ensure `DATABASE_URL` etc. reach dev servers                                                                                                                   |
 | **Zitadel issuer ± trailing slash**                   | Zitadel v4.10.1 omits trailing slash in JWT `iss` claim. JWKS verifier uses array issuer `[base, base + "/"]` to match both. Don't normalize to one form                                                                                                                                                   |
+| **Overmind requires tmux**                            | `pnpm dev` uses Overmind (tmux-based process manager). Install both `tmux` and `overmind`. Turbo stays for builds; Overmind replaces it for persistent dev servers only. Use `pnpm dev:clean` to kill orphans if Overmind crashes                                                                          |
 
 **Version pin (cross-cutting):**
 
@@ -320,10 +321,20 @@ Config template: `.claude/mcp-servers.example.json`
 ### Starting Development
 
 ```bash
-docker-compose up -d          # PostgreSQL, Redis, MinIO, Zitadel
+pnpm docker:up                # Core infra + Zitadel (or --full for ClamAV, --core to skip Zitadel)
 pnpm install
 pnpm db:migrate               # Run Drizzle migrations
-pnpm dev                      # API: 4000, Web: 3000
+pnpm dev                      # Overmind: builds packages, then API: 4000, Web: 3000
+```
+
+**Overmind commands** (run from project root while `pnpm dev` is running):
+
+```bash
+overmind connect api           # Attach to API logs (detach: Ctrl+B D)
+overmind connect web           # Attach to Web logs
+overmind restart api           # Restart API only (Web continues)
+overmind kill                  # Stop all dev servers
+pnpm dev:clean                # Kill orphaned processes + stale files (fallback)
 ```
 
 ### Running Tests

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+api: pnpm --filter @colophony/api dev
+web: pnpm --filter @colophony/web dev

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -249,9 +249,9 @@
 
 ### Dev Environment
 
-- [ ] [P1] Add Overmind as process manager for dev servers — replaces `turbo run dev` for persistent server lifecycle (API + web); Turbo stays for build graph. Overmind manages tmux session so killing it kills entire process group — eliminates orphaned `tsx watch` / `next-server` / `postcss` processes that accumulate across sessions. Turbo's SIGINT forwarding is a known open issue (#9666, #9694). — (manual QA session 2026-02-21, found 60 orphaned processes)
-- [ ] [P2] Add `dev:clean` script — kill processes on ports 4000/3000, remove stale lock files (`apps/web/.next/dev/lock`). Fallback for when Overmind isn't running or crashes. Add as `pnpm dev:clean` in root package.json. — (manual QA session 2026-02-21)
-- [ ] [P2] Simplify Docker profile handling — wrapper script or Makefile target that always includes `--profile auth` for Zitadel. Current setup requires remembering `docker compose --profile auth up -d zitadel` separately from `docker compose up -d`. — (manual QA session 2026-02-21)
+- [x] [P1] Add Overmind as process manager for dev servers — replaces `turbo run dev` for persistent server lifecycle (API + web); Turbo stays for build graph. Overmind manages tmux session so killing it kills entire process group — eliminates orphaned `tsx watch` / `next-server` / `postcss` processes that accumulate across sessions. Turbo's SIGINT forwarding is a known open issue (#9666, #9694). — (manual QA session 2026-02-21, found 60 orphaned processes; done 2026-02-21)
+- [x] [P2] Add `dev:clean` script — kill processes on ports 4000/3000, remove stale lock files (`apps/web/.next/dev/lock`). Fallback for when Overmind isn't running or crashes. Add as `pnpm dev:clean` in root package.json. — (manual QA session 2026-02-21; done 2026-02-21)
+- [x] [P2] Simplify Docker profile handling — wrapper script or Makefile target that always includes `--profile auth` for Zitadel. Current setup requires remembering `docker compose --profile auth up -d zitadel` separately from `docker compose up -d`. — (manual QA session 2026-02-21; done 2026-02-21)
 - [ ] [P3] Docker Compose staging override — `docker-compose.staging.yml` with built API/web production images alongside shared infra services. For local staging testing and future deployed staging. Do NOT use `docker compose watch` for Next.js (Turbopack hot-reload bug, docker/compose#12827). — (manual QA session 2026-02-21)
 
 ### QA Observations

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,30 @@ Newest entries first.
 
 ---
 
+## 2026-02-21 — Overmind Process Manager (Dev Environment)
+
+### Done
+
+- Implemented Overmind as dev process manager replacing `turbo run dev` for persistent servers
+  - `Procfile.dev`: API + Web process definitions
+  - `scripts/dev.sh`: checks for tmux/overmind, builds workspace packages via Turbo, then `exec`s Overmind
+  - `scripts/dev-clean.sh`: fallback cleanup — kills processes on ports 4000/3000, stops Overmind session, removes stale Next.js lock and Overmind socket
+- Added Docker Compose profile wrapper (`scripts/docker-up.sh`) — default includes `--profile auth` for Zitadel; `--full` adds ClamAV, `--core` skips Zitadel
+- Wired `pnpm dev`, `pnpm dev:clean`, `pnpm docker:up` in root package.json
+- Updated CLAUDE.md: Starting Development section, Overmind commands reference, quirks table
+- Added `.overmind.sock` to .gitignore
+- Marked 3 backlog items done: Overmind, dev:clean, Docker profile handling
+
+### Decisions
+
+- Overmind replaces Turbo for persistent dev servers only; Turbo stays for builds (`turbo run build`)
+- `exec overmind start` (replaces shell process) for clean signal handling on Ctrl+C
+- `overmind kill` over `pkill -f overmind` — project-scoped via `.overmind.sock`, safe for multi-project setups
+- `xargs -r` (GNU flag) prevents empty xargs invocation on port cleanup
+- `lsof` for port detection — portable across WSL2/Linux/macOS
+
+---
+
 ## 2026-02-21 — Manual QA & Dev Environment Review
 
 ### Done

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev",
+    "dev": "bash scripts/dev.sh",
+    "dev:clean": "bash scripts/dev-clean.sh",
     "lint": "turbo run lint",
     "test": "turbo run test",
     "test:cov": "turbo run test:cov",
@@ -23,6 +24,7 @@
     "db:reset": "bash scripts/db-reset.sh",
     "sdk:export-spec": "pnpm --filter @colophony/api exec tsx ../../scripts/export-openapi.ts",
     "sdk:export-schema": "pnpm --filter @colophony/api exec tsx ../../scripts/export-schema.ts",
+    "docker:up": "bash scripts/docker-up.sh",
     "clean": "turbo run clean && rm -rf node_modules",
     "prepare": "husky"
   },

--- a/scripts/dev-clean.sh
+++ b/scripts/dev-clean.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Cleanup script for orphaned dev processes and stale files.
+# Idempotent — safe to run even when nothing needs cleaning.
+
+echo "Cleaning up dev environment..."
+
+# Kill processes on dev server ports
+for port in 4000 3000; do
+  pids=$(lsof -ti :"$port" 2>/dev/null || true)
+  if [ -n "$pids" ]; then
+    echo "Killing processes on port $port: $pids"
+    echo "$pids" | xargs -r kill -9 2>/dev/null || true
+  fi
+done
+
+# Stop Overmind session (project-scoped via .overmind.sock)
+if [ -S .overmind.sock ]; then
+  echo "Stopping Overmind session..."
+  overmind kill 2>/dev/null || true
+  # Remove stale socket if overmind kill didn't clean up
+  if [ -S .overmind.sock ]; then
+    echo "Removing stale Overmind socket..."
+    rm -f .overmind.sock
+  fi
+fi
+
+# Remove stale Next.js dev lock
+if [ -f apps/web/.next/dev/lock ]; then
+  echo "Removing stale Next.js lock..."
+  rm -f apps/web/.next/dev/lock
+fi
+
+echo "Done."

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Overmind process manager wrapper for dev servers.
+# Builds workspace packages first (via Turbo), then starts API + Web via Overmind.
+
+# Check for required binaries
+if ! command -v tmux &>/dev/null; then
+  echo "Error: tmux is required but not installed."
+  echo "  Ubuntu/Debian: sudo apt install tmux"
+  echo "  macOS: brew install tmux"
+  exit 1
+fi
+
+if ! command -v overmind &>/dev/null; then
+  echo "Error: overmind is required but not installed."
+  echo "  Install: https://github.com/DarthSim/overmind#installation"
+  echo "  Ubuntu/Debian: sudo apt install overmind (or download binary from releases)"
+  echo "  macOS: brew install overmind"
+  exit 1
+fi
+
+# Build workspace packages (not apps) so dist/ exports resolve
+echo "Building workspace packages..."
+pnpm exec turbo run build --filter='./packages/*'
+
+# Start dev servers via Overmind (exec replaces shell for clean signal handling)
+exec overmind start -f Procfile.dev

--- a/scripts/docker-up.sh
+++ b/scripts/docker-up.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Docker Compose wrapper that simplifies profile handling.
+#
+# Usage:
+#   bash scripts/docker-up.sh          # Core infra + Zitadel (default)
+#   bash scripts/docker-up.sh --full   # Core infra + Zitadel + ClamAV
+#   bash scripts/docker-up.sh --core   # Core infra only (no Zitadel)
+
+PROFILES="--profile auth"
+
+case "${1:-}" in
+  --full)
+    PROFILES="--profile auth --profile full"
+    echo "Starting all services (core + Zitadel + ClamAV)..."
+    ;;
+  --core)
+    PROFILES=""
+    echo "Starting core services only (no Zitadel)..."
+    ;;
+  *)
+    echo "Starting core services + Zitadel..."
+    ;;
+esac
+
+# shellcheck disable=SC2086
+docker compose $PROFILES up -d


### PR DESCRIPTION
## Summary

- **Overmind replaces Turbo for dev servers** — `pnpm dev` now builds workspace packages via Turbo then starts API + Web via Overmind (tmux-based process manager). Eliminates orphaned `tsx watch` / `next-server` / `postcss` processes from Turbo's broken SIGINT forwarding (#9666, #9694). Last QA session found 60 orphaned processes.
- **`pnpm dev:clean`** — fallback cleanup: kills processes on ports 4000/3000, stops Overmind session, removes stale locks
- **`pnpm docker:up`** — Docker Compose wrapper that includes `--profile auth` by default (Zitadel). Flags: `--full` (+ ClamAV), `--core` (skip Zitadel)

## Test plan

All manual (dev tooling, no automated tests):

- [ ] `pnpm dev` starts both servers — API on :4000, Web on :3000, `tmux ls` shows Overmind session
- [ ] Ctrl+C kills all — no orphans on `lsof -i :4000` or `lsof -i :3000`
- [ ] `overmind connect api` — attaches to API logs, detach with Ctrl+B D
- [ ] `overmind restart api` — API restarts, Web continues
- [ ] `pnpm dev:clean` — kills orphaned processes, removes stale files
- [ ] Missing overmind binary — prints install instructions, exits 1
- [ ] Package builds run first — delete `packages/types/dist/`, run `pnpm dev`, verify build before servers
- [ ] `pnpm docker:up` — starts core + Zitadel
- [ ] `pnpm docker:up -- --core` — starts core only
- [ ] `pnpm docker:up -- --full` — starts core + Zitadel + ClamAV