### PR TITLE
feat(register): add did:web DID document resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,27 +28,30 @@ Per-directory CLAUDE.md files contain domain-specific details:
 - **`apps/api/CLAUDE.md`** — Hook registration, tRPC procedures, auth, webhooks
 - **`apps/web/CLAUDE.md`** — tRPC client, providers, auth utilities, conventions
 
-| What                    | Path                                                                     |
-| ----------------------- | ------------------------------------------------------------------------ |
-| **Drizzle schema**      | `packages/db/src/schema/` (one file per table group)                     |
-| **Drizzle migrations**  | `packages/db/migrations/`                                                |
-| **Drizzle client**      | `packages/db/src/client.ts`                                              |
-| **RLS context**         | `packages/db/src/context.ts` (`withRls()`)                               |
-| **Shared Zod schemas**  | `packages/types/src/`                                                    |
-| **Zitadel auth client** | `packages/auth-client/src/`                                              |
-| **Fastify app entry**   | `apps/api/src/main.ts`                                                   |
-| **Fastify hooks**       | `apps/api/src/hooks/` (auth, rate-limit, org-context, db-context, audit) |
-| **Service layer**       | `apps/api/src/services/`                                                 |
-| **tRPC (internal)**     | `apps/api/src/trpc/`                                                     |
-| **Zitadel webhook**     | `apps/api/src/webhooks/zitadel.webhook.ts`                               |
-| **Stripe webhook**      | `apps/api/src/webhooks/stripe.webhook.ts`                                |
-| **Documenso webhook**   | `apps/api/src/webhooks/documenso.webhook.ts`                             |
-| **Inngest functions**   | `apps/api/src/inngest/`                                                  |
-| **CMS adapters**        | `apps/api/src/adapters/cms/`                                             |
-| **Next.js frontend**    | `apps/web/`                                                              |
-| **tRPC client**         | `apps/web/src/lib/trpc.ts`                                               |
-| **Env config (Zod)**    | `apps/api/src/config/env.ts`                                             |
-| **Backlog**             | `docs/backlog.md` (track-organized, drives session focus)                |
+| What                     | Path                                                                     |
+| ------------------------ | ------------------------------------------------------------------------ |
+| **Drizzle schema**       | `packages/db/src/schema/` (one file per table group)                     |
+| **Drizzle migrations**   | `packages/db/migrations/`                                                |
+| **Drizzle client**       | `packages/db/src/client.ts`                                              |
+| **RLS context**          | `packages/db/src/context.ts` (`withRls()`)                               |
+| **Shared Zod schemas**   | `packages/types/src/`                                                    |
+| **Zitadel auth client**  | `packages/auth-client/src/`                                              |
+| **Fastify app entry**    | `apps/api/src/main.ts`                                                   |
+| **Fastify hooks**        | `apps/api/src/hooks/` (auth, rate-limit, org-context, db-context, audit) |
+| **Service layer**        | `apps/api/src/services/`                                                 |
+| **tRPC (internal)**      | `apps/api/src/trpc/`                                                     |
+| **Zitadel webhook**      | `apps/api/src/webhooks/zitadel.webhook.ts`                               |
+| **Stripe webhook**       | `apps/api/src/webhooks/stripe.webhook.ts`                                |
+| **Documenso webhook**    | `apps/api/src/webhooks/documenso.webhook.ts`                             |
+| **Inngest functions**    | `apps/api/src/inngest/`                                                  |
+| **CMS adapters**         | `apps/api/src/adapters/cms/`                                             |
+| **Federation discovery** | `apps/api/src/federation/discovery.routes.ts`                            |
+| **Federation DID**       | `apps/api/src/federation/did.routes.ts`                                  |
+| **Federation service**   | `apps/api/src/services/federation.service.ts`                            |
+| **Next.js frontend**     | `apps/web/`                                                              |
+| **tRPC client**          | `apps/web/src/lib/trpc.ts`                                               |
+| **Env config (Zod)**     | `apps/api/src/config/env.ts`                                             |
+| **Backlog**              | `docs/backlog.md` (track-organized, drives session focus)                |
 
 Full project structure: [docs/architecture-v2-planning.md](docs/architecture-v2-planning.md)
 
