### PR TITLE
fix(hopper): show human-readable labels in form validation errors

### DIFF
--- a/apps/api/src/services/form-validation.service.spec.ts
+++ b/apps/api/src/services/form-validation.service.spec.ts
@@ -230,7 +230,7 @@ describe('validateFieldValue', () => {
       'non-fiction',
     );
     expect(errors).toHaveLength(1);
-    expect(errors[0].message).toContain('must be one of');
+    expect(errors[0].message).toContain('must be one of: Poetry, Fiction');
   });
 
   it('accepts valid select option', () => {
@@ -262,7 +262,7 @@ describe('validateFieldValue', () => {
       'b',
     );
     expect(errors).toHaveLength(1);
-    expect(errors[0].message).toContain('must be one of');
+    expect(errors[0].message).toContain('must be one of: A');
   });
 
   // -----------------------------------------------------------------------
@@ -293,7 +293,7 @@ describe('validateFieldValue', () => {
       ['a', 'invalid'],
     );
     expect(errors).toHaveLength(1);
-    expect(errors[0].message).toContain('invalid option');
+    expect(errors[0].message).toContain('Valid options: A, B');
   });
 
   it('accepts valid multi_select values', () => {
@@ -325,7 +325,7 @@ describe('validateFieldValue', () => {
       ['y'],
     );
     expect(errors).toHaveLength(1);
-    expect(errors[0].message).toContain('invalid option');
+    expect(errors[0].message).toContain('Valid options: X');
   });
 
   // -----------------------------------------------------------------------

--- a/apps/api/src/services/form-validation.service.ts
+++ b/apps/api/src/services/form-validation.service.ts
@@ -181,9 +181,10 @@ export function validateFieldValue(
       if (parsed.success) {
         const validValues = parsed.data.options.map((o) => o.value);
         if (!validValues.includes(value)) {
+          const validLabels = parsed.data.options.map((o) => o.label);
           errors.push({
             fieldKey: field.fieldKey,
-            message: `${field.label} must be one of: ${validValues.join(', ')}`,
+            message: `${field.label} must be one of: ${validLabels.join(', ')}`,
           });
         }
       }
@@ -200,12 +201,14 @@ export function validateFieldValue(
       }
       const parsed = selectFieldConfigSchema.safeParse(config);
       if (parsed.success) {
-        const validValues = parsed.data.options.map((o) => o.value);
+        const { options } = parsed.data;
+        const validValues = options.map((o) => o.value);
         for (const v of value) {
           if (typeof v !== 'string' || !validValues.includes(v)) {
+            const validLabels = options.map((o) => o.label);
             errors.push({
               fieldKey: field.fieldKey,
-              message: `${field.label} contains invalid option: ${String(v)}`,
+              message: `${field.label} contains invalid option. Valid options: ${validLabels.join(', ')}`,
             });
             break;
           }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -116,7 +116,7 @@
 - [x] Form selector UI in submission creation — submitters need a way to select a published form when creating a submission (currently requires DB linkage) — (manual QA 2026-02-20; done 2026-02-20)
 - [x] [P2] E2E Playwright tests for embed form flow — 10 tests (8 core + 2 wizard), CI job added — (DEVLOG 2026-02-22, embed widget session; done 2026-02-22)
 - [x] [P2] Manual QA of embed form widget — test iframe embedding on third-party page, identity step, form filling (flat + wizard), file uploads with scan status, error states, theme inheritance — (backlog 2026-02-23; done 2026-02-23 — found + fixed CORS + dark mode bugs)
-- [ ] [P3] Embed form genre validation: show human-readable labels instead of raw enum values — (manual QA 2026-02-23)
+- [x] [P3] Embed form genre validation: show human-readable labels instead of raw enum values — (manual QA 2026-02-23; done 2026-02-23)
 - [x] [P2] Migration 0015 production reliability — `db:verify` / `db:verify:repair` scripts check `information_schema` for FK constraint drift and auto-repair; integrated into `db:reset` — (GDPR manual QA 2026-02-23; done 2026-02-23)
 
 ---

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,20 @@ Newest entries first.
 
 ---
 
+## 2026-02-23 — Track 3 Polish + Dependabot Triage
+
+### Done
+
+- Fixed embed form genre validation: error messages now show human-readable labels ("Fiction", "Poetry") instead of raw enum values ("fiction", "poetry") — `form-validation.service.ts` select/radio/multi_select/checkbox cases
+- Updated 3 test assertions to verify labels in error messages
+- Triaged 4 Dependabot PRs: closed ESLint 10 pair (#153, #154) — blocked by `eslint-plugin-react` upstream incompatibility (jsx-eslint/eslint-plugin-react#3977); #151 (jest-environment-jsdom 30) and #152 (Tailwind 4) are major version bumps with failing CI, deferred
+
+### Decisions
+
+- ESLint 10 upgrade deferred until `eslint-plugin-react` and `eslint-config-next` release compatible versions
+
+---
+
 ## 2026-02-23 — Embed Form QA: CORS + Dark Mode Fixes
 
 ### Done


### PR DESCRIPTION
## Summary

- Select/radio/multi-select/checkbox validation error messages now display field option **labels** instead of raw enum values (e.g., "Fiction" not "fiction")
- Closed Dependabot ESLint 10 PRs (#153, #154) — `eslint-plugin-react` doesn't support ESLint 10 yet

## Test plan

- [x] Updated 3 existing test assertions to verify labels are shown
- [x] All 27 form-validation tests pass
- [x] Pre-push type-check + lint pass