### PR TITLE
fix: improve dev server startup reliability

### DIFF
--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -196,6 +196,15 @@ Run these commands in parallel:
 docker compose ps --format '{{.Name}}\t{{.Status}}' 2>/dev/null || echo "Docker Compose not running"
 ```
 
+Check for stale dev processes blocking ports 3000/4000:
+
+```bash
+lsof -ti :3000 2>/dev/null && echo "stale:3000" || true
+lsof -ti :4000 2>/dev/null && echo "stale:4000" || true
+```
+
+If stale processes are found on either port, report them in the briefing and suggest running `pnpm dev:clean` before starting dev servers.
+
 Also check if the Codex review tmux window is available (part of the `colophony` tmux session):
 
 ```bash

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "dev": "tsx watch --env-file=.env src/main.ts",
+    "dev": "tsx watch --env-file-if-exists=.env src/main.ts",
     "start": "node dist/main.js",
     "start:prod": "node dist/main.js",
     "lint": "eslint \"{src,test}/**/*.ts\"",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "dev": "tsx watch src/main.ts",
+    "dev": "tsx watch --env-file=.env src/main.ts",
     "start": "node dist/main.js",
     "start:prod": "node dist/main.js",
     "lint": "eslint \"{src,test}/**/*.ts\"",

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,20 @@ Newest entries first.
 
 ---
 
+## 2026-02-22 — Dev Server Startup Reliability
+
+### Done
+
+- Added `--env-file=.env` to API dev script (`apps/api/package.json`) so `tsx watch` loads env vars before Zod validation — fixes ZodError on `DATABASE_URL` in clean shells
+- Added stale process cleanup (`dev-clean.sh`) to `scripts/dev.sh` before Overmind starts — kills leftover processes on ports 3000/4000 from previous sessions
+- Added port occupancy check (3000/4000) to `/start-session` skill infrastructure step — surfaces stale processes in session briefing
+
+### Decisions
+
+- Used `--env-file` (Node 22+ / tsx native) rather than adding a `dotenv` import to `main.ts` — keeps the app code clean, env loading is a runner concern
+
+---
+
 ## 2026-02-21 — Multi-Page Wizard Renderer + Builder Page UI (PR 2)
 
 ### Done

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -20,6 +20,9 @@ if ! command -v overmind &>/dev/null; then
   exit 1
 fi
 
+# Clean up stale processes from previous sessions
+bash scripts/dev-clean.sh 2>/dev/null || true
+
 # Build workspace packages (not apps) so dist/ exports resolve
 echo "Building workspace packages..."
 pnpm exec turbo run build --filter='./packages/*'


### PR DESCRIPTION
## Summary

- Add `--env-file=.env` to API dev script so `tsx watch` loads env vars before Zod validation (fixes ZodError on `DATABASE_URL` in clean shells)
- Run `dev-clean.sh` before Overmind starts in `dev.sh` to kill stale processes on ports 3000/4000
- Add port occupancy check to `/start-session` skill infrastructure step

## Test plan

- [ ] Kill any running dev servers: `pnpm dev:clean`
- [ ] Run `pnpm dev` from a clean shell (no pre-sourced env) — API should start without ZodError
- [ ] Kill Overmind, run `pnpm dev` again — should start cleanly (dev.sh runs cleanup first)