### PR TITLE
feat(relay): outbound webhook delivery system

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -39,6 +39,9 @@
 | Email worker      | `src/workers/email.worker.ts`                     |
 | Email service     | `src/services/email.service.ts`                   |
 | Notif pref svc    | `src/services/notification-preference.service.ts` |
+| Webhook queue     | `src/queues/webhook.queue.ts`                     |
+| Webhook worker    | `src/workers/webhook.worker.ts`                   |
+| Webhook service   | `src/services/webhook.service.ts`                 |
 | CMS adapters      | `src/adapters/cms/`                               |
 | Documenso adapter | `src/adapters/documenso.adapter.ts`               |
 | Outbox poller     | `src/workers/outbox-poller.worker.ts`             |
@@ -233,6 +236,18 @@ Workers and queues are started in `main.ts` and closed during graceful shutdown.
 - **Flow**: Iterates storage keys, deletes from clean or quarantine bucket, logs audit event
 - **Retries**: 5 attempts, exponential backoff from 60s, 30-day fail retention
 - **Always active**: Not gated on `VIRUS_SCAN_ENABLED` — runs whenever GDPR deletion occurs
+
+### Webhook Worker
+
+- **Queue**: `webhook` — jobs enqueued from `webhookDelivery` Inngest function via `enqueueWebhook()`
+- **Job idempotency**: `jobId: deliveryId` prevents duplicate deliveries
+- **Flow**: QUEUED → DELIVERING → DELIVERED/FAILED (tracked in `webhook_deliveries` table)
+- **Processing**: Compute HMAC-SHA256 signature → HTTP POST with headers (`X-Webhook-Signature`, `X-Webhook-Id`, `User-Agent`) → update status + audit
+- **Retries**: 8 attempts, custom backoff [1s, 5s, 30s, 2m, 10m, 1h, 1h, 1h]
+- **Concurrency**: 10 (I/O-bound HTTP calls)
+- **Timeout**: 30s per delivery (AbortController)
+- **Auto-disable**: After 5 consecutive final failures for an endpoint, sets endpoint status to DISABLED
+- **Always active**: No feature flag — harmless when no endpoints registered
 
 ### Env Vars
 

