### PR TITLE
feat(hopper): embeddable submission form — frontend widget

### DIFF
--- a/apps/web/src/app/embed/[token]/page.tsx
+++ b/apps/web/src/app/embed/[token]/page.tsx
@@ -1,0 +1,12 @@
+import { EmbedForm } from "@/components/embed/embed-form";
+
+export default async function EmbedPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+
+  return <EmbedForm token={token} apiUrl={apiUrl} />;
+}

--- a/apps/web/src/components/embed/__tests__/embed-form.spec.tsx
+++ b/apps/web/src/components/embed/__tests__/embed-form.spec.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EmbedForm } from "../embed-form";
+import "../../../../test/setup";
+
+const mockFetchEmbedForm = jest.fn();
+const mockSubmitEmbedForm = jest.fn();
+const mockPrepareEmbedUpload = jest.fn();
+
+jest.mock("@/lib/embed-api", () => ({
+  fetchEmbedForm: (...args: unknown[]) => mockFetchEmbedForm(...args),
+  submitEmbedForm: (...args: unknown[]) => mockSubmitEmbedForm(...args),
+  prepareEmbedUpload: (...args: unknown[]) => mockPrepareEmbedUpload(...args),
+  fetchUploadStatus: jest
+    .fn()
+    .mockResolvedValue({ files: [], allClean: false }),
+}));
+
+// Mock tus-js-client
+jest.mock("tus-js-client", () => ({
+  Upload: jest.fn().mockImplementation(() => ({
+    start: jest.fn(),
+    abort: jest.fn(),
+  })),
+}));
+
+const validFormResponse = {
+  period: {
+    id: "p-1",
+    name: "Spring 2026",
+    opensAt: "2026-01-01T00:00:00Z",
+    closesAt: "2026-06-01T00:00:00Z",
+  },
+  form: {
+    id: "f-1",
+    name: "Poetry Form",
+    fields: [
+      {
+        fieldKey: "bio",
+        fieldType: "textarea",
+        label: "Bio",
+        description: null,
+        placeholder: "Short bio",
+        required: false,
+        config: null,
+        sortOrder: 0,
+      },
+    ],
+    pages: [],
+  },
+  theme: null,
+  organizationId: "org-1",
+};
+
+describe("EmbedForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows loading spinner initially", () => {
+    mockFetchEmbedForm.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<EmbedForm token="col_emb_test" apiUrl="http://localhost:4000" />);
+
+    // Loader2 renders as an SVG with animate-spin
+    expect(document.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+
+  it("shows error for invalid token", async () => {
+    mockFetchEmbedForm.mockRejectedValue({
+      status: 404,
+      error: "Not Found",
+      message: "Invalid embed token",
+    });
+
+    render(<EmbedForm token="col_emb_bad" apiUrl="http://localhost:4000" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid link/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error for closed period", async () => {
+    mockFetchEmbedForm.mockRejectedValue({
+      status: 410,
+      error: "Gone",
+      message: "Submission period closed",
+    });
+
+    render(<EmbedForm token="col_emb_old" apiUrl="http://localhost:4000" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/submissions closed/i)).toBeInTheDocument();
+    });
+  });
+
+  it("transitions identity to form", async () => {
+    const user = userEvent.setup();
+    mockFetchEmbedForm.mockResolvedValue(validFormResponse);
+
+    render(<EmbedForm token="col_emb_ok" apiUrl="http://localhost:4000" />);
+
+    // Wait for identity step
+    await waitFor(() => {
+      expect(screen.getByText("Spring 2026")).toBeInTheDocument();
+    });
+
+    // Fill email and continue
+    await user.type(screen.getByLabelText(/email/i), "writer@test.com");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    // Form step should appear with title input
+    await waitFor(() => {
+      expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+    });
+  });
+
+  it("submits successfully", async () => {
+    const user = userEvent.setup();
+    mockFetchEmbedForm.mockResolvedValue(validFormResponse);
+    mockSubmitEmbedForm.mockResolvedValue({
+      success: true,
+      submissionId: "sub-123",
+      message: "Done",
+    });
+
+    render(<EmbedForm token="col_emb_ok" apiUrl="http://localhost:4000" />);
+
+    // Identity step
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    });
+    await user.type(screen.getByLabelText(/email/i), "writer@test.com");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    // Form step
+    await waitFor(() => {
+      expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+    });
+    await user.type(screen.getByLabelText(/title/i), "My Poem");
+    await user.click(screen.getByRole("button", { name: /submit/i }));
+
+    // Success screen
+    await waitFor(() => {
+      expect(screen.getByText(/submission received/i)).toBeInTheDocument();
+      expect(screen.getByText(/sub-123/)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/embed/__tests__/embed-identity-step.spec.tsx
+++ b/apps/web/src/components/embed/__tests__/embed-identity-step.spec.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EmbedIdentityStep } from "../embed-identity-step";
+import "../../../../test/setup";
+
+describe("EmbedIdentityStep", () => {
+  const defaultProps = {
+    periodName: "Spring 2026 Submissions",
+    onContinue: jest.fn(),
+    isLoading: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requires email field", async () => {
+    const user = userEvent.setup();
+    render(<EmbedIdentityStep {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/please enter a valid email/i),
+      ).toBeInTheDocument();
+    });
+
+    expect(defaultProps.onContinue).not.toHaveBeenCalled();
+  });
+
+  it("validates email format", async () => {
+    const user = userEvent.setup();
+    render(<EmbedIdentityStep {...defaultProps} />);
+
+    // Type an invalid email and submit
+    const emailInput = screen.getByPlaceholderText("your@email.com");
+    await user.type(emailInput, "notanemail");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    // RHF with zodResolver rejects invalid email — onContinue should not fire.
+    // Note: jsdom's type="email" native validation may prevent form submission
+    // before Zod runs, so we check the behavioral outcome rather than error text.
+    await waitFor(() => {
+      expect(defaultProps.onContinue).not.toHaveBeenCalled();
+    });
+  });
+
+  it("name is optional", async () => {
+    const user = userEvent.setup();
+    render(<EmbedIdentityStep {...defaultProps} />);
+
+    await user.type(screen.getByLabelText(/email/i), "writer@example.com");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(defaultProps.onContinue).toHaveBeenCalledWith({
+        email: "writer@example.com",
+        name: undefined,
+      });
+    });
+  });
+
+  it("calls onContinue with email and name", async () => {
+    const user = userEvent.setup();
+    render(<EmbedIdentityStep {...defaultProps} />);
+
+    await user.type(screen.getByLabelText(/email/i), "writer@example.com");
+    await user.type(screen.getByLabelText(/name/i), "Jane Doe");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(defaultProps.onContinue).toHaveBeenCalledWith({
+        email: "writer@example.com",
+        name: "Jane Doe",
+      });
+    });
+  });
+});

