### PR TITLE
feat(register): add federation signature verification middleware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **Federation trust**     | `apps/api/src/federation/trust.routes.ts` (S2S), `trust-admin.routes.ts` |
 | **Trust service**        | `apps/api/src/services/trust.service.ts`                                 |
 | **HTTP signatures**      | `apps/api/src/federation/http-signatures.ts`                             |
+| **Federation auth**      | `apps/api/src/federation/federation-auth.ts` (S2S signature middleware)  |
 | **Next.js frontend**     | `apps/web/`                                                              |
 | **tRPC client**          | `apps/web/src/lib/trpc.ts`                                               |
 | **Env config (Zod)**     | `apps/api/src/config/env.ts`                                             |

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -40,6 +40,7 @@
 | Trust admin       | `src/federation/trust-admin.routes.ts`     |
 | Trust service     | `src/services/trust.service.ts`            |
 | HTTP signatures   | `src/federation/http-signatures.ts`        |
+| Federation auth   | `src/federation/federation-auth.ts`        |
 
 ### Service Method Naming
 

--- a/apps/api/src/federation/federation-auth.spec.ts
+++ b/apps/api/src/federation/federation-auth.spec.ts
@@ -352,4 +352,8 @@ describe('extractDomainFromKeyId', () => {
   it('returns null for did:web: with empty domain', () => {
     expect(extractDomainFromKeyId('did:web:#main')).toBeNull();
   });
+
+  it('returns null for malformed percent-encoding in DID key', () => {
+    expect(extractDomainFromKeyId('did:web:%ZZ#main')).toBeNull();
+  });
 });

