### PR TITLE
fix(hopper): invalidate submissions list cache after create

### DIFF
--- a/apps/web/src/components/submissions/submission-form.tsx
+++ b/apps/web/src/components/submissions/submission-form.tsx
@@ -169,6 +169,7 @@ export function SubmissionForm({ mode, submissionId }: SubmissionFormProps) {
   const createMutation = trpc.submissions.create.useMutation({
     onSuccess: (data) => {
       toast.success("Submission created");
+      utils.submissions.mySubmissions.invalidate();
       router.push(`/submissions/${data.id}`);
     },
     onError: (err) => {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -257,7 +257,7 @@
 ### QA Observations
 
 - [x] [P2] Submission detail page: display custom form field data — `/submissions/[id]` detail view only shows Title, Content, and History. Custom form fields (Category, Word Count, Bio from form definitions) are not rendered. Form data is persisted and visible on edit page but not on read-only detail view. — (manual QA 2026-02-21, conditional logic testing; done 2026-02-21)
-- [ ] [P3] Submissions list stale cache after create — after creating a new submission via "Create Draft", navigating to My Submissions shows "No submissions" until page reload. Likely TanStack Query cache not invalidated on create mutation success. Submission does exist (API returned 200, detail page loads). — (manual QA 2026-02-21, conditional logic testing)
+- [x] [P3] Submissions list stale cache after create — after creating a new submission via "Create Draft", navigating to My Submissions shows "No submissions" until page reload. Likely TanStack Query cache not invalidated on create mutation success. Submission does exist (API returned 200, detail page loads). — (manual QA 2026-02-21, conditional logic testing; done 2026-02-21)
 
 ---
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,16 @@ Newest entries first.
 
 ---
 
+## 2026-02-21 — Fix Submissions List Stale Cache
+
+### Done
+
+- Fixed stale cache bug: after creating a submission via "Create Draft", navigating to My Submissions showed "No submissions" until page reload
+- Root cause: `createMutation.onSuccess` in `submission-form.tsx` was missing `utils.submissions.mySubmissions.invalidate()` — the update and submit mutations already had their invalidation calls
+- One-line fix, all 22 existing tests pass
+
+---
+
 ## 2026-02-21 — Fix Submission Detail Form Fields
 
 ### Done


### PR DESCRIPTION
## Summary

- Add `utils.submissions.mySubmissions.invalidate()` to `createMutation.onSuccess` in `submission-form.tsx`
- Fixes stale cache bug where My Submissions showed "No submissions" after creating a draft until page reload
- The update and submit mutations already invalidated their queries; create was the only one missing it

## Test plan

- [x] All 22 existing `submission-form.spec.tsx` tests pass
- [ ] Manual: create a submission, navigate to My Submissions — list should show the new submission immediately