@@ -392,7 +395,7 @@ See [docs/architecture-v2-planning.md Section 6](docs/architecture-v2-planning.m
 | 2     | Colophony API (REST, GraphQL, tRPC, SDKs)                | 3-8    | Pending         |
 | 3     | Hopper — Submission Management                           | 5-12   | Pending         |
 | 4     | Slate — Publication Pipeline                             | 8-15   | Pending         |
-| 5     | Register — Identity & Federation                         | 10-18  | Pending         |
+| 5     | Register — Identity & Federation                         | 10-18  | **In progress** |
 | 6     | Colophony Plugins                                        | 14-20  | Pending         |
 | —     | Relay — Notifications (cross-cutting)                    | 1-20   | Pending         |
 

--- a/apps/api/src/federation/did.routes.spec.ts
+++ b/apps/api/src/federation/did.routes.spec.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import type { Env } from '../config/env.js';
+
+// Mock federation service
+const mockGetInstanceDidDocument = vi.fn();
+const mockGetUserDidDocument = vi.fn();
+
+vi.mock('../services/federation.service.js', () => ({
+  federationService: {
+    getInstanceDidDocument: (...args: unknown[]) =>
+      mockGetInstanceDidDocument(...args),
+    getUserDidDocument: (...args: unknown[]) => mockGetUserDidDocument(...args),
+  },
+  FederationDisabledError: class extends Error {
+    override name = 'FederationDisabledError' as const;
+  },
+  FederationNotConfiguredError: class extends Error {
+    override name = 'FederationNotConfiguredError' as const;
+  },
+  UserDidNotFoundError: class extends Error {
+    override name = 'UserDidNotFoundError' as const;
+  },
+}));
+
+const testEnv: Env = {
+  DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  PORT: 0,
+  HOST: '127.0.0.1',
+  NODE_ENV: 'test',
+  LOG_LEVEL: 'fatal',
+  REDIS_HOST: 'localhost',
+  REDIS_PORT: 6379,
+  REDIS_PASSWORD: '',
+  CORS_ORIGIN: 'http://localhost:3000',
+  RATE_LIMIT_DEFAULT_MAX: 60,
+  RATE_LIMIT_AUTH_MAX: 200,
+  RATE_LIMIT_WINDOW_SECONDS: 60,
+  RATE_LIMIT_KEY_PREFIX: 'colophony:rl',
+  AUTH_FAILURE_THROTTLE_MAX: 10,
+  AUTH_FAILURE_THROTTLE_WINDOW_SECONDS: 300,
+  WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS: 300,
+  WEBHOOK_RATE_LIMIT_MAX: 100,
+  S3_ENDPOINT: 'http://localhost:9000',
+  S3_BUCKET: 'submissions',
+  S3_QUARANTINE_BUCKET: 'quarantine',
+  S3_ACCESS_KEY: 'minioadmin',
+  S3_SECRET_KEY: 'minioadmin',
+  S3_REGION: 'us-east-1',
+  TUS_ENDPOINT: 'http://localhost:1080/files/',
+  CLAMAV_HOST: 'localhost',
+  CLAMAV_PORT: 3310,
+  VIRUS_SCAN_ENABLED: true,
+  DEV_AUTH_BYPASS: false,
+  FEDERATION_ENABLED: true,
+  FEDERATION_DOMAIN: 'magazine.example',
+  INNGEST_DEV: false,
+};
+
+const sampleInstanceDoc = {
+  '@context': [
+    'https://www.w3.org/ns/did/v1',
+    'https://w3id.org/security/suites/jws-2020/v1',
+  ],
+  id: 'did:web:magazine.example',
+  verificationMethod: [
+    {
+      id: 'did:web:magazine.example#main',
+      type: 'JsonWebKey2020',
+      controller: 'did:web:magazine.example',
+      publicKeyJwk: { kty: 'OKP', crv: 'Ed25519', x: 'test-x-value' },
+    },
+  ],
+  authentication: ['did:web:magazine.example#main'],
+  assertionMethod: ['did:web:magazine.example#main'],
+  service: [
+    {
+      id: 'did:web:magazine.example#federation',
+      type: 'ColophonyFederation',
+      serviceEndpoint: 'https://magazine.example/.well-known/colophony',
+    },
+  ],
+};
+
+const sampleUserDoc = {
+  '@context': [
+    'https://www.w3.org/ns/did/v1',
+    'https://w3id.org/security/suites/jws-2020/v1',
+  ],
+  id: 'did:web:magazine.example:users:alice',
+  verificationMethod: [
+    {
+      id: 'did:web:magazine.example:users:alice#key-1',
+      type: 'JsonWebKey2020',
+      controller: 'did:web:magazine.example:users:alice',
+      publicKeyJwk: { kty: 'OKP', crv: 'Ed25519', x: 'user-x-value' },
+    },
+  ],
+  authentication: ['did:web:magazine.example:users:alice#key-1'],
+  assertionMethod: ['did:web:magazine.example:users:alice#key-1'],
+  service: [
+    {
+      id: 'did:web:magazine.example:users:alice#submitter',
+      type: 'ColophonySubmitter',
+      serviceEndpoint: 'https://magazine.example/users/alice',
+    },
+  ],
+};
+
+describe('Federation DID Routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const { registerFederationDidRoutes } = await import('./did.routes.js');
+    app = Fastify({ logger: false });
+    await registerFederationDidRoutes(app, { env: testEnv });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /.well-known/did.json', () => {
+    it('returns 200 with valid instance DID document', async () => {
+      mockGetInstanceDidDocument.mockResolvedValueOnce(sampleInstanceDoc);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/did.json',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body['@context']).toContain('https://www.w3.org/ns/did/v1');
+      expect(body.id).toBe('did:web:magazine.example');
+      expect(body.verificationMethod[0].type).toBe('JsonWebKey2020');
+    });
+
+    it('instance DID has Cache-Control max-age=3600', async () => {
+      mockGetInstanceDidDocument.mockResolvedValueOnce(sampleInstanceDoc);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/did.json',
+      });
+
+      expect(response.headers['cache-control']).toBe('public, max-age=3600');
+    });
+
+    it('instance DID returns 503 when federation disabled', async () => {
+      const { FederationDisabledError } =
+        await import('../services/federation.service.js');
+      mockGetInstanceDidDocument.mockRejectedValueOnce(
+        new FederationDisabledError(),
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/did.json',
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.json().error).toBe('federation_unavailable');
+    });
+
+    it('instance DID returns 503 when federation not configured', async () => {
+      const { FederationNotConfiguredError } =
+        await import('../services/federation.service.js');
+      mockGetInstanceDidDocument.mockRejectedValueOnce(
+        new FederationNotConfiguredError(),
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/did.json',
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.json().error).toBe('federation_unavailable');
+    });
+
+    it('instance DID includes CORS headers', async () => {
+      mockGetInstanceDidDocument.mockResolvedValueOnce(sampleInstanceDoc);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/did.json',
+        headers: { origin: 'https://other.example' },
+      });
+
+      expect(response.headers['access-control-allow-origin']).toBe(
+        'https://other.example',
+      );
+    });
+  });
+
+  describe('GET /users/:localPart/did.json', () => {
+    it('returns 200 with valid user DID document', async () => {
+      mockGetUserDidDocument.mockResolvedValueOnce(sampleUserDoc);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/users/alice/did.json',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.id).toBe('did:web:magazine.example:users:alice');
+      expect(body.verificationMethod[0].publicKeyJwk.kty).toBe('OKP');
+      expect(body.service[0].type).toBe('ColophonySubmitter');
+    });
+
+    it('user DID has Cache-Control max-age=300', async () => {
+      mockGetUserDidDocument.mockResolvedValueOnce(sampleUserDoc);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/users/alice/did.json',
+      });
+
+      expect(response.headers['cache-control']).toBe('public, max-age=300');
+    });
+
+    it('user DID returns 404 for unknown user', async () => {
+      const { UserDidNotFoundError } =
+        await import('../services/federation.service.js');
+      mockGetUserDidDocument.mockRejectedValueOnce(
+        new UserDidNotFoundError('nobody'),
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/users/nobody/did.json',
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json().error).toBe('not_found');
+    });
+
+    it('user DID returns 503 when federation disabled', async () => {
+      const { FederationDisabledError } =
+        await import('../services/federation.service.js');
+      mockGetUserDidDocument.mockRejectedValueOnce(
+        new FederationDisabledError(),
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/users/alice/did.json',
+      });
+
+      expect(response.statusCode).toBe(503);
+    });
+
+    it('sanitizes localPart parameter', async () => {
+      const callsBefore = mockGetUserDidDocument.mock.calls.length;
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/users/..%2F..%2Fetc/did.json',
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toBe('invalid_local_part');
+      // No new calls to getUserDidDocument after this request
+      expect(mockGetUserDidDocument.mock.calls.length).toBe(callsBefore);
+    });
+  });
+});

