### PR TITLE
feat(hopper): embeddable submission forms — backend foundation

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -2,29 +2,32 @@
 
 ## Key Paths
 
-| What              | Path                                 |
-| ----------------- | ------------------------------------ |
-| App entry         | `src/main.ts`                        |
-| Env config (Zod)  | `src/config/env.ts`                  |
-| Fastify hooks     | `src/hooks/`                         |
-| Service layer     | `src/services/`                      |
-| Manuscript svc    | `src/services/manuscript.service.ts` |
-| tRPC router       | `src/trpc/router.ts`                 |
-| tRPC client types | `src/trpc/client-types.ts`           |
-| tRPC init         | `src/trpc/init.ts`                   |
-| tRPC context      | `src/trpc/context.ts`                |
-| REST router       | `src/rest/router.ts`                 |
-| REST context      | `src/rest/context.ts`                |
-| REST error mapper | `src/rest/error-mapper.ts`           |
-| REST org handlers | `src/rest/routers/organizations.ts`  |
-| GraphQL schema    | `src/graphql/schema.ts`              |
-| GraphQL builder   | `src/graphql/builder.ts`             |
-| GraphQL guards    | `src/graphql/guards.ts`              |
-| GraphQL resolvers | `src/graphql/resolvers/`             |
-| GraphQL router    | `src/graphql/router.ts`              |
-| tusd webhook      | `src/webhooks/tusd.webhook.ts`       |
-| Zitadel webhook   | `src/webhooks/zitadel.webhook.ts`    |
-| Stripe webhook    | `src/webhooks/stripe.webhook.ts`     |
+| What              | Path                                       |
+| ----------------- | ------------------------------------------ |
+| App entry         | `src/main.ts`                              |
+| Env config (Zod)  | `src/config/env.ts`                        |
+| Fastify hooks     | `src/hooks/`                               |
+| Service layer     | `src/services/`                            |
+| Manuscript svc    | `src/services/manuscript.service.ts`       |
+| tRPC router       | `src/trpc/router.ts`                       |
+| tRPC client types | `src/trpc/client-types.ts`                 |
+| tRPC init         | `src/trpc/init.ts`                         |
+| tRPC context      | `src/trpc/context.ts`                      |
+| REST router       | `src/rest/router.ts`                       |
+| REST context      | `src/rest/context.ts`                      |
+| REST error mapper | `src/rest/error-mapper.ts`                 |
+| REST org handlers | `src/rest/routers/organizations.ts`        |
+| GraphQL schema    | `src/graphql/schema.ts`                    |
+| GraphQL builder   | `src/graphql/builder.ts`                   |
+| GraphQL guards    | `src/graphql/guards.ts`                    |
+| GraphQL resolvers | `src/graphql/resolvers/`                   |
+| GraphQL router    | `src/graphql/router.ts`                    |
+| Embed routes      | `src/routes/embed.routes.ts`               |
+| Embed token svc   | `src/services/embed-token.service.ts`      |
+| Embed submit svc  | `src/services/embed-submission.service.ts` |
+| tusd webhook      | `src/webhooks/tusd.webhook.ts`             |
+| Zitadel webhook   | `src/webhooks/zitadel.webhook.ts`          |
+| Stripe webhook    | `src/webhooks/stripe.webhook.ts`           |
 
 ### Service Method Naming
 

--- a/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
+++ b/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
@@ -17,6 +17,7 @@ const RLS_TABLES = [
   'manuscripts',
   'manuscript_versions',
   'files',
+  'embed_tokens',
 ];
 
 /** RLS tables where app_user has full DML (excludes audit_events which is SELECT-only + function). */

--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -317,6 +317,7 @@ describe('auth plugin', () => {
         emailVerifiedAt: null,
         createdAt: new Date(),
         updatedAt: new Date(),
+        isGuest: false,
         deletedAt: new Date(), // deactivated
         lastEventAt: null,
       });
@@ -346,6 +347,7 @@ describe('auth plugin', () => {
         emailVerifiedAt: new Date(),
         createdAt: new Date(),
         updatedAt: new Date(),
+        isGuest: false,
         deletedAt: null,
         lastEventAt: null,
       });
