### PR TITLE
fix(slate): redact CMS config in audit logs + add testConnection audit

### DIFF
--- a/apps/api/src/graphql/resolvers/cms-connections.ts
+++ b/apps/api/src/graphql/resolvers/cms-connections.ts
@@ -231,7 +231,10 @@ builder.mutationFields((t) => ({
       await requireScopes(ctx, 'cms:read');
       const { id } = idParamSchema.parse({ id: args.id });
       try {
-        return await cmsConnectionService.testConnection(orgCtx.dbTx, id);
+        return await cmsConnectionService.testConnectionWithAudit(
+          toServiceContext(orgCtx),
+          id,
+        );
       } catch (e) {
         mapServiceError(e);
       }

--- a/apps/api/src/rest/routers/cms-connections.ts
+++ b/apps/api/src/rest/routers/cms-connections.ts
@@ -149,7 +149,10 @@ const test = orgProcedure
   .input(idParamSchema)
   .handler(async ({ input, context }) => {
     try {
-      return await cmsConnectionService.testConnection(context.dbTx, input.id);
+      return await cmsConnectionService.testConnectionWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
     } catch (e) {
       mapServiceError(e);
     }

--- a/apps/api/src/services/audit.service.spec.ts
+++ b/apps/api/src/services/audit.service.spec.ts
@@ -55,6 +55,22 @@ describe('serializeValue', () => {
     expect(serializeValue('hello')).toBe('"hello"');
   });
 
+  it('scrubs apiKey variants', () => {
+    const input = {
+      adminApiKey: 'ghost_key_123',
+      api_key: 'wp_key_456',
+      apiKey: 'generic_key_789',
+      apikey: 'lower_key_000',
+      name: 'safe-value',
+    };
+    const result = JSON.parse(serializeValue(input)!);
+    expect(result.adminApiKey).toBe('[REDACTED]');
+    expect(result.api_key).toBe('[REDACTED]');
+    expect(result.apiKey).toBe('[REDACTED]');
+    expect(result.apikey).toBe('[REDACTED]');
+    expect(result.name).toBe('safe-value');
+  });
+
   it('scrubs secret keys', () => {
     const input = {
       email: 'test@example.com',

--- a/apps/api/src/services/audit.service.ts
+++ b/apps/api/src/services/audit.service.ts
@@ -21,7 +21,7 @@ import type {
 
 const MAX_VALUE_LENGTH = 8192;
 
-const SECRET_PATTERN = /token|secret|password|authorization/i;
+const SECRET_PATTERN = /token|secret|password|authorization|api.?key/i;
 
 /**
  * Safely serialize a value to JSON for audit storage.

--- a/apps/api/src/services/cms-connection.service.spec.ts
+++ b/apps/api/src/services/cms-connection.service.spec.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuditActions, AuditResources } from '@colophony/types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockTestConnection = vi.fn();
+
+vi.mock('../adapters/cms/index.js', () => ({
+  getCmsAdapter: () => ({ testConnection: mockTestConnection }),
+}));
+
+vi.mock('./errors.js', () => ({
+  assertEditorOrAdmin: vi.fn(),
+}));
+
+vi.mock('@colophony/db', () => ({
+  cmsConnections: {
+    id: 'id',
+    publicationId: 'publication_id',
+    isActive: 'is_active',
+    createdAt: 'created_at',
+  },
+  eq: vi.fn((_col: unknown, val: unknown) => ({ op: 'eq', val })),
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  desc: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  desc: vi.fn(),
+  count: vi.fn(),
+}));
+
+import { cmsConnectionService } from './cms-connection.service.js';
+import type { ServiceContext } from './types.js';
+import type { DrizzleDb } from '@colophony/db';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeServiceContext(
+  overrides: Partial<ServiceContext> = {},
+): ServiceContext {
+  return {
+    tx: makeTx(),
+    actor: { userId: 'user-1', orgId: 'org-1', role: 'ADMIN' },
+    audit: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeTx(): DrizzleDb {
+  const updateReturning = vi
+    .fn()
+    .mockResolvedValue([{ id: 'conn-1', name: 'Updated' }]);
+  const updateWhere = vi.fn().mockReturnValue({ returning: updateReturning });
+  const updateSet = vi.fn().mockReturnValue({ where: updateWhere });
+  const selectLimitResult = vi.fn().mockResolvedValue([
+    {
+      id: 'conn-1',
+      name: 'Test Connection',
+      adapterType: 'GHOST',
+      config: { url: 'https://example.com', adminApiKey: 'secret123' },
+      isActive: true,
+      organizationId: 'org-1',
+      publicationId: null,
+      lastSyncAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  ]);
+  return {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: selectLimitResult,
+        }),
+      }),
+    }),
+    update: vi.fn().mockReturnValue({ set: updateSet }),
+  } as unknown as DrizzleDb;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('cmsConnectionService.updateWithAudit', () => {
+  it('does not log config values', async () => {
+    const ctx = makeServiceContext();
+    const input = {
+      name: 'New Name',
+      config: { url: 'https://example.com', adminApiKey: 'supersecret' },
+      isActive: true,
+    };
+
+    await cmsConnectionService.updateWithAudit(ctx, 'conn-1', input);
+
+    expect(ctx.audit).toHaveBeenCalledOnce();
+    const auditCall = (ctx.audit as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(auditCall.action).toBe(AuditActions.CMS_CONNECTION_UPDATED);
+    expect(auditCall.resource).toBe(AuditResources.CMS_CONNECTION);
+    expect(auditCall.newValue).toEqual({
+      name: 'New Name',
+      isActive: true,
+      configUpdated: true,
+    });
+    // Must NOT contain raw config
+    expect(auditCall.newValue.config).toBeUndefined();
+    expect(auditCall.newValue.adminApiKey).toBeUndefined();
+    expect(auditCall.newValue.url).toBeUndefined();
+  });
+});
+
+describe('cmsConnectionService.testConnectionWithAudit', () => {
+  beforeEach(() => {
+    mockTestConnection.mockReset();
+  });
+
+  it('logs success result', async () => {
+    mockTestConnection.mockResolvedValue({ success: true });
+    const ctx = makeServiceContext();
+
+    const result = await cmsConnectionService.testConnectionWithAudit(
+      ctx,
+      'conn-1',
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(ctx.audit).toHaveBeenCalledOnce();
+    const auditCall = (ctx.audit as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(auditCall.action).toBe(AuditActions.CMS_CONNECTION_TESTED);
+    expect(auditCall.resource).toBe(AuditResources.CMS_CONNECTION);
+    expect(auditCall.resourceId).toBe('conn-1');
+    expect(auditCall.newValue).toEqual({ success: true });
+  });
+
+  it('logs failure result without error text', async () => {
+    mockTestConnection.mockResolvedValue({
+      success: false,
+      error:
+        'Connection refused: HTTP 401 Unauthorized with body containing apiKey=secret123',
+    });
+    const ctx = makeServiceContext();
+
+    const result = await cmsConnectionService.testConnectionWithAudit(
+      ctx,
+      'conn-1',
+    );
+
+    expect(result.success).toBe(false);
+    expect(ctx.audit).toHaveBeenCalledOnce();
+    const auditCall = (ctx.audit as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(auditCall.action).toBe(AuditActions.CMS_CONNECTION_TESTED);
+    expect(auditCall.newValue).toEqual({ success: false });
+    // Must NOT leak error text into audit log
+    expect(auditCall.newValue.error).toBeUndefined();
+  });
+});

--- a/apps/api/src/services/cms-connection.service.spec.ts
+++ b/apps/api/src/services/cms-connection.service.spec.ts
@@ -158,4 +158,18 @@ describe('cmsConnectionService.testConnectionWithAudit', () => {
     // Must NOT leak error text into audit log
     expect(auditCall.newValue.error).toBeUndefined();
   });
+
+  it('audits failure and re-throws when testConnection throws', async () => {
+    mockTestConnection.mockRejectedValue(new Error('Config parse error'));
+    const ctx = makeServiceContext();
+
+    await expect(
+      cmsConnectionService.testConnectionWithAudit(ctx, 'conn-1'),
+    ).rejects.toThrow('Config parse error');
+
+    expect(ctx.audit).toHaveBeenCalledOnce();
+    const auditCall = (ctx.audit as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(auditCall.action).toBe(AuditActions.CMS_CONNECTION_TESTED);
+    expect(auditCall.newValue).toEqual({ success: false });
+  });
 });

--- a/apps/api/src/services/cms-connection.service.ts
+++ b/apps/api/src/services/cms-connection.service.ts
@@ -134,7 +134,11 @@ export const cmsConnectionService = {
       action: AuditActions.CMS_CONNECTION_UPDATED,
       resource: AuditResources.CMS_CONNECTION,
       resourceId: id,
-      newValue: input,
+      newValue: {
+        ...(input.name !== undefined && { name: input.name }),
+        ...(input.isActive !== undefined && { isActive: input.isActive }),
+        ...(input.config !== undefined && { configUpdated: true }),
+      },
     });
     return updated;
   },
@@ -171,6 +175,17 @@ export const cmsConnectionService = {
 
     const adapter = getCmsAdapter(connection.adapterType);
     return adapter.testConnection(connection.config);
+  },
+
+  async testConnectionWithAudit(ctx: ServiceContext, id: string) {
+    const result = await cmsConnectionService.testConnection(ctx.tx, id);
+    await ctx.audit({
+      action: AuditActions.CMS_CONNECTION_TESTED,
+      resource: AuditResources.CMS_CONNECTION,
+      resourceId: id,
+      newValue: { success: result.success },
+    });
+    return result;
   },
 
   // -------------------------------------------------------------------------

--- a/apps/api/src/services/cms-connection.service.ts
+++ b/apps/api/src/services/cms-connection.service.ts
@@ -178,7 +178,18 @@ export const cmsConnectionService = {
   },
 
   async testConnectionWithAudit(ctx: ServiceContext, id: string) {
-    const result = await cmsConnectionService.testConnection(ctx.tx, id);
+    let result: { success: boolean; error?: string };
+    try {
+      result = await cmsConnectionService.testConnection(ctx.tx, id);
+    } catch (error) {
+      await ctx.audit({
+        action: AuditActions.CMS_CONNECTION_TESTED,
+        resource: AuditResources.CMS_CONNECTION,
+        resourceId: id,
+        newValue: { success: false },
+      });
+      throw error;
+    }
     await ctx.audit({
       action: AuditActions.CMS_CONNECTION_TESTED,
       resource: AuditResources.CMS_CONNECTION,

--- a/apps/api/src/trpc/routers/cms-connections.ts
+++ b/apps/api/src/trpc/routers/cms-connections.ts
@@ -105,7 +105,10 @@ export const cmsConnectionsRouter = createRouter({
     .output(z.object({ success: z.boolean(), error: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
       try {
-        return await cmsConnectionService.testConnection(ctx.dbTx, input.id);
+        return await cmsConnectionService.testConnectionWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
       } catch (e) {
         mapServiceError(e);
       }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -137,8 +137,8 @@
 - [x] Slate frontend PR4 — editorial calendar — (architecture doc Track 4; done 2026-02-23 PR pending)
 - [x] Slate frontend PR5 — contracts + templates (Tiptap WYSIWYG + merge fields) — (architecture doc Track 4; done 2026-02-24 PR pending)
 - [x] Slate frontend PR6 — CMS connections (CRUD, adapter config, test) — (architecture doc Track 4; done 2026-02-24)
-- [ ] [P2] Redact CMS credentials from audit logs — `updateWithAudit` writes raw `config` (including passwords) to audit table; needs field-level redaction before `newValue` storage — (Codex review 2026-02-24)
-- [ ] [P2] Add audit logging for `testConnection` — sensitive operation using stored credentials, currently not audit-logged — (Codex review 2026-02-24)
+- [x] [P2] Redact CMS credentials from audit logs — `updateWithAudit` writes raw `config` (including passwords) to audit table; needs field-level redaction before `newValue` storage — (Codex review 2026-02-24; done 2026-02-24)
+- [x] [P2] Add audit logging for `testConnection` — sensitive operation using stored credentials, currently not audit-logged — (Codex review 2026-02-24; done 2026-02-24)
 - [ ] Slate E2E tests — Playwright tests for pipeline flows — (architecture doc Track 4)
 
 ### Research / Design

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,25 @@ Newest entries first.
 
 ---
 
+## 2026-02-24 — Slate CMS Audit Redaction Fix
+
+### Done
+
+- Extended `SECRET_PATTERN` in `audit.service.ts` to catch `apiKey` variants (`adminApiKey`, `api_key`, `apiKey`) — Ghost adapter's `adminApiKey` was not being redacted
+- Redacted config in `updateWithAudit` — defense-in-depth: logs `configUpdated: true` instead of raw config values (passwords, API keys)
+- Added `CMS_CONNECTION_TESTED` audit action and `testConnectionWithAudit` service method — security-sensitive operation now tracked
+- Updated all 3 routers (tRPC, REST, GraphQL) to use `testConnectionWithAudit` instead of direct `testConnection`
+- Added unit tests: apiKey scrubbing (audit service), config redaction (cms-connection service), testConnectionWithAudit success/failure logging (3 new tests, 1 new spec file)
+- Codex plan review: 0 critical, 1 important (error text leakage) — already addressed in implementation by logging only `{ success: boolean }`
+- All 782 tests passing, type-check clean
+
+### Decisions
+
+- Log only `{ success: boolean }` for testConnection audit — adapter error text contains HTTP response bodies that could leak credentials (Codex review confirmed this risk)
+- Defense-in-depth: explicitly exclude config from audit `newValue` rather than relying solely on `serializeValue` regex
+
+---
+
 ## 2026-02-24 — Slate CMS Connections Frontend (PR6)
 
 ### Done

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -131,6 +131,7 @@ export const AuditActions = {
   CMS_CONNECTION_CREATED: "CMS_CONNECTION_CREATED",
   CMS_CONNECTION_UPDATED: "CMS_CONNECTION_UPDATED",
   CMS_CONNECTION_DELETED: "CMS_CONNECTION_DELETED",
+  CMS_CONNECTION_TESTED: "CMS_CONNECTION_TESTED",
 
   // Audit access
   AUDIT_ACCESSED: "AUDIT_ACCESSED",
@@ -346,7 +347,8 @@ export interface CmsConnectionAuditParams extends BaseAuditParams {
   action:
     | typeof AuditActions.CMS_CONNECTION_CREATED
     | typeof AuditActions.CMS_CONNECTION_UPDATED
-    | typeof AuditActions.CMS_CONNECTION_DELETED;
+    | typeof AuditActions.CMS_CONNECTION_DELETED
+    | typeof AuditActions.CMS_CONNECTION_TESTED;
 }
 
 export interface AuditAccessAuditParams extends BaseAuditParams {


### PR DESCRIPTION
## Summary

- Extend `SECRET_PATTERN` to catch `apiKey` variants (`adminApiKey`, `api_key`, `apiKey`) — Ghost adapter's `adminApiKey` was not redacted
- Redact config in `updateWithAudit` (defense-in-depth: log `configUpdated: true`, not raw values)
- Add `CMS_CONNECTION_TESTED` audit action and `testConnectionWithAudit` method with try/catch for thrown errors
- Update tRPC, REST, GraphQL routers to use `testConnectionWithAudit`
- Add unit tests (4 new tests, 1 new spec file)

Closes P2 items from code review (2026-02-24) to close out Track 4.

## Test plan

- [x] All 783 unit tests passing (`pnpm test --filter @colophony/api`)
- [x] Type-check clean (`pnpm type-check`)
- [x] plan review: 0 critical, 1 important (error text leakage — addressed)
- [x] branch review: 1 P2 finding (thrown error audit gap — addressed in 3rd commit)
- [ ] CI passes