### PR TITLE
feat(relay): in-app notification center

### DIFF
--- a/apps/api/src/hooks/db-context.ts
+++ b/apps/api/src/hooks/db-context.ts
@@ -36,6 +36,11 @@ export default fp(
     app.addHook(
       'onRequest',
       async function dbContextOnRequest(request: FastifyRequest) {
+        // SSE endpoints use reply.hijack() — onResponse never fires,
+        // so the transaction would never commit. Skip db-context; the
+        // handler uses withRls() directly (same pattern as BullMQ workers).
+        if (request.url.startsWith('/api/notifications/stream')) return;
+
         // Only set up transaction if we have an authenticated user
         if (!request.authContext?.userId) return;
 

--- a/apps/api/src/inngest/functions/slate-notifications.ts
+++ b/apps/api/src/inngest/functions/slate-notifications.ts
@@ -18,6 +18,7 @@ import { emailService } from '../../services/email.service.js';
 import { auditService } from '../../services/audit.service.js';
 import { enqueueEmail } from '../../queues/email.queue.js';
 import { validateEnv } from '../../config/env.js';
+import { queueInAppNotification } from '../helpers/queue-in-app-notification.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -162,6 +163,16 @@ export const contractReadyNotification = inngest.createFunction(
       });
     });
 
+    await step.run('queue-in-app', async () => {
+      await queueInAppNotification({
+        orgId,
+        userId: data.submitterId!,
+        eventType: 'contract.ready',
+        title: `Contract ready for signing: ${data.submissionTitle}`,
+        link: '/contracts',
+      });
+    });
+
     return { notified: 1 };
   },
 );
@@ -227,6 +238,16 @@ export const copyeditorAssignedNotification = inngest.createFunction(
           orgName: data.orgName,
         },
         subject: `You've been assigned as copyeditor: ${data.submissionTitle}`,
+      });
+    });
+
+    await step.run('queue-in-app', async () => {
+      await queueInAppNotification({
+        orgId,
+        userId: copyeditorId,
+        eventType: 'copyeditor.assigned',
+        title: `You've been assigned as copyeditor: ${data.submissionTitle}`,
+        link: '/pipeline',
       });
     });
 

--- a/apps/api/src/inngest/functions/submission-notifications.ts
+++ b/apps/api/src/inngest/functions/submission-notifications.ts
@@ -22,6 +22,7 @@ import { emailService } from '../../services/email.service.js';
 import { auditService } from '../../services/audit.service.js';
 import { enqueueEmail } from '../../queues/email.queue.js';
 import { validateEnv } from '../../config/env.js';
+import { queueInAppNotification } from '../helpers/queue-in-app-notification.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -177,6 +178,18 @@ export const submissionReceivedNotification = inngest.createFunction(
       }
     });
 
+    await step.run('queue-in-app-notifications', async () => {
+      for (const editor of editors) {
+        await queueInAppNotification({
+          orgId,
+          userId: editor.userId,
+          eventType: 'submission.received',
+          title: `New submission: ${submission.title}`,
+          link: `/submissions/${submissionId}`,
+        });
+      }
+    });
+
     return { notified: editors.length };
   },
 );
@@ -218,6 +231,16 @@ export const submissionAcceptedNotification = inngest.createFunction(
           orgName,
         },
         subject: `Your submission has been accepted: ${submission.title}`,
+      });
+    });
+
+    await step.run('queue-in-app', async () => {
+      await queueInAppNotification({
+        orgId,
+        userId: submitterId,
+        eventType: 'submission.accepted',
+        title: `Your submission has been accepted: ${submission.title}`,
+        link: `/submissions/${submissionId}`,
       });
     });
 
@@ -265,6 +288,16 @@ export const submissionRejectedNotification = inngest.createFunction(
       });
     });
 
+    await step.run('queue-in-app', async () => {
+      await queueInAppNotification({
+        orgId,
+        userId: submitterId,
+        eventType: 'submission.rejected',
+        title: `Update on your submission: ${submission.title}`,
+        link: `/submissions/${submissionId}`,
+      });
+    });
+
     return { notified: 1 };
   },
 );
@@ -309,6 +342,18 @@ export const submissionWithdrawnNotification = inngest.createFunction(
             orgName,
           },
           subject: `Submission withdrawn: ${submission.title}`,
+        });
+      }
+    });
+
+    await step.run('queue-in-app-notifications', async () => {
+      for (const editor of editors) {
+        await queueInAppNotification({
+          orgId,
+          userId: editor.userId,
+          eventType: 'submission.withdrawn',
+          title: `Submission withdrawn: ${submission.title}`,
+          link: `/submissions/${submissionId}`,
         });
       }
     });

--- a/apps/api/src/inngest/helpers/__tests__/queue-in-app-notification.spec.ts
+++ b/apps/api/src/inngest/helpers/__tests__/queue-in-app-notification.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockIsInAppEnabled = vi.fn();
+const mockCreate = vi.fn();
+const mockAuditLog = vi.fn();
+const mockPublishNotification = vi.fn();
+
+vi.mock('@colophony/db', () => ({
+  withRls: vi.fn((_ctx, fn) => fn({})),
+}));
+
+vi.mock('@colophony/types', () => ({
+  AuditActions: { IN_APP_NOTIFICATION_CREATED: 'IN_APP_NOTIFICATION_CREATED' },
+  AuditResources: { NOTIFICATION_INBOX: 'notification_inbox' },
+}));
+
+vi.mock('../../../services/notification-preference.service.js', () => ({
+  notificationPreferenceService: {
+    isInAppEnabled: (...args: unknown[]) => mockIsInAppEnabled(...args),
+  },
+}));
+
+vi.mock('../../../services/notification.service.js', () => ({
+  notificationService: {
+    create: (...args: unknown[]) => mockCreate(...args),
+  },
+}));
+
+vi.mock('../../../services/audit.service.js', () => ({
+  auditService: {
+    log: (...args: unknown[]) => mockAuditLog(...args),
+  },
+}));
+
+vi.mock('../../../sse/redis-pubsub.js', () => ({
+  publishNotification: (...args: unknown[]) => mockPublishNotification(...args),
+}));
+
+vi.mock('../../../config/env.js', () => ({
+  validateEnv: vi.fn().mockReturnValue({
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: '',
+  }),
+}));
+
+import { queueInAppNotification } from '../queue-in-app-notification.js';
+
+describe('queueInAppNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates notification and publishes when in-app enabled (default)', async () => {
+    mockIsInAppEnabled.mockResolvedValue(true);
+    mockCreate.mockResolvedValue({ id: 'notif-1' });
+    mockAuditLog.mockResolvedValue(undefined);
+    mockPublishNotification.mockResolvedValue(undefined);
+
+    const result = await queueInAppNotification({
+      orgId: 'org-1',
+      userId: 'user-1',
+      eventType: 'submission.received',
+      title: 'New submission: Test',
+      link: '/submissions/123',
+    });
+
+    expect(result).toEqual({ created: true, id: 'notif-1' });
+    expect(mockCreate).toHaveBeenCalled();
+    expect(mockPublishNotification).toHaveBeenCalled();
+  });
+
+  it('skips creation when in-app disabled by preference', async () => {
+    mockIsInAppEnabled.mockResolvedValue(false);
+
+    const result = await queueInAppNotification({
+      orgId: 'org-1',
+      userId: 'user-1',
+      eventType: 'submission.received',
+      title: 'New submission: Test',
+    });
+
+    expect(result).toEqual({ created: false });
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockPublishNotification).not.toHaveBeenCalled();
+  });
+
+  it('publishes to Redis after DB insert', async () => {
+    mockIsInAppEnabled.mockResolvedValue(true);
+    mockCreate.mockResolvedValue({ id: 'notif-2' });
+    mockAuditLog.mockResolvedValue(undefined);
+    mockPublishNotification.mockResolvedValue(undefined);
+
+    await queueInAppNotification({
+      orgId: 'org-1',
+      userId: 'user-1',
+      eventType: 'contract.ready',
+      title: 'Contract ready',
+      link: '/contracts',
+    });
+
+    expect(mockPublishNotification).toHaveBeenCalledWith(
+      expect.anything(),
+      'org-1',
+      'user-1',
+      expect.objectContaining({
+        id: 'notif-2',
+        eventType: 'contract.ready',
+        title: 'Contract ready',
+      }),
+    );
+  });
+});