--- a/apps/web/src/components/embed/__tests__/embed-upload-section.spec.tsx
+++ b/apps/web/src/components/embed/__tests__/embed-upload-section.spec.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/react";
+import { EmbedUploadSection } from "../embed-upload-section";
+import "../../../../test/setup";
+
+// Mock upload hooks
+const mockUseEmbedFileUpload = jest.fn();
+const mockUseEmbedUploadStatus = jest.fn();
+
+jest.mock("@/hooks/use-embed-file-upload", () => ({
+  useEmbedFileUpload: (...args: unknown[]) => mockUseEmbedFileUpload(...args),
+}));
+
+jest.mock("@/hooks/use-embed-upload-status", () => ({
+  useEmbedUploadStatus: (...args: unknown[]) =>
+    mockUseEmbedUploadStatus(...args),
+}));
+
+const defaultProps = {
+  token: "col_emb_test",
+  apiUrl: "http://localhost:4000",
+  uploadContext: {
+    manuscriptVersionId: "mv-1",
+    guestUserId: "gu-1",
+    tusEndpoint: "http://localhost:1080/files/",
+    maxFileSize: 50 * 1024 * 1024,
+    maxFiles: 10,
+    allowedMimeTypes: ["application/pdf"],
+  },
+  identity: { email: "test@example.com" },
+  disabled: false,
+  onUploadStateChange: jest.fn(),
+};
+
+describe("EmbedUploadSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseEmbedFileUpload.mockReturnValue({
+      uploads: [],
+      uploadFiles: jest.fn(),
+      removeUpload: jest.fn(),
+      cancelUpload: jest.fn(),
+      isUploading: false,
+    });
+    mockUseEmbedUploadStatus.mockReturnValue({
+      files: [],
+      allClean: false,
+      isPolling: false,
+      error: null,
+    });
+  });
+
+  it("renders drop zone", () => {
+    render(<EmbedUploadSection {...defaultProps} />);
+    expect(
+      screen.getByText(/drop files here or click to upload/i),
+    ).toBeInTheDocument();
+  });
+
+  it("disables when maxFiles reached", () => {
+    mockUseEmbedUploadStatus.mockReturnValue({
+      files: Array.from({ length: 10 }, (_, i) => ({
+        id: `f-${i}`,
+        filename: `file${i}.pdf`,
+        size: 100,
+        mimeType: "application/pdf",
+        scanStatus: "CLEAN",
+      })),
+      allClean: true,
+      isPolling: false,
+      error: null,
+    });
+
+    render(<EmbedUploadSection {...defaultProps} />);
+    expect(screen.getByText(/upload limit reached/i)).toBeInTheDocument();
+  });
+
+  it("shows scan status badges", () => {
+    mockUseEmbedUploadStatus.mockReturnValue({
+      files: [
+        {
+          id: "f1",
+          filename: "clean.pdf",
+          size: 100,
+          mimeType: "application/pdf",
+          scanStatus: "CLEAN",
+        },
+        {
+          id: "f2",
+          filename: "pending.pdf",
+          size: 200,
+          mimeType: "application/pdf",
+          scanStatus: "PENDING",
+        },
+      ],
+      allClean: false,
+      isPolling: true,
+      error: null,
+    });
+
+    render(<EmbedUploadSection {...defaultProps} />);
+    expect(screen.getByText("Clean")).toBeInTheDocument();
+    expect(screen.getByText("Pending scan")).toBeInTheDocument();
+  });
+
+  it("shows scanning warning", () => {
+    mockUseEmbedUploadStatus.mockReturnValue({
+      files: [
+        {
+          id: "f1",
+          filename: "test.pdf",
+          size: 100,
+          mimeType: "application/pdf",
+          scanStatus: "PENDING",
+        },
+      ],
+      allClean: false,
+      isPolling: true,
+      error: null,
+    });
+
+    render(<EmbedUploadSection {...defaultProps} />);
+    expect(screen.getByText(/files are being scanned/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/embed/embed-error.tsx
+++ b/apps/web/src/components/embed/embed-error.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface EmbedErrorProps {
+  type: "not_found" | "gone" | "rate_limited" | "validation" | "unknown";
+  message: string;
+  retryAfter?: number;
+  onRetry?: () => void;
+}
+
+const errorMessages: Record<string, { title: string; description: string }> = {
+  not_found: {
+    title: "Invalid Link",
+    description: "This submission link is not valid. Please check the URL.",
+  },
+  gone: {
+    title: "Submissions Closed",
+    description:
+      "The submission period for this form has ended or the link has been revoked.",
+  },
+  rate_limited: {
+    title: "Too Many Requests",
+    description: "Please wait before trying again.",
+  },
+  validation: {
+    title: "Submission Error",
+    description: "There was a problem with your submission.",
+  },
+  unknown: {
+    title: "Something Went Wrong",
+    description: "An unexpected error occurred. Please try again.",
+  },
+};
+
+export function EmbedError({
+  type,
+  message,
+  retryAfter,
+  onRetry,
+}: EmbedErrorProps) {
+  const [countdown, setCountdown] = useState(retryAfter ?? 0);
+
+  useEffect(() => {
+    if (countdown <= 0) return;
+    const timer = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [countdown]);
+
+  const config = errorMessages[type] ?? errorMessages.unknown;
+
+  return (
+    <div className="flex flex-col items-center text-center py-8 space-y-4">
+      <AlertCircle className="h-16 w-16 text-destructive" />
+      <div>
+        <h2 className="text-xl font-semibold">{config.title}</h2>
+        <p className="text-sm text-muted-foreground mt-2">
+          {message || config.description}
+        </p>
+      </div>
+      {onRetry && (type === "rate_limited" || type === "unknown") && (
+        <Button onClick={onRetry} disabled={countdown > 0} variant="outline">
+          {countdown > 0 ? `Retry in ${countdown}s` : "Try Again"}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/embed/embed-form-step.tsx
+++ b/apps/web/src/components/embed/embed-form-step.tsx
@@ -1,0 +1,525 @@
+"use client";
+
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import { useForm, useFormContext, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { DynamicFormField } from "@/components/submissions/form-renderer/dynamic-form-field";
+import {
+  buildFormFieldsSchema,
+  buildConditionalFormSchema,
+  type FormFieldForRenderer,
+} from "@/components/submissions/form-renderer/build-form-schema";
+import { getPageFieldPaths } from "@/components/submissions/form-renderer/build-page-schema";
+import { useConditionalFields } from "@/hooks/use-conditional-fields";
+import { useWizardForm } from "@/hooks/use-wizard-form";
+import { EmbedUploadSection, type UploadState } from "./embed-upload-section";
+import { Loader2, ArrowLeft, ArrowRight, Send } from "lucide-react";
+import type {
+  EmbedFormResponse,
+  EmbedPrepareUploadResponse,
+  PageBranchingRule,
+} from "@colophony/types";
+
+interface EmbedFormStepProps {
+  formDefinition: NonNullable<EmbedFormResponse["form"]>;
+  uploadContext: EmbedPrepareUploadResponse | null;
+  token: string;
+  apiUrl: string;
+  identity: { email: string; name?: string };
+  onSubmit: (data: {
+    title: string;
+    content?: string;
+    coverLetter?: string;
+    formData?: Record<string, unknown>;
+    manuscriptVersionId?: string;
+  }) => Promise<void>;
+  isSubmitting: boolean;
+}
+
+const baseFormSchema = z.object({
+  title: z.string().min(1, "Title is required").max(500),
+  content: z.string().max(50000).optional(),
+  coverLetter: z.string().max(10000).optional(),
+});
+
+export function EmbedFormStep({
+  formDefinition,
+  uploadContext,
+  token,
+  apiUrl,
+  identity,
+  onSubmit,
+  isSubmitting,
+}: EmbedFormStepProps) {
+  const [uploadState, setUploadState] = useState<UploadState>({
+    isUploading: false,
+    hasInfected: false,
+    allClean: false,
+    fileCount: 0,
+  });
+
+  const fields = useMemo(
+    () =>
+      [...(formDefinition.fields as FormFieldForRenderer[])].sort(
+        (a, b) =>
+          ((a as unknown as { sortOrder: number }).sortOrder ?? 0) -
+          ((b as unknown as { sortOrder: number }).sortOrder ?? 0),
+      ),
+    [formDefinition.fields],
+  );
+
+  const pages = formDefinition.pages as Array<{
+    id: string;
+    title: string;
+    description: string | null;
+    sortOrder: number;
+    branchingRules: PageBranchingRule[] | null;
+  }>;
+
+  const isWizard = pages.length > 1;
+  const hasFileUploadField = fields.some((f) => f.fieldType === "file_upload");
+
+  // Build static defaults
+  const { defaultValues: formDataDefaults } = useMemo(
+    () => buildFormFieldsSchema(fields),
+    [fields],
+  );
+
+  // schemaRef pattern from submission-form.tsx
+  const schemaRef = useRef(
+    baseFormSchema.extend({ formData: z.object({}).passthrough() }),
+  );
+
+  const form = useForm({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolver: async (values: any, context: any, options: any) => {
+      const resolver = zodResolver(schemaRef.current);
+      return resolver(values, context, options);
+    },
+    defaultValues: {
+      title: "",
+      content: "",
+      coverLetter: "",
+      formData: formDataDefaults,
+    },
+  });
+
+  // Rebuild schema reactively on formData changes
+  const watchedFormData = form.watch("formData") as Record<string, unknown>;
+
+  useEffect(() => {
+    const { schema: conditionalSchema } = buildConditionalFormSchema(
+      fields,
+      watchedFormData ?? {},
+    );
+    schemaRef.current = baseFormSchema.extend({ formData: conditionalSchema });
+  }, [fields, watchedFormData]);
+
+  const handleUploadStateChange = useCallback((state: UploadState) => {
+    setUploadState(state);
+  }, []);
+
+  const submitDisabled =
+    isSubmitting ||
+    uploadState.isUploading ||
+    uploadState.hasInfected ||
+    (uploadState.fileCount > 0 && !uploadState.allClean);
+
+  const handleFormSubmit = form.handleSubmit(async (values) => {
+    await onSubmit({
+      title: values.title,
+      content: values.content || undefined,
+      coverLetter: values.coverLetter || undefined,
+      formData: values.formData as Record<string, unknown>,
+      manuscriptVersionId: uploadContext?.manuscriptVersionId,
+    });
+  });
+
+  if (isWizard) {
+    return (
+      <FormProvider {...form}>
+        <form onSubmit={handleFormSubmit}>
+          <WizardFormContent
+            fields={fields}
+            pages={pages}
+            watchedFormData={watchedFormData ?? {}}
+            uploadContext={uploadContext}
+            hasFileUploadField={hasFileUploadField}
+            token={token}
+            apiUrl={apiUrl}
+            identity={identity}
+            onUploadStateChange={handleUploadStateChange}
+            isSubmitting={isSubmitting}
+            submitDisabled={submitDisabled}
+          />
+        </form>
+      </FormProvider>
+    );
+  }
+
+  // Flat mode
+  return (
+    <FormProvider {...form}>
+      <FlatFormContent
+        fields={fields}
+        watchedFormData={watchedFormData ?? {}}
+        uploadContext={uploadContext}
+        hasFileUploadField={hasFileUploadField}
+        token={token}
+        apiUrl={apiUrl}
+        identity={identity}
+        onUploadStateChange={handleUploadStateChange}
+        isSubmitting={isSubmitting}
+        submitDisabled={submitDisabled}
+        onSubmit={handleFormSubmit}
+      />
+    </FormProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Flat form (single page or no pages)
+// ---------------------------------------------------------------------------
+
+interface FlatFormContentProps {
+  fields: FormFieldForRenderer[];
+  watchedFormData: Record<string, unknown>;
+  uploadContext: EmbedPrepareUploadResponse | null;
+  hasFileUploadField: boolean;
+  token: string;
+  apiUrl: string;
+  identity: { email: string; name?: string };
+  onUploadStateChange: (state: UploadState) => void;
+  isSubmitting: boolean;
+  submitDisabled: boolean;
+  onSubmit: () => void;
+}
+
+function FlatFormContent({
+  fields,
+  watchedFormData,
+  uploadContext,
+  hasFileUploadField,
+  token,
+  apiUrl,
+  identity,
+  onUploadStateChange,
+  isSubmitting,
+  submitDisabled,
+  onSubmit,
+}: FlatFormContentProps) {
+  const form = useFormContext();
+  const visibilityMap = useConditionalFields(fields, watchedFormData);
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-6">
+      <FormField
+        control={form.control}
+        name="title"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>
+              Title <span className="text-destructive">*</span>
+            </FormLabel>
+            <FormControl>
+              <Input placeholder="Submission title" {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="content"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Content</FormLabel>
+            <FormControl>
+              <Textarea
+                placeholder="Your submission content (optional)"
+                rows={4}
+                {...field}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="coverLetter"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Cover Letter</FormLabel>
+            <FormControl>
+              <Textarea
+                placeholder="Cover letter (optional)"
+                rows={3}
+                {...field}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {fields.map((field) => {
+        const vis = visibilityMap.get(field.fieldKey);
+        if (vis && !vis.visible) return null;
+        if (field.fieldType === "file_upload") return null;
+
+        const effectiveField =
+          vis?.required && !field.required
+            ? { ...field, required: true }
+            : field;
+
+        return (
+          <DynamicFormField
+            key={field.fieldKey}
+            field={effectiveField}
+            disabled={isSubmitting}
+          />
+        );
+      })}
+
+      {hasFileUploadField && uploadContext && (
+        <EmbedUploadSection
+          token={token}
+          apiUrl={apiUrl}
+          uploadContext={uploadContext}
+          identity={identity}
+          disabled={isSubmitting}
+          onUploadStateChange={onUploadStateChange}
+        />
+      )}
+
+      <Button type="submit" className="w-full" disabled={submitDisabled}>
+        {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+        <Send className="mr-1 h-4 w-4" />
+        Submit
+      </Button>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Wizard form (multiple pages)
+// ---------------------------------------------------------------------------
+
+interface WizardFormContentProps {
+  fields: FormFieldForRenderer[];
+  pages: Array<{
+    id: string;
+    title: string;
+    description: string | null;
+    sortOrder: number;
+    branchingRules: PageBranchingRule[] | null;
+  }>;
+  watchedFormData: Record<string, unknown>;
+  uploadContext: EmbedPrepareUploadResponse | null;
+  hasFileUploadField: boolean;
+  token: string;
+  apiUrl: string;
+  identity: { email: string; name?: string };
+  onUploadStateChange: (state: UploadState) => void;
+  isSubmitting: boolean;
+  submitDisabled: boolean;
+}
+
+function WizardFormContent({
+  fields,
+  pages,
+  watchedFormData,
+  uploadContext,
+  hasFileUploadField,
+  token,
+  apiUrl,
+  identity,
+  onUploadStateChange,
+  isSubmitting,
+  submitDisabled,
+}: WizardFormContentProps) {
+  const formCtx = useFormContext();
+
+  const {
+    wizardPages,
+    currentStep,
+    isLastStep,
+    isFirstStep,
+    goToNext,
+    goToPrevious,
+    currentPageFields,
+    currentPage,
+    markCurrentCompleted,
+  } = useWizardForm({
+    pages,
+    fields,
+    formValues: watchedFormData,
+  });
+
+  const allFieldsVisibility = useConditionalFields(fields, watchedFormData);
+  const currentPageFieldKeys = new Set(
+    currentPageFields.map((f) => f.fieldKey),
+  );
+  const visibilityMap = new Map(
+    [...allFieldsVisibility].filter(([key]) => currentPageFieldKeys.has(key)),
+  );
+
+  const handleNext = async () => {
+    const paths = getPageFieldPaths(currentPageFields);
+    if (paths.length > 0) {
+      const isValid = await formCtx.trigger(paths);
+      if (!isValid) return;
+    }
+    markCurrentCompleted();
+    goToNext();
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Page indicator */}
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <span>
+          Page {currentStep + 1} of {wizardPages.length}
+        </span>
+        <span className="font-medium text-foreground">{currentPage.title}</span>
+      </div>
+
+      {currentPage.description && (
+        <p className="text-sm text-muted-foreground">
+          {currentPage.description}
+        </p>
+      )}
+
+      {/* First page includes title/content/coverLetter */}
+      {currentStep === 0 && (
+        <div className="space-y-6">
+          <FormField
+            control={formCtx.control}
+            name="title"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Title <span className="text-destructive">*</span>
+                </FormLabel>
+                <FormControl>
+                  <Input placeholder="Submission title" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={formCtx.control}
+            name="content"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Content</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Your submission content (optional)"
+                    rows={4}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={formCtx.control}
+            name="coverLetter"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Cover Letter</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Cover letter (optional)"
+                    rows={3}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      )}
+
+      {/* Dynamic fields for current page */}
+      <div className="space-y-6">
+        {currentPageFields.map((field) => {
+          const vis = visibilityMap.get(field.fieldKey);
+          if (vis && !vis.visible) return null;
+          if (field.fieldType === "file_upload") return null;
+
+          const effectiveField =
+            vis?.required && !field.required
+              ? { ...field, required: true }
+              : field;
+
+          return (
+            <DynamicFormField
+              key={field.fieldKey}
+              field={effectiveField}
+              disabled={isSubmitting}
+            />
+          );
+        })}
+      </div>
+
+      {/* File uploads on last step */}
+      {isLastStep && hasFileUploadField && uploadContext && (
+        <EmbedUploadSection
+          token={token}
+          apiUrl={apiUrl}
+          uploadContext={uploadContext}
+          identity={identity}
+          disabled={isSubmitting}
+          onUploadStateChange={onUploadStateChange}
+        />
+      )}
+
+      {/* Navigation */}
+      <div className="flex justify-between pt-4">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={goToPrevious}
+          disabled={isFirstStep || isSubmitting}
+        >
+          <ArrowLeft className="mr-1 h-4 w-4" />
+          Back
+        </Button>
+
+        {isLastStep ? (
+          <Button type="submit" disabled={submitDisabled}>
+            {isSubmitting && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}
+            <Send className="mr-1 h-4 w-4" />
+            Submit
+          </Button>
+        ) : (
+          <Button type="button" onClick={handleNext} disabled={isSubmitting}>
+            Next
+            <ArrowRight className="ml-1 h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/embed/embed-form.tsx
+++ b/apps/web/src/components/embed/embed-form.tsx
@@ -65,8 +65,9 @@ export function EmbedForm({ token, apiUrl }: EmbedFormProps) {
   });
 
   const [identityLoading, setIdentityLoading] = useState(false);
+  const [loadAttempt, setLoadAttempt] = useState(0);
 
-  // Load form data on mount
+  // Load form data on mount (and on retry)
   useEffect(() => {
     let cancelled = false;
 
@@ -99,7 +100,7 @@ export function EmbedForm({ token, apiUrl }: EmbedFormProps) {
     return () => {
       cancelled = true;
     };
-  }, [apiUrl, token]);
+  }, [apiUrl, token, loadAttempt]);
 
   // Handle identity continue — optionally prepare upload
   const handleIdentityContinue = useCallback(
@@ -196,6 +197,8 @@ export function EmbedForm({ token, apiUrl }: EmbedFormProps) {
       step: prev.formData ? "identity" : "loading",
       error: null,
     }));
+    // Increment to re-trigger the load effect when formData is null
+    setLoadAttempt((n) => n + 1);
   }, []);
 
   return (

--- a/apps/web/src/components/embed/embed-form.tsx
+++ b/apps/web/src/components/embed/embed-form.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  fetchEmbedForm,
+  submitEmbedForm,
+  prepareEmbedUpload,
+  type EmbedApiError,
+} from "@/lib/embed-api";
+import type {
+  EmbedFormResponse,
+  EmbedPrepareUploadResponse,
+} from "@colophony/types";
+import { EmbedThemeProvider } from "./embed-theme-provider";
+import { EmbedIdentityStep } from "./embed-identity-step";
+import { EmbedFormStep } from "./embed-form-step";
+import { EmbedSuccess } from "./embed-success";
+import { EmbedError } from "./embed-error";
+import { Loader2 } from "lucide-react";
+
+type EmbedStep =
+  | "loading"
+  | "identity"
+  | "form"
+  | "submitting"
+  | "success"
+  | "error";
+
+interface EmbedState {
+  step: EmbedStep;
+  formData: EmbedFormResponse | null;
+  identity: { email: string; name?: string } | null;
+  uploadContext: EmbedPrepareUploadResponse | null;
+  error: {
+    type: "not_found" | "gone" | "rate_limited" | "validation" | "unknown";
+    message: string;
+    retryAfter?: number;
+  } | null;
+  submissionId: string | null;
+}
+
+function mapErrorType(
+  status: number,
+): "not_found" | "gone" | "rate_limited" | "validation" | "unknown" {
+  if (status === 404) return "not_found";
+  if (status === 410) return "gone";
+  if (status === 429) return "rate_limited";
+  if (status === 400 || status === 422) return "validation";
+  return "unknown";
+}
+
+interface EmbedFormProps {
+  token: string;
+  apiUrl: string;
+}
+
+export function EmbedForm({ token, apiUrl }: EmbedFormProps) {
+  const [state, setState] = useState<EmbedState>({
+    step: "loading",
+    formData: null,
+    identity: null,
+    uploadContext: null,
+    error: null,
+    submissionId: null,
+  });
+
+  const [identityLoading, setIdentityLoading] = useState(false);
+
+  // Load form data on mount
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const data = await fetchEmbedForm(apiUrl, token);
+        if (!cancelled) {
+          setState((prev) => ({
+            ...prev,
+            step: "identity",
+            formData: data,
+          }));
+        }
+      } catch (err) {
+        if (cancelled) return;
+        const apiErr = err as EmbedApiError;
+        setState((prev) => ({
+          ...prev,
+          step: "error",
+          error: {
+            type: mapErrorType(apiErr.status ?? 500),
+            message: apiErr.message ?? "Failed to load form",
+            retryAfter: apiErr.retryAfter,
+          },
+        }));
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [apiUrl, token]);
+
+  // Handle identity continue — optionally prepare upload
+  const handleIdentityContinue = useCallback(
+    async (identity: { email: string; name?: string }) => {
+      setIdentityLoading(true);
+
+      const hasFileUpload = state.formData?.form?.fields.some(
+        (f) => (f as { fieldType?: string }).fieldType === "file_upload",
+      );
+
+      try {
+        let uploadContext: EmbedPrepareUploadResponse | null = null;
+
+        if (hasFileUpload) {
+          uploadContext = await prepareEmbedUpload(apiUrl, token, {
+            email: identity.email,
+            name: identity.name,
+          });
+        }
+
+        setState((prev) => ({
+          ...prev,
+          step: "form",
+          identity,
+          uploadContext,
+        }));
+      } catch (err) {
+        const apiErr = err as EmbedApiError;
+        setState((prev) => ({
+          ...prev,
+          step: "error",
+          error: {
+            type: mapErrorType(apiErr.status ?? 500),
+            message: apiErr.message ?? "Failed to prepare upload",
+            retryAfter: apiErr.retryAfter,
+          },
+        }));
+      } finally {
+        setIdentityLoading(false);
+      }
+    },
+    [apiUrl, token, state.formData],
+  );
+
+  // Handle form submission
+  const handleFormSubmit = useCallback(
+    async (data: {
+      title: string;
+      content?: string;
+      coverLetter?: string;
+      formData?: Record<string, unknown>;
+      manuscriptVersionId?: string;
+    }) => {
+      if (!state.identity) return;
+
+      setState((prev) => ({ ...prev, step: "submitting" }));
+
+      try {
+        const result = await submitEmbedForm(apiUrl, token, {
+          email: state.identity.email,
+          name: state.identity.name,
+          title: data.title,
+          content: data.content,
+          coverLetter: data.coverLetter,
+          formData: data.formData,
+          manuscriptVersionId: data.manuscriptVersionId,
+        });
+
+        setState((prev) => ({
+          ...prev,
+          step: "success",
+          submissionId: result.submissionId,
+        }));
+      } catch (err) {
+        const apiErr = err as EmbedApiError;
+        setState((prev) => ({
+          ...prev,
+          step: "error",
+          error: {
+            type: mapErrorType(apiErr.status ?? 500),
+            message: apiErr.message ?? "Submission failed",
+            retryAfter: apiErr.retryAfter,
+          },
+        }));
+      }
+    },
+    [apiUrl, token, state.identity],
+  );
+
+  // Handle retry from error
+  const handleRetry = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      step: prev.formData ? "identity" : "loading",
+      error: null,
+    }));
+  }, []);
+
+  return (
+    <EmbedThemeProvider theme={state.formData?.theme ?? null}>
+      <div className="max-w-2xl mx-auto p-4">
+        {state.step === "loading" && (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {state.step === "identity" && state.formData && (
+          <EmbedIdentityStep
+            periodName={state.formData.period.name}
+            onContinue={handleIdentityContinue}
+            isLoading={identityLoading}
+          />
+        )}
+
+        {(state.step === "form" || state.step === "submitting") &&
+          state.formData?.form &&
+          state.identity && (
+            <EmbedFormStep
+              formDefinition={state.formData.form}
+              uploadContext={state.uploadContext}
+              token={token}
+              apiUrl={apiUrl}
+              identity={state.identity}
+              onSubmit={handleFormSubmit}
+              isSubmitting={state.step === "submitting"}
+            />
+          )}
+
+        {state.step === "success" && state.formData && state.submissionId && (
+          <EmbedSuccess
+            submissionId={state.submissionId}
+            periodName={state.formData.period.name}
+          />
+        )}
+
+        {state.step === "error" && state.error && (
+          <EmbedError
+            type={state.error.type}
+            message={state.error.message}
+            retryAfter={state.error.retryAfter}
+            onRetry={handleRetry}
+          />
+        )}
+      </div>
+    </EmbedThemeProvider>
+  );
+}

--- a/apps/web/src/components/embed/embed-identity-step.tsx
+++ b/apps/web/src/components/embed/embed-identity-step.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Loader2 } from "lucide-react";
+
+const identitySchema = z.object({
+  email: z.string().email("Please enter a valid email address").max(255),
+  name: z.string().max(255).optional(),
+});
+
+type IdentityValues = z.infer<typeof identitySchema>;
+
+interface EmbedIdentityStepProps {
+  periodName: string;
+  onContinue: (identity: { email: string; name?: string }) => void;
+  isLoading: boolean;
+}
+
+export function EmbedIdentityStep({
+  periodName,
+  onContinue,
+  isLoading,
+}: EmbedIdentityStepProps) {
+  const form = useForm<IdentityValues>({
+    resolver: zodResolver(identitySchema),
+    defaultValues: { email: "", name: "" },
+  });
+
+  const handleSubmit = form.handleSubmit((values) => {
+    onContinue({
+      email: values.email,
+      name: values.name || undefined,
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold">{periodName}</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Enter your information to begin your submission.
+        </p>
+      </div>
+
+      <Form {...form}>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Email <span className="text-destructive">*</span>
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type="email"
+                    placeholder="your@email.com"
+                    disabled={isLoading}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="Your name (optional)"
+                    disabled={isLoading}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Continue
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/apps/web/src/components/embed/embed-success.tsx
+++ b/apps/web/src/components/embed/embed-success.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { CheckCircle } from "lucide-react";
+
+interface EmbedSuccessProps {
+  submissionId: string;
+  periodName: string;
+}
+
+export function EmbedSuccess({ submissionId, periodName }: EmbedSuccessProps) {
+  return (
+    <div className="flex flex-col items-center text-center py-8 space-y-4">
+      <CheckCircle className="h-16 w-16 text-green-600" />
+      <div>
+        <h2 className="text-xl font-semibold">Submission Received</h2>
+        <p className="text-sm text-muted-foreground mt-2">
+          Your submission to <strong>{periodName}</strong> has been received.
+        </p>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Confirmation ID: {submissionId}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/embed/embed-theme-provider.tsx
+++ b/apps/web/src/components/embed/embed-theme-provider.tsx
@@ -1,0 +1,59 @@
+import type { EmbedThemeConfig } from "@colophony/types";
+
+interface EmbedThemeProviderProps {
+  theme: EmbedThemeConfig | null;
+  children: React.ReactNode;
+}
+
+function hexToHsl(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+
+  if (max === min) {
+    return `0 0% ${Math.round(l * 100)}%`;
+  }
+
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+  let h = 0;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+  else if (max === g) h = ((b - r) / d + 2) / 6;
+  else h = ((r - g) / d + 4) / 6;
+
+  return `${Math.round(h * 360)} ${Math.round(s * 100)}% ${Math.round(l * 100)}%`;
+}
+
+export function EmbedThemeProvider({
+  theme,
+  children,
+}: EmbedThemeProviderProps) {
+  if (!theme) {
+    return <>{children}</>;
+  }
+
+  const style: React.CSSProperties = {};
+
+  if (theme.primaryColor) {
+    (style as Record<string, string>)["--primary"] = hexToHsl(
+      theme.primaryColor,
+    );
+  }
+  if (theme.borderRadius) {
+    (style as Record<string, string>)["--radius"] = theme.borderRadius;
+  }
+  if (theme.fontFamily) {
+    style.fontFamily = theme.fontFamily;
+  }
+
+  return (
+    <div style={style} className={theme.darkMode ? "dark" : undefined}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/embed/embed-upload-section.tsx
+++ b/apps/web/src/components/embed/embed-upload-section.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { useEmbedFileUpload } from "@/hooks/use-embed-file-upload";
+import { useEmbedUploadStatus } from "@/hooks/use-embed-upload-status";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import {
+  Upload,
+  File as FileIcon,
+  X,
+  CheckCircle,
+  AlertCircle,
+  Clock,
+  Loader2,
+} from "lucide-react";
+import type { EmbedPrepareUploadResponse, ScanStatus } from "@colophony/types";
+
+export interface UploadState {
+  isUploading: boolean;
+  hasInfected: boolean;
+  allClean: boolean;
+  fileCount: number;
+}
+
+interface EmbedUploadSectionProps {
+  token: string;
+  apiUrl: string;
+  uploadContext: EmbedPrepareUploadResponse;
+  identity: { email: string; name?: string };
+  disabled: boolean;
+  onUploadStateChange: (state: UploadState) => void;
+}
+
+const scanStatusConfig: Record<
+  ScanStatus,
+  {
+    label: string;
+    icon: React.ComponentType<{ className?: string }>;
+    className: string;
+  }
+> = {
+  PENDING: {
+    label: "Pending scan",
+    icon: Clock,
+    className: "bg-gray-100 text-gray-800",
+  },
+  SCANNING: {
+    label: "Scanning...",
+    icon: Loader2,
+    className: "bg-blue-100 text-blue-800",
+  },
+  CLEAN: {
+    label: "Clean",
+    icon: CheckCircle,
+    className: "bg-green-100 text-green-800",
+  },
+  INFECTED: {
+    label: "Infected",
+    icon: AlertCircle,
+    className: "bg-red-100 text-red-800",
+  },
+  FAILED: {
+    label: "Scan failed",
+    icon: AlertCircle,
+    className: "bg-orange-100 text-orange-800",
+  },
+};
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function ScanStatusBadge({ status }: { status: ScanStatus }) {
+  const config = scanStatusConfig[status];
+  const Icon = config.icon;
+
+  return (
+    <Badge variant="secondary" className={cn("gap-1", config.className)}>
+      <Icon
+        className={cn("h-3 w-3", status === "SCANNING" && "animate-spin")}
+      />
+      {config.label}
+    </Badge>
+  );
+}
+
+export function EmbedUploadSection({
+  token,
+  apiUrl,
+  uploadContext,
+  identity,
+  disabled,
+  onUploadStateChange,
+}: EmbedUploadSectionProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const { uploads, uploadFiles, removeUpload, cancelUpload, isUploading } =
+    useEmbedFileUpload({
+      manuscriptVersionId: uploadContext.manuscriptVersionId,
+      guestUserId: uploadContext.guestUserId,
+      tusEndpoint: uploadContext.tusEndpoint,
+      embedToken: token,
+      maxFileSize: uploadContext.maxFileSize,
+      allowedMimeTypes: uploadContext.allowedMimeTypes,
+    });
+
+  const { files: scannedFiles, allClean } = useEmbedUploadStatus({
+    apiUrl,
+    token,
+    manuscriptVersionId: uploadContext.manuscriptVersionId,
+    email: identity.email,
+    enabled: uploads.length > 0 || false,
+    uploadsInFlight: isUploading,
+  });
+
+  // Propagate upload state to parent
+  const hasInfected = scannedFiles.some((f) => f.scanStatus === "INFECTED");
+  const fileCount = scannedFiles.length;
+
+  useEffect(() => {
+    onUploadStateChange({
+      isUploading,
+      hasInfected,
+      allClean,
+      fileCount,
+    });
+  }, [isUploading, hasInfected, allClean, fileCount, onUploadStateChange]);
+
+  const handleFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files;
+      if (files && files.length > 0) {
+        uploadFiles(files);
+      }
+      if (inputRef.current) {
+        inputRef.current.value = "";
+      }
+    },
+    [uploadFiles],
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const files = e.dataTransfer.files;
+      if (files && files.length > 0) {
+        uploadFiles(files);
+      }
+    },
+    [uploadFiles],
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+  }, []);
+
+  const totalFiles =
+    scannedFiles.length +
+    uploads.filter((u) => u.status === "uploading" || u.status === "pending")
+      .length;
+  const canUpload = !disabled && totalFiles < uploadContext.maxFiles;
+
+  const acceptedTypes = uploadContext.allowedMimeTypes.join(",");
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-sm font-medium">Files</h3>
+        <p className="text-xs text-muted-foreground mt-1">
+          Max {formatFileSize(uploadContext.maxFileSize)} per file.{" "}
+          {uploadContext.maxFiles} files max.
+        </p>
+      </div>
+
+      {/* Drop zone */}
+      <div
+        className={cn(
+          "border-2 border-dashed rounded-lg p-6 text-center transition-colors",
+          canUpload
+            ? "border-muted-foreground/25 hover:border-primary/50 cursor-pointer"
+            : "border-muted opacity-50 cursor-not-allowed",
+        )}
+        onDrop={canUpload ? handleDrop : undefined}
+        onDragOver={canUpload ? handleDragOver : undefined}
+        onClick={() => canUpload && inputRef.current?.click()}
+      >
+        <Upload className="mx-auto h-10 w-10 text-muted-foreground" />
+        <p className="mt-2 text-sm font-medium">
+          {canUpload
+            ? "Drop files here or click to upload"
+            : "Upload limit reached"}
+        </p>
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          accept={acceptedTypes}
+          onChange={handleFileSelect}
+          className="hidden"
+          disabled={!canUpload}
+        />
+      </div>
+
+      {/* Uploading files */}
+      {uploads.length > 0 && (
+        <div className="space-y-2">
+          {uploads.map((upload) => (
+            <div
+              key={upload.id}
+              className="flex items-center gap-3 p-3 border rounded-lg"
+            >
+              <FileIcon className="h-6 w-6 text-muted-foreground flex-shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">
+                  {upload.file.name}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {formatFileSize(upload.file.size)}
+                </p>
+                {upload.status === "uploading" && (
+                  <Progress value={upload.progress} className="h-1 mt-1" />
+                )}
+                {upload.status === "error" && (
+                  <p className="text-xs text-destructive mt-1">
+                    {upload.error}
+                  </p>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {upload.status === "uploading" && (
+                  <span className="text-xs text-muted-foreground">
+                    {upload.progress}%
+                  </span>
+                )}
+                {upload.status === "processing" && upload.scanStatus && (
+                  <ScanStatusBadge status={upload.scanStatus} />
+                )}
+                {upload.status === "error" && (
+                  <AlertCircle className="h-5 w-5 text-destructive" />
+                )}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={
+                    upload.status === "uploading"
+                      ? () => cancelUpload(upload.id)
+                      : () => removeUpload(upload.id)
+                  }
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Scanned files from server */}
+      {scannedFiles.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Uploaded files</p>
+          {scannedFiles.map((file) => (
+            <div
+              key={file.id}
+              className="flex items-center gap-3 p-3 border rounded-lg"
+            >
+              <FileIcon className="h-6 w-6 text-muted-foreground flex-shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">{file.filename}</p>
+                <p className="text-xs text-muted-foreground">
+                  {formatFileSize(file.size)}
+                </p>
+              </div>
+              <ScanStatusBadge status={file.scanStatus} />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Scanning warning */}
+      {scannedFiles.some(
+        (f) => f.scanStatus === "PENDING" || f.scanStatus === "SCANNING",
+      ) && (
+        <p className="text-sm text-yellow-600 dark:text-yellow-400">
+          Files are being scanned. You can submit after all scans complete.
+        </p>
+      )}
+
+      {/* Infected warning */}
+      {hasInfected && (
+        <p className="text-sm text-destructive">
+          Some files were flagged as infected and cannot be submitted.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/embed/embed-upload-section.tsx
+++ b/apps/web/src/components/embed/embed-upload-section.tsx
@@ -114,7 +114,7 @@ export function EmbedUploadSection({
     token,
     manuscriptVersionId: uploadContext.manuscriptVersionId,
     email: identity.email,
-    enabled: uploads.length > 0 || false,
+    enabled: true,
     uploadsInFlight: isUploading,
   });
 

--- a/apps/web/src/hooks/__tests__/use-embed-file-upload.spec.ts
+++ b/apps/web/src/hooks/__tests__/use-embed-file-upload.spec.ts
@@ -1,0 +1,187 @@
+import { renderHook, act } from "@testing-library/react";
+import { useEmbedFileUpload } from "../use-embed-file-upload";
+
+let tusOnProgress:
+  | ((bytesUploaded: number, bytesTotal: number) => void)
+  | undefined;
+let tusOnSuccess: (() => void) | undefined;
+let tusOnError: ((error: Error) => void) | undefined;
+let tusConstructorArgs: Record<string, unknown>;
+const mockTusStart = jest.fn();
+const mockTusAbort = jest.fn();
+
+jest.mock("tus-js-client", () => ({
+  Upload: jest.fn().mockImplementation(
+    (
+      _file: File,
+      options: {
+        onProgress?: (bytesUploaded: number, bytesTotal: number) => void;
+        onSuccess?: () => void;
+        onError?: (error: Error) => void;
+        headers?: Record<string, string>;
+        metadata?: Record<string, string>;
+      },
+    ) => {
+      tusOnProgress = options.onProgress;
+      tusOnSuccess = options.onSuccess;
+      tusOnError = options.onError;
+      tusConstructorArgs = options as unknown as Record<string, unknown>;
+      return { start: mockTusStart, abort: mockTusAbort };
+    },
+  ),
+}));
+
+describe("useEmbedFileUpload", () => {
+  const defaultOptions = {
+    manuscriptVersionId: "mv-123",
+    guestUserId: "gu-456",
+    tusEndpoint: "http://localhost:1080/files/",
+    embedToken: "col_emb_testtoken",
+    maxFileSize: 50 * 1024 * 1024,
+    allowedMimeTypes: ["application/pdf", "text/plain"],
+    onUploadComplete: jest.fn(),
+    onError: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tusOnProgress = undefined;
+    tusOnSuccess = undefined;
+    tusOnError = undefined;
+  });
+
+  it("sends X-Embed-Token header to tus", async () => {
+    const { result } = renderHook(() => useEmbedFileUpload(defaultOptions));
+
+    const file = new File(["content"], "test.pdf", { type: "application/pdf" });
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    expect(tusConstructorArgs.headers).toEqual({
+      "X-Embed-Token": "col_emb_testtoken",
+    });
+  });
+
+  it("includes guest-user-id in tus metadata", async () => {
+    const { result } = renderHook(() => useEmbedFileUpload(defaultOptions));
+
+    const file = new File(["content"], "test.pdf", { type: "application/pdf" });
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    expect(tusConstructorArgs.metadata).toEqual(
+      expect.objectContaining({
+        "guest-user-id": "gu-456",
+        "manuscript-version-id": "mv-123",
+        filename: "test.pdf",
+        filetype: "application/pdf",
+      }),
+    );
+  });
+
+  it("rejects disallowed MIME type", async () => {
+    const { result } = renderHook(() => useEmbedFileUpload(defaultOptions));
+
+    const file = new File(["<svg>"], "bad.svg", { type: "image/svg+xml" });
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    expect(defaultOptions.onError).toHaveBeenCalledWith(
+      expect.stringContaining("not allowed"),
+    );
+    expect(mockTusStart).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized file", async () => {
+    const opts = { ...defaultOptions, maxFileSize: 100 };
+    const { result } = renderHook(() => useEmbedFileUpload(opts));
+
+    const file = new File(["x".repeat(200)], "big.pdf", {
+      type: "application/pdf",
+    });
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    expect(opts.onError).toHaveBeenCalledWith(
+      expect.stringContaining("exceeds maximum"),
+    );
+    expect(mockTusStart).not.toHaveBeenCalled();
+  });
+
+  it("tracks upload progress", async () => {
+    const { result } = renderHook(() => useEmbedFileUpload(defaultOptions));
+
+    const file = new File(["content"], "test.pdf", { type: "application/pdf" });
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    act(() => {
+      tusOnProgress?.(50, 100);
+    });
+
+    const uploading = result.current.uploads.find(
+      (u) => u.status === "uploading",
+    );
+    expect(uploading?.progress).toBe(50);
+  });
+
+  it("handles tus error with status mapping", async () => {
+    const { result } = renderHook(() => useEmbedFileUpload(defaultOptions));
+
+    const file = new File(["content"], "test.pdf", { type: "application/pdf" });
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    const tusError = new Error("Upload failed") as Error & {
+      originalResponse: { getStatus: () => number };
+    };
+    (
+      tusError as unknown as { originalResponse: { getStatus: () => number } }
+    ).originalResponse = { getStatus: () => 413 };
+
+    act(() => {
+      tusOnError?.(tusError);
+    });
+
+    expect(defaultOptions.onError).toHaveBeenCalledWith("File is too large");
+  });
+
+  it("cancelUpload calls abort", async () => {
+    const { result } = renderHook(() => useEmbedFileUpload(defaultOptions));
+
+    const file = new File(["content"], "test.pdf", { type: "application/pdf" });
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    const uploadId = result.current.uploads[0]?.id;
+    expect(uploadId).toBeDefined();
+
+    act(() => {
+      result.current.cancelUpload(uploadId!);
+    });
+
+    expect(mockTusAbort).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onUploadComplete on success", async () => {
+    const { result } = renderHook(() => useEmbedFileUpload(defaultOptions));
+
+    const file = new File(["content"], "test.pdf", { type: "application/pdf" });
+    await act(async () => {
+      await result.current.uploadFile(file);
+    });
+
+    act(() => {
+      tusOnSuccess?.();
+    });
+
+    expect(defaultOptions.onUploadComplete).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/__tests__/use-embed-upload-status.spec.ts
+++ b/apps/web/src/hooks/__tests__/use-embed-upload-status.spec.ts
@@ -1,0 +1,195 @@
+import { renderHook, act } from "@testing-library/react";
+import { useEmbedUploadStatus } from "../use-embed-upload-status";
+
+const mockFetchUploadStatus = jest.fn();
+
+jest.mock("@/lib/embed-api", () => ({
+  fetchUploadStatus: (...args: unknown[]) => mockFetchUploadStatus(...args),
+}));
+
+describe("useEmbedUploadStatus", () => {
+  const defaultOptions = {
+    apiUrl: "http://localhost:4000",
+    token: "col_emb_test",
+    manuscriptVersionId: "mv-123",
+    email: "test@example.com",
+    enabled: true,
+    uploadsInFlight: false,
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("polls every 3s when enabled", async () => {
+    mockFetchUploadStatus.mockResolvedValue({
+      files: [
+        {
+          id: "f1",
+          filename: "a.pdf",
+          size: 100,
+          mimeType: "application/pdf",
+          scanStatus: "PENDING",
+        },
+      ],
+      allClean: false,
+    });
+
+    renderHook(() => useEmbedUploadStatus(defaultOptions));
+
+    // Initial poll
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    expect(mockFetchUploadStatus).toHaveBeenCalledTimes(1);
+
+    // After 3 seconds
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(3000);
+    });
+    expect(mockFetchUploadStatus).toHaveBeenCalledTimes(2);
+
+    // After 6 seconds total
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(3000);
+    });
+    expect(mockFetchUploadStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops when allClean and no uploads in flight", async () => {
+    mockFetchUploadStatus.mockResolvedValue({
+      files: [
+        {
+          id: "f1",
+          filename: "a.pdf",
+          size: 100,
+          mimeType: "application/pdf",
+          scanStatus: "CLEAN",
+        },
+      ],
+      allClean: true,
+    });
+
+    const { result } = renderHook(() =>
+      useEmbedUploadStatus({ ...defaultOptions, uploadsInFlight: false }),
+    );
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.allClean).toBe(true);
+
+    // After many more intervals, no additional calls
+    const callCount = mockFetchUploadStatus.mock.calls.length;
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(9000);
+    });
+    expect(mockFetchUploadStatus).toHaveBeenCalledTimes(callCount);
+  });
+
+  it("keeps polling when uploads in flight even if no files yet", async () => {
+    mockFetchUploadStatus.mockResolvedValue({
+      files: [],
+      allClean: false,
+    });
+
+    renderHook(() =>
+      useEmbedUploadStatus({ ...defaultOptions, uploadsInFlight: true }),
+    );
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    const initial = mockFetchUploadStatus.mock.calls.length;
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(6000);
+    });
+    // Should keep polling
+    expect(mockFetchUploadStatus.mock.calls.length).toBeGreaterThan(initial);
+  });
+
+  it("backs off on 429", async () => {
+    const error = { status: 429, message: "Rate limited", retryAfter: 10 };
+    mockFetchUploadStatus.mockRejectedValueOnce(error);
+    mockFetchUploadStatus.mockResolvedValue({
+      files: [
+        {
+          id: "f1",
+          filename: "a.pdf",
+          size: 100,
+          mimeType: "application/pdf",
+          scanStatus: "PENDING",
+        },
+      ],
+      allClean: false,
+    });
+
+    renderHook(() => useEmbedUploadStatus(defaultOptions));
+
+    // Initial poll triggers 429
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    // After 3s (old interval), should not have polled again yet
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(3000);
+    });
+    const callsAt3s = mockFetchUploadStatus.mock.calls.length;
+
+    // After 10s (retryAfter), should have polled again
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(7000);
+    });
+    expect(mockFetchUploadStatus.mock.calls.length).toBeGreaterThan(callsAt3s);
+  });
+
+  it("cleans up on unmount", async () => {
+    mockFetchUploadStatus.mockResolvedValue({
+      files: [
+        {
+          id: "f1",
+          filename: "a.pdf",
+          size: 100,
+          mimeType: "application/pdf",
+          scanStatus: "PENDING",
+        },
+      ],
+      allClean: false,
+    });
+
+    const { unmount } = renderHook(() => useEmbedUploadStatus(defaultOptions));
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    const callsBeforeUnmount = mockFetchUploadStatus.mock.calls.length;
+
+    unmount();
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(9000);
+    });
+    // No additional calls after unmount
+    expect(mockFetchUploadStatus).toHaveBeenCalledTimes(callsBeforeUnmount);
+  });
+
+  it("does not poll when disabled", async () => {
+    renderHook(() =>
+      useEmbedUploadStatus({ ...defaultOptions, enabled: false }),
+    );
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(10000);
+    });
+
+    expect(mockFetchUploadStatus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/use-embed-file-upload.ts
+++ b/apps/web/src/hooks/use-embed-file-upload.ts
@@ -1,0 +1,203 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import * as tus from "tus-js-client";
+import type { UploadingFile } from "./use-file-upload";
+
+interface UseEmbedFileUploadOptions {
+  manuscriptVersionId: string;
+  guestUserId: string;
+  tusEndpoint: string;
+  embedToken: string;
+  maxFileSize: number;
+  allowedMimeTypes: string[];
+  onUploadComplete?: () => void;
+  onError?: (error: string) => void;
+}
+
+function mapTusError(error: tus.DetailedError | Error): string {
+  if ("originalResponse" in error) {
+    const detailed = error as tus.DetailedError;
+    const status = detailed.originalResponse?.getStatus();
+    if (status === 413) return "File is too large";
+    if (status === 415) return "File type not allowed";
+    if (status === 403) return "Not authorized to upload";
+    if (status === 429) return "Too many uploads. Please try again later";
+  }
+  return error.message || "Upload failed";
+}
+
+export function useEmbedFileUpload({
+  manuscriptVersionId,
+  guestUserId,
+  tusEndpoint,
+  embedToken,
+  maxFileSize,
+  allowedMimeTypes,
+  onUploadComplete,
+  onError,
+}: UseEmbedFileUploadOptions) {
+  const [uploads, setUploads] = useState<Map<string, UploadingFile>>(new Map());
+  const tusInstances = useRef<Map<string, tus.Upload>>(new Map());
+
+  const updateUpload = useCallback(
+    (id: string, update: Partial<UploadingFile>) => {
+      setUploads((prev) => {
+        const newMap = new Map(prev);
+        const existing = newMap.get(id);
+        if (existing) {
+          newMap.set(id, { ...existing, ...update });
+        }
+        return newMap;
+      });
+    },
+    [],
+  );
+
+  const removeUpload = useCallback((id: string) => {
+    tusInstances.current.delete(id);
+    setUploads((prev) => {
+      const newMap = new Map(prev);
+      newMap.delete(id);
+      return newMap;
+    });
+  }, []);
+
+  const cancelUpload = useCallback(
+    (id: string) => {
+      const instance = tusInstances.current.get(id);
+      if (instance) {
+        instance.abort(true);
+      }
+      removeUpload(id);
+    },
+    [removeUpload],
+  );
+
+  const uploadFile = useCallback(
+    async (file: File) => {
+      const uploadId = crypto.randomUUID();
+
+      // Client-side MIME type validation
+      const fileType = file.type || "application/octet-stream";
+      if (allowedMimeTypes.length > 0 && !allowedMimeTypes.includes(fileType)) {
+        const errorMsg = `File type "${fileType}" is not allowed`;
+        setUploads((prev) => {
+          const newMap = new Map(prev);
+          newMap.set(uploadId, {
+            id: uploadId,
+            file,
+            progress: 0,
+            status: "error",
+            error: errorMsg,
+          });
+          return newMap;
+        });
+        onError?.(errorMsg);
+        return;
+      }
+
+      // Client-side file size validation
+      if (file.size > maxFileSize) {
+        const errorMsg = `File exceeds maximum size of ${Math.round(maxFileSize / (1024 * 1024))}MB`;
+        setUploads((prev) => {
+          const newMap = new Map(prev);
+          newMap.set(uploadId, {
+            id: uploadId,
+            file,
+            progress: 0,
+            status: "error",
+            error: errorMsg,
+          });
+          return newMap;
+        });
+        onError?.(errorMsg);
+        return;
+      }
+
+      // Add to uploads map
+      setUploads((prev) => {
+        const newMap = new Map(prev);
+        newMap.set(uploadId, {
+          id: uploadId,
+          file,
+          progress: 0,
+          status: "uploading",
+        });
+        return newMap;
+      });
+
+      const upload = new tus.Upload(file, {
+        endpoint: tusEndpoint,
+        retryDelays: [0, 1000, 3000, 5000],
+        chunkSize: 5 * 1024 * 1024,
+        metadata: {
+          filename: file.name,
+          filetype: fileType,
+          "guest-user-id": guestUserId,
+          "manuscript-version-id": manuscriptVersionId,
+        },
+        headers: {
+          "X-Embed-Token": embedToken,
+        },
+        onProgress: (bytesUploaded, bytesTotal) => {
+          const progress = Math.round((bytesUploaded / bytesTotal) * 100);
+          updateUpload(uploadId, { progress });
+        },
+        onSuccess: () => {
+          updateUpload(uploadId, {
+            progress: 100,
+            status: "processing",
+            scanStatus: "PENDING",
+          });
+          tusInstances.current.delete(uploadId);
+          onUploadComplete?.();
+        },
+        onError: (error) => {
+          const message = mapTusError(error);
+          updateUpload(uploadId, {
+            status: "error",
+            error: message,
+          });
+          tusInstances.current.delete(uploadId);
+          onError?.(message);
+        },
+      });
+
+      tusInstances.current.set(uploadId, upload);
+      upload.start();
+    },
+    [
+      manuscriptVersionId,
+      guestUserId,
+      tusEndpoint,
+      embedToken,
+      maxFileSize,
+      allowedMimeTypes,
+      updateUpload,
+      onUploadComplete,
+      onError,
+    ],
+  );
+
+  const uploadFiles = useCallback(
+    async (files: FileList | File[]) => {
+      const fileArray = Array.from(files);
+      for (const file of fileArray) {
+        await uploadFile(file);
+      }
+    },
+    [uploadFile],
+  );
+
+  return {
+    uploads: Array.from(uploads.values()),
+    uploadFile,
+    uploadFiles,
+    removeUpload,
+    cancelUpload,
+    isUploading: Array.from(uploads.values()).some(
+      (u) => u.status === "uploading" || u.status === "pending",
+    ),
+  };
+}

--- a/apps/web/src/hooks/use-embed-file-upload.ts
+++ b/apps/web/src/hooks/use-embed-file-upload.ts
@@ -197,7 +197,10 @@ export function useEmbedFileUpload({
     removeUpload,
     cancelUpload,
     isUploading: Array.from(uploads.values()).some(
-      (u) => u.status === "uploading" || u.status === "pending",
+      (u) =>
+        u.status === "uploading" ||
+        u.status === "pending" ||
+        u.status === "processing",
     ),
   };
 }

--- a/apps/web/src/hooks/use-embed-upload-status.ts
+++ b/apps/web/src/hooks/use-embed-upload-status.ts
@@ -62,8 +62,14 @@ export function useEmbedUploadStatus({
         setAllClean(result.allClean);
         setError(null);
 
-        // Reset interval to base on successful poll
-        pollIntervalMs.current = BASE_POLL_INTERVAL;
+        // Reset interval to base rate after successful poll (recovers from 429 backoff)
+        if (pollIntervalMs.current !== BASE_POLL_INTERVAL) {
+          pollIntervalMs.current = BASE_POLL_INTERVAL;
+          if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+          }
+          intervalRef.current = setInterval(doPoll, BASE_POLL_INTERVAL);
+        }
 
         // Stop polling when no uploads in flight AND all files are in terminal state
         const allTerminal =

--- a/apps/web/src/hooks/use-embed-upload-status.ts
+++ b/apps/web/src/hooks/use-embed-upload-status.ts
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { fetchUploadStatus, type EmbedApiError } from "@/lib/embed-api";
+import type { EmbedUploadStatusResponse } from "@colophony/types";
+
+const BASE_POLL_INTERVAL = 3000;
+
+interface UseEmbedUploadStatusOptions {
+  apiUrl: string;
+  token: string;
+  manuscriptVersionId: string | null;
+  email: string;
+  enabled: boolean;
+  uploadsInFlight: boolean;
+}
+
+function isTerminalStatus(status: string): boolean {
+  return status === "CLEAN" || status === "INFECTED" || status === "FAILED";
+}
+
+export function useEmbedUploadStatus({
+  apiUrl,
+  token,
+  manuscriptVersionId,
+  email,
+  enabled,
+  uploadsInFlight,
+}: UseEmbedUploadStatusOptions) {
+  const [files, setFiles] = useState<EmbedUploadStatusResponse["files"]>([]);
+  const [allClean, setAllClean] = useState(false);
+  const [isPolling, setIsPolling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollIntervalMs = useRef(BASE_POLL_INTERVAL);
+
+  useEffect(() => {
+    if (!enabled || !manuscriptVersionId) {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      setIsPolling(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function doPoll() {
+      if (cancelled || !manuscriptVersionId) return;
+
+      try {
+        const result = await fetchUploadStatus(
+          apiUrl,
+          token,
+          manuscriptVersionId,
+          email,
+        );
+        if (cancelled) return;
+
+        setFiles(result.files);
+        setAllClean(result.allClean);
+        setError(null);
+
+        // Reset interval to base on successful poll
+        pollIntervalMs.current = BASE_POLL_INTERVAL;
+
+        // Stop polling when no uploads in flight AND all files are in terminal state
+        const allTerminal =
+          result.files.length > 0 &&
+          result.files.every((f) => isTerminalStatus(f.scanStatus));
+        if (!uploadsInFlight && allTerminal) {
+          if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+            intervalRef.current = null;
+          }
+          setIsPolling(false);
+        }
+      } catch (err) {
+        if (cancelled) return;
+
+        const apiErr = err as EmbedApiError;
+        if (apiErr.status === 429 && apiErr.retryAfter) {
+          // Back off on rate limit — restart interval with longer delay
+          pollIntervalMs.current = apiErr.retryAfter * 1000;
+          if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+          }
+          intervalRef.current = setInterval(doPoll, pollIntervalMs.current);
+        } else {
+          setError(apiErr.message ?? "Failed to check upload status");
+        }
+      }
+    }
+
+    // Initial poll
+    doPoll();
+
+    // Set up interval
+    intervalRef.current = setInterval(doPoll, pollIntervalMs.current);
+    setIsPolling(true);
+
+    return () => {
+      cancelled = true;
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      setIsPolling(false);
+    };
+  }, [enabled, manuscriptVersionId, apiUrl, token, email, uploadsInFlight]);
+
+  return { files, allClean, isPolling, error };
+}

--- a/apps/web/src/lib/__tests__/embed-api.spec.ts
+++ b/apps/web/src/lib/__tests__/embed-api.spec.ts
@@ -1,0 +1,206 @@
+import {
+  fetchEmbedForm,
+  submitEmbedForm,
+  prepareEmbedUpload,
+  fetchUploadStatus,
+  type EmbedApiError,
+} from "../embed-api";
+
+const API_URL = "http://localhost:4000";
+const TOKEN = "col_emb_testtoken123";
+
+describe("embed-api", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function mockFetch(
+    status: number,
+    body: unknown,
+    headers?: Record<string, string>,
+  ) {
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? "OK" : "Error",
+      headers: {
+        get: (name: string) => headers?.[name] ?? null,
+      },
+      json: () => Promise.resolve(body),
+    });
+  }
+
+  // fetchEmbedForm
+  describe("fetchEmbedForm", () => {
+    it("returns parsed form data on success", async () => {
+      const formData = {
+        period: {
+          id: "p1",
+          name: "Spring",
+          opensAt: "2026-01-01",
+          closesAt: "2026-06-01",
+        },
+        form: null,
+        theme: null,
+        organizationId: "org-1",
+      };
+      mockFetch(200, formData);
+
+      const result = await fetchEmbedForm(API_URL, TOKEN);
+      expect(result).toEqual(formData);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        `${API_URL}/embed/${TOKEN}`,
+        expect.objectContaining({ headers: { Accept: "application/json" } }),
+      );
+    });
+
+    it("throws EmbedApiError on 404", async () => {
+      mockFetch(404, { error: "Not Found", message: "Invalid embed token" });
+
+      try {
+        await fetchEmbedForm(API_URL, TOKEN);
+        fail("Should have thrown");
+      } catch (err) {
+        const apiErr = err as EmbedApiError;
+        expect(apiErr.status).toBe(404);
+        expect(apiErr.message).toBe("Invalid embed token");
+      }
+    });
+
+    it("throws EmbedApiError on 410", async () => {
+      mockFetch(410, { error: "Gone", message: "Submission period closed" });
+
+      try {
+        await fetchEmbedForm(API_URL, TOKEN);
+        fail("Should have thrown");
+      } catch (err) {
+        const apiErr = err as EmbedApiError;
+        expect(apiErr.status).toBe(410);
+        expect(apiErr.message).toBe("Submission period closed");
+      }
+    });
+
+    it("handles network error gracefully", async () => {
+      globalThis.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("Network error"));
+
+      await expect(fetchEmbedForm(API_URL, TOKEN)).rejects.toThrow(
+        "Network error",
+      );
+    });
+  });
+
+  // submitEmbedForm
+  describe("submitEmbedForm", () => {
+    it("returns submission result on success", async () => {
+      const result = {
+        success: true,
+        submissionId: "sub-1",
+        message: "Submitted",
+      };
+      mockFetch(200, result);
+
+      const response = await submitEmbedForm(API_URL, TOKEN, {
+        email: "test@example.com",
+        title: "My Poem",
+      });
+      expect(response).toEqual(result);
+    });
+
+    it("throws with details on 400 validation error", async () => {
+      mockFetch(400, {
+        error: "Bad Request",
+        message: "Validation failed",
+        details: [{ path: "email", message: "Required" }],
+      });
+
+      try {
+        await submitEmbedForm(API_URL, TOKEN, { email: "", title: "" });
+        fail("Should have thrown");
+      } catch (err) {
+        const apiErr = err as EmbedApiError;
+        expect(apiErr.status).toBe(400);
+        expect(apiErr.details).toHaveLength(1);
+        expect(apiErr.details![0].path).toBe("email");
+      }
+    });
+
+    it("includes retryAfter on 429", async () => {
+      mockFetch(
+        429,
+        { error: "Too Many Requests", message: "Rate limited" },
+        { "Retry-After": "30" },
+      );
+
+      try {
+        await submitEmbedForm(API_URL, TOKEN, { email: "x@y.com", title: "T" });
+        fail("Should have thrown");
+      } catch (err) {
+        const apiErr = err as EmbedApiError;
+        expect(apiErr.status).toBe(429);
+        expect(apiErr.retryAfter).toBe(30);
+      }
+    });
+
+    it("throws on 410 gone", async () => {
+      mockFetch(410, { error: "Gone", message: "Period closed" });
+
+      try {
+        await submitEmbedForm(API_URL, TOKEN, { email: "x@y.com", title: "T" });
+        fail("Should have thrown");
+      } catch (err) {
+        expect((err as EmbedApiError).status).toBe(410);
+      }
+    });
+  });
+
+  // prepareEmbedUpload
+  describe("prepareEmbedUpload", () => {
+    it("returns upload context on success", async () => {
+      const ctx = {
+        manuscriptVersionId: "mv-1",
+        guestUserId: "gu-1",
+        tusEndpoint: "http://localhost:1080/files/",
+        maxFileSize: 52428800,
+        maxFiles: 10,
+        allowedMimeTypes: ["application/pdf"],
+      };
+      mockFetch(200, ctx);
+
+      const result = await prepareEmbedUpload(API_URL, TOKEN, {
+        email: "x@y.com",
+      });
+      expect(result).toEqual(ctx);
+    });
+  });
+
+  // fetchUploadStatus
+  describe("fetchUploadStatus", () => {
+    it("returns file status list", async () => {
+      const status = {
+        files: [
+          {
+            id: "f1",
+            filename: "a.pdf",
+            size: 100,
+            mimeType: "application/pdf",
+            scanStatus: "CLEAN",
+          },
+        ],
+        allClean: true,
+      };
+      mockFetch(200, status);
+
+      const result = await fetchUploadStatus(API_URL, TOKEN, "mv-1", "x@y.com");
+      expect(result.allClean).toBe(true);
+      expect(result.files).toHaveLength(1);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("email=x%40y.com"),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/apps/web/src/lib/embed-api.ts
+++ b/apps/web/src/lib/embed-api.ts
@@ -1,0 +1,95 @@
+import type {
+  EmbedFormResponse,
+  EmbedSubmitInput,
+  EmbedPrepareUploadResponse,
+  EmbedUploadStatusResponse,
+} from "@colophony/types";
+
+export interface EmbedApiError {
+  status: number;
+  error: string;
+  message: string;
+  details?: Array<{ path: string; message: string }>;
+  retryAfter?: number;
+}
+
+async function handleResponse<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({
+      error: res.statusText,
+      message: res.statusText,
+    }));
+    const err: EmbedApiError = {
+      status: res.status,
+      error: body.error ?? res.statusText,
+      message: body.message ?? res.statusText,
+      details: body.details,
+    };
+    if (res.status === 429) {
+      const retryAfter = res.headers.get("Retry-After");
+      if (retryAfter) {
+        err.retryAfter = parseInt(retryAfter, 10);
+      }
+    }
+    throw err;
+  }
+  return res.json() as Promise<T>;
+}
+
+export async function fetchEmbedForm(
+  apiUrl: string,
+  token: string,
+): Promise<EmbedFormResponse> {
+  const res = await fetch(`${apiUrl}/embed/${token}`, {
+    headers: { Accept: "application/json" },
+  });
+  return handleResponse<EmbedFormResponse>(res);
+}
+
+export async function submitEmbedForm(
+  apiUrl: string,
+  token: string,
+  body: EmbedSubmitInput,
+): Promise<{ success: boolean; submissionId: string; message: string }> {
+  const res = await fetch(`${apiUrl}/embed/${token}/submit`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  return handleResponse(res);
+}
+
+export async function prepareEmbedUpload(
+  apiUrl: string,
+  token: string,
+  body: { email: string; name?: string },
+): Promise<EmbedPrepareUploadResponse> {
+  const res = await fetch(`${apiUrl}/embed/${token}/prepare-upload`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  return handleResponse<EmbedPrepareUploadResponse>(res);
+}
+
+export async function fetchUploadStatus(
+  apiUrl: string,
+  token: string,
+  manuscriptVersionId: string,
+  email: string,
+): Promise<EmbedUploadStatusResponse> {
+  const params = new URLSearchParams({ email });
+  const res = await fetch(
+    `${apiUrl}/embed/${token}/upload-status/${manuscriptVersionId}?${params}`,
+    {
+      headers: { Accept: "application/json" },
+    },
+  );
+  return handleResponse<EmbedUploadStatusResponse>(res);
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -102,7 +102,7 @@
 - [x] Conditional logic engine — (architecture doc Track 3, form-builder-research.md; done 2026-02-21)
 - [x] Form branching logic PR 1 — schema, evaluation engine, all API surfaces, form builder UI, renderer; single-page branching complete — (roadmap idea 2026-02-21; done 2026-02-21)
 - [x] Form branching logic PR 2 — multi-page wizard renderer, per-page validation, page navigation with branching rules, stepper UI — (roadmap idea 2026-02-21; done 2026-02-21)
-- [~] Embeddable forms (iframe) — PR 1 backend foundation done 2026-02-22; PR 2 file uploads done 2026-02-22; PR 3 (frontend widget) pending — (architecture doc Track 3, form-builder-research.md)
+- [x] Embeddable forms (iframe) — PR 1 backend foundation done 2026-02-22; PR 2 file uploads done 2026-02-22; PR 3 frontend widget done 2026-02-22 — (architecture doc Track 3, form-builder-research.md)
 - [x] Submission periods UI — schema exists, no UI — (DEVLOG 2026-02-15; done 2026-02-21)
 - [x] Submission periods: REST oRPC router + GraphQL resolvers for parity with forms/submissions — (DEVLOG 2026-02-21, deferred from submission periods PR; done 2026-02-21)
 - [x] Editor dashboard rewrite (`/editor` pages) — submission queue + detail view reuse — (DEVLOG 2026-02-15; done 2026-02-21)
@@ -114,6 +114,7 @@
 - [ ] Org deletion — needs careful cascade handling — (DEVLOG 2026-02-13)
 - [ ] [P3] Form editor: debounce or batch field add/update API calls to avoid 429 rate limiting on rapid edits — (manual QA 2026-02-20)
 - [x] Form selector UI in submission creation — submitters need a way to select a published form when creating a submission (currently requires DB linkage) — (manual QA 2026-02-20; done 2026-02-20)
+- [ ] [P2] E2E Playwright tests for embed form flow — requires embed token creation + iframe testing — (DEVLOG 2026-02-22, embed widget session)
 
 ---
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,28 @@ Newest entries first.
 
 ---
 
+## 2026-02-22 — Embed Form Frontend Widget (PR 3)
+
+### Done
+
+- Built embeddable submission form frontend widget at `/embed/[token]` — renders inside iframe on third-party sites, consumes REST embed endpoints (PRs #146, #147) without tRPC or OIDC
+- 11 source files: embed-api client (plain fetch), theme provider (CSS variables from hex→HSL), page route, form orchestrator (state machine), identity step, form step (flat + wizard modes), upload section (drag-and-drop + scan status), success/error components, tus upload hook (`X-Embed-Token` auth), upload status polling hook
+- Reused `DynamicFormField`, `useConditionalFields`, `useWizardForm`, `buildFormFieldsSchema`, `buildConditionalFormSchema` without modification — zero tRPC dependency in these components
+- Faithfully replicated `schemaRef` pattern from `submission-form.tsx` for reactive conditional validation with `formData.*` namespace
+- Upload state propagation via `onUploadStateChange` callback — parent gates submit on `{ isUploading, hasInfected, allClean, fileCount }`
+- Polling continues while tus uploads are in flight (handles async file record creation after tusd post-finish webhook)
+- 6 test files with 37 tests (326 total web tests passing): API client (8), upload hook (8), polling hook (6), form orchestration (5), identity step (4), upload section (4)
+- Codex plan review done — all 4 findings (formData namespace, upload state propagation, polling stop condition, type name) pre-addressed in implementation
+- Type-check clean, lint clean (0 errors, 2 warnings matching existing codebase patterns)
+
+### Decisions
+
+- Separate `useEmbedFileUpload` hook rather than modifying `useFileUpload` — duplicates 10-line `mapTusError` but avoids touching existing auth-dependent hook
+- Page placed under root layout (Providers wrapper creates QueryClient + tRPC link but makes zero network requests since no queries triggered) — avoids route group refactor
+- jsdom `type="email"` native validation blocks Zod validation in tests — tested behavioral outcome (onContinue not called) instead of error message text
+
+---
+
 ## 2026-02-22 — Embed Form File Uploads (PR 2)
 
 ### Done


### PR DESCRIPTION
## Summary

- Builds the frontend widget for embeddable submission forms — a Next.js page at `/embed/[token]` rendered inside iframes on third-party sites, consuming REST endpoints from PRs #146 and #147 without tRPC or OIDC
- 11 source files: embed-api client (plain fetch), theme provider (CSS variables), page route, form orchestrator (state machine), identity step, form step (flat + wizard modes with schemaRef pattern), upload section (drag-and-drop + scan status), success/error components, tus upload hook (X-Embed-Token auth), upload status polling hook
- 6 test files with 37 tests (326 total web tests passing)
- Reuses DynamicFormField, useConditionalFields, useWizardForm, buildFormFieldsSchema, buildConditionalFormSchema without modification
- branch review: 4 findings addressed (processing status in isUploading, always-on polling, retry re-fetch, 429 backoff recovery)

## Test plan

- [ ] Unit tests pass (326/326)
- [ ] Type-check clean
- [ ] Lint clean (0 errors, 19 warnings — all pre-existing)
- [ ] Manual test: create embed token, navigate to `/embed/<token>`, verify form loads
- [ ] Manual test: fill identity, form fields, upload file, submit
- [ ] Manual test: error states (expired token 410, invalid token 404)
- [ ] Manual test: theme application (primaryColor, darkMode)
- [ ] Manual test: iframe embedding on external page