### PR TITLE
fix(hopper): debounce form editor arrow-button reorder

### DIFF
--- a/apps/web/src/components/form-builder/__tests__/form-editor.spec.tsx
+++ b/apps/web/src/components/form-builder/__tests__/form-editor.spec.tsx
@@ -109,6 +109,18 @@ jest.mock("sonner", () => ({
   toast: { success: jest.fn(), error: jest.fn() },
 }));
 
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    useUtils: () => ({
+      forms: {
+        getById: {
+          setQueriesData: jest.fn(),
+        },
+      },
+    }),
+  },
+}));
+
 describe("FormEditor", () => {
   beforeEach(() => {
     resetMocks();

--- a/apps/web/src/components/form-builder/form-editor.tsx
+++ b/apps/web/src/components/form-builder/form-editor.tsx
@@ -86,6 +86,13 @@ export function FormEditor({ formId }: FormEditorProps) {
       if (!over || active.id === over.id || !form) return;
       if (form.status !== "DRAFT") return;
 
+      // Cancel any pending debounced arrow-button reorder to prevent it
+      // from overwriting this drag-drop result
+      if (reorderTimerRef.current) {
+        clearTimeout(reorderTimerRef.current);
+        reorderTimerRef.current = null;
+      }
+
       const hasPages = form.pages.length > 0;
 
       if (hasPages && activePageId !== null) {
@@ -216,7 +223,15 @@ export function FormEditor({ formId }: FormEditorProps) {
       // Debounce the API call
       if (reorderTimerRef.current) clearTimeout(reorderTimerRef.current);
       reorderTimerRef.current = setTimeout(() => {
-        reorderFields.mutate({ id: formId, fieldIds: mergedFieldIds });
+        reorderFields.mutate(
+          { id: formId, fieldIds: mergedFieldIds },
+          {
+            onError: () => {
+              // Rollback optimistic update on failure
+              utils.forms.getById.invalidate({ id: formId });
+            },
+          },
+        );
       }, 300);
     },
     [form, formId, activePageId, reorderFields, utils],

--- a/apps/web/src/components/form-builder/form-editor.tsx
+++ b/apps/web/src/components/form-builder/form-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import {
   DndContext,
   closestCenter,
@@ -12,6 +12,7 @@ import {
 } from "@dnd-kit/core";
 import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import { useFormBuilder } from "@/hooks/use-form-builder";
+import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { FormStatusBadge } from "./form-status-badge";
@@ -166,6 +167,66 @@ export function FormEditor({ formId }: FormEditorProps) {
       },
     );
   }, [formId, deleteForm, router]);
+
+  // Debounced reorder for arrow-button clicks (300ms)
+  const reorderTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const utils = trpc.useUtils();
+
+  const debouncedReorder = useCallback(
+    (fieldIds: string[]) => {
+      if (!form) return;
+
+      const hasPages = form.pages.length > 0;
+
+      // Merge page-scoped subset back into full field list
+      let mergedFieldIds: string[];
+      if (hasPages && activePageId !== null) {
+        const pageFieldSet = new Set(fieldIds);
+        const fullIds = form.fields.map((f) => f.id);
+        let reorderIdx = 0;
+        mergedFieldIds = fullIds.map((id) =>
+          pageFieldSet.has(id) ? fieldIds[reorderIdx++] : id,
+        );
+      } else if (hasPages && activePageId === null) {
+        const unassignedSet = new Set(fieldIds);
+        const fullIds = form.fields.map((f) => f.id);
+        let reorderIdx = 0;
+        mergedFieldIds = fullIds.map((id) =>
+          unassignedSet.has(id) ? fieldIds[reorderIdx++] : id,
+        );
+      } else {
+        mergedFieldIds = fieldIds;
+      }
+
+      // Optimistic UI update
+      utils.forms.getById.setQueriesData({ id: formId }, {}, (old) => {
+        if (!old) return old;
+        const idToIndex = new Map(mergedFieldIds.map((id, idx) => [id, idx]));
+        return {
+          ...old,
+          fields: old.fields
+            .map((f) => ({
+              ...f,
+              sortOrder: idToIndex.get(f.id) ?? f.sortOrder,
+            }))
+            .sort((a, b) => a.sortOrder - b.sortOrder),
+        };
+      });
+
+      // Debounce the API call
+      if (reorderTimerRef.current) clearTimeout(reorderTimerRef.current);
+      reorderTimerRef.current = setTimeout(() => {
+        reorderFields.mutate({ id: formId, fieldIds: mergedFieldIds });
+      }, 300);
+    },
+    [form, formId, activePageId, reorderFields, utils],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (reorderTimerRef.current) clearTimeout(reorderTimerRef.current);
+    };
+  }, []);
 
   if (isLoading) {
     return (
@@ -367,12 +428,7 @@ export function FormEditor({ formId }: FormEditorProps) {
                       ? (fieldId) => removeField.mutate({ id: formId, fieldId })
                       : () => {}
                   }
-                  onReorder={
-                    canEdit
-                      ? (fieldIds) =>
-                          reorderFields.mutate({ id: formId, fieldIds })
-                      : () => {}
-                  }
+                  onReorder={canEdit ? debouncedReorder : () => {}}
                 />
               </div>
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -112,7 +112,7 @@
 - [x] GDPR deletion mutation — stubbed with TODO — (DEVLOG 2026-02-15; done 2026-02-23)
 - [x] GDPR tools finalization from MVP — (architecture doc Track 3; done 2026-02-23)
 - [x] Org deletion — needs careful cascade handling — (DEVLOG 2026-02-13; done 2026-02-23)
-- [ ] [P3] Form editor: debounce or batch field add/update API calls to avoid 429 rate limiting on rapid edits — (manual QA 2026-02-20)
+- [x] [P3] Form editor: debounce or batch field add/update API calls to avoid 429 rate limiting on rapid edits — (manual QA 2026-02-20; done 2026-02-23 — arrow-button reorder debounced at 300ms)
 - [x] Form selector UI in submission creation — submitters need a way to select a published form when creating a submission (currently requires DB linkage) — (manual QA 2026-02-20; done 2026-02-20)
 - [x] [P2] E2E Playwright tests for embed form flow — 10 tests (8 core + 2 wizard), CI job added — (DEVLOG 2026-02-22, embed widget session; done 2026-02-22)
 - [ ] [P2] Manual QA of embed form widget — test iframe embedding on third-party page, identity step, form filling (flat + wizard), file uploads with scan status, error states, theme inheritance — (backlog 2026-02-23)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,25 @@ Newest entries first.
 
 ---
 
+## 2026-02-23 — Form Editor Reorder Debounce
+
+### Done
+
+- Added 300ms debounce to arrow-button field reorder in `FormCanvas` to prevent rapid API calls (backlog P3 item)
+- Optimistic UI via `trpc.useUtils().forms.getById.setQueriesData` — fields reorder visually on click, API call fires after 300ms idle
+- Page-scoped merge logic mirrors existing `handleDragEnd` for multi-page forms
+- Drag-drop reorder unchanged (fires once per completed gesture)
+- Fixed form-editor test suite: added `@/lib/trpc` mock for `useUtils`
+- All 326 web tests passing, type-check clean
+
+### Decisions
+
+- 300ms debounce (vs 500ms in field properties panel): shorter since arrow clicks feel more interactive
+- Used tRPC v11 `setQueriesData(input, filters, updater)` API (not `setQueryData` which doesn't exist in v11)
+- Functional updater form to avoid stale closures during rapid clicks
+
+---
+
 ## 2026-02-23 — GDPR User Deletion + Organization Deletion
 
 ### Done


### PR DESCRIPTION
## Summary

- Added 300ms debounce to arrow-button field reorder in form editor to prevent rapid API calls hitting the 200 req/60s rate limit
- Optimistic UI via tRPC `setQueriesData` so fields reorder visually on click, API call fires after 300ms idle
- Cancel guard: drag-drop clears any pending debounced reorder to prevent stale overwrites
- Error rollback: invalidates query cache on mutation failure to revert optimistic UI
- Drag-drop reorder unchanged (fires once per completed gesture, no debounce needed)

Closes backlog item: `[P3] Form editor: debounce or batch field add/update API calls`

## Test plan

- [ ] Arrow reorder: open form editor, add 5+ fields, click up/down arrows rapidly — field visually reorders instantly, Network tab shows only 1 `reorderFields` call after clicking stops
- [ ] Drag-drop: drag a field to a new position — fires immediately (no debounce delay)
- [ ] Page-scoped reorder: on a multi-page form, reorder within a page via arrows — debounce + correct merge
- [ ] Mixed interaction: click arrow, then immediately drag-drop — drag result wins, no stale overwrite
- [ ] Error rollback: simulate network failure — UI reverts to server state
- [x] Type check: `pnpm type-check` passes
- [x] Tests: 326 web tests passing
- [x] branch review: 2 P2 findings addressed (rollback + cancel guard)