--- a/apps/api/src/federation/did.routes.ts
+++ b/apps/api/src/federation/did.routes.ts
@@ -1,0 +1,67 @@
+import type { FastifyInstance } from 'fastify';
+import cors from '@fastify/cors';
+import type { Env } from '../config/env.js';
+import {
+  federationService,
+  FederationDisabledError,
+  FederationNotConfiguredError,
+  UserDidNotFoundError,
+} from '../services/federation.service.js';
+
+export async function registerFederationDidRoutes(
+  app: FastifyInstance,
+  opts: { env: Env },
+): Promise<void> {
+  const { env } = opts;
+
+  // Permissive CORS — DID documents must be accessible from any origin
+  await app.register(cors, { origin: true, credentials: false });
+
+  // Instance DID document: did:web:<domain> → GET /.well-known/did.json
+  app.get('/.well-known/did.json', async (_request, reply) => {
+    try {
+      const doc = await federationService.getInstanceDidDocument(env);
+      return reply
+        .header('content-type', 'application/did+json')
+        .header('cache-control', 'public, max-age=3600')
+        .send(doc);
+    } catch (err) {
+      if (
+        err instanceof FederationDisabledError ||
+        err instanceof FederationNotConfiguredError
+      ) {
+        return reply.status(503).send({ error: 'federation_unavailable' });
+      }
+      throw err;
+    }
+  });
+
+  // User DID document: did:web:<domain>:users:<localPart> → GET /users/:localPart/did.json
+  app.get('/users/:localPart/did.json', async (request, reply) => {
+    const { localPart } = request.params as { localPart: string };
+
+    // Sanitize: only allow alphanumeric, dots, hyphens, underscores
+    if (!/^[\w.+-]+$/.test(localPart)) {
+      return reply.status(400).send({ error: 'invalid_local_part' });
+    }
+
+    try {
+      const doc = await federationService.getUserDidDocument(env, localPart);
+      return reply
+        .header('content-type', 'application/did+json')
+        .header('cache-control', 'public, max-age=300')
+        .send(doc);
+    } catch (err) {
+      if (
+        err instanceof FederationDisabledError ||
+        err instanceof FederationNotConfiguredError
+      ) {
+        return reply.status(503).send({ error: 'federation_unavailable' });
+      }
+      if (err instanceof UserDidNotFoundError) {
+        return reply.status(404).send({ error: 'not_found' });
+      }
+      throw err;
+    }
+  });
+}

--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -194,6 +194,32 @@ describe('auth plugin', () => {
       expect(response.statusCode).toBe(404);
     });
 
