### PR TITLE
chore: remove Prisma references from Docker artifacts + bump nodemailer types

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -72,7 +72,7 @@
     "@types/ioredis-mock": "^8.2.6",
     "@types/mjml": "^4.7.4",
     "@types/node": "^25.3.0",
-    "@types/nodemailer": "^7.0.9",
+    "@types/nodemailer": "^7.0.11",
     "@types/pg": "^8.11.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -11,16 +11,12 @@ RUN pnpm install --frozen-lockfile
 
 # Stage 2: builder — build packages and Next.js app
 FROM deps AS builder
-# OpenSSL is required for Prisma to detect the correct engine binary (OpenSSL 3.x on Alpine 3.23+)
-RUN apk add --no-cache openssl
 ARG NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_TUS_URL
 ENV NEXT_PUBLIC_TUS_URL=$NEXT_PUBLIC_TUS_URL
 COPY packages/ packages/
 COPY apps/web/ apps/web/
-# Prisma generate needed because @colophony/types may depend on Prisma types
-RUN pnpm --filter @colophony/db generate
 RUN pnpm --filter @colophony/types build
 RUN pnpm --filter @colophony/db build
 RUN pnpm --filter @colophony/web build

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,7 +26,7 @@ services:
     networks:
       - colophony
 
-  # NestJS API + tRPC server
+  # Fastify API + tRPC server
   api:
     build:
       context: .
@@ -272,16 +272,13 @@ services:
     entrypoint: ["sh", "-c"]
     command:
       - |
-        # Install psql for RLS policy application, openssl for Prisma engine
-        apk add --no-cache postgresql16-client openssl
-        # Run migrations and apply RLS
+        apk add --no-cache postgresql16-client
         /app/scripts/init-prod.sh
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-colophony}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-colophony}
       APP_DATABASE_URL: postgresql://app_user:${APP_USER_PASSWORD}@postgres:5432/${POSTGRES_DB:-colophony}
     volumes:
       - ./scripts/init-prod.sh:/app/scripts/init-prod.sh:ro
-      - ./packages/db/prisma:/app/prisma:ro
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -266,14 +266,13 @@ services:
     entrypoint: ["sh", "-c"]
     command:
       - |
-        apk add --no-cache postgresql16-client openssl
+        apk add --no-cache postgresql16-client
         /app/scripts/init-prod.sh
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-colophony}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-colophony_staging}
       APP_DATABASE_URL: postgresql://app_user:${APP_USER_PASSWORD}@postgres:5432/${POSTGRES_DB:-colophony_staging}
     volumes:
       - ./scripts/init-prod.sh:/app/scripts/init-prod.sh:ro
-      - ./packages/db/prisma:/app/prisma:ro
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -249,7 +249,7 @@
 
 ### [P3] Low — Unused or minimal impact
 
