### PR TITLE
fix(db): post-migration FK verification and repair for 0015

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -116,7 +116,7 @@
 - [x] Form selector UI in submission creation — submitters need a way to select a published form when creating a submission (currently requires DB linkage) — (manual QA 2026-02-20; done 2026-02-20)
 - [x] [P2] E2E Playwright tests for embed form flow — 10 tests (8 core + 2 wizard), CI job added — (DEVLOG 2026-02-22, embed widget session; done 2026-02-22)
 - [ ] [P2] Manual QA of embed form widget — test iframe embedding on third-party page, identity step, form filling (flat + wizard), file uploads with scan status, error states, theme inheritance — (backlog 2026-02-23)
-- [ ] [P2] Migration 0015 production reliability — Drizzle `migrate()` silently records migration in journal but FK constraint DDL doesn't execute on existing DB; works on clean DB. Need verification step or manual migration runner for production deployments — (GDPR manual QA 2026-02-23)
+- [x] [P2] Migration 0015 production reliability — `db:verify` / `db:verify:repair` scripts check `information_schema` for FK constraint drift and auto-repair; integrated into `db:reset` — (GDPR manual QA 2026-02-23; done 2026-02-23)
 
 ---
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -27,7 +27,7 @@ Newest entries first.
 
 ### Issues Found
 
-- Migration 0015 FK constraints silently fail on existing DB — Drizzle `migrate()` records migration in journal but DDL doesn't execute (known quirk). Works on clean DB via `db:reset`. Needs production mitigation strategy.
+- ~~Migration 0015 FK constraints silently fail on existing DB~~ — resolved: `db:verify` / `db:verify:repair` scripts detect and repair FK constraint drift (session 3)
 
 ### Decisions
 
@@ -37,6 +37,27 @@ Newest entries first.
 - `insert_audit_event()` raw SQL instead of `logDirect()` (which rejects `organizationId` param)
 - `validateEnv()` inside handlers, not module-level (test compatibility)
 - Org deletion audit events use NULL `organization_id` — matches `deleteUser` pattern; deleted org ID in `resource_id` + `new_value` JSON for traceability
+
+---
+
+## 2026-02-23 — Migration 0015 Production Reliability
+
+### Done
+
+- Created `packages/db/src/verify-migrations.ts` — post-migration FK verification and repair script
+- Queries `information_schema.referential_constraints` + `columns` for all 9 FK constraints and 5 nullable columns from migration 0015
+- Check mode (`db:verify`): reports mismatches, exits 1 if any found
+- Repair mode (`db:verify:repair`): auto-fixes with `DROP CONSTRAINT IF EXISTS` + re-add, each in own transaction; repairs nullable columns before FK constraints
+- Added `db:verify` / `db:verify:repair` root aliases and package scripts
+- Integrated verification into `db:reset` (runs after migrations)
+- Updated `packages/db/CLAUDE.md` with verify workflow and Drizzle workaround documentation
+
+### Decisions
+
+- Verification approach (not replacing migration runner): less invasive, independently valuable for production health checks
+- `DROP CONSTRAINT IF EXISTS` for robustness against both wrong and missing constraints
+- Nullable columns repaired before FK constraints (dependency ordering)
+- Repair statements hardcoded per-expectation (not dynamically extracted from migration file) for `IF EXISTS` safety
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "db:check": "pnpm --filter @colophony/db check",
     "db:studio": "pnpm --filter @colophony/db studio",
     "db:seed": "pnpm --filter @colophony/db seed",
+    "db:verify": "pnpm --filter @colophony/db verify",
+    "db:verify:repair": "pnpm --filter @colophony/db verify:repair",
     "db:reset": "bash scripts/db-reset.sh",
     "sdk:export-spec": "pnpm --filter @colophony/api exec tsx ../../scripts/export-openapi.ts",
     "sdk:export-schema": "pnpm --filter @colophony/api exec tsx ../../scripts/export-schema.ts",

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -81,11 +81,15 @@ Manuscripts use `owner_id = current_user_id()` instead of org-scoped isolation. 
 ## Migration Workflow
 
 ```bash
-pnpm db:generate    # Generate migration from schema changes
-pnpm db:migrate     # Run Drizzle migrations
-pnpm db:seed        # Seed test data
-pnpm db:reset       # Drop and recreate with migrations + RLS
+pnpm db:generate        # Generate migration from schema changes
+pnpm db:migrate         # Run Drizzle migrations
+pnpm db:seed            # Seed test data
+pnpm db:reset           # Drop and recreate with migrations + RLS + verify
+pnpm db:verify          # Check FK constraints match expected state (exit 1 on mismatch)
+pnpm db:verify:repair   # Check + auto-repair any mismatched FK constraints
 ```