+    it('skips auth for /.well-known/did.json', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/did.json',
+      });
+      // 404 because no route registered, but auth hook didn't block
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('skips auth for /users/alice/did.json', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/users/alice/did.json',
+      });
+      // 404 because no route registered, but auth hook didn't block
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('does not skip auth for /users/alice/profile', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/users/alice/profile',
+      });
+      expect(response.statusCode).toBe(401);
+    });
+
     it('skips auth for /trpc/health', async () => {
       const response = await app.inject({
         method: 'GET',

--- a/apps/api/src/hooks/auth.ts
+++ b/apps/api/src/hooks/auth.ts
@@ -47,7 +47,10 @@ const PUBLIC_EXACT = [
 function isPublicRoute(url: string): boolean {
   const path = url.split('?')[0].replace(/\/+$/, '') || '/';
   if (PUBLIC_EXACT.includes(path)) return true;
-  return PUBLIC_PREFIXES.some((prefix) => path.startsWith(prefix));
+  if (PUBLIC_PREFIXES.some((prefix) => path.startsWith(prefix))) return true;
+  // DID document endpoints (did:web resolution)
+  if (path.endsWith('/did.json')) return true;
+  return false;
 }
 
 export interface AuthPluginOptions {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -35,6 +35,7 @@ import {
 } from './queues/index.js';
 import { registerInngestRoutes } from './inngest/serve.js';
 import { registerFederationDiscoveryRoutes } from './federation/discovery.routes.js';
+import { registerFederationDidRoutes } from './federation/did.routes.js';
 
 export async function buildApp(env: Env): Promise<FastifyInstance> {
   const app = Fastify({
@@ -157,10 +158,13 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
     await registerInngestRoutes(scope);
   });
 
-  // Federation discovery — isolated scope (public .well-known endpoints)
+  // Federation — isolated scopes (public endpoints)
   if (env.FEDERATION_ENABLED) {
     await app.register(async (scope) => {
       await registerFederationDiscoveryRoutes(scope, { env });
+    });
+    await app.register(async (scope) => {
+      await registerFederationDidRoutes(scope, { env });
     });
   }
 

--- a/apps/api/src/services/federation.service.spec.ts
+++ b/apps/api/src/services/federation.service.spec.ts
@@ -671,6 +671,7 @@ describe('federationService', () => {
       const result = await federationService.getOrCreateUserKeypair(
         'user-1',
         'magazine.example',
+        'alice',
       );
 
       expect(result.publicKey).toBe('other-process-pub-key');

--- a/apps/api/src/services/federation.service.spec.ts
+++ b/apps/api/src/services/federation.service.spec.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Env } from '../config/env.js';
 
+// Generate real keypair at module level using vi.hoisted to run before mocks
+const { testKeypairHoisted } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const c = require('node:crypto') as typeof import('node:crypto');
+  const kp = c.generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+  return { testKeypairHoisted: kp };
+});
+
 // Mock @colophony/db
 vi.mock('@colophony/db', () => ({
   db: {
@@ -20,9 +31,20 @@ vi.mock('@colophony/db', () => ({
     slug: 'slug',
     federationOptedOut: 'federation_opted_out',
   },
-  users: { id: 'id', email: 'email' },
+  users: {
+    id: 'id',
+    email: 'email',
+    deletedAt: 'deleted_at',
+    isGuest: 'is_guest',
+  },
+  userKeys: {
+    publicKey: 'public_key',
+    keyId: 'key_id',
+    userId: 'user_id',
+  },
   eq: vi.fn((_col, val) => ({ _eq: val })),
   and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  isNull: vi.fn((col) => ({ _isNull: col })),
   sql: vi.fn(),
 }));
 
@@ -42,9 +64,10 @@ vi.mock('node:crypto', async () => {
     default: {
       ...actual,
       generateKeyPairSync: vi.fn(() => ({
-        publicKey: 'mock-ed25519-public-key-pem',
-        privateKey: 'mock-ed25519-private-key-pem',
+        publicKey: testKeypairHoisted.publicKey,
+        privateKey: testKeypairHoisted.privateKey,
       })),
+      createPublicKey: actual.createPublicKey,
     },
   };
 });
@@ -98,6 +121,9 @@ function mockSelectChain(rows: unknown[]) {
   };
 }
 
+// Alias for readability in test data
+const testKeypair = testKeypairHoisted;
+
 describe('federationService', () => {
   let dbModule: {
     db: { select: ReturnType<typeof vi.fn>; insert: ReturnType<typeof vi.fn> };
@@ -128,8 +154,8 @@ describe('federationService', () => {
           mockSelectChain([
             {
               id: 'new-id',
-              publicKey: 'mock-ed25519-public-key-pem',
-              privateKey: 'mock-ed25519-private-key-pem',
+              publicKey: testKeypair.publicKey,
+              privateKey: testKeypair.privateKey,
               keyId: 'magazine.example#main',
               mode: 'allowlist',
               contactEmail: null,
@@ -153,7 +179,7 @@ describe('federationService', () => {
           publicKeyEncoding: { type: 'spki', format: 'pem' },
         }),
       );
-      expect(config.publicKey).toBe('mock-ed25519-public-key-pem');
+      expect(config.publicKey).toBe(testKeypair.publicKey);
     });
 
     it('returns existing config from DB', async () => {
@@ -367,7 +393,7 @@ describe('federationService', () => {
     it('audit logs key generation', async () => {
       const { federationService } = await import('./federation.service.js');
 
-      const generatedPub = 'mock-ed25519-public-key-pem';
+      const generatedPub = testKeypair.publicKey;
 
       dbModule.db.insert.mockReturnValue({
         values: vi.fn().mockReturnValue({
@@ -380,7 +406,7 @@ describe('federationService', () => {
           {
             id: 'new-id',
             publicKey: generatedPub,
-            privateKey: 'mock-ed25519-private-key-pem',
+            privateKey: testKeypair.privateKey,
             keyId: 'magazine.example#main',
             mode: 'allowlist',
             contactEmail: null,
@@ -489,6 +515,306 @@ describe('federationService', () => {
           'acct:alice@magazine.example',
         ),
       ).rejects.toThrow(FederationDisabledError);
+    });
+  });
+
+  describe('getInstanceDidDocument', () => {
+    it('returns valid DID document with JWK', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      const configRow = {
+        id: 'cfg-id',
+        publicKey: testKeypair.publicKey,
+        privateKey: testKeypair.privateKey,
+        keyId: 'magazine.example#main',
+        mode: 'allowlist' as const,
+        contactEmail: null,
+        capabilities: ['identity'],
+        enabled: true,
+      };
+
+      dbModule.db.select.mockReturnValueOnce(mockSelectChain([configRow]));
+
+      const doc = await federationService.getInstanceDidDocument(baseEnv);
+
+      expect(doc['@context']).toContain('https://www.w3.org/ns/did/v1');
+      expect(doc.id).toBe('did:web:magazine.example');
+      expect(doc.verificationMethod[0].type).toBe('JsonWebKey2020');
+      expect(doc.verificationMethod[0].publicKeyJwk.kty).toBe('OKP');
+      expect(doc.verificationMethod[0].publicKeyJwk.crv).toBe('Ed25519');
+      expect(doc.verificationMethod[0].publicKeyJwk.x).toBeTruthy();
+      expect(doc.authentication).toContain('did:web:magazine.example#main');
+      expect(doc.service![0].type).toBe('ColophonyFederation');
+    });
+
+    it('throws FederationDisabledError when not enabled', async () => {
+      const { federationService, FederationDisabledError } =
+        await import('./federation.service.js');
+
+      const disabledConfig = {
+        id: 'cfg-id',
+        publicKey: testKeypair.publicKey,
+        privateKey: testKeypair.privateKey,
+        keyId: 'magazine.example#main',
+        mode: 'allowlist' as const,
+        contactEmail: null,
+        capabilities: ['identity'],
+        enabled: false,
+      };
+
+      dbModule.db.select.mockReturnValueOnce(mockSelectChain([disabledConfig]));
+
+      await expect(
+        federationService.getInstanceDidDocument(baseEnv),
+      ).rejects.toThrow(FederationDisabledError);
+    });
+  });
+
+  describe('getUserDidDocument', () => {
+    const enabledConfig = {
+      id: 'cfg-id',
+      publicKey: testKeypair.publicKey,
+      privateKey: testKeypair.privateKey,
+      keyId: 'magazine.example#main',
+      mode: 'allowlist' as const,
+      contactEmail: null,
+      capabilities: ['identity'],
+      enabled: true,
+    };
+
+    it('returns valid DID document for existing user', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      dbModule.db.select
+        // getOrInitConfig
+        .mockReturnValueOnce(mockSelectChain([enabledConfig]))
+        // getUserDidDocument -> user lookup
+        .mockReturnValueOnce(
+          mockSelectChain([{ id: 'user-1', deletedAt: null, isGuest: false }]),
+        )
+        // getOrCreateUserKeypair -> existing keypair lookup
+        .mockReturnValueOnce(
+          mockSelectChain([
+            {
+              publicKey: testKeypair.publicKey,
+              keyId: 'did:web:magazine.example:users:user-1#key-1',
+            },
+          ]),
+        );
+
+      const doc = await federationService.getUserDidDocument(baseEnv, 'alice');
+
+      expect(doc.id).toBe('did:web:magazine.example:users:alice');
+      expect(doc.verificationMethod[0].publicKeyJwk.kty).toBe('OKP');
+      expect(doc.service![0].type).toBe('ColophonySubmitter');
+    });
+
+    it('lazily generates keypair on first request', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      dbModule.db.select
+        // getOrInitConfig
+        .mockReturnValueOnce(mockSelectChain([enabledConfig]))
+        // user lookup
+        .mockReturnValueOnce(
+          mockSelectChain([{ id: 'user-1', deletedAt: null, isGuest: false }]),
+        )
+        // getOrCreateUserKeypair -> no existing keypair
+        .mockReturnValueOnce(mockSelectChain([]))
+        // read-back after insert
+        .mockReturnValueOnce(
+          mockSelectChain([
+            {
+              publicKey: testKeypair.publicKey,
+              keyId: 'did:web:magazine.example:users:user-1#key-1',
+            },
+          ]),
+        );
+
+      dbModule.db.insert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockResolvedValue({ rowCount: 1 }),
+        }),
+      });
+
+      const doc = await federationService.getUserDidDocument(baseEnv, 'alice');
+
+      expect(doc.verificationMethod[0].publicKeyJwk.kty).toBe('OKP');
+      expect(cryptoModule.default.generateKeyPairSync).toHaveBeenCalledWith(
+        'ed25519',
+        expect.any(Object),
+      );
+    });
+
+    it('handles concurrent keypair generation race', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      dbModule.db.select
+        // getOrCreateUserKeypair -> no existing keypair
+        .mockReturnValueOnce(mockSelectChain([]))
+        // read-back after INSERT ON CONFLICT returns other process's keypair
+        .mockReturnValueOnce(
+          mockSelectChain([
+            {
+              publicKey: 'other-process-pub-key',
+              keyId: 'other-process-key-id',
+            },
+          ]),
+        );
+
+      dbModule.db.insert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockResolvedValue({ rowCount: 0 }),
+        }),
+      });
+
+      const result = await federationService.getOrCreateUserKeypair(
+        'user-1',
+        'magazine.example',
+      );
+
+      expect(result.publicKey).toBe('other-process-pub-key');
+    });
+
+    it('throws UserDidNotFoundError for unknown user', async () => {
+      const { federationService, UserDidNotFoundError } =
+        await import('./federation.service.js');
+
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([enabledConfig]))
+        .mockReturnValueOnce(mockSelectChain([]));
+
+      await expect(
+        federationService.getUserDidDocument(baseEnv, 'nobody'),
+      ).rejects.toThrow(UserDidNotFoundError);
+    });
+
+    it('throws UserDidNotFoundError for deleted user', async () => {
+      const { federationService, UserDidNotFoundError } =
+        await import('./federation.service.js');
+
+      // The query filters out deleted users, so empty result is returned
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([enabledConfig]))
+        .mockReturnValueOnce(mockSelectChain([]));
+
+      await expect(
+        federationService.getUserDidDocument(baseEnv, 'deleted-user'),
+      ).rejects.toThrow(UserDidNotFoundError);
+    });
+
+    it('throws UserDidNotFoundError for guest user', async () => {
+      const { federationService, UserDidNotFoundError } =
+        await import('./federation.service.js');
+
+      // The query filters out guest users, so empty result is returned
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([enabledConfig]))
+        .mockReturnValueOnce(mockSelectChain([]));
+
+      await expect(
+        federationService.getUserDidDocument(baseEnv, 'guest-user'),
+      ).rejects.toThrow(UserDidNotFoundError);
+    });
+
+    it('DID document never contains private key material', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([enabledConfig]))
+        .mockReturnValueOnce(
+          mockSelectChain([{ id: 'user-1', deletedAt: null, isGuest: false }]),
+        )
+        .mockReturnValueOnce(
+          mockSelectChain([
+            {
+              publicKey: testKeypair.publicKey,
+              keyId: 'did:web:magazine.example:users:user-1#key-1',
+            },
+          ]),
+        );
+
+      const doc = await federationService.getUserDidDocument(baseEnv, 'alice');
+
+      const serialized = JSON.stringify(doc);
+      expect(serialized).not.toContain('PRIVATE');
+      expect(serialized).not.toContain(testKeypair.privateKey);
+    });
+  });
+
+  describe('domainToDid', () => {
+    it('encodes port as %3A', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      const configRow = {
+        id: 'cfg-id',
+        publicKey: testKeypair.publicKey,
+        privateKey: testKeypair.privateKey,
+        keyId: 'localhost:4000#main',
+        mode: 'allowlist' as const,
+        contactEmail: null,
+        capabilities: ['identity'],
+        enabled: true,
+      };
+
+      dbModule.db.select.mockReturnValueOnce(mockSelectChain([configRow]));
+
+      const envWithPort: Env = {
+        ...baseEnv,
+        FEDERATION_DOMAIN: 'localhost:4000',
+      };
+
+      const doc = await federationService.getInstanceDidDocument(envWithPort);
+
+      expect(doc.id).toBe('did:web:localhost%3A4000');
+    });
+
+    it('passes through portless domain unchanged', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      const configRow = {
+        id: 'cfg-id',
+        publicKey: testKeypair.publicKey,
+        privateKey: testKeypair.privateKey,
+        keyId: 'magazine.example#main',
+        mode: 'allowlist' as const,
+        contactEmail: null,
+        capabilities: ['identity'],
+        enabled: true,
+      };
+
+      dbModule.db.select.mockReturnValueOnce(mockSelectChain([configRow]));
+
+      const doc = await federationService.getInstanceDidDocument(baseEnv);
+
+      expect(doc.id).toBe('did:web:magazine.example');
+    });
+  });
+
+  describe('pemToJwk', () => {
+    it('correctly converts Ed25519 PEM to JWK', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      const configRow = {
+        id: 'cfg-id',
+        publicKey: testKeypair.publicKey,
+        privateKey: testKeypair.privateKey,
+        keyId: 'magazine.example#main',
+        mode: 'allowlist' as const,
+        contactEmail: null,
+        capabilities: ['identity'],
+        enabled: true,
+      };
+
+      dbModule.db.select.mockReturnValueOnce(mockSelectChain([configRow]));
+
+      const doc = await federationService.getInstanceDidDocument(baseEnv);
+      const jwk = doc.verificationMethod[0].publicKeyJwk;
+
+      expect(jwk.kty).toBe('OKP');
+      expect(jwk.crv).toBe('Ed25519');
+      expect(typeof jwk.x).toBe('string');
+      expect(jwk.x.length).toBeGreaterThan(0);
     });
   });
 });

