### PR TITLE
feat(slate): add CMS connections frontend UI

### DIFF
--- a/apps/web/src/__tests__/cms-utils.spec.ts
+++ b/apps/web/src/__tests__/cms-utils.spec.ts
@@ -1,0 +1,82 @@
+import {
+  cmsAdapterConfig,
+  getAdapterLabel,
+  getAdapterConfigFields,
+  maskConfigValue,
+} from "@/lib/cms-utils";
+
+describe("cmsAdapterConfig", () => {
+  it("has WORDPRESS and GHOST entries", () => {
+    expect(cmsAdapterConfig).toHaveProperty("WORDPRESS");
+    expect(cmsAdapterConfig).toHaveProperty("GHOST");
+  });
+
+  it("WORDPRESS has 3 config fields", () => {
+    expect(cmsAdapterConfig.WORDPRESS.configFields).toHaveLength(3);
+    const keys = cmsAdapterConfig.WORDPRESS.configFields.map((f) => f.key);
+    expect(keys).toEqual(["siteUrl", "username", "applicationPassword"]);
+  });
+
+  it("GHOST has 2 config fields", () => {
+    expect(cmsAdapterConfig.GHOST.configFields).toHaveLength(2);
+    const keys = cmsAdapterConfig.GHOST.configFields.map((f) => f.key);
+    expect(keys).toEqual(["apiUrl", "adminApiKey"]);
+  });
+
+  it("all fields have label and placeholder", () => {
+    for (const adapter of Object.values(cmsAdapterConfig)) {
+      for (const field of adapter.configFields) {
+        expect(field.label).toBeTruthy();
+        expect(field.placeholder).toBeTruthy();
+      }
+    }
+  });
+});
+
+describe("getAdapterLabel", () => {
+  it("returns WordPress for WORDPRESS", () => {
+    expect(getAdapterLabel("WORDPRESS")).toBe("WordPress");
+  });
+
+  it("returns Ghost for GHOST", () => {
+    expect(getAdapterLabel("GHOST")).toBe("Ghost");
+  });
+});
+
+describe("getAdapterConfigFields", () => {
+  it("returns config fields for WORDPRESS", () => {
+    const fields = getAdapterConfigFields("WORDPRESS");
+    expect(fields).toHaveLength(3);
+    expect(fields[0].key).toBe("siteUrl");
+  });
+
+  it("returns config fields for GHOST", () => {
+    const fields = getAdapterConfigFields("GHOST");
+    expect(fields).toHaveLength(2);
+    expect(fields[0].key).toBe("apiUrl");
+  });
+});
+
+describe("maskConfigValue", () => {
+  it("masks password fields showing last 4 chars", () => {
+    expect(maskConfigValue("supersecretpassword", "password")).toBe("••••word");
+  });
+
+  it("returns full value for non-password fields", () => {
+    expect(maskConfigValue("https://example.com", "url")).toBe(
+      "https://example.com",
+    );
+    expect(maskConfigValue("admin", "text")).toBe("admin");
+  });
+
+  it("handles short password values", () => {
+    expect(maskConfigValue("abc", "password")).toBe("••••");
+    expect(maskConfigValue("abcd", "password")).toBe("••••");
+  });
+
+  it("handles empty/null values", () => {
+    expect(maskConfigValue("", "password")).toBe("••••");
+    expect(maskConfigValue(null, "password")).toBe("••••");
+    expect(maskConfigValue(undefined, "password")).toBe("••••");
+  });
+});