-- [ ] nodemailer 7 → 8 — Relay email foundation now built; evaluate upgrade — (dependabot #77)
+- [x] nodemailer 7 → 8 — already at v8.0.1; bumped @types/nodemailer 7.0.9 → 7.0.11 — (dependabot #77; done 2026-02-26)
 
 ### Upgrade order notes
 
@@ -286,7 +286,7 @@
 - [x] [P1] Add Overmind as process manager for dev servers — replaces `turbo run dev` for persistent server lifecycle (API + web); Turbo stays for build graph. Overmind manages tmux session so killing it kills entire process group — eliminates orphaned `tsx watch` / `next-server` / `postcss` processes that accumulate across sessions. Turbo's SIGINT forwarding is a known open issue (#9666, #9694). — (manual QA session 2026-02-21, found 60 orphaned processes; done 2026-02-21)
 - [x] [P2] Add `dev:clean` script — kill processes on ports 4000/3000, remove stale lock files (`apps/web/.next/dev/lock`). Fallback for when Overmind isn't running or crashes. Add as `pnpm dev:clean` in root package.json. — (manual QA session 2026-02-21; done 2026-02-21)
 - [x] [P2] Simplify Docker profile handling — wrapper script or Makefile target that always includes `--profile auth` for Zitadel. Current setup requires remembering `docker compose --profile auth up -d zitadel` separately from `docker compose up -d`. — (manual QA session 2026-02-21; done 2026-02-21)
-- [ ] [P3] Docker Compose staging override — `docker-compose.staging.yml` with built API/web production images alongside shared infra services. For local staging testing and future deployed staging. Do NOT use `docker compose watch` for Next.js (Turbopack hot-reload bug, docker/compose#12827). — (manual QA session 2026-02-21)
+- [x] [P3] Docker Compose staging override — `docker-compose.staging.yml` with built API/web production images alongside shared infra services. For local staging testing and future deployed staging. Do NOT use `docker compose watch` for Next.js (Turbopack hot-reload bug, docker/compose#12827). — (manual QA session 2026-02-21; done 2026-02-26)
 - [x] [P2] Zitadel dev setup automation — `pnpm zitadel:setup` provisions Zitadel and patches .env files after volume wipe — (manual QA friction 2026-02-24; done 2026-02-24)
 - [x] [P2] Stale org context recovery — `useOrganization` detects stale localStorage org ID and auto-switches — (manual QA friction 2026-02-24; done 2026-02-24)
 - [x] [P2] Slate seed data — publications, pipeline items, issues, contracts, CMS connections in `db:seed` — (manual QA friction 2026-02-24; done 2026-02-24)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,24 @@ Newest entries first.
 
 ---
 
+## 2026-02-26 — Prisma Cleanup & nodemailer Types Bump
+
+### Done
+
+- **Removed all Prisma references from prod/staging Docker artifacts:**
+  - `scripts/init-prod.sh`: rewrote Step 1 from `prisma migrate deploy` to `pnpm --filter @colophony/db migrate`; removed ~140 lines of manual RLS SQL (redundant with Drizzle migrations 0000-0034); replaced hardcoded 9-table RLS verification with dynamic `pg_class` query (`relrowsecurity = true`); added minimum-table-count safety check
+  - `docker-compose.prod.yml`: removed `./packages/db/prisma:/app/prisma:ro` volume mount, removed `openssl` from migrate service `apk add`, fixed comment `NestJS` → `Fastify`
+  - `docker-compose.staging.yml`: same migrate service fixes as prod
+  - `apps/web/Dockerfile`: removed `apk add openssl` (Prisma engine detection), removed `pnpm --filter @colophony/db generate` (Drizzle doesn't need build-time codegen)
+- **Bumped `@types/nodemailer` 7.0.9 → 7.0.11** (aligns with nodemailer v8 already at 8.0.1)
+- **Marked backlog item done:** Docker Compose staging override
+
+### Decisions
+
+- Dynamic RLS verification via `pg_class` query instead of hardcoded table list — future-proof as new tables are added via migrations
+
+---
+
 ## 2026-02-26 — Relay In-App Notification Center
 
 ### Done

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,8 +155,8 @@ importers:
         specifier: ^25.3.0
         version: 25.3.0
       '@types/nodemailer':
-        specifier: ^7.0.9
-        version: 7.0.9
+        specifier: ^7.0.11
+        version: 7.0.11
       '@types/pg':
         specifier: ^8.11.0
         version: 8.16.0
@@ -3772,8 +3772,8 @@ packages:
   '@types/node@25.3.0':
     resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
 
-  '@types/nodemailer@7.0.9':
-    resolution: {integrity: sha512-vI8oF1M+8JvQhsId0Pc38BdUP2evenIIys7c7p+9OZXSPOH5c1dyINP1jT8xQ2xPuBUXmIC87s+91IZMDjH8Ow==}
+  '@types/nodemailer@7.0.11':
+    resolution: {integrity: sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==}
 
   '@types/oracledb@6.5.2':
     resolution: {integrity: sha512-kK1eBS/Adeyis+3OlBDMeQQuasIDLUYXsi2T15ccNJ0iyUpQ4xDF7svFu3+bGVrI0CMBUclPciz+lsQR3JX3TQ==}
@@ -11857,7 +11857,7 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@types/nodemailer@7.0.9':
+  '@types/nodemailer@7.0.11':
     dependencies:
       '@types/node': 25.3.0
 

--- a/scripts/init-prod.sh
+++ b/scripts/init-prod.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Production initialization script
-# Runs Prisma migrations, applies RLS policies, and grants permissions
+# Runs Drizzle migrations, grants permissions, and verifies RLS
 # Designed to be idempotent — safe to run multiple times
 set -e
 
@@ -16,165 +16,17 @@ if [ -z "$APP_DATABASE_URL" ]; then
   echo "WARNING: APP_DATABASE_URL not set, skipping RLS verification"
 fi
 
-# Step 1: Run Prisma migrations (idempotent by design)
+# Step 1: Run Drizzle migrations (idempotent — tracks applied migrations in journal)
 echo ""
-echo "Step 1: Running Prisma migrations..."
-./packages/db/node_modules/.bin/prisma migrate deploy --schema ./prisma/schema.prisma
+echo "Step 1: Running Drizzle migrations..."
+pnpm --filter @colophony/db migrate
 echo "Migrations complete."
 
-# Step 2: Apply RLS policies
-# Uses DO $$ blocks and IF NOT EXISTS for idempotency
+# Step 2: Grant permissions to app_user (GRANT is idempotent)
+# Drizzle migrations handle schema, RLS policies, helper functions, indexes, and triggers.
+# Role grants are NOT in migrations — they must be applied here.
 echo ""
-echo "Step 2: Applying RLS policies..."
-
-psql "$DATABASE_URL" <<-'EOSQL'
--- Helper functions (CREATE OR REPLACE is idempotent)
-CREATE OR REPLACE FUNCTION current_org_id() RETURNS uuid AS $$
-  SELECT NULLIF(current_setting('app.current_org', true), '')::uuid;
-$$ LANGUAGE sql STABLE;
-
-CREATE OR REPLACE FUNCTION current_user_id() RETURNS uuid AS $$
-  SELECT NULLIF(current_setting('app.user_id', true), '')::uuid;
-$$ LANGUAGE sql STABLE;
-
--- Enable RLS on all tenant tables (idempotent)
-ALTER TABLE submissions ENABLE ROW LEVEL SECURITY;
-ALTER TABLE submissions FORCE ROW LEVEL SECURITY;
-
-ALTER TABLE submission_files ENABLE ROW LEVEL SECURITY;
-ALTER TABLE submission_files FORCE ROW LEVEL SECURITY;
-
-ALTER TABLE submission_history ENABLE ROW LEVEL SECURITY;
-ALTER TABLE submission_history FORCE ROW LEVEL SECURITY;
-
-ALTER TABLE payments ENABLE ROW LEVEL SECURITY;
-ALTER TABLE payments FORCE ROW LEVEL SECURITY;
-
-ALTER TABLE audit_events ENABLE ROW LEVEL SECURITY;
-ALTER TABLE audit_events FORCE ROW LEVEL SECURITY;
-
-ALTER TABLE submission_periods ENABLE ROW LEVEL SECURITY;
-ALTER TABLE submission_periods FORCE ROW LEVEL SECURITY;
-
-ALTER TABLE retention_policies ENABLE ROW LEVEL SECURITY;
-ALTER TABLE retention_policies FORCE ROW LEVEL SECURITY;
-
-ALTER TABLE user_consents ENABLE ROW LEVEL SECURITY;
-ALTER TABLE user_consents FORCE ROW LEVEL SECURITY;
-
-ALTER TABLE organization_members ENABLE ROW LEVEL SECURITY;
-ALTER TABLE organization_members FORCE ROW LEVEL SECURITY;
-
--- Create RLS policies (use DO blocks with IF NOT EXISTS pattern)
-DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'submissions' AND policyname = 'org_isolation') THEN
-    CREATE POLICY org_isolation ON submissions
-      FOR ALL USING (organization_id = current_org_id())
-      WITH CHECK (organization_id = current_org_id());
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'submission_files' AND policyname = 'org_isolation') THEN
-    CREATE POLICY org_isolation ON submission_files
-      FOR ALL
-      USING (submission_id IN (SELECT id FROM submissions WHERE organization_id = current_org_id()))
-      WITH CHECK (submission_id IN (SELECT id FROM submissions WHERE organization_id = current_org_id()));
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'submission_history' AND policyname = 'org_isolation') THEN
-    CREATE POLICY org_isolation ON submission_history
-      FOR ALL
-      USING (submission_id IN (SELECT id FROM submissions WHERE organization_id = current_org_id()))
-      WITH CHECK (submission_id IN (SELECT id FROM submissions WHERE organization_id = current_org_id()));
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'payments' AND policyname = 'org_isolation') THEN
-    CREATE POLICY org_isolation ON payments
-      FOR ALL USING (organization_id = current_org_id())
-      WITH CHECK (organization_id = current_org_id());
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'audit_events' AND policyname = 'org_isolation') THEN
-    CREATE POLICY org_isolation ON audit_events
-      FOR ALL
-      USING (organization_id IS NULL OR organization_id = current_org_id())
-      WITH CHECK (organization_id IS NULL OR organization_id = current_org_id());
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'submission_periods' AND policyname = 'org_isolation') THEN
-    CREATE POLICY org_isolation ON submission_periods
-      FOR ALL USING (organization_id = current_org_id())
-      WITH CHECK (organization_id = current_org_id());
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'retention_policies' AND policyname = 'org_isolation') THEN
-    CREATE POLICY org_isolation ON retention_policies
-      FOR ALL
-      USING (organization_id IS NULL OR organization_id = current_org_id())
-      WITH CHECK (organization_id IS NULL OR organization_id = current_org_id());
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'user_consents' AND policyname = 'org_isolation') THEN
-    CREATE POLICY org_isolation ON user_consents
-      FOR ALL
-      USING (organization_id IS NULL OR organization_id = current_org_id())
-      WITH CHECK (organization_id IS NULL OR organization_id = current_org_id());
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'organization_members' AND policyname = 'org_isolation') THEN
-    CREATE POLICY org_isolation ON organization_members
-      FOR SELECT USING (organization_id = current_org_id());
-  END IF;
-END $$;
-
-DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'organization_members' AND policyname = 'org_admin_modify') THEN
-    CREATE POLICY org_admin_modify ON organization_members
-      FOR ALL USING (organization_id = current_org_id())
-      WITH CHECK (organization_id = current_org_id());
-  END IF;
-END $$;
-
--- Full-text search index and trigger
-CREATE INDEX IF NOT EXISTS idx_submissions_search ON submissions USING GIN(search_vector);
-
-CREATE OR REPLACE FUNCTION submissions_search_trigger() RETURNS trigger AS $$
-BEGIN
-  NEW.search_vector := to_tsvector('english',
-    COALESCE(NEW.title, '') || ' ' ||
-    COALESCE(NEW.content, '') || ' ' ||
-    COALESCE(NEW.cover_letter, '')
-  );
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-DROP TRIGGER IF EXISTS submissions_search_update ON submissions;
-CREATE TRIGGER submissions_search_update
-  BEFORE INSERT OR UPDATE ON submissions
-  FOR EACH ROW EXECUTE FUNCTION submissions_search_trigger();
-EOSQL
-
-echo "RLS policies applied."
-
-# Step 3: Grant permissions to app_user (GRANT is idempotent)
-echo ""
-echo "Step 3: Granting permissions to app_user..."
+echo "Step 2: Granting permissions to app_user..."
 
 psql "$DATABASE_URL" <<-'EOSQL'
 GRANT USAGE ON SCHEMA public TO app_user;