--- a/apps/api/src/inngest/functions/__tests__/webhook-delivery.spec.ts
+++ b/apps/api/src/inngest/functions/__tests__/webhook-delivery.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+
+const mockGetActiveEndpointsForEvent = vi.fn();
+const mockCreateDelivery = vi.fn();
+vi.mock('../../../services/webhook.service.js', () => ({
+  webhookService: {
+    getActiveEndpointsForEvent: (...args: unknown[]) =>
+      mockGetActiveEndpointsForEvent(...args),
+    createDelivery: (...args: unknown[]) => mockCreateDelivery(...args),
+  },
+}));
+
+const mockEnqueueWebhook = vi.fn();
+vi.mock('../../../queues/webhook.queue.js', () => ({
+  enqueueWebhook: (...args: unknown[]) => mockEnqueueWebhook(...args),
+}));
+
+vi.mock('../../../config/env.js', () => ({
+  validateEnv: () => ({
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: '',
+  }),
+}));
+
+vi.mock('@colophony/db', () => ({
+  withRls: vi.fn((_ctx: unknown, fn: (tx: string) => unknown) => fn('mock-tx')),
+}));
+
+// Mock Inngest client — capture function config
+let capturedFunction: {
+  config: Record<string, unknown>;
+  triggers: unknown[];
+  handler: (args: {
+    event: Record<string, unknown>;
+    step: Record<string, unknown>;
+  }) => Promise<unknown>;
+};
+
+vi.mock('../../client.js', () => ({
+  inngest: {
+    createFunction: (
+      config: Record<string, unknown>,
+      triggers: unknown[],
+      handler: (args: Record<string, unknown>) => Promise<unknown>,
+    ) => {
+      capturedFunction = { config, triggers, handler };
+      return { config, triggers, handler };
+    },
+  },
+}));
+
+describe('webhookDelivery Inngest function', () => {
+  beforeAll(async () => {
+    // Import after mocks so vi.mock intercepts all dependencies
+    await import('../webhook-delivery.js');
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('listens to all expected event types', () => {
+    expect(capturedFunction.triggers).toHaveLength(10);
+    const eventNames = capturedFunction.triggers.map(
+      (t: unknown) => (t as { event: string }).event,
+    );
+    expect(eventNames).toContain('hopper/submission.submitted');
+    expect(eventNames).toContain('hopper/submission.accepted');
+    expect(eventNames).toContain('hopper/submission.rejected');
+    expect(eventNames).toContain('hopper/submission.withdrawn');
+    expect(eventNames).toContain('slate/pipeline.copyeditor-assigned');
+    expect(eventNames).toContain('slate/pipeline.copyedit-completed');
+    expect(eventNames).toContain('slate/pipeline.author-review-completed');
+    expect(eventNames).toContain('slate/pipeline.proofread-completed');
+    expect(eventNames).toContain('slate/contract.generated');
+    expect(eventNames).toContain('slate/issue.published');
+  });
+
+  it('skips when no active endpoints found', async () => {
+    mockGetActiveEndpointsForEvent.mockResolvedValueOnce([]);
+
+    const stepRun = vi.fn((_label: string, fn: () => Promise<unknown>) => fn());
+    const event = {
+      name: 'hopper/submission.submitted',
+      id: 'evt-1',
+      data: { orgId: 'org-1', submissionId: 'sub-1' },
+    };
+
+    const result = await capturedFunction.handler({
+      event,
+      step: { run: stepRun },
+    });
+    expect(result).toEqual({ skipped: true, reason: 'no-endpoints' });
+    expect(mockEnqueueWebhook).not.toHaveBeenCalled();
+  });
+
+  it('fans out to multiple endpoints', async () => {
+    const endpoints = [
+      { id: 'ep-1', url: 'https://a.com', secret: 'sec-a' },
+      { id: 'ep-2', url: 'https://b.com', secret: 'sec-b' },
+    ];
+    mockGetActiveEndpointsForEvent.mockResolvedValueOnce(endpoints);
+    mockCreateDelivery
+      .mockResolvedValueOnce({ id: 'del-1' })
+      .mockResolvedValueOnce({ id: 'del-2' });
+    mockEnqueueWebhook.mockResolvedValue(undefined);
+
+    const stepRun = vi.fn((_label: string, fn: () => Promise<unknown>) => fn());
+    const event = {
+      name: 'hopper/submission.submitted',
+      id: 'evt-1',
+      data: { orgId: 'org-1', submissionId: 'sub-1' },
+    };
+
+    const result = await capturedFunction.handler({
+      event,
+      step: { run: stepRun },
+    });
+
+    expect(result).toEqual({ delivered: 2 });
+    expect(mockCreateDelivery).toHaveBeenCalledTimes(2);
+    expect(mockEnqueueWebhook).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/inngest/functions/index.ts
+++ b/apps/api/src/inngest/functions/index.ts
@@ -11,3 +11,4 @@ export {
   contractReadyNotification,
   copyeditorAssignedNotification,
 } from './slate-notifications.js';
+export { webhookDelivery } from './webhook-delivery.js';

--- a/apps/api/src/inngest/functions/webhook-delivery.ts
+++ b/apps/api/src/inngest/functions/webhook-delivery.ts
@@ -1,0 +1,70 @@
+import { withRls } from '@colophony/db';
+import { inngest } from '../client.js';
+import { webhookService } from '../../services/webhook.service.js';
+import { enqueueWebhook } from '../../queues/webhook.queue.js';
+import { validateEnv } from '../../config/env.js';
+
+export const webhookDelivery = inngest.createFunction(
+  { id: 'webhook-delivery', name: 'Webhook Delivery', retries: 3 },
+  [
+    { event: 'hopper/submission.submitted' },
+    { event: 'hopper/submission.accepted' },
+    { event: 'hopper/submission.rejected' },
+    { event: 'hopper/submission.withdrawn' },
+    { event: 'slate/pipeline.copyeditor-assigned' },
+    { event: 'slate/pipeline.copyedit-completed' },
+    { event: 'slate/pipeline.author-review-completed' },
+    { event: 'slate/pipeline.proofread-completed' },
+    { event: 'slate/contract.generated' },
+    { event: 'slate/issue.published' },
+  ],
+  async ({ event, step }) => {
+    const orgId = (event.data as { orgId: string }).orgId;
+
+    // Step 1: Find active endpoints subscribed to this event
+    const endpoints = await step.run('get-endpoints', async () =>
+      withRls({ orgId }, async (tx) =>
+        webhookService.getActiveEndpointsForEvent(tx, orgId, event.name),
+      ),
+    );
+
+    if (endpoints.length === 0) {
+      return { skipped: true, reason: 'no-endpoints' };
+    }
+
+    // Step 2: Create delivery records and enqueue jobs
+    await step.run('enqueue-deliveries', async () => {
+      const env = validateEnv();
+
+      for (const endpoint of endpoints) {
+        const delivery = await withRls({ orgId }, async (tx) =>
+          webhookService.createDelivery(tx, {
+            organizationId: orgId,
+            webhookEndpointId: endpoint.id,
+            eventType: event.name,
+            eventId: event.id ?? crypto.randomUUID(),
+            payload: event.data as Record<string, unknown>,
+          }),
+        );
+
+        const payload = {
+          id: delivery.id,
+          event: event.name,
+          timestamp: new Date().toISOString(),
+          organizationId: orgId,
+          data: event.data as Record<string, unknown>,
+        };
+
+        await enqueueWebhook(env, {
+          deliveryId: delivery.id,
+          orgId,
+          endpointUrl: endpoint.url,
+          secret: endpoint.secret,
+          payload,
+        });
+      }
+    });
+
+    return { delivered: endpoints.length };
+  },
+);

--- a/apps/api/src/inngest/serve.ts
+++ b/apps/api/src/inngest/serve.ts
@@ -11,6 +11,7 @@ import {
   submissionWithdrawnNotification,
   contractReadyNotification,
   copyeditorAssignedNotification,
+  webhookDelivery,
 } from './functions/index.js';
 
 /**
@@ -35,6 +36,7 @@ export async function registerInngestRoutes(
       submissionWithdrawnNotification,
       contractReadyNotification,
       copyeditorAssignedNotification,
+      webhookDelivery,
     ],
   });
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -30,6 +30,8 @@ import {
   stopTransferFetchWorker,
   startEmailWorker,
   stopEmailWorker,
+  startWebhookWorker,
+  stopWebhookWorker,
 } from './workers/index.js';
 import {
   closeFileScanQueue,
@@ -38,6 +40,7 @@ import {
   closeOutboxPollerQueue,
   closeTransferFetchQueue,
   closeEmailQueue,
+  closeWebhookQueue,
 } from './queues/index.js';
 import { registerInngestRoutes } from './inngest/serve.js';
 import { registerFederationDiscoveryRoutes } from './federation/discovery.routes.js';
@@ -314,6 +317,10 @@ async function start(): Promise<void> {
     app.log.info('Email worker started');
   }
 
+  // Start webhook delivery worker
+  startWebhookWorker(env);
+  app.log.info('Webhook delivery worker started');
+
   // Hub registration (fire-and-forget — don't block startup)
   if (env.HUB_DOMAIN && env.HUB_REGISTRATION_TOKEN) {
     hubClientService.registerWithHub(env).catch((err) => {
@@ -345,6 +352,8 @@ async function start(): Promise<void> {
       await closeTransferFetchQueue();
       await stopEmailWorker();
       await closeEmailQueue();
+      await stopWebhookWorker();
+      await closeWebhookQueue();
       // TODO: Close DB pool when connection management is centralized
       // TODO: Close Redis connections
       app.log.info('Server closed');

--- a/apps/api/src/queues/__tests__/webhook.queue.spec.ts
+++ b/apps/api/src/queues/__tests__/webhook.queue.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockAdd = vi.fn();
+const mockClose = vi.fn();
+
+vi.mock('bullmq', () => ({
+  Queue: vi.fn().mockImplementation(function () {
+    return { add: mockAdd, close: mockClose };
+  }),
+}));
+
+import {
+  enqueueWebhook,
+  closeWebhookQueue,
+  getWebhookBackoffDelay,
+} from '../webhook.queue.js';
+import type { Env } from '../../config/env.js';
+
+const testEnv = {
+  REDIS_HOST: 'localhost',
+  REDIS_PORT: 6379,
+  REDIS_PASSWORD: '',
+} as Env;
+
+describe('webhook queue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enqueues a webhook job with deliveryId as jobId for idempotency', async () => {
+    mockAdd.mockResolvedValueOnce({});
+
+    const payload = {
+      id: 'del-123',
+      event: 'hopper/submission.submitted',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      organizationId: 'org-1',
+      data: { submissionId: 'sub-1' },
+    };
+
+    await enqueueWebhook(testEnv, {
+      deliveryId: 'del-123',
+      orgId: 'org-1',
+      endpointUrl: 'https://example.com/webhook',
+      secret: 'test-secret',
+      payload,
+    });
+
+    expect(mockAdd).toHaveBeenCalledWith(
+      'deliver',
+      {
+        deliveryId: 'del-123',
+        orgId: 'org-1',
+        endpointUrl: 'https://example.com/webhook',
+        secret: 'test-secret',
+        payload,
+      },
+      { jobId: 'del-123' },
+    );
+  });
+
+  it('closes queue on shutdown', async () => {
+    mockAdd.mockResolvedValueOnce({});
+    await enqueueWebhook(testEnv, {
+      deliveryId: 'del-456',
+      orgId: 'org-1',
+      endpointUrl: 'https://example.com',
+      secret: 'secret',
+      payload: {
+        id: 'del-456',
+        event: 'webhook.test',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        organizationId: 'org-1',
+        data: {},
+      },
+    });
+    await closeWebhookQueue();
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it('returns correct backoff delays for each attempt', () => {
+    expect(getWebhookBackoffDelay(0)).toBe(1_000);
+    expect(getWebhookBackoffDelay(1)).toBe(5_000);
+    expect(getWebhookBackoffDelay(2)).toBe(30_000);
+    expect(getWebhookBackoffDelay(3)).toBe(120_000);
+    expect(getWebhookBackoffDelay(4)).toBe(600_000);
+    expect(getWebhookBackoffDelay(5)).toBe(3_600_000);
+    expect(getWebhookBackoffDelay(6)).toBe(3_600_000);
+    expect(getWebhookBackoffDelay(7)).toBe(3_600_000);
+    // Beyond array length, clamps to last value
+    expect(getWebhookBackoffDelay(100)).toBe(3_600_000);
+  });
+});

--- a/apps/api/src/queues/index.ts
+++ b/apps/api/src/queues/index.ts
@@ -26,3 +26,10 @@ export {
   closeEmailQueue,
   type EmailJobData,
 } from './email.queue.js';
+
+export {
+  enqueueWebhook,
+  closeWebhookQueue,
+  type WebhookJobData,
+  type WebhookPayload,
+} from './webhook.queue.js';

--- a/apps/api/src/queues/webhook.queue.ts
+++ b/apps/api/src/queues/webhook.queue.ts
@@ -1,0 +1,64 @@
+import { Queue } from 'bullmq';
+import type { Env } from '../config/env.js';
+
+export interface WebhookPayload {
+  id: string;
+  event: string;
+  timestamp: string;
+  organizationId: string;
+  data: Record<string, unknown>;
+}
+
+export interface WebhookJobData {
+  deliveryId: string;
+  orgId: string;
+  endpointUrl: string;
+  secret: string;
+  payload: WebhookPayload;
+}
+
+// Custom backoff delays: 1s, 5s, 30s, 2m, 10m, 1h, 1h, 1h
+const BACKOFF_DELAYS = [
+  1_000, 5_000, 30_000, 120_000, 600_000, 3_600_000, 3_600_000, 3_600_000,
+];
+
+let queue: Queue<WebhookJobData> | null = null;
+
+function getQueue(env: Env): Queue<WebhookJobData> {
+  if (!queue) {
+    queue = new Queue<WebhookJobData>('webhook', {
+      connection: {
+        host: env.REDIS_HOST,
+        port: env.REDIS_PORT,
+        password: env.REDIS_PASSWORD || undefined,
+      },
+      defaultJobOptions: {
+        attempts: 8,
+        backoff: {
+          type: 'custom',
+        },
+        removeOnComplete: { age: 86_400 },
+        removeOnFail: { age: 604_800 },
+      },
+    });
+  }
+  return queue;
+}
+
+export function getWebhookBackoffDelay(attemptsMade: number): number {
+  return BACKOFF_DELAYS[Math.min(attemptsMade, BACKOFF_DELAYS.length - 1)];
+}
+
+export async function enqueueWebhook(
+  env: Env,
+  data: WebhookJobData,
+): Promise<void> {
+  await getQueue(env).add('deliver', data, { jobId: data.deliveryId });
+}
+
+export async function closeWebhookQueue(): Promise<void> {
+  if (queue) {
+    await queue.close();
+    queue = null;
+  }
+}

--- a/apps/api/src/queues/webhook.queue.ts
+++ b/apps/api/src/queues/webhook.queue.ts
@@ -18,6 +18,8 @@ export interface WebhookJobData {
 }
 
 // Custom backoff delays: 1s, 5s, 30s, 2m, 10m, 1h, 1h, 1h
+// Final 3 attempts are capped at 1h to avoid multi-day delivery windows
+// while still giving endpoints time to recover from extended outages.
 const BACKOFF_DELAYS = [
   1_000, 5_000, 30_000, 120_000, 600_000, 3_600_000, 3_600_000, 3_600_000,
 ];

--- a/apps/api/src/services/webhook.service.spec.ts
+++ b/apps/api/src/services/webhook.service.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@colophony/db', () => {
+  const eq = vi.fn();
+  const and = vi.fn();
+  return {
+    webhookEndpoints: {
+      id: 'id',
+      organizationId: 'organization_id',
+      url: 'url',
+      secret: 'secret',
+      status: 'status',
+      eventTypes: 'event_types',
+      createdAt: 'created_at',
+    },
+    webhookDeliveries: {
+      id: 'id',
+      webhookEndpointId: 'webhook_endpoint_id',
+      eventType: 'event_type',
+      status: 'status',
+      createdAt: 'created_at',
+    },
+    eq,
+    and,
+    sql: vi.fn(),
+  };
+});
+
+import { webhookService } from './webhook.service.js';
+
+describe('webhookService', () => {
+  it('exports expected endpoint methods', () => {
+    /* eslint-disable @typescript-eslint/unbound-method */
+    expect(webhookService.createEndpoint).toBeTypeOf('function');
+    expect(webhookService.updateEndpoint).toBeTypeOf('function');
+    expect(webhookService.deleteEndpoint).toBeTypeOf('function');
+    expect(webhookService.getEndpoint).toBeTypeOf('function');
+    expect(webhookService.listEndpoints).toBeTypeOf('function');
+    expect(webhookService.rotateSecret).toBeTypeOf('function');
+    expect(webhookService.getActiveEndpointsForEvent).toBeTypeOf('function');
+    /* eslint-enable @typescript-eslint/unbound-method */
+  });
+
+  it('exports expected delivery methods', () => {
+    /* eslint-disable @typescript-eslint/unbound-method */
+    expect(webhookService.createDelivery).toBeTypeOf('function');
+    expect(webhookService.updateDeliveryStatus).toBeTypeOf('function');
+    expect(webhookService.listDeliveries).toBeTypeOf('function');
+    expect(webhookService.retryDelivery).toBeTypeOf('function');
+    expect(webhookService.countRecentFailures).toBeTypeOf('function');
+    /* eslint-enable @typescript-eslint/unbound-method */
+  });
+});

--- a/apps/api/src/services/webhook.service.ts
+++ b/apps/api/src/services/webhook.service.ts
@@ -1,0 +1,251 @@
+import crypto from 'node:crypto';
+import {
+  webhookEndpoints,
+  webhookDeliveries,
+  eq,
+  and,
+  sql,
+  type DrizzleDb,
+} from '@colophony/db';
+import { desc, count } from 'drizzle-orm';
+
+interface CreateEndpointParams {
+  organizationId: string;
+  url: string;
+  description?: string;
+  eventTypes: string[];
+}
+
+interface UpdateEndpointParams {
+  url?: string;
+  description?: string;
+  eventTypes?: string[];
+  status?: 'ACTIVE' | 'DISABLED';
+}
+
+interface CreateDeliveryParams {
+  organizationId: string;
+  webhookEndpointId: string;
+  eventType: string;
+  eventId: string;
+  payload: Record<string, unknown>;
+}
+
+interface ListDeliveriesParams {
+  endpointId?: string;
+  eventType?: string;
+  status?: 'QUEUED' | 'DELIVERING' | 'DELIVERED' | 'FAILED';
+  page: number;
+  limit: number;
+}
+
+function redactSecret<T extends Record<string, unknown>>(
+  row: T,
+): Omit<T, 'secret'> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { secret, ...rest } = row;
+  return rest;
+}
+
+export const webhookService = {
+  async createEndpoint(tx: DrizzleDb, params: CreateEndpointParams) {
+    const secret = crypto.randomBytes(32).toString('hex');
+    const [row] = await tx
+      .insert(webhookEndpoints)
+      .values({
+        organizationId: params.organizationId,
+        url: params.url,
+        secret,
+        description: params.description ?? null,
+        eventTypes: params.eventTypes,
+        status: 'ACTIVE',
+      })
+      .returning();
+    return row;
+  },
+
+  async updateEndpoint(
+    tx: DrizzleDb,
+    id: string,
+    params: UpdateEndpointParams,
+  ) {
+    const update: Record<string, unknown> = { updatedAt: new Date() };
+    if (params.url !== undefined) update.url = params.url;
+    if (params.description !== undefined)
+      update.description = params.description;
+    if (params.eventTypes !== undefined) update.eventTypes = params.eventTypes;
+    if (params.status !== undefined) update.status = params.status;
+
+    const [row] = await tx
+      .update(webhookEndpoints)
+      .set(update)
+      .where(eq(webhookEndpoints.id, id))
+      .returning();
+    return row ? redactSecret(row) : null;
+  },
+
+  async deleteEndpoint(tx: DrizzleDb, id: string) {
+    await tx.delete(webhookEndpoints).where(eq(webhookEndpoints.id, id));
+  },
+
+  async getEndpoint(tx: DrizzleDb, id: string) {
+    const [row] = await tx
+      .select()
+      .from(webhookEndpoints)
+      .where(eq(webhookEndpoints.id, id))
+      .limit(1);
+    return row ? redactSecret(row) : null;
+  },
+
+  async listEndpoints(tx: DrizzleDb, params: { page: number; limit: number }) {
+    const { page, limit } = params;
+    const offset = (page - 1) * limit;
+
+    const [items, countResult] = await Promise.all([
+      tx
+        .select()
+        .from(webhookEndpoints)
+        .orderBy(desc(webhookEndpoints.createdAt))
+        .limit(limit)
+        .offset(offset),
+      tx.select({ count: count() }).from(webhookEndpoints),
+    ]);
+
+    const total = countResult[0]?.count ?? 0;
+    return {
+      items: items.map(redactSecret),
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async rotateSecret(tx: DrizzleDb, id: string) {
+    const secret = crypto.randomBytes(32).toString('hex');
+    const [row] = await tx
+      .update(webhookEndpoints)
+      .set({ secret, updatedAt: new Date() })
+      .where(eq(webhookEndpoints.id, id))
+      .returning();
+    return row;
+  },
+
+  async getActiveEndpointsForEvent(
+    tx: DrizzleDb,
+    _orgId: string,
+    eventType: string,
+  ) {
+    return tx
+      .select()
+      .from(webhookEndpoints)
+      .where(
+        and(
+          eq(webhookEndpoints.status, 'ACTIVE'),
+          sql`${webhookEndpoints.eventTypes}::jsonb @> ${JSON.stringify([eventType])}::jsonb`,
+        ),
+      );
+  },
+
+  async createDelivery(tx: DrizzleDb, params: CreateDeliveryParams) {
+    const [row] = await tx
+      .insert(webhookDeliveries)
+      .values({
+        organizationId: params.organizationId,
+        webhookEndpointId: params.webhookEndpointId,
+        eventType: params.eventType,
+        eventId: params.eventId,
+        payload: params.payload,
+        status: 'QUEUED',
+      })
+      .returning();
+    return row;
+  },
+
+  async updateDeliveryStatus(
+    tx: DrizzleDb,
+    id: string,
+    status: 'QUEUED' | 'DELIVERING' | 'DELIVERED' | 'FAILED',
+    params?: {
+      httpStatusCode?: number;
+      responseBody?: string;
+      errorMessage?: string;
+      attempts?: number;
+      nextRetryAt?: Date | null;
+      deliveredAt?: Date;
+    },
+  ) {
+    const update: Record<string, unknown> = { status };
+    if (params?.httpStatusCode !== undefined)
+      update.httpStatusCode = params.httpStatusCode;
+    if (params?.responseBody !== undefined)
+      update.responseBody = params.responseBody?.slice(0, 4096);
+    if (params?.errorMessage !== undefined)
+      update.errorMessage = params.errorMessage?.slice(0, 2048);
+    if (params?.attempts !== undefined) update.attempts = params.attempts;
+    if (params?.nextRetryAt !== undefined)
+      update.nextRetryAt = params.nextRetryAt;
+    if (params?.deliveredAt !== undefined)
+      update.deliveredAt = params.deliveredAt;
+
+    await tx
+      .update(webhookDeliveries)
+      .set(update)
+      .where(eq(webhookDeliveries.id, id));
+  },
+
+  async listDeliveries(tx: DrizzleDb, params: ListDeliveriesParams) {
+    const { page, limit, endpointId, eventType, status } = params;
+    const offset = (page - 1) * limit;
+
+    const conditions = [];
+    if (endpointId)
+      conditions.push(eq(webhookDeliveries.webhookEndpointId, endpointId));
+    if (eventType) conditions.push(eq(webhookDeliveries.eventType, eventType));
+    if (status) conditions.push(eq(webhookDeliveries.status, status));
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const [items, countResult] = await Promise.all([
+      tx
+        .select()
+        .from(webhookDeliveries)
+        .where(where)
+        .orderBy(desc(webhookDeliveries.createdAt))
+        .limit(limit)
+        .offset(offset),
+      tx.select({ count: count() }).from(webhookDeliveries).where(where),
+    ]);
+
+    const total = countResult[0]?.count ?? 0;
+    return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
+  },
+
+  async retryDelivery(tx: DrizzleDb, deliveryId: string) {
+    const [row] = await tx
+      .update(webhookDeliveries)
+      .set({
+        status: 'QUEUED',
+        httpStatusCode: null,
+        responseBody: null,
+        errorMessage: null,
+        nextRetryAt: null,
+      })
+      .where(eq(webhookDeliveries.id, deliveryId))
+      .returning();
+    return row;
+  },
+
+  async countRecentFailures(tx: DrizzleDb, endpointId: string) {
+    const [result] = await tx
+      .select({ count: count() })
+      .from(webhookDeliveries)
+      .where(
+        and(
+          eq(webhookDeliveries.webhookEndpointId, endpointId),
+          eq(webhookDeliveries.status, 'FAILED'),
+        ),
+      );
+    return result?.count ?? 0;
+  },
+};

--- a/apps/api/src/services/webhook.service.ts
+++ b/apps/api/src/services/webhook.service.ts
@@ -32,6 +32,7 @@ interface CreateDeliveryParams {
 }
 
 interface ListDeliveriesParams {
+  organizationId?: string;
   endpointId?: string;
   eventType?: string;
   status?: 'QUEUED' | 'DELIVERING' | 'DELIVERED' | 'FAILED';
@@ -195,10 +196,13 @@ export const webhookService = {
   },
 
   async listDeliveries(tx: DrizzleDb, params: ListDeliveriesParams) {
-    const { page, limit, endpointId, eventType, status } = params;
+    const { page, limit, organizationId, endpointId, eventType, status } =
+      params;
     const offset = (page - 1) * limit;
 
     const conditions = [];
+    if (organizationId)
+      conditions.push(eq(webhookDeliveries.organizationId, organizationId));
     if (endpointId)
       conditions.push(eq(webhookDeliveries.webhookEndpointId, endpointId));
     if (eventType) conditions.push(eq(webhookDeliveries.eventType, eventType));
@@ -237,6 +241,7 @@ export const webhookService = {
   },
 
   async countRecentFailures(tx: DrizzleDb, endpointId: string) {
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000); // 24h window
     const [result] = await tx
       .select({ count: count() })
       .from(webhookDeliveries)
@@ -244,6 +249,7 @@ export const webhookService = {
         and(
           eq(webhookDeliveries.webhookEndpointId, endpointId),
           eq(webhookDeliveries.status, 'FAILED'),
+          sql`${webhookDeliveries.createdAt} >= ${since.toISOString()}`,
         ),
       );
     return result?.count ?? 0;

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -18,6 +18,7 @@ import { contractsRouter } from './routers/contracts.js';
 import { issuesRouter } from './routers/issues.js';
 import { cmsConnectionsRouter } from './routers/cms-connections.js';
 import { notificationPreferencesRouter } from './routers/notification-preferences.js';
+import { webhooksRouter } from './routers/webhooks.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -57,6 +58,7 @@ export const appRouter = t.router({
   issues: issuesRouter,
   cmsConnections: cmsConnectionsRouter,
   notificationPreferences: notificationPreferencesRouter,
+  webhooks: webhooksRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/webhooks.spec.ts
+++ b/apps/api/src/trpc/routers/webhooks.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the service
+const mockCreateEndpoint = vi.fn();
+const mockUpdateEndpoint = vi.fn();
+const mockDeleteEndpoint = vi.fn();
+const mockGetEndpoint = vi.fn();
+const mockListEndpoints = vi.fn();
+const mockRotateSecret = vi.fn();
+const mockCreateDelivery = vi.fn();
+const mockListDeliveries = vi.fn();
+const mockRetryDelivery = vi.fn();
+const mockGetActiveEndpointsForEvent = vi.fn();
+
+vi.mock('../../services/webhook.service.js', () => ({
+  webhookService: {
+    createEndpoint: (...args: unknown[]) => mockCreateEndpoint(...args),
+    updateEndpoint: (...args: unknown[]) => mockUpdateEndpoint(...args),
+    deleteEndpoint: (...args: unknown[]) => mockDeleteEndpoint(...args),
+    getEndpoint: (...args: unknown[]) => mockGetEndpoint(...args),
+    listEndpoints: (...args: unknown[]) => mockListEndpoints(...args),
+    rotateSecret: (...args: unknown[]) => mockRotateSecret(...args),
+    createDelivery: (...args: unknown[]) => mockCreateDelivery(...args),
+    listDeliveries: (...args: unknown[]) => mockListDeliveries(...args),
+    retryDelivery: (...args: unknown[]) => mockRetryDelivery(...args),
+    getActiveEndpointsForEvent: (...args: unknown[]) =>
+      mockGetActiveEndpointsForEvent(...args),
+  },
+}));
+
+vi.mock('../../queues/webhook.queue.js', () => ({
+  enqueueWebhook: vi.fn(),
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: () => ({
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: '',
+  }),
+}));
+
+vi.mock('@colophony/db', () => ({
+  webhookEndpoints: { id: 'id' },
+  eq: vi.fn(),
+}));
+
+// Mock tRPC init with a passthrough stub
+vi.mock('../init.js', () => {
+  const passthrough = {
+    input: vi.fn().mockReturnThis(),
+    output: vi.fn().mockReturnThis(),
+    query: vi.fn().mockReturnThis(),
+    mutation: vi.fn().mockReturnThis(),
+    use: vi.fn().mockReturnThis(),
+  };
+  return {
+    orgProcedure: passthrough,
+    adminProcedure: passthrough,
+    createRouter: vi.fn((routes) => routes),
+  };
+});
+
+vi.mock('@colophony/types', () => ({
+  createWebhookEndpointSchema: {},
+  updateWebhookEndpointSchema: {},
+  listWebhookDeliveriesSchema: {},
+  AuditActions: {
+    WEBHOOK_ENDPOINT_CREATED: 'WEBHOOK_ENDPOINT_CREATED',
+    WEBHOOK_ENDPOINT_UPDATED: 'WEBHOOK_ENDPOINT_UPDATED',
+    WEBHOOK_ENDPOINT_DELETED: 'WEBHOOK_ENDPOINT_DELETED',
+    WEBHOOK_ENDPOINT_SECRET_ROTATED: 'WEBHOOK_ENDPOINT_SECRET_ROTATED',
+    WEBHOOK_DELIVERY_RETRIED: 'WEBHOOK_DELIVERY_RETRIED',
+  },
+  AuditResources: {
+    WEBHOOK_ENDPOINT: 'webhook_endpoint',
+    WEBHOOK_DELIVERY: 'webhook_delivery',
+  },
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    object: vi.fn().mockReturnValue({
+      merge: vi.fn().mockReturnValue({}),
+    }),
+    string: vi.fn().mockReturnValue({
+      uuid: vi.fn().mockReturnValue({}),
+    }),
+    number: vi.fn().mockReturnValue({
+      int: vi.fn().mockReturnValue({
+        min: vi.fn().mockReturnValue({
+          default: vi.fn().mockReturnValue({}),
+          max: vi.fn().mockReturnValue({
+            default: vi.fn().mockReturnValue({}),
+          }),
+        }),
+      }),
+    }),
+  },
+}));
+
+import { webhooksRouter } from './webhooks.js';
+
+describe('webhooksRouter', () => {
+  it('exports all expected procedures', () => {
+    expect(webhooksRouter).toHaveProperty('create');
+    expect(webhooksRouter).toHaveProperty('update');
+    expect(webhooksRouter).toHaveProperty('delete');
+    expect(webhooksRouter).toHaveProperty('getById');
+    expect(webhooksRouter).toHaveProperty('list');
+    expect(webhooksRouter).toHaveProperty('rotateSecret');
+    expect(webhooksRouter).toHaveProperty('test');
+    expect(webhooksRouter).toHaveProperty('deliveries');
+    expect(webhooksRouter).toHaveProperty('retryDelivery');
+  });
+});

--- a/apps/api/src/trpc/routers/webhooks.ts
+++ b/apps/api/src/trpc/routers/webhooks.ts
@@ -1,0 +1,197 @@
+import { z } from 'zod';
+import {
+  createWebhookEndpointSchema,
+  updateWebhookEndpointSchema,
+  listWebhookDeliveriesSchema,
+  AuditActions,
+  AuditResources,
+} from '@colophony/types';
+import { webhookEndpoints, eq } from '@colophony/db';
+import { adminProcedure, orgProcedure, createRouter } from '../init.js';
+import { webhookService } from '../../services/webhook.service.js';
+import { enqueueWebhook } from '../../queues/webhook.queue.js';
+import { validateEnv } from '../../config/env.js';
+
+export const webhooksRouter = createRouter({
+  create: adminProcedure
+    .input(createWebhookEndpointSchema)
+    .mutation(async ({ ctx, input }) => {
+      const row = await webhookService.createEndpoint(ctx.dbTx, {
+        organizationId: ctx.authContext.orgId,
+        url: input.url,
+        description: input.description,
+        eventTypes: input.eventTypes,
+      });
+      await ctx.audit({
+        action: AuditActions.WEBHOOK_ENDPOINT_CREATED,
+        resource: AuditResources.WEBHOOK_ENDPOINT,
+        resourceId: row.id,
+        newValue: { url: input.url, eventTypes: input.eventTypes },
+      });
+      return row;
+    }),
+
+  update: adminProcedure
+    .input(
+      z.object({ id: z.string().uuid() }).merge(updateWebhookEndpointSchema),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...params } = input;
+      const row = await webhookService.updateEndpoint(ctx.dbTx, id, params);
+      await ctx.audit({
+        action: AuditActions.WEBHOOK_ENDPOINT_UPDATED,
+        resource: AuditResources.WEBHOOK_ENDPOINT,
+        resourceId: id,
+        newValue: params,
+      });
+      return row;
+    }),
+
+  delete: adminProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      await webhookService.deleteEndpoint(ctx.dbTx, input.id);
+      await ctx.audit({
+        action: AuditActions.WEBHOOK_ENDPOINT_DELETED,
+        resource: AuditResources.WEBHOOK_ENDPOINT,
+        resourceId: input.id,
+      });
+      return { success: true };
+    }),
+
+  getById: orgProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      return webhookService.getEndpoint(ctx.dbTx, input.id);
+    }),
+
+  list: orgProcedure
+    .input(
+      z.object({
+        page: z.number().int().min(1).default(1),
+        limit: z.number().int().min(1).max(100).default(20),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      return webhookService.listEndpoints(ctx.dbTx, input);
+    }),
+
+  rotateSecret: adminProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const row = await webhookService.rotateSecret(ctx.dbTx, input.id);
+      await ctx.audit({
+        action: AuditActions.WEBHOOK_ENDPOINT_SECRET_ROTATED,
+        resource: AuditResources.WEBHOOK_ENDPOINT,
+        resourceId: input.id,
+      });
+      return row;
+    }),
+
+  test: adminProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const env = validateEnv();
+      const orgId = ctx.authContext.orgId;
+
+      // Get the endpoint (including secret for delivery)
+      const [endpoint] = await ctx.dbTx
+        .select()
+        .from(webhookEndpoints)
+        .where(eq(webhookEndpoints.id, input.id))
+        .limit(1);
+
+      if (!endpoint) {
+        throw new Error('Webhook endpoint not found');
+      }
+
+      const delivery = await webhookService.createDelivery(ctx.dbTx, {
+        organizationId: orgId,
+        webhookEndpointId: input.id,
+        eventType: 'webhook.test',
+        eventId: crypto.randomUUID(),
+        payload: {
+          event: 'webhook.test',
+          data: { message: 'Test webhook from Colophony' },
+        },
+      });
+
+      const payload = {
+        id: delivery.id,
+        event: 'webhook.test',
+        timestamp: new Date().toISOString(),
+        organizationId: orgId,
+        data: { message: 'Test webhook from Colophony' } as Record<
+          string,
+          unknown
+        >,
+      };
+
+      await enqueueWebhook(env, {
+        deliveryId: delivery.id,
+        orgId,
+        endpointUrl: endpoint.url,
+        secret: endpoint.secret,
+        payload,
+      });
+
+      return { deliveryId: delivery.id };
+    }),
+
+  deliveries: orgProcedure
+    .input(listWebhookDeliveriesSchema)
+    .query(async ({ ctx, input }) => {
+      return webhookService.listDeliveries(ctx.dbTx, input);
+    }),
+
+  retryDelivery: adminProcedure
+    .input(z.object({ deliveryId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const env = validateEnv();
+      const orgId = ctx.authContext.orgId;
+
+      const delivery = await webhookService.retryDelivery(
+        ctx.dbTx,
+        input.deliveryId,
+      );
+
+      if (!delivery) {
+        throw new Error('Delivery not found');
+      }
+
+      // Get the endpoint for the delivery
+      const [endpoint] = await ctx.dbTx
+        .select()
+        .from(webhookEndpoints)
+        .where(eq(webhookEndpoints.id, delivery.webhookEndpointId))
+        .limit(1);
+
+      if (!endpoint) {
+        throw new Error('Webhook endpoint not found');
+      }
+
+      const payload = {
+        id: delivery.id,
+        event: delivery.eventType,
+        timestamp: new Date().toISOString(),
+        organizationId: orgId,
+        data: delivery.payload as Record<string, unknown>,
+      };
+
+      await enqueueWebhook(env, {
+        deliveryId: delivery.id,
+        orgId,
+        endpointUrl: endpoint.url,
+        secret: endpoint.secret,
+        payload,
+      });
+
+      await ctx.audit({
+        action: AuditActions.WEBHOOK_DELIVERY_RETRIED,
+        resource: AuditResources.WEBHOOK_DELIVERY,
+        resourceId: input.deliveryId,
+      });
+
+      return delivery;
+    }),
+});

