### PR TITLE
feat(register): track 5 production hardening

### DIFF
--- a/apps/api/src/__tests__/rls/helpers/db-setup.ts
+++ b/apps/api/src/__tests__/rls/helpers/db-setup.ts
@@ -155,6 +155,57 @@ export async function globalTeardown(): Promise<void> {
   isSetUp = false;
 }
 
+/**
+ * Apply migrations from 0000 through the given tag (inclusive).
+ * Uses the same statement-splitting pattern as globalSetup().
+ */
+export async function applyMigrationsUpTo(
+  pool: Pool,
+  upToTag: string,
+): Promise<void> {
+  const journalPath = path.join(migrationsFolder, 'meta', '_journal.json');
+  const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8')) as {
+    entries: Array<{ tag: string }>;
+  };
+
+  for (const entry of journal.entries) {
+    const sqlPath = path.join(migrationsFolder, `${entry.tag}.sql`);
+    const sql = fs.readFileSync(sqlPath, 'utf8');
+
+    const statements = sql
+      .split('--> statement-breakpoint')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+
+    for (const statement of statements) {
+      await pool.query(statement);
+    }
+
+    if (entry.tag === upToTag) break;
+  }
+}
+
+/**
+ * Apply a single migration by tag.
+ * Throws if any statement fails (useful for testing dirty-data scenarios).
+ */
+export async function applySingleMigration(
+  pool: Pool,
+  tag: string,
+): Promise<void> {
+  const sqlPath = path.join(migrationsFolder, `${tag}.sql`);
+  const sql = fs.readFileSync(sqlPath, 'utf8');
+
+  const statements = sql
+    .split('--> statement-breakpoint')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  for (const statement of statements) {
+    await pool.query(statement);
+  }
+}
+
 // Automatic cleanup when the process exits (singleFork mode shares pools)
 process.on('beforeExit', () => {
   void globalTeardown();

--- a/apps/api/src/__tests__/rls/migration-enum-cast.test.ts
+++ b/apps/api/src/__tests__/rls/migration-enum-cast.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import {
+  applyMigrationsUpTo,
+  applySingleMigration,
+} from './helpers/db-setup.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ADMIN_URL =
+  process.env.DATABASE_TEST_URL ??
+  'postgresql://test:test@localhost:5433/colophony_test';
+
+let adminPool: Pool;
+
+beforeAll(async () => {
+  adminPool = new Pool({
+    connectionString: ADMIN_URL,
+    max: 3,
+    idleTimeoutMillis: 1000,
+  });
+});
+
+afterAll(async () => {
+  await adminPool.end();
+});
+
+/**
+ * Reset the database to the state after migration 0030 (before enum casts).
+ * Creates required roles and applies migrations 0000–0030.
+ */
+async function resetToMigration0030(): Promise<void> {
+  // Drop and recreate schema
+  await adminPool.query('DROP SCHEMA IF EXISTS public CASCADE');
+  await adminPool.query('CREATE SCHEMA public');
+  await adminPool.query('GRANT ALL ON SCHEMA public TO PUBLIC');
+
+  // Create roles needed by migrations
+  await adminPool.query(`
+    DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user') THEN
+        CREATE ROLE app_user LOGIN PASSWORD 'app_password'
+          NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+      ELSE
+        ALTER ROLE app_user NOSUPERUSER NOBYPASSRLS;
+      END IF;
+    END $$;
+  `);
+  await adminPool.query(`
+    DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'audit_writer') THEN
+        CREATE ROLE audit_writer NOLOGIN
+          NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+      ELSE
+        ALTER ROLE audit_writer NOSUPERUSER NOBYPASSRLS;
+      END IF;
+    END $$;
+  `);
+  await adminPool.query('GRANT USAGE ON SCHEMA public TO audit_writer');
+  await adminPool.query('GRANT USAGE ON SCHEMA public TO app_user');
+
+  await applyMigrationsUpTo(adminPool, '0030_user_key_rotation');
+}
+
+/**
+ * Helper to check if a column is an enum type.
+ */
+async function getColumnType(table: string, column: string): Promise<string> {
+  const result = await adminPool.query<{ data_type: string; udt_name: string }>(
+    `SELECT data_type, udt_name FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2`,
+    [table, column],
+  );
+  if (result.rows.length === 0) return 'MISSING';
+  return result.rows[0].data_type === 'USER-DEFINED'
+    ? result.rows[0].udt_name
+    : result.rows[0].data_type;
+}
+
+/**
+ * Helper to check if an enum type exists.
+ */
+async function enumExists(enumName: string): Promise<boolean> {
+  const result = await adminPool.query(
+    `SELECT 1 FROM pg_type WHERE typname = $1 AND typtype = 'e'`,
+    [enumName],
+  );
+  return result.rows.length > 0;
+}
+
+/**
+ * Helper to check if a table exists.
+ */
+async function tableExists(tableName: string): Promise<boolean> {
+  const result = await adminPool.query(
+    `SELECT 1 FROM information_schema.tables
+     WHERE table_schema = 'public' AND table_name = $1`,
+    [tableName],
+  );
+  return result.rows.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Migration 0031 enum casts — happy path', () => {
+  beforeEach(async () => {
+    await resetToMigration0030();
+  }, 30_000);
+
+  it('applies cleanly with valid varchar data', async () => {
+    // Insert valid rows matching the target enum values
+    const orgId = (
+      await adminPool.query<{ id: string }>(
+        `INSERT INTO organizations (name, slug) VALUES ('test-org', 'test-org') RETURNING id`,
+      )
+    ).rows[0].id;
+
+    const userId = (
+      await adminPool.query<{ id: string }>(
+        `INSERT INTO users (zitadel_user_id, email) VALUES ('z-test', 'test@example.com') RETURNING id`,
+      )
+    ).rows[0].id;
+
+    // identity_migrations.direction = 'outbound'
+    await adminPool.query(
+      `INSERT INTO identity_migrations (user_id, organization_id, direction, peer_domain, status)
+       VALUES ($1, $2, 'outbound', 'peer.example.com', 'PENDING')`,
+      [userId, orgId],
+    );
+
+    // hub_registered_instances.status = 'active'
+    await adminPool.query(
+      `INSERT INTO hub_registered_instances (domain, instance_url, public_key, key_id, status)
+       VALUES ('hub.example.com', 'https://hub.example.com', 'pk-test', 'hub.example.com#main', 'active')`,
+    );
+
+    // trusted_peers.initiated_by = 'local'
+    await adminPool.query(
+      `INSERT INTO trusted_peers (organization_id, domain, instance_url, public_key, key_id, initiated_by)
+       VALUES ($1, 'trusted.example.com', 'https://trusted.example.com', 'pk-test', 'trusted.example.com#main', 'local')`,
+      [orgId],
+    );
+
+    // Apply migration 0031
+    await applySingleMigration(adminPool, '0031_federation_cleanup');
+
+    // Assert columns are now enum types
+    expect(await getColumnType('identity_migrations', 'direction')).toBe(
+      'IdentityMigrationDirection',
+    );
+    expect(await getColumnType('hub_registered_instances', 'status')).toBe(
+      'HubInstanceStatus',
+    );
+    expect(await getColumnType('trusted_peers', 'initiated_by')).toBe(
+      'TrustInitiator',
+    );
+
+    // Assert inbound_transfers table was created
+    expect(await tableExists('inbound_transfers')).toBe(true);
+  });
+
+  it('applies cleanly with empty tables', async () => {
+    // No data — just apply migration 0031
+    await applySingleMigration(adminPool, '0031_federation_cleanup');
+
+    // Assert enum types exist
+    expect(await enumExists('IdentityMigrationDirection')).toBe(true);
+    expect(await enumExists('HubInstanceStatus')).toBe(true);
+    expect(await enumExists('TrustInitiator')).toBe(true);
+    expect(await enumExists('InboundTransferStatus')).toBe(true);
+
+    // Assert columns are now enum types
+    expect(await getColumnType('identity_migrations', 'direction')).toBe(
+      'IdentityMigrationDirection',
+    );
+    expect(await getColumnType('hub_registered_instances', 'status')).toBe(
+      'HubInstanceStatus',
+    );
+    expect(await getColumnType('trusted_peers', 'initiated_by')).toBe(
+      'TrustInitiator',
+    );
+
+    // Assert inbound_transfers table was created
+    expect(await tableExists('inbound_transfers')).toBe(true);
+  });
+});
+
+describe('Migration 0031 enum casts — dirty data', () => {
+  beforeEach(async () => {
+    await resetToMigration0030();
+  }, 30_000);
+
+  it('rejects invalid value in identity_migrations.direction', async () => {
+    const orgId = (
+      await adminPool.query<{ id: string }>(
+        `INSERT INTO organizations (name, slug) VALUES ('test-org', 'test-org') RETURNING id`,
+      )
+    ).rows[0].id;
+
+    const userId = (
+      await adminPool.query<{ id: string }>(
+        `INSERT INTO users (zitadel_user_id, email) VALUES ('z-test', 'test@example.com') RETURNING id`,
+      )
+    ).rows[0].id;
+
+    // Insert invalid direction value (must fit varchar(10))
+    await adminPool.query(
+      `INSERT INTO identity_migrations (user_id, organization_id, direction, peer_domain, status)
+       VALUES ($1, $2, 'bad', 'peer.example.com', 'PENDING')`,
+      [userId, orgId],
+    );
+
+    await expect(
+      applySingleMigration(adminPool, '0031_federation_cleanup'),
+    ).rejects.toThrow();
+  });
+
+  it('rejects case-mismatched value in hub_registered_instances.status', async () => {
+    // Insert 'Active' (capital A) — enum expects 'active'
+    await adminPool.query(
+      `INSERT INTO hub_registered_instances (domain, instance_url, public_key, key_id, status)
+       VALUES ('hub.example.com', 'https://hub.example.com', 'pk-test', 'hub.example.com#main', 'Active')`,
+    );
+
+    await expect(
+      applySingleMigration(adminPool, '0031_federation_cleanup'),
+    ).rejects.toThrow();
+  });
+
+  it('rejects invalid value in trusted_peers.initiated_by', async () => {
+    const orgId = (
+      await adminPool.query<{ id: string }>(
+        `INSERT INTO organizations (name, slug) VALUES ('test-org', 'test-org') RETURNING id`,
+      )
+    ).rows[0].id;
+
+    await adminPool.query(
+      `INSERT INTO trusted_peers (organization_id, domain, instance_url, public_key, key_id, initiated_by)
+       VALUES ($1, 'trusted.example.com', 'https://trusted.example.com', 'pk-test', 'trusted.example.com#main', 'UNKNOWN')`,
+      [orgId],
+    );
+
+    await expect(
+      applySingleMigration(adminPool, '0031_federation_cleanup'),
+    ).rejects.toThrow();
+  });
+});
+
+describe('Migration 0031 partial failure', () => {
+  beforeEach(async () => {
+    await resetToMigration0030();
+  }, 30_000);
+
+  it('documents partial state after mid-migration failure', async () => {
+    // Insert dirty data in hub_registered_instances (enum cast #2)
+    // The enum CREATEs succeed, identity_migrations ALTER succeeds (empty),
+    // but hub_registered_instances ALTER fails on invalid data.
+    await adminPool.query(
+      `INSERT INTO hub_registered_instances (domain, instance_url, public_key, key_id, status)
+       VALUES ('hub.example.com', 'https://hub.example.com', 'pk-test', 'hub.example.com#main', 'Active')`,
+    );
+
+    // Attempt migration — expect failure
+    await expect(
+      applySingleMigration(adminPool, '0031_federation_cleanup'),
+    ).rejects.toThrow();
+
+    // Document partial state: Drizzle applies statements individually (not transactionally)
+    // Enum types created before the failing ALTER should exist
+    expect(await enumExists('IdentityMigrationDirection')).toBe(true);
+    expect(await enumExists('HubInstanceStatus')).toBe(true);
+    expect(await enumExists('TrustInitiator')).toBe(true);
+    expect(await enumExists('InboundTransferStatus')).toBe(true);
+
+    // identity_migrations.direction was converted (it runs before hub)
+    expect(await getColumnType('identity_migrations', 'direction')).toBe(
+      'IdentityMigrationDirection',
+    );
+
+    // hub_registered_instances.status failed — still varchar
+    expect(await getColumnType('hub_registered_instances', 'status')).toBe(
+      'character varying',
+    );
+
+    // trusted_peers.initiated_by — not yet reached
+    expect(await getColumnType('trusted_peers', 'initiated_by')).toBe(
+      'character varying',
+    );
+
+    // inbound_transfers table was not created (comes after failing ALTER)
+    expect(await tableExists('inbound_transfers')).toBe(false);
+  });
+});

--- a/apps/api/src/__tests__/rls/migration-enum-cast.test.ts
+++ b/apps/api/src/__tests__/rls/migration-enum-cast.test.ts
@@ -256,7 +256,11 @@ describe('Migration 0031 partial failure', () => {
   }, 30_000);
 
   it('documents partial state after mid-migration failure', async () => {
-    // Insert dirty data in hub_registered_instances (enum cast #2)
+    // Drizzle-specific behavior: migration statements are applied individually,
+    // NOT wrapped in a transaction. Other ORMs (e.g., Knex, Flyway) may wrap
+    // each migration file in a transaction, producing all-or-nothing semantics.
+    //
+    // Insert dirty data in hub_registered_instances (enum cast #2).
     // The enum CREATEs succeed, identity_migrations ALTER succeeds (empty),
     // but hub_registered_instances ALTER fails on invalid data.
     await adminPool.query(

--- a/apps/api/src/federation/__tests__/federation-rate-limit.spec.ts
+++ b/apps/api/src/federation/__tests__/federation-rate-limit.spec.ts
@@ -37,6 +37,7 @@ async function buildApp(
   redis: ReturnType<typeof createMockRedis> | null,
   env = baseEnv,
   peer?: PeerConfig,
+  capability?: string,
 ): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
 
@@ -67,7 +68,7 @@ async function buildApp(
 
   // Register the plugin under test
   const mod = await import('../federation-rate-limit.js');
-  await app.register(mod.default as any, { env });
+  await app.register(mod.default as any, { env, capability });
 
   // Test route
   app.get('/test', async (_request, reply) => {
@@ -236,5 +237,95 @@ describe('federation-rate-limit', () => {
       10, // custom limit
     );
     await app.close();
+  });
+
+  it('uses capability in key when provided', async () => {
+    const redis = createMockRedis([1, 0]);
+    const app = await buildApp(
+      redis,
+      baseEnv,
+      {
+        type: 'federation',
+        domain: 'peer.example.com',
+        keyId: 'peer.example.com#main',
+      },
+      'simsub',
+    );
+
+    await app.inject({ method: 'GET', url: '/test' });
+
+    expect(redis.eval).toHaveBeenCalledWith(
+      'mock-lua-script',
+      1,
+      'test:rl:fed:simsub:peer.example.com',
+      expect.any(Number),
+      expect.any(Number),
+      expect.any(String),
+      60_000,
+      60,
+    );
+    await app.close();
+  });
+
+  it('falls back to global key when capability omitted', async () => {
+    const redis = createMockRedis([1, 0]);
+    const app = await buildApp(redis, baseEnv, {
+      type: 'federation',
+      domain: 'peer.example.com',
+      keyId: 'peer.example.com#main',
+    });
+
+    await app.inject({ method: 'GET', url: '/test' });
+
+    expect(redis.eval).toHaveBeenCalledWith(
+      'mock-lua-script',
+      1,
+      'test:rl:fed:peer.example.com',
+      expect.any(Number),
+      expect.any(Number),
+      expect.any(String),
+      60_000,
+      60,
+    );
+    await app.close();
+  });
+
+  it('different capabilities produce different keys', async () => {
+    const redisSimsub = createMockRedis([1, 0]);
+    const appSimsub = await buildApp(
+      redisSimsub,
+      baseEnv,
+      {
+        type: 'federation',
+        domain: 'peer.example.com',
+        keyId: 'peer.example.com#main',
+      },
+      'simsub',
+    );
+
+    const redisTransfer = createMockRedis([1, 0]);
+    const appTransfer = await buildApp(
+      redisTransfer,
+      baseEnv,
+      {
+        type: 'federation',
+        domain: 'peer.example.com',
+        keyId: 'peer.example.com#main',
+      },
+      'transfer',
+    );
+
+    await appSimsub.inject({ method: 'GET', url: '/test' });
+    await appTransfer.inject({ method: 'GET', url: '/test' });
+
+    const simsubKey = redisSimsub.eval.mock.calls[0][2];
+    const transferKey = redisTransfer.eval.mock.calls[0][2];
+
+    expect(simsubKey).toBe('test:rl:fed:simsub:peer.example.com');
+    expect(transferKey).toBe('test:rl:fed:transfer:peer.example.com');
+    expect(simsubKey).not.toBe(transferKey);
+
+    await appSimsub.close();
+    await appTransfer.close();
   });
 });

--- a/apps/api/src/federation/__tests__/federation-rate-limit.spec.ts
+++ b/apps/api/src/federation/__tests__/federation-rate-limit.spec.ts
@@ -328,4 +328,21 @@ describe('federation-rate-limit', () => {
     await appSimsub.close();
     await appTransfer.close();
   });
+
+  it('rejects invalid capability at registration', async () => {
+    const redis = createMockRedis([1, 0]);
+
+    await expect(
+      buildApp(
+        redis,
+        baseEnv,
+        {
+          type: 'federation',
+          domain: 'peer.example.com',
+          keyId: 'peer.example.com#main',
+        },
+        'bogus',
+      ),
+    ).rejects.toThrow(/Invalid federation rate limit capability.*bogus/);
+  });
 });

--- a/apps/api/src/federation/federation-rate-limit.ts
+++ b/apps/api/src/federation/federation-rate-limit.ts
@@ -3,6 +3,8 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import type { Env } from '../config/env.js';
 import { SLIDING_WINDOW_SCRIPT } from '../hooks/rate-limit.js';
 
+const VALID_CAPABILITIES = new Set(['simsub', 'transfer', 'migration', 'hub']);
+
 export interface FederationRateLimitOptions {
   env: Env;
   capability?: string;
@@ -21,6 +23,13 @@ export default fp(
     opts: FederationRateLimitOptions,
   ) {
     const { env, capability } = opts;
+
+    if (capability && !VALID_CAPABILITIES.has(capability)) {
+      throw new Error(
+        `Invalid federation rate limit capability: '${capability}'. ` +
+          `Valid values: ${[...VALID_CAPABILITIES].join(', ')}`,
+      );
+    }
     const limit = env.FEDERATION_RATE_LIMIT_MAX;
     const windowMs = env.FEDERATION_RATE_LIMIT_WINDOW_SECONDS * 1000;
     const prefix = env.RATE_LIMIT_KEY_PREFIX;

--- a/apps/api/src/federation/federation-rate-limit.ts
+++ b/apps/api/src/federation/federation-rate-limit.ts
@@ -5,6 +5,7 @@ import { SLIDING_WINDOW_SCRIPT } from '../hooks/rate-limit.js';
 
 export interface FederationRateLimitOptions {
   env: Env;
+  capability?: string;
 }
 
 /**
@@ -19,7 +20,7 @@ export default fp(
     app: FastifyInstance,
     opts: FederationRateLimitOptions,
   ) {
-    const { env } = opts;
+    const { env, capability } = opts;
     const limit = env.FEDERATION_RATE_LIMIT_MAX;
     const windowMs = env.FEDERATION_RATE_LIMIT_WINDOW_SECONDS * 1000;
     const prefix = env.RATE_LIMIT_KEY_PREFIX;
@@ -40,7 +41,9 @@ export default fp(
         const redis = app.rateLimitRedis;
         if (!redis) return;
 
-        const key = `${prefix}:fed:${domain}`;
+        const key = capability
+          ? `${prefix}:fed:${capability}:${domain}`
+          : `${prefix}:fed:${domain}`;
         const nowMs = Date.now();
         const requestId = `${nowMs}:${Math.random().toString(36).slice(2, 8)}`;
 
@@ -88,6 +91,7 @@ export default fp(
           request.log.warn(
             {
               identifier: domain,
+              capability,
               path: request.url,
               count,
               limit,

--- a/apps/api/src/federation/hub.routes.ts
+++ b/apps/api/src/federation/hub.routes.ts
@@ -64,7 +64,7 @@ export async function registerHubRoutes(
   // Authenticated hub routes — HTTP signature via hubAuthPlugin
   await app.register(async (scope) => {
     await scope.register(hubAuthPlugin);
-    await scope.register(federationRateLimitPlugin, { env });
+    await scope.register(federationRateLimitPlugin, { env, capability: 'hub' });
 
     /**
      * POST /federation/v1/hub/refresh — Refresh attestation.

--- a/apps/api/src/federation/migration.routes.ts
+++ b/apps/api/src/federation/migration.routes.ts
@@ -38,7 +38,10 @@ export async function registerMigrationRoutes(
   // Scope 1: S2S endpoints (HTTP signature auth via federationAuthPlugin)
   await app.register(async (s2s) => {
     await s2s.register(federationAuthPlugin);
-    await s2s.register(federationRateLimitPlugin, { env });
+    await s2s.register(federationRateLimitPlugin, {
+      env,
+      capability: 'migration',
+    });
 
     /**
      * POST /federation/v1/migrations/request

--- a/apps/api/src/federation/simsub.routes.ts
+++ b/apps/api/src/federation/simsub.routes.ts
@@ -20,7 +20,7 @@ export async function registerSimSubRoutes(
 
   // Federation signature verification (scoped — includes raw body plugin)
   await app.register(federationAuthPlugin);
-  await app.register(federationRateLimitPlugin, { env });
+  await app.register(federationRateLimitPlugin, { env, capability: 'simsub' });
 
   /**
    * POST /federation/v1/sim-sub/check

--- a/apps/api/src/federation/transfer.routes.ts
+++ b/apps/api/src/federation/transfer.routes.ts
@@ -31,7 +31,10 @@ export async function registerTransferRoutes(
   // Scope 1: S2S initiation (HTTP signature auth via federationAuthPlugin)
   await app.register(async (s2s) => {
     await s2s.register(federationAuthPlugin);
-    await s2s.register(federationRateLimitPlugin, { env });
+    await s2s.register(federationRateLimitPlugin, {
+      env,
+      capability: 'transfer',
+    });
 
     /**
      * POST /federation/v1/transfers/initiate

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -170,9 +170,9 @@
 - [x] Enum cleanup — varchar→pgEnum for identity migration direction, hub instance status, trust initiator — (plan C1; done 2026-02-25)
 - [x] Open mode auto-accept for inbound trust — (plan C2; done 2026-02-25)
 - [x] Inbound transfer tracking table with status lifecycle — (plan C4; done 2026-02-25)
-- [ ] [P3] Per-capability rate limiting — rate limit per federation capability (simsub, transfer, etc.) rather than global per-peer — (OpenCode review 2026-02-25, deferred to production hardening)
-- [ ] [P3] Migration rollback testing — enum casts can fail on dirty data; add rollback scenario tests before production deployment — (OpenCode review 2026-02-25, deferred pre-launch)
-- [ ] [P4] Consider splitting schema migrations (enum changes vs new tables) for safer production rollback — (OpenCode review 2026-02-25, deferred pre-launch)
+- [x] [P3] Per-capability rate limiting — rate limit per federation capability (simsub, transfer, etc.) rather than global per-peer — (OpenCode review 2026-02-25, deferred to production hardening; done 2026-02-26)
+- [x] [P3] Migration rollback testing — enum casts can fail on dirty data; add rollback scenario tests before production deployment — (OpenCode review 2026-02-25, deferred pre-launch; done 2026-02-26)
+- [x] [P4] Consider splitting schema migrations (enum changes vs new tables) for safer production rollback — documented as pattern + pre-flight validator instead of splitting 0031 (already applied) — (OpenCode review 2026-02-25, deferred pre-launch; done 2026-02-26)
 
 ### Design Decisions
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,22 @@ Newest entries first.
 
 ---
 
+## 2026-02-26 — Track 5 Production Hardening
+
+### Done
+
+- **Per-capability federation rate limiting** — rate limit keys now include capability (`simsub`, `transfer`, `migration`, `hub`) so a peer hammering one capability doesn't exhaust the budget for others. Same shared limits, separate Redis keys per peer per capability. Updated `federation-rate-limit.ts` + 4 route files + 3 new unit tests (11 total).
+- **Migration 0031 enum cast rollback tests** — 6 integration tests (`migration-enum-cast.test.ts`) documenting: happy path with valid data, happy path with empty tables, dirty data rejection (invalid values, case mismatches), and partial failure state showing which statements committed before the failure. Added `applyMigrationsUpTo()`/`applySingleMigration()` helpers to `db-setup.ts`.
+- **Pre-flight enum validator** — `pnpm db:validate-enums` script (`validate-enum-migration.ts`) checks varchar columns for values incompatible with target enum types before applying ALTER COLUMN casts. Hardcoded for migration 0031, serves as pattern for future enum conversions.
+- **Documentation** — Added "Migration Pattern: Enum Conversions" section to `packages/db/CLAUDE.md` covering the 3-rule pattern (separate migrations, pre-flight check, why it matters).
+
+### Decisions
+
+- Shared rate limits (no new env vars) — per-capability keys share `FEDERATION_RATE_LIMIT_MAX`/`_WINDOW_SECONDS`. Per-capability env vars can be added later without breaking changes.
+- Replacement keys, not layered — one Redis call per request instead of two. Global peer blocking deferred to network level.
+
+---
+
 ## 2026-02-26 — Sim-Sub Cross-Instance QA Test Script
 
 ### Done

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "db:seed": "pnpm --filter @colophony/db seed",
     "db:verify": "pnpm --filter @colophony/db verify",
     "db:verify:repair": "pnpm --filter @colophony/db verify:repair",
+    "db:validate-enums": "pnpm --filter @colophony/db validate-enums",
     "db:reset": "bash scripts/db-reset.sh",
     "sdk:export-spec": "pnpm --filter @colophony/api exec tsx ../../scripts/export-openapi.ts",
     "sdk:export-schema": "pnpm --filter @colophony/api exec tsx ../../scripts/export-schema.ts",

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -87,6 +87,7 @@ pnpm db:seed                  # Seed test data
 pnpm db:reset                 # Drop and recreate with migrations + RLS + verify
 pnpm db:verify                # Check FK constraints match expected state (exit 1 on mismatch)
 pnpm db:verify:repair         # Check + auto-repair any mismatched FK constraints
+pnpm db:validate-enums        # Pre-flight check for enum varchar→enum casts
 pnpm db:validate-migrations   # Check SQL files ↔ journal consistency
 pnpm db:validate-migrations:fix  # Auto-add missing journal entries
 pnpm db:add-migration <name>  # Add journal entry for a manual migration
@@ -97,6 +98,18 @@ pnpm db:add-migration <name>  # Add journal entry for a manual migration
 **Drizzle `migrate()` silent no-op workaround:** Drizzle ORM 0.44+ / journal v7 can silently record a migration as applied without executing its DDL on existing databases. `db:verify` detects this for migration 0015 (GDPR FK constraints). Run `db:verify` after `db:migrate` in production deployments. If mismatches are found, run `db:verify:repair` to re-apply the correct DDL.
 
 **init-db.sh caveat:** Only runs on first DB creation. Must `docker compose down -v` to re-run after changes.
+
+### Migration Pattern: Enum Conversions
+
+When converting `varchar` columns to PostgreSQL enums:
+
+1. **Separate concerns into distinct migrations:** `CREATE TYPE` in one statement group, `ALTER COLUMN ... USING` casts in another, `CREATE TABLE` (using the new enum) last. Drizzle applies statements individually, not transactionally — a mid-migration failure leaves partial state (some enum types created, some columns unconverted, later tables missing).
+
+2. **Run `pnpm db:validate-enums` before applying `ALTER COLUMN` migrations.** This pre-flight check queries varchar columns for values not in the target enum set. Exit 1 = dirty data that will cause the cast to fail.
+
+3. **Why this matters:** A `USING "column"::EnumType` cast fails hard if any row contains a value not in the enum (including case mismatches like `'Active'` vs `'active'`). Because Drizzle doesn't wrap migrations in a transaction, earlier statements in the same migration file will have already committed — leaving the database in a partially-migrated state that requires manual cleanup.
+
+See migration 0031 (`federation_cleanup`) and its test suite (`migration-enum-cast.test.ts`) for a concrete example.
 
 ### Production RLS Verification
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -25,6 +25,7 @@
     "seed": "tsx --env-file=.env src/seed.ts",
     "verify": "tsx --env-file=.env src/verify-migrations.ts --check",
     "verify:repair": "tsx --env-file=.env src/verify-migrations.ts --repair",
+    "validate-enums": "tsx --env-file=.env src/validate-enum-migration.ts",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/db/src/validate-enum-migration.ts
+++ b/packages/db/src/validate-enum-migration.ts
@@ -85,8 +85,9 @@ async function checkEnumCompatibility(
     // Skip if already converted to enum (USER-DEFINED)
     if (colResult.rows[0].data_type === "USER-DEFINED") continue;
 
-    // Query for values not in the target enum set
-    // Table/column names are from hardcoded checks (not user input), safe to interpolate
+    // Table/column names are from MIGRATION_0031_CHECKS (hardcoded, not user input),
+    // so identifier interpolation is safe. If this is extended to accept dynamic checks,
+    // use pg-format or parameterized identifiers.
     const placeholders = check.enumValues.map((_, i) => `$${i + 1}`).join(", ");
 
     const result = await pool.query<{ value: string; count: string }>(

--- a/packages/db/src/validate-enum-migration.ts
+++ b/packages/db/src/validate-enum-migration.ts
@@ -1,0 +1,175 @@
+/**
+ * Pre-flight enum migration validator.
+ *
+ * Checks that varchar columns contain only values compatible with their
+ * target enum types before running ALTER COLUMN ... USING casts.
+ *
+ * Usage:
+ *   pnpm db:validate-enums   # Check mode — report mismatches, exit 1 if any
+ *
+ * Pattern reference: verify-migrations.ts
+ */
+
+import { Pool } from "pg";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface EnumCastCheck {
+  table: string;
+  column: string;
+  enumName: string;
+  enumValues: string[];
+}
+
+interface EnumCastMismatch {
+  table: string;
+  column: string;
+  enumName: string;
+  invalidValues: Array<{ value: string; count: number }>;
+}
+
+// ---------------------------------------------------------------------------
+// Checks for migration 0031 (federation_cleanup)
+// ---------------------------------------------------------------------------
+
+const MIGRATION_0031_CHECKS: EnumCastCheck[] = [
+  {
+    table: "identity_migrations",
+    column: "direction",
+    enumName: "IdentityMigrationDirection",
+    enumValues: ["outbound", "inbound"],
+  },
+  {
+    table: "hub_registered_instances",
+    column: "status",
+    enumName: "HubInstanceStatus",
+    enumValues: ["active", "suspended", "revoked"],
+  },
+  {
+    table: "trusted_peers",
+    column: "initiated_by",
+    enumName: "TrustInitiator",
+    enumValues: ["local", "remote"],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Core check function
+// ---------------------------------------------------------------------------
+
+async function checkEnumCompatibility(
+  pool: Pool,
+  checks: EnumCastCheck[],
+): Promise<EnumCastMismatch[]> {
+  const mismatches: EnumCastMismatch[] = [];
+
+  for (const check of checks) {
+    // Check if the table exists (may have been dropped or not yet created)
+    const tableResult = await pool.query(
+      `SELECT 1 FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_name = $1`,
+      [check.table],
+    );
+    if (tableResult.rows.length === 0) continue;
+
+    // Check if the column still exists and is a varchar type
+    const colResult = await pool.query<{ data_type: string }>(
+      `SELECT data_type FROM information_schema.columns
+       WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2`,
+      [check.table, check.column],
+    );
+    if (colResult.rows.length === 0) continue;
+
+    // Skip if already converted to enum (USER-DEFINED)
+    if (colResult.rows[0].data_type === "USER-DEFINED") continue;
+
+    // Query for values not in the target enum set
+    // Table/column names are from hardcoded checks (not user input), safe to interpolate
+    const placeholders = check.enumValues.map((_, i) => `$${i + 1}`).join(", ");
+
+    const result = await pool.query<{ value: string; count: string }>(
+      `SELECT "${check.column}" AS value, COUNT(*) AS count
+       FROM "${check.table}"
+       WHERE "${check.column}" IS NOT NULL
+         AND "${check.column}" NOT IN (${placeholders})
+       GROUP BY "${check.column}"`,
+      check.enumValues,
+    );
+
+    if (result.rows.length > 0) {
+      mismatches.push({
+        table: check.table,
+        column: check.column,
+        enumName: check.enumName,
+        invalidValues: result.rows.map((r) => ({
+          value: r.value,
+          count: Number(r.count),
+        })),
+      });
+    }
+  }
+
+  return mismatches;
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+function reportMismatches(mismatches: EnumCastMismatch[]): void {
+  console.error(`\nFound ${mismatches.length} incompatible column(s):\n`);
+  for (const m of mismatches) {
+    console.error(`  ${m.table}.${m.column} → ${m.enumName}`);
+    for (const v of m.invalidValues) {
+      console.error(
+        `    '${v.value}' (${v.count} row${v.count === 1 ? "" : "s"})`,
+      );
+    }
+  }
+  console.error("\nFix these values before applying the enum migration.\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("ERROR: DATABASE_URL environment variable is required");
+    process.exit(2);
+  }
+
+  const pool = new Pool({ connectionString: databaseUrl });
+
+  try {
+    await pool.query("SELECT 1");
+  } catch (err) {
+    console.error(
+      `ERROR: Cannot connect to database: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(2);
+  }
+
+  try {
+    console.log("Checking enum compatibility for migration 0031...");
+    const mismatches = await checkEnumCompatibility(
+      pool,
+      MIGRATION_0031_CHECKS,
+    );
+
+    if (mismatches.length === 0) {
+      console.log("All enum cast checks passed — safe to apply migration.");
+      process.exit(0);
+    }
+
+    reportMismatches(mismatches);
+    process.exit(1);
+  } finally {
+    await pool.end();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- **Per-capability federation rate limiting** — rate limit keys now include capability (`simsub`, `transfer`, `migration`, `hub`) so a peer exhausting one capability budget doesn't affect others. Allowlist validation at registration time.
- **Migration 0031 enum cast rollback tests** — 6 integration tests documenting happy path, dirty data rejection, and partial failure state when Drizzle applies statements non-transactionally.
- **Pre-flight enum validator** — `pnpm db:validate-enums` checks varchar columns for values incompatible with target enum types before applying ALTER COLUMN casts. Hardcoded for migration 0031, documented as reusable pattern.

Closes the three remaining P3/P4 items from Track 5 (Register — Identity & Federation).

## Test plan

- [x] `federation-rate-limit.spec.ts` — 12 tests (8 existing + 4 new: capability key, fallback key, different capabilities, invalid capability rejection)
- [x] `migration-enum-cast.test.ts` — 6 new RLS integration tests (valid data, empty tables, 3 dirty data scenarios, partial failure state)
- [x] `pnpm db:validate-enums` — runs against dev/test DB, reports clean or dirty data
- [x] `pnpm type-check` — passes
- [x] `pnpm lint` — passes
- [x] Full RLS suite (`pnpm --filter @colophony/api test:rls`) — 104 tests pass

## Code Review

OpenCode branch review: **LGTM**. Three suggestions addressed:
1. Capability allowlist validation with test
2. pg-format note on identifier interpolation
3. Drizzle-specific behavior comment on partial failure test