@@ -188,27 +40,43 @@ EOSQL
 
 echo "Permissions granted."
 
-# Step 4: Verify RLS enforcement
+# Step 3: Verify RLS enforcement
+# Query pg_class dynamically for all tables with RLS enabled — no hardcoded list needed.
 echo ""
-echo "Step 4: Verifying RLS enforcement..."
+echo "Step 3: Verifying RLS enforcement..."
 
+RLS_FAIL=0
 psql "$DATABASE_URL" -t -A -c "
-SELECT relname, relrowsecurity, relforcerowsecurity
-FROM pg_class
-WHERE relname IN (
-  'submissions', 'submission_files', 'submission_history',
-  'payments', 'audit_events', 'submission_periods',
-  'retention_policies', 'user_consents', 'organization_members'
-)
-ORDER BY relname;
+SELECT c.relname, c.relrowsecurity, c.relforcerowsecurity
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public'
+  AND c.relkind = 'r'
+  AND c.relrowsecurity = true
+ORDER BY c.relname;
 " | while IFS='|' read -r table rls force; do
   if [ "$rls" = "t" ] && [ "$force" = "t" ]; then
     echo "  $table: RLS enabled + forced"
   else
-    echo "  ERROR: $table: rls=$rls force=$force"
+    echo "  ERROR: $table: rls=$rls force=$force (expected both true)"
     exit 1
   fi
 done
