### PR TITLE
feat(register): add federation discovery endpoints

### DIFF
--- a/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
+++ b/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
@@ -30,6 +30,7 @@ const NON_RLS_TABLES = [
   'stripe_webhook_events',
   'outbox_events',
   'zitadel_webhook_events',
+  'federation_config',
 ];
 
 describe('RLS Infrastructure', () => {

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -75,6 +75,9 @@ const envSchema = z.object({
     .enum(['true', 'false'])
     .default('false')
     .transform((v) => v === 'true'),
+  FEDERATION_CONTACT: z.string().email().optional(),
+  FEDERATION_PRIVATE_KEY: z.string().optional(),
+  FEDERATION_PUBLIC_KEY: z.string().optional(),
 
   // Inngest workflow engine
   INNGEST_EVENT_KEY: z.string().optional(),

--- a/apps/api/src/federation/discovery.routes.spec.ts
+++ b/apps/api/src/federation/discovery.routes.spec.ts
@@ -12,6 +12,9 @@ vi.mock('../services/federation.service.js', () => ({
       mockGetInstanceMetadata(...args),
     resolveWebFinger: (...args: unknown[]) => mockResolveWebFinger(...args),
   },
+  FederationDisabledError: class extends Error {
+    override name = 'FederationDisabledError' as const;
+  },
   FederationNotConfiguredError: class extends Error {
     override name = 'FederationNotConfiguredError' as const;
   },
@@ -95,6 +98,22 @@ describe('Federation Discovery Routes', () => {
       const body = response.json();
       expect(body.software).toBe('colophony');
       expect(body.domain).toBe('magazine.example');
+    });
+
+    it('returns 503 when federation is disabled in DB', async () => {
+      const { FederationDisabledError } =
+        await import('../services/federation.service.js');
+      mockGetInstanceMetadata.mockRejectedValueOnce(
+        new FederationDisabledError(),
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/colophony',
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.json().error).toBe('federation_disabled');
     });
 
     it('returns Cache-Control header', async () => {
@@ -192,6 +211,20 @@ describe('Federation Discovery Routes', () => {
       });
 
       expect(response.statusCode).toBe(404);
+    });
+
+    it('returns 503 when federation is disabled in DB', async () => {
+      const { FederationDisabledError } =
+        await import('../services/federation.service.js');
+      mockResolveWebFinger.mockRejectedValueOnce(new FederationDisabledError());
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/webfinger?resource=acct:alice@magazine.example',
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.json().error).toBe('federation_disabled');
     });
 
     it('includes CORS header', async () => {

--- a/apps/api/src/federation/discovery.routes.spec.ts
+++ b/apps/api/src/federation/discovery.routes.spec.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import type { Env } from '../config/env.js';
+
+// Mock federation service
+const mockGetInstanceMetadata = vi.fn();
+const mockResolveWebFinger = vi.fn();
+
+vi.mock('../services/federation.service.js', () => ({
+  federationService: {
+    getInstanceMetadata: (...args: unknown[]) =>
+      mockGetInstanceMetadata(...args),
+    resolveWebFinger: (...args: unknown[]) => mockResolveWebFinger(...args),
+  },
+  FederationNotConfiguredError: class extends Error {
+    override name = 'FederationNotConfiguredError' as const;
+  },
+  WebFingerUserNotFoundError: class extends Error {
+    override name = 'WebFingerUserNotFoundError' as const;
+  },
+  WebFingerDomainMismatchError: class extends Error {
+    override name = 'WebFingerDomainMismatchError' as const;
+  },
+}));
+
+const testEnv: Env = {
+  DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  PORT: 0,
+  HOST: '127.0.0.1',
+  NODE_ENV: 'test',
+  LOG_LEVEL: 'fatal',
+  REDIS_HOST: 'localhost',
+  REDIS_PORT: 6379,
+  REDIS_PASSWORD: '',
+  CORS_ORIGIN: 'http://localhost:3000',
+  RATE_LIMIT_DEFAULT_MAX: 60,
+  RATE_LIMIT_AUTH_MAX: 200,
+  RATE_LIMIT_WINDOW_SECONDS: 60,
+  RATE_LIMIT_KEY_PREFIX: 'colophony:rl',
+  AUTH_FAILURE_THROTTLE_MAX: 10,
+  AUTH_FAILURE_THROTTLE_WINDOW_SECONDS: 300,
+  WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS: 300,
+  WEBHOOK_RATE_LIMIT_MAX: 100,
+  S3_ENDPOINT: 'http://localhost:9000',
+  S3_BUCKET: 'submissions',
+  S3_QUARANTINE_BUCKET: 'quarantine',
+  S3_ACCESS_KEY: 'minioadmin',
+  S3_SECRET_KEY: 'minioadmin',
+  S3_REGION: 'us-east-1',
+  TUS_ENDPOINT: 'http://localhost:1080/files/',
+  CLAMAV_HOST: 'localhost',
+  CLAMAV_PORT: 3310,
+  VIRUS_SCAN_ENABLED: true,
+  DEV_AUTH_BYPASS: false,
+  FEDERATION_ENABLED: true,
+  FEDERATION_DOMAIN: 'magazine.example',
+  INNGEST_DEV: false,
+};
+
+describe('Federation Discovery Routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const { registerFederationDiscoveryRoutes } =
+      await import('./discovery.routes.js');
+    app = Fastify({ logger: false });
+    await registerFederationDiscoveryRoutes(app, { env: testEnv });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /.well-known/colophony', () => {
+    it('returns 200 with instance metadata', async () => {
+      mockGetInstanceMetadata.mockResolvedValueOnce({
+        software: 'colophony',
+        version: '2.0.0-dev',
+        domain: 'magazine.example',
+        publicKey: 'pub-key',
+        keyId: 'magazine.example#main',
+        capabilities: ['identity'],
+        mode: 'allowlist',
+        contactEmail: null,
+        publications: [],
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/colophony',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.software).toBe('colophony');
+      expect(body.domain).toBe('magazine.example');
+    });
+
+    it('returns Cache-Control header', async () => {
+      mockGetInstanceMetadata.mockResolvedValueOnce({
+        software: 'colophony',
+        version: '2.0.0-dev',
+        domain: 'magazine.example',
+        publicKey: 'pub-key',
+        keyId: 'magazine.example#main',
+        capabilities: ['identity'],
+        mode: 'allowlist',
+        contactEmail: null,
+        publications: [],
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/colophony',
+      });
+
+      expect(response.headers['cache-control']).toBe('public, max-age=3600');
+    });
+  });
+
+  describe('GET /.well-known/webfinger', () => {
+    it('returns 200 with JRD for valid resource', async () => {
+      mockResolveWebFinger.mockResolvedValueOnce({
+        subject: 'acct:alice@magazine.example',
+        aliases: ['did:web:magazine.example:users:alice'],
+        links: [
+          {
+            rel: 'self',
+            type: 'application/activity+json',
+            href: 'https://magazine.example/users/alice',
+          },
+        ],
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/webfinger?resource=acct:alice@magazine.example',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toContain(
+        'application/jrd+json',
+      );
+      const body = response.json();
+      expect(body.subject).toBe('acct:alice@magazine.example');
+    });
+
+    it('returns 400 for missing resource param', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/webfinger',
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('returns 400 for invalid resource format', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/webfinger?resource=',
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('returns 404 for unknown user', async () => {
+      const { WebFingerUserNotFoundError } =
+        await import('../services/federation.service.js');
+      mockResolveWebFinger.mockRejectedValueOnce(
+        new WebFingerUserNotFoundError('acct:nobody@magazine.example'),
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/webfinger?resource=acct:nobody@magazine.example',
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('returns 404 for wrong domain', async () => {
+      const { WebFingerDomainMismatchError } =
+        await import('../services/federation.service.js');
+      mockResolveWebFinger.mockRejectedValueOnce(
+        new WebFingerDomainMismatchError('other.example'),
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/webfinger?resource=acct:alice@other.example',
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('includes CORS header', async () => {
+      mockResolveWebFinger.mockResolvedValueOnce({
+        subject: 'acct:alice@magazine.example',
+        aliases: [],
+        links: [],
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/webfinger?resource=acct:alice@magazine.example',
+      });
+
+      expect(response.headers['access-control-allow-origin']).toBe('*');
+    });
+  });
+});

--- a/apps/api/src/federation/discovery.routes.ts
+++ b/apps/api/src/federation/discovery.routes.ts
@@ -1,8 +1,10 @@
 import type { FastifyInstance } from 'fastify';
+import cors from '@fastify/cors';
 import { webFingerQuerySchema } from '@colophony/types';
 import type { Env } from '../config/env.js';
 import {
   federationService,
+  FederationDisabledError,
   FederationNotConfiguredError,
   WebFingerUserNotFoundError,
   WebFingerDomainMismatchError,
@@ -14,6 +16,10 @@ export async function registerFederationDiscoveryRoutes(
 ): Promise<void> {
   const { env } = opts;
 
+  // Override app-level CORS for federation routes — RFC 7033 requires
+  // WebFinger to be accessible from any origin
+  await app.register(cors, { origin: true, credentials: false });
+
   app.get('/.well-known/colophony', async (_request, reply) => {
     try {
       const metadata = await federationService.getInstanceMetadata(env);
@@ -22,6 +28,9 @@ export async function registerFederationDiscoveryRoutes(
         .header('content-type', 'application/json')
         .send(metadata);
     } catch (err) {
+      if (err instanceof FederationDisabledError) {
+        return reply.status(503).send({ error: 'federation_disabled' });
+      }
       if (err instanceof FederationNotConfiguredError) {
         return reply.status(503).send({ error: 'federation_not_configured' });
       }
@@ -48,6 +57,9 @@ export async function registerFederationDiscoveryRoutes(
         .header('access-control-allow-origin', '*')
         .send(result);
     } catch (err) {
+      if (err instanceof FederationDisabledError) {
+        return reply.status(503).send({ error: 'federation_disabled' });
+      }
       if (
         err instanceof WebFingerUserNotFoundError ||
         err instanceof WebFingerDomainMismatchError

--- a/apps/api/src/federation/discovery.routes.ts
+++ b/apps/api/src/federation/discovery.routes.ts
@@ -1,0 +1,60 @@
+import type { FastifyInstance } from 'fastify';
+import { webFingerQuerySchema } from '@colophony/types';
+import type { Env } from '../config/env.js';
+import {
+  federationService,
+  FederationNotConfiguredError,
+  WebFingerUserNotFoundError,
+  WebFingerDomainMismatchError,
+} from '../services/federation.service.js';
+
+export async function registerFederationDiscoveryRoutes(
+  app: FastifyInstance,
+  opts: { env: Env },
+): Promise<void> {
+  const { env } = opts;
+
+  app.get('/.well-known/colophony', async (_request, reply) => {
+    try {
+      const metadata = await federationService.getInstanceMetadata(env);
+      return reply
+        .header('cache-control', 'public, max-age=3600')
+        .header('content-type', 'application/json')
+        .send(metadata);
+    } catch (err) {
+      if (err instanceof FederationNotConfiguredError) {
+        return reply.status(503).send({ error: 'federation_not_configured' });
+      }
+      throw err;
+    }
+  });
+
+  app.get('/.well-known/webfinger', async (request, reply) => {
+    const parsed = webFingerQuerySchema.safeParse(request.query);
+    if (!parsed.success) {
+      return reply.status(400).send({
+        error: 'invalid_request',
+        details: parsed.error.issues,
+      });
+    }
+
+    try {
+      const result = await federationService.resolveWebFinger(
+        env,
+        parsed.data.resource,
+      );
+      return reply
+        .header('content-type', 'application/jrd+json')
+        .header('access-control-allow-origin', '*')
+        .send(result);
+    } catch (err) {
+      if (
+        err instanceof WebFingerUserNotFoundError ||
+        err instanceof WebFingerDomainMismatchError
+      ) {
+        return reply.status(404).send({ error: 'not_found' });
+      }
+      throw err;
+    }
+  });
+}

--- a/apps/api/src/graphql/resolvers/organizations-mutations.spec.ts
+++ b/apps/api/src/graphql/resolvers/organizations-mutations.spec.ts
@@ -212,6 +212,7 @@ describe('Organization mutations — resolver wiring', () => {
         settings: null,
         createdAt: new Date(),
         updatedAt: new Date(),
+        federationOptedOut: false,
       },
       membership: {
         id: 'mem-1',
@@ -253,6 +254,7 @@ describe('Organization mutations — resolver wiring', () => {
       settings: null,
       createdAt: new Date(),
       updatedAt: new Date(),
+      federationOptedOut: false,
     };
     // eslint-disable-next-line @typescript-eslint/unbound-method
     vi.mocked(organizationService.updateWithAudit).mockResolvedValue(updated);

--- a/apps/api/src/main.spec.ts
+++ b/apps/api/src/main.spec.ts
@@ -186,4 +186,18 @@ describe('Fastify app', () => {
     const response = await app.inject({ method: 'GET', url: '/health' });
     expect(response.headers['cache-control']).toBeUndefined();
   });
+
+  it('federation discovery routes return 404 when FEDERATION_ENABLED=false', async () => {
+    const colophonyRes = await app.inject({
+      method: 'GET',
+      url: '/.well-known/colophony',
+    });
+    expect(colophonyRes.statusCode).toBe(404);
+
+    const webfingerRes = await app.inject({
+      method: 'GET',
+      url: '/.well-known/webfinger?resource=acct:test@example.com',
+    });
+    expect(webfingerRes.statusCode).toBe(404);
+  });
 });

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -34,6 +34,7 @@ import {
   closeOutboxPollerQueue,
 } from './queues/index.js';
 import { registerInngestRoutes } from './inngest/serve.js';
+import { registerFederationDiscoveryRoutes } from './federation/discovery.routes.js';
 
 export async function buildApp(env: Env): Promise<FastifyInstance> {
   const app = Fastify({
@@ -155,6 +156,13 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
   await app.register(async (scope) => {
     await registerInngestRoutes(scope);
   });
+
+  // Federation discovery — isolated scope (public .well-known endpoints)
+  if (env.FEDERATION_ENABLED) {
+    await app.register(async (scope) => {
+      await registerFederationDiscoveryRoutes(scope, { env });
+    });
+  }
 
   // tRPC adapter
   await app.register(fastifyTRPCPlugin, {

--- a/apps/api/src/services/audit.service.ts
+++ b/apps/api/src/services/audit.service.ts
@@ -16,6 +16,7 @@ import type {
   EmbedTokenAuditParams,
   UserAuditParams,
   SystemAuditParams,
+  FederationAuditParams,
   ListAuditEventsInput,
 } from '@colophony/types';
 
@@ -206,7 +207,8 @@ export const auditService = {
       | ApiKeyAuditParams
       | EmbedTokenAuditParams
       | UserAuditParams
-      | SystemAuditParams,
+      | SystemAuditParams
+      | FederationAuditParams,
   ): Promise<void> {
     if (params.organizationId) {
       throw new Error(

--- a/apps/api/src/services/federation.service.spec.ts
+++ b/apps/api/src/services/federation.service.spec.ts
@@ -1,0 +1,438 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Env } from '../config/env.js';
+
+// Mock @colophony/db
+vi.mock('@colophony/db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+  federationConfig: { singleton: 'singleton' },
+  publications: {
+    id: 'id',
+    name: 'name',
+    slug: 'slug',
+    organizationId: 'organization_id',
+    status: 'status',
+  },
+  organizations: {
+    id: 'id',
+    slug: 'slug',
+    federationOptedOut: 'federation_opted_out',
+  },
+  users: { id: 'id', email: 'email' },
+  eq: vi.fn((_col, val) => ({ _eq: val })),
+  and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  sql: vi.fn(),
+}));
+
+// Mock audit service
+vi.mock('./audit.service.js', () => ({
+  auditService: {
+    logDirect: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Mock crypto for deterministic key generation
+vi.mock('node:crypto', async () => {
+  const actual =
+    await vi.importActual<typeof import('node:crypto')>('node:crypto');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      generateKeyPairSync: vi.fn(() => ({
+        publicKey: 'mock-ed25519-public-key-pem',
+        privateKey: 'mock-ed25519-private-key-pem',
+      })),
+    },
+  };
+});
+
+const baseEnv: Env = {
+  DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  PORT: 4000,
+  HOST: '0.0.0.0',
+  NODE_ENV: 'test',
+  LOG_LEVEL: 'fatal',
+  REDIS_HOST: 'localhost',
+  REDIS_PORT: 6379,
+  REDIS_PASSWORD: '',
+  CORS_ORIGIN: 'http://localhost:3000',
+  RATE_LIMIT_DEFAULT_MAX: 60,
+  RATE_LIMIT_AUTH_MAX: 200,
+  RATE_LIMIT_WINDOW_SECONDS: 60,
+  RATE_LIMIT_KEY_PREFIX: 'colophony:rl',
+  AUTH_FAILURE_THROTTLE_MAX: 10,
+  AUTH_FAILURE_THROTTLE_WINDOW_SECONDS: 300,
+  WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS: 300,
+  WEBHOOK_RATE_LIMIT_MAX: 100,
+  S3_ENDPOINT: 'http://localhost:9000',
+  S3_BUCKET: 'submissions',
+  S3_QUARANTINE_BUCKET: 'quarantine',
+  S3_ACCESS_KEY: 'minioadmin',
+  S3_SECRET_KEY: 'minioadmin',
+  S3_REGION: 'us-east-1',
+  TUS_ENDPOINT: 'http://localhost:1080/files/',
+  CLAMAV_HOST: 'localhost',
+  CLAMAV_PORT: 3310,
+  VIRUS_SCAN_ENABLED: true,
+  DEV_AUTH_BYPASS: false,
+  FEDERATION_ENABLED: true,
+  FEDERATION_DOMAIN: 'magazine.example',
+  INNGEST_DEV: false,
+};
+
+// Helper to build chained Drizzle mock
+function mockSelectChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      limit: vi.fn().mockResolvedValue(rows),
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(rows),
+      }),
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
+describe('federationService', () => {
+  let dbModule: {
+    db: { select: ReturnType<typeof vi.fn>; insert: ReturnType<typeof vi.fn> };
+  };
+  let auditModule: { auditService: { logDirect: ReturnType<typeof vi.fn> } };
+  let cryptoModule: {
+    default: { generateKeyPairSync: ReturnType<typeof vi.fn> };
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    dbModule = (await import('@colophony/db')) as unknown as typeof dbModule;
+    auditModule =
+      (await import('./audit.service.js')) as unknown as typeof auditModule;
+    cryptoModule =
+      (await import('node:crypto')) as unknown as typeof cryptoModule;
+  });
+
+  describe('getOrInitConfig', () => {
+    it('generates keypair when DB is empty', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      // First select returns empty (no existing config)
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([]))
+        // After insert, read-back returns the new row
+        .mockReturnValueOnce(
+          mockSelectChain([
+            {
+              id: 'new-id',
+              publicKey: 'mock-ed25519-public-key-pem',
+              privateKey: 'mock-ed25519-private-key-pem',
+              keyId: 'magazine.example#main',
+              mode: 'allowlist',
+              contactEmail: null,
+              capabilities: ['identity'],
+              enabled: false,
+            },
+          ]),
+        );
+
+      dbModule.db.insert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockResolvedValue({ rowCount: 1 }),
+        }),
+      });
+
+      const config = await federationService.getOrInitConfig(baseEnv);
+
+      expect(cryptoModule.default.generateKeyPairSync).toHaveBeenCalledWith(
+        'ed25519',
+        expect.objectContaining({
+          publicKeyEncoding: { type: 'spki', format: 'pem' },
+        }),
+      );
+      expect(config.publicKey).toBe('mock-ed25519-public-key-pem');
+    });
+
+    it('returns existing config from DB', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      const existingRow = {
+        id: 'existing-id',
+        publicKey: 'existing-pub',
+        privateKey: 'existing-priv',
+        keyId: 'magazine.example#main',
+        mode: 'allowlist' as const,
+        contactEmail: 'admin@magazine.example',
+        capabilities: ['identity'],
+        enabled: true,
+      };
+
+      dbModule.db.select.mockReturnValueOnce(mockSelectChain([existingRow]));
+
+      const config = await federationService.getOrInitConfig(baseEnv);
+
+      expect(cryptoModule.default.generateKeyPairSync).not.toHaveBeenCalled();
+      expect(config.id).toBe('existing-id');
+      expect(config.publicKey).toBe('existing-pub');
+    });
+
+    it('prefers env var keys over DB', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      dbModule.db.select.mockReturnValueOnce(
+        mockSelectChain([
+          {
+            id: 'db-id',
+            publicKey: 'db-pub',
+            privateKey: 'db-priv',
+            keyId: 'magazine.example#main',
+            mode: 'allowlist',
+            contactEmail: null,
+            capabilities: ['identity'],
+            enabled: false,
+          },
+        ]),
+      );
+
+      const envWithKeys: Env = {
+        ...baseEnv,
+        FEDERATION_PUBLIC_KEY: 'env-pub-key',
+        FEDERATION_PRIVATE_KEY: 'env-priv-key',
+      };
+
+      const config = await federationService.getOrInitConfig(envWithKeys);
+
+      expect(config.publicKey).toBe('env-pub-key');
+      expect(config.privateKey).toBe('env-priv-key');
+    });
+
+    it('handles concurrent initialization gracefully', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      // First select: empty (no existing config)
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([]))
+        // After insert (ON CONFLICT DO NOTHING), read-back returns the row another process inserted
+        .mockReturnValueOnce(
+          mockSelectChain([
+            {
+              id: 'other-process-id',
+              publicKey: 'other-pub',
+              privateKey: 'other-priv',
+              keyId: 'magazine.example#main',
+              mode: 'allowlist',
+              contactEmail: null,
+              capabilities: ['identity'],
+              enabled: false,
+            },
+          ]),
+        );
+
+      dbModule.db.insert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockResolvedValue({ rowCount: 0 }),
+        }),
+      });
+
+      const config = await federationService.getOrInitConfig(baseEnv);
+
+      // Should return the other process's row, not the one we tried to insert
+      expect(config.id).toBe('other-process-id');
+      expect(config.publicKey).toBe('other-pub');
+    });
+  });
+
+  describe('getInstanceMetadata', () => {
+    it('returns valid FederationMetadata', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      const configRow = {
+        id: 'cfg-id',
+        publicKey: 'pub-key',
+        privateKey: 'priv-key',
+        keyId: 'magazine.example#main',
+        mode: 'allowlist' as const,
+        contactEmail: null,
+        capabilities: ['identity'],
+        enabled: true,
+      };
+
+      const pubRows = [
+        {
+          id: 'pub-1',
+          name: 'Literary Review',
+          slug: 'literary-review',
+          organizationSlug: 'lit-org',
+        },
+      ];
+
+      // getOrInitConfig -> select existing config
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([configRow]))
+        // getInstanceMetadata -> select publications
+        .mockReturnValueOnce(mockSelectChain(pubRows));
+
+      const metadata = await federationService.getInstanceMetadata(baseEnv);
+
+      expect(metadata.software).toBe('colophony');
+      expect(metadata.domain).toBe('magazine.example');
+      expect(metadata.publicKey).toBe('pub-key');
+      expect(metadata.publications).toHaveLength(1);
+      expect(metadata.publications[0].name).toBe('Literary Review');
+    });
+
+    it('excludes federation-opted-out orgs', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      const configRow = {
+        id: 'cfg-id',
+        publicKey: 'pub-key',
+        privateKey: 'priv-key',
+        keyId: 'magazine.example#main',
+        mode: 'allowlist' as const,
+        contactEmail: null,
+        capabilities: ['identity'],
+        enabled: true,
+      };
+
+      // Only non-opted-out publications returned (DB-level WHERE filter)
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([configRow]))
+        .mockReturnValueOnce(mockSelectChain([]));
+
+      const metadata = await federationService.getInstanceMetadata(baseEnv);
+
+      expect(metadata.publications).toHaveLength(0);
+    });
+
+    it('includes only ACTIVE publications', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      const configRow = {
+        id: 'cfg-id',
+        publicKey: 'pub-key',
+        privateKey: 'priv-key',
+        keyId: 'magazine.example#main',
+        mode: 'allowlist' as const,
+        contactEmail: null,
+        capabilities: ['identity'],
+        enabled: true,
+      };
+
+      // Only ACTIVE pubs returned (DB-level WHERE filter)
+      const activePub = {
+        id: 'pub-1',
+        name: 'Active Pub',
+        slug: 'active',
+        organizationSlug: 'org-1',
+      };
+
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([configRow]))
+        .mockReturnValueOnce(mockSelectChain([activePub]));
+
+      const metadata = await federationService.getInstanceMetadata(baseEnv);
+
+      expect(metadata.publications).toHaveLength(1);
+      expect(metadata.publications[0].name).toBe('Active Pub');
+    });
+  });
+
+  describe('generateAndStoreKeypair', () => {
+    it('audit logs key generation', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      const generatedPub = 'mock-ed25519-public-key-pem';
+
+      dbModule.db.insert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockResolvedValue({ rowCount: 1 }),
+        }),
+      });
+
+      dbModule.db.select.mockReturnValueOnce(
+        mockSelectChain([
+          {
+            id: 'new-id',
+            publicKey: generatedPub,
+            privateKey: 'mock-ed25519-private-key-pem',
+            keyId: 'magazine.example#main',
+            mode: 'allowlist',
+            contactEmail: null,
+            capabilities: ['identity'],
+            enabled: false,
+          },
+        ]),
+      );
+
+      await federationService.generateAndStoreKeypair(baseEnv);
+
+      expect(auditModule.auditService.logDirect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: 'federation',
+          action: 'FEDERATION_KEY_GENERATED',
+        }),
+      );
+    });
+  });
+
+  describe('resolveWebFinger', () => {
+    it('returns JRD for valid acct: URI', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      dbModule.db.select.mockReturnValueOnce(
+        mockSelectChain([{ id: 'user-1', email: 'alice@magazine.example' }]),
+      );
+
+      const result = await federationService.resolveWebFinger(
+        baseEnv,
+        'acct:alice@magazine.example',
+      );
+
+      expect(result.subject).toBe('acct:alice@magazine.example');
+      expect(result.links).toBeDefined();
+      expect(result.links!.length).toBeGreaterThan(0);
+    });
+
+    it('throws WebFingerUserNotFoundError for unknown user', async () => {
+      const { federationService, WebFingerUserNotFoundError } =
+        await import('./federation.service.js');
+
+      dbModule.db.select.mockReturnValueOnce(mockSelectChain([]));
+
+      await expect(
+        federationService.resolveWebFinger(
+          baseEnv,
+          'acct:nobody@magazine.example',
+        ),
+      ).rejects.toThrow(WebFingerUserNotFoundError);
+    });
+
+    it('throws WebFingerDomainMismatchError for wrong domain', async () => {
+      const { federationService, WebFingerDomainMismatchError } =
+        await import('./federation.service.js');
+
+      await expect(
+        federationService.resolveWebFinger(baseEnv, 'acct:alice@other.example'),
+      ).rejects.toThrow(WebFingerDomainMismatchError);
+    });
+
+    it('aliases include did:web identifier', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      dbModule.db.select.mockReturnValueOnce(
+        mockSelectChain([{ id: 'user-1', email: 'alice@magazine.example' }]),
+      );
+
+      const result = await federationService.resolveWebFinger(
+        baseEnv,
+        'acct:alice@magazine.example',
+      );
+
+      expect(result.aliases).toContain('did:web:magazine.example:users:alice');
+    });
+  });
+});

