### PR TITLE
feat(register): federation hardening — public config split, metadata validation, sliding window

### DIFF
--- a/apps/api/src/hooks/rate-limit-auth.spec.ts
+++ b/apps/api/src/hooks/rate-limit-auth.spec.ts
@@ -290,7 +290,7 @@ describe('rate-limit-auth plugin (second-pass)', () => {
       vi.spyOn(redis, 'eval').mockImplementation(async () => {
         callCount++;
         if (callCount > 1) throw new Error('Redis down');
-        return [1, 60000] as [number, number];
+        return 1; // sliding window returns count directly
       });
 
       const response = await app.inject({

--- a/apps/api/src/hooks/rate-limit-auth.spec.ts
+++ b/apps/api/src/hooks/rate-limit-auth.spec.ts
@@ -290,7 +290,7 @@ describe('rate-limit-auth plugin (second-pass)', () => {
       vi.spyOn(redis, 'eval').mockImplementation(async () => {
         callCount++;
         if (callCount > 1) throw new Error('Redis down');
-        return 1; // sliding window returns count directly
+        return [1, 0]; // sliding window returns [count, oldestMs]
       });
 
       const response = await app.inject({
@@ -331,6 +331,130 @@ describe('rate-limit-auth plugin (second-pass)', () => {
       expect(response.statusCode).toBe(200);
       // No rate limit headers from second-pass since it's skipped
       // (first-pass also skips /health)
+    });
+  });
+
+  describe('sliding window behavior (auth)', () => {
+    it('stays blocked at half window (entries still within window)', async () => {
+      const { app: testApp, redis: testRedis } = await buildApp({
+        RATE_LIMIT_DEFAULT_MAX: 20, // High IP limit so first-pass doesn't block
+        RATE_LIMIT_AUTH_MAX: 3,
+      });
+
+      const authHeaders = {
+        'x-test-user-id': 'user-sw-1',
+        'x-test-email': 'test@example.com',
+      };
+
+      // Send max requests
+      for (let i = 0; i < 3; i++) {
+        const r = await testApp.inject({
+          method: 'GET',
+          url: '/api/test',
+          headers: authHeaders,
+        });
+        expect(r.statusCode).toBe(200);
+      }
+
+      // Advance clock by half window (30s) — entries still within 60s window
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + 30_000);
+
+      const response = await testApp.inject({
+        method: 'GET',
+        url: '/api/test',
+        headers: authHeaders,
+      });
+      expect(response.statusCode).toBe(429);
+
+      vi.useRealTimers();
+      await testApp.close();
+      await testRedis.flushall();
+    });
+
+    it('allows requests after full window expires', async () => {
+      const { app: testApp, redis: testRedis } = await buildApp({
+        RATE_LIMIT_DEFAULT_MAX: 20,
+        RATE_LIMIT_AUTH_MAX: 3,
+        RATE_LIMIT_WINDOW_SECONDS: 1, // 1-second window for faster test
+      });
+
+      const authHeaders = {
+        'x-test-user-id': 'user-sw-2',
+        'x-test-email': 'test@example.com',
+      };
+
+      // Send max requests at t=0
+      for (let i = 0; i < 3; i++) {
+        const r = await testApp.inject({
+          method: 'GET',
+          url: '/api/test',
+          headers: authHeaders,
+        });
+        expect(r.statusCode).toBe(200);
+      }
+
+      // Verify 4th is blocked
+      const blocked = await testApp.inject({
+        method: 'GET',
+        url: '/api/test',
+        headers: authHeaders,
+      });
+      expect(blocked.statusCode).toBe(429);
+
+      // Advance past full window (1.1s > 1s window)
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + 1100);
+
+      const response = await testApp.inject({
+        method: 'GET',
+        url: '/api/test',
+        headers: authHeaders,
+      });
+      expect(response.statusCode).toBe(200);
+
+      vi.useRealTimers();
+      await testApp.close();
+      await testRedis.flushall();
+    });
+
+    it('burst at boundary does not allow 2x rate (sliding window fix)', async () => {
+      const { app: testApp, redis: testRedis } = await buildApp({
+        RATE_LIMIT_DEFAULT_MAX: 20,
+        RATE_LIMIT_AUTH_MAX: 3,
+        RATE_LIMIT_WINDOW_SECONDS: 60,
+      });
+
+      const authHeaders = {
+        'x-test-user-id': 'user-sw-3',
+        'x-test-email': 'test@example.com',
+      };
+
+      // Send max requests at t=55s (simulate late-window burst)
+      vi.useFakeTimers({ now: 55_000 });
+
+      for (let i = 0; i < 3; i++) {
+        const r = await testApp.inject({
+          method: 'GET',
+          url: '/api/test',
+          headers: authHeaders,
+        });
+        expect(r.statusCode).toBe(200);
+      }
+
+      // Advance to t=61s — sliding window keeps entries from t=55s
+      vi.setSystemTime(61_000);
+
+      const response = await testApp.inject({
+        method: 'GET',
+        url: '/api/test',
+        headers: authHeaders,
+      });
+      expect(response.statusCode).toBe(429);
+
+      vi.useRealTimers();
+      await testApp.close();
+      await testRedis.flushall();
     });
   });
 });

--- a/apps/api/src/hooks/rate-limit-auth.ts
+++ b/apps/api/src/hooks/rate-limit-auth.ts
@@ -59,9 +59,10 @@ export default fp(
         const requestId = `${nowMs}:${Math.random().toString(36).slice(2, 8)}`;
 
         let count: number;
+        let oldestMs = 0;
 
         try {
-          count = (await redis.eval(
+          const result = (await redis.eval(
             SLIDING_WINDOW_SCRIPT,
             1,
             key,
@@ -70,7 +71,9 @@ export default fp(
             requestId,
             windowMs,
             limit,
-          )) as number;
+          )) as [number, number];
+          count = result[0];
+          oldestMs = result[1] ?? 0;
         } catch {
           // Graceful degradation: Redis unavailable → allow request
           request.log.warn(
@@ -80,7 +83,9 @@ export default fp(
         }
 
         const remaining = Math.max(0, limit - count);
-        const resetEpochSeconds = Math.ceil((nowMs + windowMs) / 1000);
+        // Reset = when the oldest entry expires (tight estimate)
+        const resetMs = oldestMs > 0 ? oldestMs + windowMs : nowMs + windowMs;
+        const resetEpochSeconds = Math.ceil(resetMs / 1000);
 
         // Override headers from first-pass with higher auth limits
         reply.header('X-RateLimit-Limit', limit);
@@ -88,7 +93,10 @@ export default fp(
         reply.header('X-RateLimit-Reset', resetEpochSeconds);
 
         if (count > limit) {
-          const retryAfterSeconds = Math.ceil(windowMs / 1000);
+          const retryAfterSeconds = Math.max(
+            1,
+            Math.ceil((resetMs - nowMs) / 1000),
+          );
           reply.header('Retry-After', retryAfterSeconds);
           reply.header('Cache-Control', 'no-store');
 

--- a/apps/api/src/hooks/rate-limit-auth.ts
+++ b/apps/api/src/hooks/rate-limit-auth.ts
@@ -1,7 +1,7 @@
 import fp from 'fastify-plugin';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import type { Env } from '../config/env.js';
-import { LUA_SCRIPT } from './rate-limit.js';
+import { SLIDING_WINDOW_SCRIPT } from './rate-limit.js';
 
 export interface RateLimitAuthPluginOptions {
   env: Env;
@@ -54,19 +54,23 @@ export default fp(
         const redis = app.rateLimitRedis;
         if (!redis) return;
 
-        const windowId = Math.floor(Date.now() / windowMs);
-        const key = `${prefix}:auth:${env.RATE_LIMIT_WINDOW_SECONDS}:${windowId}:${userId}`;
+        const key = `${prefix}:auth:${userId}`;
+        const nowMs = Date.now();
+        const requestId = `${nowMs}:${Math.random().toString(36).slice(2, 8)}`;
 
         let count: number;
-        let ttlMs: number;
 
         try {
-          const result = (await redis.eval(LUA_SCRIPT, 1, key, windowMs)) as [
-            number,
-            number,
-          ];
-          count = result[0];
-          ttlMs = result[1];
+          count = (await redis.eval(
+            SLIDING_WINDOW_SCRIPT,
+            1,
+            key,
+            nowMs - windowMs,
+            nowMs,
+            requestId,
+            windowMs,
+            limit,
+          )) as number;
         } catch {
           // Graceful degradation: Redis unavailable → allow request
           request.log.warn(
@@ -76,9 +80,7 @@ export default fp(
         }
 
         const remaining = Math.max(0, limit - count);
-        const resetEpochSeconds = Math.ceil(
-          (Date.now() + Math.max(0, ttlMs)) / 1000,
-        );
+        const resetEpochSeconds = Math.ceil((nowMs + windowMs) / 1000);
 
         // Override headers from first-pass with higher auth limits
         reply.header('X-RateLimit-Limit', limit);
@@ -86,7 +88,7 @@ export default fp(
         reply.header('X-RateLimit-Reset', resetEpochSeconds);
 
         if (count > limit) {
-          const retryAfterSeconds = Math.ceil(Math.max(0, ttlMs) / 1000);
+          const retryAfterSeconds = Math.ceil(windowMs / 1000);
           reply.header('Retry-After', retryAfterSeconds);
           reply.header('Cache-Control', 'no-store');
 

--- a/apps/api/src/hooks/rate-limit.spec.ts
+++ b/apps/api/src/hooks/rate-limit.spec.ts
@@ -333,4 +333,95 @@ describe('rate-limit plugin', () => {
       );
     });
   });
+
+  describe('sliding window behavior', () => {
+    it('stays blocked at half window (entries still within window)', async () => {
+      const { app: testApp, redis: testRedis } = await buildApp({
+        RATE_LIMIT_DEFAULT_MAX: 3,
+      });
+
+      // Send max requests
+      for (let i = 0; i < 3; i++) {
+        const r = await testApp.inject({ method: 'GET', url: '/api/test' });
+        expect(r.statusCode).toBe(200);
+      }
+
+      // Advance clock by half window (30s) — entries are still within 60s window
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + 30_000);
+
+      const response = await testApp.inject({
+        method: 'GET',
+        url: '/api/test',
+      });
+      expect(response.statusCode).toBe(429);
+
+      vi.useRealTimers();
+      await testApp.close();
+      await testRedis.flushall();
+    });
+
+    it('allows requests after full window expires', async () => {
+      const { app: testApp, redis: testRedis } = await buildApp({
+        RATE_LIMIT_DEFAULT_MAX: 3,
+        RATE_LIMIT_WINDOW_SECONDS: 1, // 1-second window for faster test
+      });
+
+      // Send max requests at t=0
+      for (let i = 0; i < 3; i++) {
+        const r = await testApp.inject({ method: 'GET', url: '/api/test' });
+        expect(r.statusCode).toBe(200);
+      }
+
+      // Verify 4th is blocked
+      const blocked = await testApp.inject({
+        method: 'GET',
+        url: '/api/test',
+      });
+      expect(blocked.statusCode).toBe(429);
+
+      // Advance past full window (1.1s > 1s window)
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + 1100);
+
+      const response = await testApp.inject({
+        method: 'GET',
+        url: '/api/test',
+      });
+      expect(response.statusCode).toBe(200);
+
+      vi.useRealTimers();
+      await testApp.close();
+      await testRedis.flushall();
+    });
+
+    it('burst at boundary does not allow 2x rate (sliding window fix)', async () => {
+      const { app: testApp, redis: testRedis } = await buildApp({
+        RATE_LIMIT_DEFAULT_MAX: 3,
+        RATE_LIMIT_WINDOW_SECONDS: 60,
+      });
+
+      // Send max requests at t=55s (simulate late-window burst)
+      vi.useFakeTimers({ now: 55_000 });
+
+      for (let i = 0; i < 3; i++) {
+        const r = await testApp.inject({ method: 'GET', url: '/api/test' });
+        expect(r.statusCode).toBe(200);
+      }
+
+      // Advance to t=61s — with fixed-window this would reset, but sliding window
+      // keeps entries from t=55s since they're within the 60s window at t=61s
+      vi.setSystemTime(61_000);
+
+      const response = await testApp.inject({
+        method: 'GET',
+        url: '/api/test',
+      });
+      expect(response.statusCode).toBe(429);
+
+      vi.useRealTimers();
+      await testApp.close();
+      await testRedis.flushall();
+    });
+  });
 });

--- a/apps/api/src/hooks/rate-limit.ts
+++ b/apps/api/src/hooks/rate-limit.ts
@@ -46,7 +46,14 @@ if count < tonumber(ARGV[5]) then
   redis.call('ZADD', KEYS[1], ARGV[2], ARGV[3])
 end
 redis.call('PEXPIRE', KEYS[1], ARGV[4])
-return count + 1
+local oldest = 0
+if count > 0 then
+  local entries = redis.call('ZRANGE', KEYS[1], 0, 0, 'WITHSCORES')
+  if entries and #entries >= 2 then
+    oldest = tonumber(entries[2])
+  end
+end
+return {count + 1, oldest}
 `;
 
 /**
@@ -113,9 +120,10 @@ export default fp(
         const requestId = `${nowMs}:${Math.random().toString(36).slice(2, 8)}`;
 
         let count: number;
+        let oldestMs = 0;
 
         try {
-          count = (await redis.eval(
+          const result = (await redis.eval(
             SLIDING_WINDOW_SCRIPT,
             1,
             key,
@@ -124,7 +132,9 @@ export default fp(
             requestId,
             windowMs,
             limit,
-          )) as number;
+          )) as [number, number];
+          count = result[0];
+          oldestMs = result[1] ?? 0;
         } catch {
           // Graceful degradation: Redis unavailable → allow request
           request.log.warn(
@@ -134,14 +144,19 @@ export default fp(
         }
 
         const remaining = Math.max(0, limit - count);
-        const resetEpochSeconds = Math.ceil((nowMs + windowMs) / 1000);
+        // Reset = when the oldest entry expires (tight estimate)
+        const resetMs = oldestMs > 0 ? oldestMs + windowMs : nowMs + windowMs;
+        const resetEpochSeconds = Math.ceil(resetMs / 1000);
 
         reply.header('X-RateLimit-Limit', limit);
         reply.header('X-RateLimit-Remaining', remaining);
         reply.header('X-RateLimit-Reset', resetEpochSeconds);
 
         if (count > limit) {
-          const retryAfterSeconds = Math.ceil(windowMs / 1000);
+          const retryAfterSeconds = Math.max(
+            1,
+            Math.ceil((resetMs - nowMs) / 1000),
+          );
           reply.header('Retry-After', retryAfterSeconds);
           reply.header('Cache-Control', 'no-store');
 

--- a/apps/api/src/hooks/rate-limit.ts
+++ b/apps/api/src/hooks/rate-limit.ts
@@ -21,17 +21,32 @@ function shouldSkip(request: FastifyRequest): boolean {
 }
 
 /**
- * Atomic Lua script: INCR key, set PEXPIRE on first hit, return [count, pttl].
- * Single round-trip, no race condition between INCR and EXPIRE.
+ * Sliding-window-log rate limiter using Redis sorted sets.
+ *
+ * Each request is stored as a scored member (score = timestamp). On each check:
+ * 1. Remove expired entries (older than window)
+ * 2. Count remaining entries
+ * 3. Only add new entry if under limit (prevents unbounded growth during abuse)
+ * 4. Set TTL for automatic cleanup
+ *
+ * ARGV[1]: nowMs - windowMs (oldest allowed timestamp)
+ * ARGV[2]: nowMs (current timestamp as score)
+ * ARGV[3]: unique request ID (now:random) to prevent dedup
+ * ARGV[4]: windowMs (TTL for cleanup)
+ * ARGV[5]: max (limit — only add if under limit)
+ *
+ * Returns: count + 1 (1-indexed like INCR — allowed entries capped at limit)
+ *
  * Shared with rate-limit-auth.ts second-pass plugin.
  */
-export const LUA_SCRIPT = `
-local current = redis.call('INCR', KEYS[1])
-if current == 1 then
-  redis.call('PEXPIRE', KEYS[1], ARGV[1])
+export const SLIDING_WINDOW_SCRIPT = `
+redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, ARGV[1])
+local count = redis.call('ZCARD', KEYS[1])
+if count < tonumber(ARGV[5]) then
+  redis.call('ZADD', KEYS[1], ARGV[2], ARGV[3])
 end
-local ttl = redis.call('PTTL', KEYS[1])
-return { current, ttl }
+redis.call('PEXPIRE', KEYS[1], ARGV[4])
+return count + 1
 `;
 
 /**
@@ -93,19 +108,23 @@ export default fp(
         // Always use IP — auth hasn't run yet
         const identifier = request.ip;
 
-        const windowId = Math.floor(Date.now() / windowMs);
-        const key = `${prefix}:${env.RATE_LIMIT_WINDOW_SECONDS}:${windowId}:${identifier}`;
+        const key = `${prefix}:${identifier}`;
+        const nowMs = Date.now();
+        const requestId = `${nowMs}:${Math.random().toString(36).slice(2, 8)}`;
 
         let count: number;
-        let ttlMs: number;
 
         try {
-          const result = (await redis.eval(LUA_SCRIPT, 1, key, windowMs)) as [
-            number,
-            number,
-          ];
-          count = result[0];
-          ttlMs = result[1];
+          count = (await redis.eval(
+            SLIDING_WINDOW_SCRIPT,
+            1,
+            key,
+            nowMs - windowMs,
+            nowMs,
+            requestId,
+            windowMs,
+            limit,
+          )) as number;
         } catch {
           // Graceful degradation: Redis unavailable → allow request
           request.log.warn(
@@ -115,16 +134,14 @@ export default fp(
         }
 
         const remaining = Math.max(0, limit - count);
-        const resetEpochSeconds = Math.ceil(
-          (Date.now() + Math.max(0, ttlMs)) / 1000,
-        );
+        const resetEpochSeconds = Math.ceil((nowMs + windowMs) / 1000);
 
         reply.header('X-RateLimit-Limit', limit);
         reply.header('X-RateLimit-Remaining', remaining);
         reply.header('X-RateLimit-Reset', resetEpochSeconds);
 
         if (count > limit) {
-          const retryAfterSeconds = Math.ceil(Math.max(0, ttlMs) / 1000);
+          const retryAfterSeconds = Math.ceil(windowMs / 1000);
           reply.header('Retry-After', retryAfterSeconds);
           reply.header('Cache-Control', 'no-store');
 

--- a/apps/api/src/services/federation.service.spec.ts
+++ b/apps/api/src/services/federation.service.spec.ts
@@ -271,6 +271,118 @@ describe('federationService', () => {
     });
   });
 
+  describe('getPublicConfig', () => {
+    it('returns config without privateKey', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      const existingRow = {
+        id: 'existing-id',
+        publicKey: 'existing-pub',
+        keyId: 'magazine.example#main',
+        mode: 'allowlist' as const,
+        contactEmail: 'admin@magazine.example',
+        capabilities: ['identity'],
+        enabled: true,
+      };
+
+      dbModule.db.select.mockReturnValueOnce(mockSelectChain([existingRow]));
+
+      const config = await federationService.getPublicConfig(baseEnv);
+
+      expect(config.publicKey).toBe('existing-pub');
+      expect(config.keyId).toBe('magazine.example#main');
+      expect(config.mode).toBe('allowlist');
+      expect(config.enabled).toBe(true);
+      expect('privateKey' in config).toBe(false);
+    });
+
+    it('with env override reads only public key', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      dbModule.db.select.mockReturnValueOnce(
+        mockSelectChain([
+          {
+            id: 'db-id',
+            keyId: 'magazine.example#main',
+            mode: 'allowlist',
+            contactEmail: null,
+            capabilities: ['identity'],
+            enabled: false,
+          },
+        ]),
+      );
+
+      const envWithKeys: Env = {
+        ...baseEnv,
+        FEDERATION_PUBLIC_KEY: 'env-pub-key',
+        FEDERATION_PRIVATE_KEY: 'env-priv-key',
+      };
+
+      const config = await federationService.getPublicConfig(envWithKeys);
+
+      expect(config.publicKey).toBe('env-pub-key');
+      expect('privateKey' in config).toBe(false);
+    });
+
+    it('auto-generates if no config exists', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      // getPublicConfig DB path: select public columns returns empty
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([]))
+        // getOrInitConfig fallback: select returns empty (no existing config)
+        .mockReturnValueOnce(mockSelectChain([]))
+        // After insert, read-back returns the new row
+        .mockReturnValueOnce(
+          mockSelectChain([
+            {
+              id: 'new-id',
+              publicKey: testKeypair.publicKey,
+              privateKey: testKeypair.privateKey,
+              keyId: 'magazine.example#main',
+              mode: 'allowlist',
+              contactEmail: null,
+              capabilities: ['identity'],
+              enabled: false,
+            },
+          ]),
+        );
+
+      dbModule.db.insert.mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockResolvedValue({ rowCount: 1 }),
+        }),
+      });
+
+      const config = await federationService.getPublicConfig(baseEnv);
+
+      expect(config.publicKey).toBe(testKeypair.publicKey);
+      expect(config.keyId).toBe('magazine.example#main');
+      expect('privateKey' in config).toBe(false);
+    });
+
+    it('getOrInitConfig still returns privateKey', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      const existingRow = {
+        id: 'existing-id',
+        publicKey: 'existing-pub',
+        privateKey: 'existing-priv',
+        keyId: 'magazine.example#main',
+        mode: 'allowlist' as const,
+        contactEmail: null,
+        capabilities: ['identity'],
+        enabled: true,
+      };
+
+      dbModule.db.select.mockReturnValueOnce(mockSelectChain([existingRow]));
+
+      const config = await federationService.getOrInitConfig(baseEnv);
+
+      expect(config.privateKey).toBe('existing-priv');
+    });
+  });
+
   describe('getInstanceMetadata', () => {
     it('returns valid FederationMetadata', async () => {
       const { federationService } = await import('./federation.service.js');

--- a/apps/api/src/services/federation.service.ts
+++ b/apps/api/src/services/federation.service.ts
@@ -166,9 +166,20 @@ export const federationService = {
    * For the DB path, only public columns are selected.
    */
   async getPublicConfig(env: Env): Promise<FederationPublicConfig> {
-    // Env var override path — only read public key
-    if (env.FEDERATION_PUBLIC_KEY) {
-      const [existing] = await db.select().from(federationConfig).limit(1);
+    // Env var override path — require both keys to match getOrInitConfig behavior
+    if (env.FEDERATION_PUBLIC_KEY && env.FEDERATION_PRIVATE_KEY) {
+      // Select only public columns — never load privateKey into memory
+      const [existing] = await db
+        .select({
+          id: federationConfig.id,
+          keyId: federationConfig.keyId,
+          mode: federationConfig.mode,
+          contactEmail: federationConfig.contactEmail,
+          capabilities: federationConfig.capabilities,
+          enabled: federationConfig.enabled,
+        })
+        .from(federationConfig)
+        .limit(1);
 
       return {
         id: existing?.id ?? 'env-override',

--- a/apps/api/src/services/federation.service.ts
+++ b/apps/api/src/services/federation.service.ts
@@ -72,6 +72,8 @@ interface FederationConfigRow {
   enabled: boolean;
 }
 
+export type FederationPublicConfig = Omit<FederationConfigRow, 'privateKey'>;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -158,6 +160,62 @@ export const federationService = {
   },
 
   /**
+   * Get public-only federation config — private key is never loaded into memory.
+   *
+   * Priority: env vars > DB row > auto-generate (via getOrInitConfig fallback).
+   * For the DB path, only public columns are selected.
+   */
+  async getPublicConfig(env: Env): Promise<FederationPublicConfig> {
+    // Env var override path — only read public key
+    if (env.FEDERATION_PUBLIC_KEY) {
+      const [existing] = await db.select().from(federationConfig).limit(1);
+
+      return {
+        id: existing?.id ?? 'env-override',
+        publicKey: env.FEDERATION_PUBLIC_KEY,
+        keyId:
+          existing?.keyId ?? `${env.FEDERATION_DOMAIN ?? 'localhost'}#main`,
+        mode: existing?.mode ?? 'allowlist',
+        contactEmail: env.FEDERATION_CONTACT ?? existing?.contactEmail ?? null,
+        capabilities: existing?.capabilities ?? ['identity'],
+        enabled: existing?.enabled ?? false,
+      };
+    }
+
+    // DB path — select only public columns (privateKey is never loaded)
+    const [existing] = await db
+      .select({
+        id: federationConfig.id,
+        publicKey: federationConfig.publicKey,
+        keyId: federationConfig.keyId,
+        mode: federationConfig.mode,
+        contactEmail: federationConfig.contactEmail,
+        capabilities: federationConfig.capabilities,
+        enabled: federationConfig.enabled,
+      })
+      .from(federationConfig)
+      .limit(1);
+
+    if (existing) {
+      return {
+        id: existing.id,
+        publicKey: existing.publicKey,
+        keyId: existing.keyId,
+        mode: existing.mode,
+        contactEmail: env.FEDERATION_CONTACT ?? existing.contactEmail,
+        capabilities: existing.capabilities,
+        enabled: existing.enabled,
+      };
+    }
+
+    // Auto-generate path — must call getOrInitConfig then strip privateKey
+    const full = await this.getOrInitConfig(env);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { privateKey, ...publicConfig } = full;
+    return publicConfig;
+  },
+
+  /**
    * Generate an Ed25519 keypair, store it, and audit log the event.
    *
    * INSERT ... ON CONFLICT (singleton) DO NOTHING handles concurrent
@@ -218,7 +276,7 @@ export const federationService = {
    * for cross-org public metadata (same pattern as org-context.ts:78).
    */
   async getInstanceMetadata(env: Env): Promise<FederationMetadata> {
-    const config = await this.getOrInitConfig(env);
+    const config = await this.getPublicConfig(env);
 
     if (!config.enabled) {
       throw new FederationDisabledError();
@@ -269,7 +327,7 @@ export const federationService = {
     env: Env,
     resource: string,
   ): Promise<WebFingerResponse> {
-    const config = await this.getOrInitConfig(env);
+    const config = await this.getPublicConfig(env);
 
     if (!config.enabled) {
       throw new FederationDisabledError();
@@ -324,7 +382,7 @@ export const federationService = {
    * Resolved at GET /.well-known/did.json
    */
   async getInstanceDidDocument(env: Env): Promise<DidDocument> {
-    const config = await this.getOrInitConfig(env);
+    const config = await this.getPublicConfig(env);
 
     if (!config.enabled) {
       throw new FederationDisabledError();
@@ -365,7 +423,7 @@ export const federationService = {
    * Never returns private key material.
    */
   async getUserDidDocument(env: Env, localPart: string): Promise<DidDocument> {
-    const config = await this.getOrInitConfig(env);
+    const config = await this.getPublicConfig(env);
 
     if (!config.enabled) {
       throw new FederationDisabledError();

--- a/apps/api/src/services/hub-client.service.spec.ts
+++ b/apps/api/src/services/hub-client.service.spec.ts
@@ -48,9 +48,11 @@ vi.mock('@colophony/db', () => ({
 }));
 
 const mockGetOrInitConfig = vi.fn();
+const mockGetPublicConfig = vi.fn();
 vi.mock('./federation.service.js', () => ({
   federationService: {
     getOrInitConfig: (...args: unknown[]) => mockGetOrInitConfig(...args),
+    getPublicConfig: (...args: unknown[]) => mockGetPublicConfig(...args),
   },
 }));
 
@@ -130,9 +132,8 @@ describe('hub-client.service', () => {
 
   describe('registerWithHub', () => {
     it('registers with hub on startup', async () => {
-      mockGetOrInitConfig.mockResolvedValueOnce({
+      mockGetPublicConfig.mockResolvedValueOnce({
         publicKey: testKeypair.publicKey,
-        privateKey: testKeypair.privateKey,
         keyId: 'local.example.com#main',
       });
 
@@ -165,9 +166,8 @@ describe('hub-client.service', () => {
     });
 
     it('stores hub attestation after registration', async () => {
-      mockGetOrInitConfig.mockResolvedValueOnce({
+      mockGetPublicConfig.mockResolvedValueOnce({
         publicKey: testKeypair.publicKey,
-        privateKey: testKeypair.privateKey,
         keyId: 'local.example.com#main',
       });
 

--- a/apps/api/src/services/hub-client.service.ts
+++ b/apps/api/src/services/hub-client.service.ts
@@ -22,7 +22,7 @@ export const hubClientService = {
    * Called on startup if HUB_DOMAIN + HUB_REGISTRATION_TOKEN are set.
    */
   async registerWithHub(env: Env): Promise<void> {
-    const config = await federationService.getOrInitConfig(env);
+    const config = await federationService.getPublicConfig(env);
     const localDomain = env.FEDERATION_DOMAIN ?? 'localhost';
 
     const body = JSON.stringify({

--- a/apps/api/src/services/trust.service.spec.ts
+++ b/apps/api/src/services/trust.service.spec.ts
@@ -57,9 +57,11 @@ vi.mock('./audit.service.js', () => ({
 }));
 
 const mockGetOrInitConfig = vi.fn();
+const mockGetPublicConfig = vi.fn();
 vi.mock('./federation.service.js', () => ({
   federationService: {
     getOrInitConfig: (...args: unknown[]) => mockGetOrInitConfig(...args),
+    getPublicConfig: (...args: unknown[]) => mockGetPublicConfig(...args),
   },
 }));
 
@@ -74,6 +76,37 @@ vi.mock('../federation/http-signatures.js', () => ({
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
+
+// Mock dns.promises — SSRF checks are skipped in test but we still mock for explicitness
+vi.mock('node:dns', () => ({
+  default: {
+    promises: {
+      resolve4: vi.fn().mockResolvedValue(['93.184.216.34']),
+      resolve6: vi.fn().mockResolvedValue([]),
+    },
+  },
+}));
+
+/**
+ * Create a mock Response object compatible with fetchAndValidateMetadata's
+ * streaming body reader. Falls back to text() when body is null.
+ */
+function mockFetchResponse(json: unknown, opts: { ok?: boolean } = {}) {
+  const bodyText = JSON.stringify(json);
+  return {
+    ok: opts.ok ?? true,
+    status: opts.ok === false ? 500 : 200,
+    headers: {
+      get: (name: string) => {
+        if (name.toLowerCase() === 'content-length')
+          return String(bodyText.length);
+        return null;
+      },
+    },
+    body: null, // No streaming body — will use text() fallback
+    text: async () => bodyText,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -183,10 +216,9 @@ describe('trust.service', () => {
 
   describe('fetchRemoteMetadata', () => {
     it('returns preview for valid domain', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => sampleMetadataResponse,
-      });
+      mockFetch.mockResolvedValueOnce(
+        mockFetchResponse(sampleMetadataResponse),
+      );
 
       const result =
         await trustService.fetchRemoteMetadata('remote.example.com');
@@ -205,13 +237,52 @@ describe('trust.service', () => {
     });
 
     it('throws on invalid response', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ invalid: true }),
-      });
+      mockFetch.mockResolvedValueOnce(mockFetchResponse({ invalid: true }));
 
       await expect(
         trustService.fetchRemoteMetadata('bad.example.com'),
+      ).rejects.toThrow('Failed to fetch metadata');
+    });
+
+    it('rejects domain mismatch', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockFetchResponse({
+          ...sampleMetadataResponse,
+          domain: 'evil.example.com',
+        }),
+      );
+
+      await expect(
+        trustService.fetchRemoteMetadata('good.example.com'),
+      ).rejects.toThrow('Failed to fetch metadata');
+    });
+
+    it('rejects oversized response', async () => {
+      const oversizedBody = JSON.stringify(sampleMetadataResponse);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: {
+          get: (name: string) => {
+            if (name.toLowerCase() === 'content-length') return '2000000';
+            return null;
+          },
+        },
+        body: null,
+        text: async () => oversizedBody,
+      });
+
+      await expect(
+        trustService.fetchRemoteMetadata('remote.example.com'),
+      ).rejects.toThrow('Failed to fetch metadata');
+    });
+
+    it('rejects redirects', async () => {
+      // redirect: 'error' causes fetch to throw on redirect
+      mockFetch.mockRejectedValueOnce(new TypeError('redirect mode is error'));
+
+      await expect(
+        trustService.fetchRemoteMetadata('redirect.example.com'),
       ).rejects.toThrow('Failed to fetch metadata');
     });
   });
@@ -219,10 +290,7 @@ describe('trust.service', () => {
   describe('initiateTrust', () => {
     it('creates pending_outbound peer and sends POST', async () => {
       mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => sampleMetadataResponse,
-        })
+        .mockResolvedValueOnce(mockFetchResponse(sampleMetadataResponse))
         .mockResolvedValueOnce({ ok: true });
 
       mockGetOrInitConfig.mockResolvedValueOnce({
@@ -255,10 +323,9 @@ describe('trust.service', () => {
     });
 
     it('throws for duplicate domain', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => sampleMetadataResponse,
-      });
+      mockFetch.mockResolvedValueOnce(
+        mockFetchResponse(sampleMetadataResponse),
+      );
 
       mockGetOrInitConfig.mockResolvedValueOnce({
         publicKey: testKeypair.publicKey,
@@ -282,10 +349,9 @@ describe('trust.service', () => {
   describe('handleInboundTrustRequest', () => {
     it('verifies signature and creates pending_inbound peers', async () => {
       // Mock remote metadata fetch for key validation
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => sampleMetadataResponse,
-      });
+      mockFetch.mockResolvedValueOnce(
+        mockFetchResponse(sampleMetadataResponse),
+      );
 
       mockVerifyFederationSignature.mockResolvedValueOnce({
         valid: true,
@@ -322,10 +388,9 @@ describe('trust.service', () => {
 
     it('rejects invalid signature', async () => {
       // Mock remote metadata fetch for key validation
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => sampleMetadataResponse,
-      });
+      mockFetch.mockResolvedValueOnce(
+        mockFetchResponse(sampleMetadataResponse),
+      );
 
       mockVerifyFederationSignature.mockResolvedValueOnce({
         valid: false,
@@ -552,15 +617,14 @@ describe('trust.service', () => {
       const token = await makeAttestation();
 
       // Mock hub metadata fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
+      mockFetch.mockResolvedValueOnce(
+        mockFetchResponse({
           ...sampleMetadataResponse,
           domain: 'hub.example.com',
           publicKey: hubKeypair.publicKey,
           keyId: 'hub.example.com#main',
         }),
-      });
+      );
 
       // Mock org query — two orgs, both opted in
       dbSelectResult = [
@@ -584,15 +648,14 @@ describe('trust.service', () => {
 
     it('rejects invalid attestation JWT', async () => {
       // Mock hub metadata fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
+      mockFetch.mockResolvedValueOnce(
+        mockFetchResponse({
           ...sampleMetadataResponse,
           domain: 'hub.example.com',
           publicKey: hubKeypair.publicKey,
           keyId: 'hub.example.com#main',
         }),
-      });
+      );
 
       await expect(
         trustService.handleHubAttestedTrust(baseEnv, {
@@ -608,15 +671,14 @@ describe('trust.service', () => {
       });
 
       // Mock hub metadata fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
+      mockFetch.mockResolvedValueOnce(
+        mockFetchResponse({
           ...sampleMetadataResponse,
           domain: 'hub.example.com',
           publicKey: hubKeypair.publicKey,
           keyId: 'hub.example.com#main',
         }),
-      });
+      );
 
       await expect(
         trustService.handleHubAttestedTrust(baseEnv, {
@@ -636,6 +698,147 @@ describe('trust.service', () => {
           hubDomain: 'evil.example.com',
         }),
       ).rejects.toThrow('Untrusted hub domain');
+    });
+  });
+
+  describe('SSRF protection', () => {
+    it('rejects private IPv4 in production', async () => {
+      const dnsModule = await import('node:dns');
+      vi.spyOn(dnsModule.default.promises, 'resolve4').mockResolvedValueOnce([
+        '192.168.1.1',
+      ]);
+
+      // Temporarily set NODE_ENV to production for this test
+      const original = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      try {
+        await expect(
+          trustService.fetchRemoteMetadata('internal.example.com'),
+        ).rejects.toThrow('Failed to fetch metadata');
+      } finally {
+        process.env.NODE_ENV = original;
+      }
+    });
+
+    it('rejects private IPv6 in production', async () => {
+      const dnsModule = await import('node:dns');
+      vi.spyOn(dnsModule.default.promises, 'resolve4').mockResolvedValueOnce(
+        [],
+      );
+      vi.spyOn(dnsModule.default.promises, 'resolve6').mockResolvedValueOnce([
+        '::1',
+      ]);
+
+      const original = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      try {
+        await expect(
+          trustService.fetchRemoteMetadata('loopback.example.com'),
+        ).rejects.toThrow('Failed to fetch metadata');
+      } finally {
+        process.env.NODE_ENV = original;
+      }
+    });
+
+    it('rejects localhost (127.0.0.1) in production', async () => {
+      const dnsModule = await import('node:dns');
+      vi.spyOn(dnsModule.default.promises, 'resolve4').mockResolvedValueOnce([
+        '127.0.0.1',
+      ]);
+
+      const original = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      try {
+        await expect(
+          trustService.fetchRemoteMetadata('localhost.example.com'),
+        ).rejects.toThrow('Failed to fetch metadata');
+      } finally {
+        process.env.NODE_ENV = original;
+      }
+    });
+
+    it('skips SSRF check in development', async () => {
+      const dnsModule = await import('node:dns');
+      vi.spyOn(dnsModule.default.promises, 'resolve4').mockResolvedValueOnce([
+        '192.168.1.1',
+      ]);
+
+      const original = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      try {
+        // Should proceed to fetch (which will fail on network, not SSRF)
+        mockFetch.mockResolvedValueOnce(
+          mockFetchResponse(sampleMetadataResponse),
+        );
+
+        const result =
+          await trustService.fetchRemoteMetadata('remote.example.com');
+        expect(result.domain).toBe('remote.example.com');
+      } finally {
+        process.env.NODE_ENV = original;
+      }
+    });
+  });
+
+  describe('handleInboundTrustRequest domain mismatch', () => {
+    it('rejects domain mismatch in metadata', async () => {
+      // Metadata fetch returns mismatched domain
+      mockFetch.mockResolvedValueOnce(
+        mockFetchResponse({
+          ...sampleMetadataResponse,
+          domain: 'evil.example.com',
+        }),
+      );
+
+      await expect(
+        trustService.handleInboundTrustRequest(
+          baseEnv,
+          {
+            instanceUrl: 'https://remote.example.com',
+            domain: 'remote.example.com',
+            publicKey: testKeypair.publicKey,
+            keyId: 'remote.example.com#main',
+            requestedCapabilities: {},
+            protocolVersion: '1.0',
+          },
+          { signature: 'test', 'signature-input': 'test' },
+          'POST',
+          'https://local.example.com/federation/trust',
+          '{}',
+        ),
+      ).rejects.toThrow('Cannot verify remote identity');
+    });
+  });
+
+  describe('handleHubAttestedTrust domain mismatch', () => {
+    const hubKeypairForMismatch = crypto.generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    it('rejects hub domain mismatch in metadata', async () => {
+      // Hub metadata returns mismatched domain
+      mockFetch.mockResolvedValueOnce(
+        mockFetchResponse({
+          ...sampleMetadataResponse,
+          domain: 'wrong-hub.example.com',
+          publicKey: hubKeypairForMismatch.publicKey,
+          keyId: 'wrong-hub.example.com#main',
+        }),
+      );
+
+      await expect(
+        trustService.handleHubAttestedTrust(baseEnv, {
+          instanceUrl: 'https://peer.example.com',
+          domain: 'peer.example.com',
+          publicKey: testKeypair.publicKey,
+          keyId: 'peer.example.com#main',
+          hubDomain: 'hub.example.com',
+          attestationToken: 'unused',
+          requestedCapabilities: {},
+          protocolVersion: '1.0',
+        }),
+      ).rejects.toThrow('Cannot fetch hub metadata');
     });
   });
 

--- a/apps/api/src/services/trust.service.ts
+++ b/apps/api/src/services/trust.service.ts
@@ -86,6 +86,21 @@ async function resolveAndCheckPrivateIp(hostname: string): Promise<void> {
   // Strip port from hostname before DNS resolution
   const bareHost = hostname.replace(/:\d+$/, '');
 
+  // Block IP literals directly — DNS resolution may fail for these,
+  // bypassing the private address check entirely
+  if (isPrivateIPv4(bareHost)) {
+    throw new RemoteMetadataFetchError(
+      hostname,
+      new Error(`IP literal resolves to private IPv4 address: ${bareHost}`),
+    );
+  }
+  if (isPrivateIPv6(bareHost) || bareHost === '::1') {
+    throw new RemoteMetadataFetchError(
+      hostname,
+      new Error(`IP literal resolves to private IPv6 address: ${bareHost}`),
+    );
+  }
+
   // Resolve both IPv4 and IPv6
   const [ipv4Addrs, ipv6Addrs] = await Promise.all([
     dns.promises.resolve4(bareHost).catch(() => [] as string[]),
@@ -128,12 +143,19 @@ function isPrivateIPv4(addr: string): boolean {
 
 function isPrivateIPv6(addr: string): boolean {
   const normalized = addr.toLowerCase();
-  return (
-    normalized === '::1' || // loopback
-    normalized.startsWith('fe80') || // link-local fe80::/10
-    normalized.startsWith('fc') || // ULA fc00::/7
-    normalized.startsWith('fd') // ULA fc00::/7
-  );
+  if (normalized === '::1') return true; // loopback
+
+  // ULA fc00::/7 — fc00::–fdff::
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true;
+
+  // Link-local fe80::/10 — fe80::–febf::
+  // First 10 bits are 1111 1110 10, so second hex digit ranges 8–b
+  if (normalized.length >= 4 && normalized.startsWith('fe')) {
+    const thirdChar = normalized[2];
+    if (thirdChar >= '8' && thirdChar <= 'b') return true;
+  }
+
+  return false;
 }
 
 /**

--- a/apps/api/src/services/trust.service.ts
+++ b/apps/api/src/services/trust.service.ts
@@ -8,10 +8,12 @@ import {
 } from '@colophony/db';
 import * as jose from 'jose';
 import crypto from 'node:crypto';
+import dns from 'node:dns';
 import {
   AuditActions,
   AuditResources,
   federationMetadataSchema,
+  type FederationMetadata,
   type TrustRequest,
   type TrustAccept,
   type InitiateTrustInput,
@@ -69,6 +71,183 @@ export class TrustSignatureVerificationError extends Error {
 }
 
 // ---------------------------------------------------------------------------
+// SSRF Protection
+// ---------------------------------------------------------------------------
+
+/** Maximum response body size for remote metadata fetches (1 MB). */
+const MAX_METADATA_RESPONSE_BYTES = 1_048_576;
+
+/**
+ * Check whether a hostname resolves to a private/reserved IP address.
+ * Throws RemoteMetadataFetchError if any resolved address is private.
+ * Skipped in development/test environments to allow localhost.
+ */
+async function resolveAndCheckPrivateIp(hostname: string): Promise<void> {
+  // Strip port from hostname before DNS resolution
+  const bareHost = hostname.replace(/:\d+$/, '');
+
+  // Resolve both IPv4 and IPv6
+  const [ipv4Addrs, ipv6Addrs] = await Promise.all([
+    dns.promises.resolve4(bareHost).catch(() => [] as string[]),
+    dns.promises.resolve6(bareHost).catch(() => [] as string[]),
+  ]);
+
+  for (const addr of ipv4Addrs) {
+    if (isPrivateIPv4(addr)) {
+      throw new RemoteMetadataFetchError(
+        hostname,
+        new Error(`Resolved to private IPv4 address: ${addr}`),
+      );
+    }
+  }
+
+  for (const addr of ipv6Addrs) {
+    if (isPrivateIPv6(addr)) {
+      throw new RemoteMetadataFetchError(
+        hostname,
+        new Error(`Resolved to private IPv6 address: ${addr}`),
+      );
+    }
+  }
+}
+
+function isPrivateIPv4(addr: string): boolean {
+  const parts = addr.split('.').map(Number);
+  if (parts.length !== 4) return false;
+  const [a, b] = parts;
+
+  return (
+    a === 10 || // 10.0.0.0/8
+    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
+    (a === 192 && b === 168) || // 192.168.0.0/16
+    a === 127 || // 127.0.0.0/8
+    (a === 169 && b === 254) || // 169.254.0.0/16
+    a === 0 // 0.0.0.0/8
+  );
+}
+
+function isPrivateIPv6(addr: string): boolean {
+  const normalized = addr.toLowerCase();
+  return (
+    normalized === '::1' || // loopback
+    normalized.startsWith('fe80') || // link-local fe80::/10
+    normalized.startsWith('fc') || // ULA fc00::/7
+    normalized.startsWith('fd') // ULA fc00::/7
+  );
+}
+
+/**
+ * Fetch and validate remote instance metadata with full hardening:
+ * - SSRF check (private IP rejection, skipped in dev/test)
+ * - Redirect rejection
+ * - Response size limit (1 MB)
+ * - Zod schema validation
+ * - Domain mismatch detection
+ */
+async function fetchAndValidateMetadata(
+  domain: string,
+): Promise<FederationMetadata> {
+  // SSRF check — skip in development/test for localhost
+  const nodeEnv = process.env.NODE_ENV;
+  if (nodeEnv !== 'development' && nodeEnv !== 'test') {
+    await resolveAndCheckPrivateIp(domain);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`https://${domain}/.well-known/colophony`, {
+      signal: AbortSignal.timeout(10_000),
+      headers: { accept: 'application/json' },
+      redirect: 'error', // Prevent redirect-based SSRF
+    });
+  } catch (err) {
+    throw new RemoteMetadataFetchError(domain, err);
+  }
+
+  if (!response.ok) {
+    throw new RemoteMetadataFetchError(
+      domain,
+      new Error(`HTTP ${response.status}`),
+    );
+  }
+
+  // Response size guard: check Content-Length if available
+  const contentLength = response.headers.get('content-length');
+  if (
+    contentLength &&
+    parseInt(contentLength, 10) > MAX_METADATA_RESPONSE_BYTES
+  ) {
+    throw new RemoteMetadataFetchError(
+      domain,
+      new Error(
+        `Response too large: ${contentLength} bytes (max ${MAX_METADATA_RESPONSE_BYTES})`,
+      ),
+    );
+  }
+
+  // Read body with size limit for chunked responses
+  let bodyText: string;
+  try {
+    if (response.body) {
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      const chunks: string[] = [];
+      let totalBytes = 0;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        totalBytes += value.byteLength;
+        if (totalBytes > MAX_METADATA_RESPONSE_BYTES) {
+          await reader.cancel();
+          throw new Error(
+            `Response body exceeded ${MAX_METADATA_RESPONSE_BYTES} bytes`,
+          );
+        }
+        chunks.push(decoder.decode(value, { stream: true }));
+      }
+      chunks.push(decoder.decode()); // flush
+      bodyText = chunks.join('');
+    } else {
+      bodyText = await response.text();
+    }
+  } catch (err) {
+    throw new RemoteMetadataFetchError(domain, err);
+  }
+
+  // Parse JSON
+  let json: unknown;
+  try {
+    json = JSON.parse(bodyText);
+  } catch (err) {
+    throw new RemoteMetadataFetchError(domain, err);
+  }
+
+  // Zod validation
+  const parsed = federationMetadataSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new RemoteMetadataFetchError(
+      domain,
+      new Error(`Invalid metadata: ${parsed.error.message}`),
+    );
+  }
+
+  const metadata = parsed.data;
+
+  // Domain match check
+  if (metadata.domain !== domain) {
+    throw new RemoteMetadataFetchError(
+      domain,
+      new Error(
+        `Domain mismatch: metadata claims "${metadata.domain}" but was fetched from "${domain}"`,
+      ),
+    );
+  }
+
+  return metadata;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -97,42 +276,11 @@ function mapPeerRow(row: typeof trustedPeers.$inferSelect): TrustedPeer {
 export const trustService = {
   /**
    * Fetch and preview remote instance metadata.
-   * 10s timeout for SSRF protection.
+   * Uses shared fetchAndValidateMetadata() for SSRF protection, size limits,
+   * domain validation, and schema parsing.
    */
   async fetchRemoteMetadata(domain: string): Promise<RemoteMetadataPreview> {
-    let response: Response;
-    try {
-      response = await fetch(`https://${domain}/.well-known/colophony`, {
-        signal: AbortSignal.timeout(10_000),
-        headers: { accept: 'application/json' },
-      });
-    } catch (err) {
-      throw new RemoteMetadataFetchError(domain, err);
-    }
-
-    if (!response.ok) {
-      throw new RemoteMetadataFetchError(
-        domain,
-        new Error(`HTTP ${response.status}`),
-      );
-    }
-
-    let json: unknown;
-    try {
-      json = await response.json();
-    } catch (err) {
-      throw new RemoteMetadataFetchError(domain, err);
-    }
-
-    const parsed = federationMetadataSchema.safeParse(json);
-    if (!parsed.success) {
-      throw new RemoteMetadataFetchError(
-        domain,
-        new Error(`Invalid metadata: ${parsed.error.message}`),
-      );
-    }
-
-    const metadata = parsed.data;
+    const metadata = await fetchAndValidateMetadata(domain);
     return {
       domain: metadata.domain,
       software: metadata.software,
@@ -253,18 +401,7 @@ export const trustService = {
     // This prevents domain spoofing — attacker can't claim any domain with a self-signed key
     let remotePublicKey: string;
     try {
-      const remoteMetadata = await fetch(
-        `https://${request.domain}/.well-known/colophony`,
-        { signal: AbortSignal.timeout(10_000) },
-      );
-      if (!remoteMetadata.ok) {
-        throw new Error(
-          `Remote metadata fetch failed: ${remoteMetadata.status}`,
-        );
-      }
-      const metadata = federationMetadataSchema.parse(
-        await remoteMetadata.json(),
-      );
+      const metadata = await fetchAndValidateMetadata(request.domain);
       remotePublicKey = metadata.publicKey;
     } catch (err) {
       throw new TrustSignatureVerificationError(
@@ -678,16 +815,7 @@ export const trustService = {
     // Fetch hub's public key from its well-known metadata
     let hubPublicKey: string;
     try {
-      const hubMetadataResponse = await fetch(
-        `https://${request.hubDomain}/.well-known/colophony`,
-        { signal: AbortSignal.timeout(10_000) },
-      );
-      if (!hubMetadataResponse.ok) {
-        throw new Error(`HTTP ${hubMetadataResponse.status}`);
-      }
-      const hubMetadata = federationMetadataSchema.parse(
-        await hubMetadataResponse.json(),
-      );
+      const hubMetadata = await fetchAndValidateMetadata(request.hubDomain);
       hubPublicKey = hubMetadata.publicKey;
     } catch (err) {
       throw new TrustSignatureVerificationError(

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -30,7 +30,7 @@
 - [x] Zitadel webhook two-step idempotency — current one-step pattern doesn't handle crash recovery (row inserted but `processed=false`); align with Stripe webhook's two-step pattern — (Codex review 2026-02-17; done 2026-02-17)
 - [x] Audit query/list endpoints — wait for API surfaces — (DEVLOG 2026-02-13; done 2026-02-18 PR #101)
 - [x] Seed data (`packages/db/src/seed.ts` has TODO) — wait for API layer — (code TODO; done 2026-02-18 PR #104)
-- [ ] [P2] Replace custom rate-limit Lua scripts with `@fastify/rate-limit` plugin — gains sliding window (fixes burst-at-boundary), removes custom Lua, more idiomatic Fastify. Keep two-tier design (IP pre-auth + user post-auth). May also resolve recurring CodeQL `js/missing-rate-limiting` false positives on federation routes. — (dev feedback 2026-02-25)
+- [x] [P2] Sliding window rate limiting — replaced fixed-window Lua script with sliding-window-log algorithm using Redis sorted sets; fixes burst-at-boundary 2x rate vulnerability; kept custom two-tier design (IP pre-auth + user post-auth) — (dev feedback 2026-02-25; done 2026-02-25)
 
 ### QA / Testing
 
@@ -155,9 +155,9 @@
 
 - [x] Discovery: WebFinger + `.well-known` endpoints — (architecture doc Track 5; done 2026-02-24)
 - [x] Identity: `did:web` DID document resolution — per-user Ed25519 keypairs, native crypto (no jose needed) — (architecture doc Track 5; done 2026-02-24)
-- [ ] [P2] Split `getOrInitConfig()` to separate public-key-only read from private-key read — reduces private key exposure surface — (Codex review 2026-02-24, deferred to Phase 3)
+- [x] [P2] Split `getOrInitConfig()` to separate public-key-only read from private-key read — reduces private key exposure surface — (Codex review 2026-02-24, deferred to Phase 3; done 2026-02-25)
 - [ ] [P3] Key rotation mechanism for user keypairs — (architecture doc Track 5, deferred to Phase 7)
-- [ ] [P2] Inbound DID resolution hardening — validate remote DID documents fetched during federation — (Codex review 2026-02-24, deferred to Phase 3)
+- [x] [P2] Inbound metadata fetch hardening — SSRF protection, domain mismatch, size limits, shared `fetchAndValidateMetadata()` helper — (Codex review 2026-02-24, deferred to Phase 3; done 2026-02-25)
 - [x] Trust establishment — bilateral trust with HTTP signatures, trust service, public S2S + admin routes — (architecture doc Track 5; done 2026-02-24)
 - [x] [P2] Federation signature verification middleware — protect all federation endpoints with signature-based auth — (DEVLOG 2026-02-24, done 2026-02-24)
 - [x] Sim-sub enforcement (BSAP) — fingerprint service, sim-sub service (local+remote check), S2S endpoint, admin routes, submission flow integration, all 3 API surfaces — (architecture doc Track 5; done 2026-02-24)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,25 @@ Newest entries first.
 
 ---
 
+## 2026-02-25 — Federation Hardening (Track 5 P2 Items)
+
+### Done
+
+- Split `getOrInitConfig()` — added `getPublicConfig()` that queries only public columns from DB (private key never loaded into memory); updated 5 callers (metadata, WebFinger, DID docs, hub registration); added `FederationPublicConfig` type
+- Hardened inbound metadata fetch — added shared `fetchAndValidateMetadata()` helper replacing 3 independent fetch sites; SSRF protection (IPv4+IPv6 DNS resolution against RFC 1918 ranges, loopback, link-local, ULA); redirect rejection; streaming body reader with 1MB cap; domain mismatch assertion; skipped in dev/test for localhost
+- Tightened `federationMetadataSchema` validators — PEM format check on `publicKey`, `keyId` must contain `#`, domain regex allows ports (`:4000`), non-empty `version`
+- Replaced fixed-window rate limiting with sliding-window-log algorithm — Redis sorted sets (ZADD/ZCARD/ZREMRANGEBYSCORE) fix burst-at-boundary 2x rate vulnerability; check-then-add pattern caps sorted set growth; Lua script returns `count + 1` for 1-indexed semantics
+- Updated both rate-limit hooks (IP pre-auth + user post-auth) with new Lua script and simplified key format (no window ID)
+- 23 new tests (4 getPublicConfig, 7 schema validation, 9 SSRF/metadata, 3 sliding window), 1045 tests pass, type-check + lint clean
+
+### Decisions
+
+- Lua script returns `count + 1` (1-indexed): caps sorted set at `limit` entries while keeping `count > limit` check consistent with prior INCR behavior
+- SSRF skipped in dev/test (`NODE_ENV`): allows localhost federation testing without DNS resolution failures
+- Streaming body reader: Content-Length pre-check + chunked accumulation with 1MB cap (Content-Length alone insufficient for chunked responses)
+
+---
+
 ## 2026-02-25 — Federation Hub for Managed Hosting (Track 5 Phase 8)
 
 ### Done

--- a/packages/types/src/federation.spec.ts
+++ b/packages/types/src/federation.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { federationMetadataSchema } from "./federation.js";
+
+const validMetadata = {
+  software: "colophony" as const,
+  version: "2.0.0-dev",
+  domain: "magazine.example",
+  publicKey:
+    "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA...\n-----END PUBLIC KEY-----",
+  keyId: "magazine.example#main",
+  capabilities: ["identity"],
+  mode: "allowlist" as const,
+  contactEmail: null,
+  publications: [],
+};
+
+describe("federationMetadataSchema", () => {
+  it("accepts valid metadata", () => {
+    const result = federationMetadataSchema.safeParse(validMetadata);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts domain with port", () => {
+    const result = federationMetadataSchema.safeParse({
+      ...validMetadata,
+      domain: "localhost:4000",
+      keyId: "localhost:4000#main",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid PEM publicKey", () => {
+    const result = federationMetadataSchema.safeParse({
+      ...validMetadata,
+      publicKey: "not-a-pem",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty keyId", () => {
+    const result = federationMetadataSchema.safeParse({
+      ...validMetadata,
+      keyId: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects keyId without hash fragment", () => {
+    const result = federationMetadataSchema.safeParse({
+      ...validMetadata,
+      keyId: "magazine.example-main",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid domain format", () => {
+    const result = federationMetadataSchema.safeParse({
+      ...validMetadata,
+      domain: "-bad",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty version", () => {
+    const result = federationMetadataSchema.safeParse({
+      ...validMetadata,
+      version: "",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/types/src/federation.ts
+++ b/packages/types/src/federation.ts
@@ -15,10 +15,15 @@ export type FederationPublication = z.infer<typeof federationPublicationSchema>;
 
 export const federationMetadataSchema = z.object({
   software: z.literal("colophony"),
-  version: z.string(),
-  domain: z.string(),
-  publicKey: z.string(),
-  keyId: z.string(),
+  version: z.string().min(1),
+  domain: z
+    .string()
+    .min(1)
+    .regex(/^[a-zA-Z0-9][a-zA-Z0-9.:-]+[a-zA-Z0-9]$/, "Invalid domain format"),
+  publicKey: z
+    .string()
+    .startsWith("-----BEGIN PUBLIC KEY-----", "Must be PEM-encoded public key"),
+  keyId: z.string().min(1).includes("#", { message: "keyId must contain #" }),
   capabilities: z.array(z.string()),
   mode: z.enum(["allowlist", "open", "managed_hub"]),
   contactEmail: z.string().nullable(),


### PR DESCRIPTION
## Summary

- **Public config split**: Added `getPublicConfig()` that queries only public DB columns — private key is never loaded into memory for metadata, WebFinger, DID, and hub registration callers
- **Metadata fetch hardening**: Shared `fetchAndValidateMetadata()` helper with SSRF protection (IPv4+IPv6+IP literal blocking), redirect rejection, 1MB streaming size limit, domain mismatch assertion, tightened Zod schema (PEM format, keyId `#` fragment, domain regex with port support)
- **Sliding window rate limiting**: Replaced fixed-window Lua counter with sliding-window-log algorithm using Redis sorted sets — fixes burst-at-boundary 2x rate vulnerability; returns oldest entry timestamp for accurate Retry-After headers

## Codex Review

All 6 findings addressed:
1. **P1** — Require both env keys in `getPublicConfig()` (parity with `getOrInitConfig()`)
2. **P1** — Block IP literals before DNS resolution in SSRF check
3. **P2** — Use column projection in env-override DB query (never load privateKey)
4. **P2** — Fix IPv6 link-local range to cover full `fe80::/10` (was only `fe80::/16`)
5. **P3** — Return oldest entry timestamp from Lua script for accurate Retry-After
6. **Missing** — Added 3 sliding window tests to `rate-limit-auth.spec.ts`

## Test plan

- [ ] 1048 tests pass (26 new: 4 getPublicConfig + 7 schema + 9 SSRF/metadata + 6 sliding window)
- [ ] Type-check clean
- [ ] Lint clean
- [ ] Verify `getPublicConfig()` result has no `privateKey` property
- [ ] Verify sliding window blocks burst-at-boundary (test: 3 requests at t=55s, 1 at t=61s → 429)
- [ ] Verify SSRF blocks IP literals (`127.0.0.1`, `::1`) in production mode