--- a/apps/api/src/federation/federation-auth.spec.ts
+++ b/apps/api/src/federation/federation-auth.spec.ts
@@ -1,0 +1,355 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from 'vitest';
+import Fastify, {
+  type FastifyInstance,
+  type FastifyPluginAsync,
+} from 'fastify';
+
+// Mock DB
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockLimit = vi.fn();
+
+vi.mock('@colophony/db', () => ({
+  db: {
+    select: (...args: unknown[]) => {
+      mockSelect(...args);
+      return { from: mockFrom };
+    },
+  },
+  trustedPeers: {
+    domain: 'domain',
+    status: 'status',
+    publicKey: 'public_key',
+    keyId: 'key_id',
+  },
+  eq: (a: unknown, b: unknown) => ({ op: 'eq', a, b }),
+  and: (...args: unknown[]) => ({ op: 'and', args }),
+}));
+
+// Mock HTTP signatures
+const mockVerifyFederationSignature = vi.fn();
+
+vi.mock('./http-signatures.js', () => ({
+  verifyFederationSignature: (...args: unknown[]) =>
+    mockVerifyFederationSignature(...args),
+}));
+
+// Chain DB mock helpers
+function setupDbChain(result: unknown[]) {
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockWhere.mockReturnValue({ limit: mockLimit });
+  mockLimit.mockResolvedValue(result);
+}
+
+// Valid signature headers for testing
+const VALID_KEY_ID = 'example.com#main';
+const VALID_SIG_INPUT = `sig1=("@method" "@target-uri" "date");alg="ed25519";keyid="${VALID_KEY_ID}"`;
+const VALID_SIG = 'sig1=:dGVzdHNpZw==:';
+
+function makeHeaders(
+  overrides: Record<string, string> = {},
+): Record<string, string> {
+  return {
+    signature: VALID_SIG,
+    'signature-input': VALID_SIG_INPUT,
+    date: new Date().toUTCString(),
+    'content-type': 'application/json',
+    ...overrides,
+  };
+}
+
+describe('federation-auth plugin', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const mod = await import('./federation-auth.js');
+
+    app = Fastify({ logger: false });
+    await app.register(mod.default as unknown as FastifyPluginAsync);
+
+    // Test route that returns the decorated peer context
+    app.post('/test', async (request) => {
+      return { peer: request.federationPeer };
+    });
+
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- Missing headers ---
+
+  it('returns 401 when Signature header missing', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/test',
+      headers: { 'signature-input': VALID_SIG_INPUT },
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({ error: 'missing_signature' });
+  });
+
+  it('returns 401 when Signature-Input header missing', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/test',
+      headers: { signature: VALID_SIG },
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({ error: 'missing_signature' });
+  });
+
+  // --- Parse failures ---
+
+  it('returns 401 when keyId cannot be parsed from Signature-Input', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/test',
+      headers: makeHeaders({
+        'signature-input': 'sig1=(malformed-no-keyid)',
+      }),
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({ error: 'invalid_signature_input' });
+  });
+
+  it('returns 401 when domain cannot be extracted from keyId', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/test',
+      headers: makeHeaders({
+        'signature-input': `sig1=("@method");alg="ed25519";keyid="random-garbage"`,
+      }),
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({ error: 'invalid_key_id' });
+  });
+
+  // --- DB lookup failures ---
+
+  it('returns 401 when no active trusted peer found', async () => {
+    setupDbChain([]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/test',
+      headers: makeHeaders(),
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({ error: 'untrusted_peer' });
+  });
+
+  // --- Signature verification failures ---
+
+  it('returns 401 when signature verification fails', async () => {
+    setupDbChain([{ publicKey: 'PEM-KEY', keyId: VALID_KEY_ID }]);
+    mockVerifyFederationSignature.mockResolvedValueOnce({
+      valid: false,
+      keyId: VALID_KEY_ID,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/test',
+      headers: makeHeaders(),
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({ error: 'signature_invalid' });
+  });
+
+  it('returns 401 when verification throws', async () => {
+    setupDbChain([{ publicKey: 'PEM-KEY', keyId: VALID_KEY_ID }]);
+    mockVerifyFederationSignature.mockRejectedValueOnce(
+      new Error('crypto error'),
+    );
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/test',
+      headers: makeHeaders(),
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({ error: 'signature_verification_error' });
+  });
+
+  // --- Success cases ---
+
+  it('decorates request on valid instance key', async () => {
+    setupDbChain([{ publicKey: 'PEM-KEY', keyId: VALID_KEY_ID }]);
+    mockVerifyFederationSignature.mockResolvedValueOnce({
+      valid: true,
+      keyId: VALID_KEY_ID,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/test',
+      headers: makeHeaders(),
+      payload: { data: 'test' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      peer: { domain: 'example.com', keyId: VALID_KEY_ID },
+    });
+  });
+
+  it('decorates request on valid DID user key', async () => {
+    const didKeyId = 'did:web:example.com:users:alice#key-1';
+    const sigInput = `sig1=("@method");alg="ed25519";keyid="${didKeyId}"`;
+
+    setupDbChain([{ publicKey: 'PEM-KEY', keyId: didKeyId }]);
+    mockVerifyFederationSignature.mockResolvedValueOnce({
+      valid: true,
+      keyId: didKeyId,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/test',
+      headers: makeHeaders({ 'signature-input': sigInput }),
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      peer: { domain: 'example.com', keyId: didKeyId },
+    });
+  });
+
+  it('handles domain with port (instance key)', async () => {
+    const portKeyId = 'localhost:4000#main';
+    const sigInput = `sig1=("@method");alg="ed25519";keyid="${portKeyId}"`;
+
+    setupDbChain([{ publicKey: 'PEM-KEY', keyId: portKeyId }]);
+    mockVerifyFederationSignature.mockResolvedValueOnce({
+      valid: true,
+      keyId: portKeyId,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/test',
+      headers: makeHeaders({ 'signature-input': sigInput }),
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      peer: { domain: 'localhost:4000', keyId: portKeyId },
+    });
+  });
+
+  it('handles encoded port in DID key', async () => {
+    const didKeyId = 'did:web:localhost%3A4000:users:bob#key-1';
+    const sigInput = `sig1=("@method");alg="ed25519";keyid="${didKeyId}"`;
+
+    setupDbChain([{ publicKey: 'PEM-KEY', keyId: didKeyId }]);
+    mockVerifyFederationSignature.mockResolvedValueOnce({
+      valid: true,
+      keyId: didKeyId,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/test',
+      headers: makeHeaders({ 'signature-input': sigInput }),
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      peer: { domain: 'localhost:4000', keyId: didKeyId },
+    });
+  });
+});
+
+// --- extractDomainFromKeyId unit tests ---
+
+describe('extractDomainFromKeyId', () => {
+  let extractDomainFromKeyId: (keyId: string) => string | null;
+
+  beforeAll(async () => {
+    const mod = await import('./federation-auth.js');
+    extractDomainFromKeyId = mod.extractDomainFromKeyId;
+  });
+
+  it('extracts domain from instance key (domain#fragment)', () => {
+    expect(extractDomainFromKeyId('example.com#main')).toBe('example.com');
+  });
+
+  it('extracts domain with port from instance key', () => {
+    expect(extractDomainFromKeyId('localhost:4000#main')).toBe(
+      'localhost:4000',
+    );
+  });
+
+  it('extracts domain from instance DID key', () => {
+    expect(extractDomainFromKeyId('did:web:example.com#main')).toBe(
+      'example.com',
+    );
+  });
+
+  it('extracts domain from user DID key', () => {
+    expect(
+      extractDomainFromKeyId('did:web:example.com:users:alice#key-1'),
+    ).toBe('example.com');
+  });
+
+  it('decodes percent-encoded port in DID key', () => {
+    expect(extractDomainFromKeyId('did:web:localhost%3A4000#main')).toBe(
+      'localhost:4000',
+    );
+  });
+
+  it('decodes percent-encoded port in user DID key', () => {
+    expect(
+      extractDomainFromKeyId('did:web:localhost%3A4000:users:bob#key-1'),
+    ).toBe('localhost:4000');
+  });
+
+  it('returns null for random garbage', () => {
+    expect(extractDomainFromKeyId('random-garbage')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(extractDomainFromKeyId('')).toBeNull();
+  });
+
+  it('returns null for bare fragment without domain', () => {
+    expect(extractDomainFromKeyId('#main')).toBeNull();
+  });
+
+  it('returns null for did:web: with empty domain', () => {
+    expect(extractDomainFromKeyId('did:web:#main')).toBeNull();
+  });
+});

--- a/apps/api/src/federation/federation-auth.ts
+++ b/apps/api/src/federation/federation-auth.ts
@@ -46,7 +46,11 @@ export function extractDomainFromKeyId(keyId: string): string | null {
       colonIndex >= 0 ? pathPart.slice(0, colonIndex) : pathPart;
     if (!encodedDomain) return null;
     // Decode percent-encoded colons (e.g., localhost%3A4000 → localhost:4000)
-    return decodeURIComponent(encodedDomain);
+    try {
+      return decodeURIComponent(encodedDomain);
+    } catch {
+      return null;
+    }
   }
 
   // Instance key: domain#fragment (e.g., example.com#main, localhost:4000#main)
@@ -121,6 +125,7 @@ export default fp(
           .where(
             and(
               eq(trustedPeers.domain, domain),
+              eq(trustedPeers.keyId, keyId),
               eq(trustedPeers.status, 'active'),
             ),
           )
@@ -132,18 +137,19 @@ export default fp(
 
         const peer = activePeers[0];
 
-        // Build key lookup using stored public key
+        // Build key lookup using stored public key (keyId already matched by DB query)
         const keyLookup = async (
           lookupKeyId: string,
         ): Promise<string | null> => {
-          if (lookupKeyId === peer.keyId || lookupKeyId === keyId) {
+          if (lookupKeyId === keyId) {
             return peer.publicKey;
           }
           return null;
         };
 
-        // Reconstruct full URL for signature verification
-        const fullUrl = `${request.protocol}://${request.hostname}${request.url}`;
+        // Reconstruct full URL for signature verification.
+        // Use request.host (not hostname) to preserve the port for non-default ports.
+        const fullUrl = `${request.protocol}://${request.host}${request.url}`;
         const rawBody = (request as any).rawBody as string | undefined;
 
         try {

--- a/apps/api/src/federation/federation-auth.ts
+++ b/apps/api/src/federation/federation-auth.ts
@@ -1,0 +1,178 @@
+import fp from 'fastify-plugin';
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { db, trustedPeers, eq, and } from '@colophony/db';
+import { verifyFederationSignature } from './http-signatures.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FederationPeerContext {
+  /** Verified remote domain extracted from the signature keyId */
+  domain: string;
+  /** The keyId from the verified signature */
+  keyId: string;
+}
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    federationPeer: FederationPeerContext | null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the remote domain from a federation keyId.
+ *
+ * Supported formats:
+ *  - Instance key: `example.com#main` or `localhost:4000#main`
+ *  - Instance DID key: `did:web:example.com#main` or `did:web:localhost%3A4000#main`
+ *  - User DID key: `did:web:example.com:users:alice#key-1` or `did:web:localhost%3A4000:users:bob#key-1`
+ */
+export function extractDomainFromKeyId(keyId: string): string | null {
+  // DID-based keyId: did:web:<encoded-domain>[:path...]#fragment
+  if (keyId.startsWith('did:web:')) {
+    const withoutPrefix = keyId.slice('did:web:'.length);
+    // Strip the fragment (#key-1, #main, etc.)
+    const hashIndex = withoutPrefix.indexOf('#');
+    const pathPart =
+      hashIndex >= 0 ? withoutPrefix.slice(0, hashIndex) : withoutPrefix;
+    // Domain is the first path segment (before any `:` path separator)
+    const colonIndex = pathPart.indexOf(':');
+    const encodedDomain =
+      colonIndex >= 0 ? pathPart.slice(0, colonIndex) : pathPart;
+    if (!encodedDomain) return null;
+    // Decode percent-encoded colons (e.g., localhost%3A4000 → localhost:4000)
+    return decodeURIComponent(encodedDomain);
+  }
+
+  // Instance key: domain#fragment (e.g., example.com#main, localhost:4000#main)
+  const hashIndex = keyId.indexOf('#');
+  if (hashIndex > 0) {
+    const domain = keyId.slice(0, hashIndex);
+    // Basic validation: must contain at least one dot or colon (port)
+    if (domain.includes('.') || domain.includes(':')) {
+      return domain;
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+export default fp(
+  async function federationAuthPlugin(app: FastifyInstance) {
+    // Register raw body plugin for signature verification (scoped)
+    const rawBodyPlugin = await import('fastify-raw-body');
+    await app.register(rawBodyPlugin.default, {
+      field: 'rawBody',
+      global: true,
+      encoding: 'utf8',
+      runFirst: true,
+    });
+
+    // Decorate requests with federationPeer
+    app.decorateRequest('federationPeer', null);
+
+    // Pre-handler: verify HTTP signature on every request in this scope
+    app.addHook(
+      'preHandler',
+      async (request: FastifyRequest, reply: FastifyReply) => {
+        const signatureHeader = request.headers['signature'] as
+          | string
+          | undefined;
+        const signatureInputHeader = request.headers['signature-input'] as
+          | string
+          | undefined;
+
+        if (!signatureHeader || !signatureInputHeader) {
+          return reply.status(401).send({ error: 'missing_signature' });
+        }
+
+        // Parse keyId from Signature-Input
+        const keyIdMatch = signatureInputHeader.match(/keyid="([^"]+)"/);
+        if (!keyIdMatch) {
+          return reply.status(401).send({ error: 'invalid_signature_input' });
+        }
+        const keyId = keyIdMatch[1];
+
+        // Extract domain from keyId
+        const domain = extractDomainFromKeyId(keyId);
+        if (!domain) {
+          return reply.status(401).send({ error: 'invalid_key_id' });
+        }
+
+        // Look up active trusted peers for this domain across all orgs.
+        // Uses superuser db — justified: this is a pre-auth S2S lookup with no
+        // org context available. Only reads domain, publicKey, keyId, and status.
+        // Same pattern as trust.service.ts handleInboundTrustAccept.
+        const activePeers = await db
+          .select({
+            publicKey: trustedPeers.publicKey,
+            keyId: trustedPeers.keyId,
+          })
+          .from(trustedPeers)
+          .where(
+            and(
+              eq(trustedPeers.domain, domain),
+              eq(trustedPeers.status, 'active'),
+            ),
+          )
+          .limit(1);
+
+        if (activePeers.length === 0) {
+          return reply.status(401).send({ error: 'untrusted_peer' });
+        }
+
+        const peer = activePeers[0];
+
+        // Build key lookup using stored public key
+        const keyLookup = async (
+          lookupKeyId: string,
+        ): Promise<string | null> => {
+          if (lookupKeyId === peer.keyId || lookupKeyId === keyId) {
+            return peer.publicKey;
+          }
+          return null;
+        };
+
+        // Reconstruct full URL for signature verification
+        const fullUrl = `${request.protocol}://${request.hostname}${request.url}`;
+        const rawBody = (request as any).rawBody as string | undefined;
+
+        try {
+          const result = await verifyFederationSignature(
+            { keyLookup },
+            {
+              method: request.method,
+              url: fullUrl,
+              headers: request.headers as Record<string, string>,
+              body: rawBody,
+            },
+          );
+
+          if (!result.valid) {
+            return reply.status(401).send({ error: 'signature_invalid' });
+          }
+        } catch {
+          return reply
+            .status(401)
+            .send({ error: 'signature_verification_error' });
+        }
+
+        // Decorate request with verified peer info
+        request.federationPeer = { domain, keyId };
+      },
+    );
+  },
+  {
+    name: 'federation-auth',
+    fastify: '5.x',
+  },
+);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -158,7 +158,7 @@
 - [ ] [P3] Key rotation mechanism for user keypairs — (architecture doc Track 5, deferred to Phase 7)
 - [ ] [P2] Inbound DID resolution hardening — validate remote DID documents fetched during federation — (Codex review 2026-02-24, deferred to Phase 3)
 - [x] Trust establishment — bilateral trust with HTTP signatures, trust service, public S2S + admin routes — (architecture doc Track 5; done 2026-02-24)
-- [ ] [P2] Federation signature verification middleware — protect all federation endpoints with signature-based auth — (DEVLOG 2026-02-24, deferred to PR2)
+- [x] [P2] Federation signature verification middleware — protect all federation endpoints with signature-based auth — (DEVLOG 2026-02-24, done 2026-02-24)
 - [ ] Sim-sub enforcement (BSAP) — manuscript entity (Track 3) is the natural anchor for cross-instance tracking — (architecture doc Track 5)
 - [ ] Piece transfer — (architecture doc Track 5)
 - [ ] Identity migration — (architecture doc Track 5)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,25 @@ Newest entries first.
 
 ---
 
+## 2026-02-24 — Federation Signature Verification Middleware (Track 5)
+
+### Done
+
+- Implemented federation signature verification middleware (`federation-auth.ts`) — Fastify plugin for S2S HTTP Message Signature auth
+- Plugin extracts and verifies peer identity from RFC 9421 signatures, decorates `request.federationPeer` with `{ domain, keyId }`
+- Supports instance keys (`domain#main`), DID instance keys (`did:web:domain#main`), and DID user keys (`did:web:domain:users:alice#key-1`) including percent-encoded ports
+- 21 tests covering all error paths (missing headers, parse failures, untrusted peers, signature failures) and success cases
+- All 892 tests pass, type-check + lint clean
+
+### Decisions
+
+- Scoped plugin (not global): registered only in federation S2S scopes via Fastify's isolated plugin system
+- Minimal peer context (least-privilege): only `domain` and `keyId` exposed — route handlers query `trusted_peers` via RLS for org-specific info
+- Superuser DB for cross-org key lookup: justified pre-auth S2S pattern with no org context, same pattern as `trust.service.ts handleInboundTrustAccept`
+- Trust routes unchanged: keep own verification via `trustService` (they handle non-active/non-existent peers with different key resolution)
+
+---
+
 ## 2026-02-24 — Trust Establishment (Track 5 Phase 3)
 
 ### Done


### PR DESCRIPTION
## Summary

- New Fastify plugin (`federation-auth.ts`) that verifies HTTP Message Signatures (RFC 9421) on inbound S2S federation requests
- Extracts verified peer identity into `request.federationPeer` (`{ domain, keyId }`) for downstream route handlers
- Supports instance keys, DID instance keys, and DID user keys with percent-encoded ports
- 22 tests covering all error paths and success cases (893 total passing)

## Design Decisions

- **Scoped plugin:** Registered only in federation S2S scopes, not globally
- **Minimal peer context:** Only `domain` + `keyId` exposed — handlers query `trusted_peers` via RLS for org-specific info
- **Superuser DB for key lookup:** Justified pre-auth S2S pattern with no org context (same as `trust.service.ts:handleInboundTrustAccept`)
- **Trust routes unchanged:** Keep own verification via `trustService`

## Consumer Requirements (future PRs)

1. Add S2S route prefix to `PUBLIC_PREFIXES` in `auth.ts`
2. Register plugin in isolated Fastify scope in `main.ts`
3. Query org-specific peer info via RLS if needed

## Codex Review

Addressed 3 findings:
- P1: Use `request.host` instead of `request.hostname` to preserve port in signed URI
- P2: Wrap `decodeURIComponent` in try/catch for malformed DID percent-encoding
- P2: Match trusted peer by `keyId` in DB query instead of arbitrary `limit(1)`

Dismissed 1 finding:
- P1: Plugin not registered in `main.ts` — by design, no S2S consumers yet (documented in plan)

## Test plan

- [x] 22 unit tests pass (`pnpm --filter @colophony/api test -- federation-auth`)
- [x] 893 total tests pass (`pnpm test`)
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean
- [x] Existing federation tests unaffected