@@ -610,6 +612,7 @@ describe('auth plugin', () => {
         zitadelUserId: 'zitadel-deactivated',
         emailVerified: true,
         emailVerifiedAt: null,
+        isGuest: false,
         createdAt: new Date(),
         updatedAt: new Date(),
         deletedAt: new Date(),
@@ -886,6 +889,7 @@ describe('auth plugin', () => {
         emailVerifiedAt: new Date(),
         createdAt: new Date(),
         updatedAt: new Date(),
+        isGuest: false,
         deletedAt: null,
         lastEventAt: null,
       });

--- a/apps/api/src/hooks/auth.ts
+++ b/apps/api/src/hooks/auth.ts
@@ -27,7 +27,13 @@ declare module 'fastify' {
  * 2. Add a corresponding test in auth.spec.ts
  * 3. Document in apps/api/CLAUDE.md
  */
-const PUBLIC_PREFIXES = ['/health', '/ready', '/webhooks/', '/.well-known/'];
+const PUBLIC_PREFIXES = [
+  '/health',
+  '/ready',
+  '/webhooks/',
+  '/.well-known/',
+  '/embed/',
+];
 const PUBLIC_EXACT = [
   '/',
   '/health',

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -12,6 +12,7 @@ import auditPlugin from './hooks/audit.js';
 import { registerZitadelWebhooks } from './webhooks/zitadel.webhook.js';
 import { registerTusdWebhooks } from './webhooks/tusd.webhook.js';
 import { registerStripeWebhooks } from './webhooks/stripe.webhook.js';
+import { registerEmbedRoutes } from './routes/embed.routes.js';
 import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
 import { appRouter } from './trpc/router.js';
 import { createContext } from './trpc/context.js';
@@ -125,6 +126,11 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
   });
   await app.register(async (scope) => {
     await registerStripeWebhooks(scope, { env });
+  });
+
+  // Embed routes — isolated scope (own auth via token verification)
+  await app.register(async (scope) => {
+    await registerEmbedRoutes(scope, { env });
   });
 
   // tRPC adapter

--- a/apps/api/src/routes/embed.routes.spec.ts
+++ b/apps/api/src/routes/embed.routes.spec.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockEmbedTokenService, mockEmbedSubmissionService } = vi.hoisted(() => {
+  const mockEmbedTokenService = {
+    verifyToken: vi.fn(),
+  };
+  const mockEmbedSubmissionService = {
+    submitFromEmbed: vi.fn(),
+    loadFormForEmbed: vi.fn(),
+  };
+  return { mockEmbedTokenService, mockEmbedSubmissionService };
+});
+
+vi.mock('../services/embed-token.service.js', () => ({
+  embedTokenService: mockEmbedTokenService,
+}));
+
+vi.mock('../services/embed-submission.service.js', () => ({
+  embedSubmissionService: mockEmbedSubmissionService,
+  PeriodClosedError: class PeriodClosedError extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = 'PeriodClosedError';
+    }
+  },
+}));
+
+// Mock ioredis
+vi.mock('ioredis', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      connect: vi.fn().mockResolvedValue(undefined),
+      eval: vi.fn().mockResolvedValue([1, 60000]),
+      quit: vi.fn().mockResolvedValue(undefined),
+    })),
+  };
+});
+
+import Fastify from 'fastify';
+import { registerEmbedRoutes } from './embed.routes.js';
+import type { VerifiedEmbedToken } from '../services/embed-token.service.js';
+
+function makeVerifiedToken(
+  overrides: Partial<VerifiedEmbedToken> = {},
+): VerifiedEmbedToken {
+  const now = new Date();
+  return {
+    id: 'token-1',
+    organizationId: 'org-1',
+    submissionPeriodId: 'period-1',
+    allowedOrigins: [],
+    themeConfig: null,
+    active: true,
+    expiresAt: null,
+    period: {
+      name: 'Fall 2026',
+      opensAt: new Date(now.getTime() - 86400000),
+      closesAt: new Date(now.getTime() + 86400000),
+      formDefinitionId: null,
+      maxSubmissions: null,
+      fee: null,
+    },
+    ...overrides,
+  };
+}
+
+const testEnv = {
+  REDIS_HOST: 'localhost',
+  REDIS_PORT: 6379,
+  REDIS_PASSWORD: '',
+  RATE_LIMIT_WINDOW_SECONDS: 60,
+  RATE_LIMIT_KEY_PREFIX: 'test:rl',
+} as any;
+
+async function buildTestApp() {
+  const app = Fastify({ logger: false });
+  await app.register(async (scope) => {
+    await registerEmbedRoutes(scope, { env: testEnv });
+  });
+  return app;
+}
+
+describe('embed routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /embed/:token', () => {
+    it('returns 404 for invalid token', async () => {
+      mockEmbedTokenService.verifyToken.mockResolvedValueOnce(null);
+
+      const app = await buildTestApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/embed/col_emb_invalidtokenvalue1234567890',
+      });
+
+      expect(res.statusCode).toBe(404);
+      expect(JSON.parse(res.body)).toMatchObject({ error: 'not_found' });
+    });
+
+    it('returns form definition for valid token', async () => {
+      const token = makeVerifiedToken();
+      mockEmbedTokenService.verifyToken.mockResolvedValueOnce(token);
+      mockEmbedSubmissionService.loadFormForEmbed.mockResolvedValueOnce(null);
+
+      const app = await buildTestApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/embed/col_emb_abcdef1234567890abcdef1234567890',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.period.name).toBe('Fall 2026');
+      expect(body.form).toBeNull();
+      expect(body.organizationId).toBe('org-1');
+    });
+
+    it('returns 410 for closed period', async () => {
+      const closedToken = makeVerifiedToken({
+        period: {
+          name: 'Expired',
+          opensAt: new Date('2020-01-01'),
+          closesAt: new Date('2020-12-31'),
+          formDefinitionId: null,
+          maxSubmissions: null,
+          fee: null,
+        },
+      });
+      mockEmbedTokenService.verifyToken.mockResolvedValueOnce(closedToken);
+
+      const app = await buildTestApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/embed/col_emb_abcdef1234567890abcdef1234567890',
+      });
+
+      expect(res.statusCode).toBe(410);
+    });
+
+    it('sets frame-ancestors CSP header from allowedOrigins', async () => {
+      const token = makeVerifiedToken({
+        allowedOrigins: ['https://magazine.com', 'https://blog.example.org'],
+      });
+      mockEmbedTokenService.verifyToken.mockResolvedValueOnce(token);
+      mockEmbedSubmissionService.loadFormForEmbed.mockResolvedValueOnce(null);
+
+      const app = await buildTestApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/embed/col_emb_abcdef1234567890abcdef1234567890',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['content-security-policy']).toBe(
+        'frame-ancestors https://magazine.com https://blog.example.org',
+      );
+    });
+  });
+
+  describe('POST /embed/:token/submit', () => {
+    it('creates guest user and submission', async () => {
+      const token = makeVerifiedToken();
+      mockEmbedTokenService.verifyToken.mockResolvedValueOnce(token);
+      mockEmbedSubmissionService.submitFromEmbed.mockResolvedValueOnce({
+        submissionId: 'sub-1',
+        userId: 'user-1',
+      });
+
+      const app = await buildTestApp();
+      const res = await app.inject({
+        method: 'POST',
+        url: '/embed/col_emb_abcdef1234567890abcdef1234567890/submit',
+        payload: {
+          email: 'writer@example.com',
+          title: 'My Poem',
+          content: 'Roses are red...',
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.success).toBe(true);
+      expect(body.submissionId).toBe('sub-1');
+    });
+
+    it('returns 400 for invalid email', async () => {
+      const token = makeVerifiedToken();
+      mockEmbedTokenService.verifyToken.mockResolvedValueOnce(token);
+
+      const app = await buildTestApp();
+      const res = await app.inject({
+        method: 'POST',
+        url: '/embed/col_emb_abcdef1234567890abcdef1234567890/submit',
+        payload: {
+          email: 'not-an-email',
+          title: 'My Poem',
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      const body = JSON.parse(res.body);
+      expect(body.error).toBe('validation_error');
+    });
+
+    it('returns 403 for disallowed origin', async () => {
+      const token = makeVerifiedToken({
+        allowedOrigins: ['https://allowed.com'],
+      });
+      mockEmbedTokenService.verifyToken.mockResolvedValueOnce(token);
+
+      const app = await buildTestApp();
+      const res = await app.inject({
+        method: 'POST',
+        url: '/embed/col_emb_abcdef1234567890abcdef1234567890/submit',
+        headers: {
+          origin: 'https://evil.com',
+        },
+        payload: {
+          email: 'writer@example.com',
+          title: 'My Poem',
+        },
+      });
+
+      expect(res.statusCode).toBe(403);
+      const body = JSON.parse(res.body);
+      expect(body.error).toBe('forbidden');
+    });
+
+    it('returns 404 for invalid token', async () => {
+      mockEmbedTokenService.verifyToken.mockResolvedValueOnce(null);
+
+      const app = await buildTestApp();
+      const res = await app.inject({
+        method: 'POST',
+        url: '/embed/col_emb_invalidtokenvalue1234567890/submit',
+        payload: {
+          email: 'writer@example.com',
+          title: 'My Poem',
+        },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+});

--- a/apps/api/src/routes/embed.routes.ts
+++ b/apps/api/src/routes/embed.routes.ts
@@ -207,15 +207,19 @@ export async function registerEmbedRoutes(
 
       // Check origin on POST (CSRF protection)
       const origin = request.headers.origin;
-      if (
-        token.allowedOrigins.length > 0 &&
-        origin &&
-        !token.allowedOrigins.includes(origin)
-      ) {
-        return reply.status(403).send({
-          error: 'forbidden',
-          message: 'Origin not allowed for this embed token',
-        });
+      if (token.allowedOrigins.length > 0) {
+        if (!origin) {
+          return reply.status(403).send({
+            error: 'forbidden',
+            message: 'Origin header required for this embed token',
+          });
+        }
+        if (!token.allowedOrigins.includes(origin)) {
+          return reply.status(403).send({
+            error: 'forbidden',
+            message: 'Origin not allowed for this embed token',
+          });
+        }
       }
 
       // Validate body

--- a/apps/api/src/routes/embed.routes.ts
+++ b/apps/api/src/routes/embed.routes.ts
@@ -1,0 +1,259 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import Redis from 'ioredis';
+import { embedSubmitSchema } from '@colophony/types';
+import type { Env } from '../config/env.js';
+import {
+  embedTokenService,
+  type VerifiedEmbedToken,
+} from '../services/embed-token.service.js';
+import {
+  embedSubmissionService,
+  PeriodClosedError,
+} from '../services/embed-submission.service.js';
+
+/**
+ * Atomic Lua script: INCR key, set PEXPIRE on first hit, return [count, pttl].
+ */
+const RATE_LIMIT_LUA = `
+local current = redis.call('INCR', KEYS[1])
+if current == 1 then
+  redis.call('PEXPIRE', KEYS[1], ARGV[1])
+end
+local ttl = redis.call('PTTL', KEYS[1])
+return { current, ttl }
+`;
+
+export async function registerEmbedRoutes(
+  app: FastifyInstance,
+  opts: { env: Env },
+): Promise<void> {
+  const { env } = opts;
+
+  // Lazy Redis connection for embed rate limiting
+  let redis: Redis | null = null;
+
+  function getRedis(): Redis | null {
+    if (redis) return redis;
+    try {
+      redis = new Redis({
+        host: env.REDIS_HOST,
+        port: env.REDIS_PORT,
+        password: env.REDIS_PASSWORD || undefined,
+        lazyConnect: true,
+        enableOfflineQueue: false,
+        maxRetriesPerRequest: 0,
+        connectTimeout: 5000,
+        commandTimeout: 1000,
+      });
+      redis.connect().catch(() => {
+        // Connection failure handled per-request via graceful degradation
+      });
+      return redis;
+    } catch {
+      return null;
+    }
+  }
+
+  app.addHook('onClose', async () => {
+    if (redis) {
+      await redis.quit().catch(() => {
+        // Ignore quit errors during shutdown
+      });
+    }
+  });
+
+  /**
+   * Verify embed token from URL param.
+   * Returns token details or sends error reply.
+   */
+  async function verifyTokenParam(
+    request: FastifyRequest<{ Params: { token: string } }>,
+    reply: FastifyReply,
+  ): Promise<VerifiedEmbedToken | undefined> {
+    const { token: plainTextToken } = request.params;
+
+    // Basic format check
+    if (!plainTextToken.startsWith('col_emb_') || plainTextToken.length < 20) {
+      void reply
+        .status(404)
+        .send({ error: 'not_found', message: 'Invalid embed token' });
+      return undefined;
+    }
+
+    const verified = await embedTokenService.verifyToken(plainTextToken);
+
+    if (!verified) {
+      void reply
+        .status(404)
+        .send({ error: 'not_found', message: 'Invalid embed token' });
+      return undefined;
+    }
+
+    if (!verified.active) {
+      void reply.status(404).send({
+        error: 'not_found',
+        message: 'Embed token has been revoked',
+      });
+      return undefined;
+    }
+
+    // Check expiration
+    if (verified.expiresAt && verified.expiresAt < new Date()) {
+      void reply
+        .status(410)
+        .send({ error: 'gone', message: 'Embed token has expired' });
+      return undefined;
+    }
+
+    // Check period dates
+    const now = new Date();
+    if (now > verified.period.closesAt) {
+      void reply
+        .status(410)
+        .send({ error: 'gone', message: 'Submission period has closed' });
+      return undefined;
+    }
+
+    return verified;
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /embed/:token — public form definition
+  // ---------------------------------------------------------------------------
+  app.get<{ Params: { token: string } }>(
+    '/embed/:token',
+    async (request, reply) => {
+      const token = await verifyTokenParam(request, reply);
+      if (!token) return;
+
+      // Set CSP frame-ancestors
+      const origins =
+        token.allowedOrigins.length > 0 ? token.allowedOrigins.join(' ') : '*';
+      void reply.header(
+        'content-security-policy',
+        `frame-ancestors ${origins}`,
+      );
+
+      // Load form definition
+      const form = await embedSubmissionService.loadFormForEmbed(token);
+
+      return {
+        period: {
+          id: token.submissionPeriodId,
+          name: token.period.name,
+          opensAt: token.period.opensAt,
+          closesAt: token.period.closesAt,
+        },
+        form,
+        theme: token.themeConfig,
+        organizationId: token.organizationId,
+      };
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // POST /embed/:token/submit — submit from embed form
+  // ---------------------------------------------------------------------------
+  app.post<{ Params: { token: string } }>(
+    '/embed/:token/submit',
+    {
+      bodyLimit: 512 * 1024, // 512KB
+      /* eslint-disable @typescript-eslint/no-misused-promises */
+      preHandler: async function embedRateLimit(
+        request: FastifyRequest,
+        reply: FastifyReply,
+      ) {
+        // Rate limit per IP
+        const redisClient = getRedis();
+        if (!redisClient) return; // Graceful degradation
+
+        const windowMs = env.RATE_LIMIT_WINDOW_SECONDS * 1000;
+        const windowId = Math.floor(Date.now() / windowMs);
+        const key = `${env.RATE_LIMIT_KEY_PREFIX}:embed:${request.ip}:${windowId}`;
+
+        try {
+          const result = (await redisClient.eval(
+            RATE_LIMIT_LUA,
+            1,
+            key,
+            windowMs,
+          )) as [number, number];
+          const count = result[0];
+
+          // Stricter limit for embed submissions (10 per window per IP)
+          const embedLimit = 10;
+          if (count > embedLimit) {
+            const remainingMs = windowMs - (Date.now() % windowMs);
+            const retryAfterSeconds = Math.ceil(remainingMs / 1000);
+            reply.header('Retry-After', retryAfterSeconds);
+            request.log.warn(
+              { ip: request.ip, count, limit: embedLimit },
+              'Embed submission rate limit exceeded',
+            );
+            return reply.status(429).send({
+              error: 'rate_limit_exceeded',
+              message: 'Too many submissions. Please try again later.',
+            });
+          }
+        } catch {
+          request.log.warn('Embed rate limit Redis error — allowing request');
+        }
+      },
+      /* eslint-enable @typescript-eslint/no-misused-promises */
+    },
+    async (request, reply) => {
+      const token = await verifyTokenParam(request, reply);
+      if (!token) return;
+
+      // Check origin on POST (CSRF protection)
+      const origin = request.headers.origin;
+      if (
+        token.allowedOrigins.length > 0 &&
+        origin &&
+        !token.allowedOrigins.includes(origin)
+      ) {
+        return reply.status(403).send({
+          error: 'forbidden',
+          message: 'Origin not allowed for this embed token',
+        });
+      }
+
+      // Validate body
+      const parsed = embedSubmitSchema.safeParse(request.body);
+      if (!parsed.success) {
+        const errors = parsed.error.issues.map((i) => ({
+          path: i.path.join('.'),
+          message: i.message,
+        }));
+        return reply.status(400).send({
+          error: 'validation_error',
+          message: 'Invalid submission data',
+          details: errors,
+        });
+      }
+
+      try {
+        const { submissionId } = await embedSubmissionService.submitFromEmbed(
+          token,
+          parsed.data,
+          request.ip,
+          request.headers['user-agent'],
+        );
+
+        return {
+          success: true,
+          submissionId,
+          message: 'Submission received successfully',
+        };
+      } catch (err) {
+        if (err instanceof PeriodClosedError) {
+          return reply.status(410).send({
+            error: 'gone',
+            message: err.message,
+          });
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/apps/api/src/services/audit.service.ts
+++ b/apps/api/src/services/audit.service.ts
@@ -13,6 +13,7 @@ import type {
   AuditLogParams,
   AuthAuditParams,
   ApiKeyAuditParams,
+  EmbedTokenAuditParams,
   ListAuditEventsInput,
 } from '@colophony/types';
 
@@ -197,7 +198,9 @@ export const auditService = {
    *
    * Errors propagate — caller is responsible for try/catch.
    */
-  async logDirect(params: AuthAuditParams | ApiKeyAuditParams): Promise<void> {
+  async logDirect(
+    params: AuthAuditParams | ApiKeyAuditParams | EmbedTokenAuditParams,
+  ): Promise<void> {
     if (params.organizationId) {
       throw new Error(
         'logDirect must not include organizationId — use auditService.log() inside a transaction for org-scoped events',

--- a/apps/api/src/services/embed-submission.service.spec.ts
+++ b/apps/api/src/services/embed-submission.service.spec.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockDb, mockWithRls, mockAuditService, mockSubmissionService } =
+  vi.hoisted(() => {
+    const mockDb = {
+      select: vi.fn(),
+      insert: vi.fn(),
+    };
+    const mockWithRls = vi.fn();
+    const mockAuditService = {
+      log: vi.fn(),
+      logDirect: vi.fn(),
+    };
+    const mockSubmissionService = {
+      create: vi.fn(),
+      updateStatus: vi.fn(),
+    };
+    return { mockDb, mockWithRls, mockAuditService, mockSubmissionService };
+  });
+
+vi.mock('@colophony/db', () => ({
+  db: mockDb,
+  withRls: mockWithRls,
+  users: {
+    id: 'id',
+    email: 'email',
+    isGuest: 'is_guest',
+    emailVerified: 'email_verified',
+  },
+  formDefinitions: { id: 'id', name: 'name' },
+  formFields: {
+    formDefinitionId: 'form_definition_id',
+    sortOrder: 'sort_order',
+  },
+  formPages: {
+    formDefinitionId: 'form_definition_id',
+    sortOrder: 'sort_order',
+  },
+  eq: vi.fn((_col: unknown, val: unknown) => val),
+  sql: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  asc: vi.fn(),
+}));
+
+vi.mock('./audit.service.js', () => ({
+  auditService: mockAuditService,
+}));
+
+vi.mock('./submission.service.js', () => ({
+  submissionService: mockSubmissionService,
+}));
+
+import {
+  embedSubmissionService,
+  PeriodClosedError,
+} from './embed-submission.service.js';
+import type { VerifiedEmbedToken } from './embed-token.service.js';
+
+function makeToken(
+  overrides: Partial<VerifiedEmbedToken> = {},
+): VerifiedEmbedToken {
+  const now = new Date();
+  return {
+    id: 'token-1',
+    organizationId: 'org-1',
+    submissionPeriodId: 'period-1',
+    allowedOrigins: [],
+    themeConfig: null,
+    active: true,
+    expiresAt: null,
+    period: {
+      name: 'Fall 2026',
+      opensAt: new Date(now.getTime() - 86400000),
+      closesAt: new Date(now.getTime() + 86400000),
+      formDefinitionId: null,
+      maxSubmissions: null,
+      fee: null,
+    },
+    ...overrides,
+  };
+}
+
+describe('embedSubmissionService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('findOrCreateGuestUser', () => {
+    it('creates user with isGuest=true for unknown email', async () => {
+      // Mock select (find existing) — empty result
+      mockDb.select.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      // Mock insert (create guest)
+      mockDb.insert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: 'new-user-1' }]),
+        }),
+      });
+
+      const result =
+        await embedSubmissionService.findOrCreateGuestUser('New@Example.COM');
+
+      expect(result.id).toBe('new-user-1');
+      expect(result.isNew).toBe(true);
+    });
+
+    it('returns existing user for known email (case-insensitive)', async () => {
+      mockDb.select.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: 'existing-user-1' }]),
+          }),
+        }),
+      });
+
+      const result = await embedSubmissionService.findOrCreateGuestUser(
+        'EXISTING@example.com',
+      );
+
+      expect(result.id).toBe('existing-user-1');
+      expect(result.isNew).toBe(false);
+    });
+  });
+
+  describe('submitFromEmbed', () => {
+    it('creates submission in SUBMITTED status with history entries', async () => {
+      // Mock findOrCreateGuestUser
+      mockDb.select.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: 'user-1' }]),
+          }),
+        }),
+      });
+
+      // Mock withRls to execute the callback
+      mockWithRls.mockImplementation(
+        async (_ctx: unknown, fn: (tx: unknown) => Promise<unknown>) => {
+          return fn({} as never);
+        },
+      );
+
+      mockSubmissionService.create.mockResolvedValue({
+        id: 'sub-1',
+        status: 'DRAFT',
+      });
+      mockSubmissionService.updateStatus.mockResolvedValue({
+        submission: { id: 'sub-1', status: 'SUBMITTED' },
+        historyEntry: { id: 'history-1' },
+      });
+      mockAuditService.log.mockResolvedValue(undefined);
+
+      const token = makeToken();
+      const result = await embedSubmissionService.submitFromEmbed(
+        token,
+        {
+          email: 'writer@example.com',
+          title: 'My Poem',
+          content: 'Roses are red...',
+        },
+        '127.0.0.1',
+        'TestAgent/1.0',
+      );
+
+      expect(result.submissionId).toBe('sub-1');
+      expect(result.userId).toBe('user-1');
+
+      // Verify create was called for DRAFT
+      expect(mockSubmissionService.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ title: 'My Poem' }),
+        'org-1',
+        'user-1',
+      );
+
+      // Verify updateStatus was called for DRAFT→SUBMITTED
+      expect(mockSubmissionService.updateStatus).toHaveBeenCalledWith(
+        expect.anything(),
+        'sub-1',
+        'SUBMITTED',
+        'user-1',
+        undefined,
+        'submitter',
+      );
+    });
+
+    it('throws PeriodClosedError when period not open', async () => {
+      mockDb.select.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: 'user-1' }]),
+          }),
+        }),
+      });
+
+      mockWithRls.mockImplementation(
+        async (_ctx: unknown, fn: (tx: unknown) => Promise<unknown>) => {
+          return fn({} as never);
+        },
+      );
+
+      const closedToken = makeToken({
+        period: {
+          name: 'Expired Period',
+          opensAt: new Date('2020-01-01'),
+          closesAt: new Date('2020-12-31'),
+          formDefinitionId: null,
+          maxSubmissions: null,
+          fee: null,
+        },
+      });
+
+      await expect(
+        embedSubmissionService.submitFromEmbed(
+          closedToken,
+          {
+            email: 'writer@example.com',
+            title: 'Late Submission',
+          },
+          '127.0.0.1',
+          undefined,
+        ),
+      ).rejects.toThrow(PeriodClosedError);
+    });
+
+    it('uses existing registered user when email matches', async () => {
+      // Existing user found
+      mockDb.select.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: 'existing-user' }]),
+          }),
+        }),
+      });
+
+      mockWithRls.mockImplementation(
+        async (_ctx: unknown, fn: (tx: unknown) => Promise<unknown>) => {
+          return fn({} as never);
+        },
+      );
+
+      mockSubmissionService.create.mockResolvedValue({ id: 'sub-1' });
+      mockSubmissionService.updateStatus.mockResolvedValue({
+        submission: { id: 'sub-1' },
+        historyEntry: {},
+      });
+      mockAuditService.log.mockResolvedValue(undefined);
+
+      const result = await embedSubmissionService.submitFromEmbed(
+        makeToken(),
+        { email: 'existing@example.com', title: 'Test' },
+        '127.0.0.1',
+        undefined,
+      );
+
+      expect(result.userId).toBe('existing-user');
+      // Should NOT call logDirect for guest user creation
+      expect(mockAuditService.logDirect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/services/embed-submission.service.ts
+++ b/apps/api/src/services/embed-submission.service.ts
@@ -1,0 +1,205 @@
+import {
+  db,
+  users,
+  formDefinitions,
+  formPages,
+  formFields,
+  eq,
+  sql,
+} from '@colophony/db';
+import { withRls } from '@colophony/db';
+import { asc } from 'drizzle-orm';
+import type { EmbedSubmitInput } from '@colophony/types';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { VerifiedEmbedToken } from './embed-token.service.js';
+import { auditService } from './audit.service.js';
+import { submissionService } from './submission.service.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class PeriodClosedError extends Error {
+  constructor(periodName: string) {
+    super(`Submission period "${periodName}" is not currently open`);
+    this.name = 'PeriodClosedError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const embedSubmissionService = {
+  /**
+   * Find an existing user by email (case-insensitive) or create a guest user.
+   * Uses the shared `db` instance (no RLS on users table).
+   */
+  async findOrCreateGuestUser(
+    email: string,
+    _name?: string,
+  ): Promise<{ id: string; isNew: boolean }> {
+    const normalizedEmail = email.toLowerCase().trim();
+
+    // Try to find existing user by lowercase email
+    const [existing] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(sql`lower(${users.email}) = ${normalizedEmail}`)
+      .limit(1);
+
+    if (existing) {
+      return { id: existing.id, isNew: false };
+    }
+
+    // Create guest user
+    const [created] = await db
+      .insert(users)
+      .values({
+        email: normalizedEmail,
+        isGuest: true,
+        emailVerified: false,
+      })
+      .returning({ id: users.id });
+
+    return { id: created.id, isNew: true };
+  },
+
+  /**
+   * Submit from an embedded form.
+   *
+   * 1. Find/create guest user (outside RLS — users table has no RLS)
+   * 2. Open RLS transaction with org+user context
+   * 3. Validate period is open
+   * 4. Create DRAFT submission, then transition to SUBMITTED via updateStatus
+   *    (reuses invariant checks: form validation, file scan verification)
+   * 5. Audit log
+   */
+  async submitFromEmbed(
+    token: VerifiedEmbedToken,
+    input: EmbedSubmitInput,
+    ipAddress: string,
+    userAgent: string | undefined,
+  ): Promise<{ submissionId: string; userId: string }> {
+    // Step 1: Find/create guest user (no RLS)
+    const { id: userId, isNew } =
+      await embedSubmissionService.findOrCreateGuestUser(
+        input.email,
+        input.name,
+      );
+
+    if (isNew) {
+      // Audit guest user creation outside RLS (no org context needed)
+      await auditService.logDirect({
+        action: AuditActions.GUEST_USER_CREATED,
+        resource: AuditResources.EMBED_TOKEN,
+        resourceId: userId,
+        ipAddress,
+        userAgent,
+        newValue: { email: input.email, embedTokenId: token.id },
+      });
+    }
+
+    // Step 2: RLS transaction with org + user context
+    const result = await withRls(
+      { orgId: token.organizationId, userId },
+      async (tx) => {
+        // Step 3: Validate period is open
+        const now = new Date();
+        if (now < token.period.opensAt || now > token.period.closesAt) {
+          throw new PeriodClosedError(token.period.name);
+        }
+
+        // Step 4a: Create DRAFT submission
+        const submission = await submissionService.create(
+          tx,
+          {
+            title: input.title,
+            content: input.content,
+            coverLetter: input.coverLetter,
+            submissionPeriodId: token.submissionPeriodId,
+            formData: input.formData,
+          },
+          token.organizationId,
+          userId,
+        );
+
+        // Step 4b: Transition DRAFT → SUBMITTED (reuses invariant checks)
+        await submissionService.updateStatus(
+          tx,
+          submission.id,
+          'SUBMITTED',
+          userId,
+          undefined,
+          'submitter',
+        );
+
+        // Step 5: Audit log
+        await auditService.log(tx, {
+          action: AuditActions.EMBED_SUBMISSION_CREATED,
+          resource: AuditResources.EMBED_TOKEN,
+          resourceId: submission.id,
+          actorId: userId,
+          organizationId: token.organizationId,
+          ipAddress,
+          userAgent,
+          newValue: {
+            title: input.title,
+            embedTokenId: token.id,
+            submissionPeriodId: token.submissionPeriodId,
+          },
+        });
+
+        return { submissionId: submission.id };
+      },
+    );
+
+    return { ...result, userId };
+  },
+
+  /**
+   * Load form definition with fields and pages for the embed response.
+   * Uses RLS context from the token's org.
+   */
+  async loadFormForEmbed(token: VerifiedEmbedToken): Promise<{
+    id: string;
+    name: string;
+    fields: unknown[];
+    pages: unknown[];
+  } | null> {
+    if (!token.period.formDefinitionId) return null;
+
+    return withRls({ orgId: token.organizationId }, async (tx) => {
+      const [form] = await tx
+        .select({
+          id: formDefinitions.id,
+          name: formDefinitions.name,
+        })
+        .from(formDefinitions)
+        .where(eq(formDefinitions.id, token.period.formDefinitionId!))
+        .limit(1);
+
+      if (!form) return null;
+
+      const [fields, pages] = await Promise.all([
+        tx
+          .select()
+          .from(formFields)
+          .where(eq(formFields.formDefinitionId, form.id))
+          .orderBy(asc(formFields.sortOrder)),
+        tx
+          .select()
+          .from(formPages)
+          .where(eq(formPages.formDefinitionId, form.id))
+          .orderBy(asc(formPages.sortOrder)),
+      ]);
+
+      return {
+        id: form.id,
+        name: form.name,
+        fields,
+        pages,
+      };
+    });
+  },
+};

--- a/apps/api/src/services/embed-submission.service.ts
+++ b/apps/api/src/services/embed-submission.service.ts
@@ -52,17 +52,34 @@ export const embedSubmissionService = {
       return { id: existing.id, isNew: false };
     }
 
-    // Create guest user
-    const [created] = await db
-      .insert(users)
-      .values({
-        email: normalizedEmail,
-        isGuest: true,
-        emailVerified: false,
-      })
-      .returning({ id: users.id });
+    // Create guest user — retry on unique constraint race (concurrent submissions)
+    try {
+      const [created] = await db
+        .insert(users)
+        .values({
+          email: normalizedEmail,
+          isGuest: true,
+          emailVerified: false,
+        })
+        .returning({ id: users.id });
 
-    return { id: created.id, isNew: true };
+      return { id: created.id, isNew: true };
+    } catch (err: unknown) {
+      // Unique constraint violation (23505) — another request created the user concurrently
+      if (
+        err instanceof Error &&
+        'code' in err &&
+        (err as { code: string }).code === '23505'
+      ) {
+        const [raced] = await db
+          .select({ id: users.id })
+          .from(users)
+          .where(sql`lower(${users.email}) = ${normalizedEmail}`)
+          .limit(1);
+        if (raced) return { id: raced.id, isNew: false };
+      }
+      throw err;
+    }
   },
 
   /**

--- a/apps/api/src/services/embed-token.service.spec.ts
+++ b/apps/api/src/services/embed-token.service.spec.ts
@@ -21,6 +21,9 @@ vi.mock('@colophony/db', () => ({
     createdAt: 'created_at',
     expiresAt: 'expires_at',
   },
+  submissionPeriods: {
+    id: 'id',
+  },
   eq: vi.fn((_col: unknown, val: unknown) => val),
   and: vi.fn((...args: unknown[]) => args),
   sql: vi.fn(),
@@ -89,24 +92,36 @@ describe('embedTokenService', () => {
     });
   });
 
+  /** Helper to build a mockTx with period lookup + insert chain */
+  function createMockTx(insertResult: unknown[]) {
+    return {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: 'period-1' }]),
+          }),
+        }),
+      }),
+      insert: vi.fn().mockReturnThis(),
+      values: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue(insertResult),
+    } as unknown as Parameters<typeof embedTokenService.create>[0];
+  }
+
   describe('create', () => {
     it('generates token with col_emb_ prefix', async () => {
-      const mockTx = {
-        insert: vi.fn().mockReturnThis(),
-        values: vi.fn().mockReturnThis(),
-        returning: vi.fn().mockResolvedValue([
-          {
-            id: 'token-1',
-            submissionPeriodId: 'period-1',
-            tokenPrefix: 'col_emb_',
-            allowedOrigins: ['https://example.com'],
-            themeConfig: {},
-            active: true,
-            createdAt: new Date(),
-            expiresAt: null,
-          },
-        ]),
-      } as unknown as Parameters<typeof embedTokenService.create>[0];
+      const mockTx = createMockTx([
+        {
+          id: 'token-1',
+          submissionPeriodId: 'period-1',
+          tokenPrefix: 'col_emb_',
+          allowedOrigins: ['https://example.com'],
+          themeConfig: {},
+          active: true,
+          createdAt: new Date(),
+          expiresAt: null,
+        },
+      ]);
 
       const result = await embedTokenService.create(mockTx, 'org-1', 'user-1', {
         submissionPeriodId: 'period-1',
@@ -118,22 +133,18 @@ describe('embedTokenService', () => {
     });
 
     it('stores SHA-256 hash, never plain text', async () => {
-      const mockTx = {
-        insert: vi.fn().mockReturnThis(),
-        values: vi.fn().mockReturnThis(),
-        returning: vi.fn().mockResolvedValue([
-          {
-            id: 'token-1',
-            submissionPeriodId: 'period-1',
-            tokenPrefix: 'col_emb_',
-            allowedOrigins: [],
-            themeConfig: {},
-            active: true,
-            createdAt: new Date(),
-            expiresAt: null,
-          },
-        ]),
-      } as unknown as Parameters<typeof embedTokenService.create>[0];
+      const mockTx = createMockTx([
+        {
+          id: 'token-1',
+          submissionPeriodId: 'period-1',
+          tokenPrefix: 'col_emb_',
+          allowedOrigins: [],
+          themeConfig: {},
+          active: true,
+          createdAt: new Date(),
+          expiresAt: null,
+        },
+      ]);
 
       await embedTokenService.create(mockTx, 'org-1', 'user-1', {
         submissionPeriodId: 'period-1',
@@ -151,22 +162,18 @@ describe('embedTokenService', () => {
     });
 
     it('stores allowedOrigins and themeConfig', async () => {
-      const mockTx = {
-        insert: vi.fn().mockReturnThis(),
-        values: vi.fn().mockReturnThis(),
-        returning: vi.fn().mockResolvedValue([
-          {
-            id: 'token-1',
-            submissionPeriodId: 'period-1',
-            tokenPrefix: 'col_emb_',
-            allowedOrigins: ['https://example.com'],
-            themeConfig: { primaryColor: '#ff0000' },
-            active: true,
-            createdAt: new Date(),
-            expiresAt: null,
-          },
-        ]),
-      } as unknown as Parameters<typeof embedTokenService.create>[0];
+      const mockTx = createMockTx([
+        {
+          id: 'token-1',
+          submissionPeriodId: 'period-1',
+          tokenPrefix: 'col_emb_',
+          allowedOrigins: ['https://example.com'],
+          themeConfig: { primaryColor: '#ff0000' },
+          active: true,
+          createdAt: new Date(),
+          expiresAt: null,
+        },
+      ]);
 
       await embedTokenService.create(mockTx, 'org-1', 'user-1', {
         submissionPeriodId: 'period-1',

--- a/apps/api/src/services/embed-token.service.spec.ts
+++ b/apps/api/src/services/embed-token.service.spec.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import crypto from 'node:crypto';
+
+const { mockPoolQuery } = vi.hoisted(() => {
+  const mockPoolQuery = vi.fn();
+  return { mockPoolQuery };
+});
+
+vi.mock('@colophony/db', () => ({
+  pool: { query: mockPoolQuery },
+  embedTokens: {
+    id: 'id',
+    organizationId: 'organization_id',
+    submissionPeriodId: 'submission_period_id',
+    tokenHash: 'token_hash',
+    tokenPrefix: 'token_prefix',
+    allowedOrigins: 'allowed_origins',
+    themeConfig: 'theme_config',
+    active: 'active',
+    createdBy: 'created_by',
+    createdAt: 'created_at',
+    expiresAt: 'expires_at',
+  },
+  eq: vi.fn((_col: unknown, val: unknown) => val),
+  and: vi.fn((...args: unknown[]) => args),
+  sql: vi.fn(),
+  DrizzleDb: {},
+}));
+
+vi.mock('@colophony/types', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@colophony/types')>();
+  return { ...original };
+});
+
+import { embedTokenService } from './embed-token.service.js';
+
+describe('embedTokenService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('verifyToken', () => {
+    it('returns token details with joined period data', async () => {
+      const plainTextToken = 'col_emb_abcdef1234567890abcdef1234567890';
+      const expectedHash = crypto
+        .createHash('sha256')
+        .update(plainTextToken)
+        .digest('hex');
+
+      const now = new Date();
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'token-1',
+            organization_id: 'org-1',
+            submission_period_id: 'period-1',
+            allowed_origins: ['https://example.com'],
+            theme_config: { primaryColor: '#3b82f6' },
+            active: true,
+            expires_at: null,
+            period_name: 'Fall 2026',
+            period_opens_at: new Date(now.getTime() - 86400000),
+            period_closes_at: new Date(now.getTime() + 86400000),
+            period_form_definition_id: 'form-1',
+            period_max_submissions: 100,
+            period_fee: '5.00',
+          },
+        ],
+      });
+
+      const result = await embedTokenService.verifyToken(plainTextToken);
+
+      expect(mockPoolQuery).toHaveBeenCalledWith(
+        'SELECT * FROM verify_embed_token($1)',
+        [expectedHash],
+      );
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('token-1');
+      expect(result!.organizationId).toBe('org-1');
+      expect(result!.period.name).toBe('Fall 2026');
+      expect(result!.period.formDefinitionId).toBe('form-1');
+    });
+
+    it('returns null for invalid token', async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+      const result = await embedTokenService.verifyToken('col_emb_unknown');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('create', () => {
+    it('generates token with col_emb_ prefix', async () => {
+      const mockTx = {
+        insert: vi.fn().mockReturnThis(),
+        values: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([
+          {
+            id: 'token-1',
+            submissionPeriodId: 'period-1',
+            tokenPrefix: 'col_emb_',
+            allowedOrigins: ['https://example.com'],
+            themeConfig: {},
+            active: true,
+            createdAt: new Date(),
+            expiresAt: null,
+          },
+        ]),
+      } as unknown as Parameters<typeof embedTokenService.create>[0];
+
+      const result = await embedTokenService.create(mockTx, 'org-1', 'user-1', {
+        submissionPeriodId: 'period-1',
+        allowedOrigins: ['https://example.com'],
+      });
+
+      expect(result.plainTextToken).toMatch(/^col_emb_[0-9a-f]{32}$/);
+      expect(result.id).toBe('token-1');
+    });
+
+    it('stores SHA-256 hash, never plain text', async () => {
+      const mockTx = {
+        insert: vi.fn().mockReturnThis(),
+        values: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([
+          {
+            id: 'token-1',
+            submissionPeriodId: 'period-1',
+            tokenPrefix: 'col_emb_',
+            allowedOrigins: [],
+            themeConfig: {},
+            active: true,
+            createdAt: new Date(),
+            expiresAt: null,
+          },
+        ]),
+      } as unknown as Parameters<typeof embedTokenService.create>[0];
+
+      await embedTokenService.create(mockTx, 'org-1', 'user-1', {
+        submissionPeriodId: 'period-1',
+        allowedOrigins: [],
+      });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const insertCall = mockTx.insert as ReturnType<typeof vi.fn>;
+      const valuesCall =
+        insertCall.mock.results[0].value.values.mock.calls[0][0];
+      // tokenHash should be a 64-char hex string (SHA-256)
+      expect(valuesCall.tokenHash).toMatch(/^[0-9a-f]{64}$/);
+      // Should not store the plain text token
+      expect(valuesCall.tokenHash).not.toMatch(/^col_emb_/);
+    });
+
+    it('stores allowedOrigins and themeConfig', async () => {
+      const mockTx = {
+        insert: vi.fn().mockReturnThis(),
+        values: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([
+          {
+            id: 'token-1',
+            submissionPeriodId: 'period-1',
+            tokenPrefix: 'col_emb_',
+            allowedOrigins: ['https://example.com'],
+            themeConfig: { primaryColor: '#ff0000' },
+            active: true,
+            createdAt: new Date(),
+            expiresAt: null,
+          },
+        ]),
+      } as unknown as Parameters<typeof embedTokenService.create>[0];
+
+      await embedTokenService.create(mockTx, 'org-1', 'user-1', {
+        submissionPeriodId: 'period-1',
+        allowedOrigins: ['https://example.com'],
+        themeConfig: { primaryColor: '#ff0000' },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const insertCall = mockTx.insert as ReturnType<typeof vi.fn>;
+      const valuesCall =
+        insertCall.mock.results[0].value.values.mock.calls[0][0];
+      expect(valuesCall.allowedOrigins).toEqual(['https://example.com']);
+      expect(valuesCall.themeConfig).toEqual({ primaryColor: '#ff0000' });
+    });
+  });
+
+  describe('revoke', () => {
+    it('sets active = false', async () => {
+      const mockTx = {
+        update: vi.fn().mockReturnThis(),
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi
+          .fn()
+          .mockResolvedValue([{ id: 'token-1', active: false }]),
+      } as unknown as Parameters<typeof embedTokenService.revoke>[0];
+
+      const result = await embedTokenService.revoke(mockTx, 'token-1');
+      expect(result).not.toBeNull();
+      expect(result?.active).toBe(false);
+    });
+
+    it('returns null when token not found', async () => {
+      const mockTx = {
+        update: vi.fn().mockReturnThis(),
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([]),
+      } as unknown as Parameters<typeof embedTokenService.revoke>[0];
+
+      const result = await embedTokenService.revoke(mockTx, 'nonexistent');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('list', () => {
+    it('returns tokens for specific period', async () => {
+      const items = [
+        {
+          id: 'token-1',
+          submissionPeriodId: 'period-1',
+          tokenPrefix: 'col_emb_',
+          allowedOrigins: [],
+          themeConfig: {},
+          active: true,
+          createdAt: new Date(),
+          expiresAt: null,
+        },
+      ];
+
+      const mockTx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockResolvedValue(items),
+            }),
+          }),
+        }),
+      } as unknown as Parameters<typeof embedTokenService.list>[0];
+
+      const result = await embedTokenService.list(mockTx, 'period-1');
+      expect(result).toEqual(items);
+    });
+  });
+});

--- a/apps/api/src/services/embed-token.service.ts
+++ b/apps/api/src/services/embed-token.service.ts
@@ -1,5 +1,12 @@
 import crypto from 'node:crypto';
-import { pool, embedTokens, eq, and, type DrizzleDb } from '@colophony/db';
+import {
+  pool,
+  embedTokens,
+  submissionPeriods,
+  eq,
+  and,
+  type DrizzleDb,
+} from '@colophony/db';
 import type { CreateEmbedTokenInput } from '@colophony/types';
 import { EMBED_TOKEN_PREFIX } from '@colophony/types';
 
@@ -55,6 +62,17 @@ export const embedTokenService = {
     createdBy: string,
     input: CreateEmbedTokenInput,
   ) {
+    // Verify the submission period exists within the caller's org (RLS-scoped)
+    const [period] = await tx
+      .select({ id: submissionPeriods.id })
+      .from(submissionPeriods)
+      .where(eq(submissionPeriods.id, input.submissionPeriodId))
+      .limit(1);
+
+    if (!period) {
+      throw new Error('Submission period not found');
+    }
+
     const { plainTextToken, tokenHash, tokenPrefix } = generateToken();
 
     const [row] = await tx

--- a/apps/api/src/services/embed-token.service.ts
+++ b/apps/api/src/services/embed-token.service.ts
@@ -1,0 +1,179 @@
+import crypto from 'node:crypto';
+import { pool, embedTokens, eq, and, type DrizzleDb } from '@colophony/db';
+import type { CreateEmbedTokenInput } from '@colophony/types';
+import { EMBED_TOKEN_PREFIX } from '@colophony/types';
+
+/** Token data returned from verify_embed_token() SECURITY DEFINER function. */
+export interface VerifiedEmbedToken {
+  id: string;
+  organizationId: string;
+  submissionPeriodId: string;
+  allowedOrigins: string[];
+  themeConfig: Record<string, unknown> | null;
+  active: boolean;
+  expiresAt: Date | null;
+  period: {
+    name: string;
+    opensAt: Date;
+    closesAt: Date;
+    formDefinitionId: string | null;
+    maxSubmissions: number | null;
+    fee: string | null;
+  };
+}
+
+/**
+ * Generate a new embed token.
+ * Format: col_emb_<32 random hex chars> (40 chars total, 128 bits of entropy).
+ */
+function generateToken(): {
+  plainTextToken: string;
+  tokenHash: string;
+  tokenPrefix: string;
+} {
+  const randomPart = crypto.randomBytes(16).toString('hex');
+  const plainTextToken = `${EMBED_TOKEN_PREFIX}${randomPart}`;
+  const tokenHash = crypto
+    .createHash('sha256')
+    .update(plainTextToken)
+    .digest('hex');
+  return { plainTextToken, tokenHash, tokenPrefix: EMBED_TOKEN_PREFIX };
+}
+
+function hashToken(plainTextToken: string): string {
+  return crypto.createHash('sha256').update(plainTextToken).digest('hex');
+}
+
+export const embedTokenService = {
+  /**
+   * Create a new embed token. Returns the plain text token (shown once).
+   * Runs inside the caller's RLS transaction.
+   */
+  async create(
+    tx: DrizzleDb,
+    orgId: string,
+    createdBy: string,
+    input: CreateEmbedTokenInput,
+  ) {
+    const { plainTextToken, tokenHash, tokenPrefix } = generateToken();
+
+    const [row] = await tx
+      .insert(embedTokens)
+      .values({
+        organizationId: orgId,
+        submissionPeriodId: input.submissionPeriodId,
+        tokenHash,
+        tokenPrefix,
+        allowedOrigins: input.allowedOrigins ?? [],
+        themeConfig: input.themeConfig ?? {},
+        createdBy,
+        expiresAt: input.expiresAt ?? null,
+      })
+      .returning({
+        id: embedTokens.id,
+        submissionPeriodId: embedTokens.submissionPeriodId,
+        tokenPrefix: embedTokens.tokenPrefix,
+        allowedOrigins: embedTokens.allowedOrigins,
+        themeConfig: embedTokens.themeConfig,
+        active: embedTokens.active,
+        createdAt: embedTokens.createdAt,
+        expiresAt: embedTokens.expiresAt,
+      });
+
+    return { ...row, plainTextToken };
+  },
+
+  /**
+   * List embed tokens for a specific submission period (RLS handles org filtering).
+   */
+  async list(tx: DrizzleDb, submissionPeriodId: string) {
+    return tx
+      .select({
+        id: embedTokens.id,
+        submissionPeriodId: embedTokens.submissionPeriodId,
+        tokenPrefix: embedTokens.tokenPrefix,
+        allowedOrigins: embedTokens.allowedOrigins,
+        themeConfig: embedTokens.themeConfig,
+        active: embedTokens.active,
+        createdAt: embedTokens.createdAt,
+        expiresAt: embedTokens.expiresAt,
+      })
+      .from(embedTokens)
+      .where(eq(embedTokens.submissionPeriodId, submissionPeriodId))
+      .orderBy(embedTokens.createdAt);
+  },
+
+  /**
+   * Revoke an embed token by setting active = false.
+   */
+  async revoke(tx: DrizzleDb, tokenId: string) {
+    const [updated] = await tx
+      .update(embedTokens)
+      .set({ active: false })
+      .where(and(eq(embedTokens.id, tokenId)))
+      .returning({
+        id: embedTokens.id,
+        active: embedTokens.active,
+      });
+    return updated ?? null;
+  },
+
+  /**
+   * Hard delete an embed token.
+   */
+  async delete(tx: DrizzleDb, tokenId: string) {
+    const [deleted] = await tx
+      .delete(embedTokens)
+      .where(eq(embedTokens.id, tokenId))
+      .returning({ id: embedTokens.id });
+    return deleted ?? null;
+  },
+
+  /**
+   * Verify an embed token by hashing and looking up via SECURITY DEFINER function.
+   * Bypasses RLS for cross-org lookup (same pattern as verify_api_key).
+   * Returns token details + period data, or null if not found.
+   */
+  async verifyToken(
+    plainTextToken: string,
+  ): Promise<VerifiedEmbedToken | null> {
+    const tokenHash = hashToken(plainTextToken);
+
+    const result = await pool.query<{
+      id: string;
+      organization_id: string;
+      submission_period_id: string;
+      allowed_origins: string[];
+      theme_config: Record<string, unknown> | null;
+      active: boolean;
+      expires_at: Date | null;
+      period_name: string;
+      period_opens_at: Date;
+      period_closes_at: Date;
+      period_form_definition_id: string | null;
+      period_max_submissions: number | null;
+      period_fee: string | null;
+    }>('SELECT * FROM verify_embed_token($1)', [tokenHash]);
+
+    if (result.rows.length === 0) return null;
+
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      organizationId: row.organization_id,
+      submissionPeriodId: row.submission_period_id,
+      allowedOrigins: row.allowed_origins,
+      themeConfig: row.theme_config,
+      active: row.active,
+      expiresAt: row.expires_at,
+      period: {
+        name: row.period_name,
+        opensAt: row.period_opens_at,
+        closesAt: row.period_closes_at,
+        formDefinitionId: row.period_form_definition_id,
+        maxSubmissions: row.period_max_submissions,
+        fee: row.period_fee,
+      },
+    };
+  },
+};

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -9,6 +9,7 @@ import { auditRouter } from './routers/audit.js';
 import { formsRouter } from './routers/forms.js';
 import { periodsRouter } from './routers/periods.js';
 import { manuscriptsRouter } from './routers/manuscripts.js';
+import { embedTokensRouter } from './routers/embed-tokens.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -40,6 +41,7 @@ export const appRouter = t.router({
   audit: auditRouter,
   forms: formsRouter,
   periods: periodsRouter,
+  embedTokens: embedTokensRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/embed-tokens.spec.ts
+++ b/apps/api/src/trpc/routers/embed-tokens.spec.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { TRPCContext } from '../context.js';
+
+const { mockEmbedTokenService } = vi.hoisted(() => {
+  const mockEmbedTokenService = {
+    create: vi.fn(),
+    list: vi.fn(),
+    revoke: vi.fn(),
+  };
+  return { mockEmbedTokenService };
+});
+
+vi.mock('../../services/embed-token.service.js', () => ({
+  embedTokenService: mockEmbedTokenService,
+}));
+
+import { appRouter } from '../router.js';
+
+function makeContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
+  return {
+    authContext: null,
+    dbTx: null,
+    audit: vi.fn(),
+    ...overrides,
+  };
+}
+
+function orgContext(
+  role: 'ADMIN' | 'EDITOR' | 'READER' = 'ADMIN',
+  overrides: Partial<TRPCContext> = {},
+): TRPCContext {
+  const mockTx = {} as never;
+  return makeContext({
+    authContext: {
+      userId: 'user-1',
+      zitadelUserId: 'zid-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+      orgId: 'org-1',
+      role,
+    },
+    dbTx: mockTx,
+    audit: vi.fn(),
+    ...overrides,
+  });
+}
+
+const createCaller = (appRouter as any).createCaller as (
+  ctx: TRPCContext,
+) => any;
+
+describe('embedTokens router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('generates token and returns plain text key (admin only)', async () => {
+      const created = {
+        id: 'a1111111-1111-1111-a111-111111111111',
+        submissionPeriodId: 'b2222222-2222-2222-a222-222222222222',
+        tokenPrefix: 'col_emb_',
+        plainTextToken: 'col_emb_abcdef1234567890abcdef1234567890',
+        allowedOrigins: ['https://example.com'],
+        themeConfig: null,
+        active: true,
+        createdAt: new Date(),
+        expiresAt: null,
+      };
+      mockEmbedTokenService.create.mockResolvedValueOnce(created);
+
+      const ctx = orgContext('ADMIN');
+      const caller = createCaller(ctx);
+      const result = await caller.embedTokens.create({
+        submissionPeriodId: 'b2222222-2222-2222-a222-222222222222',
+        allowedOrigins: ['https://example.com'],
+      });
+
+      expect(result.plainTextToken).toBe(created.plainTextToken);
+      expect(mockEmbedTokenService.create).toHaveBeenCalledWith(
+        expect.anything(),
+        'org-1',
+        'user-1',
+        {
+          submissionPeriodId: 'b2222222-2222-2222-a222-222222222222',
+          allowedOrigins: ['https://example.com'],
+        },
+      );
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'EMBED_TOKEN_CREATED',
+          resource: 'embed_token',
+          resourceId: 'a1111111-1111-1111-a111-111111111111',
+        }),
+      );
+    });
+
+    it('rejects non-admin roles', async () => {
+      const caller = createCaller(orgContext('EDITOR'));
+      await expect(
+        caller.embedTokens.create({
+          submissionPeriodId: 'b2222222-2222-2222-a222-222222222222',
+        }),
+      ).rejects.toThrow('Admin role required');
+    });
+  });
+
+  describe('listByPeriod', () => {
+    it('returns tokens for period', async () => {
+      const tokens = [
+        {
+          id: 'a1111111-1111-1111-a111-111111111111',
+          submissionPeriodId: 'b2222222-2222-2222-a222-222222222222',
+          tokenPrefix: 'col_emb_',
+          allowedOrigins: [],
+          themeConfig: null,
+          active: true,
+          createdAt: new Date(),
+          expiresAt: null,
+        },
+      ];
+      mockEmbedTokenService.list.mockResolvedValueOnce(tokens);
+
+      const caller = createCaller(orgContext('READER'));
+      const result = await caller.embedTokens.listByPeriod({
+        submissionPeriodId: 'b2222222-2222-2222-a222-222222222222',
+      });
+
+      expect(result).toEqual(tokens);
+      expect(mockEmbedTokenService.list).toHaveBeenCalledWith(
+        expect.anything(),
+        'b2222222-2222-2222-a222-222222222222',
+      );
+    });
+  });
+
+  describe('revoke', () => {
+    it('deactivates the token', async () => {
+      mockEmbedTokenService.revoke.mockResolvedValueOnce({
+        id: 'a1111111-1111-1111-a111-111111111111',
+        active: false,
+      });
+
+      const ctx = orgContext('ADMIN');
+      const caller = createCaller(ctx);
+      const result = await caller.embedTokens.revoke({
+        tokenId: 'a1111111-1111-1111-a111-111111111111',
+      });
+
+      expect(result.active).toBe(false);
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'EMBED_TOKEN_REVOKED',
+          resource: 'embed_token',
+          resourceId: 'a1111111-1111-1111-a111-111111111111',
+        }),
+      );
+    });
+
+    it('throws NOT_FOUND when token does not exist', async () => {
+      mockEmbedTokenService.revoke.mockResolvedValueOnce(null);
+
+      const caller = createCaller(orgContext('ADMIN'));
+      await expect(
+        caller.embedTokens.revoke({
+          tokenId: 'b2222222-2222-2222-a222-222222222222',
+        }),
+      ).rejects.toThrow('Embed token not found');
+    });
+
+    it('rejects non-admin users', async () => {
+      const caller = createCaller(orgContext('EDITOR'));
+      await expect(
+        caller.embedTokens.revoke({
+          tokenId: 'a1111111-1111-1111-a111-111111111111',
+        }),
+      ).rejects.toThrow('Admin role required');
+    });
+  });
+});