+
+**Drizzle `migrate()` silent no-op workaround:** Drizzle ORM 0.44+ / journal v7 can silently record a migration as applied without executing its DDL on existing databases. `db:verify` detects this for migration 0015 (GDPR FK constraints). Run `db:verify` after `db:migrate` in production deployments. If mismatches are found, run `db:verify:repair` to re-apply the correct DDL.
 
 **init-db.sh caveat:** Only runs on first DB creation. Must `docker compose down -v` to re-run after changes.
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -22,6 +22,8 @@
     "check": "drizzle-kit check",
     "studio": "drizzle-kit studio",
     "seed": "tsx --env-file=.env src/seed.ts",
+    "verify": "tsx --env-file=.env src/verify-migrations.ts --check",
+    "verify:repair": "tsx --env-file=.env src/verify-migrations.ts --repair",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/db/src/verify-migrations.ts
+++ b/packages/db/src/verify-migrations.ts
@@ -1,0 +1,312 @@
+/**
+ * Post-migration FK constraint verification and repair script.
+ *
+ * Drizzle `migrate()` has a known bug (ORM 0.44+ / journal v7) where it
+ * silently records a migration as applied without executing the DDL on
+ * existing databases. This script detects FK constraint drift introduced
+ * by migration 0015 (gdpr_fk_constraints) and optionally repairs it.
+ *
+ * Usage:
+ *   pnpm db:verify          # Check mode (default) — report mismatches, exit 1 if any
+ *   pnpm db:verify:repair   # Repair mode — fix mismatches, then verify
+ */
+
+import { Pool } from "pg";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface FkExpectation {
+  table: string;
+  column: string;
+  referencedTable: string;
+  deleteRule: string;
+  constraintName: string;
+}
+
+interface NullableExpectation {
+  table: string;
+  column: string;
+  nullable: boolean;
+}
+
+interface Mismatch {
+  type: "fk_delete_rule" | "nullable";
+  table: string;
+  column: string;
+  expected: string;
+  actual: string;
+  repairStatements: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Expected state from migration 0015 (gdpr_fk_constraints)
+// ---------------------------------------------------------------------------
+
+const EXPECTED_FK_CONSTRAINTS: FkExpectation[] = [
+  {
+    table: "audit_events",
+    column: "organization_id",
+    referencedTable: "organizations",
+    deleteRule: "SET NULL",
+    constraintName: "audit_events_organization_id_organizations_id_fk",
+  },
+  {
+    table: "audit_events",
+    column: "actor_id",
+    referencedTable: "users",
+    deleteRule: "SET NULL",
+    constraintName: "audit_events_actor_id_users_id_fk",
+  },
+  {
+    table: "dsar_requests",
+    column: "user_id",
+    referencedTable: "users",
+    deleteRule: "CASCADE",
+    constraintName: "dsar_requests_user_id_users_id_fk",
+  },
+  {
+    table: "submissions",
+    column: "submitter_id",
+    referencedTable: "users",
+    deleteRule: "SET NULL",
+    constraintName: "submissions_submitter_id_users_id_fk",
+  },
+  {
+    table: "manuscripts",
+    column: "owner_id",
+    referencedTable: "users",
+    deleteRule: "CASCADE",
+    constraintName: "manuscripts_owner_id_users_id_fk",
+  },
+  {
+    table: "api_keys",
+    column: "created_by",
+    referencedTable: "users",
+    deleteRule: "SET NULL",
+    constraintName: "api_keys_created_by_users_id_fk",
+  },
+  {
+    table: "form_definitions",
+    column: "created_by",
+    referencedTable: "users",
+    deleteRule: "SET NULL",
+    constraintName: "form_definitions_created_by_users_id_fk",
+  },
+  {
+    table: "embed_tokens",
+    column: "created_by",
+    referencedTable: "users",
+    deleteRule: "SET NULL",
+    constraintName: "embed_tokens_created_by_users_id_fk",
+  },
+  {
+    table: "payments",
+    column: "organization_id",
+    referencedTable: "organizations",
+    deleteRule: "SET NULL",
+    constraintName: "payments_organization_id_organizations_id_fk",
+  },
+];
+
+const EXPECTED_NULLABLE: NullableExpectation[] = [
+  { table: "submissions", column: "submitter_id", nullable: true },
+  { table: "api_keys", column: "created_by", nullable: true },
+  { table: "form_definitions", column: "created_by", nullable: true },
+  { table: "embed_tokens", column: "created_by", nullable: true },
+  { table: "payments", column: "organization_id", nullable: true },
+];
+
+// ---------------------------------------------------------------------------
+// Checks
+// ---------------------------------------------------------------------------
+
+async function checkFkConstraints(pool: Pool): Promise<Mismatch[]> {
+  const mismatches: Mismatch[] = [];
+
+  for (const expected of EXPECTED_FK_CONSTRAINTS) {
+    const result = await pool.query<{ delete_rule: string }>(
+      `SELECT rc.delete_rule
+       FROM information_schema.referential_constraints rc
+       JOIN information_schema.table_constraints tc
+         ON rc.constraint_name = tc.constraint_name
+         AND rc.constraint_schema = tc.constraint_schema
+       WHERE tc.constraint_schema = 'public'
+         AND rc.constraint_name = $1`,
+      [expected.constraintName],
+    );
+
+    const actual = result.rows[0]?.delete_rule ?? "MISSING";
+
+    if (actual !== expected.deleteRule) {
+      const refColumn = expected.column === "organization_id" ? "id" : "id";
+      mismatches.push({
+        type: "fk_delete_rule",
+        table: expected.table,
+        column: expected.column,
+        expected: expected.deleteRule,
+        actual,
+        repairStatements: [
+          `ALTER TABLE "${expected.table}" DROP CONSTRAINT IF EXISTS "${expected.constraintName}"`,
+          `ALTER TABLE "${expected.table}" ADD CONSTRAINT "${expected.constraintName}" FOREIGN KEY ("${expected.column}") REFERENCES "public"."${expected.referencedTable}"("${refColumn}") ON DELETE ${expected.deleteRule} ON UPDATE NO ACTION`,
+        ],
+      });
+    }
+  }
+
+  return mismatches;
+}
+
+async function checkNullable(pool: Pool): Promise<Mismatch[]> {
+  const mismatches: Mismatch[] = [];
+
+  for (const expected of EXPECTED_NULLABLE) {
+    const result = await pool.query<{ is_nullable: string }>(
+      `SELECT is_nullable
+       FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = $1
+         AND column_name = $2`,
+      [expected.table, expected.column],
+    );
+
+    const actual = result.rows[0]?.is_nullable ?? "MISSING";
+    const expectedValue = expected.nullable ? "YES" : "NO";
+
+    if (actual !== expectedValue) {
+      const alterAction = expected.nullable ? "DROP NOT NULL" : "SET NOT NULL";
+      mismatches.push({
+        type: "nullable",
+        table: expected.table,
+        column: expected.column,
+        expected: expectedValue,
+        actual,
+        repairStatements: [
+          `ALTER TABLE "${expected.table}" ALTER COLUMN "${expected.column}" ${alterAction}`,
+        ],
+      });
+    }
+  }
+
+  return mismatches;
+}
+
+// ---------------------------------------------------------------------------
+// Repair
+// ---------------------------------------------------------------------------
+
+async function repair(pool: Pool, mismatches: Mismatch[]): Promise<void> {
+  for (const mismatch of mismatches) {
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      for (const stmt of mismatch.repairStatements) {
+        console.log(`  Executing: ${stmt}`);
+        await client.query(stmt);
+      }
+      await client.query("COMMIT");
+      console.log(
+        `  Fixed: ${mismatch.table}.${mismatch.column} (${mismatch.type})`,
+      );
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw new Error(
+        `Failed to repair ${mismatch.table}.${mismatch.column}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      client.release();
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+function reportMismatches(mismatches: Mismatch[]): void {
+  console.log(`\nFound ${mismatches.length} mismatch(es):\n`);
+  for (const m of mismatches) {
+    const label = m.type === "fk_delete_rule" ? "FK delete rule" : "nullable";
+    console.log(
+      `  ${m.table}.${m.column} — ${label}: expected ${m.expected}, got ${m.actual}`,
+    );
+  }
+  console.log();
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const mode = process.argv.includes("--repair") ? "repair" : "check";
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("ERROR: DATABASE_URL environment variable is required");
+    process.exit(2);
+  }
+
+  const pool = new Pool({ connectionString: databaseUrl });
+
+  try {
+    // Verify connectivity
+    await pool.query("SELECT 1");
+  } catch (err) {
+    console.error(
+      `ERROR: Cannot connect to database: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(2);
+  }
+
+  try {
+    console.log("Checking FK constraints (migration 0015)...");
+    const fkMismatches = await checkFkConstraints(pool);
+
+    console.log("Checking nullable columns (migration 0015)...");
+    const nullMismatches = await checkNullable(pool);
+
+    const allMismatches = [...fkMismatches, ...nullMismatches];
+
+    if (allMismatches.length === 0) {
+      console.log("\nAll migration 0015 checks passed.");
+      process.exit(0);
+    }
+
+    reportMismatches(allMismatches);
+
+    if (mode === "check") {
+      console.log("Run with --repair to fix these mismatches.");
+      process.exit(1);
+    }
+
+    // Repair mode — fix nullable columns first (FK constraints may depend on them)
+    const nullFirst = [
+      ...allMismatches.filter((m) => m.type === "nullable"),
+      ...allMismatches.filter((m) => m.type === "fk_delete_rule"),
+    ];
+
+    console.log("Repairing mismatches...\n");
+    await repair(pool, nullFirst);
+
+    // Verify after repair
+    console.log("\nVerifying repair...");
+    const postFk = await checkFkConstraints(pool);
+    const postNull = await checkNullable(pool);
+    const postAll = [...postFk, ...postNull];
+
+    if (postAll.length > 0) {
+      reportMismatches(postAll);
+      console.error("ERROR: Some mismatches remain after repair.");
+      process.exit(1);
+    }
+
+    console.log("All migration 0015 checks passed after repair.");
+    process.exit(0);
+  } finally {
+    await pool.end();
+  }
+}
+
+main();

--- a/scripts/db-reset.sh
+++ b/scripts/db-reset.sh
@@ -19,4 +19,7 @@ sleep 5
 echo "Running migrations..."
 pnpm --filter @colophony/db migrate
 
+echo "Verifying migration state..."
+pnpm --filter @colophony/db verify
+
 echo "Database reset complete."


### PR DESCRIPTION
## Summary

- Adds `db:verify` / `db:verify:repair` scripts that query `information_schema` to detect FK constraint drift from migration 0015 (GDPR FK constraints) and optionally auto-repair
- Addresses Drizzle `migrate()` silent no-op bug (ORM 0.44+ / journal v7) where DDL is recorded but not executed on existing databases
- Integrated into `db:reset` for regression catching

## Changes

- `packages/db/src/verify-migrations.ts` — new verification/repair script (check 9 FK constraints + 5 nullable columns, repair with `DROP CONSTRAINT IF EXISTS`)
- `packages/db/package.json` — added `verify` / `verify:repair` scripts
- Root `package.json` — added `db:verify` / `db:verify:repair` aliases
- `scripts/db-reset.sh` — added verification step after migrations
- `packages/db/CLAUDE.md` — documented verify workflow and Drizzle workaround
- `docs/backlog.md` — marked migration 0015 reliability item done

## Test plan

- [ ] Run `pnpm db:verify` on clean database (after `db:reset`) — all checks pass
- [ ] Manually break a constraint (`ALTER TABLE audit_events ... ON DELETE RESTRICT`), verify detects mismatch (exit 1)
- [ ] Run `pnpm db:verify:repair` — fixes constraint, reports success
- [ ] Run `pnpm db:verify` again — passes
- [ ] Run `pnpm db:reset` — completes with verification passing
- [ ] Existing RLS tests still pass
- [ ] Existing unit tests still pass