### PR TITLE
fix(hopper): manuscript QA — file count staleness, submission link, upload retry

### DIFF
--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -312,8 +312,8 @@ export const submissionService = {
 
     if (!submission) return null;
 
-    // Get files via manuscript version (if attached)
-    const [versionFiles, [submitter]] = await Promise.all([
+    // Get files via manuscript version (if attached) + manuscript info
+    const [versionFiles, [submitter], manuscriptInfo] = await Promise.all([
       submission.manuscriptVersionId
         ? tx
             .select()
@@ -328,12 +328,29 @@ export const submissionService = {
         .from(users)
         .where(eq(users.id, submission.submitterId))
         .limit(1),
+      submission.manuscriptVersionId
+        ? tx
+            .select({
+              manuscriptId: manuscripts.id,
+              manuscriptTitle: manuscripts.title,
+              versionNumber: manuscriptVersions.versionNumber,
+            })
+            .from(manuscriptVersions)
+            .innerJoin(
+              manuscripts,
+              eq(manuscriptVersions.manuscriptId, manuscripts.id),
+            )
+            .where(eq(manuscriptVersions.id, submission.manuscriptVersionId))
+            .limit(1)
+            .then((rows) => rows[0] ?? null)
+        : Promise.resolve(null),
     ]);
 
     return {
       ...submission,
       files: versionFiles,
       submitterEmail: submitter?.email ?? null,
+      manuscript: manuscriptInfo,
     };
   },
 

--- a/apps/api/src/trpc/routers/submissions.spec.ts
+++ b/apps/api/src/trpc/routers/submissions.spec.ts
@@ -172,6 +172,7 @@ function makeDraftSubmission(submitterId = USER_ID) {
     ...makeSubmissionBase(submitterId),
     files: [],
     submitterEmail: 'test@example.com',
+    manuscript: null,
   };
 }
 

--- a/apps/web/src/components/manuscripts/manuscript-detail.tsx
+++ b/apps/web/src/components/manuscripts/manuscript-detail.tsx
@@ -324,6 +324,11 @@ export function ManuscriptDetail({ manuscriptId }: ManuscriptDetailProps) {
                     manuscriptVersionId={version.id}
                     files={version.files}
                     readOnly={version !== versionsNewestFirst[0]}
+                    onFileChange={() =>
+                      utils.manuscripts.getDetail.invalidate({
+                        id: manuscriptId,
+                      })
+                    }
                   />
                 </CardContent>
               </Card>

--- a/apps/web/src/components/manuscripts/manuscript-version-files.tsx
+++ b/apps/web/src/components/manuscripts/manuscript-version-files.tsx
@@ -27,6 +27,7 @@ interface ManuscriptVersionFilesProps {
   manuscriptVersionId: string;
   files: FileRecord[];
   readOnly?: boolean;
+  onFileChange?: () => void;
 }
 
 const scanStatusConfig: Record<
@@ -88,9 +89,15 @@ export function ManuscriptVersionFiles({
   manuscriptVersionId,
   files,
   readOnly,
+  onFileChange,
 }: ManuscriptVersionFilesProps) {
   if (!readOnly) {
-    return <FileUpload manuscriptVersionId={manuscriptVersionId} />;
+    return (
+      <FileUpload
+        manuscriptVersionId={manuscriptVersionId}
+        onFileChange={onFileChange}
+      />
+    );
   }
 
   if (files.length === 0) {

--- a/apps/web/src/components/submissions/file-upload.tsx
+++ b/apps/web/src/components/submissions/file-upload.tsx
@@ -284,7 +284,12 @@ export function FileUpload({
         console.error("Failed to delete file:", error);
       }
     },
-    [deleteMutation, utils.files.listByManuscriptVersion, manuscriptVersionId],
+    [
+      deleteMutation,
+      utils.files.listByManuscriptVersion,
+      manuscriptVersionId,
+      onFileChange,
+    ],
   );
 
   const totalFiles = (existingFiles?.length ?? 0) + uploads.length;

--- a/apps/web/src/components/submissions/file-upload.tsx
+++ b/apps/web/src/components/submissions/file-upload.tsx
@@ -26,6 +26,7 @@ import {
 interface FileUploadProps {
   manuscriptVersionId?: string | null;
   disabled?: boolean;
+  onFileChange?: () => void;
 }
 
 const scanStatusConfig: Record<
@@ -175,7 +176,11 @@ function ExistingFileItem({
   );
 }
 
-export function FileUpload({ manuscriptVersionId, disabled }: FileUploadProps) {
+export function FileUpload({
+  manuscriptVersionId,
+  disabled,
+  onFileChange,
+}: FileUploadProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   // Track whether uploads are in "processing" state (waiting for post-finish
   // webhook to create the file record). Used by refetchInterval below.
@@ -190,6 +195,7 @@ export function FileUpload({ manuscriptVersionId, disabled }: FileUploadProps) {
       if (manuscriptVersionId) {
         utils.files.listByManuscriptVersion.invalidate({ manuscriptVersionId });
       }
+      onFileChange?.();
     },
   });
 
@@ -273,6 +279,7 @@ export function FileUpload({ manuscriptVersionId, disabled }: FileUploadProps) {
             manuscriptVersionId,
           });
         }
+        onFileChange?.();
       } catch (error) {
         console.error("Failed to delete file:", error);
       }

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -37,6 +37,7 @@ import {
   CheckCircle,
   AlertCircle,
   Loader2,
+  BookOpen,
 } from "lucide-react";
 import {
   EDITOR_ALLOWED_TRANSITIONS,
@@ -262,6 +263,31 @@ export function SubmissionDetail({
                 <div className="whitespace-pre-wrap text-sm">
                   {submission.coverLetter}
                 </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Linked manuscript */}
+          {submission.manuscript && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Linked Manuscript</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Link
+                  href={`/manuscripts/${submission.manuscript.manuscriptId}`}
+                  className="flex items-center gap-3 p-3 border rounded-lg hover:bg-accent transition-colors"
+                >
+                  <BookOpen className="h-5 w-5 text-muted-foreground flex-shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium truncate">
+                      {submission.manuscript.manuscriptTitle}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Version {submission.manuscript.versionNumber}
+                    </p>
+                  </div>
+                </Link>
               </CardContent>
             </Card>
           )}

--- a/apps/web/src/hooks/use-file-upload.ts
+++ b/apps/web/src/hooks/use-file-upload.ts
@@ -184,6 +184,7 @@ export function useFileUpload({
               utils.files.listByManuscriptVersion.invalidate({
                 manuscriptVersionId: manuscriptVersionId!,
               });
+              onUploadComplete?.(uploadId);
             }, 4000);
           },
           onError: (error) => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,8 @@ services:
       - http://host.docker.internal:4000/webhooks/tusd
       - -hooks-http-forward-headers
       - Authorization,X-Organization-Id
+      - -cors-allow-headers
+      - X-Organization-Id
       - -behind-proxy
       - -verbose
     depends_on:

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -19,12 +19,19 @@ Newest entries first.
 - Installed shadcn popover + command UI components
 - 24 new tests + 3 updated tests (289 total web tests passing)
 - 3 page routes: `/manuscripts`, `/manuscripts/new`, `/manuscripts/[id]`
+- **QA session (session 2):** full manual QA of manuscript frontend
+- Fixed dev server port conflicts: Overmind `--no-port` flag in `dev.sh`, `fuser` fallback in `dev-clean.sh`
+- Fixed tusd CORS: added `-cors-allow-headers X-Organization-Id` to `docker-compose.yml`
+- Fixed file count staleness (P3): threaded `onFileChange` callback from ManuscriptDetail → ManuscriptVersionFiles → FileUpload to invalidate `manuscripts.getDetail` on upload/delete
+- Fixed manuscript link on submission detail (P3): joined manuscript title/ID/version in `getById` service method, added `manuscript` field to `submissionDetailSchema`, added "Linked Manuscript" card to submission detail page
+- All manuscript flows QA-verified: library (search, pagination), create (standalone + from picker), edit, delete, file upload/delete, versioning, ManuscriptPicker, cross-navigation between submissions and manuscripts, editor dashboard
 
 ### Decisions
 
 - ManuscriptPicker uses internal state for selection, not fully controlled — `value` prop reserved for future use
 - ReadOnlyFileItem download uses state-driven useQuery + useEffect since `getDownloadUrl` is a query procedure (not mutation)
 - Editable ManuscriptVersionFiles just renders FileUpload as-is (avoids duplicating file list rendering)
+- Manuscript info in submission `getById`: joined in service layer rather than adding a new tRPC procedure — simpler single query
 
 ---
 

--- a/packages/types/src/submission.ts
+++ b/packages/types/src/submission.ts
@@ -165,6 +165,14 @@ export const submissionDetailSchema = submissionSchema.extend({
     .email()
     .nullable()
     .describe("Email address of the submitter"),
+  manuscript: z
+    .object({
+      manuscriptId: z.string().uuid(),
+      manuscriptTitle: z.string(),
+      versionNumber: z.number().int(),
+    })
+    .nullable()
+    .describe("Linked manuscript info (null if no manuscript attached)"),
 });
 
 export type SubmissionDetail = z.infer<typeof submissionDetailSchema>;

--- a/scripts/dev-clean.sh
+++ b/scripts/dev-clean.sh
@@ -6,12 +6,15 @@ set -uo pipefail
 
 echo "Cleaning up dev environment..."
 
-# Kill processes on dev server ports
+# Kill processes on dev server ports (lsof + fuser for thorough detection)
 for port in 4000 3000; do
   pids=$(lsof -ti :"$port" 2>/dev/null || true)
-  if [ -n "$pids" ]; then
-    echo "Killing processes on port $port: $pids"
-    echo "$pids" | xargs -r kill -9 2>/dev/null || true
+  # fuser catches processes lsof misses (e.g., next-server on 0.0.0.0)
+  fuser_pids=$(fuser "$port"/tcp 2>/dev/null | tr -s ' ' '\n' | grep -v '^$' || true)
+  all_pids=$(echo "$pids $fuser_pids" | tr ' ' '\n' | sort -u | grep -v '^$' || true)
+  if [ -n "$all_pids" ]; then
+    echo "Killing processes on port $port: $(echo $all_pids | tr '\n' ' ')"
+    echo "$all_pids" | xargs -r kill -9 2>/dev/null || true
   fi
 done
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -28,4 +28,6 @@ echo "Building workspace packages..."
 pnpm exec turbo run build --filter='./packages/*'
 
 # Start dev servers via Overmind (exec replaces shell for clean signal handling)
-exec overmind start -f Procfile.dev
+# --no-port: let each process use its own PORT (API from .env, Next.js default 3000)
+# Without this, Overmind sets PORT=5000/5100 which breaks Zitadel OIDC redirect URIs
+exec overmind start -f Procfile.dev --no-port


### PR DESCRIPTION
## Summary

- **File count staleness (P3):** Manuscript detail page now invalidates `manuscripts.getDetail` when files are uploaded or deleted, so the version file count badge updates immediately without a page refresh.
- **Submission → manuscript link (P3):** Submission detail page now shows a "Linked Manuscript" card when the submission has an associated manuscript, with a clickable link to the manuscript detail.
- **Upload retry invalidation (code review):** The second delayed invalidation (4s) in `use-file-upload.ts` now also fires `onUploadComplete`, ensuring the manuscript detail cache is refreshed even when the webhook takes longer than 1.5s to persist the file record.
- **Dev environment fixes (P1/P2):** Fixed tusd CORS headers for manuscript uploads and resolved Overmind port conflicts.

## Test plan

- [x] Manual QA: file upload → version file count badge updates immediately
- [x] Manual QA: file deletion → count updates immediately
- [x] Manual QA: submission detail shows linked manuscript card
- [x] Manual QA: manuscript link navigates to manuscript detail
- [x] Manual QA: create manuscript from submission form
- [x] Manual QA: manuscript search, edit, delete flows
- [x] Unit tests pass (712 tests)
- [x] branch review (P1 dismissed as false positive, P2 fixed)