--- a/apps/web/src/app/(dashboard)/slate/cms/[id]/edit/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/cms/[id]/edit/page.tsx
@@ -1,0 +1,14 @@
+import { CmsConnectionForm } from "@/components/slate/cms-connection-form";
+
+export default async function EditCmsConnectionPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <div className="p-6">
+      <CmsConnectionForm connectionId={id} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/slate/cms/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/cms/[id]/page.tsx
@@ -1,0 +1,14 @@
+import { CmsConnectionDetail } from "@/components/slate/cms-connection-detail";
+
+export default async function CmsConnectionDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <div className="p-6">
+      <CmsConnectionDetail connectionId={id} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/slate/cms/new/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/cms/new/page.tsx
@@ -1,0 +1,9 @@
+import { CmsConnectionForm } from "@/components/slate/cms-connection-form";
+
+export default function NewCmsConnectionPage() {
+  return (
+    <div className="p-6">
+      <CmsConnectionForm />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/slate/cms/page.tsx
+++ b/apps/web/src/app/(dashboard)/slate/cms/page.tsx
@@ -1,0 +1,9 @@
+import { CmsConnectionList } from "@/components/slate/cms-connection-list";
+
+export default function CmsConnectionsPage() {
+  return (
+    <div className="p-6">
+      <CmsConnectionList />
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -14,6 +14,7 @@ import {
   FileSignature,
   FileText,
   GitBranch,
+  Globe,
   Inbox,
   LayoutDashboard,
   Library,
@@ -40,6 +41,7 @@ const slateNavigation = [
   { name: "Issues", href: "/slate/issues", icon: BookCopy },
   { name: "Calendar", href: "/slate/calendar", icon: Calendar },
   { name: "Contracts", href: "/slate/contracts", icon: FileSignature },
+  { name: "CMS", href: "/slate/cms", icon: Globe },
 ];
 
 const adminNavigation = [

--- a/apps/web/src/components/slate/cms-connection-detail.tsx
+++ b/apps/web/src/components/slate/cms-connection-detail.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { format } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import {
+  getAdapterLabel,
+  getAdapterConfigFields,
+  maskConfigValue,
+} from "@/lib/cms-utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import { ArrowLeft, Loader2, Pencil, Trash2, Wifi } from "lucide-react";
+
+interface CmsConnectionDetailProps {
+  connectionId: string;
+}
+
+export function CmsConnectionDetail({
+  connectionId,
+}: CmsConnectionDetailProps) {
+  const router = useRouter();
+  const utils = trpc.useUtils();
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const { data: connection, isPending: isLoading } =
+    trpc.cmsConnections.getById.useQuery({ id: connectionId });
+
+  const publicationId = connection?.publicationId ?? undefined;
+  const { data: publication } = trpc.publications.getById.useQuery(
+    { id: publicationId! },
+    { enabled: !!publicationId },
+  );
+
+  const deleteMutation = trpc.cmsConnections.delete.useMutation({
+    onSuccess: () => {
+      toast.success("Connection deleted");
+      utils.cmsConnections.list.invalidate();
+      router.push("/slate/cms");
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const testMutation = trpc.cmsConnections.test.useMutation({
+    onSuccess: (result) => {
+      if (result.success) {
+        toast.success("Connection test successful");
+      } else {
+        toast.error(result.error ?? "Connection test failed");
+      }
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-64" />
+        <div className="grid gap-6 md:grid-cols-3">
+          <Skeleton className="h-96 md:col-span-2" />
+          <Skeleton className="h-48" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!connection) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">Connection not found</p>
+        <Link href="/slate/cms">
+          <Button variant="link">Back to connections</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  const configFields = getAdapterConfigFields(connection.adapterType);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <Link
+          href="/slate/cms"
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="mr-1 h-4 w-4" />
+          Back to connections
+        </Link>
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">{connection.name}</h1>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              onClick={() => testMutation.mutate({ id: connectionId })}
+              disabled={testMutation.isPending}
+            >
+              {testMutation.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Wifi className="mr-2 h-4 w-4" />
+              )}
+              Test Connection
+            </Button>
+            <Link href={`/slate/cms/${connectionId}/edit`}>
+              <Button variant="outline">
+                <Pencil className="mr-2 h-4 w-4" />
+                Edit
+              </Button>
+            </Link>
+            <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive">
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete Connection</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Are you sure you want to delete &ldquo;{connection.name}
+                    &rdquo;? This action cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => deleteMutation.mutate({ id: connectionId })}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-3">
+        {/* Main — Configuration */}
+        <Card className="md:col-span-2">
+          <CardHeader>
+            <CardTitle>Configuration</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {configFields.map((field) => {
+                const value = connection.config[field.key];
+                return (
+                  <div key={field.key}>
+                    <p className="text-sm font-medium text-muted-foreground">
+                      {field.label}
+                    </p>
+                    <p className="text-sm mt-1 font-mono">
+                      {maskConfigValue(value, field.type)}
+                    </p>
+                  </div>
+                );
+              })}
+              {configFields.length === 0 && (
+                <p className="text-sm text-muted-foreground">
+                  No configuration fields
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Adapter
+                </p>
+                <div className="mt-1">
+                  <Badge variant="outline">
+                    {getAdapterLabel(connection.adapterType)}
+                  </Badge>
+                </div>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Publication
+                </p>
+                <p className="text-sm mt-1">
+                  {publication ? publication.name : "Org-wide"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Status
+                </p>
+                <div className="flex items-center gap-2 mt-1">
+                  <span
+                    className={`inline-block h-2 w-2 rounded-full ${connection.isActive ? "bg-green-500" : "bg-gray-300"}`}
+                  />
+                  <span className="text-sm">
+                    {connection.isActive ? "Active" : "Inactive"}
+                  </span>
+                </div>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Last Sync
+                </p>
+                <p className="text-sm mt-1">
+                  {connection.lastSyncAt
+                    ? format(new Date(connection.lastSyncAt), "PPP")
+                    : "Never"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Created
+                </p>
+                <p className="text-sm mt-1">
+                  {format(new Date(connection.createdAt), "PPP")}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Updated
+                </p>
+                <p className="text-sm mt-1">
+                  {format(new Date(connection.updatedAt), "PPP")}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/cms-connection-form.tsx
+++ b/apps/web/src/components/slate/cms-connection-form.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useForm, useWatch } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { trpc } from "@/lib/trpc";
+import {
+  cmsAdapterConfig,
+  getAdapterConfigFields,
+  type ConfigField,
+} from "@/lib/cms-utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormDescription,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "sonner";
+import { ArrowLeft, Eye, EyeOff, Loader2 } from "lucide-react";
+import { cmsAdapterTypeValues, type CmsAdapterType } from "@colophony/types";
+
+const formSchema = z.object({
+  name: z.string().trim().min(1, "Name is required").max(255),
+  adapterType: z.enum(cmsAdapterTypeValues),
+  publicationId: z.string().uuid().optional().or(z.literal("")),
+  isActive: z.boolean(),
+  config: z.record(z.string(), z.unknown()),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+interface CmsConnectionFormProps {
+  connectionId?: string;
+}
+
+export function CmsConnectionForm({ connectionId }: CmsConnectionFormProps) {
+  const router = useRouter();
+  const utils = trpc.useUtils();
+  const isEdit = !!connectionId;
+  const [visiblePasswords, setVisiblePasswords] = useState<
+    Record<string, boolean>
+  >({});
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: "",
+      adapterType: "WORDPRESS",
+      publicationId: "",
+      isActive: true,
+      config: {},
+    },
+  });
+
+  const adapterType = useWatch({ control: form.control, name: "adapterType" });
+  const configValues = useWatch({ control: form.control, name: "config" });
+  const configFields = getAdapterConfigFields(adapterType as CmsAdapterType);
+
+  const {
+    data: connection,
+    isPending: isLoadingConnection,
+    error: loadError,
+  } = trpc.cmsConnections.getById.useQuery(
+    { id: connectionId! },
+    { enabled: isEdit },
+  );
+
+  const { data: publications } = trpc.publications.list.useQuery({
+    limit: 100,
+  });
+
+  useEffect(() => {
+    if (connection) {
+      form.reset({
+        name: connection.name,
+        adapterType: connection.adapterType,
+        publicationId: connection.publicationId ?? "",
+        isActive: connection.isActive,
+        config: connection.config,
+      });
+    }
+  }, [connection, form]);
+
+  const createMutation = trpc.cmsConnections.create.useMutation({
+    onSuccess: (result) => {
+      toast.success("Connection created");
+      utils.cmsConnections.list.invalidate();
+      router.push(`/slate/cms/${result.id}`);
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const updateMutation = trpc.cmsConnections.update.useMutation({
+    onSuccess: (result) => {
+      toast.success("Connection updated");
+      utils.cmsConnections.getById.invalidate({ id: connectionId! });
+      utils.cmsConnections.list.invalidate();
+      router.push(`/slate/cms/${result.id}`);
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const onSubmit = (data: FormData) => {
+    const pubId = data.publicationId || undefined;
+    if (isEdit) {
+      updateMutation.mutate({
+        id: connectionId!,
+        name: data.name,
+        config: data.config,
+        isActive: data.isActive,
+      });
+    } else {
+      createMutation.mutate({
+        name: data.name,
+        adapterType: data.adapterType,
+        publicationId: pubId,
+        config: data.config,
+      });
+    }
+  };
+
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  const togglePasswordVisibility = (key: string) => {
+    setVisiblePasswords((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  if (isEdit && isLoadingConnection) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    );
+  }
+
+  if (isEdit && loadError) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">Connection not found</p>
+        <Link href="/slate/cms">
+          <Button variant="link">Back to connections</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href={isEdit ? `/slate/cms/${connectionId}` : "/slate/cms"}
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="mr-1 h-4 w-4" />
+          {isEdit ? "Back to connection" : "Back to connections"}
+        </Link>
+        <h1 className="text-2xl font-bold mt-2">
+          {isEdit ? "Edit Connection" : "New CMS Connection"}
+        </h1>
+      </div>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Connection Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="My WordPress Site" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="adapterType"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Adapter Type</FormLabel>
+                    <Select
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      disabled={isEdit}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select adapter" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {Object.entries(cmsAdapterConfig).map(
+                          ([key, config]) => (
+                            <SelectItem key={key} value={key}>
+                              {config.label}
+                            </SelectItem>
+                          ),
+                        )}
+                      </SelectContent>
+                    </Select>
+                    {isEdit && (
+                      <FormDescription>
+                        Adapter type cannot be changed after creation
+                      </FormDescription>
+                    )}
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="publicationId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Publication</FormLabel>
+                    <Select
+                      value={field.value || "none"}
+                      onValueChange={(v) =>
+                        field.onChange(v === "none" ? "" : v)
+                      }
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Org-wide (no specific publication)" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="none">
+                          Org-wide (no specific publication)
+                        </SelectItem>
+                        {publications?.items.map((pub) => (
+                          <SelectItem key={pub.id} value={pub.id}>
+                            {pub.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormDescription>
+                      Optionally bind this connection to a specific publication
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="isActive"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between rounded-lg border p-3">
+                    <div className="space-y-0.5">
+                      <FormLabel>Active</FormLabel>
+                      <FormDescription>
+                        Enable or disable this connection
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                {cmsAdapterConfig[adapterType as CmsAdapterType]?.label ?? ""}{" "}
+                Configuration
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {configFields.map((cf: ConfigField) => (
+                <div key={cf.key} className="space-y-2">
+                  <label className="text-sm font-medium">{cf.label}</label>
+                  <div className="relative">
+                    <Input
+                      type={
+                        cf.type === "password" && !visiblePasswords[cf.key]
+                          ? "password"
+                          : "text"
+                      }
+                      placeholder={cf.placeholder}
+                      value={String(configValues?.[cf.key] ?? "")}
+                      onChange={(e) =>
+                        form.setValue(`config.${cf.key}`, e.target.value, {
+                          shouldDirty: true,
+                        })
+                      }
+                    />
+                    {cf.type === "password" && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7 p-0"
+                        onClick={() => togglePasswordVisibility(cf.key)}
+                      >
+                        {visiblePasswords[cf.key] ? (
+                          <EyeOff className="h-4 w-4" />
+                        ) : (
+                          <Eye className="h-4 w-4" />
+                        )}
+                      </Button>
+                    )}
+                  </div>
+                  {cf.description && (
+                    <p className="text-sm text-muted-foreground">
+                      {cf.description}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <div className="flex justify-between">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() =>
+                router.push(
+                  isEdit ? `/slate/cms/${connectionId}` : "/slate/cms",
+                )
+              }
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {isEdit ? "Save Changes" : "Create Connection"}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/cms-connection-form.tsx
+++ b/apps/web/src/components/slate/cms-connection-form.tsx
@@ -37,7 +37,7 @@ import { toast } from "sonner";
 import { ArrowLeft, Eye, EyeOff, Loader2 } from "lucide-react";
 import { cmsAdapterTypeValues, type CmsAdapterType } from "@colophony/types";
 
-const formSchema = z.object({
+const baseFormSchema = z.object({
   name: z.string().trim().min(1, "Name is required").max(255),
   adapterType: z.enum(cmsAdapterTypeValues),
   publicationId: z.string().uuid().optional().or(z.literal("")),
@@ -45,7 +45,7 @@ const formSchema = z.object({
   config: z.record(z.string(), z.unknown()),
 });
 
-type FormData = z.infer<typeof formSchema>;
+type FormData = z.infer<typeof baseFormSchema>;
 
 interface CmsConnectionFormProps {
   connectionId?: string;
@@ -58,6 +58,22 @@ export function CmsConnectionForm({ connectionId }: CmsConnectionFormProps) {
   const [visiblePasswords, setVisiblePasswords] = useState<
     Record<string, boolean>
   >({});
+
+  const formSchema = baseFormSchema.superRefine((data, ctx) => {
+    const fields = getAdapterConfigFields(data.adapterType);
+    for (const field of fields) {
+      if (field.required) {
+        const val = data.config[field.key];
+        if (!val || String(val).trim() === "") {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `${field.label} is required`,
+            path: ["config", field.key],
+          });
+        }
+      }
+    }
+  });
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
@@ -119,7 +135,6 @@ export function CmsConnectionForm({ connectionId }: CmsConnectionFormProps) {
   });
 
   const onSubmit = (data: FormData) => {
-    const pubId = data.publicationId || undefined;
     if (isEdit) {
       updateMutation.mutate({
         id: connectionId!,
@@ -131,7 +146,7 @@ export function CmsConnectionForm({ connectionId }: CmsConnectionFormProps) {
       createMutation.mutate({
         name: data.name,
         adapterType: data.adapterType,
-        publicationId: pubId,
+        publicationId: data.publicationId || undefined,
         config: data.config,
       });
     }
@@ -246,6 +261,7 @@ export function CmsConnectionForm({ connectionId }: CmsConnectionFormProps) {
                       onValueChange={(v) =>
                         field.onChange(v === "none" ? "" : v)
                       }
+                      disabled={isEdit}
                     >
                       <FormControl>
                         <SelectTrigger>
@@ -264,7 +280,9 @@ export function CmsConnectionForm({ connectionId }: CmsConnectionFormProps) {
                       </SelectContent>
                     </Select>
                     <FormDescription>
-                      Optionally bind this connection to a specific publication
+                      {isEdit
+                        ? "Publication cannot be changed after creation"
+                        : "Optionally bind this connection to a specific publication"}
                     </FormDescription>
                     <FormMessage />
                   </FormItem>
@@ -339,6 +357,11 @@ export function CmsConnectionForm({ connectionId }: CmsConnectionFormProps) {
                   {cf.description && (
                     <p className="text-sm text-muted-foreground">
                       {cf.description}
+                    </p>
+                  )}
+                  {form.formState.errors.config?.[cf.key] && (
+                    <p className="text-sm font-medium text-destructive">
+                      {form.formState.errors.config[cf.key]?.message as string}
                     </p>
                   )}
                 </div>

--- a/apps/web/src/components/slate/cms-connection-list.tsx
+++ b/apps/web/src/components/slate/cms-connection-list.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { format } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { getAdapterLabel } from "@/lib/cms-utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Globe, Plus } from "lucide-react";
+import type { CmsAdapterType } from "@colophony/types";
+
+type AdapterFilter = CmsAdapterType | "ALL";
+
+const ADAPTER_TABS: Array<{ value: AdapterFilter; label: string }> = [
+  { value: "ALL", label: "All" },
+  { value: "WORDPRESS", label: "WordPress" },
+  { value: "GHOST", label: "Ghost" },
+];
+
+export function CmsConnectionList() {
+  const { isAdmin } = useOrganization();
+  const [adapterFilter, setAdapterFilter] = useState<AdapterFilter>("ALL");
+  const [publicationFilter, setPublicationFilter] = useState<string>("ALL");
+  const [page, setPage] = useState(1);
+
+  const { data: publications } = trpc.publications.list.useQuery({
+    limit: 100,
+  });
+
+  const pubMap = new Map(publications?.items.map((p) => [p.id, p.name]) ?? []);
+
+  const { data, isPending: isLoading } = trpc.cmsConnections.list.useQuery({
+    publicationId: publicationFilter === "ALL" ? undefined : publicationFilter,
+    page,
+    limit: 20,
+  });
+
+  // Client-side adapter filtering (single-digit counts per org)
+  const filteredItems =
+    data?.items.filter(
+      (c) => adapterFilter === "ALL" || c.adapterType === adapterFilter,
+    ) ?? [];
+
+  const handleAdapterChange = (value: string) => {
+    setAdapterFilter(value as AdapterFilter);
+    setPage(1);
+  };
+
+  const handlePublicationChange = (value: string) => {
+    setPublicationFilter(value);
+    setPage(1);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="rounded-lg bg-primary/10 p-2">
+            <Globe className="h-5 w-5 text-primary" />
+          </div>
+          <h1 className="text-2xl font-bold">CMS Connections</h1>
+        </div>
+        {isAdmin && (
+          <Link href="/slate/cms/new">
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              New Connection
+            </Button>
+          </Link>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <Tabs value={adapterFilter} onValueChange={handleAdapterChange}>
+          <TabsList>
+            {ADAPTER_TABS.map((tab) => (
+              <TabsTrigger key={tab.value} value={tab.value}>
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+
+        {publications && publications.items.length > 0 && (
+          <Select
+            value={publicationFilter}
+            onValueChange={handlePublicationChange}
+          >
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="All publications" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ALL">All publications</SelectItem>
+              {publications.items.map((pub) => (
+                <SelectItem key={pub.id} value={pub.id}>
+                  {pub.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Connections</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : filteredItems.length === 0 ? (
+            <div className="text-center py-12">
+              <p className="text-muted-foreground">No CMS connections yet</p>
+              {isAdmin && (
+                <Link href="/slate/cms/new">
+                  <Button variant="link">
+                    Create your first CMS connection
+                  </Button>
+                </Link>
+              )}
+            </div>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Adapter</TableHead>
+                    <TableHead>Publication</TableHead>
+                    <TableHead>Active</TableHead>
+                    <TableHead>Last Sync</TableHead>
+                    <TableHead>Created</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredItems.map((connection) => (
+                    <TableRow key={connection.id}>
+                      <TableCell>
+                        <Link
+                          href={`/slate/cms/${connection.id}`}
+                          className="font-medium hover:underline"
+                        >
+                          {connection.name}
+                        </Link>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline">
+                          {getAdapterLabel(connection.adapterType)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {connection.publicationId
+                          ? (pubMap.get(connection.publicationId) ?? "—")
+                          : "Org-wide"}
+                      </TableCell>
+                      <TableCell>
+                        <span
+                          className={`inline-block h-2 w-2 rounded-full ${connection.isActive ? "bg-green-500" : "bg-gray-300"}`}
+                        />
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {connection.lastSyncAt
+                          ? format(new Date(connection.lastSyncAt), "PP")
+                          : "Never"}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {format(new Date(connection.createdAt), "PP")}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+
+              {data && data.total > 20 && (
+                <div className="flex justify-center gap-2 mt-4">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={page === 1}
+                  >
+                    Previous
+                  </Button>
+                  <span className="flex items-center text-sm text-muted-foreground">
+                    Page {page} of {Math.ceil(data.total / 20)}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((p) => p + 1)}
+                    disabled={page * 20 >= data.total}
+                  >
+                    Next
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/slate/slate-dashboard.tsx
+++ b/apps/web/src/components/slate/slate-dashboard.tsx
@@ -66,7 +66,7 @@ const sections = [
     href: "/slate/cms",
     icon: Globe,
     cta: "View Connections",
-    comingSoon: true,
+    comingSoon: false,
   },
 ];
 

--- a/apps/web/src/lib/cms-utils.ts
+++ b/apps/web/src/lib/cms-utils.ts
@@ -1,0 +1,88 @@
+import type { CmsAdapterType } from "@colophony/types";
+
+export interface ConfigField {
+  key: string;
+  label: string;
+  placeholder: string;
+  type: "text" | "password" | "url";
+  required: boolean;
+  description?: string;
+}
+
+interface AdapterConfig {
+  label: string;
+  badgeVariant: "default" | "secondary" | "outline";
+  configFields: ConfigField[];
+}
+
+export const cmsAdapterConfig: Record<CmsAdapterType, AdapterConfig> = {
+  WORDPRESS: {
+    label: "WordPress",
+    badgeVariant: "default",
+    configFields: [
+      {
+        key: "siteUrl",
+        label: "Site URL",
+        placeholder: "https://example.com",
+        type: "url",
+        required: true,
+        description: "The URL of your WordPress site",
+      },
+      {
+        key: "username",
+        label: "Username",
+        placeholder: "admin",
+        type: "text",
+        required: true,
+        description: "WordPress username with API access",
+      },
+      {
+        key: "applicationPassword",
+        label: "Application Password",
+        placeholder: "xxxx xxxx xxxx xxxx xxxx xxxx",
+        type: "password",
+        required: true,
+        description:
+          "Generate an application password in WordPress under Users → Profile",
+      },
+    ],
+  },
+  GHOST: {
+    label: "Ghost",
+    badgeVariant: "secondary",
+    configFields: [
+      {
+        key: "apiUrl",
+        label: "API URL",
+        placeholder: "https://your-site.ghost.io",
+        type: "url",
+        required: true,
+        description: "Your Ghost site URL",
+      },
+      {
+        key: "adminApiKey",
+        label: "Admin API Key",
+        placeholder: "xxxxxxxxxxxxxxxxxxxxxxxx:yyyyyyyy",
+        type: "password",
+        required: true,
+        description:
+          "Found in Ghost Admin under Settings → Integrations → Custom",
+      },
+    ],
+  },
+};
+
+export function getAdapterLabel(type: CmsAdapterType): string {
+  return cmsAdapterConfig[type].label;
+}
+
+export function getAdapterConfigFields(type: CmsAdapterType): ConfigField[] {
+  return cmsAdapterConfig[type].configFields;
+}
+
+export function maskConfigValue(value: unknown, fieldType: string): string {
+  const str = String(value ?? "");
+  if (fieldType !== "password") return str;
+  if (str.length <= 4) return "••••";
+  return "••••" + str.slice(-4);
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -136,7 +136,9 @@
 - [x] Slate frontend PR3 — issues + sections (CRUD, item assignment, DnD reordering) — (architecture doc Track 4; done 2026-02-23)
 - [x] Slate frontend PR4 — editorial calendar — (architecture doc Track 4; done 2026-02-23 PR pending)
 - [x] Slate frontend PR5 — contracts + templates (Tiptap WYSIWYG + merge fields) — (architecture doc Track 4; done 2026-02-24 PR pending)
-- [ ] Slate frontend PR6 — CMS connections (CRUD, adapter config, test) — (architecture doc Track 4)
+- [x] Slate frontend PR6 — CMS connections (CRUD, adapter config, test) — (architecture doc Track 4; done 2026-02-24)
+- [ ] [P2] Redact CMS credentials from audit logs — `updateWithAudit` writes raw `config` (including passwords) to audit table; needs field-level redaction before `newValue` storage — (Codex review 2026-02-24)
+- [ ] [P2] Add audit logging for `testConnection` — sensitive operation using stored credentials, currently not audit-logged — (Codex review 2026-02-24)
 - [ ] Slate E2E tests — Playwright tests for pipeline flows — (architecture doc Track 4)
 
 ### Research / Design

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-24 — Slate CMS Connections Frontend (PR6)
+
+### Done
+
+- **CMS connections CRUD**: List with adapter type tabs (All/WordPress/Ghost), publication filter dropdown, pagination; create/edit form with dynamic adapter-specific config fields and password show/hide toggles; detail page with masked credentials, test connection button, edit/delete actions
+- **Adapter config system**: `cms-utils.ts` — typed config field definitions per adapter (WordPress: siteUrl/username/applicationPassword; Ghost: apiUrl/adminApiKey), label helpers, password masking (last 4 chars)
+- **Page routes**: `/slate/cms` (list), `/slate/cms/new` (create), `/slate/cms/[id]` (detail), `/slate/cms/[id]/edit` (edit) — all follow Next.js 16 async params pattern
+- **Navigation**: Dashboard CMS Connections card flipped from "Coming Soon" to active; sidebar CMS entry with Globe icon
+- **Unit tests**: 12 tests (adapter config structure, label helpers, config field accessors, password masking) — all passing
+- **Type-check + lint**: Zero errors, zero new warnings
+- Codex plan review: 0 critical, 3 important (all backend-only — audit log credential leak, test connection audit logging, loose config schema — deferred to backlog)
+- 11 new files, 2 modified, ~1073 lines added
+- **Slate frontend feature-complete** — all 6 PRs done (publications, pipeline, issues, calendar, contracts, CMS)
+
+### Decisions
+
+- Typed form fields per adapter (not JSON editor) — only 2 adapters, matches platform's form-driven UX
+- Test button on detail page only — backend `test` mutation requires saved connection ID
+- Client-side adapter filtering — single-digit CMS connection counts per org, no server filter needed
+- `useWatch` over `form.watch` for config values — avoids react-hooks/incompatible-library lint warning from React Compiler
+
+---
+
 ## 2026-02-24 — Slate Contracts + Templates Frontend (PR5)
 
 ### Done


### PR DESCRIPTION
## Summary

- CMS connections CRUD pages with adapter-specific config forms (WordPress: siteUrl/username/applicationPassword; Ghost: apiUrl/adminApiKey)
- List view with adapter type tabs, publication filter, pagination
- Create/edit form with dynamic config fields, password show/hide toggles, required field validation
- Detail page with masked credentials, test connection button, edit/delete actions
- Dashboard CMS card activated, sidebar CMS nav entry added
- 12 unit tests for cms-utils (adapter config, labels, masking)

This is the final Slate frontend PR — all 6 PRs complete (publications, pipeline, issues, calendar, contracts, CMS).

## Test plan

- [ ] `pnpm --filter @colophony/web test` — 348 tests pass (12 new)
- [ ] `pnpm type-check` — zero errors
- [ ] `pnpm lint` — zero new warnings
- [ ] Navigate to `/slate/cms` — list page renders
- [ ] Create WordPress connection — required field validation works
- [ ] View detail — credentials masked, test button works
- [ ] Edit connection — adapter type and publication locked
- [ ] Delete connection — confirmation dialog works

## Codex Review

**Plan review:** 0 critical, 3 important (all backend-only, deferred to backlog)
**Branch review:** 3 findings, all addressed:
- P1: Publication selector now disabled in edit mode (backend doesn't support updating publicationId)
- P2: `isActive` now passed in create mutation payload
- P2: Required adapter config fields validated via `superRefine` with per-field error messages

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `cms-connection-form.tsx` | Publication editable in edit mode | Publication disabled in edit mode | Backend `updateCmsConnectionSchema` doesn't include `publicationId` |
| `cms-connection-form.tsx` | `config: z.record(...)` only | `baseFormSchema.superRefine()` with required field validation | code review P2 finding — prevents saving empty credentials |