### PR TITLE
fix(hopper): display custom form fields on submission detail page

### DIFF
--- a/apps/web/src/components/submissions/__tests__/read-only-form-fields.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/read-only-form-fields.spec.tsx
@@ -1,0 +1,249 @@
+import { render, screen } from "@testing-library/react";
+import { ReadOnlyFormFields } from "../form-renderer/read-only-form-fields";
+import "../../../../test/setup";
+
+// --- Mutable mock state ---
+let mockFormDefinition: Record<string, unknown> | null;
+let mockIsPending: boolean;
+let mockError: { message: string } | null;
+
+function resetMocks() {
+  mockFormDefinition = null;
+  mockIsPending = false;
+  mockError = null;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    forms: {
+      getById: {
+        useQuery: () => ({
+          data: mockFormDefinition,
+          isPending: mockIsPending,
+          error: mockError,
+        }),
+      },
+    },
+  },
+}));
+
+// Mock useConditionalFields — by default, all fields visible
+let mockVisibilityOverride: Map<
+  string,
+  { visible: boolean; required: boolean }
+> | null = null;
+
+jest.mock("@/hooks/use-conditional-fields", () => ({
+  useConditionalFields: (
+    fields: Array<{ fieldKey: string }>,
+    _formValues: Record<string, unknown>,
+  ) => {
+    if (mockVisibilityOverride) return mockVisibilityOverride;
+    const map = new Map<string, { visible: boolean; required: boolean }>();
+    for (const f of fields) {
+      map.set(f.fieldKey, { visible: true, required: false });
+    }
+    return map;
+  },
+}));
+
+beforeEach(() => {
+  resetMocks();
+  mockVisibilityOverride = null;
+});
+
+function makeField(overrides: Record<string, unknown>) {
+  return {
+    fieldKey: "field1",
+    fieldType: "text",
+    label: "Field One",
+    description: null,
+    placeholder: null,
+    required: false,
+    config: null,
+    conditionalRules: null,
+    sortOrder: 0,
+    ...overrides,
+  };
+}
+
+describe("ReadOnlyFormFields", () => {
+  it("renders form field labels and values", () => {
+    mockFormDefinition = {
+      name: "Poetry Submission Form",
+      description: "Fields for poetry submissions",
+      fields: [
+        makeField({
+          fieldKey: "category",
+          fieldType: "select",
+          label: "Category",
+          sortOrder: 0,
+          config: {
+            options: [
+              { label: "Poetry", value: "poetry" },
+              { label: "Fiction", value: "fiction" },
+            ],
+          },
+        }),
+        makeField({
+          fieldKey: "word_count",
+          fieldType: "number",
+          label: "Word Count",
+          sortOrder: 1,
+        }),
+      ],
+    };
+
+    render(
+      <ReadOnlyFormFields
+        formDefinitionId="form-1"
+        formData={{ category: "poetry", word_count: 250 }}
+      />,
+    );
+
+    expect(screen.getByText("Poetry Submission Form")).toBeInTheDocument();
+    expect(screen.getByText("Category")).toBeInTheDocument();
+    expect(screen.getByText("Poetry")).toBeInTheDocument();
+    expect(screen.getByText("Word Count")).toBeInTheDocument();
+    expect(screen.getByText("250")).toBeInTheDocument();
+  });
+
+  it("shows 'Not provided' for missing values", () => {
+    mockFormDefinition = {
+      name: "Test Form",
+      description: null,
+      fields: [
+        makeField({
+          fieldKey: "bio",
+          fieldType: "textarea",
+          label: "Bio",
+          sortOrder: 0,
+        }),
+        makeField({
+          fieldKey: "website",
+          fieldType: "url",
+          label: "Website",
+          sortOrder: 1,
+        }),
+      ],
+    };
+
+    render(<ReadOnlyFormFields formDefinitionId="form-1" formData={{}} />);
+
+    const notProvided = screen.getAllByText("Not provided");
+    expect(notProvided).toHaveLength(2);
+  });
+
+  it("respects conditional visibility", () => {
+    mockFormDefinition = {
+      name: "Conditional Form",
+      description: null,
+      fields: [
+        makeField({
+          fieldKey: "type",
+          fieldType: "select",
+          label: "Submission Type",
+          sortOrder: 0,
+          config: {
+            options: [
+              { label: "Poetry", value: "poetry" },
+              { label: "Fiction", value: "fiction" },
+            ],
+          },
+        }),
+        makeField({
+          fieldKey: "stanza_count",
+          fieldType: "number",
+          label: "Stanza Count",
+          sortOrder: 1,
+          conditionalRules: [
+            {
+              action: "HIDE",
+              conditions: [
+                { fieldKey: "type", operator: "NOT_EQUALS", value: "poetry" },
+              ],
+              logicalOperator: "AND",
+            },
+          ],
+        }),
+      ],
+    };
+
+    // Override visibility: hide stanza_count
+    mockVisibilityOverride = new Map([
+      ["type", { visible: true, required: false }],
+      ["stanza_count", { visible: false, required: false }],
+    ]);
+
+    render(
+      <ReadOnlyFormFields
+        formDefinitionId="form-1"
+        formData={{ type: "fiction" }}
+      />,
+    );
+
+    expect(screen.getByText("Submission Type")).toBeInTheDocument();
+    expect(screen.queryByText("Stanza Count")).not.toBeInTheDocument();
+  });
+
+  it("renders section_header and info_text presentational fields", () => {
+    mockFormDefinition = {
+      name: "Form With Sections",
+      description: null,
+      fields: [
+        makeField({
+          fieldKey: "section1",
+          fieldType: "section_header",
+          label: "About You",
+          description: "Tell us about yourself",
+          sortOrder: 0,
+        }),
+        makeField({
+          fieldKey: "info1",
+          fieldType: "info_text",
+          label: "Note",
+          description: "All fields are optional.",
+          sortOrder: 1,
+        }),
+      ],
+    };
+
+    render(<ReadOnlyFormFields formDefinitionId="form-1" formData={{}} />);
+
+    expect(screen.getByText("About You")).toBeInTheDocument();
+    expect(screen.getByText("Tell us about yourself")).toBeInTheDocument();
+    expect(screen.getByText("All fields are optional.")).toBeInTheDocument();
+  });
+
+  it("skips file_upload fields", () => {
+    mockFormDefinition = {
+      name: "Upload Form",
+      description: null,
+      fields: [
+        makeField({
+          fieldKey: "manuscript",
+          fieldType: "file_upload",
+          label: "Manuscript Upload",
+          sortOrder: 0,
+        }),
+        makeField({
+          fieldKey: "notes",
+          fieldType: "text",
+          label: "Notes",
+          sortOrder: 1,
+        }),
+      ],
+    };
+
+    render(
+      <ReadOnlyFormFields
+        formDefinitionId="form-1"
+        formData={{ notes: "Some notes" }}
+      />,
+    );
+
+    expect(screen.queryByText("Manuscript Upload")).not.toBeInTheDocument();
+    expect(screen.getByText("Notes")).toBeInTheDocument();
+    expect(screen.getByText("Some notes")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/submissions/form-renderer/index.ts
+++ b/apps/web/src/components/submissions/form-renderer/index.ts
@@ -1,4 +1,5 @@
 export { DynamicFormFields } from "./dynamic-form-fields";
+export { ReadOnlyFormFields } from "./read-only-form-fields";
 export {
   buildFormFieldsSchema,
   buildConditionalFormSchema,

--- a/apps/web/src/components/submissions/form-renderer/read-only-form-fields.tsx
+++ b/apps/web/src/components/submissions/form-renderer/read-only-form-fields.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { trpc } from "@/lib/trpc";
+import { useConditionalFields } from "@/hooks/use-conditional-fields";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import type { FormFieldForRenderer } from "./build-form-schema";
+
+interface ReadOnlyFormFieldsProps {
+  formDefinitionId: string;
+  formData: Record<string, unknown>;
+}
+
+export function ReadOnlyFormFields({
+  formDefinitionId,
+  formData,
+}: ReadOnlyFormFieldsProps) {
+  const {
+    data: formDefinition,
+    isPending,
+    error,
+  } = trpc.forms.getById.useQuery({ id: formDefinitionId });
+
+  if (isPending) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-72 mt-1" />
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>
+          Failed to load form: {error.message}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!formDefinition) return null;
+
+  const fields = [...formDefinition.fields].sort(
+    (a, b) => a.sortOrder - b.sortOrder,
+  ) as FormFieldForRenderer[];
+
+  return (
+    <ReadOnlyFieldRenderer
+      formDefinition={formDefinition}
+      fields={fields}
+      formData={formData}
+    />
+  );
+}
+
+/** Inner component to keep useConditionalFields unconditional (hooks safety). */
+function ReadOnlyFieldRenderer({
+  formDefinition,
+  fields,
+  formData,
+}: {
+  formDefinition: { name: string; description: string | null };
+  fields: FormFieldForRenderer[];
+  formData: Record<string, unknown>;
+}) {
+  const visibilityMap = useConditionalFields(fields, formData);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{formDefinition.name}</CardTitle>
+        {formDefinition.description && (
+          <CardDescription>{formDefinition.description}</CardDescription>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {fields.map((field) => {
+          const vis = visibilityMap.get(field.fieldKey);
+          if (vis && !vis.visible) return null;
+
+          return (
+            <ReadOnlyFieldValue
+              key={field.fieldKey}
+              field={field}
+              value={formData[field.fieldKey]}
+            />
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ReadOnlyFieldValue({
+  field,
+  value,
+}: {
+  field: FormFieldForRenderer;
+  value: unknown;
+}) {
+  const config = (field.config ?? {}) as Record<string, unknown>;
+  const options =
+    (config.options as Array<{ label: string; value: string }>) ?? [];
+
+  switch (field.fieldType) {
+    case "section_header":
+      return (
+        <div className="pt-4">
+          <h3 className="text-lg font-semibold">{field.label}</h3>
+          {field.description && (
+            <p className="text-sm text-muted-foreground">{field.description}</p>
+          )}
+          <Separator className="mt-2" />
+        </div>
+      );
+
+    case "info_text":
+      return (
+        <div className="rounded-lg bg-muted p-3 text-sm text-muted-foreground">
+          {field.description ?? field.label}
+        </div>
+      );
+
+    case "file_upload":
+      return null;
+
+    case "checkbox": {
+      const checked = value === true;
+      return (
+        <div className="space-y-1">
+          <p className="text-sm font-medium">{field.label}</p>
+          <p className="text-sm">{checked ? "Yes" : "No"}</p>
+        </div>
+      );
+    }
+
+    case "select":
+    case "radio": {
+      const rawValue = value as string | undefined | null;
+      const optionLabel = options.find((o) => o.value === rawValue)?.label;
+      return (
+        <div className="space-y-1">
+          <p className="text-sm font-medium">{field.label}</p>
+          {rawValue ? (
+            <p className="text-sm">{optionLabel ?? rawValue}</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">Not provided</p>
+          )}
+        </div>
+      );
+    }
+
+    case "multi_select":
+    case "checkbox_group": {
+      const values = Array.isArray(value) ? (value as string[]) : [];
+      const labels = values.map(
+        (v) => options.find((o) => o.value === v)?.label ?? v,
+      );
+      return (
+        <div className="space-y-1">
+          <p className="text-sm font-medium">{field.label}</p>
+          {labels.length > 0 ? (
+            <p className="text-sm">{labels.join(", ")}</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">Not provided</p>
+          )}
+        </div>
+      );
+    }
+
+    default: {
+      const displayValue =
+        value !== undefined && value !== null && value !== ""
+          ? String(value)
+          : null;
+      return (
+        <div className="space-y-1">
+          <p className="text-sm font-medium">{field.label}</p>
+          {displayValue ? (
+            <p className="text-sm">{displayValue}</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">Not provided</p>
+          )}
+        </div>
+      );
+    }
+  }
+}

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -43,6 +43,7 @@ import {
   type ScanStatus,
   type SubmissionStatus,
 } from "@colophony/types";
+import { ReadOnlyFormFields } from "./form-renderer/read-only-form-fields";
 
 interface SubmissionDetailProps {
   submissionId: string;
@@ -241,6 +242,14 @@ export function SubmissionDetail({
               )}
             </CardContent>
           </Card>
+
+          {/* Custom form fields */}
+          {submission.formDefinitionId && (
+            <ReadOnlyFormFields
+              formDefinitionId={submission.formDefinitionId}
+              formData={(submission.formData as Record<string, unknown>) ?? {}}
+            />
+          )}
 
           {/* Cover letter */}
           {submission.coverLetter && (

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -256,7 +256,7 @@
 
 ### QA Observations
 
-- [ ] [P2] Submission detail page: display custom form field data — `/submissions/[id]` detail view only shows Title, Content, and History. Custom form fields (Category, Word Count, Bio from form definitions) are not rendered. Form data is persisted and visible on edit page but not on read-only detail view. — (manual QA 2026-02-21, conditional logic testing)
+- [x] [P2] Submission detail page: display custom form field data — `/submissions/[id]` detail view only shows Title, Content, and History. Custom form fields (Category, Word Count, Bio from form definitions) are not rendered. Form data is persisted and visible on edit page but not on read-only detail view. — (manual QA 2026-02-21, conditional logic testing; done 2026-02-21)
 - [ ] [P3] Submissions list stale cache after create — after creating a new submission via "Create Draft", navigating to My Submissions shows "No submissions" until page reload. Likely TanStack Query cache not invalidated on create mutation success. Submission does exist (API returned 200, detail page loads). — (manual QA 2026-02-21, conditional logic testing)
 
 ---

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,26 @@ Newest entries first.
 
 ---
 
+## 2026-02-21 — Fix Submission Detail Form Fields
+
+### Done
+
+- Created `ReadOnlyFormFields` component (`apps/web/src/components/submissions/form-renderer/read-only-form-fields.tsx`) — renders persisted `formData` on the read-only submission detail view
+  - Inner-component pattern (`ReadOnlyFieldRenderer`) keeps `useConditionalFields` hook unconditional (hooks safety)
+  - Handles all field types: text/number/date/email/url/textarea/rich_text as plain text, select/radio with option label lookup, checkbox as Yes/No, multi_select/checkbox_group as comma-separated labels, section_header/info_text as presentational, file_upload skipped
+  - Missing/empty values show "Not provided" in muted text
+- Integrated into `submission-detail.tsx` between Content and Cover Letter cards, gated on `formDefinitionId` only
+- Added export from `form-renderer/index.ts`
+- Added 5 unit tests: renders values, "Not provided" for missing, conditional visibility, presentational fields, skips file_upload
+- All tests passing, type-check clean
+
+### Decisions
+
+- Gate on `formDefinitionId` only (not `formData`) — submissions linked to a form but with null data show "Not provided" for all fields rather than hiding the card
+- Codex plan review done before implementation; no code-level Codex review this session (small, focused change)
+
+---
+
 ## 2026-02-21 — Overmind Process Manager (Dev Environment)
 
 ### Done


### PR DESCRIPTION
## Summary

- Created `ReadOnlyFormFields` component to render persisted `formData` on the submission detail view (`/submissions/[id]`)
- Custom form fields (Category, Word Count, Bio, etc.) now display between Content and Cover Letter cards
- Handles all field types with appropriate read-only rendering (option label lookup, Yes/No for checkboxes, conditional visibility)
- Submissions without a form definition render identically to before

Fixes P2 QA bug from 2026-02-21: form data was persisted and visible on the edit page but not rendered on the read-only detail view.

## Test plan

- [x] Unit tests: 5 test cases passing (values, missing data, conditional visibility, presentational fields, file_upload skip)
- [x] Type-check: `pnpm type-check` clean
- [ ] Manual test: navigate to submission detail with custom form data → form fields card appears
- [ ] Manual test: submission without `formDefinitionId` renders identically to before
- [ ] Manual test: conditional fields evaluate correctly in read-only view