--- a/apps/api/src/services/federation.service.ts
+++ b/apps/api/src/services/federation.service.ts
@@ -5,13 +5,15 @@ import {
   publications,
   organizations,
   users,
+  userKeys,
 } from '@colophony/db';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, isNull } from 'drizzle-orm';
 import {
   AuditActions,
   AuditResources,
   type FederationMetadata,
   type WebFingerResponse,
+  type DidDocument,
 } from '@colophony/types';
 import type { Env } from '../config/env.js';
 import { auditService } from './audit.service.js';
@@ -48,6 +50,13 @@ export class WebFingerDomainMismatchError extends Error {
   }
 }
 
+export class UserDidNotFoundError extends Error {
+  override name = 'UserDidNotFoundError' as const;
+  constructor(localPart: string) {
+    super(`User not found for DID resolution: ${localPart}`);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -61,6 +70,41 @@ interface FederationConfigRow {
   contactEmail: string | null;
   capabilities: string[];
   enabled: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DID_CONTEXT = [
+  'https://www.w3.org/ns/did/v1',
+  'https://w3id.org/security/suites/jws-2020/v1',
+];
+
+/**
+ * Convert an Ed25519 PEM public key to JWK format.
+ * Uses Node.js native crypto — no external deps.
+ */
+function pemToJwk(pem: string): {
+  kty: 'OKP';
+  crv: 'Ed25519';
+  x: string;
+} {
+  const keyObj = crypto.createPublicKey(pem);
+  const jwk = keyObj.export({ format: 'jwk' });
+  return {
+    kty: 'OKP',
+    crv: 'Ed25519',
+    x: jwk.x as string,
+  };
+}
+
+/**
+ * Encode a domain for did:web — port colons become %3A per spec.
+ * "localhost:4000" → "localhost%3A4000"
+ */
+function domainToDid(domain: string): string {
+  return domain.replace(/:/g, '%3A');
 }
 
 // ---------------------------------------------------------------------------
@@ -271,5 +315,176 @@ export const federationService = {
         },
       ],
     };
+  },
+
+  /**
+   * Build the instance DID document (did:web:<domain>).
+   * Resolved at GET /.well-known/did.json
+   */
+  async getInstanceDidDocument(env: Env): Promise<DidDocument> {
+    const config = await this.getOrInitConfig(env);
+
+    if (!config.enabled) {
+      throw new FederationDisabledError();
+    }
+
+    const domain = env.FEDERATION_DOMAIN ?? 'localhost';
+    const didId = `did:web:${domainToDid(domain)}`;
+    const keyRef = `${didId}#main`;
+
+    return {
+      '@context': DID_CONTEXT,
+      id: didId,
+      verificationMethod: [
+        {
+          id: keyRef,
+          type: 'JsonWebKey2020',
+          controller: didId,
+          publicKeyJwk: pemToJwk(config.publicKey),
+        },
+      ],
+      authentication: [keyRef],
+      assertionMethod: [keyRef],
+      service: [
+        {
+          id: `${didId}#federation`,
+          type: 'ColophonyFederation',
+          serviceEndpoint: `https://${domain}/.well-known/colophony`,
+        },
+      ],
+    };
+  },
+
+  /**
+   * Build a user DID document (did:web:<domain>:users:<localPart>).
+   * Resolved at GET /users/:localPart/did.json
+   *
+   * Lazily generates an Ed25519 keypair on first request.
+   * Never returns private key material.
+   */
+  async getUserDidDocument(env: Env, localPart: string): Promise<DidDocument> {
+    const config = await this.getOrInitConfig(env);
+
+    if (!config.enabled) {
+      throw new FederationDisabledError();
+    }
+
+    const domain = env.FEDERATION_DOMAIN ?? 'localhost';
+
+    // Look up user by email local part — must be non-deleted, non-guest
+    const email = `${localPart}@${domain}`;
+    const [user] = await db
+      .select({
+        id: users.id,
+        deletedAt: users.deletedAt,
+        isGuest: users.isGuest,
+      })
+      .from(users)
+      .where(
+        and(
+          eq(users.email, email),
+          isNull(users.deletedAt),
+          eq(users.isGuest, false),
+        ),
+      )
+      .limit(1);
+
+    if (!user) {
+      throw new UserDidNotFoundError(localPart);
+    }
+
+    const keypair = await this.getOrCreateUserKeypair(user.id, domain);
+
+    const didId = `did:web:${domainToDid(domain)}:users:${localPart}`;
+    const keyRef = `${didId}#key-1`;
+
+    return {
+      '@context': DID_CONTEXT,
+      id: didId,
+      verificationMethod: [
+        {
+          id: keyRef,
+          type: 'JsonWebKey2020',
+          controller: didId,
+          publicKeyJwk: pemToJwk(keypair.publicKey),
+        },
+      ],
+      authentication: [keyRef],
+      assertionMethod: [keyRef],
+      service: [
+        {
+          id: `${didId}#submitter`,
+          type: 'ColophonySubmitter',
+          serviceEndpoint: `https://${domain}/users/${localPart}`,
+        },
+      ],
+    };
+  },
+
+  /**
+   * Get or lazily create an Ed25519 keypair for a user.
+   * INSERT ON CONFLICT handles concurrent generation races.
+   * Returns only the public key and keyId — never exposes private key.
+   */
+  async getOrCreateUserKeypair(
+    userId: string,
+    domain: string,
+  ): Promise<{ publicKey: string; keyId: string }> {
+    // Check for existing keypair
+    const [existing] = await db
+      .select({
+        publicKey: userKeys.publicKey,
+        keyId: userKeys.keyId,
+      })
+      .from(userKeys)
+      .where(eq(userKeys.userId, userId))
+      .limit(1);
+
+    if (existing) {
+      return existing;
+    }
+
+    // Generate new Ed25519 keypair
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const keyId = `did:web:${domainToDid(domain)}:users:${userId}#key-1`;
+
+    // INSERT ON CONFLICT handles race condition
+    await db
+      .insert(userKeys)
+      .values({
+        userId,
+        publicKey,
+        privateKey,
+        keyId,
+        algorithm: 'Ed25519',
+      })
+      .onConflictDoNothing();
+
+    // Read back (handles race where another process inserted first)
+    const [row] = await db
+      .select({
+        publicKey: userKeys.publicKey,
+        keyId: userKeys.keyId,
+      })
+      .from(userKeys)
+      .where(eq(userKeys.userId, userId))
+      .limit(1);
+
+    // Audit log if we generated the key now in DB
+    if (row && row.publicKey === publicKey) {
+      await auditService.logDirect({
+        resource: AuditResources.FEDERATION,
+        action: AuditActions.FEDERATION_USER_KEY_GENERATED,
+        actorId: userId,
+        newValue: { keyId, algorithm: 'Ed25519' },
+      });
+    }
+
+    // row is guaranteed to exist — either we inserted or another process did
+    return { publicKey: row.publicKey, keyId: row.keyId };
   },
 };