--- a/apps/api/src/trpc/routers/embed-tokens.ts
+++ b/apps/api/src/trpc/routers/embed-tokens.ts
@@ -1,0 +1,74 @@
+import { TRPCError } from '@trpc/server';
+import {
+  createEmbedTokenSchema,
+  revokeEmbedTokenSchema,
+  listEmbedTokensByPeriodSchema,
+  createEmbedTokenResponseSchema,
+  embedTokenResponseSchema,
+  AuditActions,
+  AuditResources,
+  type EmbedTokenResponse,
+  type CreateEmbedTokenResponse,
+} from '@colophony/types';
+import { z } from 'zod';
+import {
+  orgProcedure,
+  adminProcedure,
+  createRouter,
+  requireScopes,
+} from '../init.js';
+import { embedTokenService } from '../../services/embed-token.service.js';
+
+export const embedTokensRouter = createRouter({
+  create: adminProcedure
+    .input(createEmbedTokenSchema)
+    .output(createEmbedTokenResponseSchema)
+    .mutation(async ({ ctx, input }) => {
+      const result = await embedTokenService.create(
+        ctx.dbTx,
+        ctx.authContext.orgId,
+        ctx.authContext.userId,
+        input,
+      );
+      await ctx.audit({
+        action: AuditActions.EMBED_TOKEN_CREATED,
+        resource: AuditResources.EMBED_TOKEN,
+        resourceId: result.id,
+        newValue: {
+          submissionPeriodId: input.submissionPeriodId,
+          allowedOrigins: input.allowedOrigins,
+        },
+      });
+      return result as CreateEmbedTokenResponse;
+    }),
+
+  listByPeriod: orgProcedure
+    .use(requireScopes('periods:read'))
+    .input(listEmbedTokensByPeriodSchema)
+    .output(z.array(embedTokenResponseSchema))
+    .query(async ({ ctx, input }) => {
+      return embedTokenService.list(
+        ctx.dbTx,
+        input.submissionPeriodId,
+      ) as Promise<EmbedTokenResponse[]>;
+    }),
+
+  revoke: adminProcedure
+    .input(revokeEmbedTokenSchema)
+    .output(z.object({ id: z.string().uuid(), active: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const revoked = await embedTokenService.revoke(ctx.dbTx, input.tokenId);
+      if (!revoked) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Embed token not found',
+        });
+      }
+      await ctx.audit({
+        action: AuditActions.EMBED_TOKEN_REVOKED,
+        resource: AuditResources.EMBED_TOKEN,
+        resourceId: revoked.id,
+      });
+      return revoked;
+    }),
+});

