### PR TITLE
feat(relay): notification preferences UI

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/page.tsx
@@ -36,6 +36,7 @@ import {
   Plus,
   Settings as SettingsIcon,
 } from "lucide-react";
+import { NotificationPreferencesCard } from "@/components/settings/notification-preferences-card";
 
 export default function SettingsPage() {
   const { user } = useAuth();
@@ -196,6 +197,9 @@ export default function SettingsPage() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Notification Preferences */}
+      <NotificationPreferencesCard />
 
       {/* Privacy & Data */}
       <Card>

--- a/apps/web/src/components/settings/__tests__/notification-preferences-card.spec.tsx
+++ b/apps/web/src/components/settings/__tests__/notification-preferences-card.spec.tsx
@@ -1,0 +1,176 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NotificationPreferencesCard } from "../notification-preferences-card";
+import "../../../../test/setup";
+
+// --- Mutable mock state ---
+let mockPreferences: Array<{ eventType: string; enabled: boolean }> | undefined;
+let mockIsPending: boolean;
+let mockError: { message: string } | null;
+let mockRefetch: jest.Mock;
+let mockMutate: jest.Mock;
+let mockMutationPending: boolean;
+let mockCurrentOrg: { id: string; name: string; slug: string } | null;
+
+function resetMocks() {
+  mockPreferences = undefined;
+  mockIsPending = false;
+  mockError = null;
+  mockRefetch = jest.fn();
+  mockMutate = jest.fn();
+  mockMutationPending = false;
+  mockCurrentOrg = { id: "org-1", name: "Test Magazine", slug: "test-mag" };
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    notificationPreferences: {
+      list: {
+        useQuery: () => ({
+          data: mockPreferences,
+          isPending: mockIsPending,
+          error: mockError,
+          refetch: mockRefetch,
+        }),
+      },
+      upsert: {
+        useMutation: (opts?: {
+          onSuccess?: () => void;
+          onError?: (err: { message: string }) => void;
+        }) => ({
+          mutate: (...args: unknown[]) => {
+            mockMutate(...args);
+            opts?.onSuccess?.();
+          },
+          isPending: mockMutationPending,
+        }),
+      },
+    },
+    useUtils: () => ({
+      notificationPreferences: { list: { invalidate: jest.fn() } },
+    }),
+  },
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({
+    currentOrg: mockCurrentOrg,
+  }),
+}));
+
+beforeEach(() => {
+  resetMocks();
+});
+
+describe("NotificationPreferencesCard", () => {
+  it("shows org selection message when no org is selected", () => {
+    mockCurrentOrg = null;
+    render(<NotificationPreferencesCard />);
+    expect(screen.getByText(/select an organization/i)).toBeInTheDocument();
+    expect(screen.queryAllByRole("switch")).toHaveLength(0);
+  });
+
+  it("shows loading skeleton while fetching", () => {
+    mockIsPending = true;
+    render(<NotificationPreferencesCard />);
+    expect(
+      screen.getByTestId("notification-prefs-skeleton"),
+    ).toBeInTheDocument();
+    expect(screen.queryAllByRole("switch")).toHaveLength(0);
+  });
+
+  it("shows error state with retry button", () => {
+    mockError = { message: "Network error" };
+    render(<NotificationPreferencesCard />);
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/network error/i);
+    fireEvent.click(screen.getByText("Try again"));
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+
+  it("renders all 6 toggles with correct labels", () => {
+    mockPreferences = [];
+    render(<NotificationPreferencesCard />);
+    const switches = screen.getAllByRole("switch");
+    expect(switches).toHaveLength(6);
+    expect(screen.getByText("Submission Received")).toBeInTheDocument();
+    expect(screen.getByText("Submission Accepted")).toBeInTheDocument();
+    expect(screen.getByText("Submission Rejected")).toBeInTheDocument();
+    expect(screen.getByText("Submission Withdrawn")).toBeInTheDocument();
+    expect(screen.getByText("Contract Ready")).toBeInTheDocument();
+    expect(screen.getByText("Copyeditor Assigned")).toBeInTheDocument();
+  });
+
+  it("defaults all toggles to enabled when no preferences exist", () => {
+    mockPreferences = [];
+    render(<NotificationPreferencesCard />);
+    const switches = screen.getAllByRole("switch");
+    switches.forEach((sw) => {
+      expect(sw).toBeChecked();
+    });
+  });
+
+  it("reflects disabled state from existing preference records", () => {
+    mockPreferences = [
+      { eventType: "submission.received", enabled: false },
+      { eventType: "contract.ready", enabled: false },
+    ];
+    render(<NotificationPreferencesCard />);
+    expect(
+      screen.getByLabelText("Toggle Submission Received notifications"),
+    ).not.toBeChecked();
+    expect(
+      screen.getByLabelText("Toggle Contract Ready notifications"),
+    ).not.toBeChecked();
+    expect(
+      screen.getByLabelText("Toggle Submission Accepted notifications"),
+    ).toBeChecked();
+    expect(
+      screen.getByLabelText("Toggle Submission Rejected notifications"),
+    ).toBeChecked();
+  });
+
+  it("calls upsert mutation on toggle click", () => {
+    mockPreferences = [];
+    render(<NotificationPreferencesCard />);
+    fireEvent.click(
+      screen.getByLabelText("Toggle Submission Received notifications"),
+    );
+    expect(mockMutate).toHaveBeenCalledWith({
+      channel: "email",
+      eventType: "submission.received",
+      enabled: false,
+    });
+  });
+
+  it("displays org name in card description", () => {
+    mockPreferences = [];
+    mockCurrentOrg = {
+      id: "org-1",
+      name: "The Paris Review",
+      slug: "paris-review",
+    };
+    render(<NotificationPreferencesCard />);
+    expect(screen.getByText(/The Paris Review/)).toBeInTheDocument();
+  });
+
+  it("disables switches while mutation is pending", () => {
+    mockMutationPending = true;
+    mockPreferences = [];
+    render(<NotificationPreferencesCard />);
+    const switches = screen.getAllByRole("switch");
+    switches.forEach((sw) => {
+      expect(sw).toBeDisabled();
+    });
+  });
+
+  it("shows Submissions and Publication Pipeline group headings", () => {
+    mockPreferences = [];
+    render(<NotificationPreferencesCard />);
+    expect(screen.getByText("Submissions")).toBeInTheDocument();
+    expect(screen.getByText("Publication Pipeline")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/notification-preferences-card.tsx
+++ b/apps/web/src/components/settings/notification-preferences-card.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useOrganization } from "@/hooks/use-organization";
+import { trpc } from "@/lib/trpc";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { Bell, AlertCircle } from "lucide-react";
+import type { NotificationEventType } from "@colophony/types";
+
+interface EventConfig {
+  eventType: NotificationEventType;
+  label: string;
+  description: string;
+}
+
+const SUBMISSION_EVENTS: EventConfig[] = [
+  {
+    eventType: "submission.received",
+    label: "Submission Received",
+    description: "When a new submission is received",
+  },
+  {
+    eventType: "submission.accepted",
+    label: "Submission Accepted",
+    description: "When your submission is accepted",
+  },
+  {
+    eventType: "submission.rejected",
+    label: "Submission Rejected",
+    description: "When your submission is rejected",
+  },
+  {
+    eventType: "submission.withdrawn",
+    label: "Submission Withdrawn",
+    description: "When a submission is withdrawn",
+  },
+];
+
+const SLATE_EVENTS: EventConfig[] = [
+  {
+    eventType: "contract.ready",
+    label: "Contract Ready",
+    description: "When a contract is ready for signing",
+  },
+  {
+    eventType: "copyeditor.assigned",
+    label: "Copyeditor Assigned",
+    description: "When you are assigned as copyeditor",
+  },
+];
+
+function deriveEnabled(
+  preferences: Array<{ eventType: string; enabled: boolean }> | undefined,
+  eventType: NotificationEventType,
+): boolean {
+  if (!preferences) return true;
+  const record = preferences.find((p) => p.eventType === eventType);
+  return record ? record.enabled : true;
+}
+
+export function NotificationPreferencesCard() {
+  const { currentOrg } = useOrganization();
+  const {
+    data: preferences,
+    isPending,
+    error,
+    refetch,
+  } = trpc.notificationPreferences.list.useQuery(undefined, {
+    enabled: !!currentOrg,
+  });
+  const utils = trpc.useUtils();
+
+  const upsertMutation = trpc.notificationPreferences.upsert.useMutation({
+    onSuccess: () => {
+      void utils.notificationPreferences.list.invalidate();
+      toast.success("Notification preference updated");
+    },
+    onError: (err) => {
+      toast.error(err.message || "Failed to update preference");
+    },
+  });
+
+  function handleToggle(
+    eventType: NotificationEventType,
+    currentEnabled: boolean,
+  ) {
+    upsertMutation.mutate({
+      channel: "email",
+      eventType,
+      enabled: !currentEnabled,
+    });
+  }
+
+  if (!currentOrg) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Bell className="h-5 w-5" />
+            Notification Preferences
+          </CardTitle>
+          <CardDescription>
+            Select an organization to manage notification preferences.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Bell className="h-5 w-5" />
+          Notification Preferences
+        </CardTitle>
+        <CardDescription>
+          Manage email notifications for {currentOrg.name}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isPending ? (
+          <div className="space-y-4" data-testid="notification-prefs-skeleton">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="flex items-center justify-between">
+                <div className="space-y-1">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-3 w-48" />
+                </div>
+                <Skeleton className="h-5 w-9 rounded-full" />
+              </div>
+            ))}
+          </div>
+        ) : error ? (
+          <div role="alert" className="flex items-center gap-3 text-sm">
+            <AlertCircle className="h-4 w-4 text-destructive" />
+            <span className="text-destructive">
+              Failed to load preferences: {error.message}
+            </span>
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              Try again
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            <EventGroup
+              title="Submissions"
+              events={SUBMISSION_EVENTS}
+              preferences={preferences}
+              onToggle={handleToggle}
+              disabled={upsertMutation.isPending}
+            />
+            <Separator />
+            <EventGroup
+              title="Publication Pipeline"
+              events={SLATE_EVENTS}
+              preferences={preferences}
+              onToggle={handleToggle}
+              disabled={upsertMutation.isPending}
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function EventGroup({
+  title,
+  events,
+  preferences,
+  onToggle,
+  disabled,
+}: {
+  title: string;
+  events: EventConfig[];
+  preferences: Array<{ eventType: string; enabled: boolean }> | undefined;
+  onToggle: (eventType: NotificationEventType, currentEnabled: boolean) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="space-y-4">
+      <h4 className="text-sm font-medium">{title}</h4>
+      {events.map((event) => {
+        const enabled = deriveEnabled(preferences, event.eventType);
+        return (
+          <div
+            key={event.eventType}
+            className="flex items-center justify-between"
+          >
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium">{event.label}</p>
+              <p className="text-xs text-muted-foreground">
+                {event.description}
+              </p>
+            </div>
+            <Switch
+              checked={enabled}
+              onCheckedChange={() => onToggle(event.eventType, enabled)}
+              disabled={disabled}
+              aria-label={`Toggle ${event.label} notifications`}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -220,7 +220,7 @@
 ## Cross-Cutting — Relay (Notifications & Communications)
 
 - [x] Email templates + provider integration (SMTP + SendGrid) — adapters, MJML templates, BullMQ queue/worker, notification preferences, Inngest functions — (architecture doc, Relay; done 2026-02-26)
-- [ ] Notification preferences frontend — UI for users to manage email opt-in/opt-out per event type — (DEVLOG 2026-02-26)
+- [x] Notification preferences frontend — UI for users to manage email opt-in/opt-out per event type — (DEVLOG 2026-02-26; done 2026-02-26)
 - [ ] Webhook delivery system (outbound) — (architecture doc, Relay)
 - [ ] In-app notification center — (architecture doc, Relay)
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,22 @@ Newest entries first.
 
 ---
 
+## 2026-02-26 — Relay Notification Preferences UI
+
+### Done
+
+- **NotificationPreferencesCard component** — self-contained card for `/settings` page with 6 email notification toggles (4 submission + 2 publication pipeline), opt-out model (defaults enabled), immediate save via `upsert` mutation, loading skeleton, error state with retry, no-org guard
+- **10 unit tests** — full coverage: loading, error, no-org, all toggles rendered, default enabled, disabled state, toggle click mutation, org name display, mutation-pending disabled, group headings
+- **Settings page integration** — card placed between Organizations and Privacy & Data cards
+- Type-check, lint, and all tests passing
+
+### Decisions
+
+- Extracted `EventGroup` sub-component to avoid repetition across Submissions and Publication Pipeline groups
+- Used `aria-label` pattern (`Toggle {label} notifications`) for accessible switch targeting in tests
+
+---
+
 ## 2026-02-26 — Relay Email Foundation
 
 ### Done


### PR DESCRIPTION
## Summary

- Add `NotificationPreferencesCard` component to the `/settings` page with 6 email notification toggles (4 submission + 2 publication pipeline)
- Opt-out model: all toggles default to enabled; toggling saves immediately via `upsert` mutation
- Includes loading skeleton, error state with retry, no-org guard, and 10 unit tests

## Plan Overrides

| File | Planned | Actual | Rationale |
| --- | --- | --- | --- |
| `notification-preferences-card.tsx` | ~150 lines, no sub-component | ~218 lines with `EventGroup` sub-component | Extracted for cleaner code structure; avoids repeating group rendering logic |

## Test plan

- [x] `pnpm type-check` — clean
- [x] 10 unit tests passing (loading, error, no-org, all toggles, defaults, disabled state, mutation, org name, pending, headings)
- [x] `pnpm lint` — clean
- [ ] Manual QA: start dev servers, navigate to `/settings`, verify card with 6 toggles, toggle one, refresh to confirm persistence