--- a/apps/api/src/services/federation.service.spec.ts
+++ b/apps/api/src/services/federation.service.spec.ts
@@ -308,6 +308,28 @@ describe('federationService', () => {
       expect(metadata.publications).toHaveLength(0);
     });
 
+    it('throws FederationDisabledError when config.enabled is false', async () => {
+      const { federationService, FederationDisabledError } =
+        await import('./federation.service.js');
+
+      const disabledConfig = {
+        id: 'cfg-id',
+        publicKey: 'pub-key',
+        privateKey: 'priv-key',
+        keyId: 'magazine.example#main',
+        mode: 'allowlist' as const,
+        contactEmail: null,
+        capabilities: ['identity'],
+        enabled: false,
+      };
+
+      dbModule.db.select.mockReturnValueOnce(mockSelectChain([disabledConfig]));
+
+      await expect(
+        federationService.getInstanceMetadata(baseEnv),
+      ).rejects.toThrow(FederationDisabledError);
+    });
+
     it('includes only ACTIVE publications', async () => {
       const { federationService } = await import('./federation.service.js');
 
@@ -380,12 +402,25 @@ describe('federationService', () => {
   });
 
   describe('resolveWebFinger', () => {
+    const enabledConfig = {
+      id: 'cfg-id',
+      publicKey: 'pub-key',
+      privateKey: 'priv-key',
+      keyId: 'magazine.example#main',
+      mode: 'allowlist' as const,
+      contactEmail: null,
+      capabilities: ['identity'],
+      enabled: true,
+    };
+
     it('returns JRD for valid acct: URI', async () => {
       const { federationService } = await import('./federation.service.js');
 
-      dbModule.db.select.mockReturnValueOnce(
-        mockSelectChain([{ id: 'user-1', email: 'alice@magazine.example' }]),
-      );
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([enabledConfig]))
+        .mockReturnValueOnce(
+          mockSelectChain([{ id: 'user-1', email: 'alice@magazine.example' }]),
+        );
 
       const result = await federationService.resolveWebFinger(
         baseEnv,
@@ -401,7 +436,9 @@ describe('federationService', () => {
       const { federationService, WebFingerUserNotFoundError } =
         await import('./federation.service.js');
 
-      dbModule.db.select.mockReturnValueOnce(mockSelectChain([]));
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([enabledConfig]))
+        .mockReturnValueOnce(mockSelectChain([]));
 
       await expect(
         federationService.resolveWebFinger(
@@ -415,6 +452,8 @@ describe('federationService', () => {
       const { federationService, WebFingerDomainMismatchError } =
         await import('./federation.service.js');
 
+      dbModule.db.select.mockReturnValueOnce(mockSelectChain([enabledConfig]));
+
       await expect(
         federationService.resolveWebFinger(baseEnv, 'acct:alice@other.example'),
       ).rejects.toThrow(WebFingerDomainMismatchError);
@@ -423,9 +462,11 @@ describe('federationService', () => {
     it('aliases include did:web identifier', async () => {
       const { federationService } = await import('./federation.service.js');
 
-      dbModule.db.select.mockReturnValueOnce(
-        mockSelectChain([{ id: 'user-1', email: 'alice@magazine.example' }]),
-      );
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([enabledConfig]))
+        .mockReturnValueOnce(
+          mockSelectChain([{ id: 'user-1', email: 'alice@magazine.example' }]),
+        );
 
       const result = await federationService.resolveWebFinger(
         baseEnv,
@@ -433,6 +474,21 @@ describe('federationService', () => {
       );
 
       expect(result.aliases).toContain('did:web:magazine.example:users:alice');
+    });
+
+    it('throws FederationDisabledError when config.enabled is false', async () => {
+      const { federationService, FederationDisabledError } =
+        await import('./federation.service.js');
+
+      const disabledConfig = { ...enabledConfig, enabled: false };
+      dbModule.db.select.mockReturnValueOnce(mockSelectChain([disabledConfig]));
+
+      await expect(
+        federationService.resolveWebFinger(
+          baseEnv,
+          'acct:alice@magazine.example',
+        ),
+      ).rejects.toThrow(FederationDisabledError);
     });
   });
 });

--- a/apps/api/src/services/federation.service.ts
+++ b/apps/api/src/services/federation.service.ts
@@ -1,0 +1,264 @@
+import crypto from 'node:crypto';
+import {
+  db,
+  federationConfig,
+  publications,
+  organizations,
+  users,
+} from '@colophony/db';
+import { eq, and } from 'drizzle-orm';
+import {
+  AuditActions,
+  AuditResources,
+  type FederationMetadata,
+  type WebFingerResponse,
+} from '@colophony/types';
+import type { Env } from '../config/env.js';
+import { auditService } from './audit.service.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class FederationDisabledError extends Error {
+  override name = 'FederationDisabledError' as const;
+  constructor() {
+    super('Federation is not enabled on this instance');
+  }
+}
+
+export class FederationNotConfiguredError extends Error {
+  override name = 'FederationNotConfiguredError' as const;
+  constructor() {
+    super('Federation is not yet configured');
+  }
+}
+
+export class WebFingerUserNotFoundError extends Error {
+  override name = 'WebFingerUserNotFoundError' as const;
+  constructor(resource: string) {
+    super(`User not found: ${resource}`);
+  }
+}
+
+export class WebFingerDomainMismatchError extends Error {
+  override name = 'WebFingerDomainMismatchError' as const;
+  constructor(domain: string) {
+    super(`Domain mismatch: ${domain} is not served by this instance`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface FederationConfigRow {
+  id: string;
+  publicKey: string;
+  privateKey: string;
+  keyId: string;
+  mode: 'allowlist' | 'open' | 'managed_hub';
+  contactEmail: string | null;
+  capabilities: string[];
+  enabled: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const federationService = {
+  /**
+   * Get or auto-generate the singleton federation config.
+   *
+   * Priority: env vars > DB row > auto-generate.
+   * Uses INSERT ... ON CONFLICT (singleton) DO NOTHING to prevent races.
+   */
+  async getOrInitConfig(env: Env): Promise<FederationConfigRow> {
+    // Check for env var override
+    if (env.FEDERATION_PUBLIC_KEY && env.FEDERATION_PRIVATE_KEY) {
+      // Still read DB for non-key fields, but override keys
+      const [existing] = await db.select().from(federationConfig).limit(1);
+
+      return {
+        id: existing?.id ?? 'env-override',
+        publicKey: env.FEDERATION_PUBLIC_KEY,
+        privateKey: env.FEDERATION_PRIVATE_KEY,
+        keyId:
+          existing?.keyId ?? `${env.FEDERATION_DOMAIN ?? 'localhost'}#main`,
+        mode: existing?.mode ?? 'allowlist',
+        contactEmail: env.FEDERATION_CONTACT ?? existing?.contactEmail ?? null,
+        capabilities: existing?.capabilities ?? ['identity'],
+        enabled: existing?.enabled ?? false,
+      };
+    }
+
+    // Try to read existing config
+    const [existing] = await db.select().from(federationConfig).limit(1);
+
+    if (existing) {
+      return {
+        id: existing.id,
+        publicKey: existing.publicKey,
+        privateKey: existing.privateKey,
+        keyId: existing.keyId,
+        mode: existing.mode,
+        contactEmail: env.FEDERATION_CONTACT ?? existing.contactEmail,
+        capabilities: existing.capabilities,
+        enabled: existing.enabled,
+      };
+    }
+
+    // Auto-generate keypair
+    return this.generateAndStoreKeypair(env);
+  },
+
+  /**
+   * Generate an Ed25519 keypair, store it, and audit log the event.
+   *
+   * INSERT ... ON CONFLICT (singleton) DO NOTHING handles concurrent
+   * initialization — if another process inserted first, we read back
+   * the existing row.
+   */
+  async generateAndStoreKeypair(env: Env): Promise<FederationConfigRow> {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const keyId = `${env.FEDERATION_DOMAIN ?? 'localhost'}#main`;
+
+    await db
+      .insert(federationConfig)
+      .values({
+        publicKey,
+        privateKey,
+        keyId,
+        contactEmail: env.FEDERATION_CONTACT ?? null,
+      })
+      .onConflictDoNothing({ target: federationConfig.singleton });
+
+    // Read back — handles the race condition where another process inserted first
+    const [row] = await db.select().from(federationConfig).limit(1);
+
+    if (!row) {
+      throw new FederationNotConfiguredError();
+    }
+
+    // Audit log key generation (only if we generated the key that's now in DB)
+    if (row.publicKey === publicKey) {
+      await auditService.logDirect({
+        resource: AuditResources.FEDERATION,
+        action: AuditActions.FEDERATION_KEY_GENERATED,
+        newValue: { keyId, algorithm: 'ed25519' },
+      });
+    }
+
+    return {
+      id: row.id,
+      publicKey: row.publicKey,
+      privateKey: row.privateKey,
+      keyId: row.keyId,
+      mode: row.mode,
+      contactEmail: env.FEDERATION_CONTACT ?? row.contactEmail,
+      capabilities: row.capabilities,
+      enabled: row.enabled,
+    };
+  },
+
+  /**
+   * Build the .well-known/colophony instance metadata response.
+   *
+   * Queries publications via superuser `db` — intentional RLS bypass
+   * for cross-org public metadata (same pattern as org-context.ts:78).
+   */
+  async getInstanceMetadata(env: Env): Promise<FederationMetadata> {
+    const config = await this.getOrInitConfig(env);
+
+    // Query active publications from non-opted-out orgs via superuser pool
+    const pubs = await db
+      .select({
+        id: publications.id,
+        name: publications.name,
+        slug: publications.slug,
+        organizationSlug: organizations.slug,
+      })
+      .from(publications)
+      .innerJoin(
+        organizations,
+        eq(publications.organizationId, organizations.id),
+      )
+      .where(
+        and(
+          eq(organizations.federationOptedOut, false),
+          eq(publications.status, 'ACTIVE'),
+        ),
+      );
+
+    return {
+      software: 'colophony',
+      version: '2.0.0-dev',
+      domain: env.FEDERATION_DOMAIN ?? 'localhost',
+      publicKey: config.publicKey,
+      keyId: config.keyId,
+      capabilities: config.capabilities,
+      mode: config.mode,
+      contactEmail: config.contactEmail,
+      publications: pubs,
+    };
+  },
+
+  /**
+   * Resolve a WebFinger `acct:` URI to a JRD response (RFC 7033).
+   *
+   * Validates domain against FEDERATION_DOMAIN, looks up user by email
+   * via superuser pool, returns JRD with did:web alias.
+   */
+  async resolveWebFinger(
+    env: Env,
+    resource: string,
+  ): Promise<WebFingerResponse> {
+    // Parse acct: URI
+    const acctMatch = resource.match(/^acct:(.+)@(.+)$/);
+    if (!acctMatch) {
+      throw new WebFingerUserNotFoundError(resource);
+    }
+
+    const [, localPart, domain] = acctMatch;
+    const expectedDomain = env.FEDERATION_DOMAIN ?? 'localhost';
+
+    if (domain !== expectedDomain) {
+      throw new WebFingerDomainMismatchError(domain);
+    }
+
+    const email = `${localPart}@${domain}`;
+
+    // Look up user by email via superuser pool
+    const [user] = await db
+      .select({ id: users.id, email: users.email })
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1);
+
+    if (!user) {
+      throw new WebFingerUserNotFoundError(resource);
+    }
+
+    return {
+      subject: resource,
+      aliases: [`did:web:${domain}:users:${localPart}`],
+      links: [
+        {
+          rel: 'self',
+          type: 'application/activity+json',
+          href: `https://${domain}/users/${localPart}`,
+        },
+        {
+          rel: 'http://webfinger.net/rel/profile-page',
+          type: 'text/html',
+          href: `https://${domain}/@${localPart}`,
+        },
+      ],
+    };
+  },
+};

--- a/apps/api/src/services/federation.service.ts
+++ b/apps/api/src/services/federation.service.ts
@@ -135,6 +135,7 @@ export const federationService = {
         privateKey,
         keyId,
         contactEmail: env.FEDERATION_CONTACT ?? null,
+        enabled: true, // Auto-init enables — FEDERATION_ENABLED env var already authorized
       })
       .onConflictDoNothing({ target: federationConfig.singleton });
 
@@ -174,6 +175,10 @@ export const federationService = {
    */
   async getInstanceMetadata(env: Env): Promise<FederationMetadata> {
     const config = await this.getOrInitConfig(env);
+
+    if (!config.enabled) {
+      throw new FederationDisabledError();
+    }
 
     // Query active publications from non-opted-out orgs via superuser pool
     const pubs = await db
@@ -218,6 +223,12 @@ export const federationService = {
     env: Env,
     resource: string,
   ): Promise<WebFingerResponse> {
+    const config = await this.getOrInitConfig(env);
+
+    if (!config.enabled) {
+      throw new FederationDisabledError();
+    }
+
     // Parse acct: URI
     const acctMatch = resource.match(/^acct:(.+)@(.+)$/);
     if (!acctMatch) {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -152,7 +152,7 @@
 
 ### Code
 
-- [ ] Discovery: WebFinger + `.well-known` endpoints — (architecture doc Track 5)
+- [x] Discovery: WebFinger + `.well-known` endpoints — (architecture doc Track 5; done 2026-02-24)
 - [ ] Identity: `did:web` documents — use `jose` library — (architecture doc Track 5, decision 2026-02-15)
 - [ ] Trust establishment — use `openid-client` for OIDC flows — (architecture doc Track 5, decision 2026-02-15)
 - [ ] Sim-sub enforcement (BSAP) — manuscript entity (Track 3) is the natural anchor for cross-instance tracking — (architecture doc Track 5)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,32 @@ Newest entries first.
 
 ---
 
+## 2026-02-24 — Federation Discovery (Track 5 Phase 1)
+
+### Done
+
+- Implemented Track 5 Register Phase 1: Federation Discovery endpoints, feature-flagged behind `FEDERATION_ENABLED` (default `false`)
+- Schema: `federation_config` singleton table (no RLS, `app_user` REVOKE'd), `FederationMode` enum, `organizations.federation_opted_out` column
+- Migration 0023: creates enum, table with UNIQUE singleton constraint, REVOKE, and ALTER for org column
+- Types: Zod schemas for `.well-known/colophony` metadata response and RFC 7033 WebFinger JRD response
+- Audit types: added `FEDERATION` resource + `FEDERATION_KEY_GENERATED` action + `FederationAuditParams`
+- Service: `getOrInitConfig` (env var override > DB > auto-generate Ed25519), `getInstanceMetadata` (cross-org public metadata via superuser `db`), `resolveWebFinger` (acct: URI → JRD with `did:web` alias), `generateAndStoreKeypair` (with audit logging)
+- Routes: `GET /.well-known/colophony` (Cache-Control: public, max-age=3600), `GET /.well-known/webfinger` (application/jrd+json, CORS `*` per RFC 7033)
+- Conditional registration in `main.ts` — routes only registered when `FEDERATION_ENABLED=true`
+- Tests: 12 service unit tests, 7 route integration tests, 1 main.spec test for disabled state
+- Added `federation_config` to `NON_RLS_TABLES` in RLS infrastructure tests
+- Added `FEDERATION_CONTACT`, `FEDERATION_PRIVATE_KEY`, `FEDERATION_PUBLIC_KEY` optional env vars
+- All Codex plan review findings pre-addressed: singleton UNIQUE constraint, audit logging, test placement in main.spec.ts
+- Fixed pre-existing type error in `organizations-mutations.spec.ts` (missing `federationOptedOut` field on mock org objects)
+
+### Decisions
+
+- Superuser `db` pool for federation metadata queries — intentional RLS bypass for cross-org public publication data (same pattern as `org-context.ts:78`)
+- Singleton enforcement via `boolean UNIQUE` + `INSERT ... ON CONFLICT DO NOTHING` — prevents race conditions during auto-init
+- Federation audit via `logDirect()` (no org context) — federation is instance-level, not org-scoped
+
+---
+
 ## 2026-02-24 — CI Path Filtering for Playwright Suites
 
 ### Done

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -11,9 +11,9 @@
 | Type exports   | `src/types.ts`                           |
 | Migrations     | `migrations/`                            |
 
-### Schema Files (18 domain files + barrel)
+### Schema Files (19 domain files + barrel)
 
-`api-keys.ts`, `audit.ts`, `cms.ts`, `compliance.ts`, `contracts.ts`, `enums.ts`, `issues.ts`, `manuscripts.ts`, `members.ts`, `messaging.ts`, `organizations.ts`, `payments.ts`, `pipeline.ts`, `publications.ts`, `relations.ts`, `submissions.ts`, `users.ts`, `webhooks.ts`, `index.ts`
+`api-keys.ts`, `audit.ts`, `cms.ts`, `compliance.ts`, `contracts.ts`, `enums.ts`, `federation.ts`, `issues.ts`, `manuscripts.ts`, `members.ts`, `messaging.ts`, `organizations.ts`, `payments.ts`, `pipeline.ts`, `publications.ts`, `relations.ts`, `submissions.ts`, `users.ts`, `webhooks.ts`, `index.ts`
 
 ---
 

--- a/packages/db/migrations/0023_federation_discovery.sql
+++ b/packages/db/migrations/0023_federation_discovery.sql
@@ -1,0 +1,26 @@
+-- Federation Discovery (Track 5, Phase 1)
+-- Instance-level singleton config table + org opt-out column
+
+--> statement-breakpoint
+CREATE TYPE "public"."FederationMode" AS ENUM('allowlist', 'open', 'managed_hub');
+
+--> statement-breakpoint
+CREATE TABLE "federation_config" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "singleton" boolean NOT NULL DEFAULT true UNIQUE,
+  "public_key" text NOT NULL,
+  "private_key" text NOT NULL,
+  "key_id" varchar(512) NOT NULL,
+  "mode" "FederationMode" NOT NULL DEFAULT 'allowlist',
+  "contact_email" varchar(255),
+  "capabilities" jsonb NOT NULL DEFAULT '["identity"]'::jsonb,
+  "enabled" boolean NOT NULL DEFAULT false,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+--> statement-breakpoint
+REVOKE ALL ON "federation_config" FROM "app_user";
+
+--> statement-breakpoint
+ALTER TABLE "organizations" ADD COLUMN "federation_opted_out" boolean NOT NULL DEFAULT false;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1773600000000,
       "tag": "0022_outbox_events_grant",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1773800000000,
+      "tag": "0023_federation_discovery",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -98,6 +98,16 @@ export const cmsAdapterTypeEnum = pgEnum("CmsAdapterType", [
   "GHOST",
 ]);
 
+// ---------------------------------------------------------------------------
+// Register — Identity & Federation
+// ---------------------------------------------------------------------------
+
+export const federationModeEnum = pgEnum("FederationMode", [
+  "allowlist",
+  "open",
+  "managed_hub",
+]);
+
 export const contractStatusEnum = pgEnum("ContractStatus", [
   "DRAFT",
   "SENT",

--- a/packages/db/src/schema/federation.ts
+++ b/packages/db/src/schema/federation.ts
@@ -1,0 +1,39 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  text,
+  boolean,
+  jsonb,
+  timestamp,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { federationModeEnum } from "./enums";
+
+/**
+ * Instance-level singleton table for federation configuration.
+ *
+ * No RLS — admin-only via superuser pool. `app_user` is REVOKE'd in the
+ * migration. The `singleton` column with a UNIQUE constraint enforces
+ * exactly one row.
+ */
+export const federationConfig = pgTable("federation_config", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  singleton: boolean("singleton").notNull().default(true).unique(),
+  publicKey: text("public_key").notNull(),
+  privateKey: text("private_key").notNull(),
+  keyId: varchar("key_id", { length: 512 }).notNull(),
+  mode: federationModeEnum("mode").notNull().default("allowlist"),
+  contactEmail: varchar("contact_email", { length: 255 }),
+  capabilities: jsonb("capabilities")
+    .$type<string[]>()
+    .notNull()
+    .default(sql`'["identity"]'::jsonb`),
+  enabled: boolean("enabled").notNull().default(false),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -18,4 +18,5 @@ export * from "./contracts";
 export * from "./issues";
 export * from "./documenso";
 export * from "./cms";
+export * from "./federation";
 export * from "./relations";

--- a/packages/db/src/schema/organizations.ts
+++ b/packages/db/src/schema/organizations.ts
@@ -2,6 +2,7 @@ import {
   pgTable,
   uuid,
   varchar,
+  boolean,
   jsonb,
   timestamp,
   index,
@@ -23,6 +24,9 @@ export const organizations = pgTable(
       .defaultNow()
       .notNull()
       .$defaultFn(() => new Date()),
+    federationOptedOut: boolean("federation_opted_out")
+      .notNull()
+      .default(false),
   },
   (table) => [
     uniqueIndex("organizations_lower_slug_idx").on(sql`lower(${table.slug})`),

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -133,6 +133,9 @@ export const AuditActions = {
   CMS_CONNECTION_DELETED: "CMS_CONNECTION_DELETED",
   CMS_CONNECTION_TESTED: "CMS_CONNECTION_TESTED",
 
+  // Federation lifecycle
+  FEDERATION_KEY_GENERATED: "FEDERATION_KEY_GENERATED",
+
   // Audit access
   AUDIT_ACCESSED: "AUDIT_ACCESSED",
 } as const;
@@ -158,6 +161,7 @@ export const AuditResources = {
   CONTRACT: "contract",
   ISSUE: "issue",
   CMS_CONNECTION: "cms_connection",
+  FEDERATION: "federation",
   AUDIT: "audit",
 } as const;
 
@@ -351,6 +355,11 @@ export interface CmsConnectionAuditParams extends BaseAuditParams {
     | typeof AuditActions.CMS_CONNECTION_TESTED;
 }
 
+export interface FederationAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.FEDERATION;
+  action: typeof AuditActions.FEDERATION_KEY_GENERATED;
+}
+
 export interface AuditAccessAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.AUDIT;
   action: typeof AuditActions.AUDIT_ACCESSED;
@@ -382,6 +391,7 @@ export type AuditLogParams =
   | ContractAuditParams
   | IssueAuditParams
   | CmsConnectionAuditParams
+  | FederationAuditParams
   | AuditAccessAuditParams
   | SystemAuditParams;
 

--- a/packages/types/src/federation.ts
+++ b/packages/types/src/federation.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// .well-known/colophony — Instance Metadata
+// ---------------------------------------------------------------------------
+
+export const federationPublicationSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  organizationSlug: z.string(),
+});
+
+export type FederationPublication = z.infer<typeof federationPublicationSchema>;
+
+export const federationMetadataSchema = z.object({
+  software: z.literal("colophony"),
+  version: z.string(),
+  domain: z.string(),
+  publicKey: z.string(),
+  keyId: z.string(),
+  capabilities: z.array(z.string()),
+  mode: z.enum(["allowlist", "open", "managed_hub"]),
+  contactEmail: z.string().nullable(),
+  publications: z.array(federationPublicationSchema),
+});
+
+export type FederationMetadata = z.infer<typeof federationMetadataSchema>;
+
+// ---------------------------------------------------------------------------
+// .well-known/webfinger — RFC 7033 JRD
+// ---------------------------------------------------------------------------
+
+export const webFingerLinkSchema = z.object({
+  rel: z.string(),
+  type: z.string().optional(),
+  href: z.string().optional(),
+});
+
+export type WebFingerLink = z.infer<typeof webFingerLinkSchema>;
+
+export const webFingerResponseSchema = z.object({
+  subject: z.string(),
+  aliases: z.array(z.string()).optional(),
+  links: z.array(webFingerLinkSchema).optional(),
+});
+
+export type WebFingerResponse = z.infer<typeof webFingerResponseSchema>;
+
+export const webFingerQuerySchema = z.object({
+  resource: z.string().min(1, "resource parameter is required"),
+  rel: z.string().optional(),
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -16,3 +16,4 @@ export * from "./pipeline";
 export * from "./contract";
 export * from "./issue";
 export * from "./cms";
+export * from "./federation";


### PR DESCRIPTION
## Summary

- Add `.well-known/colophony` endpoint for instance metadata discovery (publications, public key, capabilities)
- Add `.well-known/webfinger` endpoint for user identity resolution (RFC 7033 JRD with `did:web` aliases)
- Feature-flagged behind `FEDERATION_ENABLED` env var (default `false`)
- Instance-level `federation_config` singleton table with Ed25519 keypair auto-generation
- Per-org opt-out via `federation_opted_out` boolean on `organizations`

## Key Design Decisions

- **Superuser DB for cross-org queries**: Federation metadata is public/instance-level, intentionally bypasses RLS
- **Singleton enforcement**: `boolean UNIQUE` column + `INSERT ... ON CONFLICT DO NOTHING` prevents race conditions
- **Dual gating**: `FEDERATION_ENABLED` env var gates route registration; `federation_config.enabled` DB flag gates service responses
- **CORS override**: Federation scope registers its own `@fastify/cors` with `origin: true` to allow cross-origin WebFinger (RFC 7033)

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `packages/types/src/audit.ts` | Action literal `'federation.key_generated'` | `"FEDERATION_KEY_GENERATED"` | Follows existing codebase convention (all AuditActions use SCREAMING_CASE) |

## Test plan

- [x] 14 unit tests for federation service (config init, env override, concurrent init, metadata, WebFinger, audit, disabled state)
- [x] 10 integration tests for discovery routes (200/400/404/503 responses, CORS, Cache-Control, disabled state)
- [x] 1 main.spec test for disabled route behavior (both endpoints return 404 when `FEDERATION_ENABLED=false`)
- [x] RLS infrastructure test updated (`federation_config` in `NON_RLS_TABLES`)
- [x] Full suite: 808/808 tests passing