### PR TITLE
feat(slate): add Track 4 publication pipeline backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,15 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
@@ -516,6 +525,15 @@ jobs:
           - 5432:5432
         options: >-
           --health-cmd "pg_isready -U colophony"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,9 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **tRPC (internal)**     | `apps/api/src/trpc/`                                                     |
 | **Zitadel webhook**     | `apps/api/src/webhooks/zitadel.webhook.ts`                               |
 | **Stripe webhook**      | `apps/api/src/webhooks/stripe.webhook.ts`                                |
+| **Documenso webhook**   | `apps/api/src/webhooks/documenso.webhook.ts`                             |
+| **Inngest functions**   | `apps/api/src/inngest/`                                                  |
+| **CMS adapters**        | `apps/api/src/adapters/cms/`                                             |
 | **Next.js frontend**    | `apps/web/`                                                              |
 | **tRPC client**         | `apps/web/src/lib/trpc.ts`                                               |
 | **Env config (Zod)**    | `apps/api/src/config/env.ts`                                             |

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -29,6 +29,13 @@
 | tusd webhook      | `src/webhooks/tusd.webhook.ts`             |
 | Zitadel webhook   | `src/webhooks/zitadel.webhook.ts`          |
 | Stripe webhook    | `src/webhooks/stripe.webhook.ts`           |
+| Documenso webhook | `src/webhooks/documenso.webhook.ts`        |
+| Inngest client    | `src/inngest/client.ts`                    |
+| Inngest functions | `src/inngest/functions/`                   |
+| Inngest serve     | `src/inngest/serve.ts`                     |
+| CMS adapters      | `src/adapters/cms/`                        |
+| Documenso adapter | `src/adapters/documenso.adapter.ts`        |
+| Outbox poller     | `src/workers/outbox-poller.worker.ts`      |
 
 ### Service Method Naming
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -53,6 +53,7 @@
     "fastify-raw-body": "^5.0.0",
     "graphql": "^16.10",
     "graphql-yoga": "^5.11",
+    "inngest": "^3.52.3",
     "ioredis": "^5.9.3",
     "nodemailer": "^8.0.1",
     "stripe": "^20.3.1",

--- a/apps/api/src/__tests__/rls/audit-write-path.test.ts
+++ b/apps/api/src/__tests__/rls/audit-write-path.test.ts
@@ -45,7 +45,10 @@ function adminDb(): DrizzleDb {
 
 /** Read all audit_events via admin (bypasses RLS). */
 async function allAuditEvents(): Promise<AuditEvent[]> {
-  return adminDb().select().from(auditEvents);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- cross-package drizzle-orm type mismatch (pnpm peer dep duplication)
+  return adminDb()
+    .select()
+    .from(auditEvents as any) as any;
 }
 
 // ---------------------------------------------------------------------------
@@ -203,7 +206,8 @@ describe('logDirect() and RLS interaction', () => {
 
 describe('log() org-scoped write via RLS transaction', () => {
   it('inserts event visible within same org context', async () => {
-    await withTestRls({ orgId: orgA.id, userId: userA.id }, (tx) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- cross-package drizzle-orm type mismatch
+    await withTestRls({ orgId: orgA.id, userId: userA.id }, (tx: any) =>
       auditService.log(tx, {
         action: AuditActions.ORG_UPDATED,
         resource: AuditResources.ORGANIZATION,
@@ -223,17 +227,19 @@ describe('log() org-scoped write via RLS transaction', () => {
     expect(rows[0].resource).toBe('organization');
 
     // Also verify tenant isolation: org A event visible in org A context
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- cross-package drizzle-orm type mismatch
     const orgARows = await withTestRls(
       { orgId: orgA.id, userId: userA.id },
-      (tx) => tx.select().from(auditEvents),
+      (tx) => tx.select().from(auditEvents as any),
     );
     expect(orgARows).toHaveLength(1);
-    expect(orgARows[0].id).toBe(rows[0].id);
+    expect((orgARows[0] as any).id).toBe(rows[0].id);
   });
 
   it('org A audit event is invisible to org B (tenant isolation)', async () => {
     // Insert via org A
-    await withTestRls({ orgId: orgA.id, userId: userA.id }, (tx) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- cross-package drizzle-orm type mismatch
+    await withTestRls({ orgId: orgA.id, userId: userA.id }, (tx: any) =>
       auditService.log(tx, {
         action: AuditActions.ORG_CREATED,
         resource: AuditResources.ORGANIZATION,
@@ -245,7 +251,8 @@ describe('log() org-scoped write via RLS transaction', () => {
     // Org B sees nothing
     const orgBRows = await withTestRls(
       { orgId: orgB.id, userId: userB.id },
-      (tx) => tx.select().from(auditEvents),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- cross-package drizzle-orm type mismatch
+      (tx) => tx.select().from(auditEvents as any),
     );
     expect(orgBRows).toHaveLength(0);
   });
@@ -270,7 +277,8 @@ describe('transaction rollback atomicity', () => {
         userA.id,
       ]);
 
-      const tx = drizzle(client);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- cross-package drizzle-orm type mismatch
+      const tx = drizzle(client) as any;
       await auditService.log(tx, {
         action: AuditActions.ORG_DELETED,
         resource: AuditResources.ORGANIZATION,

--- a/apps/api/src/__tests__/rls/helpers/factories.ts
+++ b/apps/api/src/__tests__/rls/helpers/factories.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { drizzle } from 'drizzle-orm/node-postgres';
-import { getAdminPool, type DrizzleDb } from './db-setup';
+import { getAdminPool } from './db-setup';
 import {
   organizations,
   users,
@@ -30,7 +30,9 @@ import {
   type UserConsent,
 } from '@colophony/db';
 
-function adminDb(): DrizzleDb {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- pnpm resolves two drizzle-orm copies
+// (different optional peer dep contexts); runtime is single copy, types diverge. Cast to unify.
+function adminDb(): any {
   return drizzle(getAdminPool());
 }
 

--- a/apps/api/src/__tests__/webhooks/helpers/webhook-app.ts
+++ b/apps/api/src/__tests__/webhooks/helpers/webhook-app.ts
@@ -49,6 +49,7 @@ export function createTestEnv(overrides?: Partial<Env>): Env {
     DEV_AUTH_BYPASS: false,
     FEDERATION_DOMAIN: undefined,
     FEDERATION_ENABLED: false,
+    INNGEST_DEV: false,
     ...overrides,
   };
 }

--- a/apps/api/src/adapters/cms/cms-adapter.interface.ts
+++ b/apps/api/src/adapters/cms/cms-adapter.interface.ts
@@ -1,0 +1,59 @@
+import type { CmsAdapterType } from '@colophony/types';
+
+// ---------------------------------------------------------------------------
+// CMS adapter interface — implemented per CMS platform
+// ---------------------------------------------------------------------------
+
+export interface CmsTestResult {
+  success: boolean;
+  error?: string;
+}
+
+export interface CmsPublishResult {
+  externalId: string;
+  externalUrl?: string;
+}
+
+export interface CmsIssuePayload {
+  title: string;
+  volume?: number | null;
+  issueNumber?: number | null;
+  description?: string | null;
+  coverImageUrl?: string | null;
+  publicationDate?: Date | null;
+  items: CmsPiecePayload[];
+}
+
+export interface CmsPiecePayload {
+  title: string;
+  content: string;
+  author: string;
+  sortOrder: number;
+  sectionTitle?: string | null;
+}
+
+export interface CmsAdapter {
+  readonly type: CmsAdapterType;
+
+  /** Test that the connection config is valid and reachable. */
+  testConnection(config: Record<string, unknown>): Promise<CmsTestResult>;
+
+  /** Publish an issue to the CMS. Returns the external ID/URL. */
+  publishIssue(
+    config: Record<string, unknown>,
+    issue: CmsIssuePayload,
+  ): Promise<CmsPublishResult>;
+
+  /** Unpublish/remove an issue from the CMS by its external ID. */
+  unpublishIssue(
+    config: Record<string, unknown>,
+    externalId: string,
+  ): Promise<void>;
+
+  /** Publish or update a single piece in the CMS. */
+  syncPiece(
+    config: Record<string, unknown>,
+    piece: CmsPiecePayload,
+    externalId?: string,
+  ): Promise<CmsPublishResult>;
+}

--- a/apps/api/src/adapters/cms/cms-adapter.interface.ts
+++ b/apps/api/src/adapters/cms/cms-adapter.interface.ts
@@ -27,7 +27,7 @@ export interface CmsIssuePayload {
 export interface CmsPiecePayload {
   title: string;
   content: string;
-  author: string;
+  author: string | null;
   sortOrder: number;
   sectionTitle?: string | null;
 }

--- a/apps/api/src/adapters/cms/ghost.adapter.ts
+++ b/apps/api/src/adapters/cms/ghost.adapter.ts
@@ -1,0 +1,228 @@
+import { createHmac } from 'node:crypto';
+import type {
+  CmsAdapter,
+  CmsTestResult,
+  CmsPublishResult,
+  CmsIssuePayload,
+  CmsPiecePayload,
+} from './cms-adapter.interface.js';
+
+/**
+ * Ghost CMS adapter — publishes via the Ghost Admin API.
+ *
+ * Expected config shape:
+ * ```json
+ * {
+ *   "apiUrl": "https://example.com",
+ *   "adminApiKey": "ADMIN_KEY_ID:ADMIN_KEY_SECRET"
+ * }
+ * ```
+ *
+ * The admin API key format is `id:secret` where `id` is the API key ID and
+ * `secret` is the hex-encoded secret used for JWT signing.
+ */
+export const ghostAdapter: CmsAdapter = {
+  type: 'GHOST',
+
+  async testConnection(
+    config: Record<string, unknown>,
+  ): Promise<CmsTestResult> {
+    const { apiUrl, token } = parseConfigAndSign(config);
+
+    try {
+      const res = await fetch(`${apiUrl}/ghost/api/admin/site/`, {
+        headers: { Authorization: `Ghost ${token}` },
+      });
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        return { success: false, error: `HTTP ${res.status}: ${body}` };
+      }
+
+      return { success: true };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      };
+    }
+  },
+
+  async publishIssue(
+    config: Record<string, unknown>,
+    issue: CmsIssuePayload,
+  ): Promise<CmsPublishResult> {
+    const { apiUrl, token } = parseConfigAndSign(config);
+
+    const html = buildIssueHtml(issue);
+
+    const res = await fetch(`${apiUrl}/ghost/api/admin/posts/`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Ghost ${token}`,
+      },
+      body: JSON.stringify({
+        posts: [
+          {
+            title: issue.title,
+            html,
+            status: 'published',
+          },
+        ],
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`Ghost publish failed: HTTP ${res.status} — ${body}`);
+    }
+
+    const data = (await res.json()) as {
+      posts: { id: string; url: string }[];
+    };
+    const post = data.posts[0];
+    return { externalId: post.id, externalUrl: post.url };
+  },
+
+  async unpublishIssue(
+    config: Record<string, unknown>,
+    externalId: string,
+  ): Promise<void> {
+    const { apiUrl, token } = parseConfigAndSign(config);
+
+    const res = await fetch(`${apiUrl}/ghost/api/admin/posts/${externalId}/`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Ghost ${token}`,
+      },
+    });
+
+    if (!res.ok && res.status !== 404) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`Ghost unpublish failed: HTTP ${res.status} — ${body}`);
+    }
+  },
+
+  async syncPiece(
+    config: Record<string, unknown>,
+    piece: CmsPiecePayload,
+    externalId?: string,
+  ): Promise<CmsPublishResult> {
+    const { apiUrl, token } = parseConfigAndSign(config);
+
+    const method = externalId ? 'PUT' : 'POST';
+    const url = externalId
+      ? `${apiUrl}/ghost/api/admin/posts/${externalId}/`
+      : `${apiUrl}/ghost/api/admin/posts/`;
+
+    const body = {
+      posts: [
+        {
+          title: piece.title,
+          html: piece.content,
+          status: 'published',
+        },
+      ],
+    };
+
+    // Ghost PUT requires the post's updated_at for collision detection.
+    // For updates, fetch current post first to get updated_at.
+    if (externalId) {
+      const getRes = await fetch(
+        `${apiUrl}/ghost/api/admin/posts/${externalId}/`,
+        { headers: { Authorization: `Ghost ${token}` } },
+      );
+      if (getRes.ok) {
+        const current = (await getRes.json()) as {
+          posts: { updated_at: string }[];
+        };
+        (body.posts[0] as Record<string, unknown>).updated_at =
+          current.posts[0].updated_at;
+      }
+    }
+
+    const res = await fetch(url, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Ghost ${token}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const resBody = await res.text().catch(() => '');
+      throw new Error(
+        `Ghost sync piece failed: HTTP ${res.status} — ${resBody}`,
+      );
+    }
+
+    const data = (await res.json()) as {
+      posts: { id: string; url: string }[];
+    };
+    const post = data.posts[0];
+    return { externalId: post.id, externalUrl: post.url };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseConfigAndSign(config: Record<string, unknown>): {
+  apiUrl: string;
+  token: string;
+} {
+  const apiUrl = config.apiUrl as string | undefined;
+  const adminApiKey = config.adminApiKey as string | undefined;
+
+  if (!apiUrl || !adminApiKey) {
+    throw new Error('Ghost config requires apiUrl and adminApiKey');
+  }
+
+  const [id, secret] = adminApiKey.split(':');
+  if (!id || !secret) {
+    throw new Error('Ghost adminApiKey must be in "id:secret" format');
+  }
+
+  // Ghost Admin API uses short-lived JWTs signed with the admin key secret.
+  // Build a minimal JWT (HS256) with 5-minute expiry.
+  const now = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'HS256', typ: 'JWT', kid: id }),
+  ).toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({ iat: now, exp: now + 300, aud: '/admin/' }),
+  ).toString('base64url');
+  const signature = createHmac('sha256', Buffer.from(secret, 'hex'))
+    .update(`${header}.${payload}`)
+    .digest('base64url');
+
+  return {
+    apiUrl: apiUrl.replace(/\/+$/, ''),
+    token: `${header}.${payload}.${signature}`,
+  };
+}
+
+function buildIssueHtml(issue: CmsIssuePayload): string {
+  const parts: string[] = [];
+
+  if (issue.description) {
+    parts.push(`<p>${issue.description}</p>`);
+  }
+
+  let currentSection: string | null = null;
+  for (const item of issue.items) {
+    if (item.sectionTitle && item.sectionTitle !== currentSection) {
+      currentSection = item.sectionTitle;
+      parts.push(`<h2>${currentSection}</h2>`);
+    }
+    parts.push(`<h3>${item.title}</h3>`);
+    parts.push(`<p><em>by ${item.author}</em></p>`);
+    parts.push(item.content);
+    parts.push('<hr />');
+  }
+
+  return parts.join('\n');
+}

--- a/apps/api/src/adapters/cms/ghost.adapter.ts
+++ b/apps/api/src/adapters/cms/ghost.adapter.ts
@@ -219,7 +219,7 @@ function buildIssueHtml(issue: CmsIssuePayload): string {
       parts.push(`<h2>${currentSection}</h2>`);
     }
     parts.push(`<h3>${item.title}</h3>`);
-    parts.push(`<p><em>by ${item.author}</em></p>`);
+    if (item.author) parts.push(`<p><em>by ${item.author}</em></p>`);
     parts.push(item.content);
     parts.push('<hr />');
   }

--- a/apps/api/src/adapters/cms/index.ts
+++ b/apps/api/src/adapters/cms/index.ts
@@ -1,0 +1,24 @@
+export type {
+  CmsAdapter,
+  CmsTestResult,
+  CmsPublishResult,
+  CmsIssuePayload,
+  CmsPiecePayload,
+} from './cms-adapter.interface.js';
+export { wordpressAdapter } from './wordpress.adapter.js';
+export { ghostAdapter } from './ghost.adapter.js';
+
+import type { CmsAdapterType } from '@colophony/types';
+import type { CmsAdapter } from './cms-adapter.interface.js';
+import { wordpressAdapter } from './wordpress.adapter.js';
+import { ghostAdapter } from './ghost.adapter.js';
+
+const adapters: Record<CmsAdapterType, CmsAdapter> = {
+  WORDPRESS: wordpressAdapter,
+  GHOST: ghostAdapter,
+};
+
+/** Resolve the CMS adapter implementation for a given adapter type. */
+export function getCmsAdapter(type: CmsAdapterType): CmsAdapter {
+  return adapters[type];
+}

--- a/apps/api/src/adapters/cms/wordpress.adapter.ts
+++ b/apps/api/src/adapters/cms/wordpress.adapter.ts
@@ -1,0 +1,188 @@
+import type {
+  CmsAdapter,
+  CmsTestResult,
+  CmsPublishResult,
+  CmsIssuePayload,
+  CmsPiecePayload,
+} from './cms-adapter.interface.js';
+
+/**
+ * WordPress CMS adapter — publishes via the WP REST API v2.
+ *
+ * Expected config shape:
+ * ```json
+ * {
+ *   "siteUrl": "https://example.com",
+ *   "username": "admin",
+ *   "applicationPassword": "xxxx xxxx xxxx xxxx"
+ * }
+ * ```
+ */
+export const wordpressAdapter: CmsAdapter = {
+  type: 'WORDPRESS',
+
+  async testConnection(
+    config: Record<string, unknown>,
+  ): Promise<CmsTestResult> {
+    const { siteUrl, username, applicationPassword } = parseConfig(config);
+
+    try {
+      const res = await fetch(`${siteUrl}/wp-json/wp/v2/users/me`, {
+        headers: { Authorization: basicAuth(username, applicationPassword) },
+      });
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        return { success: false, error: `HTTP ${res.status}: ${body}` };
+      }
+
+      return { success: true };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      };
+    }
+  },
+
+  async publishIssue(
+    config: Record<string, unknown>,
+    issue: CmsIssuePayload,
+  ): Promise<CmsPublishResult> {
+    const { siteUrl, username, applicationPassword } = parseConfig(config);
+
+    // Build combined HTML content from issue items
+    const html = buildIssueHtml(issue);
+
+    const res = await fetch(`${siteUrl}/wp-json/wp/v2/posts`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: basicAuth(username, applicationPassword),
+      },
+      body: JSON.stringify({
+        title: issue.title,
+        content: html,
+        status: 'publish',
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`WordPress publish failed: HTTP ${res.status} — ${body}`);
+    }
+
+    const data = (await res.json()) as { id: number; link: string };
+    return { externalId: String(data.id), externalUrl: data.link };
+  },
+
+  async unpublishIssue(
+    config: Record<string, unknown>,
+    externalId: string,
+  ): Promise<void> {
+    const { siteUrl, username, applicationPassword } = parseConfig(config);
+
+    const res = await fetch(`${siteUrl}/wp-json/wp/v2/posts/${externalId}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: basicAuth(username, applicationPassword),
+      },
+    });
+
+    if (!res.ok && res.status !== 404) {
+      const body = await res.text().catch(() => '');
+      throw new Error(
+        `WordPress unpublish failed: HTTP ${res.status} — ${body}`,
+      );
+    }
+  },
+
+  async syncPiece(
+    config: Record<string, unknown>,
+    piece: CmsPiecePayload,
+    externalId?: string,
+  ): Promise<CmsPublishResult> {
+    const { siteUrl, username, applicationPassword } = parseConfig(config);
+
+    const method = externalId ? 'PUT' : 'POST';
+    const url = externalId
+      ? `${siteUrl}/wp-json/wp/v2/posts/${externalId}`
+      : `${siteUrl}/wp-json/wp/v2/posts`;
+
+    const res = await fetch(url, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: basicAuth(username, applicationPassword),
+      },
+      body: JSON.stringify({
+        title: piece.title,
+        content: piece.content,
+        status: 'publish',
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(
+        `WordPress sync piece failed: HTTP ${res.status} — ${body}`,
+      );
+    }
+
+    const data = (await res.json()) as { id: number; link: string };
+    return { externalId: String(data.id), externalUrl: data.link };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseConfig(config: Record<string, unknown>): {
+  siteUrl: string;
+  username: string;
+  applicationPassword: string;
+} {
+  const siteUrl = config.siteUrl as string | undefined;
+  const username = config.username as string | undefined;
+  const applicationPassword = config.applicationPassword as string | undefined;
+
+  if (!siteUrl || !username || !applicationPassword) {
+    throw new Error(
+      'WordPress config requires siteUrl, username, and applicationPassword',
+    );
+  }
+
+  // Strip trailing slash
+  return {
+    siteUrl: siteUrl.replace(/\/+$/, ''),
+    username,
+    applicationPassword,
+  };
+}
+
+function basicAuth(username: string, password: string): string {
+  return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+}
+
+function buildIssueHtml(issue: CmsIssuePayload): string {
+  const parts: string[] = [];
+
+  if (issue.description) {
+    parts.push(`<p>${issue.description}</p>`);
+  }
+
+  let currentSection: string | null = null;
+  for (const item of issue.items) {
+    if (item.sectionTitle && item.sectionTitle !== currentSection) {
+      currentSection = item.sectionTitle;
+      parts.push(`<h2>${currentSection}</h2>`);
+    }
+    parts.push(`<h3>${item.title}</h3>`);
+    parts.push(`<p><em>by ${item.author}</em></p>`);
+    parts.push(item.content);
+    parts.push('<hr />');
+  }
+
+  return parts.join('\n');
+}

--- a/apps/api/src/adapters/cms/wordpress.adapter.ts
+++ b/apps/api/src/adapters/cms/wordpress.adapter.ts
@@ -179,7 +179,7 @@ function buildIssueHtml(issue: CmsIssuePayload): string {
       parts.push(`<h2>${currentSection}</h2>`);
     }
     parts.push(`<h3>${item.title}</h3>`);
-    parts.push(`<p><em>by ${item.author}</em></p>`);
+    if (item.author) parts.push(`<p><em>by ${item.author}</em></p>`);
     parts.push(item.content);
     parts.push('<hr />');
   }

--- a/apps/api/src/adapters/documenso.adapter.ts
+++ b/apps/api/src/adapters/documenso.adapter.ts
@@ -111,10 +111,10 @@ export function createDocumensoAdapter(env: Env): DocumensoAdapter | null {
         .update(payload)
         .digest('hex');
 
-      return crypto.timingSafeEqual(
-        Buffer.from(signature),
-        Buffer.from(expected),
-      );
+      const sigBuf = Buffer.from(signature);
+      const expBuf = Buffer.from(expected);
+      if (sigBuf.length !== expBuf.length) return false;
+      return crypto.timingSafeEqual(sigBuf, expBuf);
     },
   };
 }

--- a/apps/api/src/adapters/documenso.adapter.ts
+++ b/apps/api/src/adapters/documenso.adapter.ts
@@ -1,0 +1,120 @@
+import crypto from 'node:crypto';
+import type { Env } from '../config/env.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DocumensoSigner {
+  email: string;
+  name: string;
+  role?: 'SIGNER' | 'APPROVER' | 'CC';
+}
+
+export interface CreateDocumentParams {
+  title: string;
+  body: string;
+  signers: DocumensoSigner[];
+  metadata?: Record<string, string>;
+}
+
+export interface DocumensoDocument {
+  id: string;
+  status: string;
+  title: string;
+  createdAt: string;
+  completedAt?: string;
+}
+
+export interface DocumensoAdapter {
+  createDocument(params: CreateDocumentParams): Promise<string>;
+  getDocument(documensoDocumentId: string): Promise<DocumensoDocument>;
+  voidDocument(documensoDocumentId: string): Promise<void>;
+  verifyWebhookSignature(payload: string, signature: string): boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+export function createDocumensoAdapter(env: Env): DocumensoAdapter | null {
+  if (!env.DOCUMENSO_API_URL || !env.DOCUMENSO_API_KEY) {
+    return null;
+  }
+
+  const baseUrl = env.DOCUMENSO_API_URL.replace(/\/$/, '');
+  const apiKey = env.DOCUMENSO_API_KEY;
+  const webhookSecret = env.DOCUMENSO_WEBHOOK_SECRET;
+
+  async function apiRequest<T>(
+    path: string,
+    options: RequestInit = {},
+  ): Promise<T> {
+    const url = `${baseUrl}${path}`;
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => 'unknown error');
+      throw new Error(
+        `Documenso API error: ${response.status} ${response.statusText} — ${text}`,
+      );
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  return {
+    async createDocument(params: CreateDocumentParams): Promise<string> {
+      const result = await apiRequest<{ id: string }>('/api/v1/documents', {
+        method: 'POST',
+        body: JSON.stringify({
+          title: params.title,
+          recipients: params.signers.map((s) => ({
+            email: s.email,
+            name: s.name,
+            role: s.role ?? 'SIGNER',
+          })),
+          meta: {
+            ...params.metadata,
+          },
+        }),
+      });
+
+      return result.id;
+    },
+
+    async getDocument(documensoDocumentId: string): Promise<DocumensoDocument> {
+      return apiRequest<DocumensoDocument>(
+        `/api/v1/documents/${encodeURIComponent(documensoDocumentId)}`,
+      );
+    },
+
+    async voidDocument(documensoDocumentId: string): Promise<void> {
+      await apiRequest(
+        `/api/v1/documents/${encodeURIComponent(documensoDocumentId)}`,
+        { method: 'DELETE' },
+      );
+    },
+
+    verifyWebhookSignature(payload: string, signature: string): boolean {
+      if (!webhookSecret) return false;
+
+      const expected = crypto
+        .createHmac('sha256', webhookSecret)
+        .update(payload)
+        .digest('hex');
+
+      return crypto.timingSafeEqual(
+        Buffer.from(signature),
+        Buffer.from(expected),
+      );
+    },
+  };
+}

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -75,6 +75,19 @@ const envSchema = z.object({
     .enum(['true', 'false'])
     .default('false')
     .transform((v) => v === 'true'),
+
+  // Inngest workflow engine
+  INNGEST_EVENT_KEY: z.string().optional(),
+  INNGEST_SIGNING_KEY: z.string().optional(),
+  INNGEST_DEV: z
+    .enum(['true', 'false'])
+    .default('false')
+    .transform((v) => v === 'true'),
+
+  // Documenso contract signing
+  DOCUMENSO_API_URL: z.string().url().optional(),
+  DOCUMENSO_API_KEY: z.string().optional(),
+  DOCUMENSO_WEBHOOK_SECRET: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/graphql/error-mapper.ts
+++ b/apps/api/src/graphql/error-mapper.ts
@@ -50,6 +50,7 @@ import {
   IssueNotFoundError,
   IssueItemAlreadyExistsError,
 } from '../services/issue.service.js';
+import { CmsConnectionNotFoundError } from '../services/cms-connection.service.js';
 
 type GraphQLErrorCode = string;
 
@@ -99,6 +100,8 @@ const errorCodeMap: [new (...args: never[]) => Error, GraphQLErrorCode][] = [
   // Issue errors
   [IssueNotFoundError, 'NOT_FOUND'],
   [IssueItemAlreadyExistsError, 'CONFLICT'],
+  // CMS errors
+  [CmsConnectionNotFoundError, 'NOT_FOUND'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/graphql/error-mapper.ts
+++ b/apps/api/src/graphql/error-mapper.ts
@@ -43,6 +43,8 @@ import {
   PipelineItemAlreadyExistsError,
   InvalidPipelineTransitionError,
 } from '../services/pipeline.service.js';
+import { ContractTemplateNotFoundError } from '../services/contract-template.service.js';
+import { ContractNotFoundError } from '../services/contract.service.js';
 
 type GraphQLErrorCode = string;
 
@@ -85,6 +87,9 @@ const errorCodeMap: [new (...args: never[]) => Error, GraphQLErrorCode][] = [
   [PipelineItemNotFoundError, 'NOT_FOUND'],
   [PipelineItemAlreadyExistsError, 'CONFLICT'],
   [InvalidPipelineTransitionError, 'BAD_REQUEST'],
+  // Contract errors
+  [ContractTemplateNotFoundError, 'NOT_FOUND'],
+  [ContractNotFoundError, 'NOT_FOUND'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/graphql/error-mapper.ts
+++ b/apps/api/src/graphql/error-mapper.ts
@@ -42,9 +42,14 @@ import {
   PipelineItemNotFoundError,
   PipelineItemAlreadyExistsError,
   InvalidPipelineTransitionError,
+  SubmissionNotAcceptedError,
 } from '../services/pipeline.service.js';
 import { ContractTemplateNotFoundError } from '../services/contract-template.service.js';
 import { ContractNotFoundError } from '../services/contract.service.js';
+import {
+  IssueNotFoundError,
+  IssueItemAlreadyExistsError,
+} from '../services/issue.service.js';
 
 type GraphQLErrorCode = string;
 
@@ -87,9 +92,13 @@ const errorCodeMap: [new (...args: never[]) => Error, GraphQLErrorCode][] = [
   [PipelineItemNotFoundError, 'NOT_FOUND'],
   [PipelineItemAlreadyExistsError, 'CONFLICT'],
   [InvalidPipelineTransitionError, 'BAD_REQUEST'],
+  [SubmissionNotAcceptedError, 'BAD_REQUEST'],
   // Contract errors
   [ContractTemplateNotFoundError, 'NOT_FOUND'],
   [ContractNotFoundError, 'NOT_FOUND'],
+  // Issue errors
+  [IssueNotFoundError, 'NOT_FOUND'],
+  [IssueItemAlreadyExistsError, 'CONFLICT'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/graphql/error-mapper.ts
+++ b/apps/api/src/graphql/error-mapper.ts
@@ -38,6 +38,11 @@ import {
   PublicationNotFoundError,
   PublicationSlugConflictError,
 } from '../services/publication.service.js';
+import {
+  PipelineItemNotFoundError,
+  PipelineItemAlreadyExistsError,
+  InvalidPipelineTransitionError,
+} from '../services/pipeline.service.js';
 
 type GraphQLErrorCode = string;
 
@@ -76,6 +81,10 @@ const errorCodeMap: [new (...args: never[]) => Error, GraphQLErrorCode][] = [
   // Publication errors
   [PublicationNotFoundError, 'NOT_FOUND'],
   [PublicationSlugConflictError, 'CONFLICT'],
+  // Pipeline errors
+  [PipelineItemNotFoundError, 'NOT_FOUND'],
+  [PipelineItemAlreadyExistsError, 'CONFLICT'],
+  [InvalidPipelineTransitionError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/graphql/error-mapper.ts
+++ b/apps/api/src/graphql/error-mapper.ts
@@ -34,6 +34,10 @@ import {
   ManuscriptNotFoundError,
   ManuscriptVersionNotFoundError,
 } from '../services/manuscript.service.js';
+import {
+  PublicationNotFoundError,
+  PublicationSlugConflictError,
+} from '../services/publication.service.js';
 
 type GraphQLErrorCode = string;
 
@@ -69,6 +73,9 @@ const errorCodeMap: [new (...args: never[]) => Error, GraphQLErrorCode][] = [
   // Period errors
   [PeriodNotFoundError, 'NOT_FOUND'],
   [PeriodHasSubmissionsError, 'BAD_REQUEST'],
+  // Publication errors
+  [PublicationNotFoundError, 'NOT_FOUND'],
+  [PublicationSlugConflictError, 'CONFLICT'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/graphql/resolvers/cms-connections.ts
+++ b/apps/api/src/graphql/resolvers/cms-connections.ts
@@ -1,0 +1,240 @@
+import type { CmsConnection } from '@colophony/types';
+import {
+  listCmsConnectionsSchema,
+  createCmsConnectionSchema,
+  updateCmsConnectionSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { builder } from '../builder.js';
+import { requireOrgContext, requireScopes } from '../guards.js';
+import { toServiceContext } from '../../services/context.js';
+import {
+  cmsConnectionService,
+  CmsConnectionNotFoundError,
+} from '../../services/cms-connection.service.js';
+import { mapServiceError } from '../error-mapper.js';
+import { CmsConnectionType } from '../types/index.js';
+
+// ---------------------------------------------------------------------------
+// Paginated response type
+// ---------------------------------------------------------------------------
+
+const PaginatedCmsConnections = builder
+  .objectRef<{
+    items: CmsConnection[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }>('PaginatedCmsConnections')
+  .implement({
+    fields: (t) => ({
+      items: t.field({
+        type: [CmsConnectionType],
+        resolve: (r) => r.items,
+      }),
+      total: t.exposeInt('total'),
+      page: t.exposeInt('page'),
+      limit: t.exposeInt('limit'),
+      totalPages: t.exposeInt('totalPages'),
+    }),
+  });
+
+// ---------------------------------------------------------------------------
+// Test result type
+// ---------------------------------------------------------------------------
+
+const CmsTestResultType = builder
+  .objectRef<{ success: boolean; error?: string }>('CmsTestResult')
+  .implement({
+    fields: (t) => ({
+      success: t.exposeBoolean('success'),
+      error: t.exposeString('error', { nullable: true }),
+    }),
+  });
+
+// ---------------------------------------------------------------------------
+// Query fields
+// ---------------------------------------------------------------------------
+
+builder.queryFields((t) => ({
+  /** List CMS connections in the org. */
+  cmsConnections: t.field({
+    type: PaginatedCmsConnections,
+    description: 'List CMS connections in the organization.',
+    args: {
+      publicationId: t.arg.string({
+        required: false,
+        description: 'Filter by publication ID.',
+      }),
+      page: t.arg.int({
+        required: false,
+        defaultValue: 1,
+        description: 'Page number (1-based).',
+      }),
+      limit: t.arg.int({
+        required: false,
+        defaultValue: 20,
+        description: 'Items per page (1-100).',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'cms:read');
+      const input = listCmsConnectionsSchema.parse({
+        publicationId: args.publicationId ?? undefined,
+        page: args.page,
+        limit: args.limit,
+      });
+      return cmsConnectionService.list(orgCtx.dbTx, input);
+    },
+  }),
+
+  /** Get a single CMS connection by ID. */
+  cmsConnection: t.field({
+    type: CmsConnectionType,
+    nullable: true,
+    description: 'Get a CMS connection by ID.',
+    args: {
+      id: t.arg.string({
+        required: true,
+        description: 'CMS connection ID.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'cms:read');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        const connection = await cmsConnectionService.getById(orgCtx.dbTx, id);
+        if (!connection) throw new CmsConnectionNotFoundError(id);
+        return connection;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mutation fields
+// ---------------------------------------------------------------------------
+
+builder.mutationFields((t) => ({
+  /** Create a new CMS connection. */
+  createCmsConnection: t.field({
+    type: CmsConnectionType,
+    description: 'Create a new CMS connection.',
+    args: {
+      adapterType: t.arg.string({
+        required: true,
+        description: 'CMS adapter type (WORDPRESS or GHOST).',
+      }),
+      name: t.arg.string({
+        required: true,
+        description: 'Display name for this connection.',
+      }),
+      config: t.arg.string({
+        required: true,
+        description: 'JSON string of adapter-specific configuration.',
+      }),
+      publicationId: t.arg.string({
+        required: false,
+        description: 'Optional publication ID.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'cms:write');
+      const input = createCmsConnectionSchema.parse({
+        adapterType: args.adapterType,
+        name: args.name,
+        config: JSON.parse(args.config),
+        publicationId: args.publicationId ?? undefined,
+      });
+      try {
+        return await cmsConnectionService.createWithAudit(
+          toServiceContext(orgCtx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Update a CMS connection. */
+  updateCmsConnection: t.field({
+    type: CmsConnectionType,
+    description: 'Update a CMS connection.',
+    args: {
+      id: t.arg.string({ required: true, description: 'CMS connection ID.' }),
+      name: t.arg.string({ required: false, description: 'New name.' }),
+      config: t.arg.string({
+        required: false,
+        description: 'New config as JSON string.',
+      }),
+      isActive: t.arg.boolean({ required: false, description: 'Active flag.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'cms:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      const data = updateCmsConnectionSchema.parse({
+        name: args.name ?? undefined,
+        config: args.config ? JSON.parse(args.config) : undefined,
+        isActive: args.isActive ?? undefined,
+      });
+      try {
+        return await cmsConnectionService.updateWithAudit(
+          toServiceContext(orgCtx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Delete a CMS connection. */
+  deleteCmsConnection: t.field({
+    type: CmsConnectionType,
+    description: 'Delete a CMS connection.',
+    args: {
+      id: t.arg.string({ required: true, description: 'CMS connection ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'cms:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await cmsConnectionService.deleteWithAudit(
+          toServiceContext(orgCtx),
+          id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Test a CMS connection. */
+  testCmsConnection: t.field({
+    type: CmsTestResultType,
+    description: 'Test the configuration of a CMS connection.',
+    args: {
+      id: t.arg.string({ required: true, description: 'CMS connection ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'cms:read');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await cmsConnectionService.testConnection(orgCtx.dbTx, id);
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));

--- a/apps/api/src/graphql/resolvers/contracts.ts
+++ b/apps/api/src/graphql/resolvers/contracts.ts
@@ -1,0 +1,369 @@
+import type { ContractTemplate, Contract } from '@colophony/types';
+import {
+  listContractTemplatesSchema,
+  listContractsSchema,
+  createContractTemplateSchema,
+  updateContractTemplateSchema,
+  generateContractSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { builder } from '../builder.js';
+import { requireOrgContext, requireScopes } from '../guards.js';
+import { toServiceContext } from '../../services/context.js';
+import {
+  contractTemplateService,
+  ContractTemplateNotFoundError,
+} from '../../services/contract-template.service.js';
+import {
+  contractService,
+  ContractNotFoundError,
+} from '../../services/contract.service.js';
+import { mapServiceError } from '../error-mapper.js';
+import { ContractTemplateType, ContractType } from '../types/index.js';
+
+// ---------------------------------------------------------------------------
+// Paginated response types
+// ---------------------------------------------------------------------------
+
+const PaginatedContractTemplates = builder
+  .objectRef<{
+    items: ContractTemplate[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }>('PaginatedContractTemplates')
+  .implement({
+    fields: (t) => ({
+      items: t.field({
+        type: [ContractTemplateType],
+        resolve: (r) => r.items,
+      }),
+      total: t.exposeInt('total'),
+      page: t.exposeInt('page'),
+      limit: t.exposeInt('limit'),
+      totalPages: t.exposeInt('totalPages'),
+    }),
+  });
+
+const PaginatedContracts = builder
+  .objectRef<{
+    items: Contract[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }>('PaginatedContracts')
+  .implement({
+    fields: (t) => ({
+      items: t.field({
+        type: [ContractType],
+        resolve: (r) => r.items,
+      }),
+      total: t.exposeInt('total'),
+      page: t.exposeInt('page'),
+      limit: t.exposeInt('limit'),
+      totalPages: t.exposeInt('totalPages'),
+    }),
+  });
+
+// ---------------------------------------------------------------------------
+// Query fields
+// ---------------------------------------------------------------------------
+
+builder.queryFields((t) => ({
+  /** List contract templates in the org. */
+  contractTemplates: t.field({
+    type: PaginatedContractTemplates,
+    description: 'List contract templates in the organization.',
+    args: {
+      search: t.arg.string({
+        required: false,
+        description: 'Search by name.',
+      }),
+      page: t.arg.int({
+        required: false,
+        defaultValue: 1,
+        description: 'Page number (1-based).',
+      }),
+      limit: t.arg.int({
+        required: false,
+        defaultValue: 20,
+        description: 'Items per page (1-100).',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'contracts:read');
+      const input = listContractTemplatesSchema.parse({
+        search: args.search ?? undefined,
+        page: args.page,
+        limit: args.limit,
+      });
+      return contractTemplateService.list(orgCtx.dbTx, input);
+    },
+  }),
+
+  /** Get a contract template by ID. */
+  contractTemplate: t.field({
+    type: ContractTemplateType,
+    nullable: true,
+    description: 'Get a contract template by ID.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Template ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'contracts:read');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        const template = await contractTemplateService.getById(orgCtx.dbTx, id);
+        if (!template) throw new ContractTemplateNotFoundError(id);
+        return template;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** List contracts in the org. */
+  contracts: t.field({
+    type: PaginatedContracts,
+    description: 'List contracts in the organization.',
+    args: {
+      status: t.arg.string({
+        required: false,
+        description: 'Filter by contract status.',
+      }),
+      pipelineItemId: t.arg.string({
+        required: false,
+        description: 'Filter by pipeline item.',
+      }),
+      page: t.arg.int({
+        required: false,
+        defaultValue: 1,
+        description: 'Page number (1-based).',
+      }),
+      limit: t.arg.int({
+        required: false,
+        defaultValue: 20,
+        description: 'Items per page (1-100).',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'contracts:read');
+      const input = listContractsSchema.parse({
+        status: args.status ?? undefined,
+        pipelineItemId: args.pipelineItemId ?? undefined,
+        page: args.page,
+        limit: args.limit,
+      });
+      return contractService.list(orgCtx.dbTx, input);
+    },
+  }),
+
+  /** Get a contract by ID. */
+  contract: t.field({
+    type: ContractType,
+    nullable: true,
+    description: 'Get a contract by ID.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Contract ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'contracts:read');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        const contract = await contractService.getById(orgCtx.dbTx, id);
+        if (!contract) throw new ContractNotFoundError(id);
+        return contract;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mutation fields
+// ---------------------------------------------------------------------------
+
+builder.mutationFields((t) => ({
+  /** Create a contract template. */
+  createContractTemplate: t.field({
+    type: ContractTemplateType,
+    description: 'Create a new contract template.',
+    args: {
+      name: t.arg.string({ required: true, description: 'Template name.' }),
+      body: t.arg.string({
+        required: true,
+        description: 'Template body with {{merge_field}} placeholders.',
+      }),
+      description: t.arg.string({
+        required: false,
+        description: 'Template description.',
+      }),
+      isDefault: t.arg.boolean({
+        required: false,
+        description: 'Set as default template.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'contracts:write');
+      const input = createContractTemplateSchema.parse({
+        name: args.name,
+        body: args.body,
+        description: args.description ?? undefined,
+        isDefault: args.isDefault ?? undefined,
+      });
+      try {
+        return await contractTemplateService.createWithAudit(
+          toServiceContext(orgCtx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Update a contract template. */
+  updateContractTemplate: t.field({
+    type: ContractTemplateType,
+    description: 'Update an existing contract template.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Template ID.' }),
+      name: t.arg.string({ required: false, description: 'New name.' }),
+      body: t.arg.string({ required: false, description: 'New body.' }),
+      description: t.arg.string({
+        required: false,
+        description: 'New description.',
+      }),
+      isDefault: t.arg.boolean({
+        required: false,
+        description: 'Set as default.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'contracts:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      const data = updateContractTemplateSchema.parse({
+        name: args.name ?? undefined,
+        body: args.body ?? undefined,
+        description: args.description ?? undefined,
+        isDefault: args.isDefault ?? undefined,
+      });
+      try {
+        return await contractTemplateService.updateWithAudit(
+          toServiceContext(orgCtx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Delete a contract template. */
+  deleteContractTemplate: t.field({
+    type: ContractTemplateType,
+    description: 'Delete a contract template.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Template ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'contracts:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await contractTemplateService.deleteWithAudit(
+          toServiceContext(orgCtx),
+          id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Generate a contract from a template. */
+  generateContract: t.field({
+    type: ContractType,
+    description: 'Generate a contract from a template with merge data.',
+    args: {
+      pipelineItemId: t.arg.string({
+        required: true,
+        description: 'Pipeline item ID.',
+      }),
+      contractTemplateId: t.arg.string({
+        required: true,
+        description: 'Contract template ID.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'contracts:write');
+      const input = generateContractSchema.parse({
+        pipelineItemId: args.pipelineItemId,
+        contractTemplateId: args.contractTemplateId,
+      });
+      try {
+        return await contractService.generateWithAudit(
+          toServiceContext(orgCtx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Send a contract for signing. */
+  sendContract: t.field({
+    type: ContractType,
+    description: 'Send a draft contract for signing.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Contract ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'contracts:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await contractService.sendWithAudit(
+          toServiceContext(orgCtx),
+          id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Void a contract. */
+  voidContract: t.field({
+    type: ContractType,
+    description: 'Void a contract, cancelling it permanently.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Contract ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'contracts:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await contractService.voidWithAudit(
+          toServiceContext(orgCtx),
+          id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));

--- a/apps/api/src/graphql/resolvers/index.ts
+++ b/apps/api/src/graphql/resolvers/index.ts
@@ -12,3 +12,4 @@ import './publications.js';
 import './pipeline.js';
 import './contracts.js';
 import './issues.js';
+import './cms-connections.js';

--- a/apps/api/src/graphql/resolvers/index.ts
+++ b/apps/api/src/graphql/resolvers/index.ts
@@ -11,3 +11,4 @@ import './periods.js';
 import './publications.js';
 import './pipeline.js';
 import './contracts.js';
+import './issues.js';

--- a/apps/api/src/graphql/resolvers/index.ts
+++ b/apps/api/src/graphql/resolvers/index.ts
@@ -10,3 +10,4 @@ import './forms.js';
 import './periods.js';
 import './publications.js';
 import './pipeline.js';
+import './contracts.js';

--- a/apps/api/src/graphql/resolvers/index.ts
+++ b/apps/api/src/graphql/resolvers/index.ts
@@ -9,4 +9,4 @@ import './manuscripts.js';
 import './forms.js';
 import './periods.js';
 import './publications.js';
-import './publications.js';
+import './pipeline.js';

--- a/apps/api/src/graphql/resolvers/index.ts
+++ b/apps/api/src/graphql/resolvers/index.ts
@@ -8,3 +8,5 @@ import './files.js';
 import './manuscripts.js';
 import './forms.js';
 import './periods.js';
+import './publications.js';
+import './publications.js';

--- a/apps/api/src/graphql/resolvers/issues.ts
+++ b/apps/api/src/graphql/resolvers/issues.ts
@@ -1,0 +1,333 @@
+import type { Issue } from '@colophony/types';
+import {
+  listIssuesSchema,
+  createIssueSchema,
+  updateIssueSchema,
+  addIssueItemSchema,
+  addIssueSectionSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { builder } from '../builder.js';
+import { requireOrgContext, requireScopes } from '../guards.js';
+import { toServiceContext } from '../../services/context.js';
+import {
+  issueService,
+  IssueNotFoundError,
+} from '../../services/issue.service.js';
+import { mapServiceError } from '../error-mapper.js';
+import { IssueType, IssueSectionType, IssueItemType } from '../types/index.js';
+
+// ---------------------------------------------------------------------------
+// Paginated response type
+// ---------------------------------------------------------------------------
+
+const PaginatedIssues = builder
+  .objectRef<{
+    items: Issue[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }>('PaginatedIssues')
+  .implement({
+    fields: (t) => ({
+      items: t.field({
+        type: [IssueType],
+        resolve: (r) => r.items,
+      }),
+      total: t.exposeInt('total'),
+      page: t.exposeInt('page'),
+      limit: t.exposeInt('limit'),
+      totalPages: t.exposeInt('totalPages'),
+    }),
+  });
+
+// ---------------------------------------------------------------------------
+// Query fields
+// ---------------------------------------------------------------------------
+
+builder.queryFields((t) => ({
+  /** List issues in the org. */
+  issues: t.field({
+    type: PaginatedIssues,
+    description: 'List issues in the organization.',
+    args: {
+      publicationId: t.arg.string({
+        required: false,
+        description: 'Filter by publication.',
+      }),
+      status: t.arg.string({
+        required: false,
+        description: 'Filter by status.',
+      }),
+      search: t.arg.string({
+        required: false,
+        description: 'Search by title.',
+      }),
+      page: t.arg.int({
+        required: false,
+        defaultValue: 1,
+        description: 'Page number (1-based).',
+      }),
+      limit: t.arg.int({
+        required: false,
+        defaultValue: 20,
+        description: 'Items per page (1-100).',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'issues:read');
+      const input = listIssuesSchema.parse({
+        publicationId: args.publicationId ?? undefined,
+        status: args.status ?? undefined,
+        search: args.search ?? undefined,
+        page: args.page,
+        limit: args.limit,
+      });
+      return issueService.list(orgCtx.dbTx, input);
+    },
+  }),
+
+  /** Get an issue by ID. */
+  issue: t.field({
+    type: IssueType,
+    nullable: true,
+    description: 'Get an issue by ID.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Issue ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'issues:read');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        const issue = await issueService.getById(orgCtx.dbTx, id);
+        if (!issue) throw new IssueNotFoundError(id);
+        return issue;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Get items in an issue. */
+  issueItems: t.field({
+    type: [IssueItemType],
+    description: 'Get items in an issue, ordered by sort order.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Issue ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'issues:read');
+      const { id } = idParamSchema.parse({ id: args.id });
+      return issueService.getItems(orgCtx.dbTx, id);
+    },
+  }),
+
+  /** Get sections in an issue. */
+  issueSections: t.field({
+    type: [IssueSectionType],
+    description: 'Get sections in an issue.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Issue ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'issues:read');
+      const { id } = idParamSchema.parse({ id: args.id });
+      return issueService.getSections(orgCtx.dbTx, id);
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mutation fields
+// ---------------------------------------------------------------------------
+
+builder.mutationFields((t) => ({
+  /** Create an issue. */
+  createIssue: t.field({
+    type: IssueType,
+    description: 'Create a new issue for a publication.',
+    args: {
+      publicationId: t.arg.string({
+        required: true,
+        description: 'Publication ID.',
+      }),
+      title: t.arg.string({ required: true, description: 'Issue title.' }),
+      volume: t.arg.int({ required: false, description: 'Volume number.' }),
+      issueNumber: t.arg.int({
+        required: false,
+        description: 'Issue number.',
+      }),
+      description: t.arg.string({
+        required: false,
+        description: 'Issue description.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'issues:write');
+      const input = createIssueSchema.parse({
+        publicationId: args.publicationId,
+        title: args.title,
+        volume: args.volume ?? undefined,
+        issueNumber: args.issueNumber ?? undefined,
+        description: args.description ?? undefined,
+      });
+      try {
+        return await issueService.createWithAudit(
+          toServiceContext(orgCtx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Update an issue. */
+  updateIssue: t.field({
+    type: IssueType,
+    description: 'Update an existing issue.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Issue ID.' }),
+      title: t.arg.string({ required: false, description: 'New title.' }),
+      description: t.arg.string({
+        required: false,
+        description: 'New description.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'issues:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      const data = updateIssueSchema.parse({
+        title: args.title ?? undefined,
+        description: args.description ?? undefined,
+      });
+      try {
+        return await issueService.updateWithAudit(
+          toServiceContext(orgCtx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Publish an issue. */
+  publishIssue: t.field({
+    type: IssueType,
+    description: 'Publish an issue.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Issue ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'issues:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await issueService.publishWithAudit(
+          toServiceContext(orgCtx),
+          id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Archive an issue. */
+  archiveIssue: t.field({
+    type: IssueType,
+    description: 'Archive an issue.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Issue ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'issues:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await issueService.archiveWithAudit(
+          toServiceContext(orgCtx),
+          id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Add a pipeline item to an issue. */
+  addIssueItem: t.field({
+    type: IssueItemType,
+    description: 'Add a pipeline item to an issue.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Issue ID.' }),
+      pipelineItemId: t.arg.string({
+        required: true,
+        description: 'Pipeline item ID.',
+      }),
+      issueSectionId: t.arg.string({
+        required: false,
+        description: 'Section ID.',
+      }),
+      sortOrder: t.arg.int({
+        required: false,
+        description: 'Sort order.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'issues:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      const data = addIssueItemSchema.parse({
+        pipelineItemId: args.pipelineItemId,
+        issueSectionId: args.issueSectionId ?? undefined,
+        sortOrder: args.sortOrder ?? undefined,
+      });
+      try {
+        return await issueService.addItemWithAudit(
+          toServiceContext(orgCtx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Add a section to an issue. */
+  addIssueSection: t.field({
+    type: IssueSectionType,
+    description: 'Add a section to an issue.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Issue ID.' }),
+      title: t.arg.string({
+        required: true,
+        description: 'Section title.',
+      }),
+      sortOrder: t.arg.int({
+        required: false,
+        description: 'Sort order.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'issues:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      const data = addIssueSectionSchema.parse({
+        title: args.title,
+        sortOrder: args.sortOrder ?? undefined,
+      });
+      return issueService.addSection(orgCtx.dbTx, id, data);
+    },
+  }),
+}));

--- a/apps/api/src/graphql/resolvers/issues.ts
+++ b/apps/api/src/graphql/resolvers/issues.ts
@@ -8,7 +8,7 @@ import {
   idParamSchema,
 } from '@colophony/types';
 import { builder } from '../builder.js';
-import { requireOrgContext, requireScopes } from '../guards.js';
+import { requireOrgContext, requireAdmin, requireScopes } from '../guards.js';
 import { toServiceContext } from '../../services/context.js';
 import {
   issueService,
@@ -168,7 +168,7 @@ builder.mutationFields((t) => ({
       }),
     },
     resolve: async (_root, args, ctx) => {
-      const orgCtx = requireOrgContext(ctx);
+      const orgCtx = requireAdmin(ctx);
       await requireScopes(ctx, 'issues:write');
       const input = createIssueSchema.parse({
         publicationId: args.publicationId,
@@ -201,7 +201,7 @@ builder.mutationFields((t) => ({
       }),
     },
     resolve: async (_root, args, ctx) => {
-      const orgCtx = requireOrgContext(ctx);
+      const orgCtx = requireAdmin(ctx);
       await requireScopes(ctx, 'issues:write');
       const { id } = idParamSchema.parse({ id: args.id });
       const data = updateIssueSchema.parse({
@@ -228,7 +228,7 @@ builder.mutationFields((t) => ({
       id: t.arg.string({ required: true, description: 'Issue ID.' }),
     },
     resolve: async (_root, args, ctx) => {
-      const orgCtx = requireOrgContext(ctx);
+      const orgCtx = requireAdmin(ctx);
       await requireScopes(ctx, 'issues:write');
       const { id } = idParamSchema.parse({ id: args.id });
       try {
@@ -250,7 +250,7 @@ builder.mutationFields((t) => ({
       id: t.arg.string({ required: true, description: 'Issue ID.' }),
     },
     resolve: async (_root, args, ctx) => {
-      const orgCtx = requireOrgContext(ctx);
+      const orgCtx = requireAdmin(ctx);
       await requireScopes(ctx, 'issues:write');
       const { id } = idParamSchema.parse({ id: args.id });
       try {
@@ -284,7 +284,7 @@ builder.mutationFields((t) => ({
       }),
     },
     resolve: async (_root, args, ctx) => {
-      const orgCtx = requireOrgContext(ctx);
+      const orgCtx = requireAdmin(ctx);
       await requireScopes(ctx, 'issues:write');
       const { id } = idParamSchema.parse({ id: args.id });
       const data = addIssueItemSchema.parse({
@@ -320,7 +320,7 @@ builder.mutationFields((t) => ({
       }),
     },
     resolve: async (_root, args, ctx) => {
-      const orgCtx = requireOrgContext(ctx);
+      const orgCtx = requireAdmin(ctx);
       await requireScopes(ctx, 'issues:write');
       const { id } = idParamSchema.parse({ id: args.id });
       const data = addIssueSectionSchema.parse({

--- a/apps/api/src/graphql/resolvers/pipeline.ts
+++ b/apps/api/src/graphql/resolvers/pipeline.ts
@@ -1,0 +1,314 @@
+import type { PipelineItem } from '@colophony/types';
+import {
+  listPipelineItemsSchema,
+  createPipelineItemSchema,
+  updatePipelineStageSchema,
+  assignPipelineRoleSchema,
+  addPipelineCommentSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { builder } from '../builder.js';
+import { requireOrgContext, requireScopes } from '../guards.js';
+import { toServiceContext } from '../../services/context.js';
+import {
+  pipelineService,
+  PipelineItemNotFoundError,
+} from '../../services/pipeline.service.js';
+import { mapServiceError } from '../error-mapper.js';
+import {
+  PipelineItemType,
+  PipelineHistoryEntryType,
+  PipelineCommentType,
+} from '../types/index.js';
+
+// ---------------------------------------------------------------------------
+// Paginated response type
+// ---------------------------------------------------------------------------
+
+const PaginatedPipelineItems = builder
+  .objectRef<{
+    items: PipelineItem[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }>('PaginatedPipelineItems')
+  .implement({
+    fields: (t) => ({
+      items: t.field({
+        type: [PipelineItemType],
+        resolve: (r) => r.items,
+      }),
+      total: t.exposeInt('total'),
+      page: t.exposeInt('page'),
+      limit: t.exposeInt('limit'),
+      totalPages: t.exposeInt('totalPages'),
+    }),
+  });
+
+// ---------------------------------------------------------------------------
+// Query fields
+// ---------------------------------------------------------------------------
+
+builder.queryFields((t) => ({
+  /** List pipeline items in the org. */
+  pipelineItems: t.field({
+    type: PaginatedPipelineItems,
+    description: 'List pipeline items in the organization.',
+    args: {
+      stage: t.arg.string({
+        required: false,
+        description: 'Filter by pipeline stage.',
+      }),
+      publicationId: t.arg.string({
+        required: false,
+        description: 'Filter by publication.',
+      }),
+      assignedCopyeditorId: t.arg.string({
+        required: false,
+        description: 'Filter by assigned copyeditor.',
+      }),
+      assignedProofreaderId: t.arg.string({
+        required: false,
+        description: 'Filter by assigned proofreader.',
+      }),
+      search: t.arg.string({
+        required: false,
+        description: 'Search by submission title.',
+      }),
+      page: t.arg.int({
+        required: false,
+        defaultValue: 1,
+        description: 'Page number (1-based).',
+      }),
+      limit: t.arg.int({
+        required: false,
+        defaultValue: 20,
+        description: 'Items per page (1-100).',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'pipeline:read');
+      const input = listPipelineItemsSchema.parse({
+        stage: args.stage ?? undefined,
+        publicationId: args.publicationId ?? undefined,
+        assignedCopyeditorId: args.assignedCopyeditorId ?? undefined,
+        assignedProofreaderId: args.assignedProofreaderId ?? undefined,
+        search: args.search ?? undefined,
+        page: args.page,
+        limit: args.limit,
+      });
+      return pipelineService.list(orgCtx.dbTx, input);
+    },
+  }),
+
+  /** Get a single pipeline item by ID. */
+  pipelineItem: t.field({
+    type: PipelineItemType,
+    nullable: true,
+    description: 'Get a pipeline item by ID.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Pipeline item ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'pipeline:read');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        const item = await pipelineService.getById(orgCtx.dbTx, id);
+        if (!item) throw new PipelineItemNotFoundError(id);
+        return item;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Get stage transition history for a pipeline item. */
+  pipelineHistory: t.field({
+    type: [PipelineHistoryEntryType],
+    description: 'Get the stage transition history for a pipeline item.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Pipeline item ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'pipeline:read');
+      const { id } = idParamSchema.parse({ id: args.id });
+      return pipelineService.getHistory(orgCtx.dbTx, id);
+    },
+  }),
+
+  /** List comments for a pipeline item. */
+  pipelineComments: t.field({
+    type: [PipelineCommentType],
+    description: 'List all comments for a pipeline item.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Pipeline item ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'pipeline:read');
+      const { id } = idParamSchema.parse({ id: args.id });
+      return pipelineService.listComments(orgCtx.dbTx, id);
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mutation fields
+// ---------------------------------------------------------------------------
+
+builder.mutationFields((t) => ({
+  /** Create a pipeline item from an accepted submission. */
+  createPipelineItem: t.field({
+    type: PipelineItemType,
+    description: 'Move an accepted submission into the publication pipeline.',
+    args: {
+      submissionId: t.arg.string({
+        required: true,
+        description: 'Submission ID.',
+      }),
+      publicationId: t.arg.string({
+        required: false,
+        description: 'Target publication ID.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'pipeline:write');
+      const input = createPipelineItemSchema.parse({
+        submissionId: args.submissionId,
+        publicationId: args.publicationId ?? undefined,
+      });
+      try {
+        return await pipelineService.createWithAudit(
+          toServiceContext(orgCtx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Advance or change the pipeline stage. */
+  updatePipelineStage: t.field({
+    type: PipelineItemType,
+    description: 'Advance or change the pipeline stage for an item.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Pipeline item ID.' }),
+      stage: t.arg.string({
+        required: true,
+        description: 'Target pipeline stage.',
+      }),
+      comment: t.arg.string({
+        required: false,
+        description: 'Optional comment for the transition.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'pipeline:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      const data = updatePipelineStageSchema.parse({
+        stage: args.stage,
+        comment: args.comment ?? undefined,
+      });
+      try {
+        return await pipelineService.updateStageWithAudit(
+          toServiceContext(orgCtx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Assign a copyeditor to a pipeline item. */
+  assignPipelineCopyeditor: t.field({
+    type: PipelineItemType,
+    description: 'Assign a copyeditor to a pipeline item.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Pipeline item ID.' }),
+      userId: t.arg.string({
+        required: true,
+        description: 'User ID to assign.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'pipeline:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      const data = assignPipelineRoleSchema.parse({ userId: args.userId });
+      try {
+        return await pipelineService.assignCopyeditorWithAudit(
+          toServiceContext(orgCtx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Assign a proofreader to a pipeline item. */
+  assignPipelineProofreader: t.field({
+    type: PipelineItemType,
+    description: 'Assign a proofreader to a pipeline item.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Pipeline item ID.' }),
+      userId: t.arg.string({
+        required: true,
+        description: 'User ID to assign.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'pipeline:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      const data = assignPipelineRoleSchema.parse({ userId: args.userId });
+      try {
+        return await pipelineService.assignProofreaderWithAudit(
+          toServiceContext(orgCtx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Add a comment to a pipeline item. */
+  addPipelineComment: t.field({
+    type: PipelineCommentType,
+    description: 'Add a comment to a pipeline item.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Pipeline item ID.' }),
+      content: t.arg.string({
+        required: true,
+        description: 'Comment text.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'pipeline:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      const data = addPipelineCommentSchema.parse({ content: args.content });
+      try {
+        return await pipelineService.addCommentWithAudit(
+          toServiceContext(orgCtx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));

--- a/apps/api/src/graphql/resolvers/publications.ts
+++ b/apps/api/src/graphql/resolvers/publications.ts
@@ -1,0 +1,210 @@
+import type { Publication } from '@colophony/types';
+import {
+  listPublicationsSchema,
+  createPublicationSchema,
+  updatePublicationSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { builder } from '../builder.js';
+import { requireOrgContext, requireScopes } from '../guards.js';
+import { toServiceContext } from '../../services/context.js';
+import {
+  publicationService,
+  PublicationNotFoundError,
+} from '../../services/publication.service.js';
+import { mapServiceError } from '../error-mapper.js';
+import { PublicationType } from '../types/index.js';
+
+// ---------------------------------------------------------------------------
+// Paginated response type
+// ---------------------------------------------------------------------------
+
+const PaginatedPublications = builder
+  .objectRef<{
+    items: Publication[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }>('PaginatedPublications')
+  .implement({
+    fields: (t) => ({
+      items: t.field({
+        type: [PublicationType],
+        resolve: (r) => r.items,
+      }),
+      total: t.exposeInt('total'),
+      page: t.exposeInt('page'),
+      limit: t.exposeInt('limit'),
+      totalPages: t.exposeInt('totalPages'),
+    }),
+  });
+
+// ---------------------------------------------------------------------------
+// Query fields
+// ---------------------------------------------------------------------------
+
+builder.queryFields((t) => ({
+  /** List publications in the org. */
+  publications: t.field({
+    type: PaginatedPublications,
+    description: 'List publications in the organization.',
+    args: {
+      status: t.arg.string({
+        required: false,
+        description: 'Filter by publication status (ACTIVE, ARCHIVED).',
+      }),
+      search: t.arg.string({
+        required: false,
+        description: 'Search by name.',
+      }),
+      page: t.arg.int({
+        required: false,
+        defaultValue: 1,
+        description: 'Page number (1-based).',
+      }),
+      limit: t.arg.int({
+        required: false,
+        defaultValue: 20,
+        description: 'Items per page (1-100).',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'publications:read');
+      const input = listPublicationsSchema.parse({
+        status: args.status ?? undefined,
+        search: args.search ?? undefined,
+        page: args.page,
+        limit: args.limit,
+      });
+      return publicationService.list(orgCtx.dbTx, input);
+    },
+  }),
+
+  /** Get a single publication by ID. */
+  publication: t.field({
+    type: PublicationType,
+    nullable: true,
+    description: 'Get a publication by ID.',
+    args: {
+      id: t.arg.string({
+        required: true,
+        description: 'Publication ID.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'publications:read');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        const publication = await publicationService.getById(orgCtx.dbTx, id);
+        if (!publication) throw new PublicationNotFoundError(id);
+        return publication;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mutation fields
+// ---------------------------------------------------------------------------
+
+builder.mutationFields((t) => ({
+  /** Create a new publication. */
+  createPublication: t.field({
+    type: PublicationType,
+    description:
+      'Create a new publication — a named publishing venue within the organization.',
+    args: {
+      name: t.arg.string({
+        required: true,
+        description: 'Display name for the publication.',
+      }),
+      slug: t.arg.string({
+        required: true,
+        description: 'URL-friendly slug (lowercase alphanumeric + hyphens).',
+      }),
+      description: t.arg.string({
+        required: false,
+        description: 'Description of the publication.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'publications:write');
+      const input = createPublicationSchema.parse({
+        name: args.name,
+        slug: args.slug,
+        description: args.description ?? undefined,
+      });
+      try {
+        return await publicationService.createWithAudit(
+          toServiceContext(orgCtx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Update a publication. */
+  updatePublication: t.field({
+    type: PublicationType,
+    description: 'Update a publication.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Publication ID.' }),
+      name: t.arg.string({ required: false, description: 'New name.' }),
+      slug: t.arg.string({ required: false, description: 'New slug.' }),
+      description: t.arg.string({
+        required: false,
+        description: 'New description.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'publications:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      const data = updatePublicationSchema.parse({
+        name: args.name ?? undefined,
+        slug: args.slug ?? undefined,
+        description:
+          args.description === null ? null : (args.description ?? undefined),
+      });
+      try {
+        return await publicationService.updateWithAudit(
+          toServiceContext(orgCtx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /** Archive a publication. */
+  archivePublication: t.field({
+    type: PublicationType,
+    description: 'Archive a publication.',
+    args: {
+      id: t.arg.string({ required: true, description: 'Publication ID.' }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'publications:write');
+      const { id } = idParamSchema.parse({ id: args.id });
+      try {
+        return await publicationService.archiveWithAudit(
+          toServiceContext(orgCtx),
+          id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));

--- a/apps/api/src/graphql/types/cms-connection.ts
+++ b/apps/api/src/graphql/types/cms-connection.ts
@@ -1,0 +1,55 @@
+import type { CmsConnection } from '@colophony/types';
+import { builder } from '../builder.js';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const CmsAdapterTypeEnum = builder.enumType('CmsAdapterType', {
+  description: 'Type of CMS adapter.',
+  values: {
+    WORDPRESS: { description: 'WordPress REST API v2.' },
+    GHOST: { description: 'Ghost Admin API.' },
+  } as const,
+});
+
+// ---------------------------------------------------------------------------
+// Object type
+// ---------------------------------------------------------------------------
+
+export const CmsConnectionType = builder
+  .objectRef<CmsConnection>('CmsConnection')
+  .implement({
+    description:
+      'A CMS connection — configuration for publishing to an external CMS.',
+    fields: (t) => ({
+      id: t.exposeString('id', { description: 'Unique identifier.' }),
+      organizationId: t.exposeString('organizationId', {
+        description: 'ID of the owning organization.',
+      }),
+      publicationId: t.exposeString('publicationId', {
+        nullable: true,
+        description: 'ID of the associated publication (optional).',
+      }),
+      adapterType: t.exposeString('adapterType', {
+        description: 'CMS adapter type (WORDPRESS or GHOST).',
+      }),
+      name: t.exposeString('name', { description: 'Display name.' }),
+      isActive: t.exposeBoolean('isActive', {
+        description: 'Whether the connection is active.',
+      }),
+      lastSyncAt: t.expose('lastSyncAt', {
+        type: 'DateTime',
+        nullable: true,
+        description: 'When the connection was last used for publishing.',
+      }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the connection was created.',
+      }),
+      updatedAt: t.expose('updatedAt', {
+        type: 'DateTime',
+        description: 'When the connection was last updated.',
+      }),
+    }),
+  });

--- a/apps/api/src/graphql/types/contract.ts
+++ b/apps/api/src/graphql/types/contract.ts
@@ -1,0 +1,104 @@
+import type { ContractTemplate, Contract } from '@colophony/types';
+import { builder } from '../builder.js';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const ContractStatusEnum = builder.enumType('ContractStatus', {
+  description: 'Status of a contract.',
+  values: {
+    DRAFT: { description: 'Draft — not yet sent.' },
+    SENT: { description: 'Sent for signing.' },
+    VIEWED: { description: 'Viewed by the signer.' },
+    SIGNED: { description: 'Signed by the author.' },
+    COUNTERSIGNED: { description: 'Countersigned by the publisher.' },
+    COMPLETED: { description: 'Fully completed.' },
+    VOIDED: { description: 'Voided / cancelled.' },
+  } as const,
+});
+
+// ---------------------------------------------------------------------------
+// Object types
+// ---------------------------------------------------------------------------
+
+export const ContractTemplateType = builder
+  .objectRef<ContractTemplate>('ContractTemplate')
+  .implement({
+    description: 'A contract template with merge field placeholders.',
+    fields: (t) => ({
+      id: t.exposeString('id', { description: 'Template ID.' }),
+      organizationId: t.exposeString('organizationId', {
+        description: 'Organization ID.',
+      }),
+      name: t.exposeString('name', { description: 'Template name.' }),
+      description: t.exposeString('description', {
+        nullable: true,
+        description: 'Template description.',
+      }),
+      body: t.exposeString('body', {
+        description: 'Template body with {{merge_field}} placeholders.',
+      }),
+      isDefault: t.exposeBoolean('isDefault', {
+        description: 'Whether this is the default template.',
+      }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the template was created.',
+      }),
+      updatedAt: t.expose('updatedAt', {
+        type: 'DateTime',
+        description: 'When the template was last updated.',
+      }),
+    }),
+  });
+
+export const ContractType = builder.objectRef<Contract>('Contract').implement({
+  description: 'A generated contract linked to a pipeline item.',
+  fields: (t) => ({
+    id: t.exposeString('id', { description: 'Contract ID.' }),
+    organizationId: t.exposeString('organizationId', {
+      description: 'Organization ID.',
+    }),
+    pipelineItemId: t.exposeString('pipelineItemId', {
+      description: 'Pipeline item ID.',
+    }),
+    contractTemplateId: t.exposeString('contractTemplateId', {
+      nullable: true,
+      description: 'Source template ID.',
+    }),
+    status: t.exposeString('status', {
+      description: 'Contract status.',
+    }),
+    renderedBody: t.exposeString('renderedBody', {
+      description: 'Contract body with merge fields resolved.',
+    }),
+    documensoDocumentId: t.exposeString('documensoDocumentId', {
+      nullable: true,
+      description: 'Documenso document ID.',
+    }),
+    signedAt: t.expose('signedAt', {
+      type: 'DateTime',
+      nullable: true,
+      description: 'When the contract was signed.',
+    }),
+    countersignedAt: t.expose('countersignedAt', {
+      type: 'DateTime',
+      nullable: true,
+      description: 'When the contract was countersigned.',
+    }),
+    completedAt: t.expose('completedAt', {
+      type: 'DateTime',
+      nullable: true,
+      description: 'When the contract was completed.',
+    }),
+    createdAt: t.expose('createdAt', {
+      type: 'DateTime',
+      description: 'When the contract was created.',
+    }),
+    updatedAt: t.expose('updatedAt', {
+      type: 'DateTime',
+      description: 'When the contract was last updated.',
+    }),
+  }),
+});

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -33,6 +33,7 @@ export {
   IssueItemType,
   IssueStatusEnum,
 } from './issue.js';
+export { CmsConnectionType, CmsAdapterTypeEnum } from './cms-connection.js';
 export {
   SubmissionStatusChangePayload,
   CreateOrganizationPayload,

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -17,6 +17,12 @@ export {
 export { SubmissionPeriodType, PeriodStatusEnum } from './period.js';
 export { PublicationType, PublicationStatusEnum } from './publication.js';
 export {
+  PipelineItemType,
+  PipelineHistoryEntryType,
+  PipelineCommentType,
+  PipelineStageEnum,
+} from './pipeline.js';
+export {
   SubmissionStatusChangePayload,
   CreateOrganizationPayload,
   CreateApiKeyPayload,

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -28,6 +28,12 @@ export {
   ContractStatusEnum,
 } from './contract.js';
 export {
+  IssueType,
+  IssueSectionType,
+  IssueItemType,
+  IssueStatusEnum,
+} from './issue.js';
+export {
   SubmissionStatusChangePayload,
   CreateOrganizationPayload,
   CreateApiKeyPayload,

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -23,6 +23,11 @@ export {
   PipelineStageEnum,
 } from './pipeline.js';
 export {
+  ContractTemplateType,
+  ContractType,
+  ContractStatusEnum,
+} from './contract.js';
+export {
   SubmissionStatusChangePayload,
   CreateOrganizationPayload,
   CreateApiKeyPayload,

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -15,6 +15,7 @@ export {
   FormFieldTypeEnum,
 } from './form.js';
 export { SubmissionPeriodType, PeriodStatusEnum } from './period.js';
+export { PublicationType, PublicationStatusEnum } from './publication.js';
 export {
   SubmissionStatusChangePayload,
   CreateOrganizationPayload,

--- a/apps/api/src/graphql/types/issue.ts
+++ b/apps/api/src/graphql/types/issue.ts
@@ -1,0 +1,97 @@
+import type { Issue, IssueSection, IssueItem } from '@colophony/types';
+import { builder } from '../builder.js';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const IssueStatusEnum = builder.enumType('IssueStatus', {
+  description: 'Status of an issue.',
+  values: {
+    PLANNING: { description: 'Being planned.' },
+    ASSEMBLING: { description: 'Content being assembled.' },
+    READY: { description: 'Ready for publication.' },
+    PUBLISHED: { description: 'Published.' },
+    ARCHIVED: { description: 'Archived.' },
+  } as const,
+});
+
+// ---------------------------------------------------------------------------
+// Object types
+// ---------------------------------------------------------------------------
+
+export const IssueType = builder.objectRef<Issue>('Issue').implement({
+  description: 'An issue — a collection of pipeline items for publication.',
+  fields: (t) => ({
+    id: t.exposeString('id', { description: 'Issue ID.' }),
+    organizationId: t.exposeString('organizationId', {
+      description: 'Organization ID.',
+    }),
+    publicationId: t.exposeString('publicationId', {
+      description: 'Publication ID.',
+    }),
+    title: t.exposeString('title', { description: 'Issue title.' }),
+    volume: t.exposeInt('volume', {
+      nullable: true,
+      description: 'Volume number.',
+    }),
+    issueNumber: t.exposeInt('issueNumber', {
+      nullable: true,
+      description: 'Issue number.',
+    }),
+    description: t.exposeString('description', {
+      nullable: true,
+      description: 'Issue description.',
+    }),
+    coverImageUrl: t.exposeString('coverImageUrl', {
+      nullable: true,
+      description: 'Cover image URL.',
+    }),
+    status: t.exposeString('status', { description: 'Issue status.' }),
+    publicationDate: t.expose('publicationDate', {
+      type: 'DateTime',
+      nullable: true,
+      description: 'Scheduled publication date.',
+    }),
+    publishedAt: t.expose('publishedAt', {
+      type: 'DateTime',
+      nullable: true,
+      description: 'Actual publish timestamp.',
+    }),
+    createdAt: t.expose('createdAt', {
+      type: 'DateTime',
+      description: 'When the issue was created.',
+    }),
+    updatedAt: t.expose('updatedAt', {
+      type: 'DateTime',
+      description: 'When the issue was last updated.',
+    }),
+  }),
+});
+
+export const IssueSectionType = builder
+  .objectRef<IssueSection>('IssueSection')
+  .implement({
+    description: 'A section within an issue for grouping items.',
+    fields: (t) => ({
+      id: t.exposeString('id'),
+      issueId: t.exposeString('issueId'),
+      title: t.exposeString('title'),
+      sortOrder: t.exposeInt('sortOrder'),
+      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+    }),
+  });
+
+export const IssueItemType = builder
+  .objectRef<IssueItem>('IssueItem')
+  .implement({
+    description: 'A pipeline item placed in an issue.',
+    fields: (t) => ({
+      id: t.exposeString('id'),
+      issueId: t.exposeString('issueId'),
+      pipelineItemId: t.exposeString('pipelineItemId'),
+      issueSectionId: t.exposeString('issueSectionId', { nullable: true }),
+      sortOrder: t.exposeInt('sortOrder'),
+      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+    }),
+  });

--- a/apps/api/src/graphql/types/pipeline.ts
+++ b/apps/api/src/graphql/types/pipeline.ts
@@ -1,0 +1,114 @@
+import type {
+  PipelineItem,
+  PipelineHistoryEntry,
+  PipelineComment,
+} from '@colophony/types';
+import { builder } from '../builder.js';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const PipelineStageEnum = builder.enumType('PipelineStage', {
+  description: 'Stage in the publication pipeline.',
+  values: {
+    COPYEDIT_PENDING: { description: 'Awaiting copyeditor assignment.' },
+    COPYEDIT_IN_PROGRESS: { description: 'Copyediting in progress.' },
+    AUTHOR_REVIEW: { description: 'Author is reviewing copyedits.' },
+    PROOFREAD: { description: 'Proofreading in progress.' },
+    READY_TO_PUBLISH: { description: 'Ready for publication.' },
+    PUBLISHED: { description: 'Published.' },
+    WITHDRAWN: { description: 'Withdrawn from pipeline.' },
+  } as const,
+});
+
+// ---------------------------------------------------------------------------
+// Object types
+// ---------------------------------------------------------------------------
+
+export const PipelineItemType = builder
+  .objectRef<PipelineItem>('PipelineItem')
+  .implement({
+    description:
+      'A pipeline item — an accepted submission moving through the publication workflow.',
+    fields: (t) => ({
+      id: t.exposeString('id', { description: 'Pipeline item ID.' }),
+      organizationId: t.exposeString('organizationId', {
+        description: 'Organization ID.',
+      }),
+      submissionId: t.exposeString('submissionId', {
+        description: 'Linked submission ID.',
+      }),
+      publicationId: t.exposeString('publicationId', {
+        nullable: true,
+        description: 'Target publication ID.',
+      }),
+      stage: t.exposeString('stage', {
+        description: 'Current pipeline stage.',
+      }),
+      assignedCopyeditorId: t.exposeString('assignedCopyeditorId', {
+        nullable: true,
+        description: 'Assigned copyeditor user ID.',
+      }),
+      assignedProofreaderId: t.exposeString('assignedProofreaderId', {
+        nullable: true,
+        description: 'Assigned proofreader user ID.',
+      }),
+      copyeditDueAt: t.expose('copyeditDueAt', {
+        type: 'DateTime',
+        nullable: true,
+        description: 'Copyedit deadline.',
+      }),
+      proofreadDueAt: t.expose('proofreadDueAt', {
+        type: 'DateTime',
+        nullable: true,
+        description: 'Proofread deadline.',
+      }),
+      authorReviewDueAt: t.expose('authorReviewDueAt', {
+        type: 'DateTime',
+        nullable: true,
+        description: 'Author review deadline.',
+      }),
+      inngestRunId: t.exposeString('inngestRunId', {
+        nullable: true,
+        description: 'Active Inngest workflow run ID.',
+      }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the item entered the pipeline.',
+      }),
+      updatedAt: t.expose('updatedAt', {
+        type: 'DateTime',
+        description: 'When the item was last updated.',
+      }),
+    }),
+  });
+
+export const PipelineHistoryEntryType = builder
+  .objectRef<PipelineHistoryEntry>('PipelineHistoryEntry')
+  .implement({
+    description: 'A stage transition in the pipeline history.',
+    fields: (t) => ({
+      id: t.exposeString('id'),
+      pipelineItemId: t.exposeString('pipelineItemId'),
+      fromStage: t.exposeString('fromStage', { nullable: true }),
+      toStage: t.exposeString('toStage'),
+      changedBy: t.exposeString('changedBy', { nullable: true }),
+      comment: t.exposeString('comment', { nullable: true }),
+      changedAt: t.expose('changedAt', { type: 'DateTime' }),
+    }),
+  });
+
+export const PipelineCommentType = builder
+  .objectRef<PipelineComment>('PipelineComment')
+  .implement({
+    description: 'A comment on a pipeline item.',
+    fields: (t) => ({
+      id: t.exposeString('id'),
+      pipelineItemId: t.exposeString('pipelineItemId'),
+      authorId: t.exposeString('authorId', { nullable: true }),
+      content: t.exposeString('content'),
+      stage: t.exposeString('stage'),
+      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+    }),
+  });

--- a/apps/api/src/graphql/types/publication.ts
+++ b/apps/api/src/graphql/types/publication.ts
@@ -1,0 +1,50 @@
+import type { Publication } from '@colophony/types';
+import { builder } from '../builder.js';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const PublicationStatusEnum = builder.enumType('PublicationStatus', {
+  description: 'Status of a publication.',
+  values: {
+    ACTIVE: { description: 'Publication is active and accepting content.' },
+    ARCHIVED: { description: 'Publication has been archived.' },
+  } as const,
+});
+
+// ---------------------------------------------------------------------------
+// Object type
+// ---------------------------------------------------------------------------
+
+export const PublicationType = builder
+  .objectRef<Publication>('Publication')
+  .implement({
+    description:
+      'A publication — a named publishing venue within an organization.',
+    fields: (t) => ({
+      id: t.exposeString('id', { description: 'Unique identifier.' }),
+      organizationId: t.exposeString('organizationId', {
+        description: 'ID of the owning organization.',
+      }),
+      name: t.exposeString('name', { description: 'Display name.' }),
+      slug: t.exposeString('slug', {
+        description: 'URL-friendly slug (unique per org).',
+      }),
+      description: t.exposeString('description', {
+        nullable: true,
+        description: 'Optional description.',
+      }),
+      status: t.exposeString('status', {
+        description: 'Current status (ACTIVE or ARCHIVED).',
+      }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the publication was created.',
+      }),
+      updatedAt: t.expose('updatedAt', {
+        type: 'DateTime',
+        description: 'When the publication was last updated.',
+      }),
+    }),
+  });

--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -81,6 +81,7 @@ const baseEnv: Env = {
   VIRUS_SCAN_ENABLED: true,
   DEV_AUTH_BYPASS: false,
   FEDERATION_ENABLED: false,
+  INNGEST_DEV: false,
 };
 
 describe('auth plugin', () => {

--- a/apps/api/src/hooks/auth.ts
+++ b/apps/api/src/hooks/auth.ts
@@ -33,6 +33,7 @@ const PUBLIC_PREFIXES = [
   '/webhooks/',
   '/.well-known/',
   '/embed/',
+  '/api/inngest',
 ];
 const PUBLIC_EXACT = [
   '/',

--- a/apps/api/src/hooks/rate-limit-auth.spec.ts
+++ b/apps/api/src/hooks/rate-limit-auth.spec.ts
@@ -87,6 +87,7 @@ const testEnv: Env = {
   VIRUS_SCAN_ENABLED: true,
   DEV_AUTH_BYPASS: false,
   FEDERATION_ENABLED: false,
+  INNGEST_DEV: false,
 };
 
 async function buildApp(

--- a/apps/api/src/hooks/rate-limit.spec.ts
+++ b/apps/api/src/hooks/rate-limit.spec.ts
@@ -86,6 +86,7 @@ const testEnv: Env = {
   VIRUS_SCAN_ENABLED: true,
   DEV_AUTH_BYPASS: false,
   FEDERATION_ENABLED: false,
+  INNGEST_DEV: false,
 };
 
 async function buildApp(

--- a/apps/api/src/inngest/client.ts
+++ b/apps/api/src/inngest/client.ts
@@ -1,0 +1,3 @@
+import { Inngest } from 'inngest';
+
+export const inngest = new Inngest({ id: 'colophony' });

--- a/apps/api/src/inngest/events.ts
+++ b/apps/api/src/inngest/events.ts
@@ -1,0 +1,104 @@
+/**
+ * Typed Inngest event definitions for the Slate publication pipeline.
+ *
+ * Events are dispatched via the transactional outbox (`outbox_events` table)
+ * to ensure they are only sent after the DB transaction commits.
+ */
+
+// ---------------------------------------------------------------------------
+// Event payloads
+// ---------------------------------------------------------------------------
+
+export interface SubmissionAcceptedEvent {
+  name: 'slate/submission.accepted';
+  data: {
+    orgId: string;
+    submissionId: string;
+    publicationId?: string;
+  };
+}
+
+export interface CopyeditorAssignedEvent {
+  name: 'slate/pipeline.copyeditor-assigned';
+  data: {
+    orgId: string;
+    pipelineItemId: string;
+    copyeditorId: string;
+  };
+}
+
+export interface CopyeditCompletedEvent {
+  name: 'slate/pipeline.copyedit-completed';
+  data: {
+    orgId: string;
+    pipelineItemId: string;
+  };
+}
+
+export interface AuthorReviewCompletedEvent {
+  name: 'slate/pipeline.author-review-completed';
+  data: {
+    orgId: string;
+    pipelineItemId: string;
+    approved: boolean;
+  };
+}
+
+export interface ProofreadCompletedEvent {
+  name: 'slate/pipeline.proofread-completed';
+  data: {
+    orgId: string;
+    pipelineItemId: string;
+  };
+}
+
+export interface ContractGeneratedEvent {
+  name: 'slate/contract.generated';
+  data: {
+    orgId: string;
+    contractId: string;
+    pipelineItemId: string;
+  };
+}
+
+export interface ContractSignedEvent {
+  name: 'slate/contract.signed';
+  data: {
+    orgId: string;
+    contractId: string;
+    documensoDocumentId: string;
+  };
+}
+
+export interface ContractCompletedEvent {
+  name: 'slate/contract.completed';
+  data: {
+    orgId: string;
+    contractId: string;
+    documensoDocumentId: string;
+  };
+}
+
+export interface IssuePublishedEvent {
+  name: 'slate/issue.published';
+  data: {
+    orgId: string;
+    issueId: string;
+    publicationId: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Union type for all Slate events
+// ---------------------------------------------------------------------------
+
+export type SlateEvent =
+  | SubmissionAcceptedEvent
+  | CopyeditorAssignedEvent
+  | CopyeditCompletedEvent
+  | AuthorReviewCompletedEvent
+  | ProofreadCompletedEvent
+  | ContractGeneratedEvent
+  | ContractSignedEvent
+  | ContractCompletedEvent
+  | IssuePublishedEvent;

--- a/apps/api/src/inngest/functions/cms-publish.ts
+++ b/apps/api/src/inngest/functions/cms-publish.ts
@@ -1,0 +1,106 @@
+import { inngest } from '../client.js';
+import { withRls, type DrizzleDb } from '@colophony/db';
+import { cmsConnectionService } from '../../services/cms-connection.service.js';
+import { issueService } from '../../services/issue.service.js';
+import { getCmsAdapter } from '../../adapters/cms/index.js';
+import type { CmsIssuePayload } from '../../adapters/cms/cms-adapter.interface.js';
+
+/**
+ * CMS publish workflow — triggered when an issue is published.
+ *
+ * For each active CMS connection linked to the issue's publication,
+ * publishes the issue content via the appropriate CMS adapter.
+ */
+export const cmsPublishWorkflow = inngest.createFunction(
+  {
+    id: 'slate-cms-publish',
+    name: 'Slate: Publish issue to CMS',
+    retries: 3,
+  },
+  { event: 'slate/issue.published' },
+  async ({ event, step }) => {
+    const { orgId, issueId, publicationId } = event.data;
+
+    // Step 1: Load issue, sections, items, and find active CMS connections
+    const { issue, sections, items, connections } = await step.run(
+      'load-issue-and-connections',
+      async () => {
+        return withRls({ orgId }, async (tx: DrizzleDb) => {
+          const issueRow = await issueService.getById(tx, issueId);
+          if (!issueRow) {
+            throw new Error(`Issue ${issueId} not found`);
+          }
+
+          const [sectionRows, itemRows, conns] = await Promise.all([
+            issueService.getSections(tx, issueId),
+            issueService.getItems(tx, issueId),
+            cmsConnectionService.listByPublication(tx, publicationId),
+          ]);
+
+          return {
+            issue: issueRow,
+            sections: sectionRows,
+            items: itemRows,
+            connections: conns,
+          };
+        });
+      },
+    );
+
+    if (connections.length === 0) {
+      return { status: 'skipped', reason: 'No active CMS connections' };
+    }
+
+    // Step 2: Build the CMS payload
+    const sectionMap = new Map(sections.map((s) => [s.id, s.title]));
+    const payload: CmsIssuePayload = {
+      title: issue.title,
+      volume: issue.volume,
+      issueNumber: issue.issueNumber,
+      description: issue.description,
+      coverImageUrl: issue.coverImageUrl,
+      publicationDate: issue.publicationDate
+        ? new Date(issue.publicationDate)
+        : null,
+      items: items.map((item) => ({
+        title: 'Untitled', // pipeline item title resolved at publish time
+        content: '',
+        author: 'Unknown',
+        sortOrder: item.sortOrder,
+        sectionTitle: item.issueSectionId
+          ? (sectionMap.get(item.issueSectionId) ?? null)
+          : null,
+      })),
+    };
+
+    // Step 3: Publish to each CMS connection (one step per connection for retries)
+    const results = [];
+    for (const conn of connections) {
+      const result = await step.run(
+        `publish-to-${conn.adapterType.toLowerCase()}-${conn.id.slice(0, 8)}`,
+        async () => {
+          const adapter = getCmsAdapter(conn.adapterType);
+          const publishResult = await adapter.publishIssue(
+            conn.config as Record<string, unknown>,
+            payload,
+          );
+
+          // Update last sync timestamp
+          await withRls({ orgId }, async (tx: DrizzleDb) => {
+            await cmsConnectionService.updateLastSync(tx, conn.id);
+          });
+
+          return {
+            connectionId: conn.id,
+            adapterType: conn.adapterType,
+            externalId: publishResult.externalId,
+            externalUrl: publishResult.externalUrl,
+          };
+        },
+      );
+      results.push(result);
+    }
+
+    return { status: 'published', results };
+  },
+);

--- a/apps/api/src/inngest/functions/cms-publish.ts
+++ b/apps/api/src/inngest/functions/cms-publish.ts
@@ -1,5 +1,12 @@
 import { inngest } from '../client.js';
-import { withRls, type DrizzleDb } from '@colophony/db';
+import {
+  withRls,
+  pipelineItems,
+  submissions,
+  eq,
+  inArray,
+  type DrizzleDb,
+} from '@colophony/db';
 import { cmsConnectionService } from '../../services/cms-connection.service.js';
 import { issueService } from '../../services/issue.service.js';
 import { getCmsAdapter } from '../../adapters/cms/index.js';
@@ -21,38 +28,66 @@ export const cmsPublishWorkflow = inngest.createFunction(
   async ({ event, step }) => {
     const { orgId, issueId, publicationId } = event.data;
 
-    // Step 1: Load issue, sections, items, and find active CMS connections
-    const { issue, sections, items, connections } = await step.run(
-      'load-issue-and-connections',
-      async () => {
-        return withRls({ orgId }, async (tx: DrizzleDb) => {
-          const issueRow = await issueService.getById(tx, issueId);
-          if (!issueRow) {
-            throw new Error(`Issue ${issueId} not found`);
-          }
+    // Step 1: Load issue, sections, items with submission data, and CMS connections
+    const data = await step.run('load-issue-and-connections', async () => {
+      return withRls({ orgId }, async (tx: DrizzleDb) => {
+        const issueRow = await issueService.getById(tx, issueId);
+        if (!issueRow) {
+          throw new Error(`Issue ${issueId} not found`);
+        }
 
-          const [sectionRows, itemRows, conns] = await Promise.all([
-            issueService.getSections(tx, issueId),
-            issueService.getItems(tx, issueId),
-            cmsConnectionService.listByPublication(tx, publicationId),
-          ]);
+        const [sectionRows, itemRows, conns] = await Promise.all([
+          issueService.getSections(tx, issueId),
+          issueService.getItems(tx, issueId),
+          cmsConnectionService.listByPublication(tx, publicationId),
+        ]);
 
-          return {
-            issue: issueRow,
-            sections: sectionRows,
-            items: itemRows,
-            connections: conns,
-          };
-        });
-      },
-    );
+        // Load submission data for each issue item via pipeline_items → submissions
+        const pipelineItemIds = itemRows.map((item) => item.pipelineItemId);
+        const pieceData =
+          pipelineItemIds.length > 0
+            ? await tx
+                .select({
+                  pipelineItemId: pipelineItems.id,
+                  title: submissions.title,
+                  content: submissions.content,
+                })
+                .from(pipelineItems)
+                .innerJoin(
+                  submissions,
+                  eq(pipelineItems.submissionId, submissions.id),
+                )
+                .where(inArray(pipelineItems.id, pipelineItemIds))
+            : [];
+
+        return {
+          issue: issueRow,
+          sections: sectionRows,
+          items: itemRows,
+          pieceData,
+          connections: conns,
+        };
+      });
+    });
+
+    const { issue, sections, items, pieceData, connections } = data;
 
     if (connections.length === 0) {
       return { status: 'skipped', reason: 'No active CMS connections' };
     }
 
-    // Step 2: Build the CMS payload
+    // Step 2: Build the CMS payload with actual submission data
     const sectionMap = new Map(sections.map((s) => [s.id, s.title]));
+    const pieceMap = new Map(
+      pieceData.map((p) => [
+        p.pipelineItemId,
+        {
+          title: p.title ?? 'Untitled',
+          content: p.content ?? '',
+        },
+      ]),
+    );
+
     const payload: CmsIssuePayload = {
       title: issue.title,
       volume: issue.volume,
@@ -62,15 +97,21 @@ export const cmsPublishWorkflow = inngest.createFunction(
       publicationDate: issue.publicationDate
         ? new Date(issue.publicationDate)
         : null,
-      items: items.map((item) => ({
-        title: 'Untitled', // pipeline item title resolved at publish time
-        content: '',
-        author: 'Unknown',
-        sortOrder: item.sortOrder,
-        sectionTitle: item.issueSectionId
-          ? (sectionMap.get(item.issueSectionId) ?? null)
-          : null,
-      })),
+      items: items.map((item) => {
+        const piece = pieceMap.get(item.pipelineItemId) ?? {
+          title: 'Untitled',
+          content: '',
+        };
+        return {
+          title: piece.title,
+          content: piece.content,
+          author: null,
+          sortOrder: item.sortOrder,
+          sectionTitle: item.issueSectionId
+            ? (sectionMap.get(item.issueSectionId) ?? null)
+            : null,
+        };
+      }),
     };
 
     // Step 3: Publish to each CMS connection (one step per connection for retries)

--- a/apps/api/src/inngest/functions/contract-workflow.ts
+++ b/apps/api/src/inngest/functions/contract-workflow.ts
@@ -1,0 +1,89 @@
+import { withRls } from '@colophony/db';
+import { inngest } from '../client.js';
+import type { ContractGeneratedEvent } from '../events.js';
+import { contractService } from '../../services/contract.service.js';
+import { createDocumensoAdapter } from '../../adapters/documenso.adapter.js';
+import { validateEnv } from '../../config/env.js';
+
+/**
+ * Contract workflow — triggered when a contract is generated.
+ *
+ * Sends the contract to Documenso for e-signing, then waits for
+ * signature events (from Documenso webhooks → Inngest events).
+ *
+ *   DRAFT → SENT → SIGNED → COMPLETED
+ */
+export const contractWorkflow = inngest.createFunction(
+  {
+    id: 'contract-workflow',
+    name: 'Contract Signing Workflow',
+    retries: 3,
+  },
+  { event: 'slate/contract.generated' },
+  async ({ event, step }) => {
+    const { orgId, contractId, pipelineItemId } =
+      event.data as ContractGeneratedEvent['data'];
+
+    // Step 1: Send contract to Documenso
+    const documensoDocumentId = await step.run(
+      'send-to-documenso',
+      async () => {
+        const env = validateEnv();
+        const adapter = createDocumensoAdapter(env);
+        if (!adapter) {
+          throw new Error(
+            'Documenso adapter not configured — cannot send contract',
+          );
+        }
+
+        const contract = await withRls({ orgId }, async (tx) => {
+          return contractService.getById(tx, contractId);
+        });
+
+        if (!contract) {
+          throw new Error(`Contract "${contractId}" not found`);
+        }
+
+        // Create document in Documenso
+        const docId = await adapter.createDocument({
+          title: `Contract — ${contractId}`,
+          body: contract.renderedBody,
+          signers: [], // Signers will be configured via Documenso UI or API
+          metadata: {
+            colophonyContractId: contractId,
+            colophonyPipelineItemId: pipelineItemId,
+            colophonyOrgId: orgId,
+          },
+        });
+
+        // Update contract with Documenso document ID and status
+        await withRls({ orgId }, async (tx) => {
+          await contractService.updateDocumensoId(tx, contractId, docId);
+          await contractService.updateStatus(tx, contractId, 'SENT');
+        });
+
+        return docId;
+      },
+    );
+
+    // Step 2: Wait for contract to be signed
+    await step.waitForEvent('wait-for-signed', {
+      event: 'slate/contract.signed',
+      match: 'data.contractId',
+      timeout: '90d',
+    });
+
+    // Step 3: Wait for contract to be completed (countersigned/finalized)
+    await step.waitForEvent('wait-for-completed', {
+      event: 'slate/contract.completed',
+      match: 'data.contractId',
+      timeout: '90d',
+    });
+
+    return {
+      status: 'completed',
+      contractId,
+      documensoDocumentId,
+    };
+  },
+);

--- a/apps/api/src/inngest/functions/index.ts
+++ b/apps/api/src/inngest/functions/index.ts
@@ -1,0 +1,1 @@
+export { pipelineWorkflow } from './pipeline-workflow.js';

--- a/apps/api/src/inngest/functions/index.ts
+++ b/apps/api/src/inngest/functions/index.ts
@@ -1,2 +1,3 @@
 export { pipelineWorkflow } from './pipeline-workflow.js';
 export { contractWorkflow } from './contract-workflow.js';
+export { cmsPublishWorkflow } from './cms-publish.js';

--- a/apps/api/src/inngest/functions/index.ts
+++ b/apps/api/src/inngest/functions/index.ts
@@ -1,1 +1,2 @@
 export { pipelineWorkflow } from './pipeline-workflow.js';
+export { contractWorkflow } from './contract-workflow.js';

--- a/apps/api/src/inngest/functions/pipeline-workflow.ts
+++ b/apps/api/src/inngest/functions/pipeline-workflow.ts
@@ -1,0 +1,117 @@
+import { withRls } from '@colophony/db';
+import { inngest } from '../client.js';
+import type { SubmissionAcceptedEvent } from '../events.js';
+import { pipelineService } from '../../services/pipeline.service.js';
+
+/**
+ * Pipeline workflow — triggered when a submission is accepted.
+ *
+ * Creates a pipeline item at COPYEDIT_PENDING and then waits for external
+ * events to drive the item through the publication pipeline stages:
+ *
+ *   COPYEDIT_PENDING → COPYEDIT_IN_PROGRESS → AUTHOR_REVIEW
+ *     → PROOFREAD → READY_TO_PUBLISH
+ *
+ * Each stage transition is triggered by a `waitForEvent` that listens for
+ * the corresponding Inngest event dispatched by the API when a user performs
+ * an action (e.g., assigns a copyeditor, marks copyedit complete).
+ */
+export const pipelineWorkflow = inngest.createFunction(
+  {
+    id: 'pipeline-workflow',
+    name: 'Publication Pipeline Workflow',
+    retries: 3,
+  },
+  { event: 'slate/submission.accepted' },
+  async ({ event, step }) => {
+    const { orgId, submissionId, publicationId } =
+      event.data as SubmissionAcceptedEvent['data'];
+
+    // Step 1: Create pipeline item (COPYEDIT_PENDING)
+    const pipelineItem = await step.run('create-pipeline-item', async () => {
+      return withRls({ orgId }, async (tx) => {
+        return pipelineService.create(
+          tx,
+          {
+            submissionId,
+            publicationId,
+          },
+          orgId,
+        );
+      });
+    });
+
+    // Step 2: Wait for copyeditor to be assigned → COPYEDIT_IN_PROGRESS
+    await step.waitForEvent('wait-copyeditor-assigned', {
+      event: 'slate/pipeline.copyeditor-assigned',
+      match: 'data.pipelineItemId',
+      timeout: '30d',
+    });
+
+    // Step 3: Wait for copyedit to be completed
+    await step.waitForEvent('wait-copyedit-completed', {
+      event: 'slate/pipeline.copyedit-completed',
+      match: 'data.pipelineItemId',
+      timeout: '30d',
+    });
+
+    // Step 4: Advance to AUTHOR_REVIEW
+    await step.run('advance-to-author-review', async () => {
+      return withRls({ orgId }, async (tx) => {
+        return pipelineService.updateStage(
+          tx,
+          pipelineItem.id,
+          { stage: 'AUTHOR_REVIEW' },
+          orgId,
+        );
+      });
+    });
+
+    // Step 5: Wait for author review response
+    const authorReview = await step.waitForEvent('wait-author-review', {
+      event: 'slate/pipeline.author-review-completed',
+      match: 'data.pipelineItemId',
+      timeout: '30d',
+    });
+
+    // If author rejected, loop back would need a recursive approach.
+    // For v1, we advance to PROOFREAD if approved.
+    if (!authorReview || !authorReview.data.approved) {
+      // Author rejected — stay at AUTHOR_REVIEW for manual intervention
+      return { status: 'author-rejected', pipelineItemId: pipelineItem.id };
+    }
+
+    // Step 6: Advance to PROOFREAD
+    await step.run('advance-to-proofread', async () => {
+      return withRls({ orgId }, async (tx) => {
+        return pipelineService.updateStage(
+          tx,
+          pipelineItem.id,
+          { stage: 'PROOFREAD' },
+          orgId,
+        );
+      });
+    });
+
+    // Step 7: Wait for proofread to be completed
+    await step.waitForEvent('wait-proofread-completed', {
+      event: 'slate/pipeline.proofread-completed',
+      match: 'data.pipelineItemId',
+      timeout: '30d',
+    });
+
+    // Step 8: Mark READY_TO_PUBLISH
+    await step.run('advance-to-ready', async () => {
+      return withRls({ orgId }, async (tx) => {
+        return pipelineService.updateStage(
+          tx,
+          pipelineItem.id,
+          { stage: 'READY_TO_PUBLISH' },
+          orgId,
+        );
+      });
+    });
+
+    return { status: 'ready-to-publish', pipelineItemId: pipelineItem.id };
+  },
+);

--- a/apps/api/src/inngest/functions/pipeline-workflow.ts
+++ b/apps/api/src/inngest/functions/pipeline-workflow.ts
@@ -41,77 +41,90 @@ export const pipelineWorkflow = inngest.createFunction(
       });
     });
 
-    // Step 2: Wait for copyeditor to be assigned → COPYEDIT_IN_PROGRESS
+    const pipelineItemId = pipelineItem.id;
+
+    // Step 2: Wait for copyeditor to be assigned
     await step.waitForEvent('wait-copyeditor-assigned', {
       event: 'slate/pipeline.copyeditor-assigned',
-      match: 'data.pipelineItemId',
+      if: `async.data.pipelineItemId == '${pipelineItemId}'`,
       timeout: '30d',
     });
 
-    // Step 3: Wait for copyedit to be completed
+    // Step 3: Advance to COPYEDIT_IN_PROGRESS
+    await step.run('advance-to-copyedit-in-progress', async () => {
+      return withRls({ orgId }, async (tx) => {
+        return pipelineService.updateStage(
+          tx,
+          pipelineItemId,
+          { stage: 'COPYEDIT_IN_PROGRESS' },
+          orgId,
+        );
+      });
+    });
+
+    // Step 4: Wait for copyedit to be completed
     await step.waitForEvent('wait-copyedit-completed', {
       event: 'slate/pipeline.copyedit-completed',
-      match: 'data.pipelineItemId',
+      if: `async.data.pipelineItemId == '${pipelineItemId}'`,
       timeout: '30d',
     });
 
-    // Step 4: Advance to AUTHOR_REVIEW
+    // Step 5: Advance to AUTHOR_REVIEW
     await step.run('advance-to-author-review', async () => {
       return withRls({ orgId }, async (tx) => {
         return pipelineService.updateStage(
           tx,
-          pipelineItem.id,
+          pipelineItemId,
           { stage: 'AUTHOR_REVIEW' },
           orgId,
         );
       });
     });
 
-    // Step 5: Wait for author review response
+    // Step 6: Wait for author review response
     const authorReview = await step.waitForEvent('wait-author-review', {
       event: 'slate/pipeline.author-review-completed',
-      match: 'data.pipelineItemId',
+      if: `async.data.pipelineItemId == '${pipelineItemId}'`,
       timeout: '30d',
     });
 
-    // If author rejected, loop back would need a recursive approach.
-    // For v1, we advance to PROOFREAD if approved.
+    // If author rejected, stay at AUTHOR_REVIEW for manual intervention.
+    // A future version could loop back to COPYEDIT_IN_PROGRESS.
     if (!authorReview || !authorReview.data.approved) {
-      // Author rejected — stay at AUTHOR_REVIEW for manual intervention
-      return { status: 'author-rejected', pipelineItemId: pipelineItem.id };
+      return { status: 'author-rejected', pipelineItemId };
     }
 
-    // Step 6: Advance to PROOFREAD
+    // Step 7: Advance to PROOFREAD
     await step.run('advance-to-proofread', async () => {
       return withRls({ orgId }, async (tx) => {
         return pipelineService.updateStage(
           tx,
-          pipelineItem.id,
+          pipelineItemId,
           { stage: 'PROOFREAD' },
           orgId,
         );
       });
     });
 
-    // Step 7: Wait for proofread to be completed
+    // Step 8: Wait for proofread to be completed
     await step.waitForEvent('wait-proofread-completed', {
       event: 'slate/pipeline.proofread-completed',
-      match: 'data.pipelineItemId',
+      if: `async.data.pipelineItemId == '${pipelineItemId}'`,
       timeout: '30d',
     });
 
-    // Step 8: Mark READY_TO_PUBLISH
+    // Step 9: Mark READY_TO_PUBLISH
     await step.run('advance-to-ready', async () => {
       return withRls({ orgId }, async (tx) => {
         return pipelineService.updateStage(
           tx,
-          pipelineItem.id,
+          pipelineItemId,
           { stage: 'READY_TO_PUBLISH' },
           orgId,
         );
       });
     });
 
-    return { status: 'ready-to-publish', pipelineItemId: pipelineItem.id };
+    return { status: 'ready-to-publish', pipelineItemId };
   },
 );

--- a/apps/api/src/inngest/serve.ts
+++ b/apps/api/src/inngest/serve.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { serve } from 'inngest/fastify';
 import { inngest } from './client.js';
-import { pipelineWorkflow } from './functions/index.js';
+import { pipelineWorkflow, contractWorkflow } from './functions/index.js';
 
 /**
  * Register the Inngest serve endpoint at `POST /api/inngest`.
@@ -15,7 +15,7 @@ export async function registerInngestRoutes(
 ): Promise<void> {
   const handler = serve({
     client: inngest,
-    functions: [pipelineWorkflow],
+    functions: [pipelineWorkflow, contractWorkflow],
   });
 
   app.route({

--- a/apps/api/src/inngest/serve.ts
+++ b/apps/api/src/inngest/serve.ts
@@ -1,7 +1,11 @@
 import type { FastifyInstance } from 'fastify';
 import { serve } from 'inngest/fastify';
 import { inngest } from './client.js';
-import { pipelineWorkflow, contractWorkflow } from './functions/index.js';
+import {
+  pipelineWorkflow,
+  contractWorkflow,
+  cmsPublishWorkflow,
+} from './functions/index.js';
 
 /**
  * Register the Inngest serve endpoint at `POST /api/inngest`.
@@ -15,7 +19,7 @@ export async function registerInngestRoutes(
 ): Promise<void> {
   const handler = serve({
     client: inngest,
-    functions: [pipelineWorkflow, contractWorkflow],
+    functions: [pipelineWorkflow, contractWorkflow, cmsPublishWorkflow],
   });
 
   app.route({

--- a/apps/api/src/inngest/serve.ts
+++ b/apps/api/src/inngest/serve.ts
@@ -1,0 +1,26 @@
+import type { FastifyInstance } from 'fastify';
+import { serve } from 'inngest/fastify';
+import { inngest } from './client.js';
+import { pipelineWorkflow } from './functions/index.js';
+
+/**
+ * Register the Inngest serve endpoint at `POST /api/inngest`.
+ *
+ * This endpoint is called by the Inngest dev server (or cloud) to discover
+ * and invoke registered functions. It must be accessible from the Inngest
+ * container (see Docker Compose `inngest` service).
+ */
+export async function registerInngestRoutes(
+  app: FastifyInstance,
+): Promise<void> {
+  const handler = serve({
+    client: inngest,
+    functions: [pipelineWorkflow],
+  });
+
+  app.route({
+    method: ['GET', 'POST', 'PUT'],
+    url: '/api/inngest',
+    handler,
+  });
+}

--- a/apps/api/src/main.spec.ts
+++ b/apps/api/src/main.spec.ts
@@ -89,6 +89,7 @@ const testEnv: Env = {
   VIRUS_SCAN_ENABLED: true,
   DEV_AUTH_BYPASS: false,
   FEDERATION_ENABLED: false,
+  INNGEST_DEV: false,
 };
 
 describe('Fastify app', () => {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -23,8 +23,16 @@ import {
   stopFileScanWorker,
   startS3CleanupWorker,
   stopS3CleanupWorker,
+  startOutboxPollerWorker,
+  stopOutboxPollerWorker,
 } from './workers/index.js';
-import { closeFileScanQueue, closeS3CleanupQueue } from './queues/index.js';
+import {
+  closeFileScanQueue,
+  closeS3CleanupQueue,
+  startOutboxPoller,
+  closeOutboxPollerQueue,
+} from './queues/index.js';
+import { registerInngestRoutes } from './inngest/serve.js';
 
 export async function buildApp(env: Env): Promise<FastifyInstance> {
   const app = Fastify({
@@ -138,6 +146,11 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
     await registerEmbedRoutes(scope, { env });
   });
 
+  // Inngest serve endpoint — isolated scope (Inngest handles its own auth)
+  await app.register(async (scope) => {
+    await registerInngestRoutes(scope);
+  });
+
   // tRPC adapter
   await app.register(fastifyTRPCPlugin, {
     prefix: '/trpc',
@@ -213,6 +226,11 @@ async function start(): Promise<void> {
   startS3CleanupWorker(env);
   app.log.info('S3 cleanup worker started');
 
+  // Start outbox poller for Inngest event delivery
+  startOutboxPollerWorker(env);
+  await startOutboxPoller(env);
+  app.log.info('Outbox poller worker started');
+
   // Graceful shutdown
   const shutdown = async (signal: string) => {
     app.log.info(`Received ${signal}, shutting down gracefully...`);
@@ -228,6 +246,8 @@ async function start(): Promise<void> {
       await stopS3CleanupWorker();
       await closeFileScanQueue();
       await closeS3CleanupQueue();
+      await stopOutboxPollerWorker();
+      await closeOutboxPollerQueue();
       // TODO: Close DB pool when connection management is centralized
       // TODO: Close Redis connections
       app.log.info('Server closed');

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -12,6 +12,7 @@ import auditPlugin from './hooks/audit.js';
 import { registerZitadelWebhooks } from './webhooks/zitadel.webhook.js';
 import { registerTusdWebhooks } from './webhooks/tusd.webhook.js';
 import { registerStripeWebhooks } from './webhooks/stripe.webhook.js';
+import { registerDocumensoWebhooks } from './webhooks/documenso.webhook.js';
 import { registerEmbedRoutes } from './routes/embed.routes.js';
 import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
 import { appRouter } from './trpc/router.js';
@@ -139,6 +140,10 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
   });
   await app.register(async (scope) => {
     await registerStripeWebhooks(scope, { env });
+  });
+
+  await app.register(async (scope) => {
+    await registerDocumensoWebhooks(scope, { env });
   });
 
   // Embed routes — isolated scope (own auth via token verification)

--- a/apps/api/src/queues/index.ts
+++ b/apps/api/src/queues/index.ts
@@ -9,3 +9,8 @@ export {
   closeS3CleanupQueue,
   type S3CleanupJobData,
 } from './s3-cleanup.queue.js';
+
+export {
+  startOutboxPoller,
+  closeOutboxPollerQueue,
+} from './outbox-poller.queue.js';

--- a/apps/api/src/queues/outbox-poller.queue.ts
+++ b/apps/api/src/queues/outbox-poller.queue.ts
@@ -1,0 +1,48 @@
+import { Queue } from 'bullmq';
+import type { Env } from '../config/env.js';
+
+export interface OutboxPollerJobData {
+  /** Placeholder — the poller reads directly from the outbox_events table. */
+  trigger: 'scheduled';
+}
+
+let queue: Queue<OutboxPollerJobData> | null = null;
+
+function getQueue(env: Env): Queue<OutboxPollerJobData> {
+  if (!queue) {
+    queue = new Queue<OutboxPollerJobData>('outbox-poller', {
+      connection: {
+        host: env.REDIS_HOST,
+        port: env.REDIS_PORT,
+        password: env.REDIS_PASSWORD || undefined,
+      },
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 5_000 },
+        removeOnComplete: { age: 3_600 }, // 1 hour
+        removeOnFail: { age: 86_400 }, // 24 hours
+      },
+    });
+  }
+  return queue;
+}
+
+/**
+ * Start the repeatable outbox poller job.
+ * Runs every 5 seconds to check for unprocessed outbox events.
+ */
+export async function startOutboxPoller(env: Env): Promise<void> {
+  const q = getQueue(env);
+  await q.upsertJobScheduler(
+    'outbox-poll',
+    { every: 5_000 },
+    { data: { trigger: 'scheduled' } },
+  );
+}
+
+export async function closeOutboxPollerQueue(): Promise<void> {
+  if (queue) {
+    await queue.close();
+    queue = null;
+  }
+}

--- a/apps/api/src/rest/error-mapper.ts
+++ b/apps/api/src/rest/error-mapper.ts
@@ -43,6 +43,8 @@ import {
   PipelineItemAlreadyExistsError,
   InvalidPipelineTransitionError,
 } from '../services/pipeline.service.js';
+import { ContractTemplateNotFoundError } from '../services/contract-template.service.js';
+import { ContractNotFoundError } from '../services/contract.service.js';
 
 type ORPCErrorCode = ConstructorParameters<typeof ORPCError>[0];
 
@@ -85,6 +87,9 @@ const errorCodeMap: [new (...args: never[]) => Error, ORPCErrorCode][] = [
   [PipelineItemNotFoundError, 'NOT_FOUND'],
   [PipelineItemAlreadyExistsError, 'CONFLICT'],
   [InvalidPipelineTransitionError, 'BAD_REQUEST'],
+  // Contract errors
+  [ContractTemplateNotFoundError, 'NOT_FOUND'],
+  [ContractNotFoundError, 'NOT_FOUND'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/rest/error-mapper.ts
+++ b/apps/api/src/rest/error-mapper.ts
@@ -42,9 +42,14 @@ import {
   PipelineItemNotFoundError,
   PipelineItemAlreadyExistsError,
   InvalidPipelineTransitionError,
+  SubmissionNotAcceptedError,
 } from '../services/pipeline.service.js';
 import { ContractTemplateNotFoundError } from '../services/contract-template.service.js';
 import { ContractNotFoundError } from '../services/contract.service.js';
+import {
+  IssueNotFoundError,
+  IssueItemAlreadyExistsError,
+} from '../services/issue.service.js';
 
 type ORPCErrorCode = ConstructorParameters<typeof ORPCError>[0];
 
@@ -87,9 +92,13 @@ const errorCodeMap: [new (...args: never[]) => Error, ORPCErrorCode][] = [
   [PipelineItemNotFoundError, 'NOT_FOUND'],
   [PipelineItemAlreadyExistsError, 'CONFLICT'],
   [InvalidPipelineTransitionError, 'BAD_REQUEST'],
+  [SubmissionNotAcceptedError, 'BAD_REQUEST'],
   // Contract errors
   [ContractTemplateNotFoundError, 'NOT_FOUND'],
   [ContractNotFoundError, 'NOT_FOUND'],
+  // Issue errors
+  [IssueNotFoundError, 'NOT_FOUND'],
+  [IssueItemAlreadyExistsError, 'CONFLICT'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/rest/error-mapper.ts
+++ b/apps/api/src/rest/error-mapper.ts
@@ -50,6 +50,7 @@ import {
   IssueNotFoundError,
   IssueItemAlreadyExistsError,
 } from '../services/issue.service.js';
+import { CmsConnectionNotFoundError } from '../services/cms-connection.service.js';
 
 type ORPCErrorCode = ConstructorParameters<typeof ORPCError>[0];
 
@@ -99,6 +100,8 @@ const errorCodeMap: [new (...args: never[]) => Error, ORPCErrorCode][] = [
   // Issue errors
   [IssueNotFoundError, 'NOT_FOUND'],
   [IssueItemAlreadyExistsError, 'CONFLICT'],
+  // CMS errors
+  [CmsConnectionNotFoundError, 'NOT_FOUND'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/rest/error-mapper.ts
+++ b/apps/api/src/rest/error-mapper.ts
@@ -38,6 +38,11 @@ import {
   PublicationNotFoundError,
   PublicationSlugConflictError,
 } from '../services/publication.service.js';
+import {
+  PipelineItemNotFoundError,
+  PipelineItemAlreadyExistsError,
+  InvalidPipelineTransitionError,
+} from '../services/pipeline.service.js';
 
 type ORPCErrorCode = ConstructorParameters<typeof ORPCError>[0];
 
@@ -76,6 +81,10 @@ const errorCodeMap: [new (...args: never[]) => Error, ORPCErrorCode][] = [
   // Publication errors
   [PublicationNotFoundError, 'NOT_FOUND'],
   [PublicationSlugConflictError, 'CONFLICT'],
+  // Pipeline errors
+  [PipelineItemNotFoundError, 'NOT_FOUND'],
+  [PipelineItemAlreadyExistsError, 'CONFLICT'],
+  [InvalidPipelineTransitionError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/rest/error-mapper.ts
+++ b/apps/api/src/rest/error-mapper.ts
@@ -34,6 +34,10 @@ import {
   ManuscriptNotFoundError,
   ManuscriptVersionNotFoundError,
 } from '../services/manuscript.service.js';
+import {
+  PublicationNotFoundError,
+  PublicationSlugConflictError,
+} from '../services/publication.service.js';
 
 type ORPCErrorCode = ConstructorParameters<typeof ORPCError>[0];
 
@@ -69,6 +73,9 @@ const errorCodeMap: [new (...args: never[]) => Error, ORPCErrorCode][] = [
   // Period errors
   [PeriodNotFoundError, 'NOT_FOUND'],
   [PeriodHasSubmissionsError, 'BAD_REQUEST'],
+  // Publication errors
+  [PublicationNotFoundError, 'NOT_FOUND'],
+  [PublicationSlugConflictError, 'CONFLICT'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/rest/router.ts
+++ b/apps/api/src/rest/router.ts
@@ -15,6 +15,7 @@ import { publicationsRouter } from './routers/publications.js';
 import { pipelineRouter } from './routers/pipeline.js';
 import { contractTemplatesRouter } from './routers/contract-templates.js';
 import { contractsRouter } from './routers/contracts.js';
+import { issuesRouter } from './routers/issues.js';
 import type { RestContext } from './context.js';
 
 const restRouter = {
@@ -31,6 +32,7 @@ const restRouter = {
   pipeline: pipelineRouter,
   contractTemplates: contractTemplatesRouter,
   contracts: contractsRouter,
+  issues: issuesRouter,
 };
 
 const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
@@ -120,6 +122,11 @@ const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
             name: 'Contracts',
             description:
               'Generate, send, and manage contracts for pipeline items (Slate).',
+          },
+          {
+            name: 'Issues',
+            description:
+              'Assemble and manage publication issues — collections of pipeline items (Slate).',
           },
           {
             name: 'Audit',

--- a/apps/api/src/rest/router.ts
+++ b/apps/api/src/rest/router.ts
@@ -16,6 +16,7 @@ import { pipelineRouter } from './routers/pipeline.js';
 import { contractTemplatesRouter } from './routers/contract-templates.js';
 import { contractsRouter } from './routers/contracts.js';
 import { issuesRouter } from './routers/issues.js';
+import { cmsConnectionsRouter } from './routers/cms-connections.js';
 import type { RestContext } from './context.js';
 
 const restRouter = {
@@ -33,6 +34,7 @@ const restRouter = {
   contractTemplates: contractTemplatesRouter,
   contracts: contractsRouter,
   issues: issuesRouter,
+  cmsConnections: cmsConnectionsRouter,
 };
 
 const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
@@ -127,6 +129,11 @@ const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
             name: 'Issues',
             description:
               'Assemble and manage publication issues — collections of pipeline items (Slate).',
+          },
+          {
+            name: 'CMS Connections',
+            description:
+              'Manage CMS connections for publishing issues to WordPress or Ghost (Slate).',
           },
           {
             name: 'Audit',

--- a/apps/api/src/rest/router.ts
+++ b/apps/api/src/rest/router.ts
@@ -12,6 +12,7 @@ import { formsRouter } from './routers/forms.js';
 import { periodsRouter } from './routers/periods.js';
 import { manuscriptsRouter } from './routers/manuscripts.js';
 import { publicationsRouter } from './routers/publications.js';
+import { pipelineRouter } from './routers/pipeline.js';
 import type { RestContext } from './context.js';
 
 const restRouter = {
@@ -25,6 +26,7 @@ const restRouter = {
   periods: periodsRouter,
   audit: auditRouter,
   publications: publicationsRouter,
+  pipeline: pipelineRouter,
 };
 
 const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
@@ -101,14 +103,14 @@ const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
               'Manage publications — named publishing venues within an organization (Slate pipeline).',
           },
           {
+            name: 'Pipeline',
+            description:
+              'Manage the post-acceptance publication pipeline — copyedit, proofread, and publish workflow (Slate).',
+          },
+          {
             name: 'Audit',
             description:
               'Query the audit log for security and compliance. Admin-only.',
-          },
-          {
-            name: 'Publications',
-            description:
-              'Manage publications — named publishing venues within an organization.',
           },
         ],
         externalDocs: {

--- a/apps/api/src/rest/router.ts
+++ b/apps/api/src/rest/router.ts
@@ -11,6 +11,7 @@ import { auditRouter } from './routers/audit.js';
 import { formsRouter } from './routers/forms.js';
 import { periodsRouter } from './routers/periods.js';
 import { manuscriptsRouter } from './routers/manuscripts.js';
+import { publicationsRouter } from './routers/publications.js';
 import type { RestContext } from './context.js';
 
 const restRouter = {
@@ -23,6 +24,7 @@ const restRouter = {
   forms: formsRouter,
   periods: periodsRouter,
   audit: auditRouter,
+  publications: publicationsRouter,
 };
 
 const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
@@ -94,9 +96,19 @@ const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
               'Manage submission periods — time windows during which submissions are accepted.',
           },
           {
+            name: 'Publications',
+            description:
+              'Manage publications — named publishing venues within an organization (Slate pipeline).',
+          },
+          {
             name: 'Audit',
             description:
               'Query the audit log for security and compliance. Admin-only.',
+          },
+          {
+            name: 'Publications',
+            description:
+              'Manage publications — named publishing venues within an organization.',
           },
         ],
         externalDocs: {

--- a/apps/api/src/rest/router.ts
+++ b/apps/api/src/rest/router.ts
@@ -13,6 +13,8 @@ import { periodsRouter } from './routers/periods.js';
 import { manuscriptsRouter } from './routers/manuscripts.js';
 import { publicationsRouter } from './routers/publications.js';
 import { pipelineRouter } from './routers/pipeline.js';
+import { contractTemplatesRouter } from './routers/contract-templates.js';
+import { contractsRouter } from './routers/contracts.js';
 import type { RestContext } from './context.js';
 
 const restRouter = {
@@ -27,6 +29,8 @@ const restRouter = {
   audit: auditRouter,
   publications: publicationsRouter,
   pipeline: pipelineRouter,
+  contractTemplates: contractTemplatesRouter,
+  contracts: contractsRouter,
 };
 
 const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
@@ -106,6 +110,16 @@ const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
             name: 'Pipeline',
             description:
               'Manage the post-acceptance publication pipeline — copyedit, proofread, and publish workflow (Slate).',
+          },
+          {
+            name: 'Contract Templates',
+            description:
+              'Manage contract templates with merge field placeholders for generating contracts (Slate).',
+          },
+          {
+            name: 'Contracts',
+            description:
+              'Generate, send, and manage contracts for pipeline items (Slate).',
           },
           {
             name: 'Audit',

--- a/apps/api/src/rest/routers/cms-connections.ts
+++ b/apps/api/src/rest/routers/cms-connections.ts
@@ -1,0 +1,169 @@
+import {
+  listCmsConnectionsSchema,
+  createCmsConnectionSchema,
+  updateCmsConnectionSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { restPaginationQuery } from '@colophony/api-contracts';
+import {
+  cmsConnectionService,
+  CmsConnectionNotFoundError,
+} from '../../services/cms-connection.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+import { orgProcedure, requireScopes } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// Query schemas — override page/limit with z.coerce for REST query strings
+// ---------------------------------------------------------------------------
+
+const restListCmsConnectionsQuery = listCmsConnectionsSchema
+  .omit({ page: true, limit: true })
+  .merge(restPaginationQuery);
+
+// ---------------------------------------------------------------------------
+// CMS Connection routes
+// ---------------------------------------------------------------------------
+
+const list = orgProcedure
+  .use(requireScopes('cms:read'))
+  .route({
+    method: 'GET',
+    path: '/cms-connections',
+    summary: 'List CMS connections',
+    description:
+      'Returns a paginated list of CMS connections in the organization.',
+    operationId: 'listCmsConnections',
+    tags: ['CMS Connections'],
+  })
+  .input(restListCmsConnectionsQuery)
+  .handler(async ({ input, context }) => {
+    return cmsConnectionService.list(context.dbTx, input);
+  });
+
+const create = orgProcedure
+  .use(requireScopes('cms:write'))
+  .route({
+    method: 'POST',
+    path: '/cms-connections',
+    successStatus: 201,
+    summary: 'Create a CMS connection',
+    description:
+      'Create a new CMS connection (WordPress or Ghost) for the organization.',
+    operationId: 'createCmsConnection',
+    tags: ['CMS Connections'],
+  })
+  .input(createCmsConnectionSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await cmsConnectionService.createWithAudit(
+        toServiceContext(context),
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const get = orgProcedure
+  .use(requireScopes('cms:read'))
+  .route({
+    method: 'GET',
+    path: '/cms-connections/{id}',
+    summary: 'Get a CMS connection',
+    description: 'Retrieve a CMS connection by ID.',
+    operationId: 'getCmsConnection',
+    tags: ['CMS Connections'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const connection = await cmsConnectionService.getById(
+        context.dbTx,
+        input.id,
+      );
+      if (!connection) throw new CmsConnectionNotFoundError(input.id);
+      return connection;
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const update = orgProcedure
+  .use(requireScopes('cms:write'))
+  .route({
+    method: 'PATCH',
+    path: '/cms-connections/{id}',
+    summary: 'Update a CMS connection',
+    description: 'Update a CMS connection by ID.',
+    operationId: 'updateCmsConnection',
+    tags: ['CMS Connections'],
+  })
+  .input(idParamSchema.merge(updateCmsConnectionSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    try {
+      return await cmsConnectionService.updateWithAudit(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const del = orgProcedure
+  .use(requireScopes('cms:write'))
+  .route({
+    method: 'DELETE',
+    path: '/cms-connections/{id}',
+    summary: 'Delete a CMS connection',
+    description: 'Delete a CMS connection by ID.',
+    operationId: 'deleteCmsConnection',
+    tags: ['CMS Connections'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await cmsConnectionService.deleteWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const test = orgProcedure
+  .use(requireScopes('cms:read'))
+  .route({
+    method: 'POST',
+    path: '/cms-connections/{id}/test',
+    summary: 'Test a CMS connection',
+    description:
+      'Test the configuration of a CMS connection by attempting to connect.',
+    operationId: 'testCmsConnection',
+    tags: ['CMS Connections'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await cmsConnectionService.testConnection(context.dbTx, input.id);
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const cmsConnectionsRouter = {
+  list,
+  create,
+  get,
+  update,
+  del,
+  test,
+};

--- a/apps/api/src/rest/routers/contract-templates.ts
+++ b/apps/api/src/rest/routers/contract-templates.ts
@@ -1,0 +1,147 @@
+import {
+  listContractTemplatesSchema,
+  createContractTemplateSchema,
+  updateContractTemplateSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { restPaginationQuery } from '@colophony/api-contracts';
+import {
+  contractTemplateService,
+  ContractTemplateNotFoundError,
+} from '../../services/contract-template.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+import { orgProcedure, requireScopes } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// Query schemas — override page/limit with z.coerce for REST query strings
+// ---------------------------------------------------------------------------
+
+const restListQuery = listContractTemplatesSchema
+  .omit({ page: true, limit: true })
+  .merge(restPaginationQuery);
+
+// ---------------------------------------------------------------------------
+// Contract template routes
+// ---------------------------------------------------------------------------
+
+const list = orgProcedure
+  .use(requireScopes('contracts:read'))
+  .route({
+    method: 'GET',
+    path: '/contract-templates',
+    summary: 'List contract templates',
+    description:
+      'Returns a paginated list of contract templates in the organization.',
+    operationId: 'listContractTemplates',
+    tags: ['Contract Templates'],
+  })
+  .input(restListQuery)
+  .handler(async ({ input, context }) => {
+    return contractTemplateService.list(context.dbTx, input);
+  });
+
+const get = orgProcedure
+  .use(requireScopes('contracts:read'))
+  .route({
+    method: 'GET',
+    path: '/contract-templates/{id}',
+    summary: 'Get a contract template',
+    description: 'Retrieve a contract template by ID.',
+    operationId: 'getContractTemplate',
+    tags: ['Contract Templates'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const template = await contractTemplateService.getById(
+        context.dbTx,
+        input.id,
+      );
+      if (!template) throw new ContractTemplateNotFoundError(input.id);
+      return template;
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const create = orgProcedure
+  .use(requireScopes('contracts:write'))
+  .route({
+    method: 'POST',
+    path: '/contract-templates',
+    successStatus: 201,
+    summary: 'Create a contract template',
+    description: 'Create a new contract template for the organization.',
+    operationId: 'createContractTemplate',
+    tags: ['Contract Templates'],
+  })
+  .input(createContractTemplateSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await contractTemplateService.createWithAudit(
+        toServiceContext(context),
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const update = orgProcedure
+  .use(requireScopes('contracts:write'))
+  .route({
+    method: 'PATCH',
+    path: '/contract-templates/{id}',
+    summary: 'Update a contract template',
+    description: 'Update an existing contract template.',
+    operationId: 'updateContractTemplate',
+    tags: ['Contract Templates'],
+  })
+  .input(idParamSchema.merge(updateContractTemplateSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    try {
+      return await contractTemplateService.updateWithAudit(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const del = orgProcedure
+  .use(requireScopes('contracts:write'))
+  .route({
+    method: 'DELETE',
+    path: '/contract-templates/{id}',
+    summary: 'Delete a contract template',
+    description: 'Delete a contract template by ID.',
+    operationId: 'deleteContractTemplate',
+    tags: ['Contract Templates'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await contractTemplateService.deleteWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const contractTemplatesRouter = {
+  list,
+  get,
+  create,
+  update,
+  delete: del,
+};

--- a/apps/api/src/rest/routers/contracts.ts
+++ b/apps/api/src/rest/routers/contracts.ts
@@ -1,0 +1,160 @@
+import { z } from 'zod';
+import {
+  listContractsSchema,
+  generateContractSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { restPaginationQuery } from '@colophony/api-contracts';
+import {
+  contractService,
+  ContractNotFoundError,
+} from '../../services/contract.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+import { orgProcedure, requireScopes } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// Query schemas — override page/limit with z.coerce for REST query strings
+// ---------------------------------------------------------------------------
+
+const restListQuery = listContractsSchema
+  .omit({ page: true, limit: true })
+  .merge(restPaginationQuery);
+
+// ---------------------------------------------------------------------------
+// Contract routes
+// ---------------------------------------------------------------------------
+
+const list = orgProcedure
+  .use(requireScopes('contracts:read'))
+  .route({
+    method: 'GET',
+    path: '/contracts',
+    summary: 'List contracts',
+    description: 'Returns a paginated list of contracts in the organization.',
+    operationId: 'listContracts',
+    tags: ['Contracts'],
+  })
+  .input(restListQuery)
+  .handler(async ({ input, context }) => {
+    return contractService.list(context.dbTx, input);
+  });
+
+const get = orgProcedure
+  .use(requireScopes('contracts:read'))
+  .route({
+    method: 'GET',
+    path: '/contracts/{id}',
+    summary: 'Get a contract',
+    description: 'Retrieve a contract by ID.',
+    operationId: 'getContract',
+    tags: ['Contracts'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const contract = await contractService.getById(context.dbTx, input.id);
+      if (!contract) throw new ContractNotFoundError(input.id);
+      return contract;
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const listByPipelineItem = orgProcedure
+  .use(requireScopes('contracts:read'))
+  .route({
+    method: 'GET',
+    path: '/pipeline/{pipelineItemId}/contracts',
+    summary: 'List contracts for a pipeline item',
+    description: 'Retrieve all contracts linked to a pipeline item.',
+    operationId: 'listContractsByPipelineItem',
+    tags: ['Contracts'],
+  })
+  .input(z.object({ pipelineItemId: z.string().uuid() }))
+  .handler(async ({ input, context }) => {
+    return contractService.getByPipelineItemId(
+      context.dbTx,
+      input.pipelineItemId,
+    );
+  });
+
+const generate = orgProcedure
+  .use(requireScopes('contracts:write'))
+  .route({
+    method: 'POST',
+    path: '/contracts',
+    successStatus: 201,
+    summary: 'Generate a contract',
+    description: 'Generate a contract from a template with merge data.',
+    operationId: 'generateContract',
+    tags: ['Contracts'],
+  })
+  .input(generateContractSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await contractService.generateWithAudit(
+        toServiceContext(context),
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const send = orgProcedure
+  .use(requireScopes('contracts:write'))
+  .route({
+    method: 'POST',
+    path: '/contracts/{id}/send',
+    summary: 'Send a contract',
+    description: 'Send a draft contract for signing.',
+    operationId: 'sendContract',
+    tags: ['Contracts'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await contractService.sendWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const voidContract = orgProcedure
+  .use(requireScopes('contracts:write'))
+  .route({
+    method: 'POST',
+    path: '/contracts/{id}/void',
+    summary: 'Void a contract',
+    description: 'Void a contract, cancelling it permanently.',
+    operationId: 'voidContract',
+    tags: ['Contracts'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await contractService.voidWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const contractsRouter = {
+  list,
+  get,
+  listByPipelineItem,
+  generate,
+  send,
+  void: voidContract,
+};

--- a/apps/api/src/rest/routers/issues.ts
+++ b/apps/api/src/rest/routers/issues.ts
@@ -1,0 +1,303 @@
+import { z } from 'zod';
+import {
+  listIssuesSchema,
+  createIssueSchema,
+  updateIssueSchema,
+  addIssueItemSchema,
+  addIssueSectionSchema,
+  reorderItemsSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { restPaginationQuery } from '@colophony/api-contracts';
+import {
+  issueService,
+  IssueNotFoundError,
+} from '../../services/issue.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+import { orgProcedure, requireScopes } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// Query schemas
+// ---------------------------------------------------------------------------
+
+const restListQuery = listIssuesSchema
+  .omit({ page: true, limit: true })
+  .merge(restPaginationQuery);
+
+// ---------------------------------------------------------------------------
+// Issue routes
+// ---------------------------------------------------------------------------
+
+const list = orgProcedure
+  .use(requireScopes('issues:read'))
+  .route({
+    method: 'GET',
+    path: '/issues',
+    summary: 'List issues',
+    description: 'Returns a paginated list of issues in the organization.',
+    operationId: 'listIssues',
+    tags: ['Issues'],
+  })
+  .input(restListQuery)
+  .handler(async ({ input, context }) => {
+    return issueService.list(context.dbTx, input);
+  });
+
+const get = orgProcedure
+  .use(requireScopes('issues:read'))
+  .route({
+    method: 'GET',
+    path: '/issues/{id}',
+    summary: 'Get an issue',
+    description: 'Retrieve an issue by ID.',
+    operationId: 'getIssue',
+    tags: ['Issues'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const issue = await issueService.getById(context.dbTx, input.id);
+      if (!issue) throw new IssueNotFoundError(input.id);
+      return issue;
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const getItems = orgProcedure
+  .use(requireScopes('issues:read'))
+  .route({
+    method: 'GET',
+    path: '/issues/{id}/items',
+    summary: 'Get items in an issue',
+    description: 'Retrieve all items in an issue, ordered by sort order.',
+    operationId: 'getIssueItems',
+    tags: ['Issues'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    return issueService.getItems(context.dbTx, input.id);
+  });
+
+const getSections = orgProcedure
+  .use(requireScopes('issues:read'))
+  .route({
+    method: 'GET',
+    path: '/issues/{id}/sections',
+    summary: 'Get sections in an issue',
+    description: 'Retrieve all sections in an issue.',
+    operationId: 'getIssueSections',
+    tags: ['Issues'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    return issueService.getSections(context.dbTx, input.id);
+  });
+
+const create = orgProcedure
+  .use(requireScopes('issues:write'))
+  .route({
+    method: 'POST',
+    path: '/issues',
+    successStatus: 201,
+    summary: 'Create an issue',
+    description: 'Create a new issue for a publication.',
+    operationId: 'createIssue',
+    tags: ['Issues'],
+  })
+  .input(createIssueSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await issueService.createWithAudit(
+        toServiceContext(context),
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const update = orgProcedure
+  .use(requireScopes('issues:write'))
+  .route({
+    method: 'PATCH',
+    path: '/issues/{id}',
+    summary: 'Update an issue',
+    description: 'Update an existing issue.',
+    operationId: 'updateIssue',
+    tags: ['Issues'],
+  })
+  .input(idParamSchema.merge(updateIssueSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    try {
+      return await issueService.updateWithAudit(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const publish = orgProcedure
+  .use(requireScopes('issues:write'))
+  .route({
+    method: 'POST',
+    path: '/issues/{id}/publish',
+    summary: 'Publish an issue',
+    description: 'Publish an issue, marking it as publicly available.',
+    operationId: 'publishIssue',
+    tags: ['Issues'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await issueService.publishWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const archive = orgProcedure
+  .use(requireScopes('issues:write'))
+  .route({
+    method: 'POST',
+    path: '/issues/{id}/archive',
+    summary: 'Archive an issue',
+    description: 'Archive an issue.',
+    operationId: 'archiveIssue',
+    tags: ['Issues'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await issueService.archiveWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const addItem = orgProcedure
+  .use(requireScopes('issues:write'))
+  .route({
+    method: 'POST',
+    path: '/issues/{id}/items',
+    successStatus: 201,
+    summary: 'Add item to issue',
+    description: 'Add a pipeline item to an issue.',
+    operationId: 'addIssueItem',
+    tags: ['Issues'],
+  })
+  .input(idParamSchema.merge(addIssueItemSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    try {
+      return await issueService.addItemWithAudit(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const removeItem = orgProcedure
+  .use(requireScopes('issues:write'))
+  .route({
+    method: 'DELETE',
+    path: '/issues/{id}/items/{itemId}',
+    summary: 'Remove item from issue',
+    description: 'Remove a pipeline item from an issue.',
+    operationId: 'removeIssueItem',
+    tags: ['Issues'],
+  })
+  .input(z.object({ id: z.string().uuid(), itemId: z.string().uuid() }))
+  .handler(async ({ input, context }) => {
+    try {
+      return await issueService.removeItemWithAudit(
+        toServiceContext(context),
+        input.id,
+        input.itemId,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const reorderItems = orgProcedure
+  .use(requireScopes('issues:write'))
+  .route({
+    method: 'PUT',
+    path: '/issues/{id}/items/reorder',
+    summary: 'Reorder items',
+    description: 'Reorder items within an issue.',
+    operationId: 'reorderIssueItems',
+    tags: ['Issues'],
+  })
+  .input(idParamSchema.merge(reorderItemsSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    return issueService.reorderItems(context.dbTx, id, data);
+  });
+
+const addSection = orgProcedure
+  .use(requireScopes('issues:write'))
+  .route({
+    method: 'POST',
+    path: '/issues/{id}/sections',
+    successStatus: 201,
+    summary: 'Add section to issue',
+    description: 'Add a section to an issue for grouping items.',
+    operationId: 'addIssueSection',
+    tags: ['Issues'],
+  })
+  .input(idParamSchema.merge(addIssueSectionSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    return issueService.addSection(context.dbTx, id, data);
+  });
+
+const removeSection = orgProcedure
+  .use(requireScopes('issues:write'))
+  .route({
+    method: 'DELETE',
+    path: '/issues/{id}/sections/{sectionId}',
+    summary: 'Remove section from issue',
+    description: 'Remove a section from an issue.',
+    operationId: 'removeIssueSection',
+    tags: ['Issues'],
+  })
+  .input(z.object({ id: z.string().uuid(), sectionId: z.string().uuid() }))
+  .handler(async ({ input, context }) => {
+    return issueService.removeSection(context.dbTx, input.id, input.sectionId);
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const issuesRouter = {
+  list,
+  get,
+  getItems,
+  getSections,
+  create,
+  update,
+  publish,
+  archive,
+  addItem,
+  removeItem,
+  reorderItems,
+  addSection,
+  removeSection,
+};

--- a/apps/api/src/rest/routers/issues.ts
+++ b/apps/api/src/rest/routers/issues.ts
@@ -15,7 +15,7 @@ import {
 } from '../../services/issue.service.js';
 import { toServiceContext } from '../../services/context.js';
 import { mapServiceError } from '../error-mapper.js';
-import { orgProcedure, requireScopes } from '../context.js';
+import { orgProcedure, adminProcedure, requireScopes } from '../context.js';
 
 // ---------------------------------------------------------------------------
 // Query schemas
@@ -95,7 +95,7 @@ const getSections = orgProcedure
     return issueService.getSections(context.dbTx, input.id);
   });
 
-const create = orgProcedure
+const create = adminProcedure
   .use(requireScopes('issues:write'))
   .route({
     method: 'POST',
@@ -118,7 +118,7 @@ const create = orgProcedure
     }
   });
 
-const update = orgProcedure
+const update = adminProcedure
   .use(requireScopes('issues:write'))
   .route({
     method: 'PATCH',
@@ -142,7 +142,7 @@ const update = orgProcedure
     }
   });
 
-const publish = orgProcedure
+const publish = adminProcedure
   .use(requireScopes('issues:write'))
   .route({
     method: 'POST',
@@ -164,7 +164,7 @@ const publish = orgProcedure
     }
   });
 
-const archive = orgProcedure
+const archive = adminProcedure
   .use(requireScopes('issues:write'))
   .route({
     method: 'POST',
@@ -186,7 +186,7 @@ const archive = orgProcedure
     }
   });
 
-const addItem = orgProcedure
+const addItem = adminProcedure
   .use(requireScopes('issues:write'))
   .route({
     method: 'POST',
@@ -211,7 +211,7 @@ const addItem = orgProcedure
     }
   });
 
-const removeItem = orgProcedure
+const removeItem = adminProcedure
   .use(requireScopes('issues:write'))
   .route({
     method: 'DELETE',
@@ -234,7 +234,7 @@ const removeItem = orgProcedure
     }
   });
 
-const reorderItems = orgProcedure
+const reorderItems = adminProcedure
   .use(requireScopes('issues:write'))
   .route({
     method: 'PUT',
@@ -250,7 +250,7 @@ const reorderItems = orgProcedure
     return issueService.reorderItems(context.dbTx, id, data);
   });
 
-const addSection = orgProcedure
+const addSection = adminProcedure
   .use(requireScopes('issues:write'))
   .route({
     method: 'POST',
@@ -267,7 +267,7 @@ const addSection = orgProcedure
     return issueService.addSection(context.dbTx, id, data);
   });
 
-const removeSection = orgProcedure
+const removeSection = adminProcedure
   .use(requireScopes('issues:write'))
   .route({
     method: 'DELETE',

--- a/apps/api/src/rest/routers/pipeline.ts
+++ b/apps/api/src/rest/routers/pipeline.ts
@@ -1,0 +1,231 @@
+import {
+  listPipelineItemsSchema,
+  createPipelineItemSchema,
+  updatePipelineStageSchema,
+  assignPipelineRoleSchema,
+  addPipelineCommentSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { restPaginationQuery } from '@colophony/api-contracts';
+import {
+  pipelineService,
+  PipelineItemNotFoundError,
+} from '../../services/pipeline.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+import { orgProcedure, requireScopes } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// Query schemas — override page/limit with z.coerce for REST query strings
+// ---------------------------------------------------------------------------
+
+const restListPipelineQuery = listPipelineItemsSchema
+  .omit({ page: true, limit: true })
+  .merge(restPaginationQuery);
+
+// ---------------------------------------------------------------------------
+// Pipeline routes
+// ---------------------------------------------------------------------------
+
+const list = orgProcedure
+  .use(requireScopes('pipeline:read'))
+  .route({
+    method: 'GET',
+    path: '/pipeline',
+    summary: 'List pipeline items',
+    description:
+      'Returns a paginated list of pipeline items in the organization.',
+    operationId: 'listPipelineItems',
+    tags: ['Pipeline'],
+  })
+  .input(restListPipelineQuery)
+  .handler(async ({ input, context }) => {
+    return pipelineService.list(context.dbTx, input);
+  });
+
+const create = orgProcedure
+  .use(requireScopes('pipeline:write'))
+  .route({
+    method: 'POST',
+    path: '/pipeline',
+    successStatus: 201,
+    summary: 'Create a pipeline item',
+    description: 'Move an accepted submission into the publication pipeline.',
+    operationId: 'createPipelineItem',
+    tags: ['Pipeline'],
+  })
+  .input(createPipelineItemSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await pipelineService.createWithAudit(
+        toServiceContext(context),
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const get = orgProcedure
+  .use(requireScopes('pipeline:read'))
+  .route({
+    method: 'GET',
+    path: '/pipeline/{id}',
+    summary: 'Get a pipeline item',
+    description: 'Retrieve a pipeline item by ID.',
+    operationId: 'getPipelineItem',
+    tags: ['Pipeline'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const item = await pipelineService.getById(context.dbTx, input.id);
+      if (!item) throw new PipelineItemNotFoundError(input.id);
+      return item;
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const updateStage = orgProcedure
+  .use(requireScopes('pipeline:write'))
+  .route({
+    method: 'PATCH',
+    path: '/pipeline/{id}/stage',
+    summary: 'Update pipeline stage',
+    description: 'Advance or change the pipeline stage for an item.',
+    operationId: 'updatePipelineStage',
+    tags: ['Pipeline'],
+  })
+  .input(idParamSchema.merge(updatePipelineStageSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    try {
+      return await pipelineService.updateStageWithAudit(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const assignCopyeditor = orgProcedure
+  .use(requireScopes('pipeline:write'))
+  .route({
+    method: 'PUT',
+    path: '/pipeline/{id}/copyeditor',
+    summary: 'Assign copyeditor',
+    description: 'Assign a copyeditor to a pipeline item.',
+    operationId: 'assignPipelineCopyeditor',
+    tags: ['Pipeline'],
+  })
+  .input(idParamSchema.merge(assignPipelineRoleSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    try {
+      return await pipelineService.assignCopyeditorWithAudit(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const assignProofreader = orgProcedure
+  .use(requireScopes('pipeline:write'))
+  .route({
+    method: 'PUT',
+    path: '/pipeline/{id}/proofreader',
+    summary: 'Assign proofreader',
+    description: 'Assign a proofreader to a pipeline item.',
+    operationId: 'assignPipelineProofreader',
+    tags: ['Pipeline'],
+  })
+  .input(idParamSchema.merge(assignPipelineRoleSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    try {
+      return await pipelineService.assignProofreaderWithAudit(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const addComment = orgProcedure
+  .use(requireScopes('pipeline:write'))
+  .route({
+    method: 'POST',
+    path: '/pipeline/{id}/comments',
+    successStatus: 201,
+    summary: 'Add a comment',
+    description: 'Add a comment to a pipeline item.',
+    operationId: 'addPipelineComment',
+    tags: ['Pipeline'],
+  })
+  .input(idParamSchema.merge(addPipelineCommentSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    try {
+      return await pipelineService.addCommentWithAudit(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const listComments = orgProcedure
+  .use(requireScopes('pipeline:read'))
+  .route({
+    method: 'GET',
+    path: '/pipeline/{id}/comments',
+    summary: 'List comments',
+    description: 'List all comments for a pipeline item.',
+    operationId: 'listPipelineComments',
+    tags: ['Pipeline'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    return pipelineService.listComments(context.dbTx, input.id);
+  });
+
+const getHistory = orgProcedure
+  .use(requireScopes('pipeline:read'))
+  .route({
+    method: 'GET',
+    path: '/pipeline/{id}/history',
+    summary: 'Get stage history',
+    description: 'Get the stage transition history for a pipeline item.',
+    operationId: 'getPipelineHistory',
+    tags: ['Pipeline'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    return pipelineService.getHistory(context.dbTx, input.id);
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const pipelineRouter = {
+  list,
+  create,
+  get,
+  updateStage,
+  assignCopyeditor,
+  assignProofreader,
+  addComment,
+  listComments,
+  getHistory,
+};

--- a/apps/api/src/rest/routers/publications.ts
+++ b/apps/api/src/rest/routers/publications.ts
@@ -1,0 +1,148 @@
+import {
+  listPublicationsSchema,
+  createPublicationSchema,
+  updatePublicationSchema,
+  idParamSchema,
+} from '@colophony/types';
+import { restPaginationQuery } from '@colophony/api-contracts';
+import {
+  publicationService,
+  PublicationNotFoundError,
+} from '../../services/publication.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+import { orgProcedure, requireScopes } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// Query schemas — override page/limit with z.coerce for REST query strings
+// ---------------------------------------------------------------------------
+
+const restListPublicationsQuery = listPublicationsSchema
+  .omit({ page: true, limit: true })
+  .merge(restPaginationQuery);
+
+// ---------------------------------------------------------------------------
+// Publication routes
+// ---------------------------------------------------------------------------
+
+const list = orgProcedure
+  .use(requireScopes('publications:read'))
+  .route({
+    method: 'GET',
+    path: '/publications',
+    summary: 'List publications',
+    description:
+      'Returns a paginated list of publications in the organization.',
+    operationId: 'listPublications',
+    tags: ['Publications'],
+  })
+  .input(restListPublicationsQuery)
+  .handler(async ({ input, context }) => {
+    return publicationService.list(context.dbTx, input);
+  });
+
+const create = orgProcedure
+  .use(requireScopes('publications:write'))
+  .route({
+    method: 'POST',
+    path: '/publications',
+    successStatus: 201,
+    summary: 'Create a publication',
+    description:
+      'Create a new publication — a named publishing venue within the organization.',
+    operationId: 'createPublication',
+    tags: ['Publications'],
+  })
+  .input(createPublicationSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await publicationService.createWithAudit(
+        toServiceContext(context),
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const get = orgProcedure
+  .use(requireScopes('publications:read'))
+  .route({
+    method: 'GET',
+    path: '/publications/{id}',
+    summary: 'Get a publication',
+    description: 'Retrieve a publication by ID.',
+    operationId: 'getPublication',
+    tags: ['Publications'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const publication = await publicationService.getById(
+        context.dbTx,
+        input.id,
+      );
+      if (!publication) throw new PublicationNotFoundError(input.id);
+      return publication;
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const update = orgProcedure
+  .use(requireScopes('publications:write'))
+  .route({
+    method: 'PATCH',
+    path: '/publications/{id}',
+    summary: 'Update a publication',
+    description: 'Update a publication by ID.',
+    operationId: 'updatePublication',
+    tags: ['Publications'],
+  })
+  .input(idParamSchema.merge(updatePublicationSchema))
+  .handler(async ({ input, context }) => {
+    const { id, ...data } = input;
+    try {
+      return await publicationService.updateWithAudit(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const archive = orgProcedure
+  .use(requireScopes('publications:write'))
+  .route({
+    method: 'POST',
+    path: '/publications/{id}/archive',
+    summary: 'Archive a publication',
+    description: 'Archive a publication by ID.',
+    operationId: 'archivePublication',
+    tags: ['Publications'],
+  })
+  .input(idParamSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await publicationService.archiveWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const publicationsRouter = {
+  list,
+  create,
+  get,
+  update,
+  archive,
+};

--- a/apps/api/src/services/cms-connection.service.ts
+++ b/apps/api/src/services/cms-connection.service.ts
@@ -1,0 +1,198 @@
+import { cmsConnections, eq, and, type DrizzleDb } from '@colophony/db';
+import { desc, count } from 'drizzle-orm';
+import type {
+  CreateCmsConnectionInput,
+  UpdateCmsConnectionInput,
+  ListCmsConnectionsInput,
+} from '@colophony/types';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { ServiceContext } from './types.js';
+import { assertEditorOrAdmin } from './errors.js';
+import { getCmsAdapter } from '../adapters/cms/index.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class CmsConnectionNotFoundError extends Error {
+  constructor(id: string) {
+    super(`CMS connection "${id}" not found`);
+    this.name = 'CmsConnectionNotFoundError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const cmsConnectionService = {
+  // -------------------------------------------------------------------------
+  // List / Get
+  // -------------------------------------------------------------------------
+
+  async list(tx: DrizzleDb, input: ListCmsConnectionsInput) {
+    const { publicationId, page, limit } = input;
+    const offset = (page - 1) * limit;
+
+    const conditions = [];
+    if (publicationId) {
+      conditions.push(eq(cmsConnections.publicationId, publicationId));
+    }
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const [items, countResult] = await Promise.all([
+      tx
+        .select()
+        .from(cmsConnections)
+        .where(where)
+        .orderBy(desc(cmsConnections.createdAt))
+        .limit(limit)
+        .offset(offset),
+      tx.select({ count: count() }).from(cmsConnections).where(where),
+    ]);
+
+    const total = countResult[0]?.count ?? 0;
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async getById(tx: DrizzleDb, id: string) {
+    const [row] = await tx
+      .select()
+      .from(cmsConnections)
+      .where(eq(cmsConnections.id, id))
+      .limit(1);
+
+    return row ?? null;
+  },
+
+  // -------------------------------------------------------------------------
+  // Create / Update / Delete
+  // -------------------------------------------------------------------------
+
+  async create(tx: DrizzleDb, input: CreateCmsConnectionInput, orgId: string) {
+    const [row] = await tx
+      .insert(cmsConnections)
+      .values({
+        organizationId: orgId,
+        adapterType: input.adapterType,
+        name: input.name,
+        config: input.config,
+        publicationId: input.publicationId ?? null,
+      })
+      .returning();
+
+    return row;
+  },
+
+  async createWithAudit(ctx: ServiceContext, input: CreateCmsConnectionInput) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const connection = await cmsConnectionService.create(
+      ctx.tx,
+      input,
+      ctx.actor.orgId,
+    );
+    await ctx.audit({
+      action: AuditActions.CMS_CONNECTION_CREATED,
+      resource: AuditResources.CMS_CONNECTION,
+      resourceId: connection.id,
+      newValue: { name: input.name, adapterType: input.adapterType },
+    });
+    return connection;
+  },
+
+  async update(tx: DrizzleDb, id: string, input: UpdateCmsConnectionInput) {
+    const values: Record<string, unknown> = { updatedAt: new Date() };
+    if (input.name !== undefined) values.name = input.name;
+    if (input.config !== undefined) values.config = input.config;
+    if (input.isActive !== undefined) values.isActive = input.isActive;
+
+    const [row] = await tx
+      .update(cmsConnections)
+      .set(values)
+      .where(eq(cmsConnections.id, id))
+      .returning();
+
+    return row ?? null;
+  },
+
+  async updateWithAudit(
+    ctx: ServiceContext,
+    id: string,
+    input: UpdateCmsConnectionInput,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const updated = await cmsConnectionService.update(ctx.tx, id, input);
+    if (!updated) throw new CmsConnectionNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.CMS_CONNECTION_UPDATED,
+      resource: AuditResources.CMS_CONNECTION,
+      resourceId: id,
+      newValue: input,
+    });
+    return updated;
+  },
+
+  async delete(tx: DrizzleDb, id: string) {
+    const [row] = await tx
+      .delete(cmsConnections)
+      .where(eq(cmsConnections.id, id))
+      .returning();
+
+    return row ?? null;
+  },
+
+  async deleteWithAudit(ctx: ServiceContext, id: string) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const deleted = await cmsConnectionService.delete(ctx.tx, id);
+    if (!deleted) throw new CmsConnectionNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.CMS_CONNECTION_DELETED,
+      resource: AuditResources.CMS_CONNECTION,
+      resourceId: id,
+      oldValue: { name: deleted.name, adapterType: deleted.adapterType },
+    });
+    return deleted;
+  },
+
+  // -------------------------------------------------------------------------
+  // Test connection
+  // -------------------------------------------------------------------------
+
+  async testConnection(tx: DrizzleDb, id: string) {
+    const connection = await cmsConnectionService.getById(tx, id);
+    if (!connection) throw new CmsConnectionNotFoundError(id);
+
+    const adapter = getCmsAdapter(connection.adapterType);
+    return adapter.testConnection(connection.config);
+  },
+
+  // -------------------------------------------------------------------------
+  // Helpers for Inngest workers
+  // -------------------------------------------------------------------------
+
+  async listByPublication(tx: DrizzleDb, publicationId: string) {
+    return tx
+      .select()
+      .from(cmsConnections)
+      .where(
+        and(
+          eq(cmsConnections.publicationId, publicationId),
+          eq(cmsConnections.isActive, true),
+        ),
+      );
+  },
+
+  async updateLastSync(tx: DrizzleDb, id: string) {
+    await tx
+      .update(cmsConnections)
+      .set({ lastSyncAt: new Date(), updatedAt: new Date() })
+      .where(eq(cmsConnections.id, id));
+  },
+};

--- a/apps/api/src/services/contract-template.service.ts
+++ b/apps/api/src/services/contract-template.service.ts
@@ -1,0 +1,182 @@
+import { contractTemplates, eq, and, type DrizzleDb } from '@colophony/db';
+import { desc, ilike, count } from 'drizzle-orm';
+import type {
+  CreateContractTemplateInput,
+  UpdateContractTemplateInput,
+  ListContractTemplatesInput,
+} from '@colophony/types';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { ServiceContext } from './types.js';
+import { assertEditorOrAdmin } from './errors.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class ContractTemplateNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Contract template "${id}" not found`);
+    this.name = 'ContractTemplateNotFoundError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const contractTemplateService = {
+  // -------------------------------------------------------------------------
+  // List / Get
+  // -------------------------------------------------------------------------
+
+  async list(tx: DrizzleDb, input: ListContractTemplatesInput) {
+    const { search, page, limit } = input;
+    const offset = (page - 1) * limit;
+
+    const conditions = [];
+    if (search) conditions.push(ilike(contractTemplates.name, `%${search}%`));
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const [items, countResult] = await Promise.all([
+      tx
+        .select()
+        .from(contractTemplates)
+        .where(where)
+        .orderBy(desc(contractTemplates.createdAt))
+        .limit(limit)
+        .offset(offset),
+      tx.select({ count: count() }).from(contractTemplates).where(where),
+    ]);
+
+    const total = countResult[0]?.count ?? 0;
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async getById(tx: DrizzleDb, id: string) {
+    const [row] = await tx
+      .select()
+      .from(contractTemplates)
+      .where(eq(contractTemplates.id, id))
+      .limit(1);
+
+    return row ?? null;
+  },
+
+  // -------------------------------------------------------------------------
+  // Create / Update / Delete
+  // -------------------------------------------------------------------------
+
+  async create(
+    tx: DrizzleDb,
+    input: CreateContractTemplateInput,
+    orgId: string,
+  ) {
+    const [row] = await tx
+      .insert(contractTemplates)
+      .values({
+        organizationId: orgId,
+        name: input.name,
+        description: input.description ?? null,
+        body: input.body,
+        mergeFields: input.mergeFields ?? null,
+        isDefault: input.isDefault ?? false,
+      })
+      .returning();
+
+    return row;
+  },
+
+  async createWithAudit(
+    ctx: ServiceContext,
+    input: CreateContractTemplateInput,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const template = await contractTemplateService.create(
+      ctx.tx,
+      input,
+      ctx.actor.orgId,
+    );
+    await ctx.audit({
+      action: AuditActions.CONTRACT_TEMPLATE_CREATED,
+      resource: AuditResources.CONTRACT_TEMPLATE,
+      resourceId: template.id,
+      newValue: { name: input.name },
+    });
+    return template;
+  },
+
+  async update(tx: DrizzleDb, id: string, input: UpdateContractTemplateInput) {
+    const values: Record<string, unknown> = { updatedAt: new Date() };
+    if (input.name !== undefined) values.name = input.name;
+    if (input.description !== undefined)
+      values.description = input.description ?? null;
+    if (input.body !== undefined) values.body = input.body;
+    if (input.mergeFields !== undefined)
+      values.mergeFields = input.mergeFields ?? null;
+    if (input.isDefault !== undefined) values.isDefault = input.isDefault;
+
+    const [row] = await tx
+      .update(contractTemplates)
+      .set(values)
+      .where(eq(contractTemplates.id, id))
+      .returning();
+
+    return row ?? null;
+  },
+
+  async updateWithAudit(
+    ctx: ServiceContext,
+    id: string,
+    input: UpdateContractTemplateInput,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const updated = await contractTemplateService.update(ctx.tx, id, input);
+    if (!updated) throw new ContractTemplateNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.CONTRACT_TEMPLATE_UPDATED,
+      resource: AuditResources.CONTRACT_TEMPLATE,
+      resourceId: id,
+      newValue: input,
+    });
+    return updated;
+  },
+
+  async delete(tx: DrizzleDb, id: string) {
+    const [row] = await tx
+      .delete(contractTemplates)
+      .where(eq(contractTemplates.id, id))
+      .returning();
+
+    return row ?? null;
+  },
+
+  async deleteWithAudit(ctx: ServiceContext, id: string) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const deleted = await contractTemplateService.delete(ctx.tx, id);
+    if (!deleted) throw new ContractTemplateNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.CONTRACT_TEMPLATE_DELETED,
+      resource: AuditResources.CONTRACT_TEMPLATE,
+      resourceId: id,
+      oldValue: { name: deleted.name },
+    });
+    return deleted;
+  },
+
+  // -------------------------------------------------------------------------
+  // Template rendering (pure function)
+  // -------------------------------------------------------------------------
+
+  renderTemplate(body: string, mergeData: Record<string, string>): string {
+    return body.replace(/\{\{(\w+)\}\}/g, (_match, key: string) => {
+      return mergeData[key] ?? `{{${key}}}`;
+    });
+  },
+};

--- a/apps/api/src/services/contract-template.service.ts
+++ b/apps/api/src/services/contract-template.service.ts
@@ -1,5 +1,11 @@
-import { contractTemplates, eq, and, type DrizzleDb } from '@colophony/db';
-import { desc, ilike, count } from 'drizzle-orm';
+import {
+  contractTemplates,
+  eq,
+  and,
+  desc,
+  type DrizzleDb,
+} from '@colophony/db';
+import { ilike, count } from 'drizzle-orm';
 import type {
   CreateContractTemplateInput,
   UpdateContractTemplateInput,

--- a/apps/api/src/services/contract.service.ts
+++ b/apps/api/src/services/contract.service.ts
@@ -1,5 +1,5 @@
-import { contracts, eq, and, type DrizzleDb } from '@colophony/db';
-import { desc, count } from 'drizzle-orm';
+import { contracts, eq, and, desc, type DrizzleDb } from '@colophony/db';
+import { count } from 'drizzle-orm';
 import type {
   GenerateContractInput,
   ListContractsInput,
@@ -188,13 +188,20 @@ export const contractService = {
 
   async sendWithAudit(ctx: ServiceContext, id: string) {
     assertEditorOrAdmin(ctx.actor.role);
+    const contract = await contractService.getById(ctx.tx, id);
+    if (!contract) throw new ContractNotFoundError(id);
+    if (contract.status !== 'DRAFT') {
+      throw new Error(
+        `Contract "${id}" has status "${contract.status}" — only DRAFT contracts can be sent`,
+      );
+    }
     const updated = await contractService.updateStatus(ctx.tx, id, 'SENT');
     if (!updated) throw new ContractNotFoundError(id);
     await ctx.audit({
       action: AuditActions.CONTRACT_SENT,
       resource: AuditResources.CONTRACT,
       resourceId: id,
-      oldValue: { status: 'DRAFT' },
+      oldValue: { status: contract.status },
       newValue: { status: 'SENT' },
     });
     return updated;

--- a/apps/api/src/services/contract.service.ts
+++ b/apps/api/src/services/contract.service.ts
@@ -1,0 +1,218 @@
+import { contracts, eq, and, type DrizzleDb } from '@colophony/db';
+import { desc, count } from 'drizzle-orm';
+import type {
+  GenerateContractInput,
+  ListContractsInput,
+  ContractStatus,
+} from '@colophony/types';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { ServiceContext } from './types.js';
+import { assertEditorOrAdmin } from './errors.js';
+import {
+  contractTemplateService,
+  ContractTemplateNotFoundError,
+} from './contract-template.service.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class ContractNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Contract "${id}" not found`);
+    this.name = 'ContractNotFoundError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const contractService = {
+  // -------------------------------------------------------------------------
+  // List / Get
+  // -------------------------------------------------------------------------
+
+  async list(tx: DrizzleDb, input: ListContractsInput) {
+    const { status, pipelineItemId, page, limit } = input;
+    const offset = (page - 1) * limit;
+
+    const conditions = [];
+    if (status) conditions.push(eq(contracts.status, status));
+    if (pipelineItemId)
+      conditions.push(eq(contracts.pipelineItemId, pipelineItemId));
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const [items, countResult] = await Promise.all([
+      tx
+        .select()
+        .from(contracts)
+        .where(where)
+        .orderBy(desc(contracts.createdAt))
+        .limit(limit)
+        .offset(offset),
+      tx.select({ count: count() }).from(contracts).where(where),
+    ]);
+
+    const total = countResult[0]?.count ?? 0;
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async getById(tx: DrizzleDb, id: string) {
+    const [row] = await tx
+      .select()
+      .from(contracts)
+      .where(eq(contracts.id, id))
+      .limit(1);
+
+    return row ?? null;
+  },
+
+  async getByPipelineItemId(tx: DrizzleDb, pipelineItemId: string) {
+    return tx
+      .select()
+      .from(contracts)
+      .where(eq(contracts.pipelineItemId, pipelineItemId))
+      .orderBy(desc(contracts.createdAt));
+  },
+
+  // -------------------------------------------------------------------------
+  // Generate / Status / Void
+  // -------------------------------------------------------------------------
+
+  async generate(
+    tx: DrizzleDb,
+    input: GenerateContractInput,
+    orgId: string,
+    mergeDataOverrides?: Record<string, string>,
+  ) {
+    const template = await contractTemplateService.getById(
+      tx,
+      input.contractTemplateId,
+    );
+    if (!template)
+      throw new ContractTemplateNotFoundError(input.contractTemplateId);
+
+    const mergeData = { ...input.mergeData, ...mergeDataOverrides };
+    const renderedBody = contractTemplateService.renderTemplate(
+      template.body,
+      mergeData,
+    );
+
+    const [row] = await tx
+      .insert(contracts)
+      .values({
+        organizationId: orgId,
+        pipelineItemId: input.pipelineItemId,
+        contractTemplateId: input.contractTemplateId,
+        renderedBody,
+        mergeData,
+      })
+      .returning();
+
+    return row;
+  },
+
+  async generateWithAudit(
+    ctx: ServiceContext,
+    input: GenerateContractInput,
+    mergeDataOverrides?: Record<string, string>,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const contract = await contractService.generate(
+      ctx.tx,
+      input,
+      ctx.actor.orgId,
+      mergeDataOverrides,
+    );
+    await ctx.audit({
+      action: AuditActions.CONTRACT_GENERATED,
+      resource: AuditResources.CONTRACT,
+      resourceId: contract.id,
+      newValue: {
+        pipelineItemId: input.pipelineItemId,
+        contractTemplateId: input.contractTemplateId,
+      },
+    });
+    return contract;
+  },
+
+  async updateStatus(
+    tx: DrizzleDb,
+    id: string,
+    status: ContractStatus,
+    timestamps?: {
+      signedAt?: Date;
+      countersignedAt?: Date;
+      completedAt?: Date;
+    },
+  ) {
+    const values: Record<string, unknown> = {
+      status,
+      updatedAt: new Date(),
+    };
+    if (timestamps?.signedAt) values.signedAt = timestamps.signedAt;
+    if (timestamps?.countersignedAt)
+      values.countersignedAt = timestamps.countersignedAt;
+    if (timestamps?.completedAt) values.completedAt = timestamps.completedAt;
+
+    const [row] = await tx
+      .update(contracts)
+      .set(values)
+      .where(eq(contracts.id, id))
+      .returning();
+
+    return row ?? null;
+  },
+
+  async updateDocumensoId(
+    tx: DrizzleDb,
+    id: string,
+    documensoDocumentId: string,
+  ) {
+    const [row] = await tx
+      .update(contracts)
+      .set({ documensoDocumentId, updatedAt: new Date() })
+      .where(eq(contracts.id, id))
+      .returning();
+
+    return row ?? null;
+  },
+
+  async sendWithAudit(ctx: ServiceContext, id: string) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const updated = await contractService.updateStatus(ctx.tx, id, 'SENT');
+    if (!updated) throw new ContractNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.CONTRACT_SENT,
+      resource: AuditResources.CONTRACT,
+      resourceId: id,
+      oldValue: { status: 'DRAFT' },
+      newValue: { status: 'SENT' },
+    });
+    return updated;
+  },
+
+  async voidWithAudit(ctx: ServiceContext, id: string) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const contract = await contractService.getById(ctx.tx, id);
+    if (!contract) throw new ContractNotFoundError(id);
+    const updated = await contractService.updateStatus(ctx.tx, id, 'VOIDED');
+    if (!updated) throw new ContractNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.CONTRACT_VOIDED,
+      resource: AuditResources.CONTRACT,
+      resourceId: id,
+      oldValue: { status: contract.status },
+      newValue: { status: 'VOIDED' },
+    });
+    return updated;
+  },
+};

--- a/apps/api/src/services/contract.service.ts
+++ b/apps/api/src/services/contract.service.ts
@@ -83,6 +83,16 @@ export const contractService = {
       .orderBy(desc(contracts.createdAt));
   },
 
+  async getByDocumensoDocumentId(tx: DrizzleDb, documensoDocumentId: string) {
+    const [row] = await tx
+      .select()
+      .from(contracts)
+      .where(eq(contracts.documensoDocumentId, documensoDocumentId))
+      .limit(1);
+
+    return row ?? null;
+  },
+
   // -------------------------------------------------------------------------
   // Generate / Status / Void
   // -------------------------------------------------------------------------

--- a/apps/api/src/services/contract.service.ts
+++ b/apps/api/src/services/contract.service.ts
@@ -8,6 +8,7 @@ import type {
 import { AuditActions, AuditResources } from '@colophony/types';
 import type { ServiceContext } from './types.js';
 import { assertEditorOrAdmin } from './errors.js';
+import { enqueueOutboxEvent } from './outbox.js';
 import {
   contractTemplateService,
   ContractTemplateNotFoundError,
@@ -151,6 +152,14 @@ export const contractService = {
         contractTemplateId: input.contractTemplateId,
       },
     });
+
+    // Enqueue outbox event to trigger the Documenso contract workflow
+    await enqueueOutboxEvent(ctx.tx, 'slate/contract.generated', {
+      orgId: ctx.actor.orgId,
+      contractId: contract.id,
+      pipelineItemId: input.pipelineItemId,
+    });
+
     return contract;
   },
 

--- a/apps/api/src/services/issue.service.ts
+++ b/apps/api/src/services/issue.service.ts
@@ -4,9 +4,10 @@ import {
   issueItems,
   eq,
   and,
+  desc,
   type DrizzleDb,
 } from '@colophony/db';
-import { desc, ilike, count } from 'drizzle-orm';
+import { ilike, count } from 'drizzle-orm';
 import type {
   CreateIssueInput,
   UpdateIssueInput,
@@ -236,6 +237,26 @@ export const issueService = {
   // -------------------------------------------------------------------------
 
   async addItem(tx: DrizzleDb, issueId: string, input: AddIssueItemInput) {
+    // Validate section belongs to this issue (if provided)
+    if (input.issueSectionId) {
+      const [section] = await tx
+        .select({ id: issueSections.id })
+        .from(issueSections)
+        .where(
+          and(
+            eq(issueSections.id, input.issueSectionId),
+            eq(issueSections.issueId, issueId),
+          ),
+        )
+        .limit(1);
+
+      if (!section) {
+        throw new IssueNotFoundError(
+          `Section "${input.issueSectionId}" does not belong to issue "${issueId}"`,
+        );
+      }
+    }
+
     const [row] = await tx
       .insert(issueItems)
       .values({

--- a/apps/api/src/services/issue.service.ts
+++ b/apps/api/src/services/issue.service.ts
@@ -20,6 +20,7 @@ import type {
 import { AuditActions, AuditResources } from '@colophony/types';
 import type { ServiceContext } from './types.js';
 import { assertEditorOrAdmin } from './errors.js';
+import { enqueueOutboxEvent } from './outbox.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -213,6 +214,14 @@ export const issueService = {
       oldValue: { status: issue.status },
       newValue: { status: 'PUBLISHED' },
     });
+
+    // Enqueue outbox event to trigger CMS publishing
+    await enqueueOutboxEvent(ctx.tx, 'slate/issue.published', {
+      orgId: ctx.actor.orgId,
+      issueId: id,
+      publicationId: updated.publicationId,
+    });
+
     return updated;
   },
 

--- a/apps/api/src/services/issue.service.ts
+++ b/apps/api/src/services/issue.service.ts
@@ -1,0 +1,352 @@
+import {
+  issues,
+  issueSections,
+  issueItems,
+  eq,
+  and,
+  type DrizzleDb,
+} from '@colophony/db';
+import { desc, ilike, count } from 'drizzle-orm';
+import type {
+  CreateIssueInput,
+  UpdateIssueInput,
+  ListIssuesInput,
+  AddIssueItemInput,
+  AddIssueSectionInput,
+  ReorderItemsInput,
+  IssueStatus,
+} from '@colophony/types';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { ServiceContext } from './types.js';
+import { assertEditorOrAdmin } from './errors.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class IssueNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Issue "${id}" not found`);
+    this.name = 'IssueNotFoundError';
+  }
+}
+
+export class IssueSectionNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Issue section "${id}" not found`);
+    this.name = 'IssueSectionNotFoundError';
+  }
+}
+
+export class IssueItemAlreadyExistsError extends Error {
+  constructor(pipelineItemId: string) {
+    super(`Pipeline item "${pipelineItemId}" is already in this issue`);
+    this.name = 'IssueItemAlreadyExistsError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const issueService = {
+  // -------------------------------------------------------------------------
+  // List / Get
+  // -------------------------------------------------------------------------
+
+  async list(tx: DrizzleDb, input: ListIssuesInput) {
+    const { publicationId, status, search, page, limit } = input;
+    const offset = (page - 1) * limit;
+
+    const conditions = [];
+    if (publicationId) conditions.push(eq(issues.publicationId, publicationId));
+    if (status) conditions.push(eq(issues.status, status));
+    if (search) conditions.push(ilike(issues.title, `%${search}%`));
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const [items, countResult] = await Promise.all([
+      tx
+        .select()
+        .from(issues)
+        .where(where)
+        .orderBy(desc(issues.createdAt))
+        .limit(limit)
+        .offset(offset),
+      tx.select({ count: count() }).from(issues).where(where),
+    ]);
+
+    const total = countResult[0]?.count ?? 0;
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async getById(tx: DrizzleDb, id: string) {
+    const [row] = await tx
+      .select()
+      .from(issues)
+      .where(eq(issues.id, id))
+      .limit(1);
+
+    return row ?? null;
+  },
+
+  async getItems(tx: DrizzleDb, issueId: string) {
+    return tx
+      .select()
+      .from(issueItems)
+      .where(eq(issueItems.issueId, issueId))
+      .orderBy(issueItems.sortOrder);
+  },
+
+  async getSections(tx: DrizzleDb, issueId: string) {
+    return tx
+      .select()
+      .from(issueSections)
+      .where(eq(issueSections.issueId, issueId))
+      .orderBy(issueSections.sortOrder);
+  },
+
+  // -------------------------------------------------------------------------
+  // Create / Update / Status
+  // -------------------------------------------------------------------------
+
+  async create(tx: DrizzleDb, input: CreateIssueInput, orgId: string) {
+    const [row] = await tx
+      .insert(issues)
+      .values({
+        organizationId: orgId,
+        publicationId: input.publicationId,
+        title: input.title,
+        volume: input.volume ?? null,
+        issueNumber: input.issueNumber ?? null,
+        description: input.description ?? null,
+        coverImageUrl: input.coverImageUrl ?? null,
+        publicationDate: input.publicationDate ?? null,
+      })
+      .returning();
+
+    return row;
+  },
+
+  async createWithAudit(ctx: ServiceContext, input: CreateIssueInput) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const issue = await issueService.create(ctx.tx, input, ctx.actor.orgId);
+    await ctx.audit({
+      action: AuditActions.ISSUE_CREATED,
+      resource: AuditResources.ISSUE,
+      resourceId: issue.id,
+      newValue: { title: input.title },
+    });
+    return issue;
+  },
+
+  async update(tx: DrizzleDb, id: string, input: UpdateIssueInput) {
+    const values: Record<string, unknown> = { updatedAt: new Date() };
+    if (input.title !== undefined) values.title = input.title;
+    if (input.volume !== undefined) values.volume = input.volume;
+    if (input.issueNumber !== undefined) values.issueNumber = input.issueNumber;
+    if (input.description !== undefined) values.description = input.description;
+    if (input.coverImageUrl !== undefined)
+      values.coverImageUrl = input.coverImageUrl;
+    if (input.publicationDate !== undefined)
+      values.publicationDate = input.publicationDate;
+
+    const [row] = await tx
+      .update(issues)
+      .set(values)
+      .where(eq(issues.id, id))
+      .returning();
+
+    return row ?? null;
+  },
+
+  async updateWithAudit(
+    ctx: ServiceContext,
+    id: string,
+    input: UpdateIssueInput,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const updated = await issueService.update(ctx.tx, id, input);
+    if (!updated) throw new IssueNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.ISSUE_UPDATED,
+      resource: AuditResources.ISSUE,
+      resourceId: id,
+      newValue: input,
+    });
+    return updated;
+  },
+
+  async updateStatus(tx: DrizzleDb, id: string, status: IssueStatus) {
+    const values: Record<string, unknown> = {
+      status,
+      updatedAt: new Date(),
+    };
+    if (status === 'PUBLISHED') values.publishedAt = new Date();
+
+    const [row] = await tx
+      .update(issues)
+      .set(values)
+      .where(eq(issues.id, id))
+      .returning();
+
+    return row ?? null;
+  },
+
+  async publishWithAudit(ctx: ServiceContext, id: string) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const issue = await issueService.getById(ctx.tx, id);
+    if (!issue) throw new IssueNotFoundError(id);
+    const updated = await issueService.updateStatus(ctx.tx, id, 'PUBLISHED');
+    if (!updated) throw new IssueNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.ISSUE_PUBLISHED,
+      resource: AuditResources.ISSUE,
+      resourceId: id,
+      oldValue: { status: issue.status },
+      newValue: { status: 'PUBLISHED' },
+    });
+    return updated;
+  },
+
+  async archiveWithAudit(ctx: ServiceContext, id: string) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const issue = await issueService.getById(ctx.tx, id);
+    if (!issue) throw new IssueNotFoundError(id);
+    const updated = await issueService.updateStatus(ctx.tx, id, 'ARCHIVED');
+    if (!updated) throw new IssueNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.ISSUE_ARCHIVED,
+      resource: AuditResources.ISSUE,
+      resourceId: id,
+      oldValue: { status: issue.status },
+      newValue: { status: 'ARCHIVED' },
+    });
+    return updated;
+  },
+
+  // -------------------------------------------------------------------------
+  // Items
+  // -------------------------------------------------------------------------
+
+  async addItem(tx: DrizzleDb, issueId: string, input: AddIssueItemInput) {
+    const [row] = await tx
+      .insert(issueItems)
+      .values({
+        issueId,
+        pipelineItemId: input.pipelineItemId,
+        issueSectionId: input.issueSectionId ?? null,
+        sortOrder: input.sortOrder ?? 0,
+      })
+      .returning();
+
+    return row;
+  },
+
+  async addItemWithAudit(
+    ctx: ServiceContext,
+    issueId: string,
+    input: AddIssueItemInput,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    try {
+      const item = await issueService.addItem(ctx.tx, issueId, input);
+      await ctx.audit({
+        action: AuditActions.ISSUE_ITEM_ADDED,
+        resource: AuditResources.ISSUE,
+        resourceId: issueId,
+        newValue: { pipelineItemId: input.pipelineItemId },
+      });
+      return item;
+    } catch (e) {
+      // Unique constraint violation → already exists
+      if (
+        typeof e === 'object' &&
+        e !== null &&
+        'code' in e &&
+        (e as { code: string }).code === '23505'
+      ) {
+        throw new IssueItemAlreadyExistsError(input.pipelineItemId);
+      }
+      throw e;
+    }
+  },
+
+  async removeItem(tx: DrizzleDb, issueId: string, itemId: string) {
+    const [row] = await tx
+      .delete(issueItems)
+      .where(and(eq(issueItems.id, itemId), eq(issueItems.issueId, issueId)))
+      .returning();
+
+    return row ?? null;
+  },
+
+  async removeItemWithAudit(
+    ctx: ServiceContext,
+    issueId: string,
+    itemId: string,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const removed = await issueService.removeItem(ctx.tx, issueId, itemId);
+    if (removed) {
+      await ctx.audit({
+        action: AuditActions.ISSUE_ITEM_REMOVED,
+        resource: AuditResources.ISSUE,
+        resourceId: issueId,
+        oldValue: { pipelineItemId: removed.pipelineItemId },
+      });
+    }
+    return removed;
+  },
+
+  async reorderItems(tx: DrizzleDb, issueId: string, input: ReorderItemsInput) {
+    for (const { id, sortOrder } of input.items) {
+      await tx
+        .update(issueItems)
+        .set({ sortOrder })
+        .where(and(eq(issueItems.id, id), eq(issueItems.issueId, issueId)));
+    }
+    return issueService.getItems(tx, issueId);
+  },
+
+  // -------------------------------------------------------------------------
+  // Sections
+  // -------------------------------------------------------------------------
+
+  async addSection(
+    tx: DrizzleDb,
+    issueId: string,
+    input: AddIssueSectionInput,
+  ) {
+    const [row] = await tx
+      .insert(issueSections)
+      .values({
+        issueId,
+        title: input.title,
+        sortOrder: input.sortOrder ?? 0,
+      })
+      .returning();
+
+    return row;
+  },
+
+  async removeSection(tx: DrizzleDb, issueId: string, sectionId: string) {
+    const [row] = await tx
+      .delete(issueSections)
+      .where(
+        and(
+          eq(issueSections.id, sectionId),
+          eq(issueSections.issueId, issueId),
+        ),
+      )
+      .returning();
+
+    return row ?? null;
+  },
+};

--- a/apps/api/src/services/outbox.ts
+++ b/apps/api/src/services/outbox.ts
@@ -1,0 +1,23 @@
+import { outboxEvents, type DrizzleDb } from '@colophony/db';
+
+/**
+ * Insert an event into the transactional outbox.
+ *
+ * Call this inside the same RLS transaction as the mutation that triggers the
+ * event. The outbox poller (superuser) reads and delivers events to Inngest
+ * after the transaction commits.
+ *
+ * @param tx - The current RLS transaction (app_user has INSERT on outbox_events)
+ * @param eventType - Inngest event name (e.g. 'slate/contract.generated')
+ * @param payload - Event payload (must be JSON-serializable)
+ */
+export async function enqueueOutboxEvent(
+  tx: DrizzleDb,
+  eventType: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  await tx.insert(outboxEvents).values({
+    eventType,
+    payload,
+  });
+}

--- a/apps/api/src/services/pipeline.service.ts
+++ b/apps/api/src/services/pipeline.service.ts
@@ -1,0 +1,379 @@
+import {
+  pipelineItems,
+  pipelineHistory,
+  pipelineComments,
+  submissions,
+  eq,
+  and,
+  sql,
+  type DrizzleDb,
+} from '@colophony/db';
+import { desc, inArray, count } from 'drizzle-orm';
+import type {
+  CreatePipelineItemInput,
+  UpdatePipelineStageInput,
+  AssignPipelineRoleInput,
+  AddPipelineCommentInput,
+  ListPipelineItemsInput,
+  PipelineStage,
+} from '@colophony/types';
+import {
+  AuditActions,
+  AuditResources,
+  isValidPipelineTransition,
+} from '@colophony/types';
+import type { ServiceContext } from './types.js';
+import { assertEditorOrAdmin } from './errors.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class PipelineItemNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Pipeline item "${id}" not found`);
+    this.name = 'PipelineItemNotFoundError';
+  }
+}
+
+export class PipelineItemAlreadyExistsError extends Error {
+  constructor(submissionId: string) {
+    super(`Submission "${submissionId}" already has a pipeline item`);
+    this.name = 'PipelineItemAlreadyExistsError';
+  }
+}
+
+export class InvalidPipelineTransitionError extends Error {
+  constructor(from: string, to: string) {
+    super(`Invalid pipeline transition from "${from}" to "${to}"`);
+    this.name = 'InvalidPipelineTransitionError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const pipelineService = {
+  // -------------------------------------------------------------------------
+  // List / Get
+  // -------------------------------------------------------------------------
+
+  async list(tx: DrizzleDb, input: ListPipelineItemsInput) {
+    const {
+      stage,
+      publicationId,
+      assignedCopyeditorId,
+      assignedProofreaderId,
+      search,
+      page,
+      limit,
+    } = input;
+    const offset = (page - 1) * limit;
+
+    const conditions = [];
+    if (stage) conditions.push(eq(pipelineItems.stage, stage));
+    if (publicationId)
+      conditions.push(eq(pipelineItems.publicationId, publicationId));
+    if (assignedCopyeditorId)
+      conditions.push(
+        eq(pipelineItems.assignedCopyeditorId, assignedCopyeditorId),
+      );
+    if (assignedProofreaderId)
+      conditions.push(
+        eq(pipelineItems.assignedProofreaderId, assignedProofreaderId),
+      );
+
+    // Search by submission title via subquery
+    if (search) {
+      conditions.push(
+        inArray(
+          pipelineItems.submissionId,
+          tx
+            .select({ id: submissions.id })
+            .from(submissions)
+            .where(sql`${submissions.title} ILIKE ${'%' + search + '%'}`),
+        ),
+      );
+    }
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const [items, countResult] = await Promise.all([
+      tx
+        .select()
+        .from(pipelineItems)
+        .where(where)
+        .orderBy(desc(pipelineItems.createdAt))
+        .limit(limit)
+        .offset(offset),
+      tx.select({ count: count() }).from(pipelineItems).where(where),
+    ]);
+
+    const total = countResult[0]?.count ?? 0;
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async getById(tx: DrizzleDb, id: string) {
+    const [row] = await tx
+      .select()
+      .from(pipelineItems)
+      .where(eq(pipelineItems.id, id))
+      .limit(1);
+
+    return row ?? null;
+  },
+
+  async getBySubmissionId(tx: DrizzleDb, submissionId: string) {
+    const [row] = await tx
+      .select()
+      .from(pipelineItems)
+      .where(eq(pipelineItems.submissionId, submissionId))
+      .limit(1);
+
+    return row ?? null;
+  },
+
+  // -------------------------------------------------------------------------
+  // Create
+  // -------------------------------------------------------------------------
+
+  async create(tx: DrizzleDb, input: CreatePipelineItemInput, orgId: string) {
+    // Check uniqueness: one pipeline item per submission
+    const existing = await pipelineService.getBySubmissionId(
+      tx,
+      input.submissionId,
+    );
+    if (existing) throw new PipelineItemAlreadyExistsError(input.submissionId);
+
+    const [row] = await tx
+      .insert(pipelineItems)
+      .values({
+        organizationId: orgId,
+        submissionId: input.submissionId,
+        publicationId: input.publicationId ?? null,
+      })
+      .returning();
+
+    // Write initial history entry
+    await tx.insert(pipelineHistory).values({
+      pipelineItemId: row.id,
+      fromStage: null,
+      toStage: 'COPYEDIT_PENDING',
+    });
+
+    return row;
+  },
+
+  async createWithAudit(ctx: ServiceContext, input: CreatePipelineItemInput) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const item = await pipelineService.create(ctx.tx, input, ctx.actor.orgId);
+    await ctx.audit({
+      action: AuditActions.PIPELINE_ITEM_CREATED,
+      resource: AuditResources.PIPELINE_ITEM,
+      resourceId: item.id,
+      newValue: {
+        submissionId: input.submissionId,
+        publicationId: input.publicationId,
+      },
+    });
+    return item;
+  },
+
+  // -------------------------------------------------------------------------
+  // Stage transitions
+  // -------------------------------------------------------------------------
+
+  async updateStage(
+    tx: DrizzleDb,
+    id: string,
+    input: UpdatePipelineStageInput,
+    changedBy?: string,
+  ) {
+    const item = await pipelineService.getById(tx, id);
+    if (!item) throw new PipelineItemNotFoundError(id);
+
+    if (!isValidPipelineTransition(item.stage, input.stage)) {
+      throw new InvalidPipelineTransitionError(item.stage, input.stage);
+    }
+
+    const [updated] = await tx
+      .update(pipelineItems)
+      .set({ stage: input.stage, updatedAt: new Date() })
+      .where(eq(pipelineItems.id, id))
+      .returning();
+
+    // Write history entry
+    await tx.insert(pipelineHistory).values({
+      pipelineItemId: id,
+      fromStage: item.stage,
+      toStage: input.stage,
+      changedBy: changedBy ?? null,
+      comment: input.comment ?? null,
+    });
+
+    return updated;
+  },
+
+  async updateStageWithAudit(
+    ctx: ServiceContext,
+    id: string,
+    input: UpdatePipelineStageInput,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const updated = await pipelineService.updateStage(
+      ctx.tx,
+      id,
+      input,
+      ctx.actor.userId,
+    );
+    await ctx.audit({
+      action: AuditActions.PIPELINE_STAGE_CHANGED,
+      resource: AuditResources.PIPELINE_ITEM,
+      resourceId: id,
+      oldValue: { stage: updated.stage },
+      newValue: { stage: input.stage },
+    });
+    return updated;
+  },
+
+  // -------------------------------------------------------------------------
+  // Assign roles
+  // -------------------------------------------------------------------------
+
+  async assignCopyeditor(
+    tx: DrizzleDb,
+    id: string,
+    input: AssignPipelineRoleInput,
+  ) {
+    const [row] = await tx
+      .update(pipelineItems)
+      .set({ assignedCopyeditorId: input.userId, updatedAt: new Date() })
+      .where(eq(pipelineItems.id, id))
+      .returning();
+
+    return row ?? null;
+  },
+
+  async assignCopyeditorWithAudit(
+    ctx: ServiceContext,
+    id: string,
+    input: AssignPipelineRoleInput,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const updated = await pipelineService.assignCopyeditor(ctx.tx, id, input);
+    if (!updated) throw new PipelineItemNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.PIPELINE_COPYEDITOR_ASSIGNED,
+      resource: AuditResources.PIPELINE_ITEM,
+      resourceId: id,
+      newValue: { assignedCopyeditorId: input.userId },
+    });
+    return updated;
+  },
+
+  async assignProofreader(
+    tx: DrizzleDb,
+    id: string,
+    input: AssignPipelineRoleInput,
+  ) {
+    const [row] = await tx
+      .update(pipelineItems)
+      .set({ assignedProofreaderId: input.userId, updatedAt: new Date() })
+      .where(eq(pipelineItems.id, id))
+      .returning();
+
+    return row ?? null;
+  },
+
+  async assignProofreaderWithAudit(
+    ctx: ServiceContext,
+    id: string,
+    input: AssignPipelineRoleInput,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const updated = await pipelineService.assignProofreader(ctx.tx, id, input);
+    if (!updated) throw new PipelineItemNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.PIPELINE_PROOFREADER_ASSIGNED,
+      resource: AuditResources.PIPELINE_ITEM,
+      resourceId: id,
+      newValue: { assignedProofreaderId: input.userId },
+    });
+    return updated;
+  },
+
+  // -------------------------------------------------------------------------
+  // Comments
+  // -------------------------------------------------------------------------
+
+  async addComment(
+    tx: DrizzleDb,
+    pipelineItemId: string,
+    input: AddPipelineCommentInput,
+    authorId: string | null,
+    stage: PipelineStage,
+  ) {
+    const [row] = await tx
+      .insert(pipelineComments)
+      .values({
+        pipelineItemId,
+        authorId,
+        content: input.content,
+        stage,
+      })
+      .returning();
+
+    return row;
+  },
+
+  async addCommentWithAudit(
+    ctx: ServiceContext,
+    pipelineItemId: string,
+    input: AddPipelineCommentInput,
+  ) {
+    const item = await pipelineService.getById(ctx.tx, pipelineItemId);
+    if (!item) throw new PipelineItemNotFoundError(pipelineItemId);
+
+    const comment = await pipelineService.addComment(
+      ctx.tx,
+      pipelineItemId,
+      input,
+      ctx.actor.userId,
+      item.stage,
+    );
+    await ctx.audit({
+      action: AuditActions.PIPELINE_COMMENT_ADDED,
+      resource: AuditResources.PIPELINE_ITEM,
+      resourceId: pipelineItemId,
+      newValue: { commentId: comment.id },
+    });
+    return comment;
+  },
+
+  async listComments(tx: DrizzleDb, pipelineItemId: string) {
+    return tx
+      .select()
+      .from(pipelineComments)
+      .where(eq(pipelineComments.pipelineItemId, pipelineItemId))
+      .orderBy(desc(pipelineComments.createdAt));
+  },
+
+  // -------------------------------------------------------------------------
+  // History
+  // -------------------------------------------------------------------------
+
+  async getHistory(tx: DrizzleDb, pipelineItemId: string) {
+    return tx
+      .select()
+      .from(pipelineHistory)
+      .where(eq(pipelineHistory.pipelineItemId, pipelineItemId))
+      .orderBy(desc(pipelineHistory.changedAt));
+  },
+};

--- a/apps/api/src/services/pipeline.service.ts
+++ b/apps/api/src/services/pipeline.service.ts
@@ -24,6 +24,7 @@ import {
 } from '@colophony/types';
 import type { ServiceContext } from './types.js';
 import { assertEditorOrAdmin } from './errors.js';
+import { enqueueOutboxEvent } from './outbox.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -270,6 +271,30 @@ export const pipelineService = {
       oldValue: { stage: previousStage },
       newValue: { stage: input.stage },
     });
+
+    // Emit pipeline events consumed by Inngest workflows
+    const eventMap: Partial<Record<PipelineStage, string>> = {
+      AUTHOR_REVIEW: 'slate/pipeline.copyedit-completed',
+      READY_TO_PUBLISH: 'slate/pipeline.proofread-completed',
+    };
+    // Author review completion emits with approved flag based on direction
+    if (previousStage === 'AUTHOR_REVIEW') {
+      const approved = input.stage === 'PROOFREAD';
+      await enqueueOutboxEvent(
+        ctx.tx,
+        'slate/pipeline.author-review-completed',
+        { orgId: ctx.actor.orgId, pipelineItemId: id, approved },
+      );
+    } else {
+      const eventName = eventMap[input.stage];
+      if (eventName) {
+        await enqueueOutboxEvent(ctx.tx, eventName, {
+          orgId: ctx.actor.orgId,
+          pipelineItemId: id,
+        });
+      }
+    }
+
     return updated;
   },
 
@@ -305,6 +330,14 @@ export const pipelineService = {
       resourceId: id,
       newValue: { assignedCopyeditorId: input.userId },
     });
+
+    // Emit event for Inngest pipeline workflow
+    await enqueueOutboxEvent(ctx.tx, 'slate/pipeline.copyeditor-assigned', {
+      orgId: ctx.actor.orgId,
+      pipelineItemId: id,
+      copyeditorId: input.userId,
+    });
+
     return updated;
   },
 

--- a/apps/api/src/services/pipeline.service.ts
+++ b/apps/api/src/services/pipeline.service.ts
@@ -43,6 +43,15 @@ export class PipelineItemAlreadyExistsError extends Error {
   }
 }
 
+export class SubmissionNotAcceptedError extends Error {
+  constructor(submissionId: string, currentStatus: string) {
+    super(
+      `Submission "${submissionId}" has status "${currentStatus}" — only ACCEPTED submissions can enter the pipeline`,
+    );
+    this.name = 'SubmissionNotAcceptedError';
+  }
+}
+
 export class InvalidPipelineTransitionError extends Error {
   constructor(from: string, to: string) {
     super(`Invalid pipeline transition from "${from}" to "${to}"`);
@@ -145,6 +154,23 @@ export const pipelineService = {
   // -------------------------------------------------------------------------
 
   async create(tx: DrizzleDb, input: CreatePipelineItemInput, orgId: string) {
+    // Verify the submission exists and is ACCEPTED
+    const [submission] = await tx
+      .select({ id: submissions.id, status: submissions.status })
+      .from(submissions)
+      .where(eq(submissions.id, input.submissionId))
+      .limit(1);
+
+    if (!submission) {
+      throw new PipelineItemNotFoundError(input.submissionId);
+    }
+    if (submission.status !== 'ACCEPTED') {
+      throw new SubmissionNotAcceptedError(
+        input.submissionId,
+        submission.status,
+      );
+    }
+
     // Check uniqueness: one pipeline item per submission
     const existing = await pipelineService.getBySubmissionId(
       tx,
@@ -227,6 +253,10 @@ export const pipelineService = {
     input: UpdatePipelineStageInput,
   ) {
     assertEditorOrAdmin(ctx.actor.role);
+    // Capture the previous stage before the update for the audit trail
+    const current = await pipelineService.getById(ctx.tx, id);
+    if (!current) throw new PipelineItemNotFoundError(id);
+    const previousStage = current.stage;
     const updated = await pipelineService.updateStage(
       ctx.tx,
       id,
@@ -237,7 +267,7 @@ export const pipelineService = {
       action: AuditActions.PIPELINE_STAGE_CHANGED,
       resource: AuditResources.PIPELINE_ITEM,
       resourceId: id,
-      oldValue: { stage: updated.stage },
+      oldValue: { stage: previousStage },
       newValue: { stage: input.stage },
     });
     return updated;

--- a/apps/api/src/services/publication.service.ts
+++ b/apps/api/src/services/publication.service.ts
@@ -1,0 +1,193 @@
+import { publications, eq, and, sql, type DrizzleDb } from '@colophony/db';
+import { desc, ilike, count } from 'drizzle-orm';
+import type {
+  CreatePublicationInput,
+  UpdatePublicationInput,
+  ListPublicationsInput,
+} from '@colophony/types';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { ServiceContext } from './types.js';
+import { assertEditorOrAdmin } from './errors.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class PublicationNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Publication "${id}" not found`);
+    this.name = 'PublicationNotFoundError';
+  }
+}
+
+export class PublicationSlugConflictError extends Error {
+  constructor(slug: string) {
+    super(`Publication slug "${slug}" already exists in this organization`);
+    this.name = 'PublicationSlugConflictError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const publicationService = {
+  // -------------------------------------------------------------------------
+  // List / Get
+  // -------------------------------------------------------------------------
+
+  async list(tx: DrizzleDb, input: ListPublicationsInput) {
+    const { status, search, page, limit } = input;
+    const offset = (page - 1) * limit;
+
+    const conditions = [];
+    if (status) conditions.push(eq(publications.status, status));
+    if (search) conditions.push(ilike(publications.name, `%${search}%`));
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const [items, countResult] = await Promise.all([
+      tx
+        .select()
+        .from(publications)
+        .where(where)
+        .orderBy(desc(publications.createdAt))
+        .limit(limit)
+        .offset(offset),
+      tx.select({ count: count() }).from(publications).where(where),
+    ]);
+
+    const total = countResult[0]?.count ?? 0;
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async getById(tx: DrizzleDb, id: string) {
+    const [row] = await tx
+      .select()
+      .from(publications)
+      .where(eq(publications.id, id))
+      .limit(1);
+
+    return row ?? null;
+  },
+
+  async getBySlug(tx: DrizzleDb, slug: string) {
+    const [row] = await tx
+      .select()
+      .from(publications)
+      .where(sql`lower(${publications.slug}) = lower(${slug})`)
+      .limit(1);
+
+    return row ?? null;
+  },
+
+  // -------------------------------------------------------------------------
+  // Create / Update / Archive
+  // -------------------------------------------------------------------------
+
+  async create(tx: DrizzleDb, input: CreatePublicationInput, orgId: string) {
+    // Check slug uniqueness within org
+    const existing = await publicationService.getBySlug(tx, input.slug);
+    if (existing) throw new PublicationSlugConflictError(input.slug);
+
+    const [row] = await tx
+      .insert(publications)
+      .values({
+        organizationId: orgId,
+        name: input.name,
+        slug: input.slug,
+        description: input.description ?? null,
+        settings: input.settings ?? null,
+      })
+      .returning();
+
+    return row;
+  },
+
+  async createWithAudit(ctx: ServiceContext, input: CreatePublicationInput) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const publication = await publicationService.create(
+      ctx.tx,
+      input,
+      ctx.actor.orgId,
+    );
+    await ctx.audit({
+      action: AuditActions.PUBLICATION_CREATED,
+      resource: AuditResources.PUBLICATION,
+      resourceId: publication.id,
+      newValue: { name: input.name, slug: input.slug },
+    });
+    return publication;
+  },
+
+  async update(tx: DrizzleDb, id: string, input: UpdatePublicationInput) {
+    const values: Record<string, unknown> = { updatedAt: new Date() };
+    if (input.name !== undefined) values.name = input.name;
+    if (input.slug !== undefined) {
+      // Check slug uniqueness if changing
+      const existing = await publicationService.getBySlug(tx, input.slug);
+      if (existing && existing.id !== id) {
+        throw new PublicationSlugConflictError(input.slug);
+      }
+      values.slug = input.slug;
+    }
+    if (input.description !== undefined)
+      values.description = input.description ?? null;
+    if (input.settings !== undefined) values.settings = input.settings ?? null;
+
+    const [row] = await tx
+      .update(publications)
+      .set(values)
+      .where(eq(publications.id, id))
+      .returning();
+
+    return row ?? null;
+  },
+
+  async updateWithAudit(
+    ctx: ServiceContext,
+    id: string,
+    input: UpdatePublicationInput,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const updated = await publicationService.update(ctx.tx, id, input);
+    if (!updated) throw new PublicationNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.PUBLICATION_UPDATED,
+      resource: AuditResources.PUBLICATION,
+      resourceId: id,
+      newValue: input,
+    });
+    return updated;
+  },
+
+  async archive(tx: DrizzleDb, id: string) {
+    const [row] = await tx
+      .update(publications)
+      .set({ status: 'ARCHIVED', updatedAt: new Date() })
+      .where(eq(publications.id, id))
+      .returning();
+
+    return row ?? null;
+  },
+
+  async archiveWithAudit(ctx: ServiceContext, id: string) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const archived = await publicationService.archive(ctx.tx, id);
+    if (!archived) throw new PublicationNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.PUBLICATION_ARCHIVED,
+      resource: AuditResources.PUBLICATION,
+      resourceId: id,
+      oldValue: { status: 'ACTIVE' },
+      newValue: { status: 'ARCHIVED' },
+    });
+    return archived;
+  },
+};

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -38,6 +38,11 @@ import {
   PublicationNotFoundError,
   PublicationSlugConflictError,
 } from '../services/publication.service.js';
+import {
+  PipelineItemNotFoundError,
+  PipelineItemAlreadyExistsError,
+  InvalidPipelineTransitionError,
+} from '../services/pipeline.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -76,6 +81,10 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   // Publication errors
   [PublicationNotFoundError, 'NOT_FOUND'],
   [PublicationSlugConflictError, 'CONFLICT'],
+  // Pipeline errors
+  [PipelineItemNotFoundError, 'NOT_FOUND'],
+  [PipelineItemAlreadyExistsError, 'CONFLICT'],
+  [InvalidPipelineTransitionError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -34,6 +34,10 @@ import {
   ManuscriptNotFoundError,
   ManuscriptVersionNotFoundError,
 } from '../services/manuscript.service.js';
+import {
+  PublicationNotFoundError,
+  PublicationSlugConflictError,
+} from '../services/publication.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -69,6 +73,9 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   // Period errors
   [PeriodNotFoundError, 'NOT_FOUND'],
   [PeriodHasSubmissionsError, 'BAD_REQUEST'],
+  // Publication errors
+  [PublicationNotFoundError, 'NOT_FOUND'],
+  [PublicationSlugConflictError, 'CONFLICT'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -43,6 +43,8 @@ import {
   PipelineItemAlreadyExistsError,
   InvalidPipelineTransitionError,
 } from '../services/pipeline.service.js';
+import { ContractTemplateNotFoundError } from '../services/contract-template.service.js';
+import { ContractNotFoundError } from '../services/contract.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -85,6 +87,9 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [PipelineItemNotFoundError, 'NOT_FOUND'],
   [PipelineItemAlreadyExistsError, 'CONFLICT'],
   [InvalidPipelineTransitionError, 'BAD_REQUEST'],
+  // Contract errors
+  [ContractTemplateNotFoundError, 'NOT_FOUND'],
+  [ContractNotFoundError, 'NOT_FOUND'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -50,6 +50,7 @@ import {
   IssueNotFoundError,
   IssueItemAlreadyExistsError,
 } from '../services/issue.service.js';
+import { CmsConnectionNotFoundError } from '../services/cms-connection.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -99,6 +100,8 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   // Issue errors
   [IssueNotFoundError, 'NOT_FOUND'],
   [IssueItemAlreadyExistsError, 'CONFLICT'],
+  // CMS errors
+  [CmsConnectionNotFoundError, 'NOT_FOUND'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -42,9 +42,14 @@ import {
   PipelineItemNotFoundError,
   PipelineItemAlreadyExistsError,
   InvalidPipelineTransitionError,
+  SubmissionNotAcceptedError,
 } from '../services/pipeline.service.js';
 import { ContractTemplateNotFoundError } from '../services/contract-template.service.js';
 import { ContractNotFoundError } from '../services/contract.service.js';
+import {
+  IssueNotFoundError,
+  IssueItemAlreadyExistsError,
+} from '../services/issue.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -87,9 +92,13 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [PipelineItemNotFoundError, 'NOT_FOUND'],
   [PipelineItemAlreadyExistsError, 'CONFLICT'],
   [InvalidPipelineTransitionError, 'BAD_REQUEST'],
+  [SubmissionNotAcceptedError, 'BAD_REQUEST'],
   // Contract errors
   [ContractTemplateNotFoundError, 'NOT_FOUND'],
   [ContractNotFoundError, 'NOT_FOUND'],
+  // Issue errors
+  [IssueNotFoundError, 'NOT_FOUND'],
+  [IssueItemAlreadyExistsError, 'CONFLICT'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -11,6 +11,7 @@ import { periodsRouter } from './routers/periods.js';
 import { manuscriptsRouter } from './routers/manuscripts.js';
 import { embedTokensRouter } from './routers/embed-tokens.js';
 import { gdprRouter } from './routers/gdpr.js';
+import { publicationsRouter } from './routers/publications.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -43,6 +44,7 @@ export const appRouter = t.router({
   forms: formsRouter,
   periods: periodsRouter,
   embedTokens: embedTokensRouter,
+  publications: publicationsRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -16,6 +16,7 @@ import { pipelineRouter } from './routers/pipeline.js';
 import { contractTemplatesRouter } from './routers/contract-templates.js';
 import { contractsRouter } from './routers/contracts.js';
 import { issuesRouter } from './routers/issues.js';
+import { cmsConnectionsRouter } from './routers/cms-connections.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -53,6 +54,7 @@ export const appRouter = t.router({
   contractTemplates: contractTemplatesRouter,
   contracts: contractsRouter,
   issues: issuesRouter,
+  cmsConnections: cmsConnectionsRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -12,6 +12,7 @@ import { manuscriptsRouter } from './routers/manuscripts.js';
 import { embedTokensRouter } from './routers/embed-tokens.js';
 import { gdprRouter } from './routers/gdpr.js';
 import { publicationsRouter } from './routers/publications.js';
+import { pipelineRouter } from './routers/pipeline.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -45,6 +46,7 @@ export const appRouter = t.router({
   periods: periodsRouter,
   embedTokens: embedTokensRouter,
   publications: publicationsRouter,
+  pipeline: pipelineRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -15,6 +15,7 @@ import { publicationsRouter } from './routers/publications.js';
 import { pipelineRouter } from './routers/pipeline.js';
 import { contractTemplatesRouter } from './routers/contract-templates.js';
 import { contractsRouter } from './routers/contracts.js';
+import { issuesRouter } from './routers/issues.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -51,6 +52,7 @@ export const appRouter = t.router({
   pipeline: pipelineRouter,
   contractTemplates: contractTemplatesRouter,
   contracts: contractsRouter,
+  issues: issuesRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -13,6 +13,8 @@ import { embedTokensRouter } from './routers/embed-tokens.js';
 import { gdprRouter } from './routers/gdpr.js';
 import { publicationsRouter } from './routers/publications.js';
 import { pipelineRouter } from './routers/pipeline.js';
+import { contractTemplatesRouter } from './routers/contract-templates.js';
+import { contractsRouter } from './routers/contracts.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -47,6 +49,8 @@ export const appRouter = t.router({
   embedTokens: embedTokensRouter,
   publications: publicationsRouter,
   pipeline: pipelineRouter,
+  contractTemplates: contractTemplatesRouter,
+  contracts: contractsRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/cms-connections.ts
+++ b/apps/api/src/trpc/routers/cms-connections.ts
@@ -1,0 +1,113 @@
+import {
+  createCmsConnectionSchema,
+  updateCmsConnectionSchema,
+  listCmsConnectionsSchema,
+  cmsConnectionSchema,
+  idParamSchema,
+  paginatedResponseSchema,
+} from '@colophony/types';
+import { z } from 'zod';
+import {
+  orgProcedure,
+  adminProcedure,
+  createRouter,
+  requireScopes,
+} from '../init.js';
+import {
+  cmsConnectionService,
+  CmsConnectionNotFoundError,
+} from '../../services/cms-connection.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+
+export const cmsConnectionsRouter = createRouter({
+  /** List CMS connections in the org. */
+  list: orgProcedure
+    .use(requireScopes('cms:read'))
+    .input(listCmsConnectionsSchema)
+    .output(paginatedResponseSchema(cmsConnectionSchema))
+    .query(async ({ ctx, input }) => {
+      return cmsConnectionService.list(ctx.dbTx, input);
+    }),
+
+  /** Get CMS connection by ID. */
+  getById: orgProcedure
+    .use(requireScopes('cms:read'))
+    .input(idParamSchema)
+    .output(cmsConnectionSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        const connection = await cmsConnectionService.getById(
+          ctx.dbTx,
+          input.id,
+        );
+        if (!connection) throw new CmsConnectionNotFoundError(input.id);
+        return connection;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Create a new CMS connection (admin only). */
+  create: adminProcedure
+    .use(requireScopes('cms:write'))
+    .input(createCmsConnectionSchema)
+    .output(cmsConnectionSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await cmsConnectionService.createWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Update a CMS connection (admin only). */
+  update: adminProcedure
+    .use(requireScopes('cms:write'))
+    .input(idParamSchema.merge(updateCmsConnectionSchema))
+    .output(cmsConnectionSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      try {
+        return await cmsConnectionService.updateWithAudit(
+          toServiceContext(ctx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Delete a CMS connection (admin only). */
+  delete: adminProcedure
+    .use(requireScopes('cms:write'))
+    .input(idParamSchema)
+    .output(cmsConnectionSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await cmsConnectionService.deleteWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Test a CMS connection's config. */
+  test: orgProcedure
+    .use(requireScopes('cms:read'))
+    .input(idParamSchema)
+    .output(z.object({ success: z.boolean(), error: z.string().optional() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await cmsConnectionService.testConnection(ctx.dbTx, input.id);
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+});

--- a/apps/api/src/trpc/routers/contract-templates.ts
+++ b/apps/api/src/trpc/routers/contract-templates.ts
@@ -1,0 +1,99 @@
+import {
+  createContractTemplateSchema,
+  updateContractTemplateSchema,
+  listContractTemplatesSchema,
+  contractTemplateSchema,
+  idParamSchema,
+  paginatedResponseSchema,
+} from '@colophony/types';
+import {
+  orgProcedure,
+  adminProcedure,
+  createRouter,
+  requireScopes,
+} from '../init.js';
+import {
+  contractTemplateService,
+  ContractTemplateNotFoundError,
+} from '../../services/contract-template.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+
+export const contractTemplatesRouter = createRouter({
+  /** List contract templates in the org. */
+  list: orgProcedure
+    .use(requireScopes('contracts:read'))
+    .input(listContractTemplatesSchema)
+    .output(paginatedResponseSchema(contractTemplateSchema))
+    .query(async ({ ctx, input }) => {
+      return contractTemplateService.list(ctx.dbTx, input);
+    }),
+
+  /** Get contract template by ID. */
+  getById: orgProcedure
+    .use(requireScopes('contracts:read'))
+    .input(idParamSchema)
+    .output(contractTemplateSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        const template = await contractTemplateService.getById(
+          ctx.dbTx,
+          input.id,
+        );
+        if (!template) throw new ContractTemplateNotFoundError(input.id);
+        return template;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Create a contract template (admin only). */
+  create: adminProcedure
+    .use(requireScopes('contracts:write'))
+    .input(createContractTemplateSchema)
+    .output(contractTemplateSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await contractTemplateService.createWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Update a contract template (admin only). */
+  update: adminProcedure
+    .use(requireScopes('contracts:write'))
+    .input(idParamSchema.merge(updateContractTemplateSchema))
+    .output(contractTemplateSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      try {
+        return await contractTemplateService.updateWithAudit(
+          toServiceContext(ctx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Delete a contract template (admin only). */
+  delete: adminProcedure
+    .use(requireScopes('contracts:write'))
+    .input(idParamSchema)
+    .output(contractTemplateSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await contractTemplateService.deleteWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+});

--- a/apps/api/src/trpc/routers/contracts.ts
+++ b/apps/api/src/trpc/routers/contracts.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod';
+import {
+  generateContractSchema,
+  listContractsSchema,
+  contractSchema,
+  idParamSchema,
+  paginatedResponseSchema,
+} from '@colophony/types';
+import {
+  orgProcedure,
+  adminProcedure,
+  createRouter,
+  requireScopes,
+} from '../init.js';
+import {
+  contractService,
+  ContractNotFoundError,
+} from '../../services/contract.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+
+export const contractsRouter = createRouter({
+  /** List contracts in the org. */
+  list: orgProcedure
+    .use(requireScopes('contracts:read'))
+    .input(listContractsSchema)
+    .output(paginatedResponseSchema(contractSchema))
+    .query(async ({ ctx, input }) => {
+      return contractService.list(ctx.dbTx, input);
+    }),
+
+  /** Get contract by ID. */
+  getById: orgProcedure
+    .use(requireScopes('contracts:read'))
+    .input(idParamSchema)
+    .output(contractSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        const contract = await contractService.getById(ctx.dbTx, input.id);
+        if (!contract) throw new ContractNotFoundError(input.id);
+        return contract;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** List contracts for a pipeline item. */
+  listByPipelineItem: orgProcedure
+    .use(requireScopes('contracts:read'))
+    .input(z.object({ pipelineItemId: z.string().uuid() }))
+    .output(z.array(contractSchema))
+    .query(async ({ ctx, input }) => {
+      return contractService.getByPipelineItemId(
+        ctx.dbTx,
+        input.pipelineItemId,
+      );
+    }),
+
+  /** Generate a contract from a template (admin only). */
+  generate: adminProcedure
+    .use(requireScopes('contracts:write'))
+    .input(generateContractSchema)
+    .output(contractSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await contractService.generateWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Send a contract (admin only). */
+  send: adminProcedure
+    .use(requireScopes('contracts:write'))
+    .input(idParamSchema)
+    .output(contractSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await contractService.sendWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Void a contract (admin only). */
+  void: adminProcedure
+    .use(requireScopes('contracts:write'))
+    .input(idParamSchema)
+    .output(contractSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await contractService.voidWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+});

--- a/apps/api/src/trpc/routers/issues.ts
+++ b/apps/api/src/trpc/routers/issues.ts
@@ -1,0 +1,197 @@
+import { z } from 'zod';
+import {
+  createIssueSchema,
+  updateIssueSchema,
+  listIssuesSchema,
+  addIssueItemSchema,
+  addIssueSectionSchema,
+  reorderItemsSchema,
+  issueSchema,
+  issueSectionSchema,
+  issueItemSchema,
+  idParamSchema,
+  paginatedResponseSchema,
+} from '@colophony/types';
+import {
+  orgProcedure,
+  adminProcedure,
+  createRouter,
+  requireScopes,
+} from '../init.js';
+import {
+  issueService,
+  IssueNotFoundError,
+} from '../../services/issue.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+
+export const issuesRouter = createRouter({
+  /** List issues in the org. */
+  list: orgProcedure
+    .use(requireScopes('issues:read'))
+    .input(listIssuesSchema)
+    .output(paginatedResponseSchema(issueSchema))
+    .query(async ({ ctx, input }) => {
+      return issueService.list(ctx.dbTx, input);
+    }),
+
+  /** Get issue by ID. */
+  getById: orgProcedure
+    .use(requireScopes('issues:read'))
+    .input(idParamSchema)
+    .output(issueSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        const issue = await issueService.getById(ctx.dbTx, input.id);
+        if (!issue) throw new IssueNotFoundError(input.id);
+        return issue;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Get items in an issue. */
+  getItems: orgProcedure
+    .use(requireScopes('issues:read'))
+    .input(idParamSchema)
+    .output(z.array(issueItemSchema))
+    .query(async ({ ctx, input }) => {
+      return issueService.getItems(ctx.dbTx, input.id);
+    }),
+
+  /** Get sections in an issue. */
+  getSections: orgProcedure
+    .use(requireScopes('issues:read'))
+    .input(idParamSchema)
+    .output(z.array(issueSectionSchema))
+    .query(async ({ ctx, input }) => {
+      return issueService.getSections(ctx.dbTx, input.id);
+    }),
+
+  /** Create an issue (admin only). */
+  create: adminProcedure
+    .use(requireScopes('issues:write'))
+    .input(createIssueSchema)
+    .output(issueSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await issueService.createWithAudit(toServiceContext(ctx), input);
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Update an issue (admin only). */
+  update: adminProcedure
+    .use(requireScopes('issues:write'))
+    .input(idParamSchema.merge(updateIssueSchema))
+    .output(issueSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      try {
+        return await issueService.updateWithAudit(
+          toServiceContext(ctx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Publish an issue (admin only). */
+  publish: adminProcedure
+    .use(requireScopes('issues:write'))
+    .input(idParamSchema)
+    .output(issueSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await issueService.publishWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Archive an issue (admin only). */
+  archive: adminProcedure
+    .use(requireScopes('issues:write'))
+    .input(idParamSchema)
+    .output(issueSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await issueService.archiveWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Add an item to an issue. */
+  addItem: orgProcedure
+    .use(requireScopes('issues:write'))
+    .input(idParamSchema.merge(addIssueItemSchema))
+    .output(issueItemSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      try {
+        return await issueService.addItemWithAudit(
+          toServiceContext(ctx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Remove an item from an issue. */
+  removeItem: orgProcedure
+    .use(requireScopes('issues:write'))
+    .input(z.object({ id: z.string().uuid(), itemId: z.string().uuid() }))
+    .output(issueItemSchema.nullable())
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await issueService.removeItemWithAudit(
+          toServiceContext(ctx),
+          input.id,
+          input.itemId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Reorder items in an issue. */
+  reorderItems: orgProcedure
+    .use(requireScopes('issues:write'))
+    .input(idParamSchema.merge(reorderItemsSchema))
+    .output(z.array(issueItemSchema))
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      return issueService.reorderItems(ctx.dbTx, id, data);
+    }),
+
+  /** Add a section to an issue. */
+  addSection: orgProcedure
+    .use(requireScopes('issues:write'))
+    .input(idParamSchema.merge(addIssueSectionSchema))
+    .output(issueSectionSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      return issueService.addSection(ctx.dbTx, id, data);
+    }),
+
+  /** Remove a section from an issue. */
+  removeSection: orgProcedure
+    .use(requireScopes('issues:write'))
+    .input(z.object({ id: z.string().uuid(), sectionId: z.string().uuid() }))
+    .output(issueSectionSchema.nullable())
+    .mutation(async ({ ctx, input }) => {
+      return issueService.removeSection(ctx.dbTx, input.id, input.sectionId);
+    }),
+});

--- a/apps/api/src/trpc/routers/issues.ts
+++ b/apps/api/src/trpc/routers/issues.ts
@@ -167,7 +167,7 @@ export const issuesRouter = createRouter({
     }),
 
   /** Reorder items in an issue. */
-  reorderItems: orgProcedure
+  reorderItems: adminProcedure
     .use(requireScopes('issues:write'))
     .input(idParamSchema.merge(reorderItemsSchema))
     .output(z.array(issueItemSchema))
@@ -177,7 +177,7 @@ export const issuesRouter = createRouter({
     }),
 
   /** Add a section to an issue. */
-  addSection: orgProcedure
+  addSection: adminProcedure
     .use(requireScopes('issues:write'))
     .input(idParamSchema.merge(addIssueSectionSchema))
     .output(issueSectionSchema)
@@ -187,7 +187,7 @@ export const issuesRouter = createRouter({
     }),
 
   /** Remove a section from an issue. */
-  removeSection: orgProcedure
+  removeSection: adminProcedure
     .use(requireScopes('issues:write'))
     .input(z.object({ id: z.string().uuid(), sectionId: z.string().uuid() }))
     .output(issueSectionSchema.nullable())

--- a/apps/api/src/trpc/routers/pipeline.ts
+++ b/apps/api/src/trpc/routers/pipeline.ts
@@ -1,0 +1,157 @@
+import {
+  createPipelineItemSchema,
+  updatePipelineStageSchema,
+  assignPipelineRoleSchema,
+  addPipelineCommentSchema,
+  listPipelineItemsSchema,
+  pipelineItemSchema,
+  pipelineHistoryEntrySchema,
+  pipelineCommentSchema,
+  idParamSchema,
+  paginatedResponseSchema,
+} from '@colophony/types';
+import { z } from 'zod';
+import {
+  orgProcedure,
+  adminProcedure,
+  createRouter,
+  requireScopes,
+} from '../init.js';
+import {
+  pipelineService,
+  PipelineItemNotFoundError,
+} from '../../services/pipeline.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+
+export const pipelineRouter = createRouter({
+  /** List pipeline items in the org. */
+  list: orgProcedure
+    .use(requireScopes('pipeline:read'))
+    .input(listPipelineItemsSchema)
+    .output(paginatedResponseSchema(pipelineItemSchema))
+    .query(async ({ ctx, input }) => {
+      return pipelineService.list(ctx.dbTx, input);
+    }),
+
+  /** Get pipeline item by ID. */
+  getById: orgProcedure
+    .use(requireScopes('pipeline:read'))
+    .input(idParamSchema)
+    .output(pipelineItemSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        const item = await pipelineService.getById(ctx.dbTx, input.id);
+        if (!item) throw new PipelineItemNotFoundError(input.id);
+        return item;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Create a pipeline item (editor/admin). */
+  create: adminProcedure
+    .use(requireScopes('pipeline:write'))
+    .input(createPipelineItemSchema)
+    .output(pipelineItemSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await pipelineService.createWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Advance/change pipeline stage (editor/admin). */
+  updateStage: adminProcedure
+    .use(requireScopes('pipeline:write'))
+    .input(idParamSchema.merge(updatePipelineStageSchema))
+    .output(pipelineItemSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      try {
+        return await pipelineService.updateStageWithAudit(
+          toServiceContext(ctx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Assign a copyeditor (editor/admin). */
+  assignCopyeditor: adminProcedure
+    .use(requireScopes('pipeline:write'))
+    .input(idParamSchema.merge(assignPipelineRoleSchema))
+    .output(pipelineItemSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      try {
+        return await pipelineService.assignCopyeditorWithAudit(
+          toServiceContext(ctx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Assign a proofreader (editor/admin). */
+  assignProofreader: adminProcedure
+    .use(requireScopes('pipeline:write'))
+    .input(idParamSchema.merge(assignPipelineRoleSchema))
+    .output(pipelineItemSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      try {
+        return await pipelineService.assignProofreaderWithAudit(
+          toServiceContext(ctx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Add a comment to a pipeline item. */
+  addComment: orgProcedure
+    .use(requireScopes('pipeline:write'))
+    .input(idParamSchema.merge(addPipelineCommentSchema))
+    .output(pipelineCommentSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      try {
+        return await pipelineService.addCommentWithAudit(
+          toServiceContext(ctx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** List comments for a pipeline item. */
+  listComments: orgProcedure
+    .use(requireScopes('pipeline:read'))
+    .input(idParamSchema)
+    .output(z.array(pipelineCommentSchema))
+    .query(async ({ ctx, input }) => {
+      return pipelineService.listComments(ctx.dbTx, input.id);
+    }),
+
+  /** Get stage transition history for a pipeline item. */
+  getHistory: orgProcedure
+    .use(requireScopes('pipeline:read'))
+    .input(idParamSchema)
+    .output(z.array(pipelineHistoryEntrySchema))
+    .query(async ({ ctx, input }) => {
+      return pipelineService.getHistory(ctx.dbTx, input.id);
+    }),
+});

--- a/apps/api/src/trpc/routers/publications.ts
+++ b/apps/api/src/trpc/routers/publications.ts
@@ -1,0 +1,99 @@
+import {
+  createPublicationSchema,
+  updatePublicationSchema,
+  listPublicationsSchema,
+  publicationSchema,
+  idParamSchema,
+  paginatedResponseSchema,
+} from '@colophony/types';
+import {
+  orgProcedure,
+  adminProcedure,
+  createRouter,
+  requireScopes,
+} from '../init.js';
+import {
+  publicationService,
+  PublicationNotFoundError,
+} from '../../services/publication.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+
+export const publicationsRouter = createRouter({
+  /** List publications in the org. */
+  list: orgProcedure
+    .use(requireScopes('publications:read'))
+    .input(listPublicationsSchema)
+    .output(paginatedResponseSchema(publicationSchema))
+    .query(async ({ ctx, input }) => {
+      return publicationService.list(ctx.dbTx, input);
+    }),
+
+  /** Get publication by ID. */
+  getById: orgProcedure
+    .use(requireScopes('publications:read'))
+    .input(idParamSchema)
+    .output(publicationSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        const publication = await publicationService.getById(
+          ctx.dbTx,
+          input.id,
+        );
+        if (!publication) throw new PublicationNotFoundError(input.id);
+        return publication;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Create a new publication (admin only). */
+  create: adminProcedure
+    .use(requireScopes('publications:write'))
+    .input(createPublicationSchema)
+    .output(publicationSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await publicationService.createWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Update a publication (admin only). */
+  update: adminProcedure
+    .use(requireScopes('publications:write'))
+    .input(idParamSchema.merge(updatePublicationSchema))
+    .output(publicationSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      try {
+        return await publicationService.updateWithAudit(
+          toServiceContext(ctx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Archive a publication (admin only). */
+  archive: adminProcedure
+    .use(requireScopes('publications:write'))
+    .input(idParamSchema)
+    .output(publicationSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await publicationService.archiveWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+});

--- a/apps/api/src/webhooks/documenso.webhook.ts
+++ b/apps/api/src/webhooks/documenso.webhook.ts
@@ -1,0 +1,329 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import Redis from 'ioredis';
+import { pool } from '@colophony/db';
+import type { Env } from '../config/env.js';
+import { createDocumensoAdapter } from '../adapters/documenso.adapter.js';
+import { contractService } from '../services/contract.service.js';
+import { inngest } from '../inngest/client.js';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import type { DrizzleDb } from '@colophony/db';
+
+export interface DocumensoWebhookOptions {
+  env: Env;
+}
+
+/**
+ * Atomic Lua script: INCR key, set PEXPIRE on first hit, return [count, pttl].
+ */
+const RATE_LIMIT_LUA = `
+local current = redis.call('INCR', KEYS[1])
+if current == 1 then
+  redis.call('PEXPIRE', KEYS[1], ARGV[1])
+end
+local ttl = redis.call('PTTL', KEYS[1])
+return { current, ttl }
+`;
+
+/**
+ * Registers the Documenso webhook endpoint.
+ *
+ * Same pattern as stripe.webhook.ts: isolated Fastify scope, raw body parsing,
+ * signature verification, two-step idempotency via documenso_webhook_events.
+ */
+export async function registerDocumensoWebhooks(
+  app: FastifyInstance,
+  opts: DocumensoWebhookOptions,
+) {
+  const { env } = opts;
+
+  // Register raw body plugin for signature verification (scoped)
+  const rawBodyPlugin = await import('fastify-raw-body');
+  await app.register(rawBodyPlugin.default, {
+    field: 'rawBody',
+    global: true,
+    encoding: false,
+    runFirst: true,
+  });
+
+  const adapter = createDocumensoAdapter(env);
+
+  // Lazy Redis connection for webhook rate limiting
+  let redis: Redis | null = null;
+
+  function getRedis(): Redis | null {
+    if (redis) return redis;
+    try {
+      redis = new Redis({
+        host: env.REDIS_HOST,
+        port: env.REDIS_PORT,
+        password: env.REDIS_PASSWORD || undefined,
+        lazyConnect: true,
+        enableOfflineQueue: false,
+        maxRetriesPerRequest: 0,
+        connectTimeout: 5000,
+        commandTimeout: 1000,
+      });
+      redis.connect().catch(() => {
+        // Connection failure handled per-request via graceful degradation
+      });
+      return redis;
+    } catch {
+      return null;
+    }
+  }
+
+  app.addHook('onClose', async () => {
+    if (redis) {
+      await redis.quit().catch(() => {});
+    }
+  });
+
+  app.post(
+    '/webhooks/documenso',
+    {
+      config: { rawBody: true },
+      bodyLimit: 256 * 1024,
+      /* eslint-disable @typescript-eslint/no-misused-promises */
+      preHandler: async function webhookRateLimit(
+        request: FastifyRequest,
+        reply: FastifyReply,
+      ) {
+        const redisClient = getRedis();
+        if (!redisClient) return;
+
+        const windowMs = env.RATE_LIMIT_WINDOW_SECONDS * 1000;
+        const windowId = Math.floor(Date.now() / windowMs);
+        const key = `${env.RATE_LIMIT_KEY_PREFIX}:wh:documenso:${windowId}:${request.ip}`;
+
+        try {
+          const result = (await redisClient.eval(
+            RATE_LIMIT_LUA,
+            1,
+            key,
+            windowMs,
+          )) as [number, number];
+          const count = result[0];
+
+          if (count > env.WEBHOOK_RATE_LIMIT_MAX) {
+            const remainingMs = windowMs - (Date.now() % windowMs);
+            const retryAfterSeconds = Math.ceil(remainingMs / 1000);
+            reply.header('Retry-After', retryAfterSeconds);
+            request.log.warn(
+              { ip: request.ip, count, limit: env.WEBHOOK_RATE_LIMIT_MAX },
+              'Documenso webhook rate limit exceeded',
+            );
+            return reply.status(429).send({
+              error: 'rate_limit_exceeded',
+              message: 'Too many webhook requests',
+            });
+          }
+        } catch {
+          request.log.warn(
+            'Documenso webhook rate limit Redis error — allowing request',
+          );
+        }
+      },
+      /* eslint-enable @typescript-eslint/no-misused-promises */
+    },
+    async function documensoWebhookHandler(
+      request: FastifyRequest,
+      reply: FastifyReply,
+    ) {
+      const rawBody = (request as FastifyRequest & { rawBody?: Buffer })
+        .rawBody;
+      if (!rawBody) {
+        return reply.status(400).send({ error: 'missing_body' });
+      }
+
+      // Verify signature
+      if (!adapter || !env.DOCUMENSO_WEBHOOK_SECRET) {
+        if (!env.DOCUMENSO_API_URL) {
+          request.log.error('DOCUMENSO_API_URL not configured');
+        } else if (!env.DOCUMENSO_WEBHOOK_SECRET) {
+          request.log.error('DOCUMENSO_WEBHOOK_SECRET not configured');
+        }
+        return reply.status(401).send({ error: 'invalid_signature' });
+      }
+
+      const signature = request.headers['x-documenso-signature'] as
+        | string
+        | undefined;
+
+      if (!signature) {
+        request.log.warn('Missing x-documenso-signature header');
+        return reply.status(401).send({ error: 'invalid_signature' });
+      }
+
+      const payloadString = rawBody.toString('utf8');
+      if (!adapter.verifyWebhookSignature(payloadString, signature)) {
+        request.log.warn('Invalid Documenso webhook signature');
+        return reply.status(401).send({ error: 'invalid_signature' });
+      }
+
+      // Parse webhook payload
+      let webhookPayload: {
+        event: string;
+        data: {
+          id: string;
+          documentId: string;
+          status?: string;
+          [key: string]: unknown;
+        };
+      };
+      try {
+        webhookPayload = JSON.parse(payloadString) as typeof webhookPayload;
+      } catch {
+        return reply.status(400).send({ error: 'invalid_json' });
+      }
+
+      const documensoId = `${webhookPayload.event}:${webhookPayload.data.id ?? webhookPayload.data.documentId}`;
+
+      // Two-step idempotency via documenso_webhook_events
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+
+        // Step 1: Attempt to insert
+        await client.query(
+          `INSERT INTO documenso_webhook_events (id, documenso_id, type, payload, processed, received_at)
+           VALUES (gen_random_uuid(), $1, $2, $3, false, now())
+           ON CONFLICT (documenso_id) DO NOTHING`,
+          [documensoId, webhookPayload.event, JSON.stringify(webhookPayload)],
+        );
+
+        // Step 2: Check processed status
+        const statusResult = await client.query(
+          `SELECT processed FROM documenso_webhook_events WHERE documenso_id = $1`,
+          [documensoId],
+        );
+
+        if (statusResult.rows[0]?.processed === true) {
+          await client.query('COMMIT');
+          return reply.status(200).send({ status: 'already_processed' });
+        }
+
+        // Process event — collect Inngest events to send AFTER commit
+        const tx = drizzle(client);
+        const pendingEvents = await processDocumensoEvent(
+          webhookPayload,
+          request,
+          tx,
+        );
+
+        // Mark as processed
+        await client.query(
+          `UPDATE documenso_webhook_events SET processed = true, processed_at = now() WHERE documenso_id = $1`,
+          [documensoId],
+        );
+
+        await client.query('COMMIT');
+
+        // Send Inngest events after commit to avoid ghost events on rollback
+        for (const evt of pendingEvents) {
+          await inngest.send(evt).catch((err) => {
+            request.log.error(
+              err,
+              'Failed to send Inngest event after Documenso webhook commit',
+            );
+          });
+        }
+
+        return reply.status(200).send({ status: 'processed' });
+      } catch (err) {
+        await client.query('ROLLBACK');
+        request.log.error(err, 'Documenso webhook processing failed');
+        return reply.status(500).send({ error: 'processing_failed' });
+      } finally {
+        client.release();
+      }
+    },
+  );
+}
+
+interface PendingInngestEvent {
+  name: string;
+  data: Record<string, unknown>;
+}
+
+async function processDocumensoEvent(
+  payload: {
+    event: string;
+    data: {
+      id: string;
+      documentId: string;
+      status?: string;
+      [key: string]: unknown;
+    };
+  },
+  request: FastifyRequest,
+  tx: DrizzleDb,
+): Promise<PendingInngestEvent[]> {
+  const documentId = payload.data.documentId ?? payload.data.id;
+  const pendingEvents: PendingInngestEvent[] = [];
+
+  switch (payload.event) {
+    case 'DOCUMENT_SIGNED': {
+      const contract = await contractService.getByDocumensoDocumentId(
+        tx,
+        documentId,
+      );
+      if (!contract) {
+        request.log.warn(
+          { documentId },
+          'Documenso DOCUMENT_SIGNED: no matching contract found',
+        );
+        return pendingEvents;
+      }
+
+      await contractService.updateStatus(tx, contract.id, 'SIGNED', {
+        signedAt: new Date(),
+      });
+
+      pendingEvents.push({
+        name: 'slate/contract.signed',
+        data: {
+          orgId: contract.organizationId,
+          contractId: contract.id,
+          documensoDocumentId: documentId,
+        },
+      });
+      break;
+    }
+
+    case 'DOCUMENT_COMPLETED': {
+      const contract = await contractService.getByDocumensoDocumentId(
+        tx,
+        documentId,
+      );
+      if (!contract) {
+        request.log.warn(
+          { documentId },
+          'Documenso DOCUMENT_COMPLETED: no matching contract found',
+        );
+        return pendingEvents;
+      }
+
+      await contractService.updateStatus(tx, contract.id, 'COMPLETED', {
+        completedAt: new Date(),
+      });
+
+      pendingEvents.push({
+        name: 'slate/contract.completed',
+        data: {
+          orgId: contract.organizationId,
+          contractId: contract.id,
+          documensoDocumentId: documentId,
+        },
+      });
+      break;
+    }
+
+    default:
+      request.log.info(
+        { event: payload.event },
+        'Unhandled Documenso webhook event',
+      );
+  }
+
+  return pendingEvents;
+}

--- a/apps/api/src/webhooks/stripe.webhook.spec.ts
+++ b/apps/api/src/webhooks/stripe.webhook.spec.ts
@@ -142,6 +142,7 @@ const testEnv: Env = {
   VIRUS_SCAN_ENABLED: true,
   DEV_AUTH_BYPASS: false,
   FEDERATION_ENABLED: false,
+  INNGEST_DEV: false,
   STRIPE_SECRET_KEY: 'sk_test_xxx',
   STRIPE_WEBHOOK_SECRET: WEBHOOK_SECRET,
 };

--- a/apps/api/src/webhooks/zitadel.webhook.spec.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.spec.ts
@@ -145,6 +145,7 @@ const testEnv: Env = {
   VIRUS_SCAN_ENABLED: true,
   DEV_AUTH_BYPASS: false,
   FEDERATION_ENABLED: false,
+  INNGEST_DEV: false,
 };
 
 function signPayload(body: string): string {

--- a/apps/api/src/workers/index.ts
+++ b/apps/api/src/workers/index.ts
@@ -3,3 +3,7 @@ export {
   startS3CleanupWorker,
   stopS3CleanupWorker,
 } from './s3-cleanup.worker.js';
+export {
+  startOutboxPollerWorker,
+  stopOutboxPollerWorker,
+} from './outbox-poller.worker.js';

--- a/apps/api/src/workers/outbox-poller.worker.ts
+++ b/apps/api/src/workers/outbox-poller.worker.ts
@@ -10,8 +10,9 @@ let worker: Worker<OutboxPollerJobData> | null = null;
  * Process unprocessed outbox events by sending them to Inngest.
  *
  * Uses the superuser `db` instance because `outbox_events` has no RLS —
- * it's a system table. Each event is sent to Inngest individually, and marked
- * as processed on success or has its error/retry count updated on failure.
+ * it's a system table. Each event is claimed atomically (processedAt set to
+ * a sentinel value) before sending to avoid duplicate delivery if multiple
+ * poller instances overlap.
  */
 async function processOutboxEvents(): Promise<number> {
   // Fetch up to 50 unprocessed events, oldest first
@@ -27,13 +28,25 @@ async function processOutboxEvents(): Promise<number> {
   let processed = 0;
 
   for (const event of events) {
+    // Claim the row atomically — only succeeds if still unclaimed
+    const claimSentinel = new Date(0); // epoch = "claimed, not yet delivered"
+    const [claimed] = await db
+      .update(outboxEvents)
+      .set({ processedAt: claimSentinel })
+      .where(
+        sql`${outboxEvents.id} = ${event.id} AND ${outboxEvents.processedAt} IS NULL`,
+      )
+      .returning({ id: outboxEvents.id });
+
+    if (!claimed) continue; // Another poller instance already claimed this row
+
     try {
       await inngest.send({
         name: event.eventType,
         data: event.payload as Record<string, unknown>,
       });
 
-      // Mark as processed
+      // Mark as fully processed with actual timestamp
       await db
         .update(outboxEvents)
         .set({ processedAt: new Date() })
@@ -41,10 +54,11 @@ async function processOutboxEvents(): Promise<number> {
 
       processed++;
     } catch (err) {
-      // Record error but don't fail the whole batch
+      // Unclaim + record error so the event can be retried
       await db
         .update(outboxEvents)
         .set({
+          processedAt: null,
           error: err instanceof Error ? err.message : String(err),
           retryCount: sql`${outboxEvents.retryCount} + 1`,
         })

--- a/apps/api/src/workers/outbox-poller.worker.ts
+++ b/apps/api/src/workers/outbox-poller.worker.ts
@@ -1,0 +1,86 @@
+import { Worker } from 'bullmq';
+import { db, outboxEvents, eq, sql, isNull, asc } from '@colophony/db';
+import type { Env } from '../config/env.js';
+import type { OutboxPollerJobData } from '../queues/outbox-poller.queue.js';
+import { inngest } from '../inngest/client.js';
+
+let worker: Worker<OutboxPollerJobData> | null = null;
+
+/**
+ * Process unprocessed outbox events by sending them to Inngest.
+ *
+ * Uses the superuser `db` instance because `outbox_events` has no RLS —
+ * it's a system table. Each event is sent to Inngest individually, and marked
+ * as processed on success or has its error/retry count updated on failure.
+ */
+async function processOutboxEvents(): Promise<number> {
+  // Fetch up to 50 unprocessed events, oldest first
+  const events = await db
+    .select()
+    .from(outboxEvents)
+    .where(isNull(outboxEvents.processedAt))
+    .orderBy(asc(outboxEvents.createdAt))
+    .limit(50);
+
+  if (events.length === 0) return 0;
+
+  let processed = 0;
+
+  for (const event of events) {
+    try {
+      await inngest.send({
+        name: event.eventType,
+        data: event.payload as Record<string, unknown>,
+      });
+
+      // Mark as processed
+      await db
+        .update(outboxEvents)
+        .set({ processedAt: new Date() })
+        .where(eq(outboxEvents.id, event.id));
+
+      processed++;
+    } catch (err) {
+      // Record error but don't fail the whole batch
+      await db
+        .update(outboxEvents)
+        .set({
+          error: err instanceof Error ? err.message : String(err),
+          retryCount: sql`${outboxEvents.retryCount} + 1`,
+        })
+        .where(eq(outboxEvents.id, event.id));
+    }
+  }
+
+  return processed;
+}
+
+export function startOutboxPollerWorker(env: Env): void {
+  if (worker) return;
+
+  worker = new Worker<OutboxPollerJobData>(
+    'outbox-poller',
+    async () => {
+      await processOutboxEvents();
+    },
+    {
+      connection: {
+        host: env.REDIS_HOST,
+        port: env.REDIS_PORT,
+        password: env.REDIS_PASSWORD || undefined,
+      },
+      concurrency: 1, // Single poller to avoid duplicate sends
+    },
+  );
+
+  worker.on('failed', (job, err) => {
+    console.error(`Outbox poller job ${job?.id} failed:`, err.message);
+  });
+}
+
+export async function stopOutboxPollerWorker(): Promise<void> {
+  if (worker) {
+    await worker.close();
+    worker = null;
+  }
+}

--- a/apps/api/src/workers/outbox-poller.worker.ts
+++ b/apps/api/src/workers/outbox-poller.worker.ts
@@ -15,6 +15,17 @@ let worker: Worker<OutboxPollerJobData> | null = null;
  * poller instances overlap.
  */
 async function processOutboxEvents(): Promise<number> {
+  // Recover stale claims: rows claimed (processedAt = epoch) but not completed
+  // within 5 minutes are likely from a crashed worker. Reset them for retry.
+  const staleThreshold = new Date(Date.now() - 5 * 60 * 1000);
+  const claimSentinel = new Date(0);
+  await db
+    .update(outboxEvents)
+    .set({ processedAt: null, retryCount: sql`${outboxEvents.retryCount} + 1` })
+    .where(
+      sql`${outboxEvents.processedAt} = ${claimSentinel} AND ${outboxEvents.createdAt} < ${staleThreshold}`,
+    );
+
   // Fetch up to 50 unprocessed events, oldest first
   const events = await db
     .select()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,6 +173,18 @@ services:
     profiles:
       - auth
 
+  # Inngest workflow engine (optional — for Slate publication pipeline)
+  inngest:
+    image: inngest/inngest:latest
+    container_name: colophony-inngest
+    ports:
+      - '8288:8288'
+    command: dev -u http://host.docker.internal:4000/api/inngest
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    profiles:
+      - slate
+
   # ClamAV for virus scanning (optional in development)
   clamav:
     image: clamav/clamav:stable

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -125,17 +125,19 @@
 
 ### Code
 
-- [ ] Post-acceptance workflow — (architecture doc Track 4)
-- [ ] Copyedit/proofread stages — (architecture doc Track 4)
-- [ ] Contract generation + e-signature — Documenso via Tier 1 adapter — (architecture doc Track 4, decision 2026-02-15)
-- [ ] Issue assembly — (architecture doc Track 4)
-- [ ] CMS integration (WordPress, Ghost) — (architecture doc Track 4)
-- [ ] Editorial calendar — (architecture doc Track 4)
+- [x] Post-acceptance workflow — pipeline-workflow Inngest function with waitForEvent — (architecture doc Track 4; done 2026-02-23 PR pending)
+- [x] Copyedit/proofread stages — PipelineStage enum + transition state machine + pipeline service — (architecture doc Track 4; done 2026-02-23 PR pending)
+- [x] Contract generation + e-signature — contract templates with merge fields, Documenso adapter + webhook — (architecture doc Track 4, decision 2026-02-15; done 2026-02-23 PR pending)
+- [x] Issue assembly — issues, sections, items with reorder + TOC generation — (architecture doc Track 4; done 2026-02-23 PR pending)
+- [x] CMS integration (WordPress, Ghost) — CmsAdapter interface, WordPress REST API + Ghost Admin API implementations — (architecture doc Track 4; done 2026-02-23 PR pending)
+- [ ] Editorial calendar frontend — (architecture doc Track 4; backend calendar queries done, frontend pending)
+- [ ] Slate frontend — pipeline dashboard, issue assembly UI, contract management pages — (architecture doc Track 4)
+- [ ] Slate E2E tests — Playwright tests for pipeline flows — (architecture doc Track 4)
 
 ### Research / Design
 
-- [ ] Workflow orchestration evaluation: Inngest (preferred) vs Temporal — evaluate at Track 4 design time — (decision 2026-02-15)
-- [ ] CMS "starter home" scope: static pages vs blog-like vs magazine-format with issue structure — (architecture doc Open Question #4)
+- [x] Workflow orchestration evaluation: Inngest (preferred) vs Temporal — **Resolved:** Inngest chosen — step functions, waitForEvent, single Docker container — (decision 2026-02-15; resolved 2026-02-23)
+- [x] CMS "starter home" scope: static pages vs blog-like vs magazine-format with issue structure — **Resolved:** Integration-only for v2.0 (WordPress/Ghost adapters), defer built-in pages — (architecture doc Open Question #4; resolved 2026-02-23)
 
 ---
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,33 @@ Newest entries first.
 
 ---
 
+## 2026-02-23 — Slate Publication Pipeline Backend (PRs 1-7)
+
+### Done
+
+- **Publications entity** (PR 1): schema, types, service, tRPC/REST/GraphQL, `submission_periods.publication_id` FK
+- **Pipeline core** (PR 2): `pipeline_items`, `pipeline_history`, `pipeline_comments`, transition state machine, service with stage validation, all API surfaces
+- **Inngest integration** (PR 3): Docker Compose service (slate profile), env config, client/serve endpoint, `pipeline-workflow` step function with `waitForEvent`, transactional outbox pattern (outbox poller worker)
+- **Contracts** (PR 4): `contract_templates` with merge fields, `contracts` with rendered body, services for template CRUD + contract generation, all API surfaces
+- **Documenso adapter + webhook** (PR 5): adapter interface, webhook handler with two-step idempotency via `documenso_webhook_events`, `contract-workflow` Inngest function
+- **Issue assembly** (PR 6): `issues`, `issue_sections`, `issue_items`, service with TOC generation + reorder + calendar queries, all API surfaces
+- **CMS adapters** (PR 7): `cms_connections` schema, `CmsAdapter` interface, WordPress (REST API v2) and Ghost (Admin API) implementations, `cms-publish` Inngest function
+- Added outbox service (`enqueueOutboxEvent`) and `app_user` INSERT grant on `outbox_events`
+- 5 new enums, 12 new tables, all with RLS policies + FORCE
+- ~25 new audit actions + 6 new audit resources
+- 10 new API key scopes (read/write pairs for 5 entities)
+- Addressed 2 rounds of Codex review findings (contracts/issues, CMS/events)
+
+### Decisions
+
+- **Inngest** for workflow orchestration — step functions + `waitForEvent`, single Docker container
+- **Transactional outbox** for event delivery — INSERT to `outbox_events` in same DB transaction, poller delivers to Inngest post-commit
+- **Org-managed contract templates** with `{{merge_field}}` placeholders, auto-populated from submission/pipeline/org data
+- **CMS integration-only** for v2.0 — WordPress/Ghost adapters, defer built-in pages to later
+- **Publication entity** added to hierarchy: Org → Publications → Periods/Issues
+
+---
+
 ## 2026-02-23 — Tailwind CSS v3 → v4 Upgrade
 
 ### Done

--- a/docs/slate-design.md
+++ b/docs/slate-design.md
@@ -1,0 +1,122 @@
+# Track 4: Slate — Publication Pipeline Design
+
+## Context
+
+Tracks 1-3 are complete. Track 4 (Slate) covers the post-acceptance publication pipeline: copyedit, proofread, contracts, issue assembly, and CMS publishing. This design defines the full schema, services, workflows, adapter interfaces, and implementation order for all 6 Track 4 backlog items.
+
+**Decisions confirmed:**
+
+- Workflow orchestration: **Inngest** (1 Docker container, step functions, `waitForEvent`)
+- Publication hierarchy: **Add Publication entity** (Org → Publications → Periods/Issues)
+- CMS scope: **Integration-only for v2.0** (WordPress/Ghost adapters, defer built-in pages)
+- Contracts: **Org-managed templates** with merge fields, Documenso as signing mechanism
+
+---
+
+## 1. New Enums
+
+**File:** `packages/db/src/schema/enums.ts`
+
+- `publicationStatusEnum`: ACTIVE, ARCHIVED
+- `pipelineStageEnum`: COPYEDIT_PENDING, COPYEDIT_IN_PROGRESS, AUTHOR_REVIEW, PROOFREAD, READY_TO_PUBLISH, PUBLISHED, WITHDRAWN
+- `contractStatusEnum`: DRAFT, SENT, VIEWED, SIGNED, COUNTERSIGNED, COMPLETED, VOIDED
+- `issueStatusEnum`: PLANNING, ASSEMBLING, READY, PUBLISHED, ARCHIVED
+- `cmsAdapterTypeEnum`: WORDPRESS, GHOST
+
+## 2. New Tables
+
+### `publications` (packages/db/src/schema/publications.ts)
+
+- id, organization_id, name, slug, description, settings (jsonb), status, created_at, updated_at
+- RLS: org isolation policy, unique (organization_id, lower(slug))
+
+### `pipeline_items` (packages/db/src/schema/pipeline.ts)
+
+- id, organization_id, submission_id (unique 1:1), publication_id, stage, assigned_copyeditor_id, assigned_proofreader_id, due dates, inngest_run_id, timestamps
+
+### `pipeline_history`
+
+- id, pipeline_item_id, from_stage, to_stage, changed_by, comment, changed_at
+- RLS: nested SELECT on parent org
+
+### `pipeline_comments`
+
+- id, pipeline_item_id, author_id, content, stage, created_at
+- RLS: nested SELECT on parent org
+
+### `contract_templates`
+
+- id, organization_id, name, description, body, merge_fields (jsonb), is_default, timestamps
+- RLS: org isolation
+
+### `contracts`
+
+- id, organization_id, pipeline_item_id, contract_template_id, status, rendered_body, merge_data, documenso_document_id, sign dates, timestamps
+- RLS: org isolation
+
+### `issues`
+
+- id, organization_id, publication_id, title, volume, issue_number, description, cover_image_url, status, publication_date, published_at, metadata, timestamps
+- RLS: org isolation
+
+### `issue_sections`
+
+- id, issue_id, title, sort_order, created_at
+- RLS: nested SELECT on issues.organization_id
+
+### `issue_items`
+
+- id, issue_id, pipeline_item_id, issue_section_id, sort_order, created_at
+- RLS: nested SELECT on issues.organization_id
+
+### `cms_connections`
+
+- id, organization_id, publication_id, adapter_type, name, config, is_active, last_sync_at, timestamps
+- RLS: org isolation
+
+### `documenso_webhook_events`
+
+- id, documenso_id (unique), type, payload, processed, processed_at, error, received_at
+- No RLS (system table)
+
+## 3. Schema Modifications
+
+- `submission_periods`: add nullable `publication_id` FK to `publications`
+
+## 4. Pipeline Transition Logic
+
+Valid transitions defined in `packages/types/src/pipeline.ts`
+
+## 5. Inngest Integration
+
+Docker Compose service, env vars, client, events, serve endpoint, workflow functions
+
+## 6. Services
+
+publicationService, pipelineService, contractTemplateService, contractService, issueService, cmsConnectionService
+
+## 7. Types
+
+publication.ts, pipeline.ts, contract.ts, issue.ts — all with Zod schemas
+
+## 8. API Surface
+
+tRPC, REST, GraphQL for all entities. New API key scopes.
+
+## 9. Adapter Interfaces
+
+Documenso adapter, CMS adapter interface (WordPress, Ghost implementations)
+
+## 10. Implementation Order (9 PRs)
+
+| PR  | Scope                                                               | Depends On |
+| --- | ------------------------------------------------------------------- | ---------- |
+| 1   | Publications — schema, types, service, tRPC/REST/GraphQL            | —          |
+| 2   | Pipeline Core — pipeline_items, history, comments, transition logic | PR 1       |
+| 3   | Inngest Integration — Docker, env, client, serve, pipeline-workflow | PR 2       |
+| 4   | Contract Templates + Contracts — schema, types, services            | PR 2       |
+| 5   | Documenso Adapter + Webhook — adapter, handler, contract-workflow   | PR 3 + 4   |
+| 6   | Issue Assembly — issues, sections, items, TOC generation            | PR 2       |
+| 7   | CMS Adapters — connections, WordPress/Ghost, cms-publish            | PR 3 + 6   |
+| 8   | Frontend — pipeline dashboard, issue assembly UI, calendar          | PR 1-7     |
+| 9   | E2E Tests — Playwright tests for Slate pipeline flows               | PR 8       |

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -11,9 +11,9 @@
 | Type exports   | `src/types.ts`                           |
 | Migrations     | `migrations/`                            |
 
-### Schema Files (13 domain files + barrel)
+### Schema Files (18 domain files + barrel)
 
-`api-keys.ts`, `audit.ts`, `compliance.ts`, `enums.ts`, `manuscripts.ts`, `members.ts`, `messaging.ts`, `organizations.ts`, `payments.ts`, `relations.ts`, `submissions.ts`, `users.ts`, `webhooks.ts`, `index.ts`
+`api-keys.ts`, `audit.ts`, `cms.ts`, `compliance.ts`, `contracts.ts`, `enums.ts`, `issues.ts`, `manuscripts.ts`, `members.ts`, `messaging.ts`, `organizations.ts`, `payments.ts`, `pipeline.ts`, `publications.ts`, `relations.ts`, `submissions.ts`, `users.ts`, `webhooks.ts`, `index.ts`
 
 ---
 

--- a/packages/db/migrations/0016_publications.sql
+++ b/packages/db/migrations/0016_publications.sql
@@ -1,0 +1,71 @@
+-- 0016: Publications table + submission_periods.publication_id FK
+
+-- Create PublicationStatus enum
+CREATE TYPE "PublicationStatus" AS ENUM ('ACTIVE', 'ARCHIVED');
+
+--> statement-breakpoint
+
+-- Create publications table
+CREATE TABLE "publications" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "name" varchar(255) NOT NULL,
+  "slug" varchar(100) NOT NULL,
+  "description" text,
+  "settings" jsonb,
+  "status" "PublicationStatus" DEFAULT 'ACTIVE' NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+
+-- Foreign keys
+ALTER TABLE "publications"
+  ADD CONSTRAINT "publications_organization_id_organizations_id_fk"
+  FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE cascade ON UPDATE no action;
+
+--> statement-breakpoint
+
+-- Indexes
+CREATE INDEX "publications_organization_id_idx" ON "publications" USING btree ("organization_id");
+CREATE UNIQUE INDEX "publications_org_slug_idx" ON "publications" USING btree ("organization_id", lower("slug"));
+
+--> statement-breakpoint
+
+-- Enable + FORCE RLS
+ALTER TABLE "publications" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "publications" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+
+-- RLS policy: org isolation
+CREATE POLICY "org_isolation" ON "publications"
+  FOR ALL
+  USING (organization_id = current_org_id())
+  WITH CHECK (organization_id = current_org_id());
+
+--> statement-breakpoint
+
+-- Grant DML permissions to app_user
+GRANT SELECT, INSERT, UPDATE, DELETE ON "publications" TO app_user;
+
+--> statement-breakpoint
+
+-- Add publication_id FK to submission_periods
+ALTER TABLE "submission_periods"
+  ADD COLUMN "publication_id" uuid;
+
+ALTER TABLE "submission_periods"
+  ADD CONSTRAINT "submission_periods_publication_id_publications_id_fk"
+  FOREIGN KEY ("publication_id") REFERENCES "publications"("id") ON DELETE set null ON UPDATE no action;
+
+CREATE INDEX "submission_periods_publication_id_idx" ON "submission_periods" USING btree ("publication_id");
+
+--> statement-breakpoint
+
+-- updatedAt trigger (reuses the existing trigger function from 0002)
+CREATE TRIGGER "trg_publications_set_updated_at"
+  BEFORE UPDATE ON "publications"
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at();

--- a/packages/db/migrations/0017_pipeline.sql
+++ b/packages/db/migrations/0017_pipeline.sql
@@ -1,0 +1,195 @@
+-- 0017: Pipeline tables — pipeline_items, pipeline_history, pipeline_comments
+
+-- Create PipelineStage enum
+CREATE TYPE "PipelineStage" AS ENUM (
+  'COPYEDIT_PENDING',
+  'COPYEDIT_IN_PROGRESS',
+  'AUTHOR_REVIEW',
+  'PROOFREAD',
+  'READY_TO_PUBLISH',
+  'PUBLISHED',
+  'WITHDRAWN'
+);
+
+--> statement-breakpoint
+
+-- Create pipeline_items table
+CREATE TABLE "pipeline_items" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "submission_id" uuid NOT NULL,
+  "publication_id" uuid,
+  "stage" "PipelineStage" DEFAULT 'COPYEDIT_PENDING' NOT NULL,
+  "assigned_copyeditor_id" uuid,
+  "assigned_proofreader_id" uuid,
+  "copyedit_due_at" timestamp with time zone,
+  "proofread_due_at" timestamp with time zone,
+  "author_review_due_at" timestamp with time zone,
+  "inngest_run_id" varchar(255),
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+
+-- Foreign keys for pipeline_items
+ALTER TABLE "pipeline_items"
+  ADD CONSTRAINT "pipeline_items_organization_id_organizations_id_fk"
+  FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE cascade ON UPDATE no action;
+
+ALTER TABLE "pipeline_items"
+  ADD CONSTRAINT "pipeline_items_submission_id_submissions_id_fk"
+  FOREIGN KEY ("submission_id") REFERENCES "submissions"("id") ON DELETE restrict ON UPDATE no action;
+
+ALTER TABLE "pipeline_items"
+  ADD CONSTRAINT "pipeline_items_publication_id_publications_id_fk"
+  FOREIGN KEY ("publication_id") REFERENCES "publications"("id") ON DELETE set null ON UPDATE no action;
+
+ALTER TABLE "pipeline_items"
+  ADD CONSTRAINT "pipeline_items_assigned_copyeditor_id_users_id_fk"
+  FOREIGN KEY ("assigned_copyeditor_id") REFERENCES "users"("id") ON DELETE set null ON UPDATE no action;
+
+ALTER TABLE "pipeline_items"
+  ADD CONSTRAINT "pipeline_items_assigned_proofreader_id_users_id_fk"
+  FOREIGN KEY ("assigned_proofreader_id") REFERENCES "users"("id") ON DELETE set null ON UPDATE no action;
+
+--> statement-breakpoint
+
+-- Indexes for pipeline_items
+CREATE INDEX "pipeline_items_organization_id_idx" ON "pipeline_items" USING btree ("organization_id");
+CREATE UNIQUE INDEX "pipeline_items_submission_id_idx" ON "pipeline_items" USING btree ("submission_id");
+CREATE INDEX "pipeline_items_publication_id_idx" ON "pipeline_items" USING btree ("publication_id");
+CREATE INDEX "pipeline_items_org_stage_idx" ON "pipeline_items" USING btree ("organization_id", "stage");
+CREATE INDEX "pipeline_items_copyeditor_idx" ON "pipeline_items" USING btree ("assigned_copyeditor_id");
+CREATE INDEX "pipeline_items_proofreader_idx" ON "pipeline_items" USING btree ("assigned_proofreader_id");
+
+--> statement-breakpoint
+
+-- Enable + FORCE RLS on pipeline_items
+ALTER TABLE "pipeline_items" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "pipeline_items" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+
+-- RLS policy: org isolation for pipeline_items
+CREATE POLICY "org_isolation" ON "pipeline_items"
+  FOR ALL
+  USING (organization_id = current_org_id())
+  WITH CHECK (organization_id = current_org_id());
+
+--> statement-breakpoint
+
+-- Grant DML permissions to app_user
+GRANT SELECT, INSERT, UPDATE, DELETE ON "pipeline_items" TO app_user;
+
+--> statement-breakpoint
+
+-- Create pipeline_history table
+CREATE TABLE "pipeline_history" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "pipeline_item_id" uuid NOT NULL,
+  "from_stage" "PipelineStage",
+  "to_stage" "PipelineStage" NOT NULL,
+  "changed_by" uuid,
+  "comment" text,
+  "changed_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+
+-- Foreign keys for pipeline_history
+ALTER TABLE "pipeline_history"
+  ADD CONSTRAINT "pipeline_history_pipeline_item_id_pipeline_items_id_fk"
+  FOREIGN KEY ("pipeline_item_id") REFERENCES "pipeline_items"("id") ON DELETE cascade ON UPDATE no action;
+
+--> statement-breakpoint
+
+-- Indexes for pipeline_history
+CREATE INDEX "pipeline_history_item_id_idx" ON "pipeline_history" USING btree ("pipeline_item_id");
+CREATE INDEX "pipeline_history_changed_at_idx" ON "pipeline_history" USING btree ("pipeline_item_id", "changed_at");
+
+--> statement-breakpoint
+
+-- Enable + FORCE RLS on pipeline_history
+ALTER TABLE "pipeline_history" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "pipeline_history" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+
+-- RLS policy: org isolation via parent for pipeline_history
+CREATE POLICY "pipeline_history_org_isolation" ON "pipeline_history"
+  FOR ALL
+  USING (pipeline_item_id IN (
+    SELECT id FROM pipeline_items
+    WHERE organization_id = current_org_id()
+  ))
+  WITH CHECK (pipeline_item_id IN (
+    SELECT id FROM pipeline_items
+    WHERE organization_id = current_org_id()
+  ));
+
+--> statement-breakpoint
+
+-- Grant DML permissions to app_user
+GRANT SELECT, INSERT, UPDATE, DELETE ON "pipeline_history" TO app_user;
+
+--> statement-breakpoint
+
+-- Create pipeline_comments table
+CREATE TABLE "pipeline_comments" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "pipeline_item_id" uuid NOT NULL,
+  "author_id" uuid,
+  "content" text NOT NULL,
+  "stage" "PipelineStage" NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+
+-- Foreign keys for pipeline_comments
+ALTER TABLE "pipeline_comments"
+  ADD CONSTRAINT "pipeline_comments_pipeline_item_id_pipeline_items_id_fk"
+  FOREIGN KEY ("pipeline_item_id") REFERENCES "pipeline_items"("id") ON DELETE cascade ON UPDATE no action;
+
+ALTER TABLE "pipeline_comments"
+  ADD CONSTRAINT "pipeline_comments_author_id_users_id_fk"
+  FOREIGN KEY ("author_id") REFERENCES "users"("id") ON DELETE set null ON UPDATE no action;
+
+--> statement-breakpoint
+
+-- Indexes for pipeline_comments
+CREATE INDEX "pipeline_comments_item_id_idx" ON "pipeline_comments" USING btree ("pipeline_item_id");
+
+--> statement-breakpoint
+
+-- Enable + FORCE RLS on pipeline_comments
+ALTER TABLE "pipeline_comments" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "pipeline_comments" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+
+-- RLS policy: org isolation via parent for pipeline_comments
+CREATE POLICY "pipeline_comments_org_isolation" ON "pipeline_comments"
+  FOR ALL
+  USING (pipeline_item_id IN (
+    SELECT id FROM pipeline_items
+    WHERE organization_id = current_org_id()
+  ))
+  WITH CHECK (pipeline_item_id IN (
+    SELECT id FROM pipeline_items
+    WHERE organization_id = current_org_id()
+  ));
+
+--> statement-breakpoint
+
+-- Grant DML permissions to app_user
+GRANT SELECT, INSERT, UPDATE, DELETE ON "pipeline_comments" TO app_user;
+
+--> statement-breakpoint
+
+-- updatedAt trigger for pipeline_items (reuses the existing trigger function from 0002)
+CREATE TRIGGER "trg_pipeline_items_set_updated_at"
+  BEFORE UPDATE ON "pipeline_items"
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at();

--- a/packages/db/migrations/0018_contracts.sql
+++ b/packages/db/migrations/0018_contracts.sql
@@ -1,0 +1,129 @@
+-- 0018: Contract tables — contract_templates, contracts
+
+-- Create ContractStatus enum
+CREATE TYPE "ContractStatus" AS ENUM (
+  'DRAFT',
+  'SENT',
+  'VIEWED',
+  'SIGNED',
+  'COUNTERSIGNED',
+  'COMPLETED',
+  'VOIDED'
+);
+
+--> statement-breakpoint
+
+-- Create contract_templates table
+CREATE TABLE "contract_templates" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "name" varchar(255) NOT NULL,
+  "description" text,
+  "body" text NOT NULL,
+  "merge_fields" jsonb,
+  "is_default" boolean DEFAULT false NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+
+-- Create contracts table
+CREATE TABLE "contracts" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "pipeline_item_id" uuid NOT NULL,
+  "contract_template_id" uuid,
+  "status" "ContractStatus" DEFAULT 'DRAFT' NOT NULL,
+  "rendered_body" text NOT NULL,
+  "merge_data" jsonb,
+  "documenso_document_id" varchar(255),
+  "signed_at" timestamp with time zone,
+  "countersigned_at" timestamp with time zone,
+  "completed_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+
+-- Foreign keys: contract_templates
+ALTER TABLE "contract_templates"
+  ADD CONSTRAINT "contract_templates_organization_id_organizations_id_fk"
+  FOREIGN KEY ("organization_id") REFERENCES "organizations" ("id")
+  ON DELETE CASCADE;
+
+--> statement-breakpoint
+
+-- Foreign keys: contracts
+ALTER TABLE "contracts"
+  ADD CONSTRAINT "contracts_organization_id_organizations_id_fk"
+  FOREIGN KEY ("organization_id") REFERENCES "organizations" ("id")
+  ON DELETE CASCADE;
+
+--> statement-breakpoint
+
+ALTER TABLE "contracts"
+  ADD CONSTRAINT "contracts_pipeline_item_id_pipeline_items_id_fk"
+  FOREIGN KEY ("pipeline_item_id") REFERENCES "pipeline_items" ("id")
+  ON DELETE CASCADE;
+
+--> statement-breakpoint
+
+ALTER TABLE "contracts"
+  ADD CONSTRAINT "contracts_contract_template_id_contract_templates_id_fk"
+  FOREIGN KEY ("contract_template_id") REFERENCES "contract_templates" ("id")
+  ON DELETE SET NULL;
+
+--> statement-breakpoint
+
+-- Indexes: contract_templates
+CREATE INDEX "contract_templates_organization_id_idx" ON "contract_templates" USING btree ("organization_id");
+
+--> statement-breakpoint
+
+-- Indexes: contracts
+CREATE INDEX "contracts_organization_id_idx" ON "contracts" USING btree ("organization_id");
+CREATE INDEX "contracts_pipeline_item_id_idx" ON "contracts" USING btree ("pipeline_item_id");
+CREATE INDEX "contracts_org_status_idx" ON "contracts" USING btree ("organization_id", "status");
+CREATE INDEX "contracts_documenso_id_idx" ON "contracts" USING btree ("documenso_document_id");
+
+--> statement-breakpoint
+
+-- Enable RLS + FORCE on both tables
+ALTER TABLE "contract_templates" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "contract_templates" FORCE ROW LEVEL SECURITY;
+ALTER TABLE "contracts" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "contracts" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+
+-- RLS policies: org isolation
+CREATE POLICY "org_isolation" ON "contract_templates"
+  FOR ALL
+  USING (organization_id = current_org_id())
+  WITH CHECK (organization_id = current_org_id());
+
+CREATE POLICY "org_isolation" ON "contracts"
+  FOR ALL
+  USING (organization_id = current_org_id())
+  WITH CHECK (organization_id = current_org_id());
+
+--> statement-breakpoint
+
+-- GRANTs for app_user
+GRANT SELECT, INSERT, UPDATE, DELETE ON "contract_templates" TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON "contracts" TO app_user;
+
+--> statement-breakpoint
+
+-- updatedAt trigger
+CREATE TRIGGER "contract_templates_updated_at"
+  BEFORE UPDATE ON "contract_templates"
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER "contracts_updated_at"
+  BEFORE UPDATE ON "contracts"
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();

--- a/packages/db/migrations/0018_contracts.sql
+++ b/packages/db/migrations/0018_contracts.sql
@@ -118,12 +118,12 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON "contracts" TO app_user;
 --> statement-breakpoint
 
 -- updatedAt trigger
-CREATE TRIGGER "contract_templates_updated_at"
+CREATE TRIGGER "trg_contract_templates_set_updated_at"
   BEFORE UPDATE ON "contract_templates"
   FOR EACH ROW
-  EXECUTE FUNCTION update_updated_at();
+  EXECUTE FUNCTION set_updated_at();
 
-CREATE TRIGGER "contracts_updated_at"
+CREATE TRIGGER "trg_contracts_set_updated_at"
   BEFORE UPDATE ON "contracts"
   FOR EACH ROW
-  EXECUTE FUNCTION update_updated_at();
+  EXECUTE FUNCTION set_updated_at();

--- a/packages/db/migrations/0019_issues.sql
+++ b/packages/db/migrations/0019_issues.sql
@@ -1,0 +1,165 @@
+-- 0019: Issue tables — issues, issue_sections, issue_items
+
+-- Create IssueStatus enum
+CREATE TYPE "IssueStatus" AS ENUM (
+  'PLANNING',
+  'ASSEMBLING',
+  'READY',
+  'PUBLISHED',
+  'ARCHIVED'
+);
+
+--> statement-breakpoint
+
+-- Create issues table
+CREATE TABLE "issues" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "publication_id" uuid NOT NULL,
+  "title" varchar(500) NOT NULL,
+  "volume" integer,
+  "issue_number" integer,
+  "description" text,
+  "cover_image_url" varchar(1000),
+  "status" "IssueStatus" DEFAULT 'PLANNING' NOT NULL,
+  "publication_date" timestamp with time zone,
+  "published_at" timestamp with time zone,
+  "metadata" jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+
+-- Create issue_sections table
+CREATE TABLE "issue_sections" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "issue_id" uuid NOT NULL,
+  "title" varchar(255) NOT NULL,
+  "sort_order" integer DEFAULT 0 NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+
+-- Create issue_items table
+CREATE TABLE "issue_items" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "issue_id" uuid NOT NULL,
+  "pipeline_item_id" uuid NOT NULL,
+  "issue_section_id" uuid,
+  "sort_order" integer DEFAULT 0 NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+
+-- Foreign keys: issues
+ALTER TABLE "issues"
+  ADD CONSTRAINT "issues_organization_id_organizations_id_fk"
+  FOREIGN KEY ("organization_id") REFERENCES "organizations" ("id")
+  ON DELETE CASCADE;
+
+--> statement-breakpoint
+
+ALTER TABLE "issues"
+  ADD CONSTRAINT "issues_publication_id_publications_id_fk"
+  FOREIGN KEY ("publication_id") REFERENCES "publications" ("id")
+  ON DELETE CASCADE;
+
+--> statement-breakpoint
+
+-- Foreign keys: issue_sections
+ALTER TABLE "issue_sections"
+  ADD CONSTRAINT "issue_sections_issue_id_issues_id_fk"
+  FOREIGN KEY ("issue_id") REFERENCES "issues" ("id")
+  ON DELETE CASCADE;
+
+--> statement-breakpoint
+
+-- Foreign keys: issue_items
+ALTER TABLE "issue_items"
+  ADD CONSTRAINT "issue_items_issue_id_issues_id_fk"
+  FOREIGN KEY ("issue_id") REFERENCES "issues" ("id")
+  ON DELETE CASCADE;
+
+--> statement-breakpoint
+
+ALTER TABLE "issue_items"
+  ADD CONSTRAINT "issue_items_pipeline_item_id_pipeline_items_id_fk"
+  FOREIGN KEY ("pipeline_item_id") REFERENCES "pipeline_items" ("id")
+  ON DELETE CASCADE;
+
+--> statement-breakpoint
+
+ALTER TABLE "issue_items"
+  ADD CONSTRAINT "issue_items_issue_section_id_issue_sections_id_fk"
+  FOREIGN KEY ("issue_section_id") REFERENCES "issue_sections" ("id")
+  ON DELETE SET NULL;
+
+--> statement-breakpoint
+
+-- Unique constraint: one pipeline item per issue
+ALTER TABLE "issue_items"
+  ADD CONSTRAINT "issue_items_issue_pipeline_unique"
+  UNIQUE ("issue_id", "pipeline_item_id");
+
+--> statement-breakpoint
+
+-- Indexes: issues
+CREATE INDEX "issues_organization_id_idx" ON "issues" USING btree ("organization_id");
+CREATE INDEX "issues_publication_id_idx" ON "issues" USING btree ("publication_id");
+CREATE INDEX "issues_pub_date_idx" ON "issues" USING btree ("publication_id", "publication_date");
+CREATE INDEX "issues_org_status_idx" ON "issues" USING btree ("organization_id", "status");
+
+--> statement-breakpoint
+
+-- Indexes: issue_sections
+CREATE INDEX "issue_sections_issue_id_idx" ON "issue_sections" USING btree ("issue_id");
+
+--> statement-breakpoint
+
+-- Indexes: issue_items
+CREATE INDEX "issue_items_issue_id_idx" ON "issue_items" USING btree ("issue_id");
+CREATE INDEX "issue_items_pipeline_item_id_idx" ON "issue_items" USING btree ("pipeline_item_id");
+
+--> statement-breakpoint
+
+-- Enable RLS + FORCE on all tables
+ALTER TABLE "issues" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "issues" FORCE ROW LEVEL SECURITY;
+ALTER TABLE "issue_sections" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "issue_sections" FORCE ROW LEVEL SECURITY;
+ALTER TABLE "issue_items" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "issue_items" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+
+-- RLS policies
+CREATE POLICY "org_isolation" ON "issues"
+  FOR ALL
+  USING (organization_id = current_org_id())
+  WITH CHECK (organization_id = current_org_id());
+
+CREATE POLICY "issue_section_org_isolation" ON "issue_sections"
+  FOR ALL
+  USING (EXISTS (SELECT 1 FROM issues WHERE issues.id = issue_id AND issues.organization_id = current_org_id()));
+
+CREATE POLICY "issue_item_org_isolation" ON "issue_items"
+  FOR ALL
+  USING (EXISTS (SELECT 1 FROM issues WHERE issues.id = issue_id AND issues.organization_id = current_org_id()));
+
+--> statement-breakpoint
+
+-- GRANTs for app_user
+GRANT SELECT, INSERT, UPDATE, DELETE ON "issues" TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON "issue_sections" TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON "issue_items" TO app_user;
+
+--> statement-breakpoint
+
+-- updatedAt trigger (issues only — sections and items don't have updatedAt)
+CREATE TRIGGER "issues_updated_at"
+  BEFORE UPDATE ON "issues"
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();

--- a/packages/db/migrations/0019_issues.sql
+++ b/packages/db/migrations/0019_issues.sql
@@ -159,7 +159,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON "issue_items" TO app_user;
 --> statement-breakpoint
 
 -- updatedAt trigger (issues only — sections and items don't have updatedAt)
-CREATE TRIGGER "issues_updated_at"
+CREATE TRIGGER "trg_issues_set_updated_at"
   BEFORE UPDATE ON "issues"
   FOR EACH ROW
-  EXECUTE FUNCTION update_updated_at();
+  EXECUTE FUNCTION set_updated_at();

--- a/packages/db/migrations/0020_documenso_webhook_events.sql
+++ b/packages/db/migrations/0020_documenso_webhook_events.sql
@@ -1,0 +1,23 @@
+-- 0020: Documenso webhook events (system table, no RLS)
+
+CREATE TABLE "documenso_webhook_events" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "documenso_id" varchar(255) NOT NULL UNIQUE,
+  "type" varchar(255) NOT NULL,
+  "payload" jsonb NOT NULL,
+  "processed" boolean NOT NULL DEFAULT false,
+  "processed_at" timestamptz,
+  "error" text,
+  "received_at" timestamptz NOT NULL DEFAULT now()
+);
+
+--> statement-breakpoint
+
+-- Polling index for unprocessed events
+CREATE INDEX "documenso_webhook_events_polling_idx"
+  ON "documenso_webhook_events" ("processed_at", "received_at");
+
+--> statement-breakpoint
+
+-- GRANT to app_user (system table accessed by webhook handler via pool)
+GRANT SELECT, INSERT, UPDATE ON "documenso_webhook_events" TO "app_user";

--- a/packages/db/migrations/0021_cms_connections.sql
+++ b/packages/db/migrations/0021_cms_connections.sql
@@ -1,0 +1,62 @@
+-- 0021: CMS connections table
+
+-- Create CmsAdapterType enum
+CREATE TYPE "CmsAdapterType" AS ENUM ('WORDPRESS', 'GHOST');
+
+--> statement-breakpoint
+
+-- Create cms_connections table
+CREATE TABLE "cms_connections" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "publication_id" uuid,
+  "adapter_type" "CmsAdapterType" NOT NULL,
+  "name" varchar(255) NOT NULL,
+  "config" jsonb NOT NULL,
+  "is_active" boolean NOT NULL DEFAULT true,
+  "last_sync_at" timestamptz,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+--> statement-breakpoint
+
+-- Foreign keys
+ALTER TABLE "cms_connections"
+  ADD CONSTRAINT "cms_connections_organization_id_fk"
+  FOREIGN KEY ("organization_id") REFERENCES "organizations"("id")
+  ON DELETE CASCADE;
+
+ALTER TABLE "cms_connections"
+  ADD CONSTRAINT "cms_connections_publication_id_fk"
+  FOREIGN KEY ("publication_id") REFERENCES "publications"("id")
+  ON DELETE CASCADE;
+
+--> statement-breakpoint
+
+-- Indexes
+CREATE INDEX "cms_connections_organization_id_idx" ON "cms_connections" ("organization_id");
+CREATE INDEX "cms_connections_publication_id_idx" ON "cms_connections" ("publication_id");
+
+--> statement-breakpoint
+
+-- RLS
+ALTER TABLE "cms_connections" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "cms_connections" FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY "cms_connections_org_isolation" ON "cms_connections"
+  FOR ALL
+  USING (organization_id = current_org_id());
+
+--> statement-breakpoint
+
+-- GRANT permissions to app_user
+GRANT SELECT, INSERT, UPDATE, DELETE ON "cms_connections" TO app_user;
+
+--> statement-breakpoint
+
+-- updatedAt trigger
+CREATE TRIGGER "trg_cms_connections_set_updated_at"
+  BEFORE UPDATE ON "cms_connections"
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at();

--- a/packages/db/migrations/0022_outbox_events_grant.sql
+++ b/packages/db/migrations/0022_outbox_events_grant.sql
@@ -1,0 +1,6 @@
+-- 0022: Grant INSERT on outbox_events to app_user
+-- Services need to insert outbox events within the same RLS transaction
+-- to ensure atomicity (event not lost if crash between commit and outbox insert).
+-- SELECT is not granted — only the superuser outbox poller reads/updates events.
+
+GRANT INSERT ON "outbox_events" TO app_user;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1772800000000,
       "tag": "0018_contracts",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1773000000000,
+      "tag": "0019_issues",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1772200000000,
       "tag": "0015_gdpr_fk_constraints",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1772400000000,
+      "tag": "0016_publications",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1772400000000,
       "tag": "0016_publications",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1772600000000,
+      "tag": "0017_pipeline",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1772600000000,
       "tag": "0017_pipeline",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1772800000000,
+      "tag": "0018_contracts",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -32,5 +32,7 @@ export {
   not,
   isNull,
   inArray,
+  asc,
+  desc,
   sql,
 } from "drizzle-orm";

--- a/packages/db/src/schema/cms.ts
+++ b/packages/db/src/schema/cms.ts
@@ -1,0 +1,51 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  jsonb,
+  boolean,
+  timestamp,
+  index,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { cmsAdapterTypeEnum } from "./enums";
+import { organizations } from "./organizations";
+import { publications } from "./publications";
+
+const orgIsolationPolicy = pgPolicy("org_isolation", {
+  for: "all",
+  using: sql`organization_id = current_org_id()`,
+});
+
+// --- cms_connections ---
+
+export const cmsConnections = pgTable(
+  "cms_connections",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    publicationId: uuid("publication_id").references(() => publications.id, {
+      onDelete: "cascade",
+    }),
+    adapterType: cmsAdapterTypeEnum("adapter_type").notNull(),
+    name: varchar("name", { length: 255 }).notNull(),
+    config: jsonb("config").$type<Record<string, unknown>>().notNull(),
+    isActive: boolean("is_active").notNull().default(true),
+    lastSyncAt: timestamp("last_sync_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("cms_connections_organization_id_idx").on(table.organizationId),
+    index("cms_connections_publication_id_idx").on(table.publicationId),
+    orgIsolationPolicy,
+  ],
+).enableRLS();

--- a/packages/db/src/schema/contracts.ts
+++ b/packages/db/src/schema/contracts.ts
@@ -1,0 +1,95 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  text,
+  jsonb,
+  boolean,
+  timestamp,
+  index,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { contractStatusEnum } from "./enums";
+import { organizations } from "./organizations";
+import { pipelineItems } from "./pipeline";
+
+const orgIsolationPolicy = pgPolicy("org_isolation", {
+  for: "all",
+  using: sql`organization_id = current_org_id()`,
+});
+
+// --- contract_templates ---
+
+export const contractTemplates = pgTable(
+  "contract_templates",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    name: varchar("name", { length: 255 }).notNull(),
+    description: text("description"),
+    body: text("body").notNull(),
+    mergeFields: jsonb("merge_fields").$type<
+      Array<{
+        key: string;
+        label: string;
+        source: "auto" | "manual";
+        defaultValue?: string;
+      }>
+    >(),
+    isDefault: boolean("is_default").notNull().default(false),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("contract_templates_organization_id_idx").on(table.organizationId),
+    orgIsolationPolicy,
+  ],
+).enableRLS();
+
+// --- contracts ---
+
+export const contracts = pgTable(
+  "contracts",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    pipelineItemId: uuid("pipeline_item_id")
+      .notNull()
+      .references(() => pipelineItems.id, { onDelete: "cascade" }),
+    contractTemplateId: uuid("contract_template_id").references(
+      () => contractTemplates.id,
+      { onDelete: "set null" },
+    ),
+    status: contractStatusEnum("status").notNull().default("DRAFT"),
+    renderedBody: text("rendered_body").notNull(),
+    mergeData: jsonb("merge_data").$type<Record<string, string>>(),
+    documensoDocumentId: varchar("documenso_document_id", { length: 255 }),
+    signedAt: timestamp("signed_at", { withTimezone: true }),
+    countersignedAt: timestamp("countersigned_at", { withTimezone: true }),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("contracts_organization_id_idx").on(table.organizationId),
+    index("contracts_pipeline_item_id_idx").on(table.pipelineItemId),
+    index("contracts_org_status_idx").on(table.organizationId, table.status),
+    index("contracts_documenso_id_idx").on(table.documensoDocumentId),
+    orgIsolationPolicy,
+  ],
+).enableRLS();

--- a/packages/db/src/schema/documenso.ts
+++ b/packages/db/src/schema/documenso.ts
@@ -1,0 +1,34 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  jsonb,
+  boolean,
+  text,
+  timestamp,
+  index,
+} from "drizzle-orm/pg-core";
+
+// --- documenso_webhook_events (no RLS — system table for webhook idempotency) ---
+
+export const documensoWebhookEvents = pgTable(
+  "documenso_webhook_events",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    documensoId: varchar("documenso_id", { length: 255 }).notNull().unique(),
+    type: varchar("type", { length: 255 }).notNull(),
+    payload: jsonb("payload").notNull(),
+    processed: boolean("processed").default(false).notNull(),
+    processedAt: timestamp("processed_at", { withTimezone: true }),
+    error: text("error"),
+    receivedAt: timestamp("received_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("documenso_webhook_events_polling_idx").on(
+      table.processedAt,
+      table.receivedAt,
+    ),
+  ],
+);

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -84,3 +84,13 @@ export const pipelineStageEnum = pgEnum("PipelineStage", [
   "PUBLISHED",
   "WITHDRAWN",
 ]);
+
+export const contractStatusEnum = pgEnum("ContractStatus", [
+  "DRAFT",
+  "SENT",
+  "VIEWED",
+  "SIGNED",
+  "COUNTERSIGNED",
+  "COMPLETED",
+  "VOIDED",
+]);

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -93,6 +93,11 @@ export const issueStatusEnum = pgEnum("IssueStatus", [
   "ARCHIVED",
 ]);
 
+export const cmsAdapterTypeEnum = pgEnum("CmsAdapterType", [
+  "WORDPRESS",
+  "GHOST",
+]);
+
 export const contractStatusEnum = pgEnum("ContractStatus", [
   "DRAFT",
   "SENT",

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -85,6 +85,14 @@ export const pipelineStageEnum = pgEnum("PipelineStage", [
   "WITHDRAWN",
 ]);
 
+export const issueStatusEnum = pgEnum("IssueStatus", [
+  "PLANNING",
+  "ASSEMBLING",
+  "READY",
+  "PUBLISHED",
+  "ARCHIVED",
+]);
+
 export const contractStatusEnum = pgEnum("ContractStatus", [
   "DRAFT",
   "SENT",

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -65,3 +65,12 @@ export const formFieldTypeEnum = pgEnum("FormFieldType", [
   "section_header",
   "info_text",
 ]);
+
+// ---------------------------------------------------------------------------
+// Slate — Publication Pipeline
+// ---------------------------------------------------------------------------
+
+export const publicationStatusEnum = pgEnum("PublicationStatus", [
+  "ACTIVE",
+  "ARCHIVED",
+]);

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -74,3 +74,13 @@ export const publicationStatusEnum = pgEnum("PublicationStatus", [
   "ACTIVE",
   "ARCHIVED",
 ]);
+
+export const pipelineStageEnum = pgEnum("PipelineStage", [
+  "COPYEDIT_PENDING",
+  "COPYEDIT_IN_PROGRESS",
+  "AUTHOR_REVIEW",
+  "PROOFREAD",
+  "READY_TO_PUBLISH",
+  "PUBLISHED",
+  "WITHDRAWN",
+]);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -15,4 +15,5 @@ export * from "./embed-tokens";
 export * from "./publications";
 export * from "./pipeline";
 export * from "./contracts";
+export * from "./issues";
 export * from "./relations";

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -13,4 +13,5 @@ export * from "./webhooks";
 export * from "./api-keys";
 export * from "./embed-tokens";
 export * from "./publications";
+export * from "./pipeline";
 export * from "./relations";

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -17,4 +17,5 @@ export * from "./pipeline";
 export * from "./contracts";
 export * from "./issues";
 export * from "./documenso";
+export * from "./cms";
 export * from "./relations";

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -16,4 +16,5 @@ export * from "./publications";
 export * from "./pipeline";
 export * from "./contracts";
 export * from "./issues";
+export * from "./documenso";
 export * from "./relations";

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -14,4 +14,5 @@ export * from "./api-keys";
 export * from "./embed-tokens";
 export * from "./publications";
 export * from "./pipeline";
+export * from "./contracts";
 export * from "./relations";

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -12,4 +12,5 @@ export * from "./messaging";
 export * from "./webhooks";
 export * from "./api-keys";
 export * from "./embed-tokens";
+export * from "./publications";
 export * from "./relations";

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -1,0 +1,123 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  text,
+  integer,
+  jsonb,
+  timestamp,
+  index,
+  unique,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { issueStatusEnum } from "./enums";
+import { organizations } from "./organizations";
+import { publications } from "./publications";
+import { pipelineItems } from "./pipeline";
+
+const orgIsolationPolicy = pgPolicy("org_isolation", {
+  for: "all",
+  using: sql`organization_id = current_org_id()`,
+});
+
+// --- issues ---
+
+export const issues = pgTable(
+  "issues",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    publicationId: uuid("publication_id")
+      .notNull()
+      .references(() => publications.id, { onDelete: "cascade" }),
+    title: varchar("title", { length: 500 }).notNull(),
+    volume: integer("volume"),
+    issueNumber: integer("issue_number"),
+    description: text("description"),
+    coverImageUrl: varchar("cover_image_url", { length: 1000 }),
+    status: issueStatusEnum("status").notNull().default("PLANNING"),
+    publicationDate: timestamp("publication_date", { withTimezone: true }),
+    publishedAt: timestamp("published_at", { withTimezone: true }),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("issues_organization_id_idx").on(table.organizationId),
+    index("issues_publication_id_idx").on(table.publicationId),
+    index("issues_pub_date_idx").on(table.publicationId, table.publicationDate),
+    index("issues_org_status_idx").on(table.organizationId, table.status),
+    orgIsolationPolicy,
+  ],
+).enableRLS();
+
+// --- issue_sections ---
+
+const issueSectionRlsPolicy = pgPolicy("issue_section_org_isolation", {
+  for: "all",
+  using: sql`EXISTS (SELECT 1 FROM issues WHERE issues.id = issue_id AND issues.organization_id = current_org_id())`,
+});
+
+export const issueSections = pgTable(
+  "issue_sections",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    issueId: uuid("issue_id")
+      .notNull()
+      .references(() => issues.id, { onDelete: "cascade" }),
+    title: varchar("title", { length: 255 }).notNull(),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("issue_sections_issue_id_idx").on(table.issueId),
+    issueSectionRlsPolicy,
+  ],
+).enableRLS();
+
+// --- issue_items ---
+
+const issueItemRlsPolicy = pgPolicy("issue_item_org_isolation", {
+  for: "all",
+  using: sql`EXISTS (SELECT 1 FROM issues WHERE issues.id = issue_id AND issues.organization_id = current_org_id())`,
+});
+
+export const issueItems = pgTable(
+  "issue_items",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    issueId: uuid("issue_id")
+      .notNull()
+      .references(() => issues.id, { onDelete: "cascade" }),
+    pipelineItemId: uuid("pipeline_item_id")
+      .notNull()
+      .references(() => pipelineItems.id, { onDelete: "cascade" }),
+    issueSectionId: uuid("issue_section_id").references(
+      () => issueSections.id,
+      { onDelete: "set null" },
+    ),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    unique("issue_items_issue_pipeline_unique").on(
+      table.issueId,
+      table.pipelineItemId,
+    ),
+    index("issue_items_issue_id_idx").on(table.issueId),
+    index("issue_items_pipeline_item_id_idx").on(table.pipelineItemId),
+    issueItemRlsPolicy,
+  ],
+).enableRLS();

--- a/packages/db/src/schema/pipeline.ts
+++ b/packages/db/src/schema/pipeline.ts
@@ -1,0 +1,133 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  text,
+  timestamp,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { pipelineStageEnum } from "./enums";
+import { organizations } from "./organizations";
+import { submissions } from "./submissions";
+import { publications } from "./publications";
+import { users } from "./users";
+
+const orgIsolationPolicy = pgPolicy("org_isolation", {
+  for: "all",
+  using: sql`organization_id = current_org_id()`,
+});
+
+// --- pipeline_items ---
+
+export const pipelineItems = pgTable(
+  "pipeline_items",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    submissionId: uuid("submission_id")
+      .notNull()
+      .references(() => submissions.id, { onDelete: "restrict" }),
+    publicationId: uuid("publication_id").references(() => publications.id, {
+      onDelete: "set null",
+    }),
+    stage: pipelineStageEnum("stage").notNull().default("COPYEDIT_PENDING"),
+    assignedCopyeditorId: uuid("assigned_copyeditor_id").references(
+      () => users.id,
+      { onDelete: "set null" },
+    ),
+    assignedProofreaderId: uuid("assigned_proofreader_id").references(
+      () => users.id,
+      { onDelete: "set null" },
+    ),
+    copyeditDueAt: timestamp("copyedit_due_at", { withTimezone: true }),
+    proofreadDueAt: timestamp("proofread_due_at", { withTimezone: true }),
+    authorReviewDueAt: timestamp("author_review_due_at", {
+      withTimezone: true,
+    }),
+    inngestRunId: varchar("inngest_run_id", { length: 255 }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("pipeline_items_organization_id_idx").on(table.organizationId),
+    uniqueIndex("pipeline_items_submission_id_idx").on(table.submissionId),
+    index("pipeline_items_publication_id_idx").on(table.publicationId),
+    index("pipeline_items_org_stage_idx").on(table.organizationId, table.stage),
+    index("pipeline_items_copyeditor_idx").on(table.assignedCopyeditorId),
+    index("pipeline_items_proofreader_idx").on(table.assignedProofreaderId),
+    orgIsolationPolicy,
+  ],
+).enableRLS();
+
+// --- pipeline_history ---
+
+export const pipelineHistory = pgTable(
+  "pipeline_history",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    pipelineItemId: uuid("pipeline_item_id")
+      .notNull()
+      .references(() => pipelineItems.id, { onDelete: "cascade" }),
+    fromStage: pipelineStageEnum("from_stage"),
+    toStage: pipelineStageEnum("to_stage").notNull(),
+    changedBy: uuid("changed_by"),
+    comment: text("comment"),
+    changedAt: timestamp("changed_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("pipeline_history_item_id_idx").on(table.pipelineItemId),
+    index("pipeline_history_changed_at_idx").on(
+      table.pipelineItemId,
+      table.changedAt,
+    ),
+    pgPolicy("pipeline_history_org_isolation", {
+      for: "all",
+      using: sql`pipeline_item_id IN (
+        SELECT id FROM pipeline_items
+        WHERE organization_id = current_org_id()
+      )`,
+    }),
+  ],
+).enableRLS();
+
+// --- pipeline_comments ---
+
+export const pipelineComments = pgTable(
+  "pipeline_comments",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    pipelineItemId: uuid("pipeline_item_id")
+      .notNull()
+      .references(() => pipelineItems.id, { onDelete: "cascade" }),
+    authorId: uuid("author_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    content: text("content").notNull(),
+    stage: pipelineStageEnum("stage").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("pipeline_comments_item_id_idx").on(table.pipelineItemId),
+    pgPolicy("pipeline_comments_org_isolation", {
+      for: "all",
+      using: sql`pipeline_item_id IN (
+        SELECT id FROM pipeline_items
+        WHERE organization_id = current_org_id()
+      )`,
+    }),
+  ],
+).enableRLS();

--- a/packages/db/src/schema/publications.ts
+++ b/packages/db/src/schema/publications.ts
@@ -1,0 +1,51 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  text,
+  jsonb,
+  timestamp,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { publicationStatusEnum } from "./enums";
+import { organizations } from "./organizations";
+
+const orgIsolationPolicy = pgPolicy("org_isolation", {
+  for: "all",
+  using: sql`organization_id = current_org_id()`,
+});
+
+// --- publications ---
+
+export const publications = pgTable(
+  "publications",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    name: varchar("name", { length: 255 }).notNull(),
+    slug: varchar("slug", { length: 100 }).notNull(),
+    description: text("description"),
+    settings: jsonb("settings").$type<Record<string, unknown>>(),
+    status: publicationStatusEnum("status").notNull().default("ACTIVE"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("publications_organization_id_idx").on(table.organizationId),
+    uniqueIndex("publications_org_slug_idx").on(
+      table.organizationId,
+      sql`lower(${table.slug})`,
+    ),
+    orgIsolationPolicy,
+  ],
+).enableRLS();

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -15,6 +15,7 @@ import { retentionPolicies, userConsents } from "./compliance";
 import { apiKeys } from "./api-keys";
 import { publications } from "./publications";
 import { pipelineItems, pipelineHistory, pipelineComments } from "./pipeline";
+import { contractTemplates, contracts } from "./contracts";
 
 // --- organizations ---
 
@@ -30,6 +31,8 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   apiKeys: many(apiKeys),
   publications: many(publications),
   pipelineItems: many(pipelineItems),
+  contractTemplates: many(contractTemplates),
+  contracts: many(contracts),
 }));
 
 // --- users ---
@@ -314,6 +317,7 @@ export const pipelineItemsRelations = relations(
     }),
     history: many(pipelineHistory),
     comments: many(pipelineComments),
+    contracts: many(contracts),
   }),
 );
 
@@ -344,3 +348,33 @@ export const pipelineCommentsRelations = relations(
     }),
   }),
 );
+
+// --- contract_templates ---
+
+export const contractTemplatesRelations = relations(
+  contractTemplates,
+  ({ one, many }) => ({
+    organization: one(organizations, {
+      fields: [contractTemplates.organizationId],
+      references: [organizations.id],
+    }),
+    contracts: many(contracts),
+  }),
+);
+
+// --- contracts ---
+
+export const contractsRelations = relations(contracts, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [contracts.organizationId],
+    references: [organizations.id],
+  }),
+  pipelineItem: one(pipelineItems, {
+    fields: [contracts.pipelineItemId],
+    references: [pipelineItems.id],
+  }),
+  contractTemplate: one(contractTemplates, {
+    fields: [contracts.contractTemplateId],
+    references: [contractTemplates.id],
+  }),
+}));

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -14,6 +14,7 @@ import { auditEvents, dsarRequests } from "./audit";
 import { retentionPolicies, userConsents } from "./compliance";
 import { apiKeys } from "./api-keys";
 import { publications } from "./publications";
+import { pipelineItems, pipelineHistory, pipelineComments } from "./pipeline";
 
 // --- organizations ---
 
@@ -28,6 +29,7 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   userConsents: many(userConsents),
   apiKeys: many(apiKeys),
   publications: many(publications),
+  pipelineItems: many(pipelineItems),
 }));
 
 // --- users ---
@@ -181,6 +183,7 @@ export const submissionsRelations = relations(submissions, ({ one, many }) => ({
   }),
   history: many(submissionHistory),
   payments: many(payments),
+  pipelineItems: many(pipelineItems),
 }));
 
 // --- submission_history ---
@@ -278,5 +281,66 @@ export const publicationsRelations = relations(
       references: [organizations.id],
     }),
     submissionPeriods: many(submissionPeriods),
+    pipelineItems: many(pipelineItems),
+  }),
+);
+
+// --- pipeline_items ---
+
+export const pipelineItemsRelations = relations(
+  pipelineItems,
+  ({ one, many }) => ({
+    organization: one(organizations, {
+      fields: [pipelineItems.organizationId],
+      references: [organizations.id],
+    }),
+    submission: one(submissions, {
+      fields: [pipelineItems.submissionId],
+      references: [submissions.id],
+    }),
+    publication: one(publications, {
+      fields: [pipelineItems.publicationId],
+      references: [publications.id],
+    }),
+    copyeditor: one(users, {
+      fields: [pipelineItems.assignedCopyeditorId],
+      references: [users.id],
+      relationName: "pipelineItemCopyeditor",
+    }),
+    proofreader: one(users, {
+      fields: [pipelineItems.assignedProofreaderId],
+      references: [users.id],
+      relationName: "pipelineItemProofreader",
+    }),
+    history: many(pipelineHistory),
+    comments: many(pipelineComments),
+  }),
+);
+
+// --- pipeline_history ---
+
+export const pipelineHistoryRelations = relations(
+  pipelineHistory,
+  ({ one }) => ({
+    pipelineItem: one(pipelineItems, {
+      fields: [pipelineHistory.pipelineItemId],
+      references: [pipelineItems.id],
+    }),
+  }),
+);
+
+// --- pipeline_comments ---
+
+export const pipelineCommentsRelations = relations(
+  pipelineComments,
+  ({ one }) => ({
+    pipelineItem: one(pipelineItems, {
+      fields: [pipelineComments.pipelineItemId],
+      references: [pipelineItems.id],
+    }),
+    author: one(users, {
+      fields: [pipelineComments.authorId],
+      references: [users.id],
+    }),
   }),
 );

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -16,6 +16,7 @@ import { apiKeys } from "./api-keys";
 import { publications } from "./publications";
 import { pipelineItems, pipelineHistory, pipelineComments } from "./pipeline";
 import { contractTemplates, contracts } from "./contracts";
+import { issues, issueSections, issueItems } from "./issues";
 
 // --- organizations ---
 
@@ -33,6 +34,7 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   pipelineItems: many(pipelineItems),
   contractTemplates: many(contractTemplates),
   contracts: many(contracts),
+  issues: many(issues),
 }));
 
 // --- users ---
@@ -285,6 +287,7 @@ export const publicationsRelations = relations(
     }),
     submissionPeriods: many(submissionPeriods),
     pipelineItems: many(pipelineItems),
+    issues: many(issues),
   }),
 );
 
@@ -318,6 +321,7 @@ export const pipelineItemsRelations = relations(
     history: many(pipelineHistory),
     comments: many(pipelineComments),
     contracts: many(contracts),
+    issueItems: many(issueItems),
   }),
 );
 
@@ -376,5 +380,50 @@ export const contractsRelations = relations(contracts, ({ one }) => ({
   contractTemplate: one(contractTemplates, {
     fields: [contracts.contractTemplateId],
     references: [contractTemplates.id],
+  }),
+}));
+
+// --- issues ---
+
+export const issuesRelations = relations(issues, ({ one, many }) => ({
+  organization: one(organizations, {
+    fields: [issues.organizationId],
+    references: [organizations.id],
+  }),
+  publication: one(publications, {
+    fields: [issues.publicationId],
+    references: [publications.id],
+  }),
+  sections: many(issueSections),
+  items: many(issueItems),
+}));
+
+// --- issue_sections ---
+
+export const issueSectionsRelations = relations(
+  issueSections,
+  ({ one, many }) => ({
+    issue: one(issues, {
+      fields: [issueSections.issueId],
+      references: [issues.id],
+    }),
+    items: many(issueItems),
+  }),
+);
+
+// --- issue_items ---
+
+export const issueItemsRelations = relations(issueItems, ({ one }) => ({
+  issue: one(issues, {
+    fields: [issueItems.issueId],
+    references: [issues.id],
+  }),
+  pipelineItem: one(pipelineItems, {
+    fields: [issueItems.pipelineItemId],
+    references: [pipelineItems.id],
+  }),
+  section: one(issueSections, {
+    fields: [issueItems.issueSectionId],
+    references: [issueSections.id],
   }),
 }));

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -13,6 +13,7 @@ import { payments } from "./payments";
 import { auditEvents, dsarRequests } from "./audit";
 import { retentionPolicies, userConsents } from "./compliance";
 import { apiKeys } from "./api-keys";
+import { publications } from "./publications";
 
 // --- organizations ---
 
@@ -26,6 +27,7 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   retentionPolicies: many(retentionPolicies),
   userConsents: many(userConsents),
   apiKeys: many(apiKeys),
+  publications: many(publications),
 }));
 
 // --- users ---
@@ -146,6 +148,10 @@ export const submissionPeriodsRelations = relations(
       fields: [submissionPeriods.formDefinitionId],
       references: [formDefinitions.id],
     }),
+    publication: one(publications, {
+      fields: [submissionPeriods.publicationId],
+      references: [publications.id],
+    }),
     submissions: many(submissions),
   }),
 );
@@ -261,3 +267,16 @@ export const apiKeysRelations = relations(apiKeys, ({ one }) => ({
     references: [users.id],
   }),
 }));
+
+// --- publications ---
+
+export const publicationsRelations = relations(
+  publications,
+  ({ one, many }) => ({
+    organization: one(organizations, {
+      fields: [publications.organizationId],
+      references: [organizations.id],
+    }),
+    submissionPeriods: many(submissionPeriods),
+  }),
+);

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -17,6 +17,7 @@ import { publications } from "./publications";
 import { pipelineItems, pipelineHistory, pipelineComments } from "./pipeline";
 import { contractTemplates, contracts } from "./contracts";
 import { issues, issueSections, issueItems } from "./issues";
+import { cmsConnections } from "./cms";
 
 // --- organizations ---
 
@@ -35,6 +36,7 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   contractTemplates: many(contractTemplates),
   contracts: many(contracts),
   issues: many(issues),
+  cmsConnections: many(cmsConnections),
 }));
 
 // --- users ---
@@ -288,6 +290,7 @@ export const publicationsRelations = relations(
     submissionPeriods: many(submissionPeriods),
     pipelineItems: many(pipelineItems),
     issues: many(issues),
+    cmsConnections: many(cmsConnections),
   }),
 );
 
@@ -425,5 +428,18 @@ export const issueItemsRelations = relations(issueItems, ({ one }) => ({
   section: one(issueSections, {
     fields: [issueItems.issueSectionId],
     references: [issueSections.id],
+  }),
+}));
+
+// --- cms_connections ---
+
+export const cmsConnectionsRelations = relations(cmsConnections, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [cmsConnections.organizationId],
+    references: [organizations.id],
+  }),
+  publication: one(publications, {
+    fields: [cmsConnections.publicationId],
+    references: [publications.id],
   }),
 }));

--- a/packages/db/src/schema/submissions.ts
+++ b/packages/db/src/schema/submissions.ts
@@ -17,6 +17,7 @@ import { organizations } from "./organizations";
 import { users } from "./users";
 import { formDefinitions } from "./forms";
 import { manuscriptVersions } from "./manuscripts";
+import { publications } from "./publications";
 
 const tsvector = customType<{ data: string }>({
   dataType() {
@@ -48,6 +49,9 @@ export const submissionPeriods = pgTable(
       () => formDefinitions.id,
       { onDelete: "set null" },
     ),
+    publicationId: uuid("publication_id").references(() => publications.id, {
+      onDelete: "set null",
+    }),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
@@ -66,6 +70,7 @@ export const submissionPeriods = pgTable(
     index("submission_periods_form_definition_id_idx").on(
       table.formDefinitionId,
     ),
+    index("submission_periods_publication_id_idx").on(table.publicationId),
     orgIsolationPolicy,
   ],
 ).enableRLS();

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -25,6 +25,7 @@ import type {
   pipelineComments,
 } from "./schema/pipeline";
 import type { contractTemplates, contracts } from "./schema/contracts";
+import type { issues, issueSections, issueItems } from "./schema/issues";
 
 // --- Select types (what you get back from queries) ---
 
@@ -54,6 +55,9 @@ export type PipelineHistoryEntry = InferSelectModel<typeof pipelineHistory>;
 export type PipelineComment = InferSelectModel<typeof pipelineComments>;
 export type ContractTemplate = InferSelectModel<typeof contractTemplates>;
 export type Contract = InferSelectModel<typeof contracts>;
+export type Issue = InferSelectModel<typeof issues>;
+export type IssueSection = InferSelectModel<typeof issueSections>;
+export type IssueItem = InferSelectModel<typeof issueItems>;
 
 /** @deprecated Use File instead — submission_files has been replaced by the files table */
 export type SubmissionFile = File;
@@ -94,6 +98,9 @@ export type NewPipelineHistoryEntry = InferInsertModel<typeof pipelineHistory>;
 export type NewPipelineComment = InferInsertModel<typeof pipelineComments>;
 export type NewContractTemplate = InferInsertModel<typeof contractTemplates>;
 export type NewContract = InferInsertModel<typeof contracts>;
+export type NewIssue = InferInsertModel<typeof issues>;
+export type NewIssueSection = InferInsertModel<typeof issueSections>;
+export type NewIssueItem = InferInsertModel<typeof issueItems>;
 
 /** @deprecated Use NewFile instead */
 export type NewSubmissionFile = NewFile;

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -24,6 +24,7 @@ import type {
   pipelineHistory,
   pipelineComments,
 } from "./schema/pipeline";
+import type { contractTemplates, contracts } from "./schema/contracts";
 
 // --- Select types (what you get back from queries) ---
 
@@ -51,6 +52,8 @@ export type Publication = InferSelectModel<typeof publications>;
 export type PipelineItem = InferSelectModel<typeof pipelineItems>;
 export type PipelineHistoryEntry = InferSelectModel<typeof pipelineHistory>;
 export type PipelineComment = InferSelectModel<typeof pipelineComments>;
+export type ContractTemplate = InferSelectModel<typeof contractTemplates>;
+export type Contract = InferSelectModel<typeof contracts>;
 
 /** @deprecated Use File instead — submission_files has been replaced by the files table */
 export type SubmissionFile = File;
@@ -89,6 +92,8 @@ export type NewPublication = InferInsertModel<typeof publications>;
 export type NewPipelineItem = InferInsertModel<typeof pipelineItems>;
 export type NewPipelineHistoryEntry = InferInsertModel<typeof pipelineHistory>;
 export type NewPipelineComment = InferInsertModel<typeof pipelineComments>;
+export type NewContractTemplate = InferInsertModel<typeof contractTemplates>;
+export type NewContract = InferInsertModel<typeof contracts>;
 
 /** @deprecated Use NewFile instead */
 export type NewSubmissionFile = NewFile;

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -19,6 +19,11 @@ import type { retentionPolicies, userConsents } from "./schema/compliance";
 import type { outboxEvents } from "./schema/messaging";
 import type { zitadelWebhookEvents } from "./schema/webhooks";
 import type { publications } from "./schema/publications";
+import type {
+  pipelineItems,
+  pipelineHistory,
+  pipelineComments,
+} from "./schema/pipeline";
 
 // --- Select types (what you get back from queries) ---
 
@@ -43,6 +48,9 @@ export type UserConsent = InferSelectModel<typeof userConsents>;
 export type OutboxEvent = InferSelectModel<typeof outboxEvents>;
 export type ZitadelWebhookEvent = InferSelectModel<typeof zitadelWebhookEvents>;
 export type Publication = InferSelectModel<typeof publications>;
+export type PipelineItem = InferSelectModel<typeof pipelineItems>;
+export type PipelineHistoryEntry = InferSelectModel<typeof pipelineHistory>;
+export type PipelineComment = InferSelectModel<typeof pipelineComments>;
 
 /** @deprecated Use File instead — submission_files has been replaced by the files table */
 export type SubmissionFile = File;
@@ -78,6 +86,9 @@ export type NewZitadelWebhookEvent = InferInsertModel<
   typeof zitadelWebhookEvents
 >;
 export type NewPublication = InferInsertModel<typeof publications>;
+export type NewPipelineItem = InferInsertModel<typeof pipelineItems>;
+export type NewPipelineHistoryEntry = InferInsertModel<typeof pipelineHistory>;
+export type NewPipelineComment = InferInsertModel<typeof pipelineComments>;
 
 /** @deprecated Use NewFile instead */
 export type NewSubmissionFile = NewFile;

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -18,6 +18,7 @@ import type { auditEvents, dsarRequests } from "./schema/audit";
 import type { retentionPolicies, userConsents } from "./schema/compliance";
 import type { outboxEvents } from "./schema/messaging";
 import type { zitadelWebhookEvents } from "./schema/webhooks";
+import type { publications } from "./schema/publications";
 
 // --- Select types (what you get back from queries) ---
 
@@ -41,6 +42,7 @@ export type RetentionPolicy = InferSelectModel<typeof retentionPolicies>;
 export type UserConsent = InferSelectModel<typeof userConsents>;
 export type OutboxEvent = InferSelectModel<typeof outboxEvents>;
 export type ZitadelWebhookEvent = InferSelectModel<typeof zitadelWebhookEvents>;
+export type Publication = InferSelectModel<typeof publications>;
 
 /** @deprecated Use File instead — submission_files has been replaced by the files table */
 export type SubmissionFile = File;
@@ -75,6 +77,7 @@ export type NewOutboxEvent = InferInsertModel<typeof outboxEvents>;
 export type NewZitadelWebhookEvent = InferInsertModel<
   typeof zitadelWebhookEvents
 >;
+export type NewPublication = InferInsertModel<typeof publications>;
 
 /** @deprecated Use NewFile instead */
 export type NewSubmissionFile = NewFile;

--- a/packages/types/src/api-key.ts
+++ b/packages/types/src/api-key.ts
@@ -27,6 +27,8 @@ export const apiKeyScopeSchema = z
     "publications:write",
     "pipeline:read",
     "pipeline:write",
+    "contracts:read",
+    "contracts:write",
     "audit:read",
   ])
   .describe("Permission scope for the API key");

--- a/packages/types/src/api-key.ts
+++ b/packages/types/src/api-key.ts
@@ -23,6 +23,8 @@ export const apiKeyScopeSchema = z
     "api-keys:manage",
     "payments:read",
     "webhooks:manage",
+    "publications:read",
+    "publications:write",
     "audit:read",
   ])
   .describe("Permission scope for the API key");

--- a/packages/types/src/api-key.ts
+++ b/packages/types/src/api-key.ts
@@ -25,6 +25,8 @@ export const apiKeyScopeSchema = z
     "webhooks:manage",
     "publications:read",
     "publications:write",
+    "pipeline:read",
+    "pipeline:write",
     "audit:read",
   ])
   .describe("Permission scope for the API key");

--- a/packages/types/src/api-key.ts
+++ b/packages/types/src/api-key.ts
@@ -29,6 +29,8 @@ export const apiKeyScopeSchema = z
     "pipeline:write",
     "contracts:read",
     "contracts:write",
+    "issues:read",
+    "issues:write",
     "audit:read",
   ])
   .describe("Permission scope for the API key");

--- a/packages/types/src/api-key.ts
+++ b/packages/types/src/api-key.ts
@@ -31,6 +31,8 @@ export const apiKeyScopeSchema = z
     "contracts:write",
     "issues:read",
     "issues:write",
+    "cms:read",
+    "cms:write",
     "audit:read",
   ])
   .describe("Permission scope for the API key");

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -127,6 +127,11 @@ export const AuditActions = {
   PIPELINE_PROOFREADER_ASSIGNED: "PIPELINE_PROOFREADER_ASSIGNED",
   PIPELINE_COMMENT_ADDED: "PIPELINE_COMMENT_ADDED",
 
+  // CMS connection lifecycle
+  CMS_CONNECTION_CREATED: "CMS_CONNECTION_CREATED",
+  CMS_CONNECTION_UPDATED: "CMS_CONNECTION_UPDATED",
+  CMS_CONNECTION_DELETED: "CMS_CONNECTION_DELETED",
+
   // Audit access
   AUDIT_ACCESSED: "AUDIT_ACCESSED",
 } as const;
@@ -151,6 +156,7 @@ export const AuditResources = {
   CONTRACT_TEMPLATE: "contract_template",
   CONTRACT: "contract",
   ISSUE: "issue",
+  CMS_CONNECTION: "cms_connection",
   AUDIT: "audit",
 } as const;
 
@@ -335,6 +341,14 @@ export interface IssueAuditParams extends BaseAuditParams {
     | typeof AuditActions.ISSUE_ITEM_REMOVED;
 }
 
+export interface CmsConnectionAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.CMS_CONNECTION;
+  action:
+    | typeof AuditActions.CMS_CONNECTION_CREATED
+    | typeof AuditActions.CMS_CONNECTION_UPDATED
+    | typeof AuditActions.CMS_CONNECTION_DELETED;
+}
+
 export interface AuditAccessAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.AUDIT;
   action: typeof AuditActions.AUDIT_ACCESSED;
@@ -365,6 +379,7 @@ export type AuditLogParams =
   | ContractTemplateAuditParams
   | ContractAuditParams
   | IssueAuditParams
+  | CmsConnectionAuditParams
   | AuditAccessAuditParams
   | SystemAuditParams;
 

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -112,6 +112,14 @@ export const AuditActions = {
   CONTRACT_SENT: "CONTRACT_SENT",
   CONTRACT_VOIDED: "CONTRACT_VOIDED",
 
+  // Issue lifecycle
+  ISSUE_CREATED: "ISSUE_CREATED",
+  ISSUE_UPDATED: "ISSUE_UPDATED",
+  ISSUE_PUBLISHED: "ISSUE_PUBLISHED",
+  ISSUE_ARCHIVED: "ISSUE_ARCHIVED",
+  ISSUE_ITEM_ADDED: "ISSUE_ITEM_ADDED",
+  ISSUE_ITEM_REMOVED: "ISSUE_ITEM_REMOVED",
+
   // Pipeline lifecycle
   PIPELINE_ITEM_CREATED: "PIPELINE_ITEM_CREATED",
   PIPELINE_STAGE_CHANGED: "PIPELINE_STAGE_CHANGED",
@@ -142,6 +150,7 @@ export const AuditResources = {
   PIPELINE_ITEM: "pipeline_item",
   CONTRACT_TEMPLATE: "contract_template",
   CONTRACT: "contract",
+  ISSUE: "issue",
   AUDIT: "audit",
 } as const;
 
@@ -315,6 +324,17 @@ export interface ContractAuditParams extends BaseAuditParams {
     | typeof AuditActions.CONTRACT_VOIDED;
 }
 
+export interface IssueAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.ISSUE;
+  action:
+    | typeof AuditActions.ISSUE_CREATED
+    | typeof AuditActions.ISSUE_UPDATED
+    | typeof AuditActions.ISSUE_PUBLISHED
+    | typeof AuditActions.ISSUE_ARCHIVED
+    | typeof AuditActions.ISSUE_ITEM_ADDED
+    | typeof AuditActions.ISSUE_ITEM_REMOVED;
+}
+
 export interface AuditAccessAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.AUDIT;
   action: typeof AuditActions.AUDIT_ACCESSED;
@@ -344,6 +364,7 @@ export type AuditLogParams =
   | PipelineItemAuditParams
   | ContractTemplateAuditParams
   | ContractAuditParams
+  | IssueAuditParams
   | AuditAccessAuditParams
   | SystemAuditParams;
 

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -102,6 +102,13 @@ export const AuditActions = {
   PUBLICATION_UPDATED: "PUBLICATION_UPDATED",
   PUBLICATION_ARCHIVED: "PUBLICATION_ARCHIVED",
 
+  // Pipeline lifecycle
+  PIPELINE_ITEM_CREATED: "PIPELINE_ITEM_CREATED",
+  PIPELINE_STAGE_CHANGED: "PIPELINE_STAGE_CHANGED",
+  PIPELINE_COPYEDITOR_ASSIGNED: "PIPELINE_COPYEDITOR_ASSIGNED",
+  PIPELINE_PROOFREADER_ASSIGNED: "PIPELINE_PROOFREADER_ASSIGNED",
+  PIPELINE_COMMENT_ADDED: "PIPELINE_COMMENT_ADDED",
+
   // Audit access
   AUDIT_ACCESSED: "AUDIT_ACCESSED",
 } as const;
@@ -122,6 +129,7 @@ export const AuditResources = {
   PAYMENT: "payment",
   EMBED_TOKEN: "embed_token",
   PUBLICATION: "publication",
+  PIPELINE_ITEM: "pipeline_item",
   AUDIT: "audit",
 } as const;
 
@@ -269,6 +277,16 @@ export interface PublicationAuditParams extends BaseAuditParams {
     | typeof AuditActions.PUBLICATION_ARCHIVED;
 }
 
+export interface PipelineItemAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.PIPELINE_ITEM;
+  action:
+    | typeof AuditActions.PIPELINE_ITEM_CREATED
+    | typeof AuditActions.PIPELINE_STAGE_CHANGED
+    | typeof AuditActions.PIPELINE_COPYEDITOR_ASSIGNED
+    | typeof AuditActions.PIPELINE_PROOFREADER_ASSIGNED
+    | typeof AuditActions.PIPELINE_COMMENT_ADDED;
+}
+
 export interface AuditAccessAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.AUDIT;
   action: typeof AuditActions.AUDIT_ACCESSED;
@@ -295,6 +313,7 @@ export type AuditLogParams =
   | PaymentAuditParams
   | EmbedTokenAuditParams
   | PublicationAuditParams
+  | PipelineItemAuditParams
   | AuditAccessAuditParams
   | SystemAuditParams;
 

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -102,6 +102,16 @@ export const AuditActions = {
   PUBLICATION_UPDATED: "PUBLICATION_UPDATED",
   PUBLICATION_ARCHIVED: "PUBLICATION_ARCHIVED",
 
+  // Contract template lifecycle
+  CONTRACT_TEMPLATE_CREATED: "CONTRACT_TEMPLATE_CREATED",
+  CONTRACT_TEMPLATE_UPDATED: "CONTRACT_TEMPLATE_UPDATED",
+  CONTRACT_TEMPLATE_DELETED: "CONTRACT_TEMPLATE_DELETED",
+
+  // Contract lifecycle
+  CONTRACT_GENERATED: "CONTRACT_GENERATED",
+  CONTRACT_SENT: "CONTRACT_SENT",
+  CONTRACT_VOIDED: "CONTRACT_VOIDED",
+
   // Pipeline lifecycle
   PIPELINE_ITEM_CREATED: "PIPELINE_ITEM_CREATED",
   PIPELINE_STAGE_CHANGED: "PIPELINE_STAGE_CHANGED",
@@ -130,6 +140,8 @@ export const AuditResources = {
   EMBED_TOKEN: "embed_token",
   PUBLICATION: "publication",
   PIPELINE_ITEM: "pipeline_item",
+  CONTRACT_TEMPLATE: "contract_template",
+  CONTRACT: "contract",
   AUDIT: "audit",
 } as const;
 
@@ -287,6 +299,22 @@ export interface PipelineItemAuditParams extends BaseAuditParams {
     | typeof AuditActions.PIPELINE_COMMENT_ADDED;
 }
 
+export interface ContractTemplateAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.CONTRACT_TEMPLATE;
+  action:
+    | typeof AuditActions.CONTRACT_TEMPLATE_CREATED
+    | typeof AuditActions.CONTRACT_TEMPLATE_UPDATED
+    | typeof AuditActions.CONTRACT_TEMPLATE_DELETED;
+}
+
+export interface ContractAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.CONTRACT;
+  action:
+    | typeof AuditActions.CONTRACT_GENERATED
+    | typeof AuditActions.CONTRACT_SENT
+    | typeof AuditActions.CONTRACT_VOIDED;
+}
+
 export interface AuditAccessAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.AUDIT;
   action: typeof AuditActions.AUDIT_ACCESSED;
@@ -314,6 +342,8 @@ export type AuditLogParams =
   | EmbedTokenAuditParams
   | PublicationAuditParams
   | PipelineItemAuditParams
+  | ContractTemplateAuditParams
+  | ContractAuditParams
   | AuditAccessAuditParams
   | SystemAuditParams;
 

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -97,6 +97,11 @@ export const AuditActions = {
   S3_CLEANUP_COMPLETED: "S3_CLEANUP_COMPLETED",
   S3_CLEANUP_FAILED: "S3_CLEANUP_FAILED",
 
+  // Publication lifecycle
+  PUBLICATION_CREATED: "PUBLICATION_CREATED",
+  PUBLICATION_UPDATED: "PUBLICATION_UPDATED",
+  PUBLICATION_ARCHIVED: "PUBLICATION_ARCHIVED",
+
   // Audit access
   AUDIT_ACCESSED: "AUDIT_ACCESSED",
 } as const;
@@ -116,6 +121,7 @@ export const AuditResources = {
   API_KEY: "api_key",
   PAYMENT: "payment",
   EMBED_TOKEN: "embed_token",
+  PUBLICATION: "publication",
   AUDIT: "audit",
 } as const;
 
@@ -255,6 +261,14 @@ export interface EmbedTokenAuditParams extends BaseAuditParams {
     | typeof AuditActions.GUEST_USER_CREATED;
 }
 
+export interface PublicationAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.PUBLICATION;
+  action:
+    | typeof AuditActions.PUBLICATION_CREATED
+    | typeof AuditActions.PUBLICATION_UPDATED
+    | typeof AuditActions.PUBLICATION_ARCHIVED;
+}
+
 export interface AuditAccessAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.AUDIT;
   action: typeof AuditActions.AUDIT_ACCESSED;
@@ -280,6 +294,7 @@ export type AuditLogParams =
   | ApiKeyAuditParams
   | PaymentAuditParams
   | EmbedTokenAuditParams
+  | PublicationAuditParams
   | AuditAccessAuditParams
   | SystemAuditParams;
 

--- a/packages/types/src/cms.ts
+++ b/packages/types/src/cms.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// CMS adapter types
+// ---------------------------------------------------------------------------
+
+export const cmsAdapterTypeValues = ["WORDPRESS", "GHOST"] as const;
+export type CmsAdapterType = (typeof cmsAdapterTypeValues)[number];
+
+// ---------------------------------------------------------------------------
+// CMS connection
+// ---------------------------------------------------------------------------
+
+export interface CmsConnection {
+  id: string;
+  organizationId: string;
+  publicationId: string | null;
+  adapterType: CmsAdapterType;
+  name: string;
+  config: Record<string, unknown>;
+  isActive: boolean;
+  lastSyncAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Input schemas
+// ---------------------------------------------------------------------------
+
+export const createCmsConnectionSchema = z.object({
+  publicationId: z.string().uuid().optional().describe("Publication ID"),
+  adapterType: z
+    .enum(cmsAdapterTypeValues)
+    .describe("CMS adapter type (WORDPRESS or GHOST)"),
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .describe("Display name for this connection"),
+  config: z
+    .record(z.string(), z.unknown())
+    .describe("Adapter-specific configuration (API URL, credentials, etc.)"),
+});
+
+export type CreateCmsConnectionInput = z.infer<
+  typeof createCmsConnectionSchema
+>;
+
+export const updateCmsConnectionSchema = z.object({
+  name: z.string().trim().min(1).max(255).optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
+  isActive: z.boolean().optional(),
+});
+
+export type UpdateCmsConnectionInput = z.infer<
+  typeof updateCmsConnectionSchema
+>;
+
+export const listCmsConnectionsSchema = z.object({
+  publicationId: z.string().uuid().optional(),
+  page: z.number().int().min(1).default(1),
+  limit: z.number().int().min(1).max(100).default(20),
+});
+
+export type ListCmsConnectionsInput = z.infer<typeof listCmsConnectionsSchema>;
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+export const cmsConnectionSchema = z.object({
+  id: z.string().uuid(),
+  organizationId: z.string().uuid(),
+  publicationId: z.string().uuid().nullable(),
+  adapterType: z.enum(cmsAdapterTypeValues),
+  name: z.string(),
+  config: z.record(z.string(), z.unknown()),
+  isActive: z.boolean(),
+  lastSyncAt: z.date().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});

--- a/packages/types/src/contract.ts
+++ b/packages/types/src/contract.ts
@@ -1,0 +1,172 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Contract status
+// ---------------------------------------------------------------------------
+
+export const contractStatusSchema = z
+  .enum([
+    "DRAFT",
+    "SENT",
+    "VIEWED",
+    "SIGNED",
+    "COUNTERSIGNED",
+    "COMPLETED",
+    "VOIDED",
+  ])
+  .describe("Current status of the contract");
+
+export type ContractStatus = z.infer<typeof contractStatusSchema>;
+
+// ---------------------------------------------------------------------------
+// Merge field definition
+// ---------------------------------------------------------------------------
+
+export const mergeFieldDefinitionSchema = z.object({
+  key: z.string().describe("Merge field key (e.g. author_name)"),
+  label: z.string().describe("Human-readable label"),
+  source: z
+    .enum(["auto", "manual"])
+    .describe("Whether the field is auto-populated or manually entered"),
+  defaultValue: z.string().optional().describe("Default value if not provided"),
+});
+
+export type MergeFieldDefinition = z.infer<typeof mergeFieldDefinitionSchema>;
+
+// ---------------------------------------------------------------------------
+// Contract template schemas
+// ---------------------------------------------------------------------------
+
+export const contractTemplateSchema = z.object({
+  id: z.string().uuid().describe("Contract template ID"),
+  organizationId: z.string().uuid().describe("Organization ID"),
+  name: z.string().describe("Template name"),
+  description: z.string().nullable().describe("Template description"),
+  body: z.string().describe("Template body with {{merge_field}} placeholders"),
+  mergeFields: z
+    .array(mergeFieldDefinitionSchema)
+    .nullable()
+    .describe("Merge field definitions"),
+  isDefault: z.boolean().describe("Whether this is the default template"),
+  createdAt: z.date().describe("When the template was created"),
+  updatedAt: z.date().describe("When the template was last updated"),
+});
+
+export type ContractTemplate = z.infer<typeof contractTemplateSchema>;
+
+export const createContractTemplateSchema = z.object({
+  name: z.string().trim().min(1).max(255).describe("Template name"),
+  description: z.string().max(2000).optional().describe("Template description"),
+  body: z
+    .string()
+    .min(1)
+    .describe("Template body with {{merge_field}} placeholders"),
+  mergeFields: z
+    .array(mergeFieldDefinitionSchema)
+    .optional()
+    .describe("Merge field definitions"),
+  isDefault: z.boolean().optional().describe("Set as default template"),
+});
+
+export type CreateContractTemplateInput = z.infer<
+  typeof createContractTemplateSchema
+>;
+
+export const updateContractTemplateSchema = z.object({
+  name: z.string().trim().min(1).max(255).optional().describe("New name"),
+  description: z
+    .string()
+    .max(2000)
+    .nullable()
+    .optional()
+    .describe("New description (null to clear)"),
+  body: z.string().min(1).optional().describe("New template body"),
+  mergeFields: z
+    .array(mergeFieldDefinitionSchema)
+    .nullable()
+    .optional()
+    .describe("New merge field definitions"),
+  isDefault: z.boolean().optional().describe("Set as default template"),
+});
+
+export type UpdateContractTemplateInput = z.infer<
+  typeof updateContractTemplateSchema
+>;
+
+export const listContractTemplatesSchema = z.object({
+  search: z.string().trim().max(200).optional().describe("Search by name"),
+  page: z.number().int().min(1).default(1).describe("Page number (1-based)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page (1-100, default 20)"),
+});
+
+export type ListContractTemplatesInput = z.infer<
+  typeof listContractTemplatesSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Contract schemas
+// ---------------------------------------------------------------------------
+
+export const contractSchema = z.object({
+  id: z.string().uuid().describe("Contract ID"),
+  organizationId: z.string().uuid().describe("Organization ID"),
+  pipelineItemId: z.string().uuid().describe("Pipeline item ID"),
+  contractTemplateId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("Source template ID"),
+  status: contractStatusSchema,
+  renderedBody: z.string().describe("Contract body with merge fields resolved"),
+  mergeData: z
+    .record(z.string(), z.string())
+    .nullable()
+    .describe("Merge field values used"),
+  documensoDocumentId: z.string().nullable().describe("Documenso document ID"),
+  signedAt: z.date().nullable().describe("When the contract was signed"),
+  countersignedAt: z
+    .date()
+    .nullable()
+    .describe("When the contract was countersigned"),
+  completedAt: z.date().nullable().describe("When the contract was completed"),
+  createdAt: z.date().describe("When the contract was created"),
+  updatedAt: z.date().describe("When the contract was last updated"),
+});
+
+export type Contract = z.infer<typeof contractSchema>;
+
+export const generateContractSchema = z.object({
+  pipelineItemId: z.string().uuid().describe("Pipeline item ID"),
+  contractTemplateId: z.string().uuid().describe("Contract template to use"),
+  mergeData: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe("Override merge field values"),
+});
+
+export type GenerateContractInput = z.infer<typeof generateContractSchema>;
+
+export const listContractsSchema = z.object({
+  status: contractStatusSchema.optional().describe("Filter by status"),
+  pipelineItemId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Filter by pipeline item"),
+  page: z.number().int().min(1).default(1).describe("Page number (1-based)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page (1-100, default 20)"),
+});
+
+export type ListContractsInput = z.infer<typeof listContractsSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,3 +13,4 @@ export * from "./api-key";
 export * from "./embed";
 export * from "./publication";
 export * from "./pipeline";
+export * from "./contract";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -15,3 +15,4 @@ export * from "./publication";
 export * from "./pipeline";
 export * from "./contract";
 export * from "./issue";
+export * from "./cms";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -14,3 +14,4 @@ export * from "./embed";
 export * from "./publication";
 export * from "./pipeline";
 export * from "./contract";
+export * from "./issue";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -11,3 +11,4 @@ export * from "./common";
 export * from "./audit";
 export * from "./api-key";
 export * from "./embed";
+export * from "./publication";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -12,3 +12,4 @@ export * from "./audit";
 export * from "./api-key";
 export * from "./embed";
 export * from "./publication";
+export * from "./pipeline";

--- a/packages/types/src/issue.ts
+++ b/packages/types/src/issue.ts
@@ -1,0 +1,174 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Issue status
+// ---------------------------------------------------------------------------
+
+export const issueStatusSchema = z
+  .enum(["PLANNING", "ASSEMBLING", "READY", "PUBLISHED", "ARCHIVED"])
+  .describe("Current status of the issue");
+
+export type IssueStatus = z.infer<typeof issueStatusSchema>;
+
+// ---------------------------------------------------------------------------
+// Issue schemas
+// ---------------------------------------------------------------------------
+
+export const issueSchema = z.object({
+  id: z.string().uuid().describe("Issue ID"),
+  organizationId: z.string().uuid().describe("Organization ID"),
+  publicationId: z.string().uuid().describe("Publication ID"),
+  title: z.string().describe("Issue title"),
+  volume: z.number().int().nullable().describe("Volume number"),
+  issueNumber: z.number().int().nullable().describe("Issue number"),
+  description: z.string().nullable().describe("Issue description"),
+  coverImageUrl: z.string().nullable().describe("Cover image URL"),
+  status: issueStatusSchema,
+  publicationDate: z.date().nullable().describe("Scheduled publication date"),
+  publishedAt: z.date().nullable().describe("Actual publish timestamp"),
+  metadata: z.record(z.string(), z.unknown()).nullable().describe("Metadata"),
+  createdAt: z.date().describe("When the issue was created"),
+  updatedAt: z.date().describe("When the issue was last updated"),
+});
+
+export type Issue = z.infer<typeof issueSchema>;
+
+export const issueSectionSchema = z.object({
+  id: z.string().uuid().describe("Section ID"),
+  issueId: z.string().uuid().describe("Issue ID"),
+  title: z.string().describe("Section title"),
+  sortOrder: z.number().int().describe("Sort order"),
+  createdAt: z.date().describe("When the section was created"),
+});
+
+export type IssueSection = z.infer<typeof issueSectionSchema>;
+
+export const issueItemSchema = z.object({
+  id: z.string().uuid().describe("Issue item ID"),
+  issueId: z.string().uuid().describe("Issue ID"),
+  pipelineItemId: z.string().uuid().describe("Pipeline item ID"),
+  issueSectionId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("Section ID (if assigned)"),
+  sortOrder: z.number().int().describe("Sort order within section"),
+  createdAt: z.date().describe("When the item was added"),
+});
+
+export type IssueItem = z.infer<typeof issueItemSchema>;
+
+// ---------------------------------------------------------------------------
+// Input schemas
+// ---------------------------------------------------------------------------
+
+export const createIssueSchema = z.object({
+  publicationId: z.string().uuid().describe("Publication ID"),
+  title: z.string().trim().min(1).max(500).describe("Issue title"),
+  volume: z.number().int().positive().optional().describe("Volume number"),
+  issueNumber: z.number().int().positive().optional().describe("Issue number"),
+  description: z.string().max(5000).optional().describe("Issue description"),
+  coverImageUrl: z
+    .string()
+    .url()
+    .max(1000)
+    .optional()
+    .describe("Cover image URL"),
+  publicationDate: z.coerce
+    .date()
+    .optional()
+    .describe("Scheduled publication date"),
+});
+
+export type CreateIssueInput = z.infer<typeof createIssueSchema>;
+
+export const updateIssueSchema = z.object({
+  title: z.string().trim().min(1).max(500).optional().describe("New title"),
+  volume: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .optional()
+    .describe("New volume number"),
+  issueNumber: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .optional()
+    .describe("New issue number"),
+  description: z
+    .string()
+    .max(5000)
+    .nullable()
+    .optional()
+    .describe("New description"),
+  coverImageUrl: z
+    .string()
+    .url()
+    .max(1000)
+    .nullable()
+    .optional()
+    .describe("New cover image URL"),
+  publicationDate: z.coerce
+    .date()
+    .nullable()
+    .optional()
+    .describe("New publication date"),
+});
+
+export type UpdateIssueInput = z.infer<typeof updateIssueSchema>;
+
+export const listIssuesSchema = z.object({
+  publicationId: z.string().uuid().optional().describe("Filter by publication"),
+  status: issueStatusSchema.optional().describe("Filter by status"),
+  search: z.string().trim().max(200).optional().describe("Search by title"),
+  page: z.number().int().min(1).default(1).describe("Page number (1-based)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page (1-100, default 20)"),
+});
+
+export type ListIssuesInput = z.infer<typeof listIssuesSchema>;
+
+export const addIssueItemSchema = z.object({
+  pipelineItemId: z.string().uuid().describe("Pipeline item to add"),
+  issueSectionId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Section to place item in"),
+  sortOrder: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Sort order within section"),
+});
+
+export type AddIssueItemInput = z.infer<typeof addIssueItemSchema>;
+
+export const addIssueSectionSchema = z.object({
+  title: z.string().trim().min(1).max(255).describe("Section title"),
+  sortOrder: z.number().int().min(0).optional().describe("Sort order"),
+});
+
+export type AddIssueSectionInput = z.infer<typeof addIssueSectionSchema>;
+
+export const reorderItemsSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        id: z.string().uuid(),
+        sortOrder: z.number().int().min(0),
+      }),
+    )
+    .describe("Items with new sort orders"),
+});
+
+export type ReorderItemsInput = z.infer<typeof reorderItemsSchema>;

--- a/packages/types/src/pipeline.ts
+++ b/packages/types/src/pipeline.ts
@@ -1,0 +1,183 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Pipeline stage
+// ---------------------------------------------------------------------------
+
+export const pipelineStageSchema = z
+  .enum([
+    "COPYEDIT_PENDING",
+    "COPYEDIT_IN_PROGRESS",
+    "AUTHOR_REVIEW",
+    "PROOFREAD",
+    "READY_TO_PUBLISH",
+    "PUBLISHED",
+    "WITHDRAWN",
+  ])
+  .describe("Current pipeline stage for the piece");
+
+export type PipelineStage = z.infer<typeof pipelineStageSchema>;
+
+// ---------------------------------------------------------------------------
+// Stage transition logic
+// ---------------------------------------------------------------------------
+
+export const VALID_PIPELINE_TRANSITIONS: Record<
+  PipelineStage,
+  PipelineStage[]
+> = {
+  COPYEDIT_PENDING: ["COPYEDIT_IN_PROGRESS", "WITHDRAWN"],
+  COPYEDIT_IN_PROGRESS: ["AUTHOR_REVIEW", "WITHDRAWN"],
+  AUTHOR_REVIEW: ["COPYEDIT_IN_PROGRESS", "PROOFREAD", "WITHDRAWN"],
+  PROOFREAD: ["READY_TO_PUBLISH", "AUTHOR_REVIEW", "WITHDRAWN"],
+  READY_TO_PUBLISH: ["PUBLISHED", "PROOFREAD", "WITHDRAWN"],
+  PUBLISHED: [],
+  WITHDRAWN: [],
+};
+
+export function isValidPipelineTransition(
+  from: PipelineStage,
+  to: PipelineStage,
+): boolean {
+  return VALID_PIPELINE_TRANSITIONS[from].includes(to);
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline item response schema
+// ---------------------------------------------------------------------------
+
+export const pipelineItemSchema = z.object({
+  id: z.string().uuid().describe("Pipeline item ID"),
+  organizationId: z.string().uuid().describe("Organization ID"),
+  submissionId: z.string().uuid().describe("Linked submission ID"),
+  publicationId: z.string().uuid().nullable().describe("Target publication ID"),
+  stage: pipelineStageSchema,
+  assignedCopyeditorId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("Assigned copyeditor user ID"),
+  assignedProofreaderId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("Assigned proofreader user ID"),
+  copyeditDueAt: z.date().nullable().describe("Copyedit deadline"),
+  proofreadDueAt: z.date().nullable().describe("Proofread deadline"),
+  authorReviewDueAt: z.date().nullable().describe("Author review deadline"),
+  inngestRunId: z
+    .string()
+    .nullable()
+    .describe("Active Inngest workflow run ID"),
+  createdAt: z.date().describe("When the item entered the pipeline"),
+  updatedAt: z.date().describe("When the item was last updated"),
+});
+
+export type PipelineItem = z.infer<typeof pipelineItemSchema>;
+
+// ---------------------------------------------------------------------------
+// Pipeline history entry
+// ---------------------------------------------------------------------------
+
+export const pipelineHistoryEntrySchema = z.object({
+  id: z.string().uuid(),
+  pipelineItemId: z.string().uuid(),
+  fromStage: pipelineStageSchema.nullable(),
+  toStage: pipelineStageSchema,
+  changedBy: z.string().uuid().nullable(),
+  comment: z.string().nullable(),
+  changedAt: z.date(),
+});
+
+export type PipelineHistoryEntry = z.infer<typeof pipelineHistoryEntrySchema>;
+
+// ---------------------------------------------------------------------------
+// Pipeline comment
+// ---------------------------------------------------------------------------
+
+export const pipelineCommentSchema = z.object({
+  id: z.string().uuid(),
+  pipelineItemId: z.string().uuid(),
+  authorId: z.string().uuid().nullable(),
+  content: z.string(),
+  stage: pipelineStageSchema,
+  createdAt: z.date(),
+});
+
+export type PipelineComment = z.infer<typeof pipelineCommentSchema>;
+
+// ---------------------------------------------------------------------------
+// Input schemas
+// ---------------------------------------------------------------------------
+
+export const createPipelineItemSchema = z.object({
+  submissionId: z.string().uuid().describe("Submission to enter the pipeline"),
+  publicationId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Target publication (optional)"),
+});
+
+export type CreatePipelineItemInput = z.infer<typeof createPipelineItemSchema>;
+
+export const updatePipelineStageSchema = z.object({
+  stage: pipelineStageSchema.describe("Target stage"),
+  comment: z
+    .string()
+    .max(2000)
+    .optional()
+    .describe("Optional comment for the transition"),
+});
+
+export type UpdatePipelineStageInput = z.infer<
+  typeof updatePipelineStageSchema
+>;
+
+export const assignPipelineRoleSchema = z.object({
+  userId: z.string().uuid().describe("User ID to assign"),
+});
+
+export type AssignPipelineRoleInput = z.infer<typeof assignPipelineRoleSchema>;
+
+export const addPipelineCommentSchema = z.object({
+  content: z
+    .string()
+    .trim()
+    .min(1)
+    .max(5000)
+    .describe("Comment text (max 5,000 chars)"),
+});
+
+export type AddPipelineCommentInput = z.infer<typeof addPipelineCommentSchema>;
+
+export const listPipelineItemsSchema = z.object({
+  stage: pipelineStageSchema.optional().describe("Filter by pipeline stage"),
+  publicationId: z.string().uuid().optional().describe("Filter by publication"),
+  assignedCopyeditorId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Filter by assigned copyeditor"),
+  assignedProofreaderId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Filter by assigned proofreader"),
+  search: z
+    .string()
+    .trim()
+    .max(200)
+    .optional()
+    .describe("Search by submission title"),
+  page: z.number().int().min(1).default(1).describe("Page number (1-based)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page (1-100, default 20)"),
+});
+
+export type ListPipelineItemsInput = z.infer<typeof listPipelineItemsSchema>;

--- a/packages/types/src/publication.ts
+++ b/packages/types/src/publication.ts
@@ -1,0 +1,129 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Publication status
+// ---------------------------------------------------------------------------
+
+export const publicationStatusSchema = z
+  .enum(["ACTIVE", "ARCHIVED"])
+  .describe("Current status of the publication");
+
+export type PublicationStatus = z.infer<typeof publicationStatusSchema>;
+
+// ---------------------------------------------------------------------------
+// Publication response schema
+// ---------------------------------------------------------------------------
+
+export const publicationSchema = z.object({
+  id: z.string().uuid().describe("Unique identifier for the publication"),
+  organizationId: z.string().uuid().describe("ID of the owning organization"),
+  name: z.string().describe("Display name of the publication"),
+  slug: z.string().describe("URL-friendly slug (unique per org)"),
+  description: z
+    .string()
+    .nullable()
+    .describe("Optional description of the publication"),
+  settings: z
+    .record(z.string(), z.unknown())
+    .nullable()
+    .describe("Publication settings (default contract template, CMS config)"),
+  status: publicationStatusSchema,
+  createdAt: z.date().describe("When the publication was created"),
+  updatedAt: z.date().describe("When the publication was last updated"),
+});
+
+export type Publication = z.infer<typeof publicationSchema>;
+
+// ---------------------------------------------------------------------------
+// Create / Update input schemas
+// ---------------------------------------------------------------------------
+
+export const createPublicationSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .describe("Display name for the publication"),
+  slug: z
+    .string()
+    .trim()
+    .min(1)
+    .max(100)
+    .regex(
+      /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+      "Slug must be lowercase alphanumeric with hyphens",
+    )
+    .describe("URL-friendly slug (lowercase alphanumeric + hyphens)"),
+  description: z
+    .string()
+    .max(2000)
+    .optional()
+    .describe("Description of the publication (max 2,000 chars)"),
+  settings: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe("Publication settings"),
+});
+
+export type CreatePublicationInput = z.infer<typeof createPublicationSchema>;
+
+export const updatePublicationSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .optional()
+    .describe("New display name"),
+  slug: z
+    .string()
+    .trim()
+    .min(1)
+    .max(100)
+    .regex(
+      /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+      "Slug must be lowercase alphanumeric with hyphens",
+    )
+    .optional()
+    .describe("New URL-friendly slug"),
+  description: z
+    .string()
+    .max(2000)
+    .nullable()
+    .optional()
+    .describe("New description (null to clear)"),
+  settings: z
+    .record(z.string(), z.unknown())
+    .nullable()
+    .optional()
+    .describe("New settings (null to clear)"),
+});
+
+export type UpdatePublicationInput = z.infer<typeof updatePublicationSchema>;
+
+// ---------------------------------------------------------------------------
+// List / filter input schema
+// ---------------------------------------------------------------------------
+
+export const listPublicationsSchema = z.object({
+  status: publicationStatusSchema
+    .optional()
+    .describe("Filter by publication status"),
+  search: z
+    .string()
+    .trim()
+    .max(200)
+    .optional()
+    .describe("Search by name (max 200 chars)"),
+  page: z.number().int().min(1).default(1).describe("Page number (1-based)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page (1-100, default 20)"),
+});
+
+export type ListPublicationsInput = z.infer<typeof listPublicationsSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,13 +49,13 @@ importers:
         version: 13.0.2
       '@orpc/openapi':
         specifier: ^1.13.5
-        version: 1.13.5(fastify@5.7.4)(ws@8.19.0)
+        version: 1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)(ws@8.19.0)
       '@orpc/server':
         specifier: ^1.13.5
-        version: 1.13.5(fastify@5.7.4)(ws@8.19.0)
+        version: 1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)(ws@8.19.0)
       '@orpc/zod':
         specifier: ^1.13.5
-        version: 1.13.5(@orpc/contract@1.13.5)(@orpc/server@1.13.5(fastify@5.7.4)(ws@8.19.0))(fastify@5.7.4)(ws@8.19.0)(zod@4.3.6)
+        version: 1.13.5(@opentelemetry/api@1.9.0)(@orpc/contract@1.13.5(@opentelemetry/api@1.9.0))(@orpc/server@1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)(ws@8.19.0))(fastify@5.7.4)(ws@8.19.0)(zod@4.3.6)
       '@pothos/core':
         specifier: ^4.3
         version: 4.12.0(graphql@16.12.0)
@@ -79,7 +79,7 @@ importers:
         version: 2.2.3
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(gel@2.2.0)(pg@8.18.0)(prisma@5.22.0)
+        version: 0.45.1(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(gel@2.2.0)(pg@8.18.0)(prisma@5.22.0)
       fastify:
         specifier: ^5.2.0
         version: 5.7.4
@@ -95,6 +95,9 @@ importers:
       graphql-yoga:
         specifier: ^5.11
         version: 5.18.0(graphql@16.12.0)
+      inngest:
+        specifier: ^3.52.3
+        version: 3.52.3(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(fastify@5.7.4)(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(zod@4.3.6)
       ioredis:
         specifier: ^5.9.3
         version: 5.9.3
@@ -170,7 +173,7 @@ importers:
         version: 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.3.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/web:
     dependencies:
@@ -266,7 +269,7 @@ importers:
         version: 0.575.0(react@19.2.4)
       next:
         specifier: ^16.0.0
-        version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -366,13 +369,13 @@ importers:
         version: link:../api-contracts
       '@orpc/client':
         specifier: ^1.13.5
-        version: 1.13.5
+        version: 1.13.5(@opentelemetry/api@1.9.0)
       '@orpc/contract':
         specifier: ^1.13.5
-        version: 1.13.5
+        version: 1.13.5(@opentelemetry/api@1.9.0)
       '@orpc/openapi-client':
         specifier: ^1.13.5
-        version: 1.13.5
+        version: 1.13.5(@opentelemetry/api@1.9.0)
     devDependencies:
       '@colophony/typescript-config':
         specifier: workspace:*
@@ -385,7 +388,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.3.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/api-contracts:
     dependencies:
@@ -394,7 +397,7 @@ importers:
         version: link:../types
       '@orpc/contract':
         specifier: ^1.13.5
-        version: 1.13.5
+        version: 1.13.5(@opentelemetry/api@1.9.0)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -426,13 +429,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.3.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/db:
     dependencies:
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(gel@2.2.0)(pg@8.18.0)(prisma@5.22.0)
+        version: 0.45.1(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(gel@2.2.0)(pg@8.18.0)(prisma@5.22.0)
       pg:
         specifier: ^8.13.0
         version: 8.18.0
@@ -491,7 +494,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.3.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/typescript-config: {}
 
@@ -850,6 +853,9 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@bufbuild/protobuf@2.11.0':
+    resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1512,6 +1518,15 @@ packages:
     resolution: {integrity: sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA==}
     engines: {node: '>=18.0.0'}
 
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
     peerDependencies:
@@ -1670,6 +1685,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inngest/ai@0.1.7':
+    resolution: {integrity: sha512-5xWatW441jacGf9czKEZdgAmkvoy7GS2tp7X8GSbdGeRXzjisHR6vM+q8DQbv6rqRsmQoCQ5iShh34MguELvUQ==}
+
   '@ioredis/as-callback@3.0.0':
     resolution: {integrity: sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==}
 
@@ -1780,6 +1798,9 @@ packages:
     resolution: {integrity: sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@jpwilliams/waitgroup@2.1.1':
+    resolution: {integrity: sha512-0CxRhNfkvFCTLZBKGvKxY2FYtYW1yWhO2McLqBL0X5UWvYjIf9suH8anKW/DNutl369A75Ewyoh2iJMwBZ2tRg==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1801,6 +1822,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -1904,6 +1928,477 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@opentelemetry/api-logs@0.203.0':
+    resolution: {integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.212.0':
+    resolution: {integrity: sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/auto-instrumentations-node@0.70.0':
+    resolution: {integrity: sha512-gSt1gxQLnGL62Xoh+9A6OZksSeYAKunnzR5VKks6esI+aTTZTLveVO6sq4BoUIMUV2WtsmuEGrcUwynU7cctGw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.4.1
+      '@opentelemetry/core': ^2.0.0
+
+  '@opentelemetry/configuration@0.212.0':
+    resolution: {integrity: sha512-D8sAY6RbqMa1W8lCeiaSL2eMCW2MF87QI3y+I6DQE1j+5GrDMwiKPLdzpa/2/+Zl9v1//74LmooCTCJBvWR8Iw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/context-async-hooks@2.5.1':
+    resolution: {integrity: sha512-MHbu8XxCHcBn6RwvCt2Vpn1WnLMNECfNKYB14LI5XypcgH4IE0/DiVifVR9tAkwPMyLXN8dOoPJfya3IryLQVw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.5.1':
+    resolution: {integrity: sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.212.0':
+    resolution: {integrity: sha512-/0bk6fQG+eSFZ4L6NlckGTgUous/ib5+OVdg0x4OdwYeHzV3lTEo3it1HgnPY6UKpmX7ki+hJvxjsOql8rCeZA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.212.0':
+    resolution: {integrity: sha512-JidJasLwG/7M9RTxV/64xotDKmFAUSBc9SNlxI32QYuUMK5rVKhHNWMPDzC7E0pCAL3cu+FyiKvsTwLi2KqPYw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.212.0':
+    resolution: {integrity: sha512-RpKB5UVfxc7c6Ta1UaCrxXDTQ0OD7BCGT66a97Q5zR1x3+9fw4dSaiqMXT/6FAWj2HyFbem6Rcu1UzPZikGTWQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.212.0':
+    resolution: {integrity: sha512-/6Gqf9wpBq22XsomR1i0iPGnbQtCq2Vwnrq5oiDPjYSqveBdK1jtQbhGfmpK2mLLxk4cPDtD1ZEYdIou5K8EaA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.212.0':
+    resolution: {integrity: sha512-8hgBw3aTTRpSTkU4b9MLf/2YVLnfWp+hfnLq/1Fa2cky+vx6HqTodo+Zv1GTIrAKMOOwgysOjufy0gTxngqeBg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.212.0':
+    resolution: {integrity: sha512-C7I4WN+ghn3g7SnxXm2RK3/sRD0k/BYcXaK6lGU3yPjiM7a1M25MLuM6zY3PeVPPzzTZPfuS7+wgn/tHk768Xw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.212.0':
+    resolution: {integrity: sha512-hJFLhCJba5MW5QHexZMHZdMhBfNqNItxOsN0AZojwD1W2kU9xM+BEICowFGJFo/vNV+I2BJvTtmuKafeDSAo7Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.212.0':
+    resolution: {integrity: sha512-9xTuYWp8ClBhljDGAoa0NSsJcsxJsC9zCFKMSZJp1Osb9pjXCMRdA6fwXtlubyqe7w8FH16EWtQNKx/FWi+Ghw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.212.0':
+    resolution: {integrity: sha512-v/0wMozNoiEPRolzC4YoPo4rAT0q8r7aqdnRw3Nu7IDN0CGFzNQazkfAlBJ6N5y0FYJkban7Aw5WnN73//6YlA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.212.0':
+    resolution: {integrity: sha512-d1ivqPT0V+i0IVOOdzGaLqonjtlk5jYrW7ItutWzXL/Mk+PiYb59dymy/i2reot9dDnBFWfrsvxyqdutGF5Vig==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@2.5.1':
+    resolution: {integrity: sha512-Me6JVO7WqXGXsgr4+7o+B7qwKJQbt0c8WamFnxpkR43avgG9k/niTntwCaXiXUTjonWy0+61ZuX6CGzj9nn8CQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation-amqplib@0.59.0':
+    resolution: {integrity: sha512-xscSgOJA+GHphESDZxBHNk/zjNaEgoeufMwmiqYdL+qM27Xw3BbR9vN6Ucbq9dW6Y+oYUPgTTj17qf+Za4+uzg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-aws-lambda@0.64.0':
+    resolution: {integrity: sha512-vYhM/a8fG34/Dl/Q9gfv5Ih3OFPgqeyn79S8FN+Xs/QZw6h6L8a1lDa3CyigyicOXLCmVIM7Fc9vFD4BGqgGLA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-aws-sdk@0.67.0':
+    resolution: {integrity: sha512-btpwJnZ2RBXDh/pTpfVpInpBu9Pedi+lbLKbt3naB344SggbbYnIdT7u8EzmGIApWi9EV91vw7hm896I7nESQA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-bunyan@0.57.0':
+    resolution: {integrity: sha512-W4zLz1Y9ptCsdL+QMXR7xQaBHkJivLBmVlLCjUe23rX4V8E65fGAtlIJSKTKAfz4aEgtWgQAGMdkeqACwG0Caw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-cassandra-driver@0.57.0':
+    resolution: {integrity: sha512-xLwrK+XnN32IB5i6t/a2j+SVdjlq/BIgjpVRkke4HAsKjoSMy1GeSI+ZOiJffRLFb4MojcvH4RG2+nEg1uC6Zg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-connect@0.55.0':
+    resolution: {integrity: sha512-UfGw7ubKKZBoTRjxi5KlfeECEaXZinS20RdRNlZE5tVF+O17hJOnrcGwAoQAHp6eYmxI2jW9IQ4t6450gnNF9g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-cucumber@0.27.0':
+    resolution: {integrity: sha512-4zQ27TZMsfS7senBXqR6TaBPvfnlvI3ZfJU+RHHttzslWqK3rrSUYkgCWO79MnJpw5GtLz+V4NV2gpt/zRiCCA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation-dataloader@0.29.0':
+    resolution: {integrity: sha512-220WjRb1G1UiAKbVblSMxwxxFdpyB4wj1XYIO9BJs5r62Azj2dL5fyZiXK3/WO6wB3uLul9R946iKI1bpPxktQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-dns@0.55.0':
+    resolution: {integrity: sha512-cfWLaFi22V+sQrKY7t6QroYzT3kO9m3PpkN1OXYmuCyfwxQaXOVlF8NSAHtua/RQYw0aQl+2fe6JOWyJdEZiwA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-express@0.60.0':
+    resolution: {integrity: sha512-KghHCDqKq0D7iuPIVCuPSXut5WVAI6uwKcPrhwTUJL5VE2LC18id2vKoiAm1V8XvVlgIGAiECtEvbrFwkTCj3g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fastify@0.56.0':
+    resolution: {integrity: sha512-zotOPoZsWtMF47BjottK23XaaBSmVuwG5D/R3FlGfAAwMNFoDR3IY1OGO9v9KfOU/1/xDVkxsQ22NFfu9lE8aA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fs@0.31.0':
+    resolution: {integrity: sha512-C7tdXGDnkMgLVlE79VSekB+Y+P345zKUigvFMs5M7U0GIYA8ERx3FS0aAcY/ICIq9YwRmH2uuMb++Br5M2vNUg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-generic-pool@0.55.0':
+    resolution: {integrity: sha512-7hWiyLbEX/dIS4LZy/h8VaAQPs8oBeEqsrysDWbos0b9PF414L6Rsbi2um/omtxIs+GTvsbuqDscWigeaxyWdA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-graphql@0.59.0':
+    resolution: {integrity: sha512-NvoUH1CKqfKVUSwCVq1MnIBI29Zd84EwSoBwdWUqyyWK8oTEqzGcnaUli1obYzzZPHijApvHUtV848p1piPmXg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-grpc@0.212.0':
+    resolution: {integrity: sha512-r1t7LNKWVhSQMUrBdDJtooFmmLZ93kGuFixqeXPoUP8W+chJCxhey9l0c0+L3xriNdyB7TzvkKHhPXUDevgVEA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-hapi@0.58.0':
+    resolution: {integrity: sha512-reuRApR2KHm2VsfyDgsrLhNE+IOy4uIU6n3oMjUleReHacEEZmf4vXxdt4/qcmJ6GoUXnRN2AOu3s5N3pMrgYA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-http@0.212.0':
+    resolution: {integrity: sha512-t2nt16Uyv9irgR+tqnX96YeToOStc3X5js7Ljn3EKlI2b4Fe76VhMkTXtsTQ0aId6AsYgefrCRnXSCo/Fn/vww==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-ioredis@0.60.0':
+    resolution: {integrity: sha512-R+nnbPD9l2ruzu248qM3YDWzpdmWVaFFFv08lQqsc0EP4pT/B1GGUg06/tHOSo3L5njB2eejwyzpkvJkjaQEMA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-kafkajs@0.21.0':
+    resolution: {integrity: sha512-lkLrILnKGO7SHw1xPJnuGx2S4XwbKmQiJyzUGuEImRoU/6Gj0Nka0lkbeRd4ANN20dxr/mLdXIsUsk6DzTrX6A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-knex@0.56.0':
+    resolution: {integrity: sha512-pKqtY5lbAQ70MC5K/BJeAA1t2gAUlRBZBAJ5ergRUNs5jw8zbdOXEZOLztiuNvQqD2z4a9N0Tkde9JMFm2pKMQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-koa@0.60.0':
+    resolution: {integrity: sha512-UOmu2y2LHgPzKsm9xd0sCQJimr11YP4MKFc190Do1ufd8qds7Zd5BI3f6TudqYhH9dUIhojsQyUaS6K4nv5FsQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.56.0':
+    resolution: {integrity: sha512-vXtOValhKRgWA9tLAiTU3P37Q31OveRuM2N5iLSVHl4GzkMBQ5p50A9kSKvt5gReL6BzFDXPCM9ItJiAhSS2KQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-memcached@0.55.0':
+    resolution: {integrity: sha512-kdhW/j5X+vNCAvHVc50PZfvE7diUScg1ZkBaNFRygY3Z6IUjgPLR0luWQMDPSFun6AVo1HaMDPxbUqJrot6qrA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongodb@0.65.0':
+    resolution: {integrity: sha512-hOAJRs5vrY7fZolSYUXmf29Y+HFDHWrek0DeLq82uwMPjPSda7h6oumQnqEX5olzw357q/QG39/uJdkclJ/JUg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongoose@0.58.0':
+    resolution: {integrity: sha512-3L0Fqo1y2oreISFPWaqdt/bg3NhLgrkn5U/E/9RNG1QaM81drTMBCHseMY1q8SlejjE43ZWOy+0KbmRBlUPJ+g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql2@0.58.0':
+    resolution: {integrity: sha512-EubjV1XZb7XHrENqF7TW2lnah+KN0LddMneKNAB8PjGVKL5lJkVV/vhJ6EIcUNn9nCWmAwZ3GRcFVEDKCnyXfQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql@0.58.0':
+    resolution: {integrity: sha512-wZDrBCL3WfJclV6KywWVV3/B2ZiUYmDQdgyu3pq4jK/5qSfoDmezHzT/Nayln5MVVWMAGXIMLrCj8BKa6jaKQQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-nestjs-core@0.58.0':
+    resolution: {integrity: sha512-0lE9oW8j6nmvBHJoOxIQgKzMQQYNfX1nhiWZdXD0sNAMFsWBtvECWS7NAPSroKrEP53I04TcHCyyhcK4I9voXg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-net@0.56.0':
+    resolution: {integrity: sha512-h69x7U6f86mP3gGWWTaMkQZk0K3tBvpVMIU7E0q2kkVw6eZ5TqFm9rkaEy38moQmixiDFQ9j/2/cwxG9P7ZEeA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-openai@0.10.0':
+    resolution: {integrity: sha512-0lV2zxge2mMaruVCw/bmypWVu+aJ76rc0HBvAVFCPUI3zzJdgBZJZafGIHZ1IB2F6VvrDFL+JstEnle6V8brvA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-oracledb@0.37.0':
+    resolution: {integrity: sha512-OzMghtAEAEkXlkUrZI4QcXSZq0MILeU6WC0/N5+1MSkuIkruIeaRw99/RtyS2of8vlPDa8XbbXl32Q1RM3wSyg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-pg@0.64.0':
+    resolution: {integrity: sha512-NbfB/rlfsRI3zpTjnbvJv3qwuoGLsN8FxR/XoI+ZTn1Rs62x1IenO+TSSvk4NO+7FlXpd2MiOe8LT/oNbydHGA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-pino@0.58.0':
+    resolution: {integrity: sha512-rgy+tA7cDjuSq6dXAO40OiYP25azIDHMBtxG3RzSmCBVEYdjggl6btyuLVasX6VkOOhP2gf6PBuLMNxVwaIqAw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-redis@0.60.0':
+    resolution: {integrity: sha512-Ea/GffmmzIVHc9geaMjT94IR7poVZzIv4Kk/Lw0tbxGD3cBYcMUsLFVajKxpZsE1NRCECFpidAWeifCIKD0inw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-restify@0.57.0':
+    resolution: {integrity: sha512-kO6MsZFU+RdXOKhsKw8SOSBYGYCdFSlza+mpBQRl1DQmveZcnidchv4V5JQPtNgHxCGH+1n3hDpLdxdGUbJPNA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-router@0.56.0':
+    resolution: {integrity: sha512-PHECDGQElLazI/QbHU16C5m9fDC7DGJk+jLIwO5ca6bcp7bXhUPPUTT78l7da2pDsrz4mhv5ytYNZmBbW/Q3rA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-runtime-node@0.25.0':
+    resolution: {integrity: sha512-XaCmwBSui5KeTn8M6OzaEn1rEsNWtUkjuc1ylg0tqQTLHibNQ0n7f8v4zdF6x/nBV1OnsiYlN8RLHauGemv/TA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-socket.io@0.58.0':
+    resolution: {integrity: sha512-/xuN5YxixNgB+KQJM67UETwB+3F3OTfI4cqH4z9AbHRfFBlddlMOIIpPr3CdrwQGhMd7rrv3t8NBLxv5/UvF1w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-tedious@0.31.0':
+    resolution: {integrity: sha512-HoF2EtcyP3JR4R3jLPHohZ9lFcj1QLJyGmFfLKDTvUUjPiFuK4XZ6L1OV9HhaqvN0xY+tWKfNdCPS3r33rd0Xw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-undici@0.22.0':
+    resolution: {integrity: sha512-yb6vEWUPOrD5i7yR1XceEEqiVHbMgr5YnUPnom5eQVCjvrTkEVswyrf9i+vvJR+28wrNqILIIphWgOOx6BjnTQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+
+  '@opentelemetry/instrumentation-winston@0.56.0':
+    resolution: {integrity: sha512-ITIA0Qe61CQ6FQU/bN23pNBvJ+5U0ofoASMOOYrODtXyV9wI267AigNTTwDmv2Myt8dPEFvvVFJZKhiZLIpehA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.203.0':
+    resolution: {integrity: sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.212.0':
+    resolution: {integrity: sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.212.0':
+    resolution: {integrity: sha512-HoMv5pQlzbuxiMS0hN7oiUtg8RsJR5T7EhZccumIWxYfNo/f4wFc7LPDfFK6oHdG2JF/+qTocfqIHoom+7kLpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.212.0':
+    resolution: {integrity: sha512-YidOSlzpsun9uw0iyIWrQp6HxpMtBlECE3tiHGAsnpEqJWbAUWcMnIffvIuvTtTQ1OyRtwwaE79dWSQ8+eiB7g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.212.0':
+    resolution: {integrity: sha512-bj7zYFOg6Db7NUwsRZQ/WoVXpAf41WY2gsd3kShSfdpZQDRKHWJiRZIg7A8HvWsf97wb05rMFzPbmSHyjEl9tw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@2.5.1':
+    resolution: {integrity: sha512-AU6sZgunZrZv/LTeHP+9IQsSSH5p3PtOfDPe8VTdwYH69nZCfvvvXehhzu+9fMW2mgJMh5RVpiH8M9xuYOu5Dg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@2.5.1':
+    resolution: {integrity: sha512-8+SB94/aSIOVGDUPRFSBRHVUm2A8ye1vC6/qcf/D+TF4qat7PC6rbJhRxiUGDXZtMtKEPM/glgv5cBGSJQymSg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/redis-common@0.38.2':
+    resolution: {integrity: sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+
+  '@opentelemetry/resource-detector-alibaba-cloud@0.33.2':
+    resolution: {integrity: sha512-EaS54zwYmOg9Ttc79juaktpCBYqyh2IquXl534sLls+c1/pc8LZfWPMqytFt+iBvSPQ6ajraUnvi6cun4AhSjQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resource-detector-aws@2.12.0':
+    resolution: {integrity: sha512-VelueKblsnQEiBVqEYcvM9VEb+B8zN6nftltdO9HAD7qi/OlicP4z/UGJ9EeW2m++WabdMoj0G3QVL8YV0P9tw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resource-detector-azure@0.20.0':
+    resolution: {integrity: sha512-iRy+O2cB6DOlQ/OONaK+L8Cp8nLS89dZVRp6KgnFAfzykXuq9Ws/ygJKcU3CCmjkgY5j2Vk3uVTre/E35bWhYg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resource-detector-container@0.8.3':
+    resolution: {integrity: sha512-5J0JP2cy655rBKM9Doz26ffO3rG+Xqm7OXeNXkckzmc3JmL6Bj3dPBKugPYsfemhEIqtf7INH9UmPQqTMuWoHg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resource-detector-gcp@0.47.0':
+    resolution: {integrity: sha512-57T/kRVdU0ch1P4KPEkmU2b5mWNlUs8hHgqrBYVF+fNZMc1jMdL1mANZhEzoLtWKIeoCEy+57Itt7RkXAYNJiQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resources@2.5.1':
+    resolution: {integrity: sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.212.0':
+    resolution: {integrity: sha512-qglb5cqTf0mOC1sDdZ7nfrPjgmAqs2OxkzOPIf2+Rqx8yKBK0pS7wRtB1xH30rqahBIut9QJDbDePyvtyqvH/Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.5.1':
+    resolution: {integrity: sha512-RKMn3QKi8nE71ULUo0g/MBvq1N4icEBo7cQSKnL3URZT16/YH3nSVgWegOjwx7FRBTrjOIkMJkCUn/ZFIEfn4A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.212.0':
+    resolution: {integrity: sha512-tJzVDk4Lo44MdgJLlP+gdYdMnjxSNsjC/IiTxj5CFSnsjzpHXwifgl3BpUX67Ty3KcdubNVfedeBc/TlqHXwwg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.5.1':
+    resolution: {integrity: sha512-iZH3Gw8cxQn0gjpOjJMmKLd9GIaNh/E3v3ST67vyzLSxHBs14HsG4dy7jMYyC5WXGdBVEcM7U/XTF5hCQxjDMw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.5.1':
+    resolution: {integrity: sha512-9lopQ6ZoElETOEN0csgmtEV5/9C7BMfA7VtF4Jape3i954b6sTY2k3Xw3CxUTKreDck/vpAuJM+EDo4zheUw+A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.39.0':
+    resolution: {integrity: sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/sql-common@0.41.2':
+    resolution: {integrity: sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
 
   '@orpc/client@1.13.5':
     resolution: {integrity: sha512-j0VJpiWiFv9Xfan3NOoouHL07nSiHX8haxYaZzHYWSdWh+ABzwa8aRTwQSUpuCfD6i0EtYEZJAB6gVwtAnQoxQ==}
@@ -2025,6 +2520,36 @@ packages:
 
   '@prisma/get-platform@5.22.0':
     resolution: {integrity: sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -3029,6 +3554,14 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@traceloop/ai-semantic-conventions@0.20.0':
+    resolution: {integrity: sha512-bvivhZU6U8TW4TKktYnjdTi+7GE4WxI8epaGjawalSKDunmxaA+4UVFQ+4tSCBvp2Scby+gnYNaTZSrtABfOlQ==}
+    engines: {node: '>=14'}
+
+  '@traceloop/instrumentation-anthropic@0.20.0':
+    resolution: {integrity: sha512-xQcPxVrKr3yT9+ZEM3skYXikJc/ocZlGDIcsBQ3mMwL3Weq1QL7jx/uGLXvrSO2Yh0DWUjWI6Q/oiRCEUM6P8w==}
+    engines: {node: '>=14'}
+
   '@trpc/client@11.10.0':
     resolution: {integrity: sha512-h0s2AwDtuhS8INRb4hlo4z3RKCkarWqlOy+3ffJgrlDxzzW6aLUN+9nDrcN4huPje1Em15tbCOqhIc6oaKYTRw==}
     peerDependencies:
@@ -3070,6 +3603,9 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/aws-lambda@8.10.160':
+    resolution: {integrity: sha512-uoO4QVQNWFPJMh26pXtmtrRfGshPUSpMZGUyUQY20FhfHEElEBOPKgVmFs1z+kbpyBsRs2JnoOPT7++Z4GA9pA==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -3082,11 +3618,20 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/bunyan@1.8.11':
+    resolution: {integrity: sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/clamscan@2.4.1':
     resolution: {integrity: sha512-KhBHhXsMGDoEkk87VRtHtDsjoqXD3epu+a09c1sjW7xqpvoihScxhZNdNIPegVCLDvPOp4khiIpy02XabseztQ==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -3123,11 +3668,32 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/memcached@2.2.10':
+    resolution: {integrity: sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/mysql@2.15.27':
+    resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
+
+  '@types/node@22.19.11':
+    resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
+
   '@types/node@25.3.0':
     resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
 
   '@types/nodemailer@7.0.9':
     resolution: {integrity: sha512-vI8oF1M+8JvQhsId0Pc38BdUP2evenIIys7c7p+9OZXSPOH5c1dyINP1jT8xQ2xPuBUXmIC87s+91IZMDjH8Ow==}
+
+  '@types/oracledb@6.5.2':
+    resolution: {integrity: sha512-kK1eBS/Adeyis+3OlBDMeQQuasIDLUYXsi2T15ccNJ0iyUpQ4xDF7svFu3+bGVrI0CMBUclPciz+lsQR3JX3TQ==}
+
+  '@types/pg-pool@2.0.7':
+    resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
+
+  '@types/pg@8.15.6':
+    resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
 
   '@types/pg@8.16.0':
     resolution: {integrity: sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==}
@@ -3145,6 +3711,9 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/tedious@4.0.14':
+    resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -3372,6 +3941,11 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3416,6 +3990,10 @@ packages:
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
+
+  ansi-regex@4.1.1:
+    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
+    engines: {node: '>=6'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -3589,6 +4167,9 @@ packages:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
@@ -3662,6 +4243,9 @@ packages:
   caniuse-lite@1.0.30001766:
     resolution: {integrity: sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==}
 
+  canonicalize@1.0.8:
+    resolution: {integrity: sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -3677,6 +4261,9 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
@@ -3777,6 +4364,9 @@ packages:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
 
+  cross-fetch@4.1.0:
+    resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
+
   cross-inspect@1.0.1:
     resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
     engines: {node: '>=16.0.0'}
@@ -3800,6 +4390,10 @@ packages:
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -4300,6 +4894,9 @@ packages:
     resolution: {integrity: sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-copy@4.0.2:
     resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
 
@@ -4374,6 +4971,10 @@ packages:
   fengari@0.1.5:
     resolution: {integrity: sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==}
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -4409,6 +5010,13 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
+  forwarded-parse@2.1.2:
+    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -4431,6 +5039,14 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gaxios@7.1.3:
+    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   gel@2.2.0:
     resolution: {integrity: sha512-q0ma7z2swmoamHQusey8ayo8+ilVdzDt4WTxSPzq/yRqvucWRfymRVMvNgmSC0XK7eNjjEZEcplxpgaNojKdmQ==}
@@ -4521,6 +5137,10 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -4565,6 +5185,9 @@ packages:
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
+
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -4634,6 +5257,12 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-in-the-middle@1.15.0:
+    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
+
+  import-in-the-middle@2.0.6:
+    resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
+
   import-local@3.2.0:
     resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
     engines: {node: '>=8'}
@@ -4653,6 +5282,43 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  inngest@3.52.3:
+    resolution: {integrity: sha512-e1sHdjjySXX56m58SMYz+1hRqBKPzxM6w5tPAEs30ocpsK2VZOqyc2aOJ4dQPixilJOphlk+IJx0SjX2gwGtPQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@sveltejs/kit': '>=1.27.3'
+      '@vercel/node': '>=2.15.9'
+      aws-lambda: '>=1.0.7'
+      express: '>=4.19.2'
+      fastify: '>=4.21.0'
+      h3: '>=1.8.1'
+      hono: '>=4.2.7'
+      koa: '>=2.14.2'
+      next: '>=12.0.0'
+      typescript: '>=5.8.0'
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      '@vercel/node':
+        optional: true
+      aws-lambda:
+        optional: true
+      express:
+        optional: true
+      fastify:
+        optional: true
+      h3:
+        optional: true
+      hono:
+        optional: true
+      koa:
+        optional: true
+      next:
+        optional: true
+      typescript:
+        optional: true
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -5014,6 +5680,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -5034,6 +5703,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -5185,6 +5857,9 @@ packages:
   lodash._stringtopath@4.8.0:
     resolution: {integrity: sha512-SXL66C731p0xPDC5LZg4wI5H+dJo/EO4KTqOMwLYCH3+FmmfAKJEZCm6ohGpI+T1xwsDsJCfL4OnhorllvlTPQ==}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
@@ -5209,6 +5884,9 @@ packages:
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -5273,6 +5951,9 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -5293,6 +5974,9 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -5353,6 +6037,24 @@ packages:
 
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
@@ -5655,6 +6357,14 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@8.0.0:
+    resolution: {integrity: sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==}
+    engines: {node: '>=12.0.0'}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -5782,6 +6492,14 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@7.5.2:
+    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
+    engines: {node: '>=8.6.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
@@ -5827,6 +6545,10 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
 
   rollup@4.57.1:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
@@ -5896,6 +6618,10 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  serialize-error-cjs@0.1.4:
+    resolution: {integrity: sha512-6a6dNqipzbCPlTFgztfNP2oG+IGcflMe/01zSzGrQcxGMKbIjOemBBD85pH92klWaJavAUWxAh9Z0aU28zxW6A==}
+    deprecated: Rolling release, please update to 0.2.0
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -6078,6 +6804,10 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  strip-ansi@5.2.0:
+    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
+    engines: {node: '>=6'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -6171,6 +6901,12 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
+  temporal-polyfill@0.2.5:
+    resolution: {integrity: sha512-ye47xp8Cb0nDguAhrrDS1JT1SzwEV9e26sSsrWzVu+yPZ7LzceEcH0i2gci9jWfOfSCCgM3Qv5nOYShVUUFUXA==}
+
+  temporal-spec@0.2.4:
+    resolution: {integrity: sha512-lDMFv4nKQrSjlkHKAlHVqKrBG4DyFfa9F74cmBZ3Iy3ed8yvWnlWSIdi4IKfSqwmazAohBNwiN64qGx4y5Q3IQ==}
+
   terser@5.46.0:
     resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
     engines: {node: '>=10'}
@@ -6231,6 +6967,9 @@ packages:
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
@@ -6388,9 +7127,16 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
+  ulid@2.4.0:
+    resolution: {integrity: sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==}
+    hasBin: true
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -6537,6 +7283,13 @@ packages:
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -6553,6 +7306,9 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -7394,6 +8150,8 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@bufbuild/protobuf@2.11.0': {}
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -7870,6 +8628,18 @@ snapshots:
       '@repeaterjs/repeater': 3.0.6
       tslib: 2.8.1
 
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
+
   '@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@19.2.4))':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -7982,6 +8752,11 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@inngest/ai@0.1.7':
+    dependencies:
+      '@types/node': 22.19.11
+      typescript: 5.9.3
 
   '@ioredis/as-callback@3.0.0': {}
 
@@ -8196,6 +8971,8 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
+  '@jpwilliams/waitgroup@2.1.1': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -8226,6 +9003,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
     optional: true
+
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
@@ -8296,19 +9075,715 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@orpc/client@1.13.5':
+  '@opentelemetry/api-logs@0.203.0':
     dependencies:
-      '@orpc/shared': 1.13.5
-      '@orpc/standard-server': 1.13.5
-      '@orpc/standard-server-fetch': 1.13.5
-      '@orpc/standard-server-peer': 1.13.5
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api-logs@0.212.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/auto-instrumentations-node@0.70.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-amqplib': 0.59.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-aws-lambda': 0.64.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-aws-sdk': 0.67.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-bunyan': 0.57.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-cassandra-driver': 0.57.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-connect': 0.55.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-cucumber': 0.27.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-dataloader': 0.29.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-dns': 0.55.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-express': 0.60.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-fastify': 0.56.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-fs': 0.31.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-generic-pool': 0.55.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-graphql': 0.59.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-grpc': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-hapi': 0.58.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-http': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-ioredis': 0.60.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-kafkajs': 0.21.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-knex': 0.56.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-koa': 0.60.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.56.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-memcached': 0.55.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mongodb': 0.65.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mongoose': 0.58.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mysql': 0.58.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mysql2': 0.58.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-nestjs-core': 0.58.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-net': 0.56.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-openai': 0.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-oracledb': 0.37.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-pg': 0.64.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-pino': 0.58.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-redis': 0.60.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-restify': 0.57.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-router': 0.56.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-runtime-node': 0.25.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-socket.io': 0.58.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-tedious': 0.31.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-undici': 0.22.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-winston': 0.56.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resource-detector-alibaba-cloud': 0.33.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resource-detector-aws': 2.12.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resource-detector-azure': 0.20.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resource-detector-container': 0.8.3(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resource-detector-gcp': 0.47.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-node': 0.212.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/configuration@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      yaml: 2.8.2
+
+  '@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.212.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.212.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-prometheus@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-zipkin@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/instrumentation-amqplib@0.59.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-aws-lambda@0.64.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@types/aws-lambda': 8.10.160
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-aws-sdk@0.67.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-bunyan@0.57.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@types/bunyan': 1.8.11
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-cassandra-driver@0.57.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-connect@0.55.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@types/connect': 3.4.38
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-cucumber@0.27.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-dataloader@0.29.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-dns@0.55.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-express@0.60.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-fastify@0.56.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-fs@0.31.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-generic-pool@0.55.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-graphql@0.59.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-grpc@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-hapi@0.58.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-http@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      forwarded-parse: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-ioredis@0.60.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/redis-common': 0.38.2
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-kafkajs@0.21.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-knex@0.56.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-koa@0.60.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.56.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-memcached@0.55.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@types/memcached': 2.2.10
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongodb@0.65.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongoose@0.58.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql2@0.58.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql@0.58.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@types/mysql': 2.15.27
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-nestjs-core@0.58.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-net@0.56.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-openai@0.10.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-oracledb@0.37.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@types/oracledb': 6.5.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-pg@0.64.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
+      '@types/pg': 8.15.6
+      '@types/pg-pool': 2.0.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-pino@0.58.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-redis@0.60.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/redis-common': 0.38.2
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-restify@0.57.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-router@0.56.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-runtime-node@0.25.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-socket.io@0.58.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-tedious@0.31.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-undici@0.22.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-winston@0.56.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.203.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-transformer@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      protobufjs: 8.0.0
+
+  '@opentelemetry/propagator-b3@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/propagator-jaeger@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/redis-common@0.38.2': {}
+
+  '@opentelemetry/resource-detector-alibaba-cloud@0.33.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/resource-detector-aws@2.12.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/resource-detector-azure@0.20.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/resource-detector-container@0.8.3(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/resource-detector-gcp@0.47.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      gcp-metadata: 8.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/sdk-logs@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-node@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      '@opentelemetry/configuration': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-http': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-prometheus': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-zipkin': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-b3': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-jaeger': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/sdk-trace-node@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/semantic-conventions@1.39.0': {}
+
+  '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@orpc/client@1.13.5(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@orpc/shared': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server-fetch': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server-peer': 1.13.5(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/contract@1.13.5':
+  '@orpc/contract@1.13.5(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@orpc/client': 1.13.5
-      '@orpc/shared': 1.13.5
+      '@orpc/client': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/shared': 1.13.5(@opentelemetry/api@1.9.0)
       '@standard-schema/spec': 1.1.0
       openapi-types: 12.1.3
     transitivePeerDependencies:
@@ -8316,13 +9791,13 @@ snapshots:
 
   '@orpc/interop@1.13.5': {}
 
-  '@orpc/json-schema@1.13.5(fastify@5.7.4)(ws@8.19.0)':
+  '@orpc/json-schema@1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)(ws@8.19.0)':
     dependencies:
-      '@orpc/contract': 1.13.5
+      '@orpc/contract': 1.13.5(@opentelemetry/api@1.9.0)
       '@orpc/interop': 1.13.5
-      '@orpc/openapi': 1.13.5(fastify@5.7.4)(ws@8.19.0)
-      '@orpc/server': 1.13.5(fastify@5.7.4)(ws@8.19.0)
-      '@orpc/shared': 1.13.5
+      '@orpc/openapi': 1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)(ws@8.19.0)
+      '@orpc/server': 1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)(ws@8.19.0)
+      '@orpc/shared': 1.13.5(@opentelemetry/api@1.9.0)
       json-schema-typed: 8.0.2
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -8330,24 +9805,24 @@ snapshots:
       - fastify
       - ws
 
-  '@orpc/openapi-client@1.13.5':
+  '@orpc/openapi-client@1.13.5(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@orpc/client': 1.13.5
-      '@orpc/contract': 1.13.5
-      '@orpc/shared': 1.13.5
-      '@orpc/standard-server': 1.13.5
+      '@orpc/client': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/contract': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/shared': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server': 1.13.5(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/openapi@1.13.5(fastify@5.7.4)(ws@8.19.0)':
+  '@orpc/openapi@1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)(ws@8.19.0)':
     dependencies:
-      '@orpc/client': 1.13.5
-      '@orpc/contract': 1.13.5
+      '@orpc/client': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/contract': 1.13.5(@opentelemetry/api@1.9.0)
       '@orpc/interop': 1.13.5
-      '@orpc/openapi-client': 1.13.5
-      '@orpc/server': 1.13.5(fastify@5.7.4)(ws@8.19.0)
-      '@orpc/shared': 1.13.5
-      '@orpc/standard-server': 1.13.5
+      '@orpc/openapi-client': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/server': 1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)(ws@8.19.0)
+      '@orpc/shared': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server': 1.13.5(@opentelemetry/api@1.9.0)
       json-schema-typed: 8.0.2
       rou3: 0.7.12
     transitivePeerDependencies:
@@ -8356,18 +9831,18 @@ snapshots:
       - fastify
       - ws
 
-  '@orpc/server@1.13.5(fastify@5.7.4)(ws@8.19.0)':
+  '@orpc/server@1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)(ws@8.19.0)':
     dependencies:
-      '@orpc/client': 1.13.5
-      '@orpc/contract': 1.13.5
+      '@orpc/client': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/contract': 1.13.5(@opentelemetry/api@1.9.0)
       '@orpc/interop': 1.13.5
-      '@orpc/shared': 1.13.5
-      '@orpc/standard-server': 1.13.5
-      '@orpc/standard-server-aws-lambda': 1.13.5
-      '@orpc/standard-server-fastify': 1.13.5(fastify@5.7.4)
-      '@orpc/standard-server-fetch': 1.13.5
-      '@orpc/standard-server-node': 1.13.5
-      '@orpc/standard-server-peer': 1.13.5
+      '@orpc/shared': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server-aws-lambda': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server-fastify': 1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)
+      '@orpc/standard-server-fetch': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server-node': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server-peer': 1.13.5(@opentelemetry/api@1.9.0)
       cookie: 1.1.1
     optionalDependencies:
       ws: 8.19.0
@@ -8375,65 +9850,67 @@ snapshots:
       - '@opentelemetry/api'
       - fastify
 
-  '@orpc/shared@1.13.5':
+  '@orpc/shared@1.13.5(@opentelemetry/api@1.9.0)':
     dependencies:
       radash: 12.1.1
       type-fest: 5.4.4
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
 
-  '@orpc/standard-server-aws-lambda@1.13.5':
+  '@orpc/standard-server-aws-lambda@1.13.5(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@orpc/shared': 1.13.5
-      '@orpc/standard-server': 1.13.5
-      '@orpc/standard-server-fetch': 1.13.5
-      '@orpc/standard-server-node': 1.13.5
+      '@orpc/shared': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server-fetch': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server-node': 1.13.5(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/standard-server-fastify@1.13.5(fastify@5.7.4)':
+  '@orpc/standard-server-fastify@1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)':
     dependencies:
-      '@orpc/shared': 1.13.5
-      '@orpc/standard-server': 1.13.5
-      '@orpc/standard-server-node': 1.13.5
+      '@orpc/shared': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server-node': 1.13.5(@opentelemetry/api@1.9.0)
     optionalDependencies:
       fastify: 5.7.4
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/standard-server-fetch@1.13.5':
+  '@orpc/standard-server-fetch@1.13.5(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@orpc/shared': 1.13.5
-      '@orpc/standard-server': 1.13.5
+      '@orpc/shared': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server': 1.13.5(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/standard-server-node@1.13.5':
+  '@orpc/standard-server-node@1.13.5(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@orpc/shared': 1.13.5
-      '@orpc/standard-server': 1.13.5
-      '@orpc/standard-server-fetch': 1.13.5
+      '@orpc/shared': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server-fetch': 1.13.5(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/standard-server-peer@1.13.5':
+  '@orpc/standard-server-peer@1.13.5(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@orpc/shared': 1.13.5
-      '@orpc/standard-server': 1.13.5
+      '@orpc/shared': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/standard-server': 1.13.5(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/standard-server@1.13.5':
+  '@orpc/standard-server@1.13.5(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@orpc/shared': 1.13.5
+      '@orpc/shared': 1.13.5(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/zod@1.13.5(@orpc/contract@1.13.5)(@orpc/server@1.13.5(fastify@5.7.4)(ws@8.19.0))(fastify@5.7.4)(ws@8.19.0)(zod@4.3.6)':
+  '@orpc/zod@1.13.5(@opentelemetry/api@1.9.0)(@orpc/contract@1.13.5(@opentelemetry/api@1.9.0))(@orpc/server@1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)(ws@8.19.0))(fastify@5.7.4)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@orpc/contract': 1.13.5
-      '@orpc/json-schema': 1.13.5(fastify@5.7.4)(ws@8.19.0)
-      '@orpc/openapi': 1.13.5(fastify@5.7.4)(ws@8.19.0)
-      '@orpc/server': 1.13.5(fastify@5.7.4)(ws@8.19.0)
-      '@orpc/shared': 1.13.5
+      '@orpc/contract': 1.13.5(@opentelemetry/api@1.9.0)
+      '@orpc/json-schema': 1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)(ws@8.19.0)
+      '@orpc/openapi': 1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)(ws@8.19.0)
+      '@orpc/server': 1.13.5(@opentelemetry/api@1.9.0)(fastify@5.7.4)(ws@8.19.0)
+      '@orpc/shared': 1.13.5(@opentelemetry/api@1.9.0)
       escape-string-regexp: 5.0.0
       wildcard-match: 5.1.4
       zod: 4.3.6
@@ -8496,6 +9973,29 @@ snapshots:
     dependencies:
       '@prisma/debug': 5.22.0
     optional: true
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -9559,6 +11059,21 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@traceloop/ai-semantic-conventions@0.20.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@traceloop/instrumentation-anthropic@0.20.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@traceloop/ai-semantic-conventions': 0.20.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@trpc/client@11.10.0(@trpc/server@11.10.0(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@trpc/server': 11.10.0(typescript@5.9.3)
@@ -9599,6 +11114,8 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/aws-lambda@8.10.160': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.0
@@ -9620,6 +11137,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/bunyan@1.8.11':
+    dependencies:
+      '@types/node': 25.3.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -9628,6 +11149,14 @@ snapshots:
   '@types/clamscan@2.4.1':
     dependencies:
       '@types/node': 25.3.0
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 25.3.0
+
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 2.1.0
 
   '@types/deep-eql@4.0.2': {}
 
@@ -9668,6 +11197,20 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/memcached@2.2.10':
+    dependencies:
+      '@types/node': 25.3.0
+
+  '@types/ms@2.1.0': {}
+
+  '@types/mysql@2.15.27':
+    dependencies:
+      '@types/node': 25.3.0
+
+  '@types/node@22.19.11':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.3.0':
     dependencies:
       undici-types: 7.18.2
@@ -9675,6 +11218,20 @@ snapshots:
   '@types/nodemailer@7.0.9':
     dependencies:
       '@types/node': 25.3.0
+
+  '@types/oracledb@6.5.2':
+    dependencies:
+      '@types/node': 25.3.0
+
+  '@types/pg-pool@2.0.7':
+    dependencies:
+      '@types/pg': 8.16.0
+
+  '@types/pg@8.15.6':
+    dependencies:
+      '@types/node': 25.3.0
+      pg-protocol: 1.11.0
+      pg-types: 2.2.0
 
   '@types/pg@8.16.0':
     dependencies:
@@ -9695,6 +11252,10 @@ snapshots:
       '@types/node': 25.3.0
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/tedious@4.0.14':
+    dependencies:
+      '@types/node': 25.3.0
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -9934,6 +11495,10 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -9945,8 +11510,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  acorn@8.16.0:
-    optional: true
+  acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
 
@@ -9975,6 +11539,8 @@ snapshots:
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
+
+  ansi-regex@4.1.1: {}
 
   ansi-regex@5.0.1: {}
 
@@ -10189,6 +11755,8 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
+  bignumber.js@9.3.1: {}
+
   bowser@2.14.1: {}
 
   brace-expansion@1.1.12:
@@ -10272,6 +11840,8 @@ snapshots:
 
   caniuse-lite@1.0.30001766: {}
 
+  canonicalize@1.0.8: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -10282,6 +11852,8 @@ snapshots:
   char-regex@1.0.2: {}
 
   ci-info@4.4.0: {}
+
+  cjs-module-lexer@1.4.3: {}
 
   cjs-module-lexer@2.2.0: {}
 
@@ -10376,6 +11948,12 @@ snapshots:
     dependencies:
       luxon: 3.7.2
 
+  cross-fetch@4.1.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   cross-inspect@1.0.1:
     dependencies:
       tslib: 2.8.1
@@ -10398,6 +11976,8 @@ snapshots:
   custom-error-instance@2.1.1: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-uri-to-buffer@4.0.1: {}
 
   data-urls@5.0.0:
     dependencies:
@@ -10490,8 +12070,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.1(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(gel@2.2.0)(pg@8.18.0)(prisma@5.22.0):
+  drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(gel@2.2.0)(pg@8.18.0)(prisma@5.22.0):
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@prisma/client': 5.22.0(prisma@5.22.0)
       '@types/pg': 8.16.0
       gel: 2.2.0
@@ -11007,6 +12588,8 @@ snapshots:
       jest-mock: 30.2.0
       jest-util: 30.2.0
 
+  extend@3.0.2: {}
+
   fast-copy@4.0.2: {}
 
   fast-decode-uri-component@1.0.1: {}
@@ -11098,6 +12681,11 @@ snapshots:
       sprintf-js: 1.1.3
       tmp: 0.2.5
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -11138,6 +12726,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
+  forwarded-parse@2.1.2: {}
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.2:
@@ -11158,6 +12752,23 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gaxios@7.1.3:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.3
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   gel@2.2.0:
     dependencies:
@@ -11263,6 +12874,8 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -11311,6 +12924,11 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
+
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
 
   hasown@2.0.2:
     dependencies:
@@ -11377,6 +12995,20 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-in-the-middle@1.15.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
+
+  import-in-the-middle@2.0.6:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
   import-local@3.2.0:
     dependencies:
       pkg-dir: 4.2.0
@@ -11392,6 +13024,43 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  inngest@3.52.3(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(fastify@5.7.4)(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      '@inngest/ai': 0.1.7
+      '@jpwilliams/waitgroup': 2.1.1
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/auto-instrumentations-node': 0.70.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))
+      '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      '@standard-schema/spec': 1.1.0
+      '@traceloop/instrumentation-anthropic': 0.20.0
+      '@types/debug': 4.1.12
+      '@types/ms': 2.1.0
+      canonicalize: 1.0.8
+      chalk: 4.1.2
+      cross-fetch: 4.1.0
+      debug: 4.4.3
+      hash.js: 1.1.7
+      json-stringify-safe: 5.0.1
+      ms: 2.1.3
+      serialize-error-cjs: 0.1.4
+      strip-ansi: 5.2.0
+      temporal-polyfill: 0.2.5
+      ulid: 2.4.0
+      zod: 4.3.6
+    optionalDependencies:
+      fastify: 5.7.4
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - encoding
+      - supports-color
 
   internal-slot@1.1.0:
     dependencies:
@@ -11979,6 +13648,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -11994,6 +13667,8 @@ snapshots:
   json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-stringify-safe@5.0.1: {}
 
   json5@1.0.2:
     dependencies:
@@ -12134,6 +13809,8 @@ snapshots:
     dependencies:
       lodash._basetostring: 4.12.0
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.defaults@4.2.0: {}
 
   lodash.isarguments@3.1.0: {}
@@ -12158,6 +13835,8 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
+
+  long@5.3.2: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -12208,6 +13887,8 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimalistic-assert@1.0.1: {}
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -12227,6 +13908,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  module-details-from-path@1.0.4: {}
 
   ms@2.1.3: {}
 
@@ -12261,7 +13944,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -12280,6 +13963,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
+      '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.58.2
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -12287,6 +13971,18 @@ snapshots:
       - babel-plugin-macros
 
   node-abort-controller@3.1.1: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
@@ -12600,6 +14296,36 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 25.3.0
+      long: 5.3.2
+
+  protobufjs@8.0.0:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 25.3.0
+      long: 5.3.2
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -12729,6 +14455,21 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+      resolve: 1.22.11
+    transitivePeerDependencies:
+      - supports-color
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   requires-port@1.0.0: {}
 
   resolve-cwd@3.0.0:
@@ -12765,6 +14506,10 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.5.0
 
   rollup@4.57.1:
     dependencies:
@@ -12851,6 +14596,8 @@ snapshots:
   semver@7.7.3: {}
 
   semver@7.7.4: {}
+
+  serialize-error-cjs@0.1.4: {}
 
   set-cookie-parser@2.7.2: {}
 
@@ -13105,6 +14852,10 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  strip-ansi@5.2.0:
+    dependencies:
+      ansi-regex: 4.1.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -13173,6 +14924,12 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  temporal-polyfill@0.2.5:
+    dependencies:
+      temporal-spec: 0.2.4
+
+  temporal-spec@0.2.4: {}
+
   terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -13229,6 +14986,8 @@ snapshots:
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
+
+  tr46@0.0.3: {}
 
   tr46@5.1.1:
     dependencies:
@@ -13396,12 +15155,16 @@ snapshots:
   uglify-js@3.19.3:
     optional: true
 
+  ulid@2.4.0: {}
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
 
@@ -13497,7 +15260,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@25.3.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -13520,6 +15283,7 @@ snapshots:
       vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 25.3.0
       jsdom: 26.1.0
     transitivePeerDependencies:
@@ -13543,6 +15307,10 @@ snapshots:
     dependencies:
       makeerror: 1.0.12
 
+  web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@7.0.0: {}
 
   whatwg-encoding@3.1.1:
@@ -13555,6 +15323,11 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

- **Publications entity** — schema, types, service, tRPC/REST/GraphQL, `submission_periods.publication_id` FK
- **Pipeline core** — `pipeline_items`, `pipeline_history`, `pipeline_comments`, stage transition state machine, service, all API surfaces
- **Inngest integration** — Docker Compose service, env config, client/serve endpoint, `pipeline-workflow` step function, transactional outbox pattern with poller worker
- **Contract templates + contracts** — merge field templates, rendered contracts, services for CRUD + generation, all API surfaces
- **Documenso adapter + webhook** — adapter interface, webhook handler with two-step idempotency, `contract-workflow` Inngest function
- **Issue assembly** — `issues`, `issue_sections`, `issue_items`, TOC generation, reorder, calendar queries, all API surfaces
- **CMS adapters** — `cms_connections`, `CmsAdapter` interface, WordPress REST API v2 + Ghost Admin API implementations, `cms-publish` Inngest function

### Scope

- 5 new enums, 12 new tables (all with RLS + FORCE)
- ~25 new audit actions, 6 new audit resources
- 10 new API key scopes (read/write pairs)
- 7 new services, 6 tRPC routers, 6 REST routers, 6 GraphQL resolvers
- Inngest workflow engine with 3 step functions
- Transactional outbox for event delivery
- Documenso + WordPress + Ghost adapter interfaces
- Backend only — frontend PR follows on separate branch

## Test plan

- [ ] `pnpm type-check` passes (verified pre-push)
- [ ] `pnpm lint` passes (verified pre-push)
- [ ] CI quality + build jobs pass
- [ ] Unit tests pass for existing services (env mock updates included)
- [ ] Manual verification: `pnpm db:migrate` applies all 7 new migrations
- [ ] Manual verification: RLS policies active on all 12 new tables
- [ ] Frontend PR follows on `feat/slate-frontend`