### PR TITLE
chore(ci): path filtering for Playwright E2E suites

### DIFF
--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -56,6 +56,22 @@
     ],
     "PostToolUse": [
       {
+        "event": "Edit(apps/**/*.ts)",
+        "script": ".claude/hooks/post-edit-lint.js"
+      },
+      {
+        "event": "Write(apps/**/*.ts)",
+        "script": ".claude/hooks/post-edit-lint.js"
+      },
+      {
+        "event": "Edit(apps/**/*.tsx)",
+        "script": ".claude/hooks/post-edit-lint.js"
+      },
+      {
+        "event": "Write(apps/**/*.tsx)",
+        "script": ".claude/hooks/post-edit-lint.js"
+      },
+      {
         "event": "Edit(**/schema/*.ts)",
         "script": ".claude/hooks/post-schema.js"
       },

--- a/.claude/hooks/post-edit-lint.js
+++ b/.claude/hooks/post-edit-lint.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+/**
+ * Post-edit hook: lint the edited file and warn on new warnings/errors.
+ *
+ * Runs eslint on the specific file that was just edited. Fast (~1-2s) compared
+ * to full `pnpm lint`. Catches issues as they're introduced rather than at
+ * commit/push time.
+ *
+ * Exit code is always 0 (advisory, never blocks). Warnings are surfaced to
+ * Claude Code so they can be fixed immediately.
+ */
+
+const { execSync } = require("child_process");
+const path = require("path");
+
+const filePath = process.env.CLAUDE_TOOL_ARGS_file_path || "";
+const cwd = process.env.CLAUDE_WORKING_DIRECTORY || process.cwd();
+
+if (!filePath) {
+  process.exit(0);
+}
+
+// Resolve absolute path
+const absPath = path.isAbsolute(filePath)
+  ? filePath
+  : path.resolve(cwd, filePath);
+
+// Determine which package owns this file to find the right eslint config
+const appsApi = path.join(cwd, "apps", "api");
+const appsWeb = path.join(cwd, "apps", "web");
+
+let eslintCwd;
+if (absPath.startsWith(appsApi)) {
+  eslintCwd = appsApi;
+} else if (absPath.startsWith(appsWeb)) {
+  eslintCwd = appsWeb;
+} else {
+  // File is in packages/ or root — no eslint config, skip
+  process.exit(0);
+}
+
+try {
+  // Run eslint on just this file. --no-error-on-unmatched-pattern avoids
+  // failures when the file doesn't match eslint's include patterns.
+  const result = execSync(
+    `npx eslint --no-error-on-unmatched-pattern --format compact "${absPath}"`,
+    {
+      cwd: eslintCwd,
+      encoding: "utf-8",
+      timeout: 15000,
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+
+  // eslint exits 0 with no output when clean
+  if (result.trim()) {
+    // Has output but exit 0 — informational only, shouldn't happen with compact format
+    process.exit(0);
+  }
+} catch (err) {
+  // eslint exits 1 on warnings/errors
+  const output = (err.stdout || "").trim();
+  const stderr = (err.stderr || "").trim();
+
+  if (!output && !stderr) {
+    // eslint failed for a non-lint reason (config error, etc.) — don't block
+    process.exit(0);
+  }
+
+  // Count warnings and errors from compact format
+  // Compact format: /path/file.ts: line X, col Y, Warning/Error - message (rule)
+  const lines = output.split("\n").filter((l) => l.includes(": line "));
+  const errorCount = lines.filter((l) => l.includes("Error -")).length;
+  const warningCount = lines.filter((l) => l.includes("Warning -")).length;
+
+  if (errorCount > 0 || warningCount > 0) {
+    const relPath = path.relative(cwd, absPath);
+    const parts = [];
+    if (errorCount > 0) parts.push(`${errorCount} error${errorCount > 1 ? "s" : ""}`);
+    if (warningCount > 0) parts.push(`${warningCount} warning${warningCount > 1 ? "s" : ""}`);
+
+    console.warn(`\n⚠️  LINT: ${relPath} has ${parts.join(" and ")}`);
+
+    // Show the actual issues (compact format is already concise)
+    for (const line of lines) {
+      // Extract just the relevant part after the filename
+      const match = line.match(/: line (\d+).*?(?:Warning|Error) - (.+)/);
+      if (match) {
+        const type = line.includes("Error -") ? "❌" : "⚠️";
+        console.warn(`   ${type}  Line ${match[1]}: ${match[2]}`);
+      }
+    }
+
+    console.warn("   Fix these before committing — do not defer lint issues.");
+  }
+}
+
+process.exit(0);

--- a/.github/scripts/detect-changes.sh
+++ b/.github/scripts/detect-changes.sh
@@ -56,11 +56,15 @@ shared_prefixes=(
   "apps/web/e2e/helpers/"
   "apps/web/e2e/global-setup.ts"
   "apps/web/e2e/global-teardown.ts"
+  "apps/web/src/app/layout.tsx"
+  "apps/web/src/app/globals.css"
+  "apps/web/tsconfig"
   ".github/"
   "docker-compose"
   "package.json"
   "pnpm-lock.yaml"
   "pnpm-workspace.yaml"
+  "tsconfig"
   "turbo.json"
 )
 
@@ -107,15 +111,12 @@ known_nonsuite_prefixes=(
   "apps/web/src/components/organizations/"
   "apps/web/src/components/periods/"
   "apps/web/src/app/(onboarding)/"
-  "apps/web/src/app/layout.tsx"
   "apps/web/src/app/page.tsx"
-  "apps/web/src/app/globals.css"
   "apps/web/src/app/favicon.ico"
   "apps/web/public/"
   "apps/web/next.config"
   "apps/web/tailwind.config"
   "apps/web/postcss.config"
-  "apps/web/tsconfig"
 )
 
 # --- Known non-suite file extensions ---

--- a/.github/scripts/detect-changes.sh
+++ b/.github/scripts/detect-changes.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# detect-changes.sh — Determine which Playwright E2E suites to run based on changed files.
+#
+# Usage: pipe file list (one per line) into stdin.
+#   echo "apps/web/src/components/slate/foo.tsx" | \
+#     GITHUB_EVENT_NAME=pull_request GITHUB_OUTPUT=/dev/stdout bash .github/scripts/detect-changes.sh
+#
+# Outputs boolean flags to $GITHUB_OUTPUT:
+#   run_submissions, run_embed, run_slate, run_uploads, run_oidc
+#
+# Behavior:
+#   - push events → all suites run (main branch always runs everything)
+#   - Shared path changes → all suites run
+#   - Suite-specific path changes → only that suite runs
+#   - Unknown paths (fail-open) → all suites run
+
+set -euo pipefail
+
+# --- Defaults ---
+run_submissions=false
+run_embed=false
+run_slate=false
+run_uploads=false
+run_oidc=false
+run_all=false
+
+# --- Push to main always runs everything ---
+if [[ "${GITHUB_EVENT_NAME:-}" == "push" ]]; then
+  run_all=true
+fi
+
+# --- Read changed files from stdin ---
+FILES=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && FILES+=("$line")
+done
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  # No files → nothing to run (docs_only will handle this)
+  run_all=true
+fi
+
+# --- Shared prefixes: changes here trigger ALL suites ---
+shared_prefixes=(
+  "packages/types/"
+  "packages/db/"
+  "packages/auth-client/"
+  "packages/api-contracts/"
+  "apps/api/src/"
+  "apps/web/src/lib/"
+  "apps/web/src/hooks/"
+  "apps/web/src/components/ui/"
+  "apps/web/src/components/auth/"
+  "apps/web/src/components/providers.tsx"
+  "apps/web/playwright.config.ts"
+  "apps/web/e2e/helpers/"
+  "apps/web/e2e/global-setup.ts"
+  "apps/web/e2e/global-teardown.ts"
+  ".github/"
+  "docker-compose"
+  "package.json"
+  "pnpm-lock.yaml"
+  "pnpm-workspace.yaml"
+  "turbo.json"
+)
+
+# --- Suite-specific prefixes ---
+submissions_prefixes=(
+  "apps/web/e2e/submissions/"
+  "apps/web/src/components/submissions/"
+  "apps/web/src/app/(dashboard)/submissions/"
+  "apps/web/src/components/form-builder/"
+  "apps/web/src/components/form-renderer/"
+)
+
+embed_prefixes=(
+  "apps/web/e2e/embed/"
+  "apps/web/src/components/embed/"
+  "apps/web/src/app/embed/"
+)
+
+slate_prefixes=(
+  "apps/web/e2e/slate/"
+  "apps/web/src/components/slate/"
+  "apps/web/src/app/(dashboard)/slate/"
+)
+
+uploads_prefixes=(
+  "apps/web/e2e/uploads/"
+  "apps/web/src/components/submissions/file-upload"
+  "apps/web/src/components/manuscripts/manuscript-version-files"
+)
+
+oidc_prefixes=(
+  "apps/web/e2e/oidc/"
+  "apps/web/src/app/auth/"
+)
+
+# --- Known non-suite prefixes (docs, configs, etc. that don't need E2E) ---
+known_nonsuite_prefixes=(
+  "docs/"
+  "scripts/"
+  ".husky/"
+  ".vscode/"
+  ".claude/"
+  "apps/web/src/components/layout/"
+  "apps/web/src/components/organizations/"
+  "apps/web/src/components/periods/"
+  "apps/web/src/app/(onboarding)/"
+  "apps/web/src/app/layout.tsx"
+  "apps/web/src/app/page.tsx"
+  "apps/web/src/app/globals.css"
+  "apps/web/src/app/favicon.ico"
+  "apps/web/public/"
+  "apps/web/next.config"
+  "apps/web/tailwind.config"
+  "apps/web/postcss.config"
+  "apps/web/tsconfig"
+)
+
+# --- Known non-suite file extensions ---
+known_nonsuite_extensions=(
+  ".md"
+  ".mdx"
+)
+
+matches_any_prefix() {
+  local file="$1"
+  shift
+  for prefix in "$@"; do
+    if [[ "$file" == "$prefix"* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+matches_any_extension() {
+  local file="$1"
+  shift
+  for ext in "$@"; do
+    if [[ "$file" == *"$ext" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# --- Classify each changed file ---
+if [[ "$run_all" == "false" ]]; then
+  for file in "${FILES[@]}"; do
+    # Shared paths → all suites
+    if matches_any_prefix "$file" "${shared_prefixes[@]}"; then
+      run_all=true
+      break
+    fi
+
+    matched=false
+
+    # Suite-specific paths
+    if matches_any_prefix "$file" "${submissions_prefixes[@]}"; then
+      run_submissions=true
+      matched=true
+    fi
+    if matches_any_prefix "$file" "${embed_prefixes[@]}"; then
+      run_embed=true
+      matched=true
+    fi
+    if matches_any_prefix "$file" "${slate_prefixes[@]}"; then
+      run_slate=true
+      matched=true
+    fi
+    if matches_any_prefix "$file" "${uploads_prefixes[@]}"; then
+      run_uploads=true
+      matched=true
+    fi
+    if matches_any_prefix "$file" "${oidc_prefixes[@]}"; then
+      run_oidc=true
+      matched=true
+    fi
+
+    # Known non-suite paths (docs, configs) — skip without triggering fail-open
+    if [[ "$matched" == "false" ]]; then
+      if matches_any_prefix "$file" "${known_nonsuite_prefixes[@]}"; then
+        matched=true
+      fi
+    fi
+    if [[ "$matched" == "false" ]]; then
+      if matches_any_extension "$file" "${known_nonsuite_extensions[@]}"; then
+        matched=true
+      fi
+    fi
+
+    # Fail-open: unknown file → run all suites
+    if [[ "$matched" == "false" ]]; then
+      echo "Unknown path (fail-open): $file"
+      run_all=true
+      break
+    fi
+  done
+fi
+
+# --- Apply run_all ---
+if [[ "$run_all" == "true" ]]; then
+  run_submissions=true
+  run_embed=true
+  run_slate=true
+  run_uploads=true
+  run_oidc=true
+fi
+
+# --- Output ---
+echo "run_submissions=$run_submissions"
+echo "run_embed=$run_embed"
+echo "run_slate=$run_slate"
+echo "run_uploads=$run_uploads"
+echo "run_oidc=$run_oidc"
+
+# Write to GITHUB_OUTPUT if available
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "run_submissions=$run_submissions"
+    echo "run_embed=$run_embed"
+    echo "run_slate=$run_slate"
+    echo "run_uploads=$run_uploads"
+    echo "run_oidc=$run_oidc"
+  } >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,15 @@ jobs:
       pull-requests: read
     outputs:
       docs_only: ${{ steps.check.outputs.docs_only }}
+      run_submissions: ${{ steps.suites.outputs.run_submissions }}
+      run_embed: ${{ steps.suites.outputs.run_embed }}
+      run_slate: ${{ steps.suites.outputs.run_slate }}
+      run_uploads: ${{ steps.suites.outputs.run_uploads }}
+      run_oidc: ${{ steps.suites.outputs.run_oidc }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/scripts
       - name: Check for code changes
         id: check
         env:
@@ -47,6 +55,12 @@ jobs:
           else
             echo "docs_only=true" >> "$GITHUB_OUTPUT"
           fi
+          # Save file list for suite detection
+          echo "$FILES" > /tmp/changed-files.txt
+      - name: Detect Playwright suites to run
+        id: suites
+        run: |
+          cat /tmp/changed-files.txt | bash .github/scripts/detect-changes.sh
 
   # ──────────────────────────────────────────────────
   # Fast checks (~1 min): lint, format, type-check
@@ -227,7 +241,7 @@ jobs:
   playwright-tests:
     name: Playwright Submissions E2E
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.run_submissions == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -310,7 +324,7 @@ jobs:
   playwright-embed:
     name: Playwright Embed E2E
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.run_embed == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -393,7 +407,7 @@ jobs:
   playwright-slate:
     name: Playwright Slate E2E
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.run_slate == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -476,7 +490,7 @@ jobs:
   playwright-uploads:
     name: Playwright Uploads E2E
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.run_uploads == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -595,7 +609,7 @@ jobs:
   playwright-oidc:
     name: Playwright OIDC E2E
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.run_oidc == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,8 @@ All other version pins are in their respective per-directory CLAUDE.md files.
 | **playwright-slate**   | Playwright E2E Slate pipeline project (30 tests)   |
 | **build**              | `pnpm build` (API + Web production build)          |
 
+**Path filtering:** Playwright suites run selectively on PRs based on changed files (`.github/scripts/detect-changes.sh`). Shared paths (packages, API, shared hooks/lib/ui) trigger all suites. Suite-specific paths (e.g., `apps/web/e2e/slate/`, `apps/web/src/components/slate/`) trigger only that suite. Unknown paths fail-open (all suites run). Push to `main` always runs everything. Fast jobs (quality, unit-tests, rls-tests, build) are unaffected — they always run on non-docs PRs.
+
 ---
 
 ## Development Workflow
@@ -220,7 +222,7 @@ All other version pins are in their respective per-directory CLAUDE.md files.
 
 **Pre-edit:** `pre-edit-validate.js` (secrets, RLS context), `pre-payment-validate.js` (idempotency), `pre-frontend-validate.js` (use client, shadcn, org context), `pre-router-audit.js` (audit logging), `pre-push-branch.js` (blocks push to main)
 
-**Post-edit:** `post-schema.js` (db:generate reminder), `post-email-template.js` (text version), `post-migration-validate.js` (RLS for new tables), `post-commit-devlog.js` (DEVLOG reminder)
+**Post-edit:** `post-edit-lint.js` (eslint on changed file — fix warnings immediately, do not defer), `post-schema.js` (db:generate reminder), `post-email-template.js` (text version), `post-migration-validate.js` (RLS for new tables), `post-commit-devlog.js` (DEVLOG reminder)
 
 ### Codex Review Integration
 

--- a/apps/api/src/__tests__/rls/audit-write-path.test.ts
+++ b/apps/api/src/__tests__/rls/audit-write-path.test.ts
@@ -45,7 +45,6 @@ function adminDb(): DrizzleDb {
 
 /** Read all audit_events via admin (bypasses RLS). */
 async function allAuditEvents(): Promise<AuditEvent[]> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- cross-package drizzle-orm type mismatch (pnpm peer dep duplication)
   return adminDb()
     .select()
     .from(auditEvents as any) as any;
@@ -206,7 +205,6 @@ describe('logDirect() and RLS interaction', () => {
 
 describe('log() org-scoped write via RLS transaction', () => {
   it('inserts event visible within same org context', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- cross-package drizzle-orm type mismatch
     await withTestRls({ orgId: orgA.id, userId: userA.id }, (tx: any) =>
       auditService.log(tx, {
         action: AuditActions.ORG_UPDATED,
@@ -227,7 +225,7 @@ describe('log() org-scoped write via RLS transaction', () => {
     expect(rows[0].resource).toBe('organization');
 
     // Also verify tenant isolation: org A event visible in org A context
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- cross-package drizzle-orm type mismatch
+
     const orgARows = await withTestRls(
       { orgId: orgA.id, userId: userA.id },
       (tx) => tx.select().from(auditEvents as any),
@@ -238,7 +236,7 @@ describe('log() org-scoped write via RLS transaction', () => {
 
   it('org A audit event is invisible to org B (tenant isolation)', async () => {
     // Insert via org A
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- cross-package drizzle-orm type mismatch
+
     await withTestRls({ orgId: orgA.id, userId: userA.id }, (tx: any) =>
       auditService.log(tx, {
         action: AuditActions.ORG_CREATED,
@@ -251,7 +249,7 @@ describe('log() org-scoped write via RLS transaction', () => {
     // Org B sees nothing
     const orgBRows = await withTestRls(
       { orgId: orgB.id, userId: userB.id },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- cross-package drizzle-orm type mismatch
+
       (tx) => tx.select().from(auditEvents as any),
     );
     expect(orgBRows).toHaveLength(0);
@@ -277,7 +275,6 @@ describe('transaction rollback atomicity', () => {
         userA.id,
       ]);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- cross-package drizzle-orm type mismatch
       const tx = drizzle(client) as any;
       await auditService.log(tx, {
         action: AuditActions.ORG_DELETED,

--- a/apps/api/src/__tests__/rls/helpers/factories.ts
+++ b/apps/api/src/__tests__/rls/helpers/factories.ts
@@ -30,7 +30,6 @@ import {
   type UserConsent,
 } from '@colophony/db';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- pnpm resolves two drizzle-orm copies
 // (different optional peer dep contexts); runtime is single copy, types diverge. Cast to unify.
 function adminDb(): any {
   return drizzle(getAdminPool());

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -9,9 +9,11 @@ const eslintConfig = [
   },
   {
     rules: {
-      // Downgraded to warn: existing OIDC guard clauses use synchronous setState
-      // in effects for early returns. Refactor deferred — see backlog.
-      "react-hooks/set-state-in-effect": "warn",
+      // Match monorepo base config: allow _-prefixed vars for intentionally unused bindings
+      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+      // React Hook Form's watch() is incompatible with React Compiler memoization.
+      // This is a known RHF limitation — the compiler skips these components automatically.
+      "react-hooks/incompatible-library": "off",
       "no-restricted-imports": ["error", {
         patterns: [{
           group: ["@colophony/api/**"],

--- a/apps/web/src/components/form-builder/field-config/conditional-rules-config.tsx
+++ b/apps/web/src/components/form-builder/field-config/conditional-rules-config.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -182,11 +182,13 @@ export function ConditionalRulesConfig({
   const [localRules, setLocalRules] = useState<ConditionalRule[] | null>(rules);
   const [enabled, setEnabled] = useState(rules !== null && rules.length > 0);
 
-  // Sync from props when the selected field changes (currentFieldKey drives this)
-  useEffect(() => {
+  // Sync from props when the selected field changes (render-time state adjustment)
+  const [prevFieldKey, setPrevFieldKey] = useState(currentFieldKey);
+  if (prevFieldKey !== currentFieldKey) {
+    setPrevFieldKey(currentFieldKey);
     setLocalRules(rules);
     setEnabled(rules !== null && rules.length > 0);
-  }, [currentFieldKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  }
 
   const availableFields = fields.filter(
     (f) =>

--- a/apps/web/src/components/form-builder/field-properties-panel.tsx
+++ b/apps/web/src/components/form-builder/field-properties-panel.tsx
@@ -81,20 +81,18 @@ export function FieldPropertiesPanel({
   );
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const fieldIdRef = useRef(field.id);
 
-  // Reset local state when selected field changes
-  useEffect(() => {
-    if (fieldIdRef.current !== field.id) {
-      fieldIdRef.current = field.id;
-      setLabel(field.label);
-      setDescription(field.description ?? "");
-      setPlaceholder(field.placeholder ?? "");
-      setRequired(field.required);
-      setConfig(field.config ?? {});
-      setSaveStatus("idle");
-    }
-  }, [field]);
+  // Reset local state when selected field changes (render-time state adjustment)
+  const [prevFieldId, setPrevFieldId] = useState(field.id);
+  if (prevFieldId !== field.id) {
+    setPrevFieldId(field.id);
+    setLabel(field.label);
+    setDescription(field.description ?? "");
+    setPlaceholder(field.placeholder ?? "");
+    setRequired(field.required);
+    setConfig(field.config ?? {});
+    setSaveStatus("idle");
+  }
 
   const debouncedSave = useCallback(
     (data: UpdateFormFieldInput) => {
@@ -107,14 +105,21 @@ export function FieldPropertiesPanel({
     [field.id, onUpdate],
   );
 
-  // Track save completion
-  useEffect(() => {
+  // Track save completion — detect transition during render, timer in effect
+  const [prevIsSaving, setPrevIsSaving] = useState(isSaving);
+  if (prevIsSaving !== isSaving) {
+    setPrevIsSaving(isSaving);
     if (!isSaving && saveStatus === "saving") {
       setSaveStatus("saved");
+    }
+  }
+
+  useEffect(() => {
+    if (saveStatus === "saved") {
       const timer = setTimeout(() => setSaveStatus("idle"), 2000);
       return () => clearTimeout(timer);
     }
-  }, [isSaving, saveStatus]);
+  }, [saveStatus]);
 
   // Cleanup debounce on unmount
   useEffect(() => {

--- a/apps/web/src/components/form-builder/page-branching-editor.tsx
+++ b/apps/web/src/components/form-builder/page-branching-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -107,11 +107,13 @@ export function PageBranchingEditor({
     page.branchingRules !== null && page.branchingRules.length > 0,
   );
 
-  // Sync from props when page changes
-  useEffect(() => {
+  // Sync from props when page changes (render-time state adjustment)
+  const [prevPageId, setPrevPageId] = useState(page.id);
+  if (prevPageId !== page.id) {
+    setPrevPageId(page.id);
     setLocalRules(page.branchingRules);
     setEnabled(page.branchingRules !== null && page.branchingRules.length > 0);
-  }, [page.id]); // eslint-disable-line react-hooks/exhaustive-deps
+  }
 
   const availableFields = allFields.filter(
     (f) =>

--- a/apps/web/src/components/manuscripts/manuscript-list.tsx
+++ b/apps/web/src/components/manuscripts/manuscript-list.tsx
@@ -24,10 +24,12 @@ export function ManuscriptList() {
   const [page, setPage] = useState(1);
   const limit = 12;
 
-  // Reset page when search changes
-  useEffect(() => {
+  // Reset page when search changes (render-time state adjustment)
+  const [prevSearch, setPrevSearch] = useState(debouncedSearch);
+  if (prevSearch !== debouncedSearch) {
+    setPrevSearch(debouncedSearch);
     setPage(1);
-  }, [debouncedSearch]);
+  }
 
   const {
     data,

--- a/apps/web/src/components/manuscripts/manuscript-version-files.tsx
+++ b/apps/web/src/components/manuscripts/manuscript-version-files.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { FileUpload } from "@/components/submissions/file-upload";
 import { Badge } from "@/components/ui/badge";
@@ -116,20 +116,20 @@ export function ManuscriptVersionFiles({
 }
 
 function ReadOnlyFileItem({ file }: { file: FileRecord }) {
-  const [downloadFileId, setDownloadFileId] = useState<string | null>(null);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const utils = trpc.useUtils();
 
-  const { data: downloadData, isFetching } = trpc.files.getDownloadUrl.useQuery(
-    { fileId: downloadFileId! },
-    { enabled: !!downloadFileId },
-  );
-
-  // Open the download URL when it arrives
-  useEffect(() => {
-    if (downloadData?.url) {
-      window.open(downloadData.url, "_blank");
-      setDownloadFileId(null);
+  const handleDownload = async () => {
+    setIsDownloading(true);
+    try {
+      const data = await utils.files.getDownloadUrl.fetch({ fileId: file.id });
+      if (data?.url) {
+        window.open(data.url, "_blank");
+      }
+    } finally {
+      setIsDownloading(false);
     }
-  }, [downloadData]);
+  };
 
   return (
     <div className="flex items-center gap-3 p-3 border rounded-lg">
@@ -147,10 +147,10 @@ function ReadOnlyFileItem({ file }: { file: FileRecord }) {
             variant="ghost"
             size="icon"
             className="h-8 w-8"
-            onClick={() => setDownloadFileId(file.id)}
-            disabled={isFetching}
+            onClick={handleDownload}
+            disabled={isDownloading}
           >
-            {isFetching ? (
+            {isDownloading ? (
               <Loader2 className="h-4 w-4 animate-spin" />
             ) : (
               <Download className="h-4 w-4" />

--- a/apps/web/src/components/slate/add-item-dialog.tsx
+++ b/apps/web/src/components/slate/add-item-dialog.tsx
@@ -74,16 +74,18 @@ export function AddItemDialog({
     return () => clearTimeout(timer);
   }, [search]);
 
-  // Reset state when dialog opens
-  useEffect(() => {
-    if (open) {
-      setSearch("");
-      setDebouncedSearch("");
-      setStageFilter("ALL");
-      setSelectedPipelineItemId(null);
-      setTargetSectionId(UNSECTIONED_VALUE);
-    }
-  }, [open]);
+  // Reset state when dialog opens (render-time state adjustment)
+  const [prevOpen, setPrevOpen] = useState(false);
+  if (open && !prevOpen) {
+    setSearch("");
+    setDebouncedSearch("");
+    setStageFilter("ALL");
+    setSelectedPipelineItemId(null);
+    setTargetSectionId(UNSECTIONED_VALUE);
+  }
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+  }
 
   const { data, isPending } = trpc.pipeline.list.useQuery(
     {

--- a/apps/web/src/components/slate/calendar-grid.tsx
+++ b/apps/web/src/components/slate/calendar-grid.tsx
@@ -7,7 +7,6 @@ import {
   endOfWeek,
   eachDayOfInterval,
   isSameMonth,
-  isSameDay,
   isToday,
   format,
 } from "date-fns";

--- a/apps/web/src/components/slate/issue-list.tsx
+++ b/apps/web/src/components/slate/issue-list.tsx
@@ -67,12 +67,10 @@ export function IssueList() {
     limit: 20,
   });
 
-  // Clamp page when data shrinks
-  useEffect(() => {
-    if (data && data.totalPages > 0 && page > data.totalPages) {
-      setPage(data.totalPages);
-    }
-  }, [data, page]);
+  // Clamp page when data shrinks (render-time state adjustment)
+  if (data && data.totalPages > 0 && page > data.totalPages) {
+    setPage(data.totalPages);
+  }
 
   const handleStatusChange = (value: string) => {
     setStatusFilter(value as IssueStatus | "ALL");

--- a/apps/web/src/components/slate/pipeline-list.tsx
+++ b/apps/web/src/components/slate/pipeline-list.tsx
@@ -52,12 +52,10 @@ export function PipelineList() {
     limit: 20,
   });
 
-  // Clamp page when data shrinks
-  useEffect(() => {
-    if (data && data.totalPages > 0 && page > data.totalPages) {
-      setPage(data.totalPages);
-    }
-  }, [data, page]);
+  // Clamp page when data shrinks (render-time state adjustment)
+  if (data && data.totalPages > 0 && page > data.totalPages) {
+    setPage(data.totalPages);
+  }
 
   const handleStageChange = (value: string) => {
     setStageFilter(value as PipelineStage | "ALL");

--- a/apps/web/src/components/slate/publication-list.tsx
+++ b/apps/web/src/components/slate/publication-list.tsx
@@ -44,12 +44,10 @@ export function PublicationList() {
     limit: 20,
   });
 
-  // Clamp page when data shrinks (e.g. after archiving the last item on a page)
-  useEffect(() => {
-    if (data && data.totalPages > 0 && page > data.totalPages) {
-      setPage(data.totalPages);
-    }
-  }, [data, page]);
+  // Clamp page when data shrinks (render-time state adjustment)
+  if (data && data.totalPages > 0 && page > data.totalPages) {
+    setPage(data.totalPages);
+  }
 
   const utils = trpc.useUtils();
 

--- a/apps/web/src/components/submissions/__tests__/submission-form.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/submission-form.spec.tsx
@@ -9,7 +9,6 @@ jest.mock("@/components/ui/select", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const React = require("react");
   const SelectContext = React.createContext({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onValueChange: (_v: string) => {},
     value: undefined as string | undefined,
   });
@@ -30,8 +29,12 @@ jest.mock("@/components/ui/select", () => {
       </SelectContext.Provider>
     ),
     SelectTrigger: ({ children }: { children: React.ReactNode }) => (
-      // eslint-disable-next-line jsx-a11y/role-has-required-aria-props
-      <button type="button" role="combobox">
+      <button
+        type="button"
+        role="combobox"
+        aria-expanded="false"
+        aria-controls="mock-listbox"
+      >
         {children}
       </button>
     ),
@@ -52,6 +55,7 @@ jest.mock("@/components/ui/select", () => {
       return (
         <div
           role="option"
+          aria-selected={ctx.value === value}
           data-value={value}
           onClick={() => ctx.onValueChange(value)}
         >

--- a/apps/web/src/hooks/use-embed-upload-status.ts
+++ b/apps/web/src/hooks/use-embed-upload-status.ts
@@ -29,10 +29,12 @@ export function useEmbedUploadStatus({
 }: UseEmbedUploadStatusOptions) {
   const [files, setFiles] = useState<EmbedUploadStatusResponse["files"]>([]);
   const [allClean, setAllClean] = useState(false);
-  const [isPolling, setIsPolling] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollIntervalMs = useRef(BASE_POLL_INTERVAL);
+
+  // Derive polling state from whether the interval is active
+  const isPolling = enabled && !!manuscriptVersionId;
 
   useEffect(() => {
     if (!enabled || !manuscriptVersionId) {
@@ -40,7 +42,6 @@ export function useEmbedUploadStatus({
         clearInterval(intervalRef.current);
         intervalRef.current = null;
       }
-      setIsPolling(false);
       return;
     }
 
@@ -80,7 +81,6 @@ export function useEmbedUploadStatus({
             clearInterval(intervalRef.current);
             intervalRef.current = null;
           }
-          setIsPolling(false);
         }
       } catch (err) {
         if (cancelled) return;
@@ -104,7 +104,6 @@ export function useEmbedUploadStatus({
 
     // Set up interval
     intervalRef.current = setInterval(doPoll, pollIntervalMs.current);
-    setIsPolling(true);
 
     return () => {
       cancelled = true;
@@ -112,7 +111,6 @@ export function useEmbedUploadStatus({
         clearInterval(intervalRef.current);
         intervalRef.current = null;
       }
-      setIsPolling(false);
     };
   }, [enabled, manuscriptVersionId, apiUrl, token, email, uploadsInFlight]);
 

--- a/apps/web/src/hooks/use-embed-upload-status.ts
+++ b/apps/web/src/hooks/use-embed-upload-status.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { fetchUploadStatus, type EmbedApiError } from "@/lib/embed-api";
 import type { EmbedUploadStatusResponse } from "@colophony/types";
 
@@ -32,9 +32,6 @@ export function useEmbedUploadStatus({
   const [error, setError] = useState<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollIntervalMs = useRef(BASE_POLL_INTERVAL);
-
-  // Derive polling state from whether the interval is active
-  const isPolling = enabled && !!manuscriptVersionId;
 
   useEffect(() => {
     if (!enabled || !manuscriptVersionId) {
@@ -113,6 +110,14 @@ export function useEmbedUploadStatus({
       }
     };
   }, [enabled, manuscriptVersionId, apiUrl, token, email, uploadsInFlight]);
+
+  // Derive polling state: active when enabled with a version ID and files aren't all terminal
+  const isPolling = useMemo(() => {
+    if (!enabled || !manuscriptVersionId) return false;
+    if (files.length === 0) return true; // waiting for first poll result
+    const allTerminal = files.every((f) => isTerminalStatus(f.scanStatus));
+    return uploadsInFlight || !allTerminal;
+  }, [enabled, manuscriptVersionId, files, uploadsInFlight]);
 
   return { files, allClean, isPolling, error };
 }

--- a/apps/web/src/hooks/use-organization.ts
+++ b/apps/web/src/hooks/use-organization.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getCurrentOrgId, setCurrentOrgId, trpc } from "@/lib/trpc";
 import { useAuth } from "./use-auth";
 
@@ -38,29 +38,34 @@ export function useOrganization() {
   const currentOrg =
     organizations.find((org) => org.id === currentOrgId) ?? null;
 
-  // If no current org but user has orgs, select the first one
-  useEffect(() => {
-    if (isAuthenticated && organizations.length > 0 && !currentOrgId) {
-      const firstId = organizations[0].id;
-      setCurrentOrgId(firstId);
-      _setCurrentOrgId(firstId);
-    }
-  }, [isAuthenticated, organizations, currentOrgId]);
+  // Resolve org: auto-select first org or recover from stale org (render-time)
+  const needsAutoSelect =
+    isAuthenticated && organizations.length > 0 && !currentOrgId;
+  const isStaleOrg =
+    isAuthenticated &&
+    !!currentOrgId &&
+    organizations.length > 0 &&
+    !organizations.some((org) => org.id === currentOrgId);
 
-  // Clear stale org context — stored org ID doesn't match any known org
-  useEffect(() => {
-    if (isAuthenticated && currentOrgId && organizations.length > 0) {
-      const isKnown = organizations.some((org) => org.id === currentOrgId);
-      if (!isKnown) {
-        console.warn("Clearing stale org context:", currentOrgId);
-        const firstId = organizations[0].id;
-        setCurrentOrgId(firstId);
-        _setCurrentOrgId(firstId);
-        // Invalidate cached queries (may contain 403 errors from stale org)
-        utils.invalidate();
-      }
+  if (needsAutoSelect || isStaleOrg) {
+    if (isStaleOrg) {
+      console.warn("Clearing stale org context:", currentOrgId);
     }
-  }, [isAuthenticated, currentOrgId, organizations]);
+    const firstId = organizations[0].id;
+    setCurrentOrgId(firstId);
+    _setCurrentOrgId(firstId);
+  }
+
+  // Invalidate cached queries when org changes (stale recovery or manual switch)
+  const prevOrgIdRef = useRef(currentOrgId);
+  useEffect(() => {
+    const prev = prevOrgIdRef.current;
+    prevOrgIdRef.current = currentOrgId;
+    // Only invalidate when switching from one valid org to another (not initial select)
+    if (prev && prev !== currentOrgId) {
+      utils.invalidate();
+    }
+  }, [currentOrgId, utils]);
 
   // Switch organization
   const switchOrganization = useCallback(
@@ -73,11 +78,8 @@ export function useOrganization() {
 
       setCurrentOrgId(orgId);
       _setCurrentOrgId(orgId);
-
-      // Invalidate queries that depend on org context
-      utils.invalidate();
     },
-    [organizations, utils],
+    [organizations],
   );
 
   // Role checks

--- a/apps/web/src/hooks/use-organization.ts
+++ b/apps/web/src/hooks/use-organization.ts
@@ -39,6 +39,8 @@ export function useOrganization() {
     organizations.find((org) => org.id === currentOrgId) ?? null;
 
   // Resolve org: auto-select first org or recover from stale org (render-time)
+  // React state update during render is safe (React batches it into the current render).
+  // localStorage sync is deferred to an effect below.
   const needsAutoSelect =
     isAuthenticated && organizations.length > 0 && !currentOrgId;
   const isStaleOrg =
@@ -47,14 +49,24 @@ export function useOrganization() {
     organizations.length > 0 &&
     !organizations.some((org) => org.id === currentOrgId);
 
-  if (needsAutoSelect || isStaleOrg) {
-    if (isStaleOrg) {
-      console.warn("Clearing stale org context:", currentOrgId);
-    }
-    const firstId = organizations[0].id;
-    setCurrentOrgId(firstId);
-    _setCurrentOrgId(firstId);
+  const resolvedOrgId =
+    needsAutoSelect || isStaleOrg ? organizations[0].id : currentOrgId;
+  if (resolvedOrgId !== currentOrgId) {
+    _setCurrentOrgId(resolvedOrgId);
   }
+
+  // Sync localStorage after render (side effect)
+  useEffect(() => {
+    if (resolvedOrgId && resolvedOrgId !== getCurrentOrgId()) {
+      if (isStaleOrg) {
+        console.warn(
+          "Clearing stale org context, switching to:",
+          resolvedOrgId,
+        );
+      }
+      setCurrentOrgId(resolvedOrgId);
+    }
+  }, [resolvedOrgId, isStaleOrg]);
 
   // Invalidate cached queries when org changes (stale recovery or manual switch)
   const prevOrgIdRef = useRef(currentOrgId);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -262,6 +262,10 @@
 - [x] Plan override log for drift detection — during implementation, when discoveries require deliberate divergence from the plan, log overrides with rationale (file, what changed, why) in a structured format (e.g., task list metadata or a plan-overrides section in the PR). Drift detection reads the override log and excludes acknowledged divergences, only flagging unlogged drift — (dev workflow session 2026-02-20; done 2026-02-20)
 - [x] Automatic Codex branch review before PR — run `/codex-review branch` automatically after implementation is complete (all tasks done, tests passing) but before creating the PR; incorporate findings before presenting the PR for user review. Mirrors the plan review integration: user sees a Codex-vetted PR, not a raw first draft — (dev workflow session 2026-02-20; done 2026-02-20)
 
+### CI
+
+- [x] [P2] CI path filtering for Playwright suites — skip irrelevant E2E suites on PRs based on changed files; `.github/scripts/detect-changes.sh` with fail-open strategy — (DEVLOG 2026-02-24; done 2026-02-24)
+
 ### Dev Environment
 
 - [x] [P1] Add Overmind as process manager for dev servers — replaces `turbo run dev` for persistent server lifecycle (API + web); Turbo stays for build graph. Overmind manages tmux session so killing it kills entire process group — eliminates orphaned `tsx watch` / `next-server` / `postcss` processes that accumulate across sessions. Turbo's SIGINT forwarding is a known open issue (#9666, #9694). — (manual QA session 2026-02-21, found 60 orphaned processes; done 2026-02-21)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,24 @@ Newest entries first.
 
 ---
 
+## 2026-02-24 — CI Path Filtering for Playwright Suites
+
+### Done
+
+- Created `.github/scripts/detect-changes.sh` — classifies changed files into Playwright suite categories (submissions, embed, slate, uploads, oidc) with shared-path detection and fail-open for unknown paths
+- Updated `.github/workflows/ci.yml` — `changes` job now outputs per-suite boolean flags; each Playwright job checks its flag before running. Fast jobs (quality, unit-tests, rls-tests, build) always run
+- Renamed branch from `feat/register-discovery` to `chore/ci-path-filtering`
+- Reviewed and configured GitHub repo settings: enabled Dependabot alerts + security updates, secret scanning + push protection, squash-only merge, auto-merge
+- Verified main branch ruleset: bumped required approvals to 1, enabled dismiss stale reviews, CODEOWNERS review, conversation resolution
+
+### Decisions
+
+- Fail-open strategy: unknown file paths trigger all suites (false negatives preferred over false positives)
+- Playwright jobs not listed as required status checks — only quality, unit-tests, rls-tests, build are required (skipped jobs satisfy required checks, but cleaner to exclude them)
+- Keep required approvals at 1 despite senior dev being out — self-approval works, forces PR-view review pause
+
+---
+
 ## 2026-02-24 — Stale OIDC Token Recovery + Slate E2E Fix
 
 ### Done


### PR DESCRIPTION
## Summary

- Add `.github/scripts/detect-changes.sh` — classifies changed files into Playwright suite categories with shared-path detection and fail-open for unknown paths
- Update CI workflow to conditionally run each Playwright suite based on changed files
- Fast jobs (quality, unit-tests, rls-tests, build) always run on non-docs PRs
- Push to `main` always runs everything

## Additional changes

- Fix ESLint warnings across web and API (pre-existing from previous session)
- Add `post-edit-lint.js` Claude Code hook for automatic ESLint on save
- Address code review findings:
  - Move `layout.tsx`, `globals.css`, `tsconfig*` from non-suite to shared prefixes
  - Fix render-time localStorage mutation in `useOrganization`
  - Derive `isPolling` from file state in `useEmbedUploadStatus`

## Test plan

- [x] Verified script locally: suite-specific, shared path, push-to-main, fail-open, multi-suite, docs-only scenarios
- [ ] Verify GitHub Actions UI shows skipped Playwright jobs as "Skipped" (not failed)
- [ ] Verify required status checks (quality, unit-tests, rls-tests, build) still pass