--- a/apps/api/src/services/federation.service.ts
+++ b/apps/api/src/services/federation.service.ts
@@ -372,7 +372,9 @@ export const federationService = {
     const domain = env.FEDERATION_DOMAIN ?? 'localhost';
 
     // Look up user by email local part — must be non-deleted, non-guest
-    const email = `${localPart}@${domain}`;
+    // Strip port from domain for email matching (did:web encodes port as %3A)
+    const emailDomain = domain.replace(/:\d+$/, '');
+    const email = `${localPart}@${emailDomain}`;
     const [user] = await db
       .select({
         id: users.id,
@@ -393,7 +395,11 @@ export const federationService = {
       throw new UserDidNotFoundError(localPart);
     }
 
-    const keypair = await this.getOrCreateUserKeypair(user.id, domain);
+    const keypair = await this.getOrCreateUserKeypair(
+      user.id,
+      domain,
+      localPart,
+    );
 
     const didId = `did:web:${domainToDid(domain)}:users:${localPart}`;
     const keyRef = `${didId}#key-1`;
@@ -429,6 +435,7 @@ export const federationService = {
   async getOrCreateUserKeypair(
     userId: string,
     domain: string,
+    localPart: string,
   ): Promise<{ publicKey: string; keyId: string }> {
     // Check for existing keypair
     const [existing] = await db
@@ -450,7 +457,7 @@ export const federationService = {
       privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
     });
 
-    const keyId = `did:web:${domainToDid(domain)}:users:${userId}#key-1`;
+    const keyId = `did:web:${domainToDid(domain)}:users:${localPart}#key-1`;
 
     // INSERT ON CONFLICT handles race condition
     await db

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -153,7 +153,10 @@
 ### Code
 
 - [x] Discovery: WebFinger + `.well-known` endpoints — (architecture doc Track 5; done 2026-02-24)
-- [ ] Identity: `did:web` documents — use `jose` library — (architecture doc Track 5, decision 2026-02-15)
+- [x] Identity: `did:web` DID document resolution — per-user Ed25519 keypairs, native crypto (no jose needed) — (architecture doc Track 5; done 2026-02-24)
+- [ ] [P2] Split `getOrInitConfig()` to separate public-key-only read from private-key read — reduces private key exposure surface — (Codex review 2026-02-24, deferred to Phase 3)
+- [ ] [P3] Key rotation mechanism for user keypairs — (architecture doc Track 5, deferred to Phase 7)
+- [ ] [P2] Inbound DID resolution hardening — validate remote DID documents fetched during federation — (Codex review 2026-02-24, deferred to Phase 3)
 - [ ] Trust establishment — use `openid-client` for OIDC flows — (architecture doc Track 5, decision 2026-02-15)
 - [ ] Sim-sub enforcement (BSAP) — manuscript entity (Track 3) is the natural anchor for cross-instance tracking — (architecture doc Track 5)
 - [ ] Piece transfer — (architecture doc Track 5)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-24 — DID Document Resolution (Track 5 Phase 2)
+
+### Done
+
+- Implemented did:web DID document resolution — instance and per-user endpoints
+- Schema: `user_keys` table for per-user Ed25519 keypairs with RLS (owner select/insert), unique index on `userId`, `app_user` grants
+- Migration 0024: table creation, ENABLE/FORCE ROW LEVEL SECURITY, two policies, GRANT
+- Types: Zod schemas for `DidDocument`, `DidVerificationMethod`, `DidServiceEndpoint`; added `FEDERATION_USER_KEY_GENERATED` audit action
+- Service: `getInstanceDidDocument` (PEM→JWK conversion via native crypto), `getUserDidDocument` (lazy Ed25519 keypair generation, non-deleted/non-guest user filter), `getOrCreateUserKeypair` (INSERT ON CONFLICT race safety), `pemToJwk`, `domainToDid` (port %3A encoding per did:web spec)
+- Routes: `GET /.well-known/did.json` (application/did+json, max-age=3600), `GET /users/:localPart/did.json` (max-age=300, input sanitization regex)
+- Auth: added `/did.json` suffix check to `isPublicRoute()` — safe since no existing routes end in `/did.json`
+- Tests: 25 new tests — 10 route, 12 service (including real Ed25519 crypto, concurrent race, private key exclusion), 3 auth bypass
+- Updated existing service test suite to use real Ed25519 keypair via `vi.hoisted()` (Vitest mock hoisting constraint)
+
+### Decisions
+
+- Per-user Ed25519 keypairs (not instance-managed) — invest now for Phase 7 identity migration
+- `JsonWebKey2020` with JWK format — native Node.js 22 crypto, zero new dependencies
+- `/did.json` suffix check in auth allowlist — spec-compliant, minimal blast radius vs explicit path list
+- Deferred: private key read splitting (Phase 3), key rotation (Phase 7), inbound DID resolution hardening (Phase 3)
+
+---
+
 ## 2026-02-24 — Security Audit: Dependabot + CodeQL Alerts
 
 ### Done

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -11,9 +11,9 @@
 | Type exports   | `src/types.ts`                           |
 | Migrations     | `migrations/`                            |
 
-### Schema Files (19 domain files + barrel)
+### Schema Files (20 domain files + barrel)
 
-`api-keys.ts`, `audit.ts`, `cms.ts`, `compliance.ts`, `contracts.ts`, `enums.ts`, `federation.ts`, `issues.ts`, `manuscripts.ts`, `members.ts`, `messaging.ts`, `organizations.ts`, `payments.ts`, `pipeline.ts`, `publications.ts`, `relations.ts`, `submissions.ts`, `users.ts`, `webhooks.ts`, `index.ts`
+`api-keys.ts`, `audit.ts`, `cms.ts`, `compliance.ts`, `contracts.ts`, `enums.ts`, `federation.ts`, `issues.ts`, `manuscripts.ts`, `members.ts`, `messaging.ts`, `organizations.ts`, `payments.ts`, `pipeline.ts`, `publications.ts`, `relations.ts`, `submissions.ts`, `user-keys.ts`, `users.ts`, `webhooks.ts`, `index.ts`
 
 ---
 

--- a/packages/db/migrations/0024_user_keys.sql
+++ b/packages/db/migrations/0024_user_keys.sql
@@ -1,0 +1,34 @@
+-- User keys for did:web DID document resolution (Track 5, Phase 2)
+-- Per-user Ed25519 keypairs with RLS
+
+--> statement-breakpoint
+CREATE TABLE "user_keys" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "public_key" text NOT NULL,
+  "private_key" text NOT NULL,
+  "key_id" varchar(512) NOT NULL,
+  "algorithm" varchar(50) NOT NULL DEFAULT 'Ed25519',
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+--> statement-breakpoint
+CREATE UNIQUE INDEX "user_keys_active_user_idx" ON "user_keys" ("user_id");
+
+--> statement-breakpoint
+ALTER TABLE "user_keys" ENABLE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+ALTER TABLE "user_keys" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+CREATE POLICY "user_keys_owner_select" ON "user_keys" FOR SELECT
+  USING (user_id = current_setting('app.user_id', true)::uuid);
+
+--> statement-breakpoint
+CREATE POLICY "user_keys_owner_insert" ON "user_keys" FOR INSERT
+  WITH CHECK (user_id = current_setting('app.user_id', true)::uuid);
+
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE ON "user_keys" TO "app_user";

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1773800000000,
       "tag": "0023_federation_discovery",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1774000000000,
+      "tag": "0024_user_keys",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -19,4 +19,5 @@ export * from "./issues";
 export * from "./documenso";
 export * from "./cms";
 export * from "./federation";
+export * from "./user-keys";
 export * from "./relations";

--- a/packages/db/src/schema/user-keys.ts
+++ b/packages/db/src/schema/user-keys.ts
@@ -1,0 +1,51 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  text,
+  timestamp,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { users } from "./users";
+
+/**
+ * Per-user Ed25519 keypairs for did:web DID document resolution.
+ *
+ * One active keypair per user (enforced by unique index on userId).
+ * RLS: user-scoped — app_user can only read/insert own keys.
+ * DID document routes use superuser `db` pool to read public keys.
+ */
+export const userKeys = pgTable(
+  "user_keys",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    publicKey: text("public_key").notNull(),
+    privateKey: text("private_key").notNull(),
+    keyId: varchar("key_id", { length: 512 }).notNull(),
+    algorithm: varchar("algorithm", { length: 50 })
+      .notNull()
+      .default("Ed25519"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("user_keys_active_user_idx").on(table.userId),
+    pgPolicy("user_keys_owner_select", {
+      for: "select",
+      using: sql`user_id = current_setting('app.user_id', true)::uuid`,
+    }),
+    pgPolicy("user_keys_owner_insert", {
+      for: "insert",
+      withCheck: sql`user_id = current_setting('app.user_id', true)::uuid`,
+    }),
+  ],
+);

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -135,6 +135,7 @@ export const AuditActions = {
 
   // Federation lifecycle
   FEDERATION_KEY_GENERATED: "FEDERATION_KEY_GENERATED",
+  FEDERATION_USER_KEY_GENERATED: "FEDERATION_USER_KEY_GENERATED",
 
   // Audit access
   AUDIT_ACCESSED: "AUDIT_ACCESSED",
@@ -357,7 +358,9 @@ export interface CmsConnectionAuditParams extends BaseAuditParams {
 
 export interface FederationAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.FEDERATION;
-  action: typeof AuditActions.FEDERATION_KEY_GENERATED;
+  action:
+    | typeof AuditActions.FEDERATION_KEY_GENERATED
+    | typeof AuditActions.FEDERATION_USER_KEY_GENERATED;
 }
 
 export interface AuditAccessAuditParams extends BaseAuditParams {

--- a/packages/types/src/federation.ts
+++ b/packages/types/src/federation.ts
@@ -51,3 +51,39 @@ export const webFingerQuerySchema = z.object({
   resource: z.string().min(1, "resource parameter is required"),
   rel: z.string().optional(),
 });
+
+// ---------------------------------------------------------------------------
+// DID Document — W3C did:web resolution
+// ---------------------------------------------------------------------------
+
+export const didVerificationMethodSchema = z.object({
+  id: z.string(),
+  type: z.literal("JsonWebKey2020"),
+  controller: z.string(),
+  publicKeyJwk: z.object({
+    kty: z.literal("OKP"),
+    crv: z.literal("Ed25519"),
+    x: z.string(),
+  }),
+});
+
+export type DidVerificationMethod = z.infer<typeof didVerificationMethodSchema>;
+
+export const didServiceEndpointSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  serviceEndpoint: z.string().url(),
+});
+
+export type DidServiceEndpoint = z.infer<typeof didServiceEndpointSchema>;
+
+export const didDocumentSchema = z.object({
+  "@context": z.array(z.string()),
+  id: z.string(),
+  verificationMethod: z.array(didVerificationMethodSchema),
+  authentication: z.array(z.string()),
+  assertionMethod: z.array(z.string()).optional(),
+  service: z.array(didServiceEndpointSchema).optional(),
+});
+
+export type DidDocument = z.infer<typeof didDocumentSchema>;


### PR DESCRIPTION
## Summary

- Adds W3C `did:web` DID document resolution endpoints (Federation Phase 2)
- Instance DID: `GET /.well-known/did.json` — resolves `did:web:<domain>` to instance DID document
- User DID: `GET /users/:localPart/did.json` — resolves `did:web:<domain>:users:<localPart>` with lazy Ed25519 keypair generation
- New `user_keys` table with per-user Ed25519 keypairs, RLS-protected (user-scoped)
- Auth bypass for `/did.json` suffix (spec-compliant public endpoints)
- `JsonWebKey2020` verification method using native Node.js 22 crypto (zero new deps)
- 25 new tests (10 route, 12 service, 3 auth)

## Plan Overrides

| File | Planned | Actual | Rationale |
| --- | --- | --- | --- |
| `packages/db/src/schema/user-keys.ts` | `.enableRLS()` in schema DSL | Omitted from schema, enforced in migration SQL | Drizzle `enableRLS()` is cosmetic; migration has `ENABLE ROW LEVEL SECURITY` + `FORCE ROW LEVEL SECURITY` |
| `packages/db/src/schema/user-keys.ts` | `current_user_id()` in RLS policy | `current_setting('app.user_id', true)::uuid` | Matches existing codebase pattern (manuscripts schema); `current_user_id()` is a DB function alias |
| `apps/api/src/services/federation.service.ts` | `didToDomain()` helper | Not implemented | No current consumer; `domainToDid()` is used but reverse is not needed yet |

## Test plan

- [x] All 833 unit tests pass (25 new)
- [x] Type-check clean across monorepo
- [x] ESLint clean
- [ ] Run migration on dev DB (`pnpm db:migrate`)
- [ ] Manual curl verification:
  - `curl localhost:4000/.well-known/did.json` → 200 instance DID doc
  - `curl localhost:4000/users/<email-localpart>/did.json` → 200 user DID doc
  - `curl localhost:4000/users/nonexistent/did.json` → 404
  - Verify no private key in any response