--- a/apps/api/src/trpc/routers/embed-tokens.ts
+++ b/apps/api/src/trpc/routers/embed-tokens.ts
@@ -24,12 +24,26 @@ export const embedTokensRouter = createRouter({
     .input(createEmbedTokenSchema)
     .output(createEmbedTokenResponseSchema)
     .mutation(async ({ ctx, input }) => {
-      const result = await embedTokenService.create(
-        ctx.dbTx,
-        ctx.authContext.orgId,
-        ctx.authContext.userId,
-        input,
-      );
+      let result;
+      try {
+        result = await embedTokenService.create(
+          ctx.dbTx,
+          ctx.authContext.orgId,
+          ctx.authContext.userId,
+          input,
+        );
+      } catch (err) {
+        if (
+          err instanceof Error &&
+          err.message === 'Submission period not found'
+        ) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Submission period not found',
+          });
+        }
+        throw err;
+      }
       await ctx.audit({
         action: AuditActions.EMBED_TOKEN_CREATED,
         resource: AuditResources.EMBED_TOKEN,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -102,7 +102,7 @@
 - [x] Conditional logic engine — (architecture doc Track 3, form-builder-research.md; done 2026-02-21)
 - [x] Form branching logic PR 1 — schema, evaluation engine, all API surfaces, form builder UI, renderer; single-page branching complete — (roadmap idea 2026-02-21; done 2026-02-21)
 - [x] Form branching logic PR 2 — multi-page wizard renderer, per-page validation, page navigation with branching rules, stepper UI — (roadmap idea 2026-02-21; done 2026-02-21)
-- [ ] Embeddable forms (iframe) — (architecture doc Track 3, form-builder-research.md)
+- [~] Embeddable forms (iframe) — PR 1 backend foundation done 2026-02-22; PR 2 (file uploads) and PR 3 (frontend) pending — (architecture doc Track 3, form-builder-research.md)
 - [x] Submission periods UI — schema exists, no UI — (DEVLOG 2026-02-15; done 2026-02-21)
 - [x] Submission periods: REST oRPC router + GraphQL resolvers for parity with forms/submissions — (DEVLOG 2026-02-21, deferred from submission periods PR; done 2026-02-21)
 - [x] Editor dashboard rewrite (`/editor` pages) — submission queue + detail view reuse — (DEVLOG 2026-02-15; done 2026-02-21)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,32 @@ Newest entries first.
 
 ---
 
+## 2026-02-22 — Embeddable Submission Forms (PR 1: Backend Foundation)
+
+### Done
+
+- Created `embed_tokens` table with RLS org isolation, `verify_embed_token()` SECURITY DEFINER function (joins submission_periods), unique `lower(email)` index on users, `is_guest` column
+- Created embed types in `@colophony/types`: Zod schemas for token CRUD, form response, submit input/output, origin validation (scheme+host+port regex, not z.url())
+- Added audit actions: `EMBED_TOKEN_CREATED`, `EMBED_TOKEN_REVOKED`, `EMBED_SUBMISSION_CREATED`, `GUEST_USER_CREATED` + `EMBED_TOKEN` resource + `EmbedTokenAuditParams` discriminant
+- Created `embed-token.service.ts`: token generation (col*emb* prefix, SHA-256 hash), CRUD, verify via SECURITY DEFINER — modeled on api-key.service.ts
+- Created `embed-submission.service.ts`: `findOrCreateGuestUser` (case-insensitive email via `lower()`), `submitFromEmbed` (guest user → withRls → DRAFT → SUBMITTED via existing `updateStatus` transition guards), `loadFormForEmbed`
+- Created embed routes in isolated Fastify scope: `GET /embed/:token` (form definition + CSP frame-ancestors), `POST /embed/:token/submit` (Redis Lua rate limiting, origin validation, Zod body parsing)
+- Created `embed-tokens` tRPC router: create (adminProcedure), listByPeriod (orgProcedure + periods:read scope), revoke (adminProcedure) — all with audit logging
+- Updated auth hook: added `/embed/` to PUBLIC_PREFIXES
+- Updated `audit.service.ts`: widened `logDirect` to accept `EmbedTokenAuditParams`
+- Added `embed_tokens` to RLS infrastructure test table list
+- 27 new tests across 4 files (739 total tests passing, 56 files)
+- All type-check, lint, and build clean
+
+### Decisions
+
+- Embed routes bypass auth/orgContext/dbContext hooks (isolated Fastify scope, like webhooks) — manage own RLS via withRls after token verification
+- Guest user creation uses shared `db` (no RLS on users table), submission creation uses `withRls({ orgId, userId })`
+- Reuse `submissionService.updateStatus()` for DRAFT→SUBMITTED to avoid bypassing transition invariants (form validation, file scan checks)
+- Origin validation uses regex for scheme+host+port only (not z.url() which allows paths — would cause CSP frame-ancestors mismatch)
+
+---
+
 ## 2026-02-22 — Manuscript Entity Frontend
 
 ### Done

--- a/packages/db/migrations/0014_embed_tokens.sql
+++ b/packages/db/migrations/0014_embed_tokens.sql
@@ -1,0 +1,99 @@
+-- Add is_guest column to users
+ALTER TABLE "users" ADD COLUMN "is_guest" boolean DEFAULT false NOT NULL;
+
+--> statement-breakpoint
+
+-- Replace non-unique lower(email) index with unique index
+-- (prevents duplicate-case accounts like User@example.com and user@example.com)
+DROP INDEX IF EXISTS "users_lower_email_idx";
+CREATE UNIQUE INDEX "users_lower_email_unique_idx" ON "users" (lower("email"));
+
+--> statement-breakpoint
+
+-- Create embed_tokens table
+CREATE TABLE "embed_tokens" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "submission_period_id" uuid NOT NULL,
+  "token_hash" varchar(128) NOT NULL,
+  "token_prefix" varchar(16) NOT NULL,
+  "allowed_origins" text[] DEFAULT ARRAY[]::text[] NOT NULL,
+  "theme_config" jsonb DEFAULT '{}'::jsonb,
+  "active" boolean DEFAULT true NOT NULL,
+  "created_by" uuid NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "expires_at" timestamp with time zone,
+  CONSTRAINT "embed_tokens_token_hash_unique" UNIQUE("token_hash")
+);
+
+--> statement-breakpoint
+
+-- Foreign keys
+ALTER TABLE "embed_tokens"
+  ADD CONSTRAINT "embed_tokens_organization_id_organizations_id_fk"
+  FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE cascade ON UPDATE no action;
+
+ALTER TABLE "embed_tokens"
+  ADD CONSTRAINT "embed_tokens_submission_period_id_submission_periods_id_fk"
+  FOREIGN KEY ("submission_period_id") REFERENCES "submission_periods"("id") ON DELETE cascade ON UPDATE no action;
+
+ALTER TABLE "embed_tokens"
+  ADD CONSTRAINT "embed_tokens_created_by_users_id_fk"
+  FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE restrict ON UPDATE no action;
+
+--> statement-breakpoint
+
+-- Indexes
+CREATE INDEX "embed_tokens_organization_id_idx" ON "embed_tokens" USING btree ("organization_id");
+CREATE INDEX "embed_tokens_submission_period_id_idx" ON "embed_tokens" USING btree ("submission_period_id");
+CREATE INDEX "embed_tokens_token_hash_idx" ON "embed_tokens" USING btree ("token_hash");
+
+--> statement-breakpoint
+
+-- Enable RLS (Drizzle generates this)
+ALTER TABLE "embed_tokens" ENABLE ROW LEVEL SECURITY;
+
+-- FORCE ROW LEVEL SECURITY (Drizzle only generates ENABLE, not FORCE)
+ALTER TABLE "embed_tokens" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+
+-- RLS policy: org isolation
+CREATE POLICY "embed_tokens_org_isolation" ON "embed_tokens"
+  FOR ALL
+  USING (organization_id = current_org_id())
+  WITH CHECK (organization_id = current_org_id());
+
+--> statement-breakpoint
+
+-- Grant DML permissions to app_user
+GRANT SELECT, INSERT, UPDATE, DELETE ON "embed_tokens" TO app_user;
+
+--> statement-breakpoint
+
+-- SECURITY DEFINER function: cross-org embed token lookup by hash
+-- Joins submission_periods to return period data alongside token fields
+CREATE OR REPLACE FUNCTION verify_embed_token(p_token_hash varchar)
+RETURNS TABLE(
+  id uuid, organization_id uuid, submission_period_id uuid,
+  allowed_origins text[], theme_config jsonb,
+  active boolean, expires_at timestamptz,
+  period_name varchar, period_opens_at timestamptz,
+  period_closes_at timestamptz, period_form_definition_id uuid,
+  period_max_submissions integer, period_fee numeric
+)
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT et.id, et.organization_id, et.submission_period_id,
+         et.allowed_origins, et.theme_config,
+         et.active, et.expires_at,
+         sp.name, sp.opens_at, sp.closes_at,
+         sp.form_definition_id, sp.max_submissions, sp.fee
+  FROM public.embed_tokens et
+  JOIN public.submission_periods sp ON sp.id = et.submission_period_id
+  WHERE et.token_hash = p_token_hash
+$$;
+
+REVOKE ALL ON FUNCTION verify_embed_token(varchar) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION verify_embed_token(varchar) TO app_user;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1771800000000,
       "tag": "0013_manuscripts",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1772000000000,
+      "tag": "0014_embed_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/embed-tokens.ts
+++ b/packages/db/src/schema/embed-tokens.ts
@@ -1,0 +1,60 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  text,
+  boolean,
+  jsonb,
+  timestamp,
+  index,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { organizations } from "./organizations";
+import { submissionPeriods } from "./submissions";
+import { users } from "./users";
+
+export interface EmbedThemeConfig {
+  primaryColor?: string;
+  fontFamily?: string;
+  borderRadius?: string;
+  darkMode?: boolean;
+}
+
+export const embedTokens = pgTable(
+  "embed_tokens",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    submissionPeriodId: uuid("submission_period_id")
+      .notNull()
+      .references(() => submissionPeriods.id, { onDelete: "cascade" }),
+    tokenHash: varchar("token_hash", { length: 128 }).notNull().unique(),
+    tokenPrefix: varchar("token_prefix", { length: 16 }).notNull(),
+    allowedOrigins: text("allowed_origins")
+      .array()
+      .notNull()
+      .default(sql`ARRAY[]::text[]`),
+    themeConfig: jsonb("theme_config").default({}).$type<EmbedThemeConfig>(),
+    active: boolean("active").default(true).notNull(),
+    createdBy: uuid("created_by")
+      .notNull()
+      .references(() => users.id, { onDelete: "restrict" }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("embed_tokens_organization_id_idx").on(table.organizationId),
+    index("embed_tokens_submission_period_id_idx").on(table.submissionPeriodId),
+    index("embed_tokens_token_hash_idx").on(table.tokenHash),
+    pgPolicy("embed_tokens_org_isolation", {
+      for: "all",
+      using: sql`organization_id = current_org_id()`,
+      withCheck: sql`organization_id = current_org_id()`,
+    }),
+  ],
+).enableRLS();

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -11,4 +11,5 @@ export * from "./compliance";
 export * from "./messaging";
 export * from "./webhooks";
 export * from "./api-keys";
+export * from "./embed-tokens";
 export * from "./relations";

--- a/packages/db/src/schema/users.ts
+++ b/packages/db/src/schema/users.ts
@@ -24,6 +24,7 @@ export const users = pgTable(
       .defaultNow()
       .notNull()
       .$defaultFn(() => new Date()),
+    isGuest: boolean("is_guest").default(false).notNull(),
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
     lastEventAt: timestamp("last_event_at", { withTimezone: true }),
   },

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -82,6 +82,16 @@ export const AuditActions = {
   PAYMENT_SUCCEEDED: "PAYMENT_SUCCEEDED",
   PAYMENT_EXPIRED: "PAYMENT_EXPIRED",
 
+  // Embed token lifecycle
+  EMBED_TOKEN_CREATED: "EMBED_TOKEN_CREATED",
+  EMBED_TOKEN_REVOKED: "EMBED_TOKEN_REVOKED",
+
+  // Embed submission
+  EMBED_SUBMISSION_CREATED: "EMBED_SUBMISSION_CREATED",
+
+  // Guest user
+  GUEST_USER_CREATED: "GUEST_USER_CREATED",
+
   // Audit access
   AUDIT_ACCESSED: "AUDIT_ACCESSED",
 } as const;
@@ -100,6 +110,7 @@ export const AuditResources = {
   AUTH: "auth",
   API_KEY: "api_key",
   PAYMENT: "payment",
+  EMBED_TOKEN: "embed_token",
   AUDIT: "audit",
 } as const;
 
@@ -229,6 +240,15 @@ export interface PaymentAuditParams extends BaseAuditParams {
     | typeof AuditActions.PAYMENT_EXPIRED;
 }
 
+export interface EmbedTokenAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.EMBED_TOKEN;
+  action:
+    | typeof AuditActions.EMBED_TOKEN_CREATED
+    | typeof AuditActions.EMBED_TOKEN_REVOKED
+    | typeof AuditActions.EMBED_SUBMISSION_CREATED
+    | typeof AuditActions.GUEST_USER_CREATED;
+}
+
 export interface AuditAccessAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.AUDIT;
   action: typeof AuditActions.AUDIT_ACCESSED;
@@ -246,6 +266,7 @@ export type AuditLogParams =
   | AuthAuditParams
   | ApiKeyAuditParams
   | PaymentAuditParams
+  | EmbedTokenAuditParams
   | AuditAccessAuditParams;
 
 // ---------------------------------------------------------------------------

--- a/packages/types/src/embed.ts
+++ b/packages/types/src/embed.ts
@@ -1,0 +1,173 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const EMBED_TOKEN_PREFIX = "col_emb_";
+
+// ---------------------------------------------------------------------------
+// Theme config
+// ---------------------------------------------------------------------------
+
+export const embedThemeConfigSchema = z
+  .object({
+    primaryColor: z
+      .string()
+      .regex(/^#[0-9a-fA-F]{6}$/)
+      .optional()
+      .describe("Primary brand color (hex, e.g. #3b82f6)"),
+    fontFamily: z
+      .string()
+      .max(100)
+      .optional()
+      .describe("CSS font-family value"),
+    borderRadius: z
+      .string()
+      .max(20)
+      .optional()
+      .describe("CSS border-radius value (e.g. 8px)"),
+    darkMode: z.boolean().optional().describe("Enable dark mode theme"),
+  })
+  .describe("Theme configuration for the embedded form");
+
+export type EmbedThemeConfig = z.infer<typeof embedThemeConfigSchema>;
+
+// ---------------------------------------------------------------------------
+// Origin validation — scheme + host + optional port, no path
+// ---------------------------------------------------------------------------
+
+const ORIGIN_RE = /^https?:\/\/[a-zA-Z0-9.-]+(:\d{1,5})?$/;
+
+export const allowedOriginSchema = z
+  .string()
+  .regex(
+    ORIGIN_RE,
+    "Must be a valid origin (scheme + host + optional port, no path)",
+  )
+  .describe("Allowed embedding origin (e.g. https://magazine.example.com)");
+
+// ---------------------------------------------------------------------------
+// Input schemas
+// ---------------------------------------------------------------------------
+
+export const createEmbedTokenSchema = z.object({
+  submissionPeriodId: z
+    .string()
+    .uuid()
+    .describe("Submission period to generate the embed for"),
+  allowedOrigins: z
+    .array(allowedOriginSchema)
+    .default([])
+    .describe("Origins allowed to embed the form (empty = any origin)"),
+  themeConfig: embedThemeConfigSchema.optional().describe("Custom theme"),
+  expiresAt: z.coerce
+    .date()
+    .optional()
+    .describe("Optional expiration date (ISO-8601)"),
+});
+
+export type CreateEmbedTokenInput = z.infer<typeof createEmbedTokenSchema>;
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+export const embedTokenResponseSchema = z.object({
+  id: z.string().uuid().describe("Embed token ID"),
+  submissionPeriodId: z.string().uuid().describe("Linked submission period"),
+  tokenPrefix: z
+    .string()
+    .describe("Token prefix for identification (col_emb_)"),
+  allowedOrigins: z
+    .array(z.string())
+    .describe("Origins allowed to embed the form"),
+  themeConfig: embedThemeConfigSchema
+    .nullable()
+    .describe("Theme configuration"),
+  active: z.boolean().describe("Whether the token is active"),
+  createdAt: z.date().describe("When the token was created"),
+  expiresAt: z
+    .date()
+    .nullable()
+    .describe("When the token expires (null = never)"),
+});
+
+export type EmbedTokenResponse = z.infer<typeof embedTokenResponseSchema>;
+
+export const createEmbedTokenResponseSchema = embedTokenResponseSchema.extend({
+  plainTextToken: z
+    .string()
+    .describe("The full embed token — shown only once, never stored"),
+});
+
+export type CreateEmbedTokenResponse = z.infer<
+  typeof createEmbedTokenResponseSchema
+>;
+
+export const embedFormResponseSchema = z
+  .object({
+    period: z
+      .object({
+        id: z.string().uuid(),
+        name: z.string(),
+        opensAt: z.date(),
+        closesAt: z.date(),
+      })
+      .describe("Submission period metadata"),
+    form: z
+      .object({
+        id: z.string().uuid(),
+        name: z.string(),
+        fields: z.array(z.unknown()),
+        pages: z.array(z.unknown()),
+      })
+      .nullable()
+      .describe("Form definition with fields and pages (null if no form)"),
+    theme: embedThemeConfigSchema.nullable().describe("Theme configuration"),
+    organizationId: z.string().uuid().describe("Organization ID"),
+  })
+  .describe("Public embed form response");
+
+export type EmbedFormResponse = z.infer<typeof embedFormResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Submit schemas
+// ---------------------------------------------------------------------------
+
+export const embedSubmitSchema = z.object({
+  email: z.string().email().max(255).describe("Submitter email address"),
+  name: z.string().max(255).optional().describe("Submitter display name"),
+  title: z.string().min(1).max(500).describe("Submission title"),
+  content: z.string().optional().describe("Submission content/body text"),
+  coverLetter: z.string().optional().describe("Cover letter text"),
+  formData: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe("Dynamic form field responses"),
+});
+
+export type EmbedSubmitInput = z.infer<typeof embedSubmitSchema>;
+
+export const embedSubmitResponseSchema = z.object({
+  success: z.literal(true),
+  submissionId: z.string().uuid().describe("Created submission ID"),
+  message: z.string().describe("Confirmation message"),
+});
+
+export type EmbedSubmitResponse = z.infer<typeof embedSubmitResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Revoke schema
+// ---------------------------------------------------------------------------
+
+export const revokeEmbedTokenSchema = z.object({
+  tokenId: z.string().uuid().describe("ID of the embed token to revoke"),
+});
+
+export const listEmbedTokensByPeriodSchema = z.object({
+  submissionPeriodId: z
+    .string()
+    .uuid()
+    .describe("Submission period to list tokens for"),
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,3 +10,4 @@ export * from "./conditional-rules";
 export * from "./common";
 export * from "./audit";
 export * from "./api-key";
+export * from "./embed";


### PR DESCRIPTION
## Summary

- Add `embed_tokens` table with RLS org isolation, `verify_embed_token()` SECURITY DEFINER function, `is_guest` column on users, unique `lower(email)` index
- Create embed token service (CRUD + SHA-256 verify), embed submission service (guest user find/create + submit via withRls with DRAFT→SUBMITTED transition)
- Add public embed routes in isolated Fastify scope: `GET /embed/:token` (form definition + CSP), `POST /embed/:token/submit` (Redis Lua rate limiting, origin validation)
- Create `embed-tokens` tRPC router: create/listByPeriod/revoke with audit logging
- 27 new tests across 4 files (739 total passing)

PR 1 of 3 for embeddable submission forms (PR 2: file uploads, PR 3: frontend).

## Codex Review

All 3 P2 findings addressed:
- Race condition in guest user creation (catch unique constraint, retry lookup)
- Origin header bypass when allowedOrigins configured (now required)
- Cross-org period validation before token creation (RLS-scoped check)

## Test plan

- [x] All 739 unit tests passing (56 files)
- [x] Type-check clean across all packages
- [x] Lint clean (API + web)
- [ ] Run migration on dev DB: `pnpm db:migrate`
- [ ] Manual: `curl GET /embed/<valid-token>` returns form definition
- [ ] Manual: `curl POST /embed/<valid-token>/submit` creates guest user + submission
- [ ] RLS test: verify embed_tokens table has proper org isolation (`pnpm test:rls`)