--- a/apps/api/src/trpc/routers/webhooks.ts
+++ b/apps/api/src/trpc/routers/webhooks.ts
@@ -141,7 +141,10 @@ export const webhooksRouter = createRouter({
   deliveries: orgProcedure
     .input(listWebhookDeliveriesSchema)
     .query(async ({ ctx, input }) => {
-      return webhookService.listDeliveries(ctx.dbTx, input);
+      return webhookService.listDeliveries(ctx.dbTx, {
+        ...input,
+        organizationId: ctx.authContext.orgId,
+      });
     }),
 
   retryDelivery: adminProcedure
@@ -156,6 +159,10 @@ export const webhooksRouter = createRouter({
       );
 
       if (!delivery) {
+        throw new Error('Delivery not found');
+      }
+
+      if (delivery.organizationId !== orgId) {
         throw new Error('Delivery not found');
       }
 

--- a/apps/api/src/workers/__tests__/webhook.worker.spec.ts
+++ b/apps/api/src/workers/__tests__/webhook.worker.spec.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import crypto from 'node:crypto';
+
+// Capture worker callback and event handlers
+let workerCallback: (job: unknown) => Promise<void>;
+let failedCallback: (job: unknown, err: Error) => Promise<void>;
+const mockClose = vi.fn();
+
+vi.mock('bullmq', () => ({
+  Worker: vi.fn().mockImplementation(function (_name, cb, _opts) {
+    workerCallback = cb;
+    return {
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === 'failed')
+          failedCallback = handler as typeof failedCallback;
+      }),
+      close: mockClose,
+    };
+  }),
+}));
+
+const mockUpdateDeliveryStatus = vi.fn();
+const mockCountRecentFailures = vi.fn();
+const mockUpdateEndpoint = vi.fn();
+vi.mock('../../services/webhook.service.js', () => ({
+  webhookService: {
+    updateDeliveryStatus: (...args: unknown[]) =>
+      mockUpdateDeliveryStatus(...args),
+    countRecentFailures: (...args: unknown[]) =>
+      mockCountRecentFailures(...args),
+    updateEndpoint: (...args: unknown[]) => mockUpdateEndpoint(...args),
+  },
+}));
+
+const mockAuditLog = vi.fn();
+vi.mock('../../services/audit.service.js', () => ({
+  auditService: {
+    log: (...args: unknown[]) => mockAuditLog(...args),
+  },
+}));
+
+vi.mock('@colophony/db', () => ({
+  withRls: vi.fn((_ctx, fn) => fn('mock-tx')),
+  webhookDeliveries: {
+    id: 'id',
+    webhookEndpointId: 'webhook_endpoint_id',
+  },
+  eq: vi.fn(),
+}));
+
+vi.mock('@colophony/types', () => ({
+  AuditActions: {
+    WEBHOOK_DELIVERED: 'WEBHOOK_DELIVERED',
+    WEBHOOK_DELIVERY_FAILED: 'WEBHOOK_DELIVERY_FAILED',
+    WEBHOOK_ENDPOINT_AUTO_DISABLED: 'WEBHOOK_ENDPOINT_AUTO_DISABLED',
+  },
+  AuditResources: {
+    WEBHOOK_DELIVERY: 'webhook_delivery',
+    WEBHOOK_ENDPOINT: 'webhook_endpoint',
+  },
+}));
+
+const mockGetWebhookBackoffDelay = vi.fn().mockReturnValue(1000);
+vi.mock('../../queues/webhook.queue.js', () => ({
+  getWebhookBackoffDelay: (...args: unknown[]) =>
+    mockGetWebhookBackoffDelay(...args),
+}));
+
+import { startWebhookWorker, stopWebhookWorker } from '../webhook.worker.js';
+import type { Env } from '../../config/env.js';
+
+const testEnv = {
+  REDIS_HOST: 'localhost',
+  REDIS_PORT: 6379,
+  REDIS_PASSWORD: '',
+} as Env;
+
+const makeJob = (overrides = {}) => ({
+  data: {
+    deliveryId: 'del-123',
+    orgId: 'org-1',
+    endpointUrl: 'https://example.com/webhook',
+    secret: 'test-secret-hex',
+    payload: {
+      id: 'del-123',
+      event: 'hopper/submission.submitted',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      organizationId: 'org-1',
+      data: { submissionId: 'sub-1' },
+    },
+  },
+  attemptsMade: 0,
+  opts: { attempts: 8 },
+  id: 'del-123',
+  ...overrides,
+});
+
+describe('webhook worker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    startWebhookWorker(testEnv);
+  });
+
+  it('computes correct HMAC-SHA256 signature and delivers successfully', async () => {
+    const job = makeJob();
+    const body = JSON.stringify(job.data.payload);
+    const expectedSig =
+      'sha256=' +
+      crypto.createHmac('sha256', 'test-secret-hex').update(body).digest('hex');
+
+    // Mock successful HTTP response
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('OK'),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await workerCallback(job);
+
+    // Verify HMAC signature header
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.com/webhook',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'X-Webhook-Signature': expectedSig,
+          'X-Webhook-Id': 'del-123',
+          'Content-Type': 'application/json',
+          'User-Agent': 'Colophony-Webhook/1.0',
+        }),
+        body,
+      }),
+    );
+
+    // Verify delivery marked as DELIVERED
+    expect(mockUpdateDeliveryStatus).toHaveBeenCalledWith(
+      'mock-tx',
+      'del-123',
+      'DELIVERED',
+      expect.objectContaining({
+        httpStatusCode: 200,
+        deliveredAt: expect.any(Date),
+      }),
+    );
+
+    // Verify audit log
+    expect(mockAuditLog).toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('throws on non-2xx response for BullMQ retry', async () => {
+    const job = makeJob();
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('Internal Server Error'),
+      }),
+    );
+
+    await expect(workerCallback(job)).rejects.toThrow(
+      'Webhook delivery failed: HTTP 500',
+    );
+
+    // Should store error details
+    expect(mockUpdateDeliveryStatus).toHaveBeenCalledWith(
+      'mock-tx',
+      'del-123',
+      'DELIVERING',
+      expect.objectContaining({
+        httpStatusCode: 500,
+        errorMessage: 'HTTP 500',
+      }),
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  it('throws on network error for BullMQ retry', async () => {
+    const job = makeJob();
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValueOnce(new Error('ECONNREFUSED')),
+    );
+
+    await expect(workerCallback(job)).rejects.toThrow('ECONNREFUSED');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('marks delivery as FAILED on final failure', async () => {
+    const job = makeJob({ attemptsMade: 8 });
+    const err = new Error('HTTP 500');
+
+    // Mock the delivery lookup for auto-disable check
+    const { withRls } = await import('@colophony/db');
+    (withRls as ReturnType<typeof vi.fn>).mockImplementation((_ctx, fn) => {
+      const mockTx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{ webhookEndpointId: 'ep-1' }]),
+            }),
+          }),
+        }),
+      };
+      return fn(mockTx);
+    });
+
+    mockCountRecentFailures.mockResolvedValueOnce(3); // Not yet at threshold
+
+    await failedCallback(job, err);
+
+    expect(mockUpdateDeliveryStatus).toHaveBeenCalledWith(
+      expect.anything(),
+      'del-123',
+      'FAILED',
+      { errorMessage: 'HTTP 500' },
+    );
+  });
+
+  it('stops worker cleanly', async () => {
+    await stopWebhookWorker();
+    expect(mockClose).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/workers/index.ts
+++ b/apps/api/src/workers/index.ts
@@ -12,3 +12,4 @@ export {
   stopTransferFetchWorker,
 } from './transfer-fetch.worker.js';
 export { startEmailWorker, stopEmailWorker } from './email.worker.js';
+export { startWebhookWorker, stopWebhookWorker } from './webhook.worker.js';

--- a/apps/api/src/workers/webhook.worker.ts
+++ b/apps/api/src/workers/webhook.worker.ts
@@ -163,7 +163,9 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
             },
           });
 