+
+# Check that at least some tables have RLS (catch empty result = migrations didn't apply)
+RLS_COUNT=$(psql "$DATABASE_URL" -t -A -c "
+SELECT count(*)
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public'
+  AND c.relkind = 'r'
+  AND c.relrowsecurity = true;
+")
+if [ "$RLS_COUNT" -lt 1 ]; then
+  echo "  ERROR: No tables have RLS enabled — migrations may not have applied correctly"
+  exit 1
+fi
+echo "  $RLS_COUNT tables with RLS verified."
 
 # Verify app_user is not superuser
 APP_USER_SUPER=$(psql "$DATABASE_URL" -t -A -c "SELECT usesuper FROM pg_user WHERE usename = 'app_user';")

--- a/scripts/init-prod.sh
+++ b/scripts/init-prod.sh
@@ -2,7 +2,7 @@
 # Production initialization script
 # Runs Drizzle migrations, grants permissions, and verifies RLS
 # Designed to be idempotent — safe to run multiple times
-set -e
+set -eo pipefail
 
 echo "=== Colophony Production Initialization ==="
 


### PR DESCRIPTION
## Summary

- Remove all Prisma references from `docker-compose.prod.yml`, `docker-compose.staging.yml`, `scripts/init-prod.sh`, and `apps/web/Dockerfile` — these are v1 ORM artifacts that would cause failures if the prod/staging compose files were run today
- Rewrite `init-prod.sh` for Drizzle: migrations via `pnpm --filter @colophony/db migrate`, remove ~140 lines of manual RLS SQL (now in Drizzle migrations 0000-0034), replace hardcoded 9-table RLS verification with dynamic `pg_class` query
- Bump `@types/nodemailer` 7.0.9 → 7.0.11 (aligns with nodemailer v8)
- Mark Docker Compose staging backlog item as done

## Test plan

- [x] `docker compose -f docker-compose.prod.yml config` validates YAML
- [x] `docker compose -f docker-compose.staging.yml config` validates YAML (requires `.env.staging` at deploy time)
- [ ] Review `init-prod.sh` manually for correctness of Drizzle migrate command, grant permissions, and dynamic RLS verification
- [ ] Verify web Dockerfile builds without openssl/Prisma generate (CI build job)