### PR TITLE
feat(slate): add publications CRUD + pipeline dashboard frontend

### DIFF
--- a/apps/web/src/app/(dashboard)/slate/issues/[id]/edit/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/issues/[id]/edit/page.tsx
@@ -1,0 +1,14 @@
+import { IssueForm } from "@/components/slate/issue-form";
+
+export default async function EditIssuePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <div className="p-6">
+      <IssueForm issueId={id} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/slate/issues/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/issues/[id]/page.tsx
@@ -1,0 +1,14 @@
+import { IssueDetail } from "@/components/slate/issue-detail";
+
+export default async function IssueDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <div className="p-6">
+      <IssueDetail issueId={id} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/slate/issues/new/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/issues/new/page.tsx
@@ -1,0 +1,9 @@
+import { IssueForm } from "@/components/slate/issue-form";
+
+export default function NewIssuePage() {
+  return (
+    <div className="p-6">
+      <IssueForm />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/slate/issues/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/issues/page.tsx
@@ -1,0 +1,9 @@
+import { IssueList } from "@/components/slate/issue-list";
+
+export default function IssuesPage() {
+  return (
+    <div className="p-6">
+      <IssueList />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/slate/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/page.tsx
@@ -1,0 +1,5 @@
+import { SlateDashboard } from "@/components/slate/slate-dashboard";
+
+export default function SlatePage() {
+  return <SlateDashboard />;
+}

--- a/apps/web/src/app/(dashboard)/slate/pipeline/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/pipeline/[id]/page.tsx
@@ -1,0 +1,14 @@
+import { PipelineDetail } from "@/components/slate/pipeline-detail";
+
+export default async function PipelineDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <div className="p-6">
+      <PipelineDetail pipelineItemId={id} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/slate/pipeline/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/pipeline/page.tsx
@@ -1,0 +1,9 @@
+import { PipelineList } from "@/components/slate/pipeline-list";
+
+export default function PipelinePage() {
+  return (
+    <div className="p-6">
+      <PipelineList />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/slate/publications/[id]/edit/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/publications/[id]/edit/page.tsx
@@ -1,0 +1,14 @@
+import { PublicationForm } from "@/components/slate/publication-form";
+
+export default async function EditPublicationPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <div className="p-6">
+      <PublicationForm publicationId={id} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/slate/publications/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/publications/[id]/page.tsx
@@ -1,0 +1,14 @@
+import { PublicationDetail } from "@/components/slate/publication-detail";
+
+export default async function PublicationDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <div className="p-6">
+      <PublicationDetail publicationId={id} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/slate/publications/new/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/publications/new/page.tsx
@@ -1,0 +1,9 @@
+import { PublicationForm } from "@/components/slate/publication-form";
+
+export default function NewPublicationPage() {
+  return (
+    <div className="p-6">
+      <PublicationForm />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/slate/publications/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/publications/page.tsx
@@ -1,0 +1,9 @@
+import { PublicationList } from "@/components/slate/publication-list";
+
+export default function PublicationsPage() {
+  return (
+    <div className="p-6">
+      <PublicationList />
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Calendar,
   ClipboardList,
   FileText,
+  GitBranch,
   Inbox,
   LayoutDashboard,
   Library,
@@ -33,6 +34,7 @@ const editorNavigation = [
 const slateNavigation = [
   { name: "Slate Dashboard", href: "/slate", icon: BookMarked },
   { name: "Publications", href: "/slate/publications", icon: Library },
+  { name: "Pipeline", href: "/slate/pipeline", icon: GitBranch },
 ];
 
 const adminNavigation = [

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { useOrganization } from "@/hooks/use-organization";
 import {
+  BookMarked,
   BookOpen,
   Building2,
   Calendar,
@@ -12,6 +13,7 @@ import {
   FileText,
   Inbox,
   LayoutDashboard,
+  Library,
   Settings,
 } from "lucide-react";
 
@@ -28,6 +30,11 @@ const editorNavigation = [
   { name: "Periods", href: "/editor/periods", icon: Calendar },
 ];
 
+const slateNavigation = [
+  { name: "Slate Dashboard", href: "/slate", icon: BookMarked },
+  { name: "Publications", href: "/slate/publications", icon: Library },
+];
+
 const adminNavigation = [
   {
     name: "Organization",
@@ -38,6 +45,7 @@ const adminNavigation = [
 
 function isActiveLink(pathname: string, href: string): boolean {
   if (href === "/editor") return pathname === "/editor";
+  if (href === "/slate") return pathname === "/slate";
   return pathname.startsWith(href);
 }
 
@@ -84,6 +92,34 @@ export function Sidebar() {
               Editor
             </p>
             {editorNavigation.map((item) => {
+              const isActive = isActiveLink(pathname, item.href);
+              return (
+                <Link
+                  key={item.name}
+                  href={item.href}
+                  className={cn(
+                    "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors",
+                    isActive
+                      ? "bg-accent text-accent-foreground"
+                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                  )}
+                >
+                  <item.icon className="h-4 w-4" />
+                  {item.name}
+                </Link>
+              );
+            })}
+          </>
+        )}
+
+        {/* Slate navigation */}
+        {isEditor && (
+          <>
+            <div className="my-4 border-t" />
+            <p className="px-3 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              Slate
+            </p>
+            {slateNavigation.map((item) => {
               const isActive = isActiveLink(pathname, item.href);
               return (
                 <Link

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { useOrganization } from "@/hooks/use-organization";
 import {
+  BookCopy,
   BookMarked,
   BookOpen,
   Building2,
@@ -35,6 +36,7 @@ const slateNavigation = [
   { name: "Slate Dashboard", href: "/slate", icon: BookMarked },
   { name: "Publications", href: "/slate/publications", icon: Library },
   { name: "Pipeline", href: "/slate/pipeline", icon: GitBranch },
+  { name: "Issues", href: "/slate/issues", icon: BookCopy },
 ];
 
 const adminNavigation = [

--- a/apps/web/src/components/slate/add-item-dialog.tsx
+++ b/apps/web/src/components/slate/add-item-dialog.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "sonner";
+import { Loader2, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { PipelineStageBadge } from "./pipeline-stage-badge";
+import type { PipelineStage } from "@colophony/types";
+
+const UNSECTIONED_VALUE = "__unsectioned__";
+
+const STAGE_TABS: Array<{ value: PipelineStage | "ALL"; label: string }> = [
+  { value: "ALL", label: "All" },
+  { value: "READY_TO_PUBLISH", label: "Ready" },
+  { value: "COPYEDIT_IN_PROGRESS", label: "Copyedit" },
+  { value: "PROOFREAD", label: "Proofread" },
+  { value: "PUBLISHED", label: "Published" },
+];
+
+interface AddItemDialogProps {
+  issueId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existingPipelineIds: Set<string>;
+  sections: Array<{ id: string; title: string }>;
+}
+
+export function AddItemDialog({
+  issueId,
+  open,
+  onOpenChange,
+  existingPipelineIds,
+  sections,
+}: AddItemDialogProps) {
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [stageFilter, setStageFilter] = useState<PipelineStage | "ALL">("ALL");
+  const [selectedPipelineItemId, setSelectedPipelineItemId] = useState<
+    string | null
+  >(null);
+  const [targetSectionId, setTargetSectionId] =
+    useState<string>(UNSECTIONED_VALUE);
+  const utils = trpc.useUtils();
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  // Reset state when dialog opens
+  useEffect(() => {
+    if (open) {
+      setSearch("");
+      setDebouncedSearch("");
+      setStageFilter("ALL");
+      setSelectedPipelineItemId(null);
+      setTargetSectionId(UNSECTIONED_VALUE);
+    }
+  }, [open]);
+
+  const { data, isPending } = trpc.pipeline.list.useQuery(
+    {
+      stage: stageFilter === "ALL" ? undefined : stageFilter,
+      search: debouncedSearch || undefined,
+      limit: 50,
+    },
+    { enabled: open },
+  );
+
+  const availableItems =
+    data?.items.filter((item) => !existingPipelineIds.has(item.id)) ?? [];
+
+  const mutation = trpc.issues.addItem.useMutation({
+    onSuccess: () => {
+      toast.success("Item added to issue");
+      utils.issues.getItems.invalidate({ id: issueId });
+      setSelectedPipelineItemId(null);
+      onOpenChange(false);
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const handleAdd = () => {
+    if (!selectedPipelineItemId) return;
+    mutation.mutate({
+      id: issueId,
+      pipelineItemId: selectedPipelineItemId,
+      issueSectionId:
+        targetSectionId === UNSECTIONED_VALUE ? undefined : targetSectionId,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Add Pipeline Item</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Search */}
+          <div className="relative">
+            <Input
+              placeholder="Search pipeline items..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+            {search && (
+              <button
+                type="button"
+                onClick={() => setSearch("")}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+
+          {/* Stage filter */}
+          <Tabs
+            value={stageFilter}
+            onValueChange={(v) => setStageFilter(v as PipelineStage | "ALL")}
+          >
+            <TabsList className="h-8">
+              {STAGE_TABS.map((tab) => (
+                <TabsTrigger
+                  key={tab.value}
+                  value={tab.value}
+                  className="text-xs px-2 py-1"
+                >
+                  {tab.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+
+          {/* Items table */}
+          <div className="max-h-[300px] overflow-auto border rounded-md">
+            {isPending ? (
+              <div className="p-4 space-y-2">
+                <Skeleton className="h-8 w-full" />
+                <Skeleton className="h-8 w-full" />
+                <Skeleton className="h-8 w-full" />
+              </div>
+            ) : availableItems.length > 0 ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Stage</TableHead>
+                    <TableHead>Submission</TableHead>
+                    <TableHead>Publication</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {availableItems.map((item) => (
+                    <TableRow
+                      key={item.id}
+                      className={cn(
+                        "cursor-pointer",
+                        selectedPipelineItemId === item.id && "bg-accent",
+                      )}
+                      onClick={() => setSelectedPipelineItemId(item.id)}
+                    >
+                      <TableCell>
+                        <PipelineStageBadge stage={item.stage} />
+                      </TableCell>
+                      <TableCell className="font-mono text-sm">
+                        {item.submissionId.slice(0, 8)}&hellip;
+                      </TableCell>
+                      <TableCell className="font-mono text-sm text-muted-foreground">
+                        {item.publicationId
+                          ? `${item.publicationId.slice(0, 8)}\u2026`
+                          : "\u2014"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <p className="text-sm text-muted-foreground py-8 text-center">
+                No available pipeline items
+              </p>
+            )}
+          </div>
+
+          {/* Target section */}
+          <div className="flex items-center gap-3">
+            <span className="text-sm font-medium">Section:</span>
+            <Select value={targetSectionId} onValueChange={setTargetSectionId}>
+              <SelectTrigger className="w-[200px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={UNSECTIONED_VALUE}>Unsectioned</SelectItem>
+                {sections.map((s) => (
+                  <SelectItem key={s.id} value={s.id}>
+                    {s.title}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleAdd}
+            disabled={!selectedPipelineItemId || mutation.isPending}
+          >
+            {mutation.isPending && (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            )}
+            Add Item
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/slate/add-section-dialog.tsx
+++ b/apps/web/src/components/slate/add-section-dialog.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+
+interface AddSectionDialogProps {
+  issueId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existingSectionCount: number;
+}
+
+export function AddSectionDialog({
+  issueId,
+  open,
+  onOpenChange,
+  existingSectionCount,
+}: AddSectionDialogProps) {
+  const [title, setTitle] = useState("");
+  const utils = trpc.useUtils();
+
+  const mutation = trpc.issues.addSection.useMutation({
+    onSuccess: () => {
+      toast.success("Section added");
+      utils.issues.getSections.invalidate({ id: issueId });
+      setTitle("");
+      onOpenChange(false);
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    mutation.mutate({
+      id: issueId,
+      title: title.trim(),
+      sortOrder: existingSectionCount,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Section</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="section-title">Title</Label>
+            <Input
+              id="section-title"
+              placeholder="e.g. Poetry, Fiction, Essays"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              autoFocus
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!title.trim() || mutation.isPending}
+            >
+              {mutation.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Add Section
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/slate/add-section-dialog.tsx
+++ b/apps/web/src/components/slate/add-section-dialog.tsx
@@ -19,14 +19,14 @@ interface AddSectionDialogProps {
   issueId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  existingSectionCount: number;
+  existingSortOrders: number[];
 }
 
 export function AddSectionDialog({
   issueId,
   open,
   onOpenChange,
-  existingSectionCount,
+  existingSortOrders,
 }: AddSectionDialogProps) {
   const [title, setTitle] = useState("");
   const utils = trpc.useUtils();
@@ -49,7 +49,8 @@ export function AddSectionDialog({
     mutation.mutate({
       id: issueId,
       title: title.trim(),
-      sortOrder: existingSectionCount,
+      sortOrder:
+        existingSortOrders.length > 0 ? Math.max(...existingSortOrders) + 1 : 0,
     });
   };
 

--- a/apps/web/src/components/slate/issue-assembly.tsx
+++ b/apps/web/src/components/slate/issue-assembly.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import { trpc } from "@/lib/trpc";
+import { IssueSectionCard } from "./issue-section-card";
+import { SortableIssueItem } from "./sortable-issue-item";
+import { AddSectionDialog } from "./add-section-dialog";
+import { AddItemDialog } from "./add-item-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensors,
+  useSensor,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { toast } from "sonner";
+import { Plus, LayoutList } from "lucide-react";
+
+/** Wire-format types (dates serialized as strings over tRPC) */
+type WireSection = {
+  id: string;
+  issueId: string;
+  title: string;
+  sortOrder: number;
+  createdAt: string;
+};
+type WireItem = {
+  id: string;
+  issueId: string;
+  pipelineItemId: string;
+  issueSectionId: string | null;
+  sortOrder: number;
+  createdAt: string;
+};
+
+interface IssueAssemblyProps {
+  issueId: string;
+  sections: WireSection[];
+  items: WireItem[];
+  isEditor: boolean;
+}
+
+export function IssueAssembly({
+  issueId,
+  sections,
+  items,
+  isEditor,
+}: IssueAssemblyProps) {
+  const [showAddSectionDialog, setShowAddSectionDialog] = useState(false);
+  const [showAddItemDialog, setShowAddItemDialog] = useState(false);
+  const utils = trpc.useUtils();
+  const reorderTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const reorderMutation = trpc.issues.reorderItems.useMutation({
+    onError: (err) => {
+      toast.error(`Reorder failed: ${err.message}`);
+      utils.issues.getItems.invalidate({ id: issueId });
+    },
+  });
+
+  const removeItemMutation = trpc.issues.removeItem.useMutation({
+    onSuccess: () => {
+      toast.success("Item removed");
+      utils.issues.getItems.invalidate({ id: issueId });
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const removeSectionMutation = trpc.issues.removeSection.useMutation({
+    onSuccess: () => {
+      toast.success("Section removed");
+      utils.issues.getSections.invalidate({ id: issueId });
+      utils.issues.getItems.invalidate({ id: issueId });
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const addItemMutation = trpc.issues.addItem.useMutation({
+    onSuccess: () => {
+      utils.issues.getItems.invalidate({ id: issueId });
+    },
+    onError: (err) => {
+      toast.error(`Failed to reassign item: ${err.message}`);
+      utils.issues.getItems.invalidate({ id: issueId });
+    },
+  });
+
+  const debouncedReorder = useCallback(
+    (reorderData: { id: string; sortOrder: number }[]) => {
+      if (reorderTimerRef.current) clearTimeout(reorderTimerRef.current);
+      reorderTimerRef.current = setTimeout(() => {
+        reorderMutation.mutate({ id: issueId, items: reorderData });
+      }, 300);
+    },
+    [issueId, reorderMutation],
+  );
+
+  const handleRemoveItem = (itemId: string) => {
+    removeItemMutation.mutate({ id: issueId, itemId });
+  };
+
+  const handleRemoveSection = (sectionId: string) => {
+    removeSectionMutation.mutate({ id: issueId, sectionId });
+  };
+
+  const handleChangeSection = (
+    itemId: string,
+    pipelineItemId: string,
+    newSectionId: string | null,
+  ) => {
+    // Remove then re-add to change section
+    removeItemMutation.mutate(
+      { id: issueId, itemId },
+      {
+        onSuccess: () => {
+          addItemMutation.mutate({
+            id: issueId,
+            pipelineItemId,
+            issueSectionId: newSectionId ?? undefined,
+          });
+        },
+      },
+    );
+  };
+
+  // Group items by section
+  const sortedSections = [...sections].sort(
+    (a, b) => a.sortOrder - b.sortOrder,
+  );
+  const unsectionedItems = items
+    .filter((i) => !i.issueSectionId)
+    .sort((a, b) => a.sortOrder - b.sortOrder);
+  const existingPipelineIds = new Set(items.map((i) => i.pipelineItemId));
+
+  // Unsectioned DnD handlers
+  const handleUnsectionedDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = unsectionedItems.findIndex((i) => i.id === active.id);
+    const newIndex = unsectionedItems.findIndex((i) => i.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const reordered = [...unsectionedItems];
+    const [moved] = reordered.splice(oldIndex, 1);
+    reordered.splice(newIndex, 0, moved);
+
+    debouncedReorder(
+      reordered.map((item, idx) => ({ id: item.id, sortOrder: idx })),
+    );
+  };
+
+  const handleUnsectionedMoveUp = (index: number) => {
+    if (index === 0) return;
+    const reordered = [...unsectionedItems];
+    [reordered[index - 1], reordered[index]] = [
+      reordered[index],
+      reordered[index - 1],
+    ];
+    debouncedReorder(
+      reordered.map((item, idx) => ({ id: item.id, sortOrder: idx })),
+    );
+  };
+
+  const handleUnsectionedMoveDown = (index: number) => {
+    if (index >= unsectionedItems.length - 1) return;
+    const reordered = [...unsectionedItems];
+    [reordered[index], reordered[index + 1]] = [
+      reordered[index + 1],
+      reordered[index],
+    ];
+    debouncedReorder(
+      reordered.map((item, idx) => ({ id: item.id, sortOrder: idx })),
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Toolbar */}
+      {isEditor && (
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowAddSectionDialog(true)}
+          >
+            <LayoutList className="mr-2 h-4 w-4" />
+            Add Section
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowAddItemDialog(true)}
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            Add Items
+          </Button>
+        </div>
+      )}
+
+      {/* Sections */}
+      {sortedSections.map((section) => {
+        const sectionItems = items.filter(
+          (i) => i.issueSectionId === section.id,
+        );
+        return (
+          <IssueSectionCard
+            key={section.id}
+            section={section}
+            items={sectionItems}
+            issueId={issueId}
+            allSections={sections}
+            isEditor={isEditor}
+            onRemoveSection={handleRemoveSection}
+            onRemoveItem={handleRemoveItem}
+            onChangeSection={handleChangeSection}
+            onReorder={debouncedReorder}
+          />
+        );
+      })}
+
+      {/* Unsectioned items */}
+      {unsectionedItems.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            Unsectioned ({unsectionedItems.length})
+          </h3>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleUnsectionedDragEnd}
+          >
+            <SortableContext
+              items={unsectionedItems.map((i) => i.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              <div className="space-y-2">
+                {unsectionedItems.map((item, idx) => (
+                  <SortableIssueItem
+                    key={item.id}
+                    item={item}
+                    sections={sections}
+                    isFirst={idx === 0}
+                    isLast={idx === unsectionedItems.length - 1}
+                    isEditor={isEditor}
+                    onMoveUp={() => handleUnsectionedMoveUp(idx)}
+                    onMoveDown={() => handleUnsectionedMoveDown(idx)}
+                    onRemove={() => handleRemoveItem(item.id)}
+                    onChangeSection={(newSectionId) =>
+                      handleChangeSection(
+                        item.id,
+                        item.pipelineItemId,
+                        newSectionId,
+                      )
+                    }
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {items.length === 0 && sections.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <LayoutList className="h-12 w-12 text-muted-foreground mb-4" />
+          <p className="text-lg font-medium">No content yet</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            Add sections and pipeline items to assemble this issue.
+          </p>
+        </div>
+      )}
+
+      {/* Dialogs */}
+      <AddSectionDialog
+        issueId={issueId}
+        open={showAddSectionDialog}
+        onOpenChange={setShowAddSectionDialog}
+        existingSectionCount={sections.length}
+      />
+      <AddItemDialog
+        issueId={issueId}
+        open={showAddItemDialog}
+        onOpenChange={setShowAddItemDialog}
+        existingPipelineIds={existingPipelineIds}
+        sections={sections}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/issue-assembly.tsx
+++ b/apps/web/src/components/slate/issue-assembly.tsx
@@ -46,6 +46,7 @@ interface IssueAssemblyProps {
   sections: WireSection[];
   items: WireItem[];
   isEditor: boolean;
+  isAdmin: boolean;
 }
 
 export function IssueAssembly({
@@ -53,6 +54,7 @@ export function IssueAssembly({
   sections,
   items,
   isEditor,
+  isAdmin,
 }: IssueAssemblyProps) {
   const [showAddSectionDialog, setShowAddSectionDialog] = useState(false);
   const [showAddItemDialog, setShowAddItemDialog] = useState(false);
@@ -67,6 +69,9 @@ export function IssueAssembly({
   );
 
   const reorderMutation = trpc.issues.reorderItems.useMutation({
+    onSuccess: () => {
+      utils.issues.getItems.invalidate({ id: issueId });
+    },
     onError: (err) => {
       toast.error(`Reorder failed: ${err.message}`);
       utils.issues.getItems.invalidate({ id: issueId });
@@ -196,16 +201,18 @@ export function IssueAssembly({
   return (
     <div className="space-y-4">
       {/* Toolbar */}
-      {isEditor && (
+      {(isAdmin || isEditor) && (
         <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setShowAddSectionDialog(true)}
-          >
-            <LayoutList className="mr-2 h-4 w-4" />
-            Add Section
-          </Button>
+          {isAdmin && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowAddSectionDialog(true)}
+            >
+              <LayoutList className="mr-2 h-4 w-4" />
+              Add Section
+            </Button>
+          )}
           <Button
             variant="outline"
             size="sm"
@@ -230,6 +237,7 @@ export function IssueAssembly({
             issueId={issueId}
             allSections={sections}
             isEditor={isEditor}
+            isAdmin={isAdmin}
             onRemoveSection={handleRemoveSection}
             onRemoveItem={handleRemoveItem}
             onChangeSection={handleChangeSection}
@@ -262,6 +270,7 @@ export function IssueAssembly({
                     isFirst={idx === 0}
                     isLast={idx === unsectionedItems.length - 1}
                     isEditor={isEditor}
+                    isAdmin={isAdmin}
                     onMoveUp={() => handleUnsectionedMoveUp(idx)}
                     onMoveDown={() => handleUnsectionedMoveDown(idx)}
                     onRemove={() => handleRemoveItem(item.id)}
@@ -296,7 +305,7 @@ export function IssueAssembly({
         issueId={issueId}
         open={showAddSectionDialog}
         onOpenChange={setShowAddSectionDialog}
-        existingSectionCount={sections.length}
+        existingSortOrders={sections.map((s) => s.sortOrder)}
       />
       <AddItemDialog
         issueId={issueId}

--- a/apps/web/src/components/slate/issue-detail.tsx
+++ b/apps/web/src/components/slate/issue-detail.tsx
@@ -308,6 +308,7 @@ export function IssueDetail({ issueId }: IssueDetailProps) {
             sections={sections}
             items={items}
             isEditor={isEditor}
+            isAdmin={isAdmin}
           />
         </TabsContent>
       </Tabs>

--- a/apps/web/src/components/slate/issue-detail.tsx
+++ b/apps/web/src/components/slate/issue-detail.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { format, formatDistanceToNow } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { IssueStatusBadge } from "./issue-status-badge";
+import { IssueAssembly } from "./issue-assembly";
+import { IssueItemsSummary } from "./issue-items-summary";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import { ArrowLeft, Archive, CheckCircle2, Pencil } from "lucide-react";
+
+interface IssueDetailProps {
+  issueId: string;
+}
+
+export function IssueDetail({ issueId }: IssueDetailProps) {
+  const { isAdmin, isEditor } = useOrganization();
+  const [activeTab, setActiveTab] = useState("overview");
+  const utils = trpc.useUtils();
+
+  const { data: issue, isPending: isLoading } = trpc.issues.getById.useQuery({
+    id: issueId,
+  });
+
+  const { data: sections = [] } = trpc.issues.getSections.useQuery({
+    id: issueId,
+  });
+
+  const { data: items = [] } = trpc.issues.getItems.useQuery({ id: issueId });
+
+  const { data: publications } = trpc.publications.list.useQuery({
+    limit: 100,
+  });
+
+  const pubMap = new Map(publications?.items.map((p) => [p.id, p.name]) ?? []);
+
+  const publishMutation = trpc.issues.publish.useMutation({
+    onSuccess: () => {
+      toast.success("Issue published");
+      utils.issues.getById.invalidate({ id: issueId });
+      utils.issues.list.invalidate();
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const archiveMutation = trpc.issues.archive.useMutation({
+    onSuccess: () => {
+      toast.success("Issue archived");
+      utils.issues.getById.invalidate({ id: issueId });
+      utils.issues.list.invalidate();
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (!issue) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">Issue not found</p>
+        <Link href="/slate/issues">
+          <Button variant="link">Back to issues</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  const canPublish =
+    isAdmin && issue.status !== "PUBLISHED" && issue.status !== "ARCHIVED";
+  const canArchive = isAdmin && issue.status !== "ARCHIVED";
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="space-y-1">
+        <Link
+          href="/slate/issues"
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="mr-1 h-4 w-4" />
+          Back to issues
+        </Link>
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold">{issue.title}</h1>
+            <div className="flex items-center gap-2 mt-1">
+              <IssueStatusBadge status={issue.status} />
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {isAdmin && (
+              <Link href={`/slate/issues/${issueId}/edit`}>
+                <Button variant="outline" size="sm">
+                  <Pencil className="mr-2 h-4 w-4" />
+                  Edit
+                </Button>
+              </Link>
+            )}
+            {canPublish && (
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button size="sm">
+                    <CheckCircle2 className="mr-2 h-4 w-4" />
+                    Publish
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Publish Issue</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Mark this issue as published? This will set the status to
+                      Published.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => publishMutation.mutate({ id: issueId })}
+                    >
+                      Publish
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            )}
+            {canArchive && (
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button variant="outline" size="sm">
+                    <Archive className="mr-2 h-4 w-4" />
+                    Archive
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Archive Issue</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Archive this issue? It will no longer appear in active
+                      lists.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => archiveMutation.mutate({ id: issueId })}
+                    >
+                      Archive
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="assembly">Assembly</TabsTrigger>
+        </TabsList>
+
+        {/* Overview Tab */}
+        <TabsContent value="overview" className="mt-6">
+          <div className="grid gap-6 md:grid-cols-3">
+            {/* Main column */}
+            <div className="md:col-span-2 space-y-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Details</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {issue.description && (
+                    <div>
+                      <p className="text-sm font-medium text-muted-foreground">
+                        Description
+                      </p>
+                      <p className="text-sm mt-1 whitespace-pre-wrap">
+                        {issue.description}
+                      </p>
+                    </div>
+                  )}
+                  <div className="grid grid-cols-2 gap-4">
+                    {issue.publicationDate && (
+                      <div>
+                        <p className="text-sm font-medium text-muted-foreground">
+                          Publication Date
+                        </p>
+                        <p className="text-sm mt-1">
+                          {format(new Date(issue.publicationDate), "PPP")}
+                        </p>
+                      </div>
+                    )}
+                    {(issue.volume != null || issue.issueNumber != null) && (
+                      <div>
+                        <p className="text-sm font-medium text-muted-foreground">
+                          Volume / Issue
+                        </p>
+                        <p className="text-sm mt-1">
+                          {issue.volume ?? "\u2014"} /{" "}
+                          {issue.issueNumber ?? "\u2014"}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Sidebar */}
+            <div className="space-y-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Metadata</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <div>
+                    <p className="text-sm font-medium text-muted-foreground">
+                      Publication
+                    </p>
+                    <Link
+                      href={`/slate/publications/${issue.publicationId}`}
+                      className="text-sm hover:underline"
+                    >
+                      {pubMap.get(issue.publicationId) ??
+                        `${issue.publicationId.slice(0, 8)}\u2026`}
+                    </Link>
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium text-muted-foreground">
+                      Status
+                    </p>
+                    <div className="mt-1">
+                      <IssueStatusBadge status={issue.status} />
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium text-muted-foreground">
+                      Created
+                    </p>
+                    <p className="text-sm mt-1">
+                      {format(new Date(issue.createdAt), "PPP")}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium text-muted-foreground">
+                      Last Updated
+                    </p>
+                    <p className="text-sm mt-1">
+                      {formatDistanceToNow(new Date(issue.updatedAt), {
+                        addSuffix: true,
+                      })}
+                    </p>
+                  </div>
+                  {issue.publishedAt && (
+                    <div>
+                      <p className="text-sm font-medium text-muted-foreground">
+                        Published At
+                      </p>
+                      <p className="text-sm mt-1">
+                        {format(new Date(issue.publishedAt), "PPP")}
+                      </p>
+                    </div>
+                  )}
+                  <div className="border-t pt-3">
+                    <IssueItemsSummary items={items} sections={sections} />
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </TabsContent>
+
+        {/* Assembly Tab */}
+        <TabsContent value="assembly" className="mt-6">
+          <IssueAssembly
+            issueId={issueId}
+            sections={sections}
+            items={items}
+            isEditor={isEditor}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/issue-form.tsx
+++ b/apps/web/src/components/slate/issue-form.tsx
@@ -132,14 +132,15 @@ export function IssueForm({ issueId }: IssueFormProps) {
     };
 
     if (isEdit) {
+      // For nullable fields, send null to clear (not undefined which means "no change")
       updateMutation.mutate({
         id: issueId!,
         title: payload.title,
-        volume: payload.volume,
-        issueNumber: payload.issueNumber,
-        description: payload.description,
-        publicationDate: payload.publicationDate,
-        coverImageUrl: payload.coverImageUrl,
+        volume: payload.volume ?? null,
+        issueNumber: payload.issueNumber ?? null,
+        description: payload.description ?? null,
+        publicationDate: payload.publicationDate ?? null,
+        coverImageUrl: payload.coverImageUrl ?? null,
       });
     } else {
       createMutation.mutate(payload);

--- a/apps/web/src/components/slate/issue-form.tsx
+++ b/apps/web/src/components/slate/issue-form.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "sonner";
+import { ArrowLeft, Loader2 } from "lucide-react";
+
+const formSchema = z.object({
+  publicationId: z.string().uuid("Please select a publication"),
+  title: z.string().trim().min(1, "Title is required").max(500),
+  volume: z.string().optional(),
+  issueNumber: z.string().optional(),
+  description: z.string().max(5000).optional(),
+  publicationDate: z.string().optional(),
+  coverImageUrl: z.string().optional(),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+interface IssueFormProps {
+  issueId?: string;
+}
+
+export function IssueForm({ issueId }: IssueFormProps) {
+  const router = useRouter();
+  const utils = trpc.useUtils();
+  const isEdit = !!issueId;
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      publicationId: "",
+      title: "",
+      volume: "",
+      issueNumber: "",
+      description: "",
+      publicationDate: "",
+      coverImageUrl: "",
+    },
+  });
+
+  const { data: publications } = trpc.publications.list.useQuery({
+    limit: 100,
+  });
+
+  const {
+    data: issue,
+    isPending: isLoadingIssue,
+    error: loadError,
+  } = trpc.issues.getById.useQuery({ id: issueId! }, { enabled: isEdit });
+
+  // Pre-populate form in edit mode
+  useEffect(() => {
+    if (issue) {
+      form.reset({
+        publicationId: issue.publicationId,
+        title: issue.title,
+        volume: issue.volume?.toString() ?? "",
+        issueNumber: issue.issueNumber?.toString() ?? "",
+        description: issue.description ?? "",
+        publicationDate: issue.publicationDate
+          ? new Date(issue.publicationDate).toISOString().split("T")[0]
+          : "",
+        coverImageUrl: issue.coverImageUrl ?? "",
+      });
+    }
+  }, [issue, form]);
+
+  const createMutation = trpc.issues.create.useMutation({
+    onSuccess: (result) => {
+      toast.success("Issue created");
+      utils.issues.list.invalidate();
+      router.push(`/slate/issues/${result.id}`);
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const updateMutation = trpc.issues.update.useMutation({
+    onSuccess: (result) => {
+      toast.success("Issue updated");
+      utils.issues.getById.invalidate({ id: issueId! });
+      utils.issues.list.invalidate();
+      router.push(`/slate/issues/${result.id}`);
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const onSubmit = (data: FormData) => {
+    const vol = data.volume ? parseInt(data.volume, 10) : undefined;
+    const issNum = data.issueNumber
+      ? parseInt(data.issueNumber, 10)
+      : undefined;
+    const payload = {
+      publicationId: data.publicationId,
+      title: data.title,
+      volume: vol && !isNaN(vol) ? vol : undefined,
+      issueNumber: issNum && !isNaN(issNum) ? issNum : undefined,
+      description: data.description || undefined,
+      publicationDate: data.publicationDate
+        ? new Date(data.publicationDate)
+        : undefined,
+      coverImageUrl: data.coverImageUrl || undefined,
+    };
+
+    if (isEdit) {
+      updateMutation.mutate({
+        id: issueId!,
+        title: payload.title,
+        volume: payload.volume,
+        issueNumber: payload.issueNumber,
+        description: payload.description,
+        publicationDate: payload.publicationDate,
+        coverImageUrl: payload.coverImageUrl,
+      });
+    } else {
+      createMutation.mutate(payload);
+    }
+  };
+
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  if (isEdit && isLoadingIssue) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-96 w-full max-w-lg" />
+      </div>
+    );
+  }
+
+  if (isEdit && loadError) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">Issue not found</p>
+        <Link href="/slate/issues">
+          <Button variant="link">Back to issues</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href={isEdit ? `/slate/issues/${issueId}` : "/slate/issues"}
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="mr-1 h-4 w-4" />
+          {isEdit ? "Back to issue" : "Back to issues"}
+        </Link>
+        <h1 className="text-2xl font-bold mt-2">
+          {isEdit ? "Edit Issue" : "New Issue"}
+        </h1>
+      </div>
+
+      <Card className="w-full max-w-lg">
+        <CardHeader>
+          <CardTitle>{isEdit ? "Issue Details" : "Create Issue"}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="publicationId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Publication</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      disabled={isEdit}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select a publication" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {publications?.items.map((pub) => (
+                          <SelectItem key={pub.id} value={pub.id}>
+                            {pub.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="title"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Title</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Spring 2026" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="grid grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="volume"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Volume</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          placeholder="1"
+                          min={1}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="issueNumber"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Issue Number</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          placeholder="1"
+                          min={1}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="A brief description of this issue..."
+                        rows={4}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="publicationDate"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Publication Date</FormLabel>
+                    <FormControl>
+                      <Input type="date" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="coverImageUrl"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Cover Image URL</FormLabel>
+                    <FormControl>
+                      <Input placeholder="https://..." {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex justify-between pt-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() =>
+                    router.push(
+                      isEdit ? `/slate/issues/${issueId}` : "/slate/issues",
+                    )
+                  }
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isPending}>
+                  {isPending && (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  )}
+                  {isEdit ? "Save Changes" : "Create Issue"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/issue-items-summary.tsx
+++ b/apps/web/src/components/slate/issue-items-summary.tsx
@@ -1,0 +1,30 @@
+interface IssueItemsSummaryProps {
+  items: Array<{ issueSectionId: string | null }>;
+  sections: Array<{ id: string; title: string }>;
+}
+
+export function IssueItemsSummary({ items, sections }: IssueItemsSummaryProps) {
+  const unsectionedCount = items.filter((i) => !i.issueSectionId).length;
+
+  return (
+    <div className="space-y-1 text-sm">
+      <p>
+        <span className="font-medium">{items.length}</span>{" "}
+        {items.length === 1 ? "item" : "items"} total
+      </p>
+      {sections.map((section) => {
+        const count = items.filter(
+          (i) => i.issueSectionId === section.id,
+        ).length;
+        return (
+          <p key={section.id} className="text-muted-foreground">
+            {section.title}: {count}
+          </p>
+        );
+      })}
+      {unsectionedCount > 0 && (
+        <p className="text-muted-foreground">Unsectioned: {unsectionedCount}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/issue-list.tsx
+++ b/apps/web/src/components/slate/issue-list.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { formatDistanceToNow } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { IssueStatusBadge } from "./issue-status-badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { BookCopy, Plus, X } from "lucide-react";
+import type { IssueStatus } from "@colophony/types";
+
+const STATUS_TABS: Array<{ value: IssueStatus | "ALL"; label: string }> = [
+  { value: "ALL", label: "All" },
+  { value: "PLANNING", label: "Planning" },
+  { value: "ASSEMBLING", label: "Assembling" },
+  { value: "READY", label: "Ready" },
+  { value: "PUBLISHED", label: "Published" },
+  { value: "ARCHIVED", label: "Archived" },
+];
+
+export function IssueList() {
+  const { isAdmin } = useOrganization();
+  const [statusFilter, setStatusFilter] = useState<IssueStatus | "ALL">("ALL");
+  const [publicationFilter, setPublicationFilter] = useState<string>("ALL");
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search);
+      setPage(1);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const { data: publications } = trpc.publications.list.useQuery({
+    limit: 100,
+  });
+
+  const pubMap = new Map(publications?.items.map((p) => [p.id, p.name]) ?? []);
+
+  const { data, isPending, error } = trpc.issues.list.useQuery({
+    status: statusFilter === "ALL" ? undefined : statusFilter,
+    publicationId: publicationFilter === "ALL" ? undefined : publicationFilter,
+    search: debouncedSearch || undefined,
+    page,
+    limit: 20,
+  });
+
+  // Clamp page when data shrinks
+  useEffect(() => {
+    if (data && data.totalPages > 0 && page > data.totalPages) {
+      setPage(data.totalPages);
+    }
+  }, [data, page]);
+
+  const handleStatusChange = (value: string) => {
+    setStatusFilter(value as IssueStatus | "ALL");
+    setPage(1);
+  };
+
+  if (isPending) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-10 w-full max-w-sm" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Issues</h1>
+        <p className="text-destructive">
+          Failed to load issues: {error.message}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Issues</h1>
+        {isAdmin && (
+          <Link href="/slate/issues/new">
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              New Issue
+            </Button>
+          </Link>
+        )}
+      </div>
+
+      {/* Search + Publication filter */}
+      <div className="flex items-center gap-4">
+        <div className="relative max-w-sm flex-1">
+          <Input
+            placeholder="Search issues..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch("")}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+        {publications && publications.items.length > 0 && (
+          <Select
+            value={publicationFilter}
+            onValueChange={(v) => {
+              setPublicationFilter(v);
+              setPage(1);
+            }}
+          >
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="All Publications" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ALL">All Publications</SelectItem>
+              {publications.items.map((pub) => (
+                <SelectItem key={pub.id} value={pub.id}>
+                  {pub.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      </div>
+
+      {/* Status tabs */}
+      <Tabs value={statusFilter} onValueChange={handleStatusChange}>
+        <TabsList>
+          {STATUS_TABS.map((tab) => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      {/* Table or empty state */}
+      {data && data.items.length > 0 ? (
+        <>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Status</TableHead>
+                <TableHead>Title</TableHead>
+                <TableHead>Publication</TableHead>
+                <TableHead>Vol / Issue</TableHead>
+                <TableHead>Pub Date</TableHead>
+                <TableHead>Updated</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.items.map((issue) => (
+                <TableRow key={issue.id}>
+                  <TableCell>
+                    <IssueStatusBadge status={issue.status} />
+                  </TableCell>
+                  <TableCell>
+                    <Link
+                      href={`/slate/issues/${issue.id}`}
+                      className="font-medium hover:underline"
+                    >
+                      {issue.title}
+                    </Link>
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {pubMap.get(issue.publicationId) ??
+                      `${issue.publicationId.slice(0, 8)}\u2026`}
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {issue.volume != null || issue.issueNumber != null
+                      ? `${issue.volume ?? "\u2014"} / ${issue.issueNumber ?? "\u2014"}`
+                      : "\u2014"}
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {issue.publicationDate
+                      ? new Date(issue.publicationDate).toLocaleDateString()
+                      : "\u2014"}
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {formatDistanceToNow(new Date(issue.updatedAt), {
+                      addSuffix: true,
+                    })}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+
+          {/* Pagination */}
+          {data.totalPages > 1 && (
+            <div className="flex items-center justify-center gap-4">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {page} of {data.totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))}
+                disabled={page >= data.totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <BookCopy className="h-12 w-12 text-muted-foreground mb-4" />
+          <p className="text-lg font-medium">No issues</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            {statusFilter !== "ALL"
+              ? "No issues with this status."
+              : debouncedSearch
+                ? "No issues match your search."
+                : "Create your first issue to start assembling a publication."}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/issue-section-card.tsx
+++ b/apps/web/src/components/slate/issue-section-card.tsx
@@ -55,6 +55,7 @@ interface IssueSectionCardProps {
   issueId: string;
   allSections: WireSection[];
   isEditor: boolean;
+  isAdmin: boolean;
   onRemoveSection: (sectionId: string) => void;
   onRemoveItem: (itemId: string) => void;
   onChangeSection: (
@@ -70,6 +71,7 @@ export function IssueSectionCard({
   items,
   allSections,
   isEditor,
+  isAdmin,
   onRemoveSection,
   onRemoveItem,
   onChangeSection,
@@ -129,7 +131,7 @@ export function IssueSectionCard({
             {items.length}
           </Badge>
         </div>
-        {isEditor && (
+        {isAdmin && (
           <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
             <AlertDialogTrigger asChild>
               <Button
@@ -178,6 +180,7 @@ export function IssueSectionCard({
                     isFirst={idx === 0}
                     isLast={idx === sorted.length - 1}
                     isEditor={isEditor}
+                    isAdmin={isAdmin}
                     onMoveUp={() => handleMoveUp(idx)}
                     onMoveDown={() => handleMoveDown(idx)}
                     onRemove={() => onRemoveItem(item.id)}

--- a/apps/web/src/components/slate/issue-section-card.tsx
+++ b/apps/web/src/components/slate/issue-section-card.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensors,
+  useSensor,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { SortableIssueItem } from "./sortable-issue-item";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Trash2 } from "lucide-react";
+
+/** Wire-format types (dates serialized as strings over tRPC) */
+type WireSection = {
+  id: string;
+  issueId: string;
+  title: string;
+  sortOrder: number;
+  createdAt: string;
+};
+type WireItem = {
+  id: string;
+  issueId: string;
+  pipelineItemId: string;
+  issueSectionId: string | null;
+  sortOrder: number;
+  createdAt: string;
+};
+
+interface IssueSectionCardProps {
+  section: WireSection;
+  items: WireItem[];
+  issueId: string;
+  allSections: WireSection[];
+  isEditor: boolean;
+  onRemoveSection: (sectionId: string) => void;
+  onRemoveItem: (itemId: string) => void;
+  onChangeSection: (
+    itemId: string,
+    pipelineItemId: string,
+    newSectionId: string | null,
+  ) => void;
+  onReorder: (items: { id: string; sortOrder: number }[]) => void;
+}
+
+export function IssueSectionCard({
+  section,
+  items,
+  allSections,
+  isEditor,
+  onRemoveSection,
+  onRemoveItem,
+  onChangeSection,
+  onReorder,
+}: IssueSectionCardProps) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const sorted = [...items].sort((a, b) => a.sortOrder - b.sortOrder);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = sorted.findIndex((i) => i.id === active.id);
+    const newIndex = sorted.findIndex((i) => i.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const reordered = [...sorted];
+    const [moved] = reordered.splice(oldIndex, 1);
+    reordered.splice(newIndex, 0, moved);
+
+    onReorder(reordered.map((item, idx) => ({ id: item.id, sortOrder: idx })));
+  };
+
+  const handleMoveUp = (index: number) => {
+    if (index === 0) return;
+    const reordered = [...sorted];
+    [reordered[index - 1], reordered[index]] = [
+      reordered[index],
+      reordered[index - 1],
+    ];
+    onReorder(reordered.map((item, idx) => ({ id: item.id, sortOrder: idx })));
+  };
+
+  const handleMoveDown = (index: number) => {
+    if (index >= sorted.length - 1) return;
+    const reordered = [...sorted];
+    [reordered[index], reordered[index + 1]] = [
+      reordered[index + 1],
+      reordered[index],
+    ];
+    onReorder(reordered.map((item, idx) => ({ id: item.id, sortOrder: idx })));
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <div className="flex items-center gap-2">
+          <CardTitle className="text-base">{section.title}</CardTitle>
+          <Badge variant="secondary" className="text-xs">
+            {items.length}
+          </Badge>
+        </div>
+        {isEditor && (
+          <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+            <AlertDialogTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 text-muted-foreground hover:text-destructive"
+              >
+                <Trash2 className="h-3 w-3" />
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Remove Section</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Remove &ldquo;{section.title}&rdquo;? Items in this section
+                  will become unsectioned.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={() => onRemoveSection(section.id)}>
+                  Remove
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        )}
+      </CardHeader>
+      <CardContent>
+        {sorted.length > 0 ? (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={sorted.map((i) => i.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              <div className="space-y-2">
+                {sorted.map((item, idx) => (
+                  <SortableIssueItem
+                    key={item.id}
+                    item={item}
+                    sections={allSections}
+                    isFirst={idx === 0}
+                    isLast={idx === sorted.length - 1}
+                    isEditor={isEditor}
+                    onMoveUp={() => handleMoveUp(idx)}
+                    onMoveDown={() => handleMoveDown(idx)}
+                    onRemove={() => onRemoveItem(item.id)}
+                    onChangeSection={(newSectionId) =>
+                      onChangeSection(
+                        item.id,
+                        item.pipelineItemId,
+                        newSectionId,
+                      )
+                    }
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        ) : (
+          <p className="text-sm text-muted-foreground py-4 text-center">
+            No items in this section
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/slate/issue-status-badge.tsx
+++ b/apps/web/src/components/slate/issue-status-badge.tsx
@@ -1,0 +1,47 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { IssueStatus } from "@colophony/types";
+
+const statusConfig: Record<IssueStatus, { label: string; className: string }> =
+  {
+    PLANNING: {
+      label: "Planning",
+      className:
+        "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+    },
+    ASSEMBLING: {
+      label: "Assembling",
+      className:
+        "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+    },
+    READY: {
+      label: "Ready",
+      className:
+        "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+    },
+    PUBLISHED: {
+      label: "Published",
+      className:
+        "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    },
+    ARCHIVED: {
+      label: "Archived",
+      className:
+        "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+    },
+  };
+
+interface IssueStatusBadgeProps {
+  status: IssueStatus;
+  className?: string;
+}
+
+export function IssueStatusBadge({ status, className }: IssueStatusBadgeProps) {
+  const config = statusConfig[status];
+
+  return (
+    <Badge variant="secondary" className={cn(config.className, className)}>
+      {config.label}
+    </Badge>
+  );
+}

--- a/apps/web/src/components/slate/pipeline-comments.tsx
+++ b/apps/web/src/components/slate/pipeline-comments.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { formatDistanceToNow } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { PipelineStageBadge } from "./pipeline-stage-badge";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "sonner";
+
+interface PipelineCommentsProps {
+  pipelineItemId: string;
+}
+
+export function PipelineComments({ pipelineItemId }: PipelineCommentsProps) {
+  const [content, setContent] = useState("");
+  const utils = trpc.useUtils();
+
+  const { data: comments, isPending: isLoading } =
+    trpc.pipeline.listComments.useQuery({ id: pipelineItemId });
+
+  const addCommentMutation = trpc.pipeline.addComment.useMutation({
+    onSuccess: () => {
+      setContent("");
+      toast.success("Comment added");
+      utils.pipeline.listComments.invalidate({ id: pipelineItemId });
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = content.trim();
+    if (!trimmed) return;
+    addCommentMutation.mutate({ id: pipelineItemId, content: trimmed });
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Add comment form */}
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <Textarea
+          placeholder="Add a comment..."
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          rows={3}
+        />
+        <Button
+          type="submit"
+          size="sm"
+          disabled={!content.trim() || addCommentMutation.isPending}
+        >
+          {addCommentMutation.isPending ? "Adding..." : "Add Comment"}
+        </Button>
+      </form>
+
+      {/* Comment list */}
+      {isLoading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full" />
+          ))}
+        </div>
+      ) : comments && comments.length > 0 ? (
+        <div className="space-y-3">
+          {comments.map((comment) => (
+            <div key={comment.id} className="rounded-lg border p-3 space-y-1.5">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                {comment.authorId && (
+                  <span className="font-mono">
+                    {comment.authorId.slice(0, 8)}&hellip;
+                  </span>
+                )}
+                <PipelineStageBadge stage={comment.stage} />
+                <span>
+                  {formatDistanceToNow(new Date(comment.createdAt), {
+                    addSuffix: true,
+                  })}
+                </span>
+              </div>
+              <p className="text-sm whitespace-pre-wrap">{comment.content}</p>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">No comments yet.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/pipeline-detail.tsx
+++ b/apps/web/src/components/slate/pipeline-detail.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import Link from "next/link";
+import { format, formatDistanceToNow } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { PipelineStageBadge } from "./pipeline-stage-badge";
+import { PipelineStageTransition } from "./pipeline-stage-transition";
+import { PipelineRoleAssignment } from "./pipeline-role-assignment";
+import { PipelineComments } from "./pipeline-comments";
+import { PipelineHistory } from "./pipeline-history";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowLeft } from "lucide-react";
+
+interface PipelineDetailProps {
+  pipelineItemId: string;
+}
+
+export function PipelineDetail({ pipelineItemId }: PipelineDetailProps) {
+  const { isAdmin } = useOrganization();
+
+  const { data: item, isPending: isLoading } = trpc.pipeline.getById.useQuery({
+    id: pipelineItemId,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (!item) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">Pipeline item not found</p>
+        <Link href="/slate/pipeline">
+          <Button variant="link">Back to pipeline</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="space-y-1">
+        <Link
+          href="/slate/pipeline"
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="mr-1 h-4 w-4" />
+          Back to pipeline
+        </Link>
+        <h1 className="text-2xl font-bold">Pipeline Item</h1>
+        <div className="flex items-center gap-2">
+          <PipelineStageBadge stage={item.stage} />
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="grid gap-6 md:grid-cols-3">
+        {/* Main column */}
+        <div className="md:col-span-2 space-y-6">
+          {/* Stage Transition */}
+          {isAdmin && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Stage Transition</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <PipelineStageTransition
+                  pipelineItemId={pipelineItemId}
+                  currentStage={item.stage}
+                />
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Info */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Submission
+                </p>
+                <Link
+                  href={`/editor/${item.submissionId}`}
+                  className="text-sm font-mono hover:underline"
+                >
+                  {item.submissionId}
+                </Link>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Publication
+                </p>
+                <p className="text-sm font-mono">
+                  {item.publicationId ?? "\u2014"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Created
+                </p>
+                <p className="text-sm">
+                  {format(new Date(item.createdAt), "PPP")}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Role Assignment */}
+          {isAdmin && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Role Assignment</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <PipelineRoleAssignment
+                  pipelineItemId={pipelineItemId}
+                  currentCopyeditorId={item.assignedCopyeditorId}
+                  currentProofreaderId={item.assignedProofreaderId}
+                />
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Comments */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Comments</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <PipelineComments pipelineItemId={pipelineItemId} />
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+          {/* Metadata */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Metadata</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Stage
+                </p>
+                <div className="mt-1">
+                  <PipelineStageBadge stage={item.stage} />
+                </div>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Copyedit Due
+                </p>
+                <p className="text-sm mt-1">
+                  {item.copyeditDueAt
+                    ? format(new Date(item.copyeditDueAt), "PPP")
+                    : "\u2014"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Proofread Due
+                </p>
+                <p className="text-sm mt-1">
+                  {item.proofreadDueAt
+                    ? format(new Date(item.proofreadDueAt), "PPP")
+                    : "\u2014"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Author Review Due
+                </p>
+                <p className="text-sm mt-1">
+                  {item.authorReviewDueAt
+                    ? format(new Date(item.authorReviewDueAt), "PPP")
+                    : "\u2014"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Inngest Run ID
+                </p>
+                <p className="text-sm mt-1 font-mono">
+                  {item.inngestRunId ?? "\u2014"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Last Updated
+                </p>
+                <p className="text-sm mt-1">
+                  {formatDistanceToNow(new Date(item.updatedAt), {
+                    addSuffix: true,
+                  })}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* History */}
+          <Card>
+            <CardHeader>
+              <CardTitle>History</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <PipelineHistory pipelineItemId={pipelineItemId} />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/pipeline-history.tsx
+++ b/apps/web/src/components/slate/pipeline-history.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { formatDistanceToNow } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { PipelineStageBadge } from "./pipeline-stage-badge";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface PipelineHistoryProps {
+  pipelineItemId: string;
+}
+
+export function PipelineHistory({ pipelineItemId }: PipelineHistoryProps) {
+  const { data: history, isPending: isLoading } =
+    trpc.pipeline.getHistory.useQuery({ id: pipelineItemId });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!history || history.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">No history available.</p>
+    );
+  }
+
+  return (
+    <div className="relative space-y-0">
+      {/* Connecting line */}
+      <div className="absolute left-[7px] top-2 bottom-2 w-px bg-border" />
+
+      {history.map((entry) => (
+        <div key={entry.id} className="relative flex gap-3 pb-4 last:pb-0">
+          {/* Dot marker */}
+          <div className="relative z-10 mt-1.5 h-[15px] w-[15px] shrink-0 rounded-full border-2 border-border bg-background" />
+
+          <div className="min-w-0 flex-1 space-y-1">
+            <div className="flex flex-wrap items-center gap-1.5 text-sm">
+              {entry.fromStage ? (
+                <>
+                  <PipelineStageBadge stage={entry.fromStage} />
+                  <span className="text-muted-foreground">&rarr;</span>
+                  <PipelineStageBadge stage={entry.toStage} />
+                </>
+              ) : (
+                <>
+                  <span className="text-muted-foreground">
+                    Entered pipeline
+                  </span>
+                  <PipelineStageBadge stage={entry.toStage} />
+                </>
+              )}
+            </div>
+
+            {entry.comment && (
+              <p className="text-sm text-muted-foreground">{entry.comment}</p>
+            )}
+
+            <p className="text-xs text-muted-foreground">
+              {entry.changedBy && (
+                <span className="font-mono">
+                  {entry.changedBy.slice(0, 8)}&hellip;{" "}
+                </span>
+              )}
+              {formatDistanceToNow(new Date(entry.changedAt), {
+                addSuffix: true,
+              })}
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/pipeline-list.tsx
+++ b/apps/web/src/components/slate/pipeline-list.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { formatDistanceToNow } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { PipelineStageBadge } from "./pipeline-stage-badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { GitBranch, X } from "lucide-react";
+import type { PipelineStage } from "@colophony/types";
+
+const STAGE_TABS: Array<{ value: PipelineStage | "ALL"; label: string }> = [
+  { value: "ALL", label: "All" },
+  { value: "COPYEDIT_PENDING", label: "Pending" },
+  { value: "COPYEDIT_IN_PROGRESS", label: "Copyediting" },
+  { value: "AUTHOR_REVIEW", label: "Author Review" },
+  { value: "PROOFREAD", label: "Proofreading" },
+  { value: "READY_TO_PUBLISH", label: "Ready" },
+  { value: "PUBLISHED", label: "Published" },
+  { value: "WITHDRAWN", label: "Withdrawn" },
+];
+
+export function PipelineList() {
+  const [stageFilter, setStageFilter] = useState<PipelineStage | "ALL">("ALL");
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search);
+      setPage(1);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const { data, isPending, error } = trpc.pipeline.list.useQuery({
+    stage: stageFilter === "ALL" ? undefined : stageFilter,
+    search: debouncedSearch || undefined,
+    page,
+    limit: 20,
+  });
+
+  // Clamp page when data shrinks
+  useEffect(() => {
+    if (data && data.totalPages > 0 && page > data.totalPages) {
+      setPage(data.totalPages);
+    }
+  }, [data, page]);
+
+  const handleStageChange = (value: string) => {
+    setStageFilter(value as PipelineStage | "ALL");
+    setPage(1);
+  };
+
+  if (isPending) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-10 w-full max-w-sm" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Pipeline</h1>
+        <p className="text-destructive">
+          Failed to load pipeline items: {error.message}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Pipeline</h1>
+
+      {/* Search */}
+      <div className="relative max-w-sm">
+        <Input
+          placeholder="Search..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        {search && (
+          <button
+            type="button"
+            onClick={() => setSearch("")}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Stage tabs */}
+      <Tabs value={stageFilter} onValueChange={handleStageChange}>
+        <TabsList>
+          {STAGE_TABS.map((tab) => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      {/* Table or empty state */}
+      {data && data.items.length > 0 ? (
+        <>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Stage</TableHead>
+                <TableHead>Submission</TableHead>
+                <TableHead>Publication</TableHead>
+                <TableHead>Copyeditor</TableHead>
+                <TableHead>Proofreader</TableHead>
+                <TableHead>Updated</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.items.map((item) => (
+                <TableRow key={item.id}>
+                  <TableCell>
+                    <PipelineStageBadge stage={item.stage} />
+                  </TableCell>
+                  <TableCell>
+                    <Link
+                      href={`/slate/pipeline/${item.id}`}
+                      className="font-mono text-sm hover:underline"
+                    >
+                      {item.submissionId.slice(0, 8)}&hellip;
+                    </Link>
+                  </TableCell>
+                  <TableCell className="font-mono text-sm text-muted-foreground">
+                    {item.publicationId
+                      ? `${item.publicationId.slice(0, 8)}\u2026`
+                      : "\u2014"}
+                  </TableCell>
+                  <TableCell className="font-mono text-sm text-muted-foreground">
+                    {item.assignedCopyeditorId
+                      ? `${item.assignedCopyeditorId.slice(0, 8)}\u2026`
+                      : "\u2014"}
+                  </TableCell>
+                  <TableCell className="font-mono text-sm text-muted-foreground">
+                    {item.assignedProofreaderId
+                      ? `${item.assignedProofreaderId.slice(0, 8)}\u2026`
+                      : "\u2014"}
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {formatDistanceToNow(new Date(item.updatedAt), {
+                      addSuffix: true,
+                    })}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+
+          {/* Pagination */}
+          {data.totalPages > 1 && (
+            <div className="flex items-center justify-center gap-4">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {page} of {data.totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))}
+                disabled={page >= data.totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <GitBranch className="h-12 w-12 text-muted-foreground mb-4" />
+          <p className="text-lg font-medium">No pipeline items</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            {stageFilter !== "ALL"
+              ? "No items in this stage."
+              : debouncedSearch
+                ? "No items match your search."
+                : "Items will appear here when submissions are sent to the pipeline."}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/pipeline-role-assignment.tsx
+++ b/apps/web/src/components/slate/pipeline-role-assignment.tsx
@@ -38,6 +38,7 @@ export function PipelineRoleAssignment({
       toast.success("Copyeditor assigned");
       closeDialog();
       utils.pipeline.getById.invalidate({ id: pipelineItemId });
+      utils.pipeline.list.invalidate();
     },
     onError: (err) => toast.error(err.message),
   });
@@ -47,6 +48,7 @@ export function PipelineRoleAssignment({
       toast.success("Proofreader assigned");
       closeDialog();
       utils.pipeline.getById.invalidate({ id: pipelineItemId });
+      utils.pipeline.list.invalidate();
     },
     onError: (err) => toast.error(err.message),
   });

--- a/apps/web/src/components/slate/pipeline-role-assignment.tsx
+++ b/apps/web/src/components/slate/pipeline-role-assignment.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState } from "react";
+import { z } from "zod";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+
+interface PipelineRoleAssignmentProps {
+  pipelineItemId: string;
+  currentCopyeditorId: string | null;
+  currentProofreaderId: string | null;
+}
+
+type RoleType = "copyeditor" | "proofreader";
+
+export function PipelineRoleAssignment({
+  pipelineItemId,
+  currentCopyeditorId,
+  currentProofreaderId,
+}: PipelineRoleAssignmentProps) {
+  const [assignRole, setAssignRole] = useState<RoleType | null>(null);
+  const [userId, setUserId] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const utils = trpc.useUtils();
+
+  const copyeditorMutation = trpc.pipeline.assignCopyeditor.useMutation({
+    onSuccess: () => {
+      toast.success("Copyeditor assigned");
+      closeDialog();
+      utils.pipeline.getById.invalidate({ id: pipelineItemId });
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const proofreaderMutation = trpc.pipeline.assignProofreader.useMutation({
+    onSuccess: () => {
+      toast.success("Proofreader assigned");
+      closeDialog();
+      utils.pipeline.getById.invalidate({ id: pipelineItemId });
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const closeDialog = () => {
+    setAssignRole(null);
+    setUserId("");
+    setValidationError(null);
+  };
+
+  const handleAssign = () => {
+    const result = z.string().uuid().safeParse(userId.trim());
+    if (!result.success) {
+      setValidationError("Please enter a valid UUID");
+      return;
+    }
+
+    const input = { id: pipelineItemId, userId: result.data };
+    if (assignRole === "copyeditor") {
+      copyeditorMutation.mutate(input);
+    } else {
+      proofreaderMutation.mutate(input);
+    }
+  };
+
+  const isPending =
+    copyeditorMutation.isPending || proofreaderMutation.isPending;
+
+  return (
+    <>
+      <div className="space-y-3">
+        {/* Copyeditor row */}
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium">Copyeditor</p>
+            <p className="text-xs text-muted-foreground font-mono">
+              {currentCopyeditorId
+                ? `${currentCopyeditorId.slice(0, 8)}\u2026`
+                : "Unassigned"}
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setAssignRole("copyeditor")}
+          >
+            Assign
+          </Button>
+        </div>
+
+        {/* Proofreader row */}
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium">Proofreader</p>
+            <p className="text-xs text-muted-foreground font-mono">
+              {currentProofreaderId
+                ? `${currentProofreaderId.slice(0, 8)}\u2026`
+                : "Unassigned"}
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setAssignRole("proofreader")}
+          >
+            Assign
+          </Button>
+        </div>
+      </div>
+
+      <Dialog
+        open={assignRole !== null}
+        onOpenChange={(open) => !open && closeDialog()}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              Assign{" "}
+              {assignRole === "copyeditor" ? "Copyeditor" : "Proofreader"}
+            </DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <Label htmlFor="user-id">User ID</Label>
+            <Input
+              id="user-id"
+              placeholder="Enter user UUID..."
+              value={userId}
+              onChange={(e) => {
+                setUserId(e.target.value);
+                setValidationError(null);
+              }}
+            />
+            {validationError && (
+              <p className="text-sm text-destructive">{validationError}</p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={closeDialog}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleAssign}
+              disabled={isPending || !userId.trim()}
+            >
+              {isPending ? "Assigning..." : "Assign"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/slate/pipeline-stage-badge.tsx
+++ b/apps/web/src/components/slate/pipeline-stage-badge.tsx
@@ -1,0 +1,59 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { PipelineStage } from "@colophony/types";
+
+const stageConfig: Record<PipelineStage, { label: string; className: string }> =
+  {
+    COPYEDIT_PENDING: {
+      label: "Copyedit Pending",
+      className:
+        "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+    },
+    COPYEDIT_IN_PROGRESS: {
+      label: "Copyediting",
+      className:
+        "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+    },
+    AUTHOR_REVIEW: {
+      label: "Author Review",
+      className:
+        "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
+    },
+    PROOFREAD: {
+      label: "Proofreading",
+      className:
+        "bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-200",
+    },
+    READY_TO_PUBLISH: {
+      label: "Ready to Publish",
+      className:
+        "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    },
+    PUBLISHED: {
+      label: "Published",
+      className:
+        "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+    },
+    WITHDRAWN: {
+      label: "Withdrawn",
+      className: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+    },
+  };
+
+interface PipelineStageBadgeProps {
+  stage: PipelineStage;
+  className?: string;
+}
+
+export function PipelineStageBadge({
+  stage,
+  className,
+}: PipelineStageBadgeProps) {
+  const config = stageConfig[stage];
+
+  return (
+    <Badge variant="secondary" className={cn(config.className, className)}>
+      {config.label}
+    </Badge>
+  );
+}

--- a/apps/web/src/components/slate/pipeline-stage-transition.tsx
+++ b/apps/web/src/components/slate/pipeline-stage-transition.tsx
@@ -8,7 +8,6 @@ import { Textarea } from "@/components/ui/textarea";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -98,14 +97,10 @@ export function PipelineStageTransition({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Confirm stage transition</DialogTitle>
-            <DialogDescription>
-              Move this item from{" "}
-              <PipelineStageBadge stage={currentStage} className="inline" /> to{" "}
-              {targetStage && (
-                <PipelineStageBadge stage={targetStage} className="inline" />
-              )}
-              ?
-            </DialogDescription>
+            <div className="text-sm text-muted-foreground flex flex-wrap items-center gap-1">
+              Move this item from <PipelineStageBadge stage={currentStage} /> to{" "}
+              {targetStage && <PipelineStageBadge stage={targetStage} />}?
+            </div>
           </DialogHeader>
 
           <Textarea

--- a/apps/web/src/components/slate/pipeline-stage-transition.tsx
+++ b/apps/web/src/components/slate/pipeline-stage-transition.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+import { trpc } from "@/lib/trpc";
+import { PipelineStageBadge } from "./pipeline-stage-badge";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import { VALID_PIPELINE_TRANSITIONS } from "@colophony/types";
+import type { PipelineStage } from "@colophony/types";
+
+interface PipelineStageTransitionProps {
+  pipelineItemId: string;
+  currentStage: PipelineStage;
+  onStageChange?: () => void;
+}
+
+function getButtonVariant(
+  stage: PipelineStage,
+): "default" | "secondary" | "destructive" {
+  if (stage === "WITHDRAWN") return "destructive";
+  if (stage === "READY_TO_PUBLISH" || stage === "PUBLISHED") return "default";
+  return "secondary";
+}
+
+export function PipelineStageTransition({
+  pipelineItemId,
+  currentStage,
+  onStageChange,
+}: PipelineStageTransitionProps) {
+  const [targetStage, setTargetStage] = useState<PipelineStage | null>(null);
+  const [comment, setComment] = useState("");
+  const utils = trpc.useUtils();
+
+  const validTransitions = VALID_PIPELINE_TRANSITIONS[currentStage];
+
+  const mutation = trpc.pipeline.updateStage.useMutation({
+    onSuccess: () => {
+      toast.success("Stage updated");
+      setTargetStage(null);
+      setComment("");
+      utils.pipeline.getById.invalidate({ id: pipelineItemId });
+      utils.pipeline.list.invalidate();
+      utils.pipeline.getHistory.invalidate({ id: pipelineItemId });
+      onStageChange?.();
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  // Terminal stages — no transitions available
+  if (validTransitions.length === 0) {
+    return null;
+  }
+
+  const handleConfirm = () => {
+    if (!targetStage) return;
+    mutation.mutate({
+      id: pipelineItemId,
+      stage: targetStage,
+      comment: comment.trim() || undefined,
+    });
+  };
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2">
+        {validTransitions.map((stage) => (
+          <Button
+            key={stage}
+            variant={getButtonVariant(stage)}
+            size="sm"
+            onClick={() => setTargetStage(stage)}
+          >
+            <PipelineStageBadge stage={stage} className="pointer-events-none" />
+          </Button>
+        ))}
+      </div>
+
+      <Dialog
+        open={targetStage !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setTargetStage(null);
+            setComment("");
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm stage transition</DialogTitle>
+            <DialogDescription>
+              Move this item from{" "}
+              <PipelineStageBadge stage={currentStage} className="inline" /> to{" "}
+              {targetStage && (
+                <PipelineStageBadge stage={targetStage} className="inline" />
+              )}
+              ?
+            </DialogDescription>
+          </DialogHeader>
+
+          <Textarea
+            placeholder="Optional comment..."
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            rows={3}
+          />
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setTargetStage(null);
+                setComment("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant={targetStage ? getButtonVariant(targetStage) : "default"}
+              onClick={handleConfirm}
+              disabled={mutation.isPending}
+            >
+              {mutation.isPending ? "Updating..." : "Confirm"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/slate/publication-card.tsx
+++ b/apps/web/src/components/slate/publication-card.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import Link from "next/link";
+import { formatDistanceToNow } from "date-fns";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { PublicationStatusBadge } from "./publication-status-badge";
+import { MoreHorizontal, Eye, Archive } from "lucide-react";
+import type { PublicationStatus } from "@colophony/types";
+
+interface PublicationCardProps {
+  publication: {
+    id: string;
+    name: string;
+    slug: string;
+    description: string | null;
+    status: PublicationStatus;
+    createdAt: Date | string;
+    updatedAt: Date | string;
+  };
+  onArchive?: (id: string) => void;
+  isAdmin: boolean;
+}
+
+export function PublicationCard({
+  publication,
+  onArchive,
+  isAdmin,
+}: PublicationCardProps) {
+  return (
+    <Card className="hover:border-primary/50 transition-colors">
+      <CardHeader className="pb-2">
+        <div className="flex items-start justify-between gap-2">
+          <Link
+            href={`/slate/publications/${publication.id}`}
+            className="flex-1 min-w-0"
+          >
+            <CardTitle className="text-base line-clamp-2 hover:underline cursor-pointer">
+              {publication.name}
+            </CardTitle>
+          </Link>
+          <div className="flex items-center gap-2 shrink-0">
+            <PublicationStatusBadge status={publication.status} />
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <MoreHorizontal className="h-4 w-4" />
+                  <span className="sr-only">Actions</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem asChild>
+                  <Link href={`/slate/publications/${publication.id}`}>
+                    <Eye className="mr-2 h-4 w-4" />
+                    View
+                  </Link>
+                </DropdownMenuItem>
+                {publication.status === "ACTIVE" && isAdmin && onArchive && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem onClick={() => onArchive(publication.id)}>
+                      <Archive className="mr-2 h-4 w-4" />
+                      Archive
+                    </DropdownMenuItem>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {publication.description && (
+          <p className="text-sm text-muted-foreground line-clamp-2 mb-2">
+            {publication.description}
+          </p>
+        )}
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          <span>/{publication.slug}</span>
+          <span>
+            Updated{" "}
+            {formatDistanceToNow(new Date(publication.updatedAt), {
+              addSuffix: true,
+            })}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/slate/publication-detail.tsx
+++ b/apps/web/src/components/slate/publication-detail.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { format, formatDistanceToNow } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { PublicationStatusBadge } from "./publication-status-badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "sonner";
+import { ArrowLeft, Edit, Archive } from "lucide-react";
+
+interface PublicationDetailProps {
+  publicationId: string;
+}
+
+export function PublicationDetail({ publicationId }: PublicationDetailProps) {
+  const { isAdmin } = useOrganization();
+  const [showArchiveDialog, setShowArchiveDialog] = useState(false);
+  const utils = trpc.useUtils();
+
+  const { data: publication, isPending: isLoading } =
+    trpc.publications.getById.useQuery({ id: publicationId });
+
+  const archiveMutation = trpc.publications.archive.useMutation({
+    onSuccess: () => {
+      toast.success("Publication archived");
+      utils.publications.getById.invalidate({ id: publicationId });
+      utils.publications.list.invalidate();
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (!publication) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">Publication not found</p>
+        <Link href="/slate/publications">
+          <Button variant="link">Back to publications</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="space-y-1">
+          <Link
+            href="/slate/publications"
+            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            Back to publications
+          </Link>
+          <h1 className="text-2xl font-bold">{publication.name}</h1>
+          <div className="flex items-center gap-2">
+            <PublicationStatusBadge status={publication.status} />
+          </div>
+        </div>
+
+        {isAdmin && (
+          <div className="flex gap-2">
+            <Link href={`/slate/publications/${publicationId}/edit`}>
+              <Button variant="outline">
+                <Edit className="mr-2 h-4 w-4" />
+                Edit
+              </Button>
+            </Link>
+            {publication.status === "ACTIVE" && (
+              <Button
+                variant="outline"
+                onClick={() => setShowArchiveDialog(true)}
+              >
+                <Archive className="mr-2 h-4 w-4" />
+                Archive
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="grid gap-6 md:grid-cols-3">
+        <div className="md:col-span-2 space-y-6">
+          {/* Details */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Description
+                </p>
+                <p className="text-sm mt-1">
+                  {publication.description || "No description provided"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Slug
+                </p>
+                <p className="text-sm mt-1 font-mono">/{publication.slug}</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Settings */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Settings</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {publication.settings ? (
+                <pre className="text-xs bg-muted p-4 rounded-lg overflow-auto max-h-64">
+                  {JSON.stringify(publication.settings, null, 2)}
+                </pre>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  No settings configured
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Metadata</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Created
+                </p>
+                <p className="text-sm mt-1">
+                  {format(new Date(publication.createdAt), "PPP")}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Last Updated
+                </p>
+                <p className="text-sm mt-1">
+                  {formatDistanceToNow(new Date(publication.updatedAt), {
+                    addSuffix: true,
+                  })}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* Archive confirmation dialog */}
+      <Dialog open={showArchiveDialog} onOpenChange={setShowArchiveDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Archive publication?</DialogTitle>
+            <DialogDescription>
+              This will archive &ldquo;{publication.name}&rdquo;. Archived
+              publications are hidden from active lists but can still be viewed.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowArchiveDialog(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                archiveMutation.mutate({ id: publicationId });
+                setShowArchiveDialog(false);
+              }}
+              disabled={archiveMutation.isPending}
+            >
+              {archiveMutation.isPending ? "Archiving..." : "Archive"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/publication-form.tsx
+++ b/apps/web/src/components/slate/publication-form.tsx
@@ -61,11 +61,14 @@ export function PublicationForm({ publicationId }: PublicationFormProps) {
     defaultValues: { name: "", slug: "", description: "" },
   });
 
-  const { data: publication, isPending: isLoadingPublication } =
-    trpc.publications.getById.useQuery(
-      { id: publicationId! },
-      { enabled: isEdit },
-    );
+  const {
+    data: publication,
+    isPending: isLoadingPublication,
+    error: loadError,
+  } = trpc.publications.getById.useQuery(
+    { id: publicationId! },
+    { enabled: isEdit },
+  );
 
   // Pre-populate form in edit mode
   useEffect(() => {
@@ -123,6 +126,17 @@ export function PublicationForm({ publicationId }: PublicationFormProps) {
       <div className="space-y-6">
         <Skeleton className="h-8 w-64" />
         <Skeleton className="h-96 w-full max-w-lg" />
+      </div>
+    );
+  }
+
+  if (isEdit && loadError) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">Publication not found</p>
+        <Link href="/slate/publications">
+          <Button variant="link">Back to publications</Button>
+        </Link>
       </div>
     );
   }

--- a/apps/web/src/components/slate/publication-form.tsx
+++ b/apps/web/src/components/slate/publication-form.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "sonner";
+import { ArrowLeft, Loader2 } from "lucide-react";
+
+const formSchema = z.object({
+  name: z.string().trim().min(1, "Name is required").max(255),
+  slug: z
+    .string()
+    .trim()
+    .min(1, "Slug is required")
+    .max(100)
+    .regex(
+      /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+      "Slug must be lowercase alphanumeric with hyphens",
+    ),
+  description: z.string().max(2000).optional(),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+interface PublicationFormProps {
+  publicationId?: string;
+}
+
+export function PublicationForm({ publicationId }: PublicationFormProps) {
+  const router = useRouter();
+  const utils = trpc.useUtils();
+  const isEdit = !!publicationId;
+  const slugManuallyEdited = useRef(false);
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { name: "", slug: "", description: "" },
+  });
+
+  const { data: publication, isPending: isLoadingPublication } =
+    trpc.publications.getById.useQuery(
+      { id: publicationId! },
+      { enabled: isEdit },
+    );
+
+  // Pre-populate form in edit mode
+  useEffect(() => {
+    if (publication) {
+      form.reset({
+        name: publication.name,
+        slug: publication.slug,
+        description: publication.description ?? "",
+      });
+      slugManuallyEdited.current = true;
+    }
+  }, [publication, form]);
+
+  const createMutation = trpc.publications.create.useMutation({
+    onSuccess: (result) => {
+      toast.success("Publication created");
+      router.push(`/slate/publications/${result.id}`);
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const updateMutation = trpc.publications.update.useMutation({
+    onSuccess: (result) => {
+      toast.success("Publication updated");
+      utils.publications.getById.invalidate({ id: publicationId! });
+      utils.publications.list.invalidate();
+      router.push(`/slate/publications/${result.id}`);
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const onSubmit = (data: FormData) => {
+    if (isEdit) {
+      updateMutation.mutate({
+        id: publicationId!,
+        ...data,
+        description: data.description || undefined,
+      });
+    } else {
+      createMutation.mutate({
+        ...data,
+        description: data.description || undefined,
+      });
+    }
+  };
+
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  if (isEdit && isLoadingPublication) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-96 w-full max-w-lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href={
+            isEdit
+              ? `/slate/publications/${publicationId}`
+              : "/slate/publications"
+          }
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="mr-1 h-4 w-4" />
+          {isEdit ? "Back to publication" : "Back to publications"}
+        </Link>
+        <h1 className="text-2xl font-bold mt-2">
+          {isEdit ? "Edit Publication" : "New Publication"}
+        </h1>
+      </div>
+
+      <Card className="w-full max-w-lg">
+        <CardHeader>
+          <CardTitle>
+            {isEdit ? "Publication Details" : "Create Publication"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="My Publication"
+                        {...field}
+                        onChange={(e) => {
+                          field.onChange(e);
+                          if (!slugManuallyEdited.current) {
+                            form.setValue("slug", slugify(e.target.value), {
+                              shouldValidate: true,
+                            });
+                          }
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="slug"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Slug</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="my-publication"
+                        {...field}
+                        onChange={(e) => {
+                          field.onChange(e);
+                          slugManuallyEdited.current = true;
+                        }}
+                      />
+                    </FormControl>
+                    <p className="text-xs text-muted-foreground">
+                      Lowercase letters, numbers, and hyphens.
+                    </p>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="A brief description of this publication..."
+                        rows={4}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex justify-between pt-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() =>
+                    router.push(
+                      isEdit
+                        ? `/slate/publications/${publicationId}`
+                        : "/slate/publications",
+                    )
+                  }
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isPending}>
+                  {isPending && (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  )}
+                  {isEdit ? "Save Changes" : "Create Publication"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/publication-list.tsx
+++ b/apps/web/src/components/slate/publication-list.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { PublicationCard } from "./publication-card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Library, Plus, X } from "lucide-react";
+import { toast } from "sonner";
+import type { PublicationStatus } from "@colophony/types";
+
+const STATUS_TABS: Array<{ value: PublicationStatus | "ALL"; label: string }> =
+  [
+    { value: "ALL", label: "All" },
+    { value: "ACTIVE", label: "Active" },
+    { value: "ARCHIVED", label: "Archived" },
+  ];
+
+export function PublicationList() {
+  const { isAdmin } = useOrganization();
+  const [statusFilter, setStatusFilter] = useState<PublicationStatus | "ALL">(
+    "ALL",
+  );
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search);
+      setPage(1);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const { data, isPending, error } = trpc.publications.list.useQuery({
+    status: statusFilter === "ALL" ? undefined : statusFilter,
+    search: debouncedSearch || undefined,
+    page,
+    limit: 20,
+  });
+
+  const utils = trpc.useUtils();
+
+  const archiveMutation = trpc.publications.archive.useMutation({
+    onSuccess: () => {
+      toast.success("Publication archived");
+      utils.publications.list.invalidate();
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const handleStatusChange = (value: string) => {
+    setStatusFilter(value as PublicationStatus | "ALL");
+    setPage(1);
+  };
+
+  const handleArchive = isAdmin
+    ? (id: string) => archiveMutation.mutate({ id })
+    : undefined;
+
+  if (isPending) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-40 w-full" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Publications</h1>
+        <p className="text-destructive">
+          Failed to load publications: {error.message}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Publications</h1>
+        {isAdmin && (
+          <Link href="/slate/publications/new">
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              New Publication
+            </Button>
+          </Link>
+        )}
+      </div>
+
+      {/* Search */}
+      <div className="relative max-w-sm">
+        <Input
+          placeholder="Search by name..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        {search && (
+          <button
+            type="button"
+            onClick={() => setSearch("")}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Status tabs */}
+      <Tabs value={statusFilter} onValueChange={handleStatusChange}>
+        <TabsList>
+          {STATUS_TABS.map((tab) => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      {/* Grid or empty state */}
+      {data && data.items.length > 0 ? (
+        <>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {data.items.map((publication) => (
+              <PublicationCard
+                key={publication.id}
+                publication={publication}
+                onArchive={handleArchive}
+                isAdmin={isAdmin}
+              />
+            ))}
+          </div>
+
+          {/* Pagination */}
+          {data.totalPages > 1 && (
+            <div className="flex items-center justify-center gap-4">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {page} of {data.totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))}
+                disabled={page >= data.totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <Library className="h-12 w-12 text-muted-foreground mb-4" />
+          <p className="text-lg font-medium">No publications</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            {statusFilter !== "ALL"
+              ? `No ${statusFilter.toLowerCase()} publications found.`
+              : debouncedSearch
+                ? "No publications match your search."
+                : "Get started by creating your first publication."}
+          </p>
+          {isAdmin && !debouncedSearch && statusFilter === "ALL" && (
+            <Link href="/slate/publications/new" className="mt-4">
+              <Button>
+                <Plus className="mr-2 h-4 w-4" />
+                New Publication
+              </Button>
+            </Link>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/publication-list.tsx
+++ b/apps/web/src/components/slate/publication-list.tsx
@@ -44,6 +44,13 @@ export function PublicationList() {
     limit: 20,
   });
 
+  // Clamp page when data shrinks (e.g. after archiving the last item on a page)
+  useEffect(() => {
+    if (data && data.totalPages > 0 && page > data.totalPages) {
+      setPage(data.totalPages);
+    }
+  }, [data, page]);
+
   const utils = trpc.useUtils();
 
   const archiveMutation = trpc.publications.archive.useMutation({

--- a/apps/web/src/components/slate/publication-status-badge.tsx
+++ b/apps/web/src/components/slate/publication-status-badge.tsx
@@ -1,0 +1,36 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { PublicationStatus } from "@colophony/types";
+
+const statusConfig: Record<
+  PublicationStatus,
+  { label: string; className: string }
+> = {
+  ACTIVE: {
+    label: "Active",
+    className:
+      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  },
+  ARCHIVED: {
+    label: "Archived",
+    className: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+  },
+};
+
+interface PublicationStatusBadgeProps {
+  status: PublicationStatus;
+  className?: string;
+}
+
+export function PublicationStatusBadge({
+  status,
+  className,
+}: PublicationStatusBadgeProps) {
+  const config = statusConfig[status];
+
+  return (
+    <Badge variant="secondary" className={cn(config.className, className)}>
+      {config.label}
+    </Badge>
+  );
+}

--- a/apps/web/src/components/slate/slate-dashboard.tsx
+++ b/apps/web/src/components/slate/slate-dashboard.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Library,
+  GitBranch,
+  BookCopy,
+  Calendar,
+  FileSignature,
+  Globe,
+} from "lucide-react";
+
+const sections = [
+  {
+    name: "Publications",
+    description: "Manage your publications and their settings",
+    href: "/slate/publications",
+    icon: Library,
+    cta: "View Publications",
+    comingSoon: false,
+  },
+  {
+    name: "Pipeline",
+    description: "Track pieces through the editorial pipeline",
+    href: "/slate/pipeline",
+    icon: GitBranch,
+    cta: "View Pipeline",
+    comingSoon: true,
+  },
+  {
+    name: "Issues",
+    description: "Assemble and organize publication issues",
+    href: "/slate/issues",
+    icon: BookCopy,
+    cta: "View Issues",
+    comingSoon: true,
+  },
+  {
+    name: "Calendar",
+    description: "Plan your editorial calendar and deadlines",
+    href: "/slate/calendar",
+    icon: Calendar,
+    cta: "View Calendar",
+    comingSoon: true,
+  },
+  {
+    name: "Contracts",
+    description: "Manage contributor contracts and templates",
+    href: "/slate/contracts",
+    icon: FileSignature,
+    cta: "View Contracts",
+    comingSoon: true,
+  },
+  {
+    name: "CMS Connections",
+    description: "Connect to external content management systems",
+    href: "/slate/cms",
+    icon: Globe,
+    cta: "View Connections",
+    comingSoon: true,
+  },
+];
+
+export function SlateDashboard() {
+  return (
+    <div className="p-6 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Slate</h1>
+        <p className="text-muted-foreground mt-1">
+          Manage your publication pipeline — from accepted pieces to published
+          issues.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {sections.map((section) => {
+          const content = (
+            <Card
+              className={`transition-colors ${section.comingSoon ? "opacity-60" : "hover:border-primary/50 cursor-pointer"}`}
+            >
+              <CardHeader>
+                <div className="flex items-center gap-3">
+                  <div className="rounded-lg bg-primary/10 p-2">
+                    <section.icon className="h-5 w-5 text-primary" />
+                  </div>
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <CardTitle className="text-base">
+                        {section.name}
+                      </CardTitle>
+                      {section.comingSoon && (
+                        <Badge variant="secondary" className="text-xs">
+                          Coming Soon
+                        </Badge>
+                      )}
+                    </div>
+                    <CardDescription>{section.description}</CardDescription>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  disabled={section.comingSoon}
+                >
+                  {section.cta}
+                </Button>
+              </CardContent>
+            </Card>
+          );
+
+          if (section.comingSoon) {
+            return <div key={section.name}>{content}</div>;
+          }
+
+          return (
+            <Link key={section.name} href={section.href}>
+              {content}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/slate-dashboard.tsx
+++ b/apps/web/src/components/slate/slate-dashboard.tsx
@@ -42,7 +42,7 @@ const sections = [
     href: "/slate/issues",
     icon: BookCopy,
     cta: "View Issues",
-    comingSoon: true,
+    comingSoon: false,
   },
   {
     name: "Calendar",

--- a/apps/web/src/components/slate/slate-dashboard.tsx
+++ b/apps/web/src/components/slate/slate-dashboard.tsx
@@ -34,7 +34,7 @@ const sections = [
     href: "/slate/pipeline",
     icon: GitBranch,
     cta: "View Pipeline",
-    comingSoon: true,
+    comingSoon: false,
   },
   {
     name: "Issues",

--- a/apps/web/src/components/slate/sortable-issue-item.tsx
+++ b/apps/web/src/components/slate/sortable-issue-item.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { GripVertical, Trash2, ChevronUp, ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/** Wire-format types (dates serialized as strings over tRPC) */
+type WireSection = {
+  id: string;
+  title: string;
+};
+type WireItem = {
+  id: string;
+  pipelineItemId: string;
+  issueSectionId: string | null;
+};
+
+interface SortableIssueItemProps {
+  item: WireItem;
+  sections: WireSection[];
+  isFirst: boolean;
+  isLast: boolean;
+  isEditor: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onRemove: () => void;
+  onChangeSection: (newSectionId: string | null) => void;
+}
+
+const UNSECTIONED_VALUE = "__unsectioned__";
+
+export function SortableIssueItem({
+  item,
+  sections,
+  isFirst,
+  isLast,
+  isEditor,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+  onChangeSection,
+}: SortableIssueItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "flex items-center gap-2 rounded-lg border p-3 bg-background transition-colors",
+        isDragging && "opacity-50",
+      )}
+    >
+      {isEditor && (
+        <button
+          className="cursor-grab touch-none text-muted-foreground hover:text-foreground"
+          aria-label="Drag to reorder"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="h-4 w-4" />
+        </button>
+      )}
+
+      <span className="font-mono text-sm text-muted-foreground min-w-0 truncate">
+        {item.pipelineItemId.slice(0, 8)}&hellip;
+      </span>
+
+      {isEditor && (
+        <>
+          <Select
+            value={item.issueSectionId ?? UNSECTIONED_VALUE}
+            onValueChange={(v) =>
+              onChangeSection(v === UNSECTIONED_VALUE ? null : v)
+            }
+          >
+            <SelectTrigger className="w-[140px] h-8 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={UNSECTIONED_VALUE}>Unsectioned</SelectItem>
+              {sections.map((s) => (
+                <SelectItem key={s.id} value={s.id}>
+                  {s.title}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <div className="flex items-center gap-0.5 shrink-0 ml-auto">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              disabled={isFirst}
+              onClick={onMoveUp}
+              aria-label="Move up"
+            >
+              <ChevronUp className="h-3 w-3" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              disabled={isLast}
+              onClick={onMoveDown}
+              aria-label="Move down"
+            >
+              <ChevronDown className="h-3 w-3" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-muted-foreground hover:text-destructive"
+              onClick={onRemove}
+              aria-label="Remove item"
+            >
+              <Trash2 className="h-3 w-3" />
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/sortable-issue-item.tsx
+++ b/apps/web/src/components/slate/sortable-issue-item.tsx
@@ -30,6 +30,7 @@ interface SortableIssueItemProps {
   isFirst: boolean;
   isLast: boolean;
   isEditor: boolean;
+  isAdmin: boolean;
   onMoveUp: () => void;
   onMoveDown: () => void;
   onRemove: () => void;
@@ -44,6 +45,7 @@ export function SortableIssueItem({
   isFirst,
   isLast,
   isEditor,
+  isAdmin,
   onMoveUp,
   onMoveDown,
   onRemove,
@@ -72,7 +74,7 @@ export function SortableIssueItem({
         isDragging && "opacity-50",
       )}
     >
-      {isEditor && (
+      {isAdmin && (
         <button
           className="cursor-grab touch-none text-muted-foreground hover:text-foreground"
           aria-label="Drag to reorder"
@@ -88,27 +90,29 @@ export function SortableIssueItem({
       </span>
 
       {isEditor && (
-        <>
-          <Select
-            value={item.issueSectionId ?? UNSECTIONED_VALUE}
-            onValueChange={(v) =>
-              onChangeSection(v === UNSECTIONED_VALUE ? null : v)
-            }
-          >
-            <SelectTrigger className="w-[140px] h-8 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={UNSECTIONED_VALUE}>Unsectioned</SelectItem>
-              {sections.map((s) => (
-                <SelectItem key={s.id} value={s.id}>
-                  {s.title}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+        <Select
+          value={item.issueSectionId ?? UNSECTIONED_VALUE}
+          onValueChange={(v) =>
+            onChangeSection(v === UNSECTIONED_VALUE ? null : v)
+          }
+        >
+          <SelectTrigger className="w-[140px] h-8 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={UNSECTIONED_VALUE}>Unsectioned</SelectItem>
+            {sections.map((s) => (
+              <SelectItem key={s.id} value={s.id}>
+                {s.title}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
 
-          <div className="flex items-center gap-0.5 shrink-0 ml-auto">
+      <div className="flex items-center gap-0.5 shrink-0 ml-auto">
+        {isAdmin && (
+          <>
             <Button
               variant="ghost"
               size="icon"
@@ -129,18 +133,20 @@ export function SortableIssueItem({
             >
               <ChevronDown className="h-3 w-3" />
             </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7 text-muted-foreground hover:text-destructive"
-              onClick={onRemove}
-              aria-label="Remove item"
-            >
-              <Trash2 className="h-3 w-3" />
-            </Button>
-          </div>
-        </>
-      )}
+          </>
+        )}
+        {isEditor && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-muted-foreground hover:text-destructive"
+            onClick={onRemove}
+            aria-label="Remove item"
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -133,7 +133,7 @@
 - [ ] Editorial calendar frontend — (architecture doc Track 4; backend calendar queries done, frontend pending)
 - [x] Slate frontend PR1 — sidebar navigation + publications CRUD — (architecture doc Track 4; done 2026-02-23)
 - [x] Slate frontend PR2 — pipeline dashboard (list/detail/transitions/comments/history/roles) — (architecture doc Track 4; done 2026-02-23)
-- [ ] Slate frontend PR3 — issues + sections (CRUD, item assignment, DnD reordering) — (architecture doc Track 4)
+- [x] Slate frontend PR3 — issues + sections (CRUD, item assignment, DnD reordering) — (architecture doc Track 4; done 2026-02-23)
 - [ ] Slate frontend PR4 — editorial calendar — (architecture doc Track 4)
 - [ ] Slate frontend PR5 — contracts + templates (Tiptap WYSIWYG + merge fields) — (architecture doc Track 4)
 - [ ] Slate frontend PR6 — CMS connections (CRUD, adapter config, test) — (architecture doc Track 4)

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -131,7 +131,12 @@
 - [x] Issue assembly — issues, sections, items with reorder + TOC generation — (architecture doc Track 4; done 2026-02-23 PR pending)
 - [x] CMS integration (WordPress, Ghost) — CmsAdapter interface, WordPress REST API + Ghost Admin API implementations — (architecture doc Track 4; done 2026-02-23 PR pending)
 - [ ] Editorial calendar frontend — (architecture doc Track 4; backend calendar queries done, frontend pending)
-- [ ] Slate frontend — pipeline dashboard, issue assembly UI, contract management pages — (architecture doc Track 4)
+- [x] Slate frontend PR1 — sidebar navigation + publications CRUD — (architecture doc Track 4; done 2026-02-23)
+- [ ] Slate frontend PR2 — pipeline dashboard (list/detail/transitions/comments/history/roles) — (architecture doc Track 4)
+- [ ] Slate frontend PR3 — issues + sections (CRUD, item assignment, DnD reordering) — (architecture doc Track 4)
+- [ ] Slate frontend PR4 — editorial calendar — (architecture doc Track 4)
+- [ ] Slate frontend PR5 — contracts + templates (Tiptap WYSIWYG + merge fields) — (architecture doc Track 4)
+- [ ] Slate frontend PR6 — CMS connections (CRUD, adapter config, test) — (architecture doc Track 4)
 - [ ] Slate E2E tests — Playwright tests for pipeline flows — (architecture doc Track 4)
 
 ### Research / Design

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -132,7 +132,7 @@
 - [x] CMS integration (WordPress, Ghost) — CmsAdapter interface, WordPress REST API + Ghost Admin API implementations — (architecture doc Track 4; done 2026-02-23 PR pending)
 - [ ] Editorial calendar frontend — (architecture doc Track 4; backend calendar queries done, frontend pending)
 - [x] Slate frontend PR1 — sidebar navigation + publications CRUD — (architecture doc Track 4; done 2026-02-23)
-- [ ] Slate frontend PR2 — pipeline dashboard (list/detail/transitions/comments/history/roles) — (architecture doc Track 4)
+- [x] Slate frontend PR2 — pipeline dashboard (list/detail/transitions/comments/history/roles) — (architecture doc Track 4; done 2026-02-23)
 - [ ] Slate frontend PR3 — issues + sections (CRUD, item assignment, DnD reordering) — (architecture doc Track 4)
 - [ ] Slate frontend PR4 — editorial calendar — (architecture doc Track 4)
 - [ ] Slate frontend PR5 — contracts + templates (Tiptap WYSIWYG + merge fields) — (architecture doc Track 4)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,34 @@ Newest entries first.
 
 ---
 
+## 2026-02-23 — Slate Frontend PR3: Issues + Sections
+
+### Done
+
+- **Issue status badge**: 5 statuses (PLANNING/ASSEMBLING/READY/PUBLISHED/ARCHIVED) with color-coded badges (blue/yellow/purple/green/gray), follows `publication-status-badge.tsx` pattern
+- **Issue list**: Table-based view with 6 status-filter tabs, 300ms debounced search, publication filter dropdown (populated from `publications.list`), pagination (20 items/page)
+- **Issue form**: Dual-purpose create/edit with react-hook-form + zodResolver, publication selector (disabled in edit), volume/issueNumber/description/publicationDate/coverImageUrl fields
+- **Issue detail**: 2-column layout with Overview/Assembly tabs (Radix Tabs), admin-gated publish/archive actions with confirm dialogs, publication link, item/section counts in sidebar
+- **Issue assembly view**: Per-section DnD reordering (PointerSensor + KeyboardSensor, closestCenter), 300ms debounced reorder mutation, arrow-button fallback, section reassignment via remove+re-add
+- **Issue section cards**: Card per section with title, item count badge, remove button with confirm dialog, embedded DndContext + SortableContext
+- **Sortable issue items**: Drag handle, pipeline item ID (truncated mono), section dropdown for reassignment, up/down arrow buttons, remove button
+- **Add section dialog**: Title input, auto-set sortOrder to existing section count
+- **Add item dialog**: Pipeline item search with 300ms debounce, stage filter tabs (compact), selectable rows with highlight, target section dropdown
+- **Navigation wiring**: Added `BookCopy` Issues entry to sidebar `slateNavigation`, set Issues `comingSoon: false` on slate dashboard
+- **Page files**: 4 route pages (list, new, detail, edit) with Next.js 16 async params pattern
+- Wire-format types used for component props (`createdAt: string` instead of `Date` due to tRPC v11 no-superjson)
+- Type-check and lint pass cleanly (0 errors, only pre-existing warnings)
+- 14 new files, 2 modified, ~2060 lines added
+
+### Decisions
+
+- Wire-format types with `createdAt: string` for tRPC data props (tRPC v11 sends dates as ISO strings, no superjson)
+- Form schema uses string fields for volume/issueNumber with parseInt in onSubmit (avoids zodResolver union type issues with `z.literal("")`)
+- Per-section `DndContext` (no cross-container DnD) — keeps DnD simple, cross-section movement via Select dropdown
+- Section reassignment via remove+re-add (no `updateItem` mutation exists), with error toast + cache invalidation on failure
+
+---
+
 ## 2026-02-23 — Slate Frontend PR2: Pipeline Dashboard
 
 ### Done

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,31 @@ Newest entries first.
 
 ---
 
+## 2026-02-23 — Slate Frontend PR2: Pipeline Dashboard
+
+### Done
+
+- **Pipeline stage badge**: 7 stages with color-coded badges (blue/yellow/orange/cyan/green/gray/red), follows `publication-status-badge.tsx` pattern
+- **Pipeline list**: Table-based view with 8 stage-filter tabs (ALL + 7 stages), 300ms debounced search, pagination (20 items/page), truncated UUID links; follows publication-list pattern
+- **Pipeline detail**: 2-column layout (main + sidebar) composing all sub-components, admin-gated stage transition and role assignment cards, skeleton loading + not-found states
+- **Stage transitions**: Button group for valid transitions from `VALID_PIPELINE_TRANSITIONS`, confirmation dialog with optional comment textarea, destructive variant for WITHDRAWN, cache invalidation on `getById`/`list`/`getHistory`
+- **Role assignment**: Copyeditor/proofreader rows with "Assign" button opening UUID input dialog, Zod UUID validation
+- **Comments**: Add comment form (textarea + submit) at top, newest-first list below with author ID, stage badge, and relative timestamp per comment
+- **History timeline**: Vertical timeline with dot markers + connecting line, from->to stage badges, "Entered pipeline" for initial entry, optional comments, relative timestamps
+- **Navigation wiring**: Added `GitBranch` Pipeline entry to sidebar `slateNavigation`, set Pipeline `comingSoon: false` on slate dashboard
+- **Page files**: List page (`/slate/pipeline`) and detail page (`/slate/pipeline/[id]`) with Next.js 16 async params pattern
+- Type-check and lint pass cleanly (0 errors, only pre-existing warnings)
+
+### Decisions
+
+- Tabs for stage filter (8 tabs matches editor submission queue pattern with short labels)
+- Table layout for pipeline list (many fields: stage, assignees, dates benefit from tabular display)
+- Flat chronological comments with stage badge (grouping by stage deferred)
+- UUID text input for role assignment (no user list/search endpoint exposed yet; proper user picker is future enhancement)
+- No "Create Pipeline Item" UI — requires submissionId from accepted submission; natural entry point is from submission detail page
+
+---
+
 ## 2026-02-23 — Slate Frontend PR1: Sidebar Navigation + Publications CRUD
 
 ### Done

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,27 @@ Newest entries first.
 
 ---
 
+## 2026-02-23 — Slate Frontend PR1: Sidebar Navigation + Publications CRUD
+
+### Done
+
+- **Sidebar navigation**: Added Slate section between Editor and Admin, gated behind `isEditor`, with BookMarked (Dashboard) and Library (Publications) icons; added `/slate` exact-match active-link rule
+- **Publication status badge**: ACTIVE (green) / ARCHIVED (gray), follows existing `StatusBadge` pattern
+- **Publication card**: Card component with name link, status badge, slug, "Updated X ago", dropdown menu (View + Archive for admin only)
+- **Publication list**: Tabs (All/Active/Archived), debounced search (300ms), responsive card grid (md:2 lg:3), Previous/Next pagination, skeleton loading + context-aware empty states, admin-only "New Publication" button + archive mutation
+- **Publication form**: Dual-purpose create/edit with react-hook-form + zodResolver, auto-slug generation from name (useRef to avoid set-state-in-effect lint warning), edit mode pre-populates via `getById` query
+- **Publication detail**: 2-column layout (details + settings | metadata sidebar), archive confirm dialog (admin-only), back link, formatted dates via `date-fns`
+- **Slate dashboard**: Card grid with Publications active link + 5 Coming Soon placeholder sections (Pipeline, Issues, Calendar, Contracts, CMS Connections)
+- **5 page files**: All Next.js 16 async params pattern for dynamic routes (`[id]`, `[id]/edit`)
+- Type-check and lint pass cleanly (0 errors, no new warnings from Slate files)
+
+### Decisions
+
+- Used `useRef` instead of `useState` for `slugManuallyEdited` flag in publication form — avoids `react-hooks/set-state-in-effect` lint warning cleanly while existing codebase uses `useState` pattern elsewhere
+- Followed existing card grid pattern from `form-list`/`form-card` for visual consistency
+
+---
+
 ## 2026-02-23 — Slate Publication Pipeline Backend (PRs 1-7)
 
 ### Done


### PR DESCRIPTION
## Summary

- **PR1: Publications CRUD** — sidebar navigation, publication list (tabs/search/pagination), detail page, create/edit forms, status badges, slate dashboard
- **PR2: Pipeline Dashboard** — pipeline list (table with 8 stage tabs, search, pagination), detail page (stage transitions, role assignment, comments, history timeline), code review fixes (cache invalidation, HTML nesting)

## Test plan

- [x] `pnpm --filter @colophony/web type-check` passes
- [x] `pnpm --filter @colophony/web lint` passes (0 errors)
- [ ] Navigate to `/slate/pipeline` — list loads with tabs, search, pagination
- [ ] Click pipeline item — detail page with all sections
- [ ] Sidebar: "Pipeline" link active under Slate
- [ ] Dashboard: Pipeline card clickable (not "Coming Soon")
- [ ] Admin: stage transition buttons + dialogs work
- [ ] Comments: add + display
- [ ] History: timeline renders transitions

## Plan Overrides

None — implementation matches approved plan.

## Codex Review

Branch review after implementation:
- **[P2] Fixed:** Added `utils.pipeline.list.invalidate()` to both role assignment success handlers
- **[P3] Fixed:** Replaced `DialogDescription` with `<div>` in stage transition dialog to avoid `<div>` (Badge) inside `<p>` (DialogDescription)
- **[P3] Deferred:** Nested `<button>` inside `<Link>` in `slate-dashboard.tsx` — pre-existing from PR1, affects all dashboard cards (not just Pipeline)