--- a/apps/api/src/inngest/helpers/queue-in-app-notification.ts
+++ b/apps/api/src/inngest/helpers/queue-in-app-notification.ts
@@ -1,0 +1,63 @@
+import { withRls } from '@colophony/db';
+import { AuditActions, AuditResources } from '@colophony/types';
+import { notificationPreferenceService } from '../../services/notification-preference.service.js';
+import { notificationService } from '../../services/notification.service.js';
+import { auditService } from '../../services/audit.service.js';
+import { publishNotification } from '../../sse/redis-pubsub.js';
+import { validateEnv } from '../../config/env.js';
+
+export async function queueInAppNotification(params: {
+  orgId: string;
+  userId: string;
+  eventType: string;
+  title: string;
+  body?: string;
+  link?: string;
+}): Promise<{ created: boolean; id?: string }> {
+  const enabled = await withRls({ orgId: params.orgId }, async (tx) => {
+    return notificationPreferenceService.isInAppEnabled(
+      tx,
+      params.orgId,
+      params.userId,
+      params.eventType,
+    );
+  });
+
+  if (!enabled) return { created: false };
+
+  const row = await withRls({ orgId: params.orgId }, async (tx) => {
+    const result = await notificationService.create(tx, {
+      organizationId: params.orgId,
+      userId: params.userId,
+      eventType: params.eventType,
+      title: params.title,
+      body: params.body,
+      link: params.link,
+    });
+    await auditService.log(tx, {
+      resource: AuditResources.NOTIFICATION_INBOX,
+      action: AuditActions.IN_APP_NOTIFICATION_CREATED,
+      resourceId: result.id,
+      organizationId: params.orgId,
+      newValue: {
+        eventType: params.eventType,
+        title: params.title,
+        userId: params.userId,
+      },
+    });
+    return result;
+  });
+
+  // Publish to Redis outside RLS transaction
+  const env = validateEnv();
+  await publishNotification(env, params.orgId, params.userId, {
+    id: row.id,
+    eventType: params.eventType,
+    title: params.title,
+    body: params.body ?? null,
+    link: params.link ?? null,
+    createdAt: new Date().toISOString(),
+  });
+
+  return { created: true, id: row.id };
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -57,6 +57,12 @@ import { registerHubRoutes } from './federation/hub.routes.js';
 import { registerHubAdminRoutes } from './federation/hub-admin.routes.js';
 import { registerKeyAdminRoutes } from './federation/key-admin.routes.js';
 import { hubClientService } from './services/hub-client.service.js';
+import { registerNotificationStreamRoute } from './sse/notification-stream.js';
+import {
+  closePublisher,
+  closeSubscriber,
+  closeAllSSEConnections,
+} from './sse/redis-pubsub.js';
 
 export async function buildApp(env: Env): Promise<FastifyInstance> {
   const app = Fastify({
@@ -243,6 +249,9 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
   // GraphQL API (Pothos + Yoga) — child scope inherits all hooks
   await app.register(registerGraphQLRoutes);
 
+  // SSE notification stream — inherits auth + org-context hooks (NOT db-context per skip)
+  await registerNotificationStreamRoute(app, { env });
+
   // Routes
   app.get('/health', async () => ({
     status: 'ok',
@@ -354,8 +363,10 @@ async function start(): Promise<void> {
       await closeEmailQueue();
       await stopWebhookWorker();
       await closeWebhookQueue();
+      await closeAllSSEConnections();
+      await closePublisher();
+      await closeSubscriber();
       // TODO: Close DB pool when connection management is centralized
-      // TODO: Close Redis connections
       app.log.info('Server closed');
     } finally {
       clearTimeout(forceExit);

--- a/apps/api/src/services/notification-preference.service.ts
+++ b/apps/api/src/services/notification-preference.service.ts
@@ -9,7 +9,7 @@ import { sql } from 'drizzle-orm';
 interface UpsertParams {
   organizationId: string;
   userId: string;
-  channel: 'email';
+  channel: 'email' | 'in_app';
   eventType: string;
   enabled: boolean;
 }
@@ -39,6 +39,32 @@ export const notificationPreferenceService = {
       .limit(1);
 
     // Default to enabled if no preference record exists
+    return pref?.enabled ?? true;
+  },
+
+  /**
+   * Check if in-app notifications are enabled for a user + event type.
+   * Returns true if no preference record exists (default: enabled).
+   */
+  async isInAppEnabled(
+    tx: DrizzleDb,
+    orgId: string,
+    userId: string,
+    eventType: string,
+  ): Promise<boolean> {
+    const [pref] = await tx
+      .select({ enabled: notificationPreferences.enabled })
+      .from(notificationPreferences)
+      .where(
+        and(
+          eq(notificationPreferences.organizationId, orgId),
+          eq(notificationPreferences.userId, userId),
+          eq(notificationPreferences.channel, 'in_app'),
+          eq(notificationPreferences.eventType, eventType),
+        ),
+      )
+      .limit(1);
+
     return pref?.enabled ?? true;
   },
 
@@ -80,7 +106,7 @@ export const notificationPreferenceService = {
     orgId: string,
     userId: string,
     preferences: Array<{
-      channel: 'email';
+      channel: 'email' | 'in_app';
       eventType: string;
       enabled: boolean;
     }>,

--- a/apps/api/src/services/notification.service.spec.ts
+++ b/apps/api/src/services/notification.service.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@colophony/db', () => {
+  return {
+    notificationsInbox: {
+      id: 'id',
+      organizationId: 'organizationId',
+      userId: 'userId',
+      eventType: 'eventType',
+      title: 'title',
+      body: 'body',
+      link: 'link',
+      readAt: 'readAt',
+      createdAt: 'createdAt',
+    },
+    eq: vi.fn(),
+    and: vi.fn(),
+    isNull: vi.fn(),
+  };
+});
+
+vi.mock('drizzle-orm', () => ({
+  desc: vi.fn(),
+  count: vi.fn(),
+  sql: vi.fn(),
+}));
+
+import { notificationService } from './notification.service.js';
+
+describe('notificationService', () => {
+  it('exports expected methods', () => {
+    /* eslint-disable @typescript-eslint/unbound-method */
+    expect(notificationService.create).toBeTypeOf('function');
+    expect(notificationService.list).toBeTypeOf('function');
+    expect(notificationService.unreadCount).toBeTypeOf('function');
+    expect(notificationService.markRead).toBeTypeOf('function');
+    expect(notificationService.markAllRead).toBeTypeOf('function');
+    /* eslint-enable @typescript-eslint/unbound-method */
+  });
+
+  describe('create', () => {
+    it('inserts notification and returns id', async () => {
+      const mockTx = {
+        insert: vi.fn().mockReturnThis(),
+        values: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([{ id: 'notif-1' }]),
+      };
+
+      const result = await notificationService.create(mockTx as any, {
+        organizationId: 'org-1',
+        userId: 'user-1',
+        eventType: 'submission.received',
+        title: 'New submission',
+        body: 'A body',
+        link: '/submissions/123',
+      });
+      expect(result).toEqual({ id: 'notif-1' });
+      expect(mockTx.insert).toHaveBeenCalled();
+    });
+  });
+
+  describe('list', () => {
+    it('returns paginated results with total count', async () => {
+      const items = [
+        { id: 'n1', title: 'Test', createdAt: new Date() },
+        { id: 'n2', title: 'Test 2', createdAt: new Date() },
+      ];
+      const mockTx = {
+        select: vi
+          .fn()
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue(items),
+                  }),
+                }),
+              }),
+            }),
+          })
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([{ total: 2 }]),
+            }),
+          }),
+      };
+
+      const result = await notificationService.list(mockTx as any, {
+        userId: 'user-1',
+        unreadOnly: false,
+        page: 1,
+        limit: 20,
+      });
+      expect(result.items).toHaveLength(2);
+      expect(result.total).toBe(2);
+    });
+
+    it('filters unread only when flag set', async () => {
+      const mockTx = {
+        select: vi
+          .fn()
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue([]),
+                  }),
+                }),
+              }),
+            }),
+          })
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([{ total: 0 }]),
+            }),
+          }),
+      };
+
+      const result = await notificationService.list(mockTx as any, {
+        userId: 'user-1',
+        unreadOnly: true,
+        page: 1,
+        limit: 20,
+      });
+      expect(result.items).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe('unreadCount', () => {
+    it('returns count of unread', async () => {
+      const mockTx = {
+        select: vi.fn().mockReturnThis(),
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([{ count: 5 }]),
+      };
+
+      const result = await notificationService.unreadCount(
+        mockTx as any,
+        'user-1',
+      );
+      expect(result).toBe(5);
+    });
+  });
+
+  describe('markRead', () => {
+    it('returns true on success', async () => {
+      const mockTx = {
+        update: vi.fn().mockReturnThis(),
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([{ id: 'notif-1' }]),
+      };
+
+      const result = await notificationService.markRead(
+        mockTx as any,
+        'notif-1',
+        'user-1',
+      );
+      expect(result).toBe(true);
+    });
+
+    it('returns false when not found', async () => {
+      const mockTx = {
+        update: vi.fn().mockReturnThis(),
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([]),
+      };
+
+      const result = await notificationService.markRead(
+        mockTx as any,
+        'notif-999',
+        'user-1',
+      );
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('markAllRead', () => {
+    it('returns count of marked notifications', async () => {
+      const mockTx = {
+        update: vi.fn().mockReturnThis(),
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi
+          .fn()
+          .mockResolvedValue([{ id: 'n1' }, { id: 'n2' }, { id: 'n3' }]),
+      };
+
+      const result = await notificationService.markAllRead(
+        mockTx as any,
+        'user-1',
+      );
+      expect(result).toBe(3);
+    });
+  });
+});

--- a/apps/api/src/services/notification.service.ts
+++ b/apps/api/src/services/notification.service.ts
@@ -1,0 +1,106 @@
+import {
+  notificationsInbox,
+  eq,
+  and,
+  isNull,
+  type DrizzleDb,
+} from '@colophony/db';
+import { desc, count } from 'drizzle-orm';
+
+interface CreateParams {
+  organizationId: string;
+  userId: string;
+  eventType: string;
+  title: string;
+  body?: string;
+  link?: string;
+}
+
+export const notificationService = {
+  async create(tx: DrizzleDb, params: CreateParams) {
+    const [row] = await tx
+      .insert(notificationsInbox)
+      .values({
+        organizationId: params.organizationId,
+        userId: params.userId,
+        eventType: params.eventType,
+        title: params.title,
+        body: params.body ?? null,
+        link: params.link ?? null,
+      })
+      .returning({ id: notificationsInbox.id });
+    return row;
+  },
+
+  async list(
+    tx: DrizzleDb,
+    params: {
+      userId: string;
+      unreadOnly: boolean;
+      page: number;
+      limit: number;
+    },
+  ) {
+    const conditions = [eq(notificationsInbox.userId, params.userId)];
+    if (params.unreadOnly) {
+      conditions.push(isNull(notificationsInbox.readAt));
+    }
+
+    const where = conditions.length === 1 ? conditions[0] : and(...conditions);
+
+    const [items, [{ total }]] = await Promise.all([
+      tx
+        .select()
+        .from(notificationsInbox)
+        .where(where)
+        .orderBy(desc(notificationsInbox.createdAt))
+        .limit(params.limit)
+        .offset((params.page - 1) * params.limit),
+      tx.select({ total: count() }).from(notificationsInbox).where(where),
+    ]);
+
+    return { items, total };
+  },
+
+  async unreadCount(tx: DrizzleDb, userId: string): Promise<number> {
+    const [row] = await tx
+      .select({ count: count() })
+      .from(notificationsInbox)
+      .where(
+        and(
+          eq(notificationsInbox.userId, userId),
+          isNull(notificationsInbox.readAt),
+        ),
+      );
+    return row.count;
+  },
+
+  async markRead(tx: DrizzleDb, id: string, userId: string): Promise<boolean> {
+    const result = await tx
+      .update(notificationsInbox)
+      .set({ readAt: new Date() })
+      .where(
+        and(
+          eq(notificationsInbox.id, id),
+          eq(notificationsInbox.userId, userId),
+          isNull(notificationsInbox.readAt),
+        ),
+      )
+      .returning({ id: notificationsInbox.id });
+    return result.length > 0;
+  },
+
+  async markAllRead(tx: DrizzleDb, userId: string): Promise<number> {
+    const result = await tx
+      .update(notificationsInbox)
+      .set({ readAt: new Date() })
+      .where(
+        and(
+          eq(notificationsInbox.userId, userId),
+          isNull(notificationsInbox.readAt),
+        ),
+      )
+      .returning({ id: notificationsInbox.id });
+    return result.length;
+  },
+};

--- a/apps/api/src/sse/__tests__/notification-stream.spec.ts
+++ b/apps/api/src/sse/__tests__/notification-stream.spec.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
 
+let mockConnectShouldFail = false;
+
 vi.mock('ioredis', () => {
-  const MockRedis = vi.fn().mockImplementation(() => ({
-    connect: vi.fn().mockResolvedValue(undefined),
-    subscribe: vi.fn().mockResolvedValue(undefined),
-    unsubscribe: vi.fn().mockResolvedValue(undefined),
-    quit: vi.fn().mockResolvedValue('OK'),
-    on: vi.fn(),
-  }));
+  class MockRedis {
+    connect = vi.fn().mockImplementation(async () => {
+      if (mockConnectShouldFail) throw new Error('ECONNREFUSED');
+    });
+    subscribe = vi.fn().mockResolvedValue(undefined);
+    unsubscribe = vi.fn().mockResolvedValue(undefined);
+    quit = vi.fn().mockResolvedValue('OK');
+    on = vi.fn();
+  }
   return { default: MockRedis };
 });
 
@@ -19,16 +23,20 @@ vi.mock('../redis-pubsub.js', () => ({
 
 import { registerNotificationStreamRoute } from '../notification-stream.js';
 
+function createTestHarness() {
+  const mockGet = vi.fn();
+  const mockApp = { get: mockGet } as any;
+  const mockEnv = {
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: '',
+  } as any;
+  return { mockGet, mockApp, mockEnv };
+}
+
 describe('registerNotificationStreamRoute', () => {
   it('registers a GET route at /api/notifications/stream', async () => {
-    const mockGet = vi.fn();
-    const mockApp = { get: mockGet } as any;
-    const mockEnv = {
-      REDIS_HOST: 'localhost',
-      REDIS_PORT: 6379,
-      REDIS_PASSWORD: '',
-    } as any;
-
+    const { mockGet, mockApp, mockEnv } = createTestHarness();
     await registerNotificationStreamRoute(mockApp, { env: mockEnv });
     expect(mockGet).toHaveBeenCalledWith(
       '/api/notifications/stream',
@@ -37,14 +45,7 @@ describe('registerNotificationStreamRoute', () => {
   });
 
   it('returns 401 when no auth context', async () => {
-    const mockGet = vi.fn();
-    const mockApp = { get: mockGet } as any;
-    const mockEnv = {
-      REDIS_HOST: 'localhost',
-      REDIS_PORT: 6379,
-      REDIS_PASSWORD: '',
-    } as any;
-
+    const { mockGet, mockApp, mockEnv } = createTestHarness();
     await registerNotificationStreamRoute(mockApp, { env: mockEnv });
 
     const handler = mockGet.mock.calls[0][1];
@@ -59,14 +60,7 @@ describe('registerNotificationStreamRoute', () => {
   });
 
   it('returns 400 when no org context', async () => {
-    const mockGet = vi.fn();
-    const mockApp = { get: mockGet } as any;
-    const mockEnv = {
-      REDIS_HOST: 'localhost',
-      REDIS_PORT: 6379,
-      REDIS_PASSWORD: '',
-    } as any;
-
+    const { mockGet, mockApp, mockEnv } = createTestHarness();
     await registerNotificationStreamRoute(mockApp, { env: mockEnv });
 
     const handler = mockGet.mock.calls[0][1];
@@ -78,5 +72,65 @@ describe('registerNotificationStreamRoute', () => {
 
     await handler(mockRequest, mockReply);
     expect(mockReply.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 429 when user exceeds max SSE connections', async () => {
+    const { mockGet, mockApp, mockEnv } = createTestHarness();
+    await registerNotificationStreamRoute(mockApp, { env: mockEnv });
+
+    const handler = mockGet.mock.calls[0][1];
+
+    // Exhaust 5 connection slots for this user
+    for (let i = 0; i < 5; i++) {
+      const req = {
+        authContext: { userId: 'user-flood', orgId: 'org-1' },
+        raw: { on: vi.fn() },
+      };
+      const rep = {
+        hijack: vi.fn(),
+        raw: { writeHead: vi.fn(), write: vi.fn(), end: vi.fn() },
+        status: vi.fn().mockReturnThis(),
+        send: vi.fn().mockReturnThis(),
+      };
+      await handler(req, rep);
+    }
+
+    // 6th connection should be rejected
+    const mockRequest = {
+      authContext: { userId: 'user-flood', orgId: 'org-1' },
+      raw: { on: vi.fn() },
+    };
+    const mockReply = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+    };
+
+    await handler(mockRequest, mockReply);
+    expect(mockReply.status).toHaveBeenCalledWith(429);
+  });
+
+  it('ends response gracefully when Redis connect fails', async () => {
+    mockConnectShouldFail = true;
+    const { mockGet, mockApp, mockEnv } = createTestHarness();
+    await registerNotificationStreamRoute(mockApp, { env: mockEnv });
+
+    const handler = mockGet.mock.calls[0][1];
+    const rawEnd = vi.fn();
+    const mockRequest = {
+      authContext: { userId: 'user-redis-fail', orgId: 'org-1' },
+      raw: { on: vi.fn() },
+    };
+    const mockReply = {
+      hijack: vi.fn(),
+      raw: { writeHead: vi.fn(), write: vi.fn(), end: rawEnd },
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+    };
+
+    await handler(mockRequest, mockReply);
+    expect(rawEnd).toHaveBeenCalled();
+
+    // Reset for other tests
+    mockConnectShouldFail = false;
   });
 });

--- a/apps/api/src/sse/__tests__/notification-stream.spec.ts
+++ b/apps/api/src/sse/__tests__/notification-stream.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('ioredis', () => {
+  const MockRedis = vi.fn().mockImplementation(() => ({
+    connect: vi.fn().mockResolvedValue(undefined),
+    subscribe: vi.fn().mockResolvedValue(undefined),
+    unsubscribe: vi.fn().mockResolvedValue(undefined),
+    quit: vi.fn().mockResolvedValue('OK'),
+    on: vi.fn(),
+  }));
+  return { default: MockRedis };
+});
+
+vi.mock('../redis-pubsub.js', () => ({
+  channelKey: vi.fn().mockReturnValue('notifications:org-1:user-1'),
+  trackConnection: vi.fn(),
+  untrackConnection: vi.fn(),
+}));
+
+import { registerNotificationStreamRoute } from '../notification-stream.js';
+
+describe('registerNotificationStreamRoute', () => {
+  it('registers a GET route at /api/notifications/stream', async () => {
+    const mockGet = vi.fn();
+    const mockApp = { get: mockGet } as any;
+    const mockEnv = {
+      REDIS_HOST: 'localhost',
+      REDIS_PORT: 6379,
+      REDIS_PASSWORD: '',
+    } as any;
+
+    await registerNotificationStreamRoute(mockApp, { env: mockEnv });
+    expect(mockGet).toHaveBeenCalledWith(
+      '/api/notifications/stream',
+      expect.any(Function),
+    );
+  });
+
+  it('returns 401 when no auth context', async () => {
+    const mockGet = vi.fn();
+    const mockApp = { get: mockGet } as any;
+    const mockEnv = {
+      REDIS_HOST: 'localhost',
+      REDIS_PORT: 6379,
+      REDIS_PASSWORD: '',
+    } as any;
+
+    await registerNotificationStreamRoute(mockApp, { env: mockEnv });
+
+    const handler = mockGet.mock.calls[0][1];
+    const mockRequest = { authContext: null };
+    const mockReply = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+    };
+
+    await handler(mockRequest, mockReply);
+    expect(mockReply.status).toHaveBeenCalledWith(401);
+  });
+
+  it('returns 400 when no org context', async () => {
+    const mockGet = vi.fn();
+    const mockApp = { get: mockGet } as any;
+    const mockEnv = {
+      REDIS_HOST: 'localhost',
+      REDIS_PORT: 6379,
+      REDIS_PASSWORD: '',
+    } as any;
+
+    await registerNotificationStreamRoute(mockApp, { env: mockEnv });
+
+    const handler = mockGet.mock.calls[0][1];
+    const mockRequest = { authContext: { userId: 'user-1', orgId: null } };
+    const mockReply = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+    };
+
+    await handler(mockRequest, mockReply);
+    expect(mockReply.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/apps/api/src/sse/__tests__/redis-pubsub.spec.ts
+++ b/apps/api/src/sse/__tests__/redis-pubsub.spec.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, vi } from 'vitest';
 
+let mockConnectShouldFail = false;
+
 vi.mock('ioredis', () => {
   class MockRedis {
-    connect = vi.fn().mockResolvedValue(undefined);
+    status = 'wait';
+    connect = vi.fn().mockImplementation(async () => {
+      if (mockConnectShouldFail) throw new Error('ECONNREFUSED');
+      (this as any).status = 'ready';
+    });
     publish = vi.fn().mockResolvedValue(1);
     quit = vi.fn().mockResolvedValue('OK');
   }
@@ -35,6 +41,7 @@ describe('redis-pubsub', () => {
 
   describe('publishNotification', () => {
     it('publishes serialized JSON to correct channel', async () => {
+      mockConnectShouldFail = false;
       const event = {
         id: 'notif-1',
         eventType: 'submission.received',
@@ -44,7 +51,6 @@ describe('redis-pubsub', () => {
         createdAt: '2026-02-26T00:00:00.000Z',
       };
 
-      // publishNotification uses getPublisher internally which creates a Redis instance
       await expect(
         publishNotification(mockEnv, 'org-1', 'user-1', event),
       ).resolves.not.toThrow();

--- a/apps/api/src/sse/__tests__/redis-pubsub.spec.ts
+++ b/apps/api/src/sse/__tests__/redis-pubsub.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('ioredis', () => {
+  class MockRedis {
+    connect = vi.fn().mockResolvedValue(undefined);
+    publish = vi.fn().mockResolvedValue(1);
+    quit = vi.fn().mockResolvedValue('OK');
+  }
+  return { default: MockRedis };
+});
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: vi.fn().mockReturnValue({
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: '',
+  }),
+}));
+
+import { channelKey, publishNotification } from '../redis-pubsub.js';
+
+describe('redis-pubsub', () => {
+  const mockEnv = {
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: '',
+  } as any;
+
+  describe('channelKey', () => {
+    it('formats channel as notifications:{orgId}:{userId}', () => {
+      const key = channelKey('org-123', 'user-456');
+      expect(key).toBe('notifications:org-123:user-456');
+    });
+  });
+
+  describe('publishNotification', () => {
+    it('publishes serialized JSON to correct channel', async () => {
+      const event = {
+        id: 'notif-1',
+        eventType: 'submission.received',
+        title: 'New submission',
+        body: null,
+        link: '/submissions/123',
+        createdAt: '2026-02-26T00:00:00.000Z',
+      };
+
+      // publishNotification uses getPublisher internally which creates a Redis instance
+      await expect(
+        publishNotification(mockEnv, 'org-1', 'user-1', event),
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/apps/api/src/sse/notification-stream.ts
+++ b/apps/api/src/sse/notification-stream.ts
@@ -7,6 +7,26 @@ import {
   untrackConnection,
 } from './redis-pubsub.js';
 
+// Per-user SSE connection limit to prevent connection exhaustion
+const MAX_CONNECTIONS_PER_USER = 5;
+const userConnectionCounts = new Map<string, number>();
+
+function incrementUserConnections(userId: string): boolean {
+  const count = userConnectionCounts.get(userId) ?? 0;
+  if (count >= MAX_CONNECTIONS_PER_USER) return false;
+  userConnectionCounts.set(userId, count + 1);
+  return true;
+}
+
+function decrementUserConnections(userId: string): void {
+  const count = userConnectionCounts.get(userId) ?? 0;
+  if (count <= 1) {
+    userConnectionCounts.delete(userId);
+  } else {
+    userConnectionCounts.set(userId, count - 1);
+  }
+}
+
 export async function registerNotificationStreamRoute(
   app: FastifyInstance,
   { env }: { env: Env },
@@ -22,6 +42,12 @@ export async function registerNotificationStreamRoute(
     }
 
     const { userId, orgId } = request.authContext;
+
+    // Rate limit: max SSE connections per user
+    if (!incrementUserConnections(userId)) {
+      return reply.status(429).send({ error: 'Too many SSE connections' });
+    }
+
     const channel = channelKey(orgId, userId);
 
     // SSE response headers
@@ -45,7 +71,14 @@ export async function registerNotificationStreamRoute(
       lazyConnect: true,
       maxRetriesPerRequest: null,
     });
-    await sub.connect();
+
+    try {
+      await sub.connect();
+    } catch {
+      decrementUserConnections(userId);
+      raw.end();
+      return;
+    }
     trackConnection(sub);
 
     // Forward messages as SSE events
@@ -53,7 +86,15 @@ export async function registerNotificationStreamRoute(
       raw.write(`event: notification\ndata: ${message}\n\n`);
     });
 
-    await sub.subscribe(channel);
+    try {
+      await sub.subscribe(channel);
+    } catch {
+      decrementUserConnections(userId);
+      untrackConnection(sub);
+      sub.quit().catch(() => undefined);
+      raw.end();
+      return;
+    }
 
     // Keep-alive ping every 30s
     const pingInterval = setInterval(() => {
@@ -61,8 +102,12 @@ export async function registerNotificationStreamRoute(
     }, 30_000);
 
     // Cleanup on disconnect
+    let cleaned = false;
     const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
       clearInterval(pingInterval);
+      decrementUserConnections(userId);
       sub
         .unsubscribe(channel)
         .catch(() => undefined)

--- a/apps/api/src/sse/notification-stream.ts
+++ b/apps/api/src/sse/notification-stream.ts
@@ -1,0 +1,79 @@
+import type { FastifyInstance } from 'fastify';
+import Redis from 'ioredis';
+import type { Env } from '../config/env.js';
+import {
+  channelKey,
+  trackConnection,
+  untrackConnection,
+} from './redis-pubsub.js';
+
+export async function registerNotificationStreamRoute(
+  app: FastifyInstance,
+  { env }: { env: Env },
+): Promise<void> {
+  app.get('/api/notifications/stream', async (request, reply) => {
+    // Auth is handled by the auth + org-context hooks.
+    // db-context is skipped for this route (see db-context.ts).
+    if (!request.authContext?.userId) {
+      return reply.status(401).send({ error: 'unauthorized' });
+    }
+    if (!request.authContext.orgId) {
+      return reply.status(400).send({ error: 'X-Organization-Id required' });
+    }
+
+    const { userId, orgId } = request.authContext;
+    const channel = channelKey(orgId, userId);
+
+    // SSE response headers
+    void reply.hijack();
+    const raw = reply.raw;
+    raw.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
+
+    // Send connected event
+    raw.write('event: connected\ndata: {}\n\n');
+
+    // Per-connection subscriber (Redis requires dedicated connection for subscribe mode)
+    const sub = new Redis({
+      host: env.REDIS_HOST,
+      port: env.REDIS_PORT,
+      password: env.REDIS_PASSWORD || undefined,
+      lazyConnect: true,
+      maxRetriesPerRequest: null,
+    });
+    await sub.connect();
+    trackConnection(sub);
+
+    // Forward messages as SSE events
+    sub.on('message', (_ch: string, message: string) => {
+      raw.write(`event: notification\ndata: ${message}\n\n`);
+    });
+
+    await sub.subscribe(channel);
+
+    // Keep-alive ping every 30s
+    const pingInterval = setInterval(() => {
+      raw.write(': ping\n\n');
+    }, 30_000);
+
+    // Cleanup on disconnect
+    const cleanup = () => {
+      clearInterval(pingInterval);
+      sub
+        .unsubscribe(channel)
+        .catch(() => undefined)
+        .finally(() => {
+          untrackConnection(sub);
+          sub.quit().catch(() => undefined);
+        });
+      raw.end();
+    };
+
+    request.raw.on('close', cleanup);
+    request.raw.on('error', cleanup);
+  });
+}

--- a/apps/api/src/sse/redis-pubsub.ts
+++ b/apps/api/src/sse/redis-pubsub.ts
@@ -1,0 +1,93 @@
+import Redis from 'ioredis';
+import type { Env } from '../config/env.js';
+
+export interface NotificationEvent {
+  id: string;
+  eventType: string;
+  title: string;
+  body?: string | null;
+  link?: string | null;
+  createdAt: string;
+}
+
+let publisher: Redis | null = null;
+let subscriber: Redis | null = null;
+
+function createRedis(env: Env): Redis {
+  return new Redis({
+    host: env.REDIS_HOST,
+    port: env.REDIS_PORT,
+    password: env.REDIS_PASSWORD || undefined,
+    lazyConnect: true,
+    maxRetriesPerRequest: 3,
+  });
+}
+
+export function getPublisher(env: Env): Redis {
+  if (!publisher) {
+    publisher = createRedis(env);
+    void publisher.connect();
+  }
+  return publisher;
+}
+
+export function getSubscriber(env: Env): Redis {
+  if (!subscriber) {
+    subscriber = createRedis(env);
+    void subscriber.connect();
+  }
+  return subscriber;
+}
+
+export function channelKey(orgId: string, userId: string): string {
+  return `notifications:${orgId}:${userId}`;
+}
+
+export async function publishNotification(
+  env: Env,
+  orgId: string,
+  userId: string,
+  event: NotificationEvent,
+): Promise<void> {
+  const pub = getPublisher(env);
+  await pub.publish(channelKey(orgId, userId), JSON.stringify(event));
+}
+
+// Track active per-connection subscribers for SSE shutdown
+const activeConnections = new Set<Redis>();
+
+export function trackConnection(redis: Redis): void {
+  activeConnections.add(redis);
+}
+
+export function untrackConnection(redis: Redis): void {
+  activeConnections.delete(redis);
+}
+
+export async function closeAllSSEConnections(): Promise<void> {
+  const promises: Promise<void>[] = [];
+  for (const conn of activeConnections) {
+    promises.push(
+      conn
+        .quit()
+        .then(() => undefined)
+        .catch(() => undefined),
+    );
+  }
+  await Promise.all(promises);
+  activeConnections.clear();
+}
+
+export async function closePublisher(): Promise<void> {
+  if (publisher) {
+    await publisher.quit().catch(() => undefined);
+    publisher = null;
+  }
+}
+
+export async function closeSubscriber(): Promise<void> {
+  if (subscriber) {
+    await subscriber.quit().catch(() => undefined);
+    subscriber = null;
+  }
+}

--- a/apps/api/src/sse/redis-pubsub.ts
+++ b/apps/api/src/sse/redis-pubsub.ts
@@ -23,18 +23,24 @@ function createRedis(env: Env): Redis {
   });
 }
 
-export function getPublisher(env: Env): Redis {
+export async function getPublisher(env: Env): Promise<Redis> {
   if (!publisher) {
     publisher = createRedis(env);
-    void publisher.connect();
+    await publisher.connect();
+  }
+  if (publisher.status !== 'ready') {
+    await publisher.connect();
   }
   return publisher;
 }
 
-export function getSubscriber(env: Env): Redis {
+export async function getSubscriber(env: Env): Promise<Redis> {
   if (!subscriber) {
     subscriber = createRedis(env);
-    void subscriber.connect();
+    await subscriber.connect();
+  }
+  if (subscriber.status !== 'ready') {
+    await subscriber.connect();
   }
   return subscriber;
 }
@@ -49,7 +55,7 @@ export async function publishNotification(
   userId: string,
   event: NotificationEvent,
 ): Promise<void> {
-  const pub = getPublisher(env);
+  const pub = await getPublisher(env);
   await pub.publish(channelKey(orgId, userId), JSON.stringify(event));
 }
 

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -18,6 +18,7 @@ import { contractsRouter } from './routers/contracts.js';
 import { issuesRouter } from './routers/issues.js';
 import { cmsConnectionsRouter } from './routers/cms-connections.js';
 import { notificationPreferencesRouter } from './routers/notification-preferences.js';
+import { notificationsRouter } from './routers/notifications.js';
 import { webhooksRouter } from './routers/webhooks.js';
 
 // Re-export procedure builders for convenience
@@ -58,6 +59,7 @@ export const appRouter = t.router({
   issues: issuesRouter,
   cmsConnections: cmsConnectionsRouter,
   notificationPreferences: notificationPreferencesRouter,
+  notifications: notificationsRouter,
   webhooks: webhooksRouter,
   retention: t.router({}),
 });

--- a/apps/api/src/trpc/routers/notifications.spec.ts
+++ b/apps/api/src/trpc/routers/notifications.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const mockList = vi.fn();
+const mockUnreadCount = vi.fn();
+const mockMarkRead = vi.fn();
+const mockMarkAllRead = vi.fn();
+
+vi.mock('../../services/notification.service.js', () => ({
+  notificationService: {
+    list: (...args: unknown[]) => mockList(...args),
+    unreadCount: (...args: unknown[]) => mockUnreadCount(...args),
+    markRead: (...args: unknown[]) => mockMarkRead(...args),
+    markAllRead: (...args: unknown[]) => mockMarkAllRead(...args),
+  },
+}));
+
+vi.mock('../init.js', () => {
+  const passthrough = {
+    input: vi.fn().mockReturnThis(),
+    output: vi.fn().mockReturnThis(),
+    query: vi.fn().mockReturnThis(),
+    mutation: vi.fn().mockReturnThis(),
+    use: vi.fn().mockReturnThis(),
+  };
+  return {
+    orgProcedure: passthrough,
+    createRouter: vi.fn((routes) => routes),
+  };
+});
+
+vi.mock('@colophony/types', () => ({
+  listNotificationsSchema: {},
+  notificationResponseSchema: {},
+  markNotificationReadSchema: {},
+  unreadCountResponseSchema: {},
+  AuditActions: {
+    IN_APP_NOTIFICATION_READ: 'IN_APP_NOTIFICATION_READ',
+    IN_APP_NOTIFICATION_ALL_READ: 'IN_APP_NOTIFICATION_ALL_READ',
+  },
+  AuditResources: { NOTIFICATION_INBOX: 'notification_inbox' },
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    array: vi.fn().mockReturnThis(),
+    object: vi.fn().mockReturnThis(),
+    number: vi.fn().mockReturnThis(),
+    boolean: vi.fn().mockReturnThis(),
+  },
+}));
+
+import { notificationsRouter } from './notifications.js';
+
+describe('notificationsRouter', () => {
+  it('exports list, unreadCount, markRead, and markAllRead procedures', () => {
+    expect(notificationsRouter).toHaveProperty('list');
+    expect(notificationsRouter).toHaveProperty('unreadCount');
+    expect(notificationsRouter).toHaveProperty('markRead');
+    expect(notificationsRouter).toHaveProperty('markAllRead');
+  });
+});

--- a/apps/api/src/trpc/routers/notifications.ts
+++ b/apps/api/src/trpc/routers/notifications.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+import {
+  listNotificationsSchema,
+  notificationResponseSchema,
+  markNotificationReadSchema,
+  unreadCountResponseSchema,
+  AuditActions,
+  AuditResources,
+} from '@colophony/types';
+import { orgProcedure, createRouter } from '../init.js';
+import { notificationService } from '../../services/notification.service.js';
+
+export const notificationsRouter = createRouter({
+  list: orgProcedure
+    .input(listNotificationsSchema)
+    .output(
+      z.object({
+        items: z.array(notificationResponseSchema),
+        total: z.number(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      return notificationService.list(ctx.dbTx, {
+        userId: ctx.authContext.userId,
+        unreadOnly: input.unreadOnly,
+        page: input.page,
+        limit: input.limit,
+      });
+    }),
+
+  unreadCount: orgProcedure
+    .output(unreadCountResponseSchema)
+    .query(async ({ ctx }) => {
+      const count = await notificationService.unreadCount(
+        ctx.dbTx,
+        ctx.authContext.userId,
+      );
+      return { count };
+    }),
+
+  markRead: orgProcedure
+    .input(markNotificationReadSchema)
+    .output(z.object({ success: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const success = await notificationService.markRead(
+        ctx.dbTx,
+        input.id,
+        ctx.authContext.userId,
+      );
+      if (success) {
+        await ctx.audit({
+          action: AuditActions.IN_APP_NOTIFICATION_READ,
+          resource: AuditResources.NOTIFICATION_INBOX,
+          resourceId: input.id,
+        });
+      }
+      return { success };
+    }),
+
+  markAllRead: orgProcedure
+    .output(z.object({ count: z.number() }))
+    .mutation(async ({ ctx }) => {
+      const count = await notificationService.markAllRead(
+        ctx.dbTx,
+        ctx.authContext.userId,
+      );
+      if (count > 0) {
+        await ctx.audit({
+          action: AuditActions.IN_APP_NOTIFICATION_ALL_READ,
+          resource: AuditResources.NOTIFICATION_INBOX,
+          newValue: { count },
+        });
+      }
+      return { count };
+    }),
+});

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Menu } from "lucide-react";
 import { Sidebar } from "./sidebar";
+import { NotificationBell } from "@/components/notifications/notification-bell";
 
 export function Header() {
   const { isAuthenticated, login } = useAuth();
@@ -40,6 +41,7 @@ export function Header() {
         {isAuthenticated ? (
           <div className="flex items-center space-x-4">
             <OrgSwitcher />
+            <NotificationBell />
             <UserMenu />
           </div>
         ) : (

--- a/apps/web/src/components/notifications/__tests__/notification-bell.spec.tsx
+++ b/apps/web/src/components/notifications/__tests__/notification-bell.spec.tsx
@@ -1,0 +1,97 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import "../../../../test/setup";
+
+let mockCurrentOrg: { id: string; name: string; slug: string } | null;
+let mockUnreadCount: number;
+
+jest.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({
+    currentOrg: mockCurrentOrg,
+  }),
+}));
+
+jest.mock("@/hooks/use-notification-stream", () => ({
+  useNotificationStream: jest.fn(),
+}));
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    notifications: {
+      unreadCount: {
+        useQuery: () => ({
+          data: mockCurrentOrg ? { count: mockUnreadCount } : undefined,
+        }),
+      },
+    },
+    useUtils: () => ({}),
+  },
+}));
+
+// Mock Popover to just render children for testability
+jest.mock("@/components/ui/popover", () => ({
+  Popover: ({
+    children,
+    open,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  }) => <div data-open={open}>{children}</div>,
+  PopoverTrigger: ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-content">{children}</div>
+  ),
+}));
+
+jest.mock("../notification-list", () => ({
+  NotificationList: ({ onClose }: { onClose?: () => void }) => (
+    <div data-testid="notification-list">NotificationList</div>
+  ),
+}));
+
+import { NotificationBell } from "../notification-bell";
+
+beforeEach(() => {
+  mockCurrentOrg = { id: "org-1", name: "Test Mag", slug: "test" };
+  mockUnreadCount = 0;
+});
+
+describe("NotificationBell", () => {
+  it("renders nothing when no current org", () => {
+    mockCurrentOrg = null;
+    const { container } = render(<NotificationBell />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders bell without badge when count is 0", () => {
+    mockUnreadCount = 0;
+    render(<NotificationBell />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByText("Notifications")).toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("renders badge with unread count", () => {
+    mockUnreadCount = 5;
+    render(<NotificationBell />);
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("caps badge at 99+", () => {
+    mockUnreadCount = 150;
+    render(<NotificationBell />);
+    expect(screen.getByText("99+")).toBeInTheDocument();
+  });
+
+  it("includes NotificationList in popover", () => {
+    render(<NotificationBell />);
+    expect(screen.getByTestId("notification-list")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/notifications/__tests__/notification-list.spec.tsx
+++ b/apps/web/src/components/notifications/__tests__/notification-list.spec.tsx
@@ -1,0 +1,149 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import "../../../../test/setup";
+
+let mockData:
+  | {
+      items: Array<{
+        id: string;
+        eventType: string;
+        title: string;
+        body: string | null;
+        link: string | null;
+        readAt: Date | null;
+        createdAt: Date;
+      }>;
+      total: number;
+    }
+  | undefined;
+let mockIsPending: boolean;
+let mockMarkReadMutate: jest.Mock;
+let mockMarkAllReadMutate: jest.Mock;
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    notifications: {
+      list: {
+        useQuery: () => ({
+          data: mockData,
+          isPending: mockIsPending,
+        }),
+      },
+      markRead: {
+        useMutation: (opts?: { onSuccess?: () => void }) => ({
+          mutate: (...args: unknown[]) => {
+            mockMarkReadMutate(...args);
+            opts?.onSuccess?.();
+          },
+          isPending: false,
+        }),
+      },
+      markAllRead: {
+        useMutation: (opts?: { onSuccess?: () => void }) => ({
+          mutate: (...args: unknown[]) => {
+            mockMarkAllReadMutate(...args);
+            opts?.onSuccess?.();
+          },
+          isPending: false,
+        }),
+      },
+    },
+    useUtils: () => ({
+      notifications: {
+        unreadCount: { invalidate: jest.fn() },
+        list: { invalidate: jest.fn() },
+      },
+    }),
+  },
+}));
+
+import { NotificationList } from "../notification-list";
+
+beforeEach(() => {
+  mockData = undefined;
+  mockIsPending = false;
+  mockMarkReadMutate = jest.fn();
+  mockMarkAllReadMutate = jest.fn();
+  mockPush.mockClear();
+});
+
+describe("NotificationList", () => {
+  it("shows loading spinner while fetching", () => {
+    mockIsPending = true;
+    render(<NotificationList />);
+    // Loader2 icon renders as an svg; we just check no list is shown
+    expect(screen.queryByText("Notifications")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when no notifications", () => {
+    mockData = { items: [], total: 0 };
+    render(<NotificationList />);
+    expect(screen.getByText("No notifications")).toBeInTheDocument();
+  });
+
+  it("renders notification items", () => {
+    mockData = {
+      items: [
+        {
+          id: "n1",
+          eventType: "submission.received",
+          title: "New submission: Test",
+          body: null,
+          link: "/submissions/123",
+          readAt: null,
+          createdAt: new Date(),
+        },
+      ],
+      total: 1,
+    };
+    render(<NotificationList />);
+    expect(screen.getByText("New submission: Test")).toBeInTheDocument();
+  });
+
+  it("calls markRead and navigates on click", () => {
+    mockData = {
+      items: [
+        {
+          id: "n1",
+          eventType: "submission.received",
+          title: "New submission: Test",
+          body: null,
+          link: "/submissions/123",
+          readAt: null,
+          createdAt: new Date(),
+        },
+      ],
+      total: 1,
+    };
+    const onClose = jest.fn();
+    render(<NotificationList onClose={onClose} />);
+    fireEvent.click(screen.getByText("New submission: Test"));
+    expect(mockMarkReadMutate).toHaveBeenCalledWith({ id: "n1" });
+    expect(mockPush).toHaveBeenCalledWith("/submissions/123");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls markAllRead on button click", () => {
+    mockData = {
+      items: [
+        {
+          id: "n1",
+          eventType: "submission.received",
+          title: "Test",
+          body: null,
+          link: null,
+          readAt: null,
+          createdAt: new Date(),
+        },
+      ],
+      total: 1,
+    };
+    render(<NotificationList />);
+    fireEvent.click(screen.getByText("Mark all read"));
+    expect(mockMarkAllReadMutate).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/notifications/notification-bell.tsx
+++ b/apps/web/src/components/notifications/notification-bell.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Bell } from "lucide-react";
+import { useOrganization } from "@/hooks/use-organization";
+import { useNotificationStream } from "@/hooks/use-notification-stream";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { NotificationList } from "./notification-list";
+import { useState } from "react";
+
+export function NotificationBell() {
+  const { currentOrg } = useOrganization();
+  const [open, setOpen] = useState(false);
+
+  useNotificationStream();
+
+  const { data } = trpc.notifications.unreadCount.useQuery(undefined, {
+    enabled: !!currentOrg,
+    refetchInterval: 60_000,
+  });
+
+  if (!currentOrg) return null;
+
+  const count = data?.count ?? 0;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="icon" className="relative">
+          <Bell className="h-5 w-5" />
+          {count > 0 && (
+            <span className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-medium text-destructive-foreground">
+              {count > 99 ? "99+" : count}
+            </span>
+          )}
+          <span className="sr-only">
+            {count > 0
+              ? `${count} unread notification${count === 1 ? "" : "s"}`
+              : "Notifications"}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-0" align="end">
+        <NotificationList onClose={() => setOpen(false)} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/notifications/notification-item.tsx
+++ b/apps/web/src/components/notifications/notification-item.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import {
+  FileText,
+  CheckCircle2,
+  XCircle,
+  Undo2,
+  FileSignature,
+  PenTool,
+} from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { cn } from "@/lib/utils";
+
+const EVENT_ICONS: Record<string, React.ElementType> = {
+  "submission.received": FileText,
+  "submission.accepted": CheckCircle2,
+  "submission.rejected": XCircle,
+  "submission.withdrawn": Undo2,
+  "contract.ready": FileSignature,
+  "copyeditor.assigned": PenTool,
+};
+
+export interface InboxNotification {
+  id: string;
+  eventType: string;
+  title: string;
+  body: string | null;
+  link: string | null;
+  readAt: string | Date | null;
+  createdAt: string | Date;
+}
+
+interface NotificationItemProps {
+  notification: InboxNotification;
+  onClick: (notification: InboxNotification) => void;
+}
+
+export function NotificationItem({
+  notification,
+  onClick,
+}: NotificationItemProps) {
+  const Icon = EVENT_ICONS[notification.eventType] ?? FileText;
+  const isUnread = !notification.readAt;
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex w-full items-start gap-3 rounded-md px-3 py-2 text-left transition-colors hover:bg-accent",
+        isUnread && "bg-accent/50",
+      )}
+      onClick={() => onClick(notification)}
+    >
+      <Icon
+        className={cn(
+          "mt-0.5 h-4 w-4 shrink-0",
+          isUnread ? "text-primary" : "text-muted-foreground",
+        )}
+      />
+      <div className="flex-1 space-y-0.5 overflow-hidden">
+        <p className={cn("truncate text-sm", isUnread && "font-medium")}>
+          {notification.title}
+        </p>
+        {notification.body && (
+          <p className="truncate text-xs text-muted-foreground">
+            {notification.body}
+          </p>
+        )}
+        <p className="text-xs text-muted-foreground">
+          {formatDistanceToNow(new Date(notification.createdAt), {
+            addSuffix: true,
+          })}
+        </p>
+      </div>
+      {isUnread && (
+        <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-primary" />
+      )}
+    </button>
+  );
+}

--- a/apps/web/src/components/notifications/notification-list.tsx
+++ b/apps/web/src/components/notifications/notification-list.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Loader2, Inbox } from "lucide-react";
+import { NotificationItem, type InboxNotification } from "./notification-item";
+
+interface NotificationListProps {
+  onClose?: () => void;
+}
+
+export function NotificationList({ onClose }: NotificationListProps) {
+  const router = useRouter();
+  const utils = trpc.useUtils();
+
+  const { data, isPending } = trpc.notifications.list.useQuery({
+    unreadOnly: false,
+    page: 1,
+    limit: 20,
+  });
+
+  const markReadMutation = trpc.notifications.markRead.useMutation({
+    onSuccess: () => {
+      void utils.notifications.unreadCount.invalidate();
+      void utils.notifications.list.invalidate();
+    },
+  });
+
+  const markAllReadMutation = trpc.notifications.markAllRead.useMutation({
+    onSuccess: () => {
+      void utils.notifications.unreadCount.invalidate();
+      void utils.notifications.list.invalidate();
+    },
+  });
+
+  function handleClick(notification: InboxNotification) {
+    if (!notification.readAt) {
+      markReadMutation.mutate({ id: notification.id });
+    }
+    if (notification.link) {
+      router.push(notification.link);
+    }
+    onClose?.();
+  }
+
+  if (isPending) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!data?.items.length) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 py-8 text-muted-foreground">
+        <Inbox className="h-8 w-8" />
+        <p className="text-sm">No notifications</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center justify-between border-b px-3 py-2">
+        <span className="text-sm font-medium">Notifications</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-auto px-2 py-1 text-xs"
+          onClick={() => markAllReadMutation.mutate()}
+          disabled={markAllReadMutation.isPending}
+        >
+          Mark all read
+        </Button>
+      </div>
+      <div className="max-h-[400px] overflow-y-auto">
+        {data.items.map((notification) => (
+          <NotificationItem
+            key={notification.id}
+            notification={notification}
+            onClick={handleClick}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/__tests__/notification-preferences-card.spec.tsx
+++ b/apps/web/src/components/settings/__tests__/notification-preferences-card.spec.tsx
@@ -3,7 +3,9 @@ import { NotificationPreferencesCard } from "../notification-preferences-card";
 import "../../../../test/setup";
 
 // --- Mutable mock state ---
-let mockPreferences: Array<{ eventType: string; enabled: boolean }> | undefined;
+let mockPreferences:
+  | Array<{ eventType: string; channel: string; enabled: boolean }>
+  | undefined;
 let mockIsPending: boolean;
 let mockError: { message: string } | null;
 let mockRefetch: jest.Mock;
@@ -91,11 +93,12 @@ describe("NotificationPreferencesCard", () => {
     expect(mockRefetch).toHaveBeenCalled();
   });
 
-  it("renders all 6 toggles with correct labels", () => {
+  it("renders 12 toggles (email + in-app per event)", () => {
     mockPreferences = [];
     render(<NotificationPreferencesCard />);
     const switches = screen.getAllByRole("switch");
-    expect(switches).toHaveLength(6);
+    // 6 events x 2 channels = 12 switches
+    expect(switches).toHaveLength(12);
     expect(screen.getByText("Submission Received")).toBeInTheDocument();
     expect(screen.getByText("Submission Accepted")).toBeInTheDocument();
     expect(screen.getByText("Submission Rejected")).toBeInTheDocument();
@@ -115,32 +118,45 @@ describe("NotificationPreferencesCard", () => {
 
   it("reflects disabled state from existing preference records", () => {
     mockPreferences = [
-      { eventType: "submission.received", enabled: false },
-      { eventType: "contract.ready", enabled: false },
+      { eventType: "submission.received", channel: "email", enabled: false },
+      { eventType: "contract.ready", channel: "in_app", enabled: false },
     ];
     render(<NotificationPreferencesCard />);
     expect(
-      screen.getByLabelText("Toggle Submission Received notifications"),
+      screen.getByLabelText("Toggle Submission Received email notifications"),
     ).not.toBeChecked();
     expect(
-      screen.getByLabelText("Toggle Contract Ready notifications"),
+      screen.getByLabelText("Toggle Submission Received in-app notifications"),
+    ).toBeChecked();
+    expect(
+      screen.getByLabelText("Toggle Contract Ready email notifications"),
+    ).toBeChecked();
+    expect(
+      screen.getByLabelText("Toggle Contract Ready in-app notifications"),
     ).not.toBeChecked();
-    expect(
-      screen.getByLabelText("Toggle Submission Accepted notifications"),
-    ).toBeChecked();
-    expect(
-      screen.getByLabelText("Toggle Submission Rejected notifications"),
-    ).toBeChecked();
   });
 
-  it("calls upsert mutation on toggle click", () => {
+  it("calls upsert mutation with channel on toggle click", () => {
     mockPreferences = [];
     render(<NotificationPreferencesCard />);
     fireEvent.click(
-      screen.getByLabelText("Toggle Submission Received notifications"),
+      screen.getByLabelText("Toggle Submission Received email notifications"),
     );
     expect(mockMutate).toHaveBeenCalledWith({
       channel: "email",
+      eventType: "submission.received",
+      enabled: false,
+    });
+  });
+
+  it("calls upsert mutation for in-app channel", () => {
+    mockPreferences = [];
+    render(<NotificationPreferencesCard />);
+    fireEvent.click(
+      screen.getByLabelText("Toggle Submission Received in-app notifications"),
+    );
+    expect(mockMutate).toHaveBeenCalledWith({
+      channel: "in_app",
       eventType: "submission.received",
       enabled: false,
     });
@@ -165,6 +181,13 @@ describe("NotificationPreferencesCard", () => {
     switches.forEach((sw) => {
       expect(sw).toBeDisabled();
     });
+  });
+
+  it("shows column headers for Email and In-App", () => {
+    mockPreferences = [];
+    render(<NotificationPreferencesCard />);
+    expect(screen.getAllByText("Email")).toHaveLength(2); // One per group
+    expect(screen.getAllByText("In-App")).toHaveLength(2);
   });
 
   it("shows Submissions and Publication Pipeline group headings", () => {

--- a/apps/web/src/components/settings/notification-preferences-card.tsx
+++ b/apps/web/src/components/settings/notification-preferences-card.tsx
@@ -59,12 +59,19 @@ const SLATE_EVENTS: EventConfig[] = [
   },
 ];
 
+type NotificationChannel = "email" | "in_app";
+
 function deriveEnabled(
-  preferences: Array<{ eventType: string; enabled: boolean }> | undefined,
+  preferences:
+    | Array<{ eventType: string; channel: string; enabled: boolean }>
+    | undefined,
   eventType: NotificationEventType,
+  channel: NotificationChannel,
 ): boolean {
   if (!preferences) return true;
-  const record = preferences.find((p) => p.eventType === eventType);
+  const record = preferences.find(
+    (p) => p.eventType === eventType && p.channel === channel,
+  );
   return record ? record.enabled : true;
 }
 
@@ -92,10 +99,11 @@ export function NotificationPreferencesCard() {
 
   function handleToggle(
     eventType: NotificationEventType,
+    channel: NotificationChannel,
     currentEnabled: boolean,
   ) {
     upsertMutation.mutate({
-      channel: "email",
+      channel,
       eventType,
       enabled: !currentEnabled,
     });
@@ -125,7 +133,7 @@ export function NotificationPreferencesCard() {
           Notification Preferences
         </CardTitle>
         <CardDescription>
-          Manage email notifications for {currentOrg.name}
+          Manage notifications for {currentOrg.name}
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -137,7 +145,10 @@ export function NotificationPreferencesCard() {
                   <Skeleton className="h-4 w-32" />
                   <Skeleton className="h-3 w-48" />
                 </div>
-                <Skeleton className="h-5 w-9 rounded-full" />
+                <div className="flex gap-4">
+                  <Skeleton className="h-5 w-9 rounded-full" />
+                  <Skeleton className="h-5 w-9 rounded-full" />
+                </div>
               </div>
             ))}
           </div>
@@ -184,15 +195,36 @@ function EventGroup({
 }: {
   title: string;
   events: EventConfig[];
-  preferences: Array<{ eventType: string; enabled: boolean }> | undefined;
-  onToggle: (eventType: NotificationEventType, currentEnabled: boolean) => void;
+  preferences:
+    | Array<{ eventType: string; channel: string; enabled: boolean }>
+    | undefined;
+  onToggle: (
+    eventType: NotificationEventType,
+    channel: NotificationChannel,
+    currentEnabled: boolean,
+  ) => void;
   disabled: boolean;
 }) {
   return (
     <div className="space-y-4">
-      <h4 className="text-sm font-medium">{title}</h4>
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-medium">{title}</h4>
+        <div className="flex gap-4 text-xs text-muted-foreground">
+          <span className="w-9 text-center">Email</span>
+          <span className="w-9 text-center">In-App</span>
+        </div>
+      </div>
       {events.map((event) => {
-        const enabled = deriveEnabled(preferences, event.eventType);
+        const emailEnabled = deriveEnabled(
+          preferences,
+          event.eventType,
+          "email",
+        );
+        const inAppEnabled = deriveEnabled(
+          preferences,
+          event.eventType,
+          "in_app",
+        );
         return (
           <div
             key={event.eventType}
@@ -204,12 +236,24 @@ function EventGroup({
                 {event.description}
               </p>
             </div>
-            <Switch
-              checked={enabled}
-              onCheckedChange={() => onToggle(event.eventType, enabled)}
-              disabled={disabled}
-              aria-label={`Toggle ${event.label} notifications`}
-            />
+            <div className="flex gap-4">
+              <Switch
+                checked={emailEnabled}
+                onCheckedChange={() =>
+                  onToggle(event.eventType, "email", emailEnabled)
+                }
+                disabled={disabled}
+                aria-label={`Toggle ${event.label} email notifications`}
+              />
+              <Switch
+                checked={inAppEnabled}
+                onCheckedChange={() =>
+                  onToggle(event.eventType, "in_app", inAppEnabled)
+                }
+                disabled={disabled}
+                aria-label={`Toggle ${event.label} in-app notifications`}
+              />
+            </div>
           </div>
         );
       })}

--- a/apps/web/src/hooks/__tests__/use-notification-stream.spec.ts
+++ b/apps/web/src/hooks/__tests__/use-notification-stream.spec.ts
@@ -1,0 +1,23 @@
+jest.mock("@/lib/trpc", () => ({
+  getAccessToken: jest.fn().mockResolvedValue(null),
+  getCurrentOrgId: jest.fn().mockReturnValue(null),
+  trpc: {
+    useUtils: jest.fn().mockReturnValue({
+      notifications: {
+        unreadCount: { invalidate: jest.fn() },
+        list: { invalidate: jest.fn() },
+      },
+    }),
+  },
+}));
+
+jest.mock("@/hooks/use-organization", () => ({
+  useOrganization: jest.fn().mockReturnValue({ currentOrg: null }),
+}));
+
+describe("useNotificationStream module", () => {
+  it("exports useNotificationStream function", async () => {
+    const mod = await import("../use-notification-stream");
+    expect(mod.useNotificationStream).toBeInstanceOf(Function);
+  });
+});

--- a/apps/web/src/hooks/use-notification-stream.ts
+++ b/apps/web/src/hooks/use-notification-stream.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { getAccessToken, getCurrentOrgId, trpc } from "@/lib/trpc";
+import { useOrganization } from "./use-organization";
+
+function getBaseUrl() {
+  return process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+}
+
+export function useNotificationStream(): void {
+  const { currentOrg } = useOrganization();
+  const utils = trpc.useUtils();
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!currentOrg) return;
+
+    let cancelled = false;
+    let reconnectTimeout: ReturnType<typeof setTimeout>;
+
+    async function connect() {
+      const token = await getAccessToken();
+      const orgId = getCurrentOrgId();
+      if (!token || !orgId || cancelled) return;
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const response = await fetch(
+          `${getBaseUrl()}/api/notifications/stream`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "x-organization-id": orgId,
+            },
+            signal: controller.signal,
+          },
+        );
+
+        if (!response.ok || !response.body) return;
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (!cancelled) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+
+          let currentEvent = "";
+          for (const line of lines) {
+            if (line.startsWith("event: ")) {
+              currentEvent = line.slice(7).trim();
+            } else if (
+              line.startsWith("data: ") &&
+              currentEvent === "notification"
+            ) {
+              void utils.notifications.unreadCount.invalidate();
+              void utils.notifications.list.invalidate();
+              currentEvent = "";
+            }
+          }
+        }
+      } catch {
+        // AbortError is expected on unmount/reconnect
+      }
+
+      // Reconnect with backoff
+      if (!cancelled) {
+        reconnectTimeout = setTimeout(connect, 5000);
+      }
+    }
+
+    void connect();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(reconnectTimeout);
+      abortRef.current?.abort();
+      abortRef.current = null;
+    };
+  }, [currentOrg?.id, utils]);
+}

--- a/apps/web/src/hooks/use-notification-stream.ts
+++ b/apps/web/src/hooks/use-notification-stream.ts
@@ -18,6 +18,7 @@ export function useNotificationStream(): void {
 
     let cancelled = false;
     let reconnectTimeout: ReturnType<typeof setTimeout>;
+    let attempt = 0;
 
     async function connect() {
       const token = await getAccessToken();
@@ -39,7 +40,12 @@ export function useNotificationStream(): void {
           },
         );
 
-        if (!response.ok || !response.body) return;
+        if (!response.ok || !response.body) {
+          throw new Error(`SSE response ${response.status}`);
+        }
+
+        // Connection succeeded — reset backoff
+        attempt = 0;
 
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
@@ -71,9 +77,11 @@ export function useNotificationStream(): void {
         // AbortError is expected on unmount/reconnect
       }
 
-      // Reconnect with backoff
+      // Reconnect with exponential backoff (1s, 2s, 4s, 8s, 16s, 30s max)
       if (!cancelled) {
-        reconnectTimeout = setTimeout(connect, 5000);
+        const delay = Math.min(1000 * Math.pow(2, attempt), 30_000);
+        attempt++;
+        reconnectTimeout = setTimeout(connect, delay);
       }
     }
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -222,7 +222,7 @@
 - [x] Email templates + provider integration (SMTP + SendGrid) — adapters, MJML templates, BullMQ queue/worker, notification preferences, Inngest functions — (architecture doc, Relay; done 2026-02-26)
 - [x] Notification preferences frontend — UI for users to manage email opt-in/opt-out per event type — (DEVLOG 2026-02-26; done 2026-02-26)
 - [x] Webhook delivery system (outbound) — (architecture doc, Relay; done 2026-02-26)
-- [ ] In-app notification center — (architecture doc, Relay)
+- [x] In-app notification center — SSE + Redis pub/sub + bell UI + dual-channel preferences — (architecture doc, Relay; done 2026-02-26)
 
 ---
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,38 @@ Newest entries first.
 
 ---
 
+## 2026-02-26 — Relay In-App Notification Center
+
+### Done
+
+- **Full in-app notification center** — implemented all 3 phases of the Relay in-app plan (19 new files, 13 modified files, 1882 insertions):
+  - DB: `notifications_inbox` table with RLS policy, 2 indexes, migration 0034; added `in_app` to `NotificationChannel` enum
+  - Notification service: CRUD (create, list w/ pagination, unreadCount, markRead, markAllRead)
+  - tRPC router: 4 procedures (list, unreadCount, markRead, markAllRead) with audit logging
+  - SSE endpoint: `GET /api/notifications/stream` via Fastify `reply.hijack()` with Redis pub/sub per org+user channel
+  - Redis pub/sub module: lazy singleton publisher/subscriber, per-connection subscriber for SSE, graceful shutdown
+  - db-context skip for SSE route (hijack prevents onResponse → transaction leak)
+  - Shared Inngest helper `queueInAppNotification`: checks preferences → creates DB row → audit logs → publishes to Redis
+  - Updated all 6 Inngest notification functions (4 submission + 2 slate) with in-app steps
+  - Frontend SSE hook: `useNotificationStream` using `fetch()` streaming (not EventSource) for custom header support
+  - NotificationBell: bell icon with unread badge (caps at 99+), Popover dropdown, 60s fallback polling
+  - NotificationList: paginated list, mark-all-read, click-to-navigate + mark-read
+  - NotificationItem: event-type icons, unread indicator, relative timestamps
+  - Dual-channel notification preferences: Email + In-App columns with per-event toggles
+  - Types: widened channel enum, 4 new Zod schemas, 3 audit actions, 1 resource
+  - 8 test files covering service, router, SSE, pub/sub, Inngest helper, bell, list, stream hook
+- **Verification fixes:** unused imports (sql, beforeEach), tRPC v11 Date serialization (InboxNotification interface with string|Date), vitest→jest conversion for web tests, ioredis mock class pattern, prettier formatting, eslint unbound-method
+- **Test results:** 1142 API tests, 384 web tests — all passing; type-check 11/11 clean; lint 0 errors
+
+### Decisions
+
+- SSE via `fetch()` streaming (not `EventSource`) — `EventSource` doesn't support custom headers; keeps auth consistent with all API calls
+- Redis pub/sub per org+user channel (`notifications:{orgId}:{userId}`) — matches RLS model, natural reconnect on org switch
+- Skip db-context hook for SSE route — `reply.hijack()` prevents `onResponse` from firing, would leak DB pool connection; handler uses `withRls()` directly (same pattern as BullMQ workers)
+- `InboxNotification` interface with `string | Date` for date fields — handles tRPC v11 Date→string serialization at the wire boundary
+
+---
+
 ## 2026-02-26 — Relay Outbound Webhook Delivery
 
 ### Done

--- a/packages/db/migrations/0034_notifications_inbox.sql
+++ b/packages/db/migrations/0034_notifications_inbox.sql
@@ -1,0 +1,53 @@
+-- Add 'in_app' to NotificationChannel enum
+ALTER TYPE "NotificationChannel" ADD VALUE IF NOT EXISTS 'in_app';
+
+--> statement-breakpoint
+
+-- Create notifications_inbox table
+CREATE TABLE IF NOT EXISTS "notifications_inbox" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "user_id" uuid NOT NULL,
+  "event_type" varchar(128) NOT NULL,
+  "title" varchar(256) NOT NULL,
+  "body" text,
+  "link" varchar(2048),
+  "read_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+
+-- Foreign key
+ALTER TABLE "notifications_inbox"
+  ADD CONSTRAINT "notifications_inbox_user_id_users_id_fk"
+  FOREIGN KEY ("user_id") REFERENCES "public"."users"("id")
+  ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+--> statement-breakpoint
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS "notifications_inbox_user_unread_idx"
+  ON "notifications_inbox" ("organization_id", "user_id", "read_at", "created_at");
+CREATE INDEX IF NOT EXISTS "notifications_inbox_user_created_idx"
+  ON "notifications_inbox" ("user_id", "created_at");
+
+--> statement-breakpoint
+
+-- Enable RLS
+ALTER TABLE "notifications_inbox" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "notifications_inbox" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+
+-- RLS policy
+CREATE POLICY "notifications_inbox_org_isolation"
+  ON "notifications_inbox" AS PERMISSIVE
+  FOR ALL
+  TO public
+  USING (organization_id = current_setting('app.current_org')::uuid);
+
+--> statement-breakpoint
+
+-- Grant permissions to app_user
+GRANT ALL ON "notifications_inbox" TO app_user;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1775800000000,
       "tag": "0033_webhook_endpoints",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1776000000000,
+      "tag": "0034_notifications_inbox",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -178,7 +178,10 @@ export const emailSendStatusEnum = pgEnum("EmailSendStatus", [
   "BOUNCED",
 ]);
 
-export const notificationChannelEnum = pgEnum("NotificationChannel", ["email"]);
+export const notificationChannelEnum = pgEnum("NotificationChannel", [
+  "email",
+  "in_app",
+]);
 
 export const webhookEndpointStatusEnum = pgEnum("WebhookEndpointStatus", [
   "ACTIVE",

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -25,5 +25,6 @@ export * from "./transfers";
 export * from "./identity-migrations";
 export * from "./hub";
 export * from "./notifications";
+export * from "./notifications-inbox";
 export * from "./webhook-endpoints";
 export * from "./relations";

--- a/packages/db/src/schema/notifications-inbox.ts
+++ b/packages/db/src/schema/notifications-inbox.ts
@@ -1,0 +1,48 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  text,
+  timestamp,
+  index,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { users } from "./users";
+
+// --- notifications_inbox (org-scoped, RLS) ---
+
+export const notificationsInbox = pgTable(
+  "notifications_inbox",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id").notNull(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id),
+    eventType: varchar("event_type", { length: 128 }).notNull(),
+    title: varchar("title", { length: 256 }).notNull(),
+    body: text("body"),
+    link: varchar("link", { length: 2048 }),
+    readAt: timestamp("read_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("notifications_inbox_user_unread_idx").on(
+      table.organizationId,
+      table.userId,
+      table.readAt,
+      table.createdAt,
+    ),
+    index("notifications_inbox_user_created_idx").on(
+      table.userId,
+      table.createdAt,
+    ),
+    pgPolicy("notifications_inbox_org_isolation", {
+      for: "all",
+      using: sql`organization_id = current_setting('app.current_org')::uuid`,
+    }),
+  ],
+).enableRLS();

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -192,6 +192,11 @@ export const AuditActions = {
   EMAIL_FAILED: "EMAIL_FAILED",
   NOTIFICATION_PREFERENCE_UPDATED: "NOTIFICATION_PREFERENCE_UPDATED",
 
+  // Relay — in-app notifications
+  IN_APP_NOTIFICATION_CREATED: "IN_APP_NOTIFICATION_CREATED",
+  IN_APP_NOTIFICATION_READ: "IN_APP_NOTIFICATION_READ",
+  IN_APP_NOTIFICATION_ALL_READ: "IN_APP_NOTIFICATION_ALL_READ",
+
   // Relay — webhooks
   WEBHOOK_ENDPOINT_CREATED: "WEBHOOK_ENDPOINT_CREATED",
   WEBHOOK_ENDPOINT_UPDATED: "WEBHOOK_ENDPOINT_UPDATED",
@@ -233,6 +238,7 @@ export const AuditResources = {
   MIGRATION: "migration",
   HUB: "hub",
   EMAIL: "email",
+  NOTIFICATION_INBOX: "notification_inbox",
   NOTIFICATION_PREFERENCE: "notification_preference",
   WEBHOOK_ENDPOINT: "webhook_endpoint",
   WEBHOOK_DELIVERY: "webhook_delivery",
@@ -505,6 +511,14 @@ export interface EmailAuditParams extends BaseAuditParams {
     | typeof AuditActions.EMAIL_FAILED;
 }
 
+export interface NotificationInboxAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.NOTIFICATION_INBOX;
+  action:
+    | typeof AuditActions.IN_APP_NOTIFICATION_CREATED
+    | typeof AuditActions.IN_APP_NOTIFICATION_READ
+    | typeof AuditActions.IN_APP_NOTIFICATION_ALL_READ;
+}
+
 export interface NotificationPreferenceAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.NOTIFICATION_PREFERENCE;
   action: typeof AuditActions.NOTIFICATION_PREFERENCE_UPDATED;
@@ -565,6 +579,7 @@ export type AuditLogParams =
   | MigrationAuditParams
   | HubAuditParams
   | EmailAuditParams
+  | NotificationInboxAuditParams
   | NotificationPreferenceAuditParams
   | WebhookEndpointAuditParams
   | WebhookDeliveryAuditParams

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -22,4 +22,5 @@ export * from "./transfer";
 export * from "./migration";
 export * from "./hub";
 export * from "./notification-preferences";
+export * from "./notification";
 export * from "./webhook";

--- a/packages/types/src/notification-preferences.ts
+++ b/packages/types/src/notification-preferences.ts
@@ -14,7 +14,7 @@ export type NotificationEventType = (typeof notificationEventTypes)[number];
 export const notificationEventTypeSchema = z.enum(notificationEventTypes);
 
 export const upsertNotificationPreferenceSchema = z.object({
-  channel: z.enum(["email"]),
+  channel: z.enum(["email", "in_app"]),
   eventType: notificationEventTypeSchema,
   enabled: z.boolean(),
 });
@@ -33,7 +33,7 @@ export type BulkUpsertNotificationPreferencesInput = z.infer<
 
 export const notificationPreferenceResponseSchema = z.object({
   id: z.string().uuid(),
-  channel: z.enum(["email"]),
+  channel: z.enum(["email", "in_app"]),
   eventType: z.string(),
   enabled: z.boolean(),
   createdAt: z.date(),

--- a/packages/types/src/notification.ts
+++ b/packages/types/src/notification.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export const listNotificationsSchema = z.object({
+  unreadOnly: z.boolean().default(false),
+  page: z.number().int().min(1).default(1),
+  limit: z.number().int().min(1).max(50).default(20),
+});
+
+export type ListNotificationsInput = z.infer<typeof listNotificationsSchema>;
+
+export const notificationResponseSchema = z.object({
+  id: z.string().uuid(),
+  eventType: z.string(),
+  title: z.string(),
+  body: z.string().nullable(),
+  link: z.string().nullable(),
+  readAt: z.date().nullable(),
+  createdAt: z.date(),
+});
+
+export type NotificationResponse = z.infer<typeof notificationResponseSchema>;
+
+export const markNotificationReadSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export type MarkNotificationReadInput = z.infer<
+  typeof markNotificationReadSchema
+>;
+
+export const unreadCountResponseSchema = z.object({
+  count: z.number().int().min(0),
+});
+
+export type UnreadCountResponse = z.infer<typeof unreadCountResponseSchema>;


### PR DESCRIPTION
## Summary

- **Full in-app notification center** with SSE real-time delivery via Redis pub/sub
- `notifications_inbox` table with RLS, tRPC CRUD router (list, unreadCount, markRead, markAllRead)
- SSE endpoint (`GET /api/notifications/stream`) using `reply.hijack()` with per-connection Redis subscribers
- Shared `queueInAppNotification` Inngest helper — all 6 notification functions (4 submission + 2 slate) now queue both email and in-app
- Frontend: NotificationBell with unread badge (99+ cap), NotificationList dropdown, SSE stream hook with exponential backoff
- Dual-channel notification preferences UI (Email + In-App columns per event type)
- Per-user SSE connection rate limiting (max 5), Redis connect/subscribe error handling
- 19 new files, 13 modified files, 28 tests across 8 test files

## Test plan

- [ ] `pnpm type-check` passes (11/11 tasks)
- [ ] `pnpm test` passes (1144 API tests, 384 web tests)
- [ ] `pnpm lint` passes (0 errors)
- [ ] Manual: trigger a submission → verify in-app notification appears in bell dropdown
- [ ] Manual: click notification → marks read, navigates to link
- [ ] Manual: toggle in-app off for event → trigger event → no in-app notification created
- [ ] Manual: switch org → bell count updates, SSE reconnects

## OpenCode Review

**Verdict:** Minor issues (all addressed)
- Added per-user SSE connection limit (max 5) to prevent connection exhaustion
- Wrapped Redis connect/subscribe in try/catch after reply.hijack()
- Made getPublisher/getSubscriber async with health checks
- Added exponential backoff (1s→30s) for frontend SSE reconnection
- Added tests for 429 rate limit and Redis connection failure

## Plan Drift Check

37/37 plan items matched. No drift detected.