-          // Auto-disable: check if this endpoint has too many consecutive failures
+          // Auto-disable: check if this endpoint has too many recent failures.
+          // Note: concurrent final failures may race, but the consequence is benign
+          // (disable at ±1 of the threshold). Atomic locking isn't worth the complexity.
           const [deliveryRow] = await tx
             .select({ webhookEndpointId: webhookDeliveries.webhookEndpointId })
             .from(webhookDeliveries)

--- a/apps/api/src/workers/webhook.worker.ts
+++ b/apps/api/src/workers/webhook.worker.ts
@@ -1,0 +1,213 @@
+import crypto from 'node:crypto';
+import { Worker } from 'bullmq';
+import { withRls, webhookDeliveries, eq } from '@colophony/db';
+import type { DrizzleDb } from '@colophony/db';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { Env } from '../config/env.js';
+import type { WebhookJobData } from '../queues/webhook.queue.js';
+import { getWebhookBackoffDelay } from '../queues/webhook.queue.js';
+import { webhookService } from '../services/webhook.service.js';
+import { auditService } from '../services/audit.service.js';
+
+const AUTO_DISABLE_THRESHOLD = 5;
+const DELIVERY_TIMEOUT_MS = 30_000;
+
+let worker: Worker<WebhookJobData> | null = null;
+
+export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
+  worker = new Worker<WebhookJobData>(
+    'webhook',
+    async (job) => {
+      const { deliveryId, orgId, endpointUrl, secret, payload } = job.data;
+
+      // Phase 1: Mark as DELIVERING + increment attempts
+      await withRls({ orgId }, async (tx: DrizzleDb) => {
+        await webhookService.updateDeliveryStatus(
+          tx,
+          deliveryId,
+          'DELIVERING',
+          {
+            attempts: job.attemptsMade + 1,
+          },
+        );
+      });
+
+      // Phase 2: Compute HMAC-SHA256 signature
+      const body = JSON.stringify(payload);
+      const signature =
+        'sha256=' +
+        crypto.createHmac('sha256', secret).update(body).digest('hex');
+
+      // Phase 3: HTTP POST with timeout
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
+
+      let response: Response;
+      try {
+        response = await fetch(endpointUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Webhook-Id': payload.id,
+            'X-Webhook-Timestamp': payload.timestamp,
+            'X-Webhook-Signature': signature,
+            'User-Agent': 'Colophony-Webhook/1.0',
+          },
+          body,
+          signal: controller.signal,
+        });
+      } catch (fetchErr) {
+        clearTimeout(timeout);
+        // Network error or timeout — store error and let BullMQ retry
+        const errorMsg =
+          fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
+        await withRls({ orgId }, async (tx: DrizzleDb) => {
+          await webhookService.updateDeliveryStatus(
+            tx,
+            deliveryId,
+            'DELIVERING',
+            { errorMessage: errorMsg },
+          );
+        });
+        throw fetchErr;
+      } finally {
+        clearTimeout(timeout);
+      }
+
+      // Phase 4: Process response
+      const responseBody = await response.text().catch(() => '');
+      const truncatedBody = responseBody.slice(0, 4096);
+
+      if (response.ok) {
+        // Success
+        await withRls({ orgId }, async (tx: DrizzleDb) => {
+          await webhookService.updateDeliveryStatus(
+            tx,
+            deliveryId,
+            'DELIVERED',
+            {
+              httpStatusCode: response.status,
+              responseBody: truncatedBody,
+              deliveredAt: new Date(),
+            },
+          );
+          await auditService.log(tx, {
+            resource: AuditResources.WEBHOOK_DELIVERY,
+            action: AuditActions.WEBHOOK_DELIVERED,
+            resourceId: deliveryId,
+            organizationId: orgId,
+            newValue: {
+              endpointUrl,
+              event: payload.event,
+              httpStatus: response.status,
+            },
+          });
+        });
+      } else {
+        // Non-2xx — store status and throw for BullMQ retry
+        await withRls({ orgId }, async (tx: DrizzleDb) => {
+          await webhookService.updateDeliveryStatus(
+            tx,
+            deliveryId,
+            'DELIVERING',
+            {
+              httpStatusCode: response.status,
+              responseBody: truncatedBody,
+              errorMessage: `HTTP ${response.status}`,
+            },
+          );
+        });
+        throw new Error(`Webhook delivery failed: HTTP ${response.status}`);
+      }
+    },
+    {
+      connection: {
+        host: env.REDIS_HOST,
+        port: env.REDIS_PORT,
+        password: env.REDIS_PASSWORD || undefined,
+      },
+      concurrency: 10,
+      settings: {
+        backoffStrategy: (attemptsMade: number) => {
+          return getWebhookBackoffDelay(attemptsMade);
+        },
+      },
+    },
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  worker.on('failed', async (job, err) => {
+    console.error(
+      `[webhook] Job ${job?.id} failed (attempt ${job?.attemptsMade}/${job?.opts.attempts}):`,
+      err.message,
+    );
+
+    // On final failure, mark as FAILED + audit + auto-disable check
+    if (job && job.attemptsMade >= (job.opts.attempts ?? 8)) {
+      try {
+        const { deliveryId, orgId, endpointUrl, payload } = job.data;
+        await withRls({ orgId }, async (tx: DrizzleDb) => {
+          await webhookService.updateDeliveryStatus(tx, deliveryId, 'FAILED', {
+            errorMessage: err.message,
+          });
+          await auditService.log(tx, {
+            resource: AuditResources.WEBHOOK_DELIVERY,
+            action: AuditActions.WEBHOOK_DELIVERY_FAILED,
+            resourceId: deliveryId,
+            organizationId: orgId,
+            newValue: {
+              endpointUrl,
+              event: payload.event,
+              error: err.message,
+              attempts: job.attemptsMade,
+            },
+          });
+
+          // Auto-disable: check if this endpoint has too many consecutive failures
+          const [deliveryRow] = await tx
+            .select({ webhookEndpointId: webhookDeliveries.webhookEndpointId })
+            .from(webhookDeliveries)
+            .where(eq(webhookDeliveries.id, deliveryId))
+            .limit(1);
+          const endpointId = deliveryRow?.webhookEndpointId;
+
+          if (endpointId) {
+            const failCount = await webhookService.countRecentFailures(
+              tx,
+              endpointId,
+            );
+            if (failCount >= AUTO_DISABLE_THRESHOLD) {
+              await webhookService.updateEndpoint(tx, endpointId, {
+                status: 'DISABLED',
+              });
+              await auditService.log(tx, {
+                resource: AuditResources.WEBHOOK_ENDPOINT,
+                action: AuditActions.WEBHOOK_ENDPOINT_AUTO_DISABLED,
+                resourceId: endpointId,
+                organizationId: orgId,
+                newValue: {
+                  endpointUrl,
+                  consecutiveFailures: failCount,
+                },
+              });
+            }
+          }
+        });
+      } catch (auditErr) {
+        console.error(
+          `[webhook] Failed to record failure for job ${job.id}:`,
+          auditErr,
+        );
+      }
+    }
+  });
+
+  return worker;
+}
+
+export async function stopWebhookWorker(): Promise<void> {
+  if (worker) {
+    await worker.close();
+    worker = null;
+  }
+}

--- a/apps/web/src/app/(dashboard)/webhooks/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/webhooks/[id]/page.tsx
@@ -1,0 +1,14 @@
+import { WebhookDetail } from "@/components/webhooks/webhook-detail";
+
+export default async function WebhookDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <div className="p-6">
+      <WebhookDetail endpointId={id} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/webhooks/new/page.tsx
+++ b/apps/web/src/app/(dashboard)/webhooks/new/page.tsx
@@ -1,0 +1,9 @@
+import { WebhookForm } from "@/components/webhooks/webhook-form";
+
+export default function NewWebhookPage() {
+  return (
+    <div className="p-6 max-w-2xl">
+      <WebhookForm />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/webhooks/page.tsx
+++ b/apps/web/src/app/(dashboard)/webhooks/page.tsx
@@ -1,0 +1,9 @@
+import { WebhookList } from "@/components/webhooks/webhook-list";
+
+export default function WebhooksPage() {
+  return (
+    <div className="p-6">
+      <WebhookList />
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   LayoutDashboard,
   Library,
   Settings,
+  Webhook,
 } from "lucide-react";
 
 const navigation = [
@@ -49,6 +50,11 @@ const adminNavigation = [
     name: "Organization",
     href: "/organizations/settings",
     icon: Building2,
+  },
+  {
+    name: "Webhooks",
+    href: "/webhooks",
+    icon: Webhook,
   },
 ];
 

--- a/apps/web/src/components/webhooks/__tests__/webhook-detail.spec.tsx
+++ b/apps/web/src/components/webhooks/__tests__/webhook-detail.spec.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "../../../../test/setup";
+
+let mockEndpoint: Record<string, unknown> | null = null;
+let mockDeliveries: unknown[] = [];
+let mockIsLoading = false;
+let mockIsAdmin = true;
+
+function resetMocks() {
+  mockEndpoint = {
+    id: "ep-1",
+    url: "https://example.com/hook",
+    description: "Test endpoint",
+    eventTypes: ["hopper/submission.submitted", "hopper/submission.accepted"],
+    status: "ACTIVE",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+  mockDeliveries = [
+    {
+      id: "del-1",
+      webhookEndpointId: "ep-1",
+      eventType: "hopper/submission.submitted",
+      eventId: "evt-1",
+      payload: {},
+      status: "DELIVERED",
+      httpStatusCode: 200,
+      responseBody: null,
+      errorMessage: null,
+      attempts: 1,
+      nextRetryAt: null,
+      deliveredAt: "2026-01-01T00:01:00.000Z",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    },
+  ];
+  mockIsLoading = false;
+  mockIsAdmin = true;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    webhooks: {
+      getById: {
+        useQuery: () => ({
+          data: mockIsLoading ? undefined : mockEndpoint,
+          isPending: mockIsLoading,
+        }),
+      },
+      deliveries: {
+        useQuery: () => ({
+          data: mockIsLoading
+            ? undefined
+            : {
+                items: mockDeliveries,
+                total: mockDeliveries.length,
+                page: 1,
+                limit: 20,
+                totalPages: 1,
+              },
+          isPending: mockIsLoading,
+        }),
+      },
+      delete: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+      rotateSecret: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+      test: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+      retryDelivery: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+    },
+    useUtils: () => ({
+      webhooks: {
+        getById: { invalidate: jest.fn() },
+        deliveries: { invalidate: jest.fn() },
+      },
+    }),
+  },
+}));
+
+jest.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({
+    isAdmin: mockIsAdmin,
+    isEditor: true,
+  }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+import { WebhookDetail } from "../webhook-detail";
+
+describe("WebhookDetail", () => {
+  beforeEach(resetMocks);
+
+  it("renders endpoint URL and event subscriptions", () => {
+    render(<WebhookDetail endpointId="ep-1" />);
+    expect(screen.getByText("https://example.com/hook")).toBeInTheDocument();
+    // May appear in both event subscriptions badges and delivery log
+    expect(
+      screen.getAllByText("hopper/submission.submitted").length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getAllByText("hopper/submission.accepted").length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders delivery log with status", () => {
+    render(<WebhookDetail endpointId="ep-1" />);
+    expect(screen.getByText("Delivery Log")).toBeInTheDocument();
+    expect(screen.getByText("DELIVERED")).toBeInTheDocument();
+    expect(screen.getByText("200")).toBeInTheDocument();
+  });
+
+  it("shows action buttons for admins", () => {
+    render(<WebhookDetail endpointId="ep-1" />);
+    expect(screen.getByText("Test")).toBeInTheDocument();
+    expect(screen.getByText("Rotate Secret")).toBeInTheDocument();
+    expect(screen.getByText("Delete")).toBeInTheDocument();
+  });
+
+  it("hides action buttons for non-admins", () => {
+    mockIsAdmin = false;
+    render(<WebhookDetail endpointId="ep-1" />);
+    expect(screen.queryByText("Test")).toBeNull();
+    expect(screen.queryByText("Rotate Secret")).toBeNull();
+    expect(screen.queryByText("Delete")).toBeNull();
+  });
+
+  it("shows not-found state when endpoint is null", () => {
+    mockEndpoint = null;
+    render(<WebhookDetail endpointId="ep-1" />);
+    expect(screen.getByText("Webhook endpoint not found")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/webhooks/__tests__/webhook-form.spec.tsx
+++ b/apps/web/src/components/webhooks/__tests__/webhook-form.spec.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "../../../../test/setup";
+
+const mockMutate = jest.fn();
+let mockIsPending = false;
+
+function resetMocks() {
+  mockMutate.mockClear();
+  mockIsPending = false;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    webhooks: {
+      create: {
+        useMutation: (opts: Record<string, unknown>) => ({
+          mutate: (data: unknown) => {
+            mockMutate(data);
+            if (typeof opts.onSuccess === "function")
+              (opts.onSuccess as (d: unknown) => void)({
+                secret: "test-secret",
+              });
+          },
+          isPending: mockIsPending,
+        }),
+      },
+    },
+  },
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+import { WebhookForm } from "../webhook-form";
+
+describe("WebhookForm", () => {
+  beforeEach(resetMocks);
+
+  it("renders URL input and event type checkboxes", () => {
+    render(<WebhookForm />);
+    expect(
+      screen.getByPlaceholderText("https://example.com/webhooks"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Submission Submitted")).toBeInTheDocument();
+    expect(screen.getByText("Issue Published")).toBeInTheDocument();
+  });
+
+  it("renders create button", () => {
+    render(<WebhookForm />);
+    expect(screen.getByText("Create Webhook")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/webhooks/__tests__/webhook-list.spec.tsx
+++ b/apps/web/src/components/webhooks/__tests__/webhook-list.spec.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "../../../../test/setup";
+
+// Mutable mock state
+let mockWebhooks: unknown[] = [];
+let mockIsPending = false;
+let mockIsAdmin = true;
+
+function resetMocks() {
+  mockWebhooks = [];
+  mockIsPending = false;
+  mockIsAdmin = true;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    webhooks: {
+      list: {
+        useQuery: () => ({
+          data: mockIsPending
+            ? undefined
+            : {
+                items: mockWebhooks,
+                total: mockWebhooks.length,
+                page: 1,
+                limit: 20,
+                totalPages: 1,
+              },
+          isPending: mockIsPending,
+        }),
+      },
+    },
+  },
+}));
+
+jest.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({
+    isAdmin: mockIsAdmin,
+    isEditor: true,
+  }),
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/webhooks",
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+import { WebhookList } from "../webhook-list";
+
+describe("WebhookList", () => {
+  beforeEach(resetMocks);
+
+  it("renders loading skeleton when pending", () => {
+    mockIsPending = true;
+    render(<WebhookList />);
+    // Skeletons are rendered (no table)
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("renders empty state with CTA when no webhooks exist", () => {
+    mockWebhooks = [];
+    render(<WebhookList />);
+    expect(
+      screen.getByText("No webhook endpoints configured"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Create your first webhook endpoint"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders webhook list with URL, events, and status", () => {
+    mockWebhooks = [
+      {
+        id: "ep-1",
+        url: "https://example.com/hook",
+        description: "Test hook",
+        eventTypes: ["hopper/submission.submitted"],
+        status: "ACTIVE",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ];
+    render(<WebhookList />);
+    expect(screen.getByText("https://example.com/hook")).toBeInTheDocument();
+    expect(screen.getByText("1 event")).toBeInTheDocument();
+    expect(screen.getByText("ACTIVE")).toBeInTheDocument();
+  });
+
+  it("hides new webhook button for non-admins", () => {
+    mockIsAdmin = false;
+    render(<WebhookList />);
+    expect(screen.queryByText("New Webhook")).toBeNull();
+  });
+});

--- a/apps/web/src/components/webhooks/event-type-selector.tsx
+++ b/apps/web/src/components/webhooks/event-type-selector.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+
+const EVENT_GROUPS = [
+  {
+    label: "Submissions",
+    events: [
+      {
+        value: "hopper/submission.submitted",
+        label: "Submission Submitted",
+      },
+      {
+        value: "hopper/submission.accepted",
+        label: "Submission Accepted",
+      },
+      {
+        value: "hopper/submission.rejected",
+        label: "Submission Rejected",
+      },
+      {
+        value: "hopper/submission.withdrawn",
+        label: "Submission Withdrawn",
+      },
+    ],
+  },
+  {
+    label: "Pipeline",
+    events: [
+      {
+        value: "slate/pipeline.copyeditor-assigned",
+        label: "Copyeditor Assigned",
+      },
+      {
+        value: "slate/pipeline.copyedit-completed",
+        label: "Copyedit Completed",
+      },
+      {
+        value: "slate/pipeline.author-review-completed",
+        label: "Author Review Completed",
+      },
+      {
+        value: "slate/pipeline.proofread-completed",
+        label: "Proofread Completed",
+      },
+    ],
+  },
+  {
+    label: "Contracts",
+    events: [
+      {
+        value: "slate/contract.generated",
+        label: "Contract Generated",
+      },
+    ],
+  },
+  {
+    label: "Issues",
+    events: [
+      {
+        value: "slate/issue.published",
+        label: "Issue Published",
+      },
+    ],
+  },
+] as const;
+
+interface EventTypeSelectorProps {
+  value: string[];
+  onChange: (value: string[]) => void;
+}
+
+export function EventTypeSelector({ value, onChange }: EventTypeSelectorProps) {
+  const toggle = (eventType: string) => {
+    if (value.includes(eventType)) {
+      onChange(value.filter((v) => v !== eventType));
+    } else {
+      onChange([...value, eventType]);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {EVENT_GROUPS.map((group) => (
+        <div key={group.label}>
+          <p className="text-sm font-medium text-muted-foreground mb-2">
+            {group.label}
+          </p>
+          <div className="space-y-2 ml-1">
+            {group.events.map((event) => (
+              <div key={event.value} className="flex items-center space-x-2">
+                <Checkbox
+                  id={event.value}
+                  checked={value.includes(event.value)}
+                  onCheckedChange={() => toggle(event.value)}
+                />
+                <Label htmlFor={event.value} className="text-sm font-normal">
+                  {event.label}
+                </Label>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/webhooks/secret-display-dialog.tsx
+++ b/apps/web/src/components/webhooks/secret-display-dialog.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Check, Copy } from "lucide-react";
+
+interface SecretDisplayDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  secret: string;
+  title?: string;
+}
+
+export function SecretDisplayDialog({
+  open,
+  onOpenChange,
+  secret,
+  title = "Webhook Secret",
+}: SecretDisplayDialogProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(secret);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            Copy this secret now. It will not be shown again.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex items-center gap-2">
+          <code className="flex-1 rounded bg-muted p-3 text-sm font-mono break-all">
+            {secret}
+          </code>
+          <Button variant="outline" size="icon" onClick={handleCopy}>
+            {copied ? (
+              <Check className="h-4 w-4" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
+        <DialogFooter>
+          <Button onClick={() => onOpenChange(false)}>Done</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/webhooks/webhook-detail.tsx
+++ b/apps/web/src/components/webhooks/webhook-detail.tsx
@@ -1,0 +1,402 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { format } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import {
+  ArrowLeft,
+  Loader2,
+  RefreshCw,
+  RotateCcw,
+  Send,
+  Trash2,
+} from "lucide-react";
+import { SecretDisplayDialog } from "./secret-display-dialog";
+
+const STATUS_COLORS: Record<string, string> = {
+  QUEUED: "bg-yellow-500",
+  DELIVERING: "bg-blue-500",
+  DELIVERED: "bg-green-500",
+  FAILED: "bg-red-500",
+};
+
+interface WebhookDetailProps {
+  endpointId: string;
+}
+
+export function WebhookDetail({ endpointId }: WebhookDetailProps) {
+  const router = useRouter();
+  const utils = trpc.useUtils();
+  const { isAdmin } = useOrganization();
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [rotateOpen, setRotateOpen] = useState(false);
+  const [secret, setSecret] = useState<string | null>(null);
+  const [secretDialogOpen, setSecretDialogOpen] = useState(false);
+  const [deliveryPage, setDeliveryPage] = useState(1);
+
+  const { data: endpoint, isPending: isLoading } =
+    trpc.webhooks.getById.useQuery({ id: endpointId });
+
+  const { data: deliveries, isPending: deliveriesLoading } =
+    trpc.webhooks.deliveries.useQuery({
+      endpointId,
+      page: deliveryPage,
+      limit: 20,
+    });
+
+  const deleteMutation = trpc.webhooks.delete.useMutation({
+    onSuccess: () => {
+      toast.success("Webhook endpoint deleted");
+      router.push("/webhooks");
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const rotateMutation = trpc.webhooks.rotateSecret.useMutation({
+    onSuccess: (data) => {
+      if (data?.secret) {
+        setSecret(data.secret);
+        setSecretDialogOpen(true);
+      }
+      utils.webhooks.getById.invalidate({ id: endpointId });
+      toast.success("Secret rotated");
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const testMutation = trpc.webhooks.test.useMutation({
+    onSuccess: () => {
+      toast.success("Test webhook sent");
+      utils.webhooks.deliveries.invalidate({ endpointId });
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const retryMutation = trpc.webhooks.retryDelivery.useMutation({
+    onSuccess: () => {
+      toast.success("Delivery queued for retry");
+      utils.webhooks.deliveries.invalidate({ endpointId });
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-64" />
+        <div className="grid gap-6 md:grid-cols-3">
+          <Skeleton className="h-96 md:col-span-2" />
+          <Skeleton className="h-48" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!endpoint) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">Webhook endpoint not found</p>
+        <Link href="/webhooks">
+          <Button variant="link">Back to webhooks</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  const eventTypes = endpoint.eventTypes as string[];
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <Link
+          href="/webhooks"
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="mr-1 h-4 w-4" />
+          Back to webhooks
+        </Link>
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold font-mono text-sm break-all">
+            {endpoint.url}
+          </h1>
+          {isAdmin && (
+            <div className="flex items-center gap-2 shrink-0 ml-4">
+              <Button
+                variant="outline"
+                onClick={() => testMutation.mutate({ id: endpointId })}
+                disabled={testMutation.isPending}
+              >
+                {testMutation.isPending ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Send className="mr-2 h-4 w-4" />
+                )}
+                Test
+              </Button>
+
+              <AlertDialog open={rotateOpen} onOpenChange={setRotateOpen}>
+                <AlertDialogTrigger asChild>
+                  <Button variant="outline">
+                    <RotateCcw className="mr-2 h-4 w-4" />
+                    Rotate Secret
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Rotate Secret</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      This will generate a new signing secret. The old secret
+                      will stop working immediately. Make sure to update your
+                      endpoint.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => rotateMutation.mutate({ id: endpointId })}
+                    >
+                      Rotate
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+
+              <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+                <AlertDialogTrigger asChild>
+                  <Button variant="destructive">
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    Delete
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Delete Webhook</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      This will permanently delete this webhook endpoint and all
+                      its delivery history. This action cannot be undone.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => deleteMutation.mutate({ id: endpointId })}
+                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    >
+                      Delete
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Endpoint details */}
+      <div className="grid gap-6 md:grid-cols-3">
+        <Card className="md:col-span-2">
+          <CardHeader>
+            <CardTitle>Event Subscriptions</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-2">
+              {eventTypes.map((event) => (
+                <Badge key={event} variant="outline">
+                  {event}
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Details</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {endpoint.description && (
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Description
+                </p>
+                <p className="text-sm mt-1">{endpoint.description}</p>
+              </div>
+            )}
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">
+                Status
+              </p>
+              <div className="flex items-center gap-2 mt-1">
+                <span
+                  className={`inline-block h-2 w-2 rounded-full ${
+                    endpoint.status === "ACTIVE"
+                      ? "bg-green-500"
+                      : "bg-gray-300"
+                  }`}
+                />
+                <span className="text-sm">{endpoint.status}</span>
+              </div>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">
+                Created
+              </p>
+              <p className="text-sm mt-1">
+                {format(new Date(endpoint.createdAt), "PPP")}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">
+                Updated
+              </p>
+              <p className="text-sm mt-1">
+                {format(new Date(endpoint.updatedAt), "PPP")}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Delivery log */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Delivery Log</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {deliveriesLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : !deliveries?.items.length ? (
+            <p className="text-center py-8 text-muted-foreground">
+              No deliveries yet
+            </p>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Event</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>HTTP</TableHead>
+                    <TableHead>Attempts</TableHead>
+                    <TableHead>Time</TableHead>
+                    {isAdmin && <TableHead />}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {deliveries.items.map((delivery) => (
+                    <TableRow key={delivery.id}>
+                      <TableCell className="font-mono text-sm">
+                        {delivery.eventType}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`inline-block h-2 w-2 rounded-full ${
+                              STATUS_COLORS[delivery.status] ?? "bg-gray-300"
+                            }`}
+                          />
+                          <span className="text-sm">{delivery.status}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {delivery.httpStatusCode ?? "—"}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {delivery.attempts}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {format(new Date(delivery.createdAt), "PP p")}
+                      </TableCell>
+                      {isAdmin && (
+                        <TableCell>
+                          {delivery.status === "FAILED" && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() =>
+                                retryMutation.mutate({
+                                  deliveryId: delivery.id,
+                                })
+                              }
+                              disabled={retryMutation.isPending}
+                            >
+                              <RefreshCw className="h-4 w-4" />
+                            </Button>
+                          )}
+                        </TableCell>
+                      )}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+
+              {deliveries.total > 20 && (
+                <div className="flex justify-center gap-2 mt-4">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setDeliveryPage((p) => Math.max(1, p - 1))}
+                    disabled={deliveryPage === 1}
+                  >
+                    Previous
+                  </Button>
+                  <span className="flex items-center text-sm text-muted-foreground">
+                    Page {deliveryPage} of {Math.ceil(deliveries.total / 20)}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setDeliveryPage((p) => p + 1)}
+                    disabled={deliveryPage * 20 >= deliveries.total}
+                  >
+                    Next
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {secret && (
+        <SecretDisplayDialog
+          open={secretDialogOpen}
+          onOpenChange={setSecretDialogOpen}
+          secret={secret}
+          title="New Webhook Secret"
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/webhooks/webhook-form.tsx
+++ b/apps/web/src/components/webhooks/webhook-form.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import type { CreateWebhookEndpointInput } from "@colophony/types";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import { EventTypeSelector } from "./event-type-selector";
+import { SecretDisplayDialog } from "./secret-display-dialog";
+
+const formSchema = z.object({
+  url: z.string().url("Must be a valid URL"),
+  description: z.string().max(512).optional(),
+  eventTypes: z.array(z.string()).min(1, "Select at least one event type"),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+export function WebhookForm() {
+  const router = useRouter();
+  const [secret, setSecret] = useState<string | null>(null);
+  const [secretDialogOpen, setSecretDialogOpen] = useState(false);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      url: "",
+      description: "",
+      eventTypes: [],
+    },
+  });
+
+  const createMutation = trpc.webhooks.create.useMutation({
+    onSuccess: (data) => {
+      if (data.secret) {
+        setSecret(data.secret);
+        setSecretDialogOpen(true);
+      } else {
+        toast.success("Webhook endpoint created");
+        router.push("/webhooks");
+      }
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const onSubmit = (values: FormValues) => {
+    createMutation.mutate(values as unknown as CreateWebhookEndpointInput);
+  };
+
+  const handleSecretDialogClose = (open: boolean) => {
+    setSecretDialogOpen(open);
+    if (!open) {
+      toast.success("Webhook endpoint created");
+      router.push("/webhooks");
+    }
+  };
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>New Webhook Endpoint</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+              <FormField
+                control={form.control}
+                name="url"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>URL</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="https://example.com/webhooks"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      The HTTPS endpoint that will receive webhook POST requests
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description (optional)</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Production webhook for..."
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="eventTypes"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Events</FormLabel>
+                    <FormControl>
+                      <EventTypeSelector
+                        value={field.value}
+                        onChange={field.onChange}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Button type="submit" disabled={createMutation.isPending}>
+                {createMutation.isPending && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                Create Webhook
+              </Button>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      {secret && (
+        <SecretDisplayDialog
+          open={secretDialogOpen}
+          onOpenChange={handleSecretDialogClose}
+          secret={secret}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/webhooks/webhook-list.tsx
+++ b/apps/web/src/components/webhooks/webhook-list.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { format } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Plus, Webhook } from "lucide-react";
+
+export function WebhookList() {
+  const { isAdmin } = useOrganization();
+  const [page, setPage] = useState(1);
+
+  const { data, isPending: isLoading } = trpc.webhooks.list.useQuery({
+    page,
+    limit: 20,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="rounded-lg bg-primary/10 p-2">
+            <Webhook className="h-5 w-5 text-primary" />
+          </div>
+          <h1 className="text-2xl font-bold">Webhooks</h1>
+        </div>
+        {isAdmin && (
+          <Link href="/webhooks/new">
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              New Webhook
+            </Button>
+          </Link>
+        )}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Endpoints</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : !data?.items.length ? (
+            <div className="text-center py-12">
+              <p className="text-muted-foreground">
+                No webhook endpoints configured
+              </p>
+              {isAdmin && (
+                <Link href="/webhooks/new">
+                  <Button variant="link">
+                    Create your first webhook endpoint
+                  </Button>
+                </Link>
+              )}
+            </div>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>URL</TableHead>
+                    <TableHead>Events</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Created</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.items.map((endpoint) => (
+                    <TableRow key={endpoint.id}>
+                      <TableCell>
+                        <Link
+                          href={`/webhooks/${endpoint.id}`}
+                          className="font-medium hover:underline font-mono text-sm"
+                        >
+                          {endpoint.url.length > 60
+                            ? endpoint.url.slice(0, 60) + "..."
+                            : endpoint.url}
+                        </Link>
+                        {endpoint.description && (
+                          <p className="text-xs text-muted-foreground mt-0.5">
+                            {endpoint.description}
+                          </p>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="secondary">
+                          {(endpoint.eventTypes as string[]).length} event
+                          {(endpoint.eventTypes as string[]).length !== 1
+                            ? "s"
+                            : ""}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`inline-block h-2 w-2 rounded-full ${
+                              endpoint.status === "ACTIVE"
+                                ? "bg-green-500"
+                                : "bg-gray-300"
+                            }`}
+                          />
+                          <span className="text-sm">{endpoint.status}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {format(new Date(endpoint.createdAt), "PP")}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+
+              {data.total > 20 && (
+                <div className="flex justify-center gap-2 mt-4">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={page === 1}
+                  >
+                    Previous
+                  </Button>
+                  <span className="flex items-center text-sm text-muted-foreground">
+                    Page {page} of {Math.ceil(data.total / 20)}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((p) => p + 1)}
+                    disabled={page * 20 >= data.total}
+                  >
+                    Next
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -188,8 +188,8 @@
 - [ ] Built-in adapters: SMTP, Stripe, S3 — (plugin research Section 11)
 - [ ] `colophony.config.ts` plugin loader — (plugin research Section 11)
 - [ ] HookEngine with typed hooks for submission lifecycle — (plugin research Section 11)
-- [ ] Webhook delivery via BullMQ with retry + dead letter queue — (plugin research Section 11)
-- [ ] Webhook configuration UI — (plugin research Section 11)
+- [x] Webhook delivery via BullMQ with retry + dead letter queue — (plugin research Section 11; done 2026-02-26 as Relay webhook system)
+- [x] Webhook configuration UI — (plugin research Section 11; done 2026-02-26 as Relay webhook admin pages)
 
 ### Phase 3-4 (v2.1-v2.2)
 
@@ -221,7 +221,7 @@
 
 - [x] Email templates + provider integration (SMTP + SendGrid) — adapters, MJML templates, BullMQ queue/worker, notification preferences, Inngest functions — (architecture doc, Relay; done 2026-02-26)
 - [x] Notification preferences frontend — UI for users to manage email opt-in/opt-out per event type — (DEVLOG 2026-02-26; done 2026-02-26)
-- [ ] Webhook delivery system (outbound) — (architecture doc, Relay)
+- [x] Webhook delivery system (outbound) — (architecture doc, Relay; done 2026-02-26)
 - [ ] In-app notification center — (architecture doc, Relay)
 
 ---

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,32 @@ Newest entries first.
 
 ---
 
+## 2026-02-26 — Relay Outbound Webhook Delivery
+
+### Done
+
+- **Full-stack outbound webhook delivery system** — implemented all 8 phases of the Relay webhook plan:
+  - DB: `webhook_endpoints` + `webhook_deliveries` tables with RLS, 2 new enums, manual migration 0033
+  - Webhook service: CRUD for endpoints + deliveries, secret generation/rotation, active endpoint lookup via JSONB contains, delivery retry
+  - BullMQ queue: `webhook` queue with 8-attempt custom backoff (1s, 5s, 30s, 2m, 10m, 1h, 1h, 1h), jobId idempotency
+  - BullMQ worker: HMAC-SHA256 signing, HTTP POST with 30s timeout, auto-disable after 5 consecutive final failures, concurrency 10
+  - Inngest function: single `webhook-delivery` function listening to all 10 events, fans out to subscribed endpoints via BullMQ
+  - tRPC router: 9 procedures (create, update, delete, getById, list, rotateSecret, test, deliveries, retryDelivery)
+  - Frontend: list/create/detail pages, delivery log table, secret display dialog, event type selector, sidebar entry (admin-only)
+  - 8 test files: service, queue, worker, Inngest, tRPC, 3 frontend components
+  - Audit constants: 8 new actions + 2 resources with discriminated union interfaces
+- **Verification fixes:** top-level await→beforeAll import, unused var prefixes, type cast for event types, prettier formatting, eslint unbound-method, multiple-element test query (getAllByText)
+- **Test results:** 101 API test files (1125 tests), 14 web test files — all passing
+
+### Decisions
+
+- Single Inngest function handles all 10 event types (simpler than one-per-event, same fan-out behavior)
+- Auto-disable threshold: 5 consecutive final failures (prevents wasting resources on broken endpoints)
+- Custom backoff schedule: [1s, 5s, 30s, 2m, 10m, 1h, 1h, 1h] — matches industry webhook practice
+- Secret shown once on create/rotate only; redacted via `redactSecret()` in list/get responses
+
+---
+
 ## 2026-02-26 — Relay Notification Preferences UI
 
 ### Done

--- a/packages/db/migrations/0033_webhook_endpoints.sql
+++ b/packages/db/migrations/0033_webhook_endpoints.sql
@@ -1,0 +1,82 @@
+-- Relay Webhook Endpoints — outbound webhook delivery system
+-- Manual migration (drizzle-kit TUI blocked in non-interactive shell)
+
+--> statement-breakpoint
+CREATE TYPE "public"."WebhookEndpointStatus" AS ENUM('ACTIVE', 'DISABLED');
+
+--> statement-breakpoint
+CREATE TYPE "public"."WebhookDeliveryStatus" AS ENUM('QUEUED', 'DELIVERING', 'DELIVERED', 'FAILED');
+
+--> statement-breakpoint
+CREATE TABLE "webhook_endpoints" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "url" varchar(2048) NOT NULL,
+  "secret" varchar(512) NOT NULL,
+  "description" varchar(512),
+  "event_types" jsonb NOT NULL,
+  "status" "WebhookEndpointStatus" DEFAULT 'ACTIVE' NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+CREATE INDEX "webhook_endpoints_org_idx" ON "webhook_endpoints" ("organization_id");
+
+--> statement-breakpoint
+CREATE INDEX "webhook_endpoints_status_idx" ON "webhook_endpoints" ("status");
+
+--> statement-breakpoint
+ALTER TABLE "webhook_endpoints" ENABLE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+ALTER TABLE "webhook_endpoints" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+CREATE POLICY "webhook_endpoints_org_isolation" ON "webhook_endpoints"
+  FOR ALL
+  USING (organization_id = current_setting('app.current_org')::uuid);
+
+--> statement-breakpoint
+GRANT ALL ON "webhook_endpoints" TO "app_user";
+
+--> statement-breakpoint
+CREATE TABLE "webhook_deliveries" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "webhook_endpoint_id" uuid NOT NULL REFERENCES "webhook_endpoints"("id") ON DELETE CASCADE,
+  "event_type" varchar(128) NOT NULL,
+  "event_id" varchar(255) NOT NULL,
+  "payload" jsonb NOT NULL,
+  "status" "WebhookDeliveryStatus" DEFAULT 'QUEUED' NOT NULL,
+  "http_status_code" integer,
+  "response_body" varchar(4096),
+  "error_message" varchar(2048),
+  "attempts" integer DEFAULT 0 NOT NULL,
+  "next_retry_at" timestamp with time zone,
+  "delivered_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+CREATE INDEX "webhook_deliveries_endpoint_created_idx" ON "webhook_deliveries" ("webhook_endpoint_id", "created_at");
+
+--> statement-breakpoint
+CREATE INDEX "webhook_deliveries_status_created_idx" ON "webhook_deliveries" ("status", "created_at");
+
+--> statement-breakpoint
+CREATE INDEX "webhook_deliveries_event_type_created_idx" ON "webhook_deliveries" ("event_type", "created_at");
+
+--> statement-breakpoint
+ALTER TABLE "webhook_deliveries" ENABLE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+ALTER TABLE "webhook_deliveries" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+CREATE POLICY "webhook_deliveries_org_isolation" ON "webhook_deliveries"
+  FOR ALL
+  USING (organization_id = current_setting('app.current_org')::uuid);
+
+--> statement-breakpoint
+GRANT ALL ON "webhook_deliveries" TO "app_user";

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1775600000000,
       "tag": "0032_relay_email_foundation",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1775800000000,
+      "tag": "0033_webhook_endpoints",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -180,6 +180,18 @@ export const emailSendStatusEnum = pgEnum("EmailSendStatus", [
 
 export const notificationChannelEnum = pgEnum("NotificationChannel", ["email"]);
 
+export const webhookEndpointStatusEnum = pgEnum("WebhookEndpointStatus", [
+  "ACTIVE",
+  "DISABLED",
+]);
+
+export const webhookDeliveryStatusEnum = pgEnum("WebhookDeliveryStatus", [
+  "QUEUED",
+  "DELIVERING",
+  "DELIVERED",
+  "FAILED",
+]);
+
 export const contractStatusEnum = pgEnum("ContractStatus", [
   "DRAFT",
   "SENT",

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -25,4 +25,5 @@ export * from "./transfers";
 export * from "./identity-migrations";
 export * from "./hub";
 export * from "./notifications";
+export * from "./webhook-endpoints";
 export * from "./relations";

--- a/packages/db/src/schema/webhook-endpoints.ts
+++ b/packages/db/src/schema/webhook-endpoints.ts
@@ -1,0 +1,85 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  jsonb,
+  integer,
+  timestamp,
+  index,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { webhookEndpointStatusEnum, webhookDeliveryStatusEnum } from "./enums";
+
+// --- webhook_endpoints (org-scoped, RLS) ---
+
+export const webhookEndpoints = pgTable(
+  "webhook_endpoints",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id").notNull(),
+    url: varchar("url", { length: 2048 }).notNull(),
+    secret: varchar("secret", { length: 512 }).notNull(),
+    description: varchar("description", { length: 512 }),
+    eventTypes: jsonb("event_types").notNull(),
+    status: webhookEndpointStatusEnum("status").default("ACTIVE").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("webhook_endpoints_org_idx").on(table.organizationId),
+    index("webhook_endpoints_status_idx").on(table.status),
+    pgPolicy("webhook_endpoints_org_isolation", {
+      for: "all",
+      using: sql`organization_id = current_setting('app.current_org')::uuid`,
+    }),
+  ],
+).enableRLS();
+
+// --- webhook_deliveries (org-scoped, RLS) ---
+
+export const webhookDeliveries = pgTable(
+  "webhook_deliveries",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id").notNull(),
+    webhookEndpointId: uuid("webhook_endpoint_id")
+      .notNull()
+      .references(() => webhookEndpoints.id, { onDelete: "cascade" }),
+    eventType: varchar("event_type", { length: 128 }).notNull(),
+    eventId: varchar("event_id", { length: 255 }).notNull(),
+    payload: jsonb("payload").notNull(),
+    status: webhookDeliveryStatusEnum("status").default("QUEUED").notNull(),
+    httpStatusCode: integer("http_status_code"),
+    responseBody: varchar("response_body", { length: 4096 }),
+    errorMessage: varchar("error_message", { length: 2048 }),
+    attempts: integer("attempts").default(0).notNull(),
+    nextRetryAt: timestamp("next_retry_at", { withTimezone: true }),
+    deliveredAt: timestamp("delivered_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("webhook_deliveries_endpoint_created_idx").on(
+      table.webhookEndpointId,
+      table.createdAt,
+    ),
+    index("webhook_deliveries_status_created_idx").on(
+      table.status,
+      table.createdAt,
+    ),
+    index("webhook_deliveries_event_type_created_idx").on(
+      table.eventType,
+      table.createdAt,
+    ),
+    pgPolicy("webhook_deliveries_org_isolation", {
+      for: "all",
+      using: sql`organization_id = current_setting('app.current_org')::uuid`,
+    }),
+  ],
+).enableRLS();

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -192,6 +192,16 @@ export const AuditActions = {
   EMAIL_FAILED: "EMAIL_FAILED",
   NOTIFICATION_PREFERENCE_UPDATED: "NOTIFICATION_PREFERENCE_UPDATED",
 
+  // Relay — webhooks
+  WEBHOOK_ENDPOINT_CREATED: "WEBHOOK_ENDPOINT_CREATED",
+  WEBHOOK_ENDPOINT_UPDATED: "WEBHOOK_ENDPOINT_UPDATED",
+  WEBHOOK_ENDPOINT_DELETED: "WEBHOOK_ENDPOINT_DELETED",
+  WEBHOOK_ENDPOINT_SECRET_ROTATED: "WEBHOOK_ENDPOINT_SECRET_ROTATED",
+  WEBHOOK_DELIVERED: "WEBHOOK_DELIVERED",
+  WEBHOOK_DELIVERY_FAILED: "WEBHOOK_DELIVERY_FAILED",
+  WEBHOOK_DELIVERY_RETRIED: "WEBHOOK_DELIVERY_RETRIED",
+  WEBHOOK_ENDPOINT_AUTO_DISABLED: "WEBHOOK_ENDPOINT_AUTO_DISABLED",
+
   // Audit access
   AUDIT_ACCESSED: "AUDIT_ACCESSED",
 } as const;
@@ -224,6 +234,8 @@ export const AuditResources = {
   HUB: "hub",
   EMAIL: "email",
   NOTIFICATION_PREFERENCE: "notification_preference",
+  WEBHOOK_ENDPOINT: "webhook_endpoint",
+  WEBHOOK_DELIVERY: "webhook_delivery",
   AUDIT: "audit",
 } as const;
 
@@ -498,6 +510,24 @@ export interface NotificationPreferenceAuditParams extends BaseAuditParams {
   action: typeof AuditActions.NOTIFICATION_PREFERENCE_UPDATED;
 }
 
+export interface WebhookEndpointAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.WEBHOOK_ENDPOINT;
+  action:
+    | typeof AuditActions.WEBHOOK_ENDPOINT_CREATED
+    | typeof AuditActions.WEBHOOK_ENDPOINT_UPDATED
+    | typeof AuditActions.WEBHOOK_ENDPOINT_DELETED
+    | typeof AuditActions.WEBHOOK_ENDPOINT_SECRET_ROTATED
+    | typeof AuditActions.WEBHOOK_ENDPOINT_AUTO_DISABLED;
+}
+
+export interface WebhookDeliveryAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.WEBHOOK_DELIVERY;
+  action:
+    | typeof AuditActions.WEBHOOK_DELIVERED
+    | typeof AuditActions.WEBHOOK_DELIVERY_FAILED
+    | typeof AuditActions.WEBHOOK_DELIVERY_RETRIED;
+}
+
 export interface AuditAccessAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.AUDIT;
   action: typeof AuditActions.AUDIT_ACCESSED;
@@ -536,6 +566,8 @@ export type AuditLogParams =
   | HubAuditParams
   | EmailAuditParams
   | NotificationPreferenceAuditParams
+  | WebhookEndpointAuditParams
+  | WebhookDeliveryAuditParams
   | AuditAccessAuditParams
   | SystemAuditParams;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -22,3 +22,4 @@ export * from "./transfer";
 export * from "./migration";
 export * from "./hub";
 export * from "./notification-preferences";
+export * from "./webhook";

--- a/packages/types/src/webhook.ts
+++ b/packages/types/src/webhook.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Webhook event types — all events that can trigger webhook deliveries
+// ---------------------------------------------------------------------------
+
+export const WEBHOOK_EVENT_TYPES = [
+  "hopper/submission.submitted",
+  "hopper/submission.accepted",
+  "hopper/submission.rejected",
+  "hopper/submission.withdrawn",
+  "slate/pipeline.copyeditor-assigned",
+  "slate/pipeline.copyedit-completed",
+  "slate/pipeline.author-review-completed",
+  "slate/pipeline.proofread-completed",
+  "slate/contract.generated",
+  "slate/issue.published",
+  "webhook.test",
+] as const;
+
+export type WebhookEventType = (typeof WEBHOOK_EVENT_TYPES)[number];
+
+export const webhookEventTypeSchema = z.enum(WEBHOOK_EVENT_TYPES);
+
+// ---------------------------------------------------------------------------
+// Input schemas
+// ---------------------------------------------------------------------------
+
+export const createWebhookEndpointSchema = z.object({
+  url: z.string().url("Must be a valid URL").max(2048),
+  description: z.string().max(512).optional(),
+  eventTypes: z
+    .array(webhookEventTypeSchema)
+    .min(1, "At least one event type is required"),
+});
+
+export type CreateWebhookEndpointInput = z.infer<
+  typeof createWebhookEndpointSchema
+>;
+
+export const updateWebhookEndpointSchema = z.object({
+  url: z.string().url("Must be a valid URL").max(2048).optional(),
+  description: z.string().max(512).optional(),
+  eventTypes: z
+    .array(webhookEventTypeSchema)
+    .min(1, "At least one event type is required")
+    .optional(),
+  status: z.enum(["ACTIVE", "DISABLED"]).optional(),
+});
+
+export type UpdateWebhookEndpointInput = z.infer<
+  typeof updateWebhookEndpointSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+export const webhookEndpointResponseSchema = z.object({
+  id: z.string().uuid(),
+  url: z.string(),
+  description: z.string().nullable(),
+  eventTypes: z.array(z.string()),
+  status: z.enum(["ACTIVE", "DISABLED"]),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type WebhookEndpointResponse = z.infer<
+  typeof webhookEndpointResponseSchema
+>;
+
+export const webhookEndpointCreatedResponseSchema =
+  webhookEndpointResponseSchema.extend({
+    secret: z.string(),
+  });
+
+export type WebhookEndpointCreatedResponse = z.infer<
+  typeof webhookEndpointCreatedResponseSchema
+>;
+
+export const webhookDeliveryResponseSchema = z.object({
+  id: z.string().uuid(),
+  webhookEndpointId: z.string().uuid(),
+  eventType: z.string(),
+  eventId: z.string(),
+  payload: z.unknown(),
+  status: z.enum(["QUEUED", "DELIVERING", "DELIVERED", "FAILED"]),
+  httpStatusCode: z.number().nullable(),
+  responseBody: z.string().nullable(),
+  errorMessage: z.string().nullable(),
+  attempts: z.number(),
+  nextRetryAt: z.date().nullable(),
+  deliveredAt: z.date().nullable(),
+  createdAt: z.date(),
+});
+
+export type WebhookDeliveryResponse = z.infer<
+  typeof webhookDeliveryResponseSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Query schemas
+// ---------------------------------------------------------------------------
+
+export const listWebhookDeliveriesSchema = z.object({
+  endpointId: z.string().uuid().optional(),
+  eventType: z.string().optional(),
+  status: z.enum(["QUEUED", "DELIVERING", "DELIVERED", "FAILED"]).optional(),
+  page: z.number().int().min(1).default(1),
+  limit: z.number().int().min(1).max(100).default(20),
+});
+
+export type ListWebhookDeliveriesInput = z.infer<
+  typeof listWebhookDeliveriesSchema
+>;


### PR DESCRIPTION
## Summary

- Complete outbound webhook delivery system for organizations to receive HTTP notifications on events
- DB schema: `webhook_endpoints` + `webhook_deliveries` tables with RLS (migration 0033)
- BullMQ queue/worker: HMAC-SHA256 signing, 8-attempt custom backoff (1s→1h), auto-disable after 5 failures
- Inngest function: listens to 10 events, fans out to subscribed endpoints
- tRPC router: 9 procedures (CRUD, rotate secret, test, deliveries, retry)
- Frontend: list/create/detail pages with delivery log, secret display dialog, event type selector
- 8 test files (1125 API tests + 71 web tests passing)

## Test plan

- [ ] `pnpm test` — all unit tests pass (verified locally)
- [ ] `pnpm type-check` — clean (verified locally)
- [ ] `pnpm lint` — clean (verified locally)
- [ ] CI pipeline passes
- [ ] `pnpm db:reset` applies migration 0033 with RLS
- [ ] Manual QA: create webhook endpoint, subscribe to events, test with webhook.site

## Plan Overrides

None — all 33 planned items matched implementation exactly (verified by OpenCode drift check).