### PR TITLE
feat: add @colophony/plugin-sdk package (Track 6, PR1 of 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **Next.js frontend**     | `apps/web/`                                                                      |
 | **tRPC client**          | `apps/web/src/lib/trpc.ts`                                                       |
 | **Env config (Zod)**     | `apps/api/src/config/env.ts`                                                     |
+| **Plugin SDK**           | `packages/plugin-sdk/src/` (adapters, hooks, config, plugin-base, testing)       |
 | **Backlog**              | `docs/backlog.md` (track-organized, drives session focus)                        |
 
 Full project structure: [docs/architecture-v2-planning.md](docs/architecture-v2-planning.md)
@@ -419,7 +420,7 @@ See [docs/architecture-v2-planning.md Section 6](docs/architecture-v2-planning.m
 | 3     | Hopper — Submission Management                           | 5-12   | Pending         |
 | 4     | Slate — Publication Pipeline                             | 8-15   | Pending         |
 | 5     | Register — Identity & Federation                         | 10-18  | **In progress** |
-| 6     | Colophony Plugins                                        | 14-20  | Pending         |
+| 6     | Colophony Plugins                                        | 14-20  | **In progress** |
 | —     | Relay — Notifications (cross-cutting)                    | 1-20   | Pending         |
 
 ---

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -184,10 +184,10 @@
 
 ### Phase 1-2 (v2 launch)
 
-- [ ] `@colophony/plugin-sdk` with adapter interfaces (Email, Payment, Storage, Search, Auth, Newsletter) — (plugin research Section 11)
-- [ ] Built-in adapters: SMTP, Stripe, S3 — (plugin research Section 11)
-- [ ] `colophony.config.ts` plugin loader — (plugin research Section 11)
-- [ ] HookEngine with typed hooks for submission lifecycle — (plugin research Section 11)
+- [x] `@colophony/plugin-sdk` with adapter interfaces (Email, Payment, Storage, Search, Auth, Newsletter) — (plugin research Section 11; done 2026-02-26)
+- [ ] Built-in adapters: SMTP, Stripe, S3 — refactor existing to implement SDK interfaces (plugin research Section 11; PR2)
+- [ ] `colophony.config.ts` plugin loader — wire `loadConfig()` into `main.ts` (plugin research Section 11; PR2)
+- [x] HookEngine with typed hooks for submission lifecycle — 14 hooks (11 action + 3 filter) (plugin research Section 11; done 2026-02-26)
 - [x] Webhook delivery via BullMQ with retry + dead letter queue — (plugin research Section 11; done 2026-02-26 as Relay webhook system)
 - [x] Webhook configuration UI — (plugin research Section 11; done 2026-02-26 as Relay webhook admin pages)
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-26 — Track 6: Plugin SDK Package (PR1 of 2)
+
+### Done
+
+- **`@colophony/plugin-sdk` package** — 28 new files, ~2,075 lines in `packages/plugin-sdk/`
+- **Adapter interfaces:** `BaseAdapter` with lifecycle (initialize/healthCheck/destroy), plus 4 domain interfaces: `EmailAdapter`, `PaymentAdapter`, `StorageAdapter`, `SearchAdapter`; `AdapterType` union includes `auth` and `newsletter` for forward compatibility
+- **AdapterRegistry:** register/resolve/tryResolve/destroyAll with typed generics
+- **HookEngine:** 14 typed hooks (11 action + 3 filter) with priority ordering, error swallowing for actions, pass-through for filters; single `on()` method with union return type
+- **Plugin system:** `PluginManifest` interface with Zod schema validation (semver, categories, permissions), `ColophonyPlugin` abstract class with two-phase lifecycle (register → bootstrap), `AuditFn` for plugin audit logging
+- **Config loader:** `defineConfig()` + `loadConfig()` — instantiates adapters, validates config via `configSchema`, runs plugin lifecycle, returns `{ registry, hookEngine, plugins }`
+- **UI types:** 8 contribution points (`dashboard.widget`, `submission.detail.section`, etc.) — type-only, no runtime code
+- **Testing utilities:** `MockEmailAdapter`, `MockPaymentAdapter`, `MockStorageAdapter`, `MockSearchAdapter`, `createMockRegisterContext`, `createMockBootstrapContext`, `createTestHarness`, `createNoopLogger`
+- **36 tests passing:** registry (7), hook-engine (10), config (6), plugin-manifest (7), testing-utils (6)
+- **Full workspace verification:** type-check 12/12, lint passes, no regressions
+
+### Decisions
+
+- Single `on()` method with union return type (`HookPayloadMap[T] | void | Promise<...>`) instead of separate `onAction()`/`onFilter()` — plan marked this as [exploratory]; union type works cleanly
+- Phase 1 plugins get no direct DB access — they interact via adapter interfaces and hook payloads only (Tier 4 `database:read`/`database:write` is Phase 3+)
+- `AuditFn` uses simplified `{ action, resourceType, resourceId?, newValue? }` params — host app bridges to the full `AuditLogParams` union
+
+---
+
 ## 2026-02-26 — Playwright E2E Type-Checking + Coverage Tooling
 
 ### Done

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@colophony/plugin-sdk",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "default": "./dist/testing/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@colophony/typescript-config": "workspace:*",
+    "@types/node": "^25.3.0",
+    "typescript": "^5.7.2",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/plugin-sdk/src/__tests__/config.spec.ts
+++ b/packages/plugin-sdk/src/__tests__/config.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from "vitest";
+import { z } from "zod";
+
+import { defineConfig, loadConfig } from "../config.js";
+import {
+  AdapterInitializationError,
+  ConfigValidationError,
+} from "../errors.js";
+import type { BaseAdapter } from "../adapters/common.js";
+import type { ColophonyPlugin } from "../plugin-base.js";
+import { createNoopLogger } from "../testing/noop-logger.js";
+
+function createAdapterClass(
+  overrides?: Partial<BaseAdapter>,
+): new () => BaseAdapter {
+  return class TestAdapter {
+    id = overrides?.id ?? "test";
+    name = overrides?.name ?? "Test";
+    version = overrides?.version ?? "1.0.0";
+    configSchema = overrides?.configSchema ?? z.object({ apiKey: z.string() });
+    initialize = overrides?.initialize ?? vi.fn().mockResolvedValue(undefined);
+    healthCheck =
+      overrides?.healthCheck ??
+      vi.fn().mockResolvedValue({ healthy: true, message: "ok" });
+    destroy = overrides?.destroy ?? vi.fn().mockResolvedValue(undefined);
+  } as unknown as new () => BaseAdapter;
+}
+
+describe("config", () => {
+  it("defineConfig returns config as-is", () => {
+    const config = { adapters: {} };
+    expect(defineConfig(config)).toBe(config);
+  });
+
+  it("loadConfig initializes adapters from constructors", async () => {
+    const initFn = vi.fn().mockResolvedValue(undefined);
+    const Cls = createAdapterClass({ id: "smtp", initialize: initFn });
+
+    const result = await loadConfig({
+      config: { adapters: { email: Cls } },
+      adapterConfigs: { email: { apiKey: "key123" } },
+      logger: createNoopLogger(),
+    });
+
+    expect(initFn).toHaveBeenCalledWith({ apiKey: "key123" });
+    expect(result.registry.has("email")).toBe(true);
+  });
+
+  it("loadConfig validates adapter config against configSchema", async () => {
+    const Cls = createAdapterClass({ id: "strict" });
+
+    await expect(
+      loadConfig({
+        config: { adapters: { email: Cls } },
+        adapterConfigs: { email: {} }, // missing apiKey
+        logger: createNoopLogger(),
+      }),
+    ).rejects.toThrow(ConfigValidationError);
+  });
+
+  it("loadConfig runs register then bootstrap on plugins", async () => {
+    const order: string[] = [];
+
+    const plugin: ColophonyPlugin = {
+      manifest: {
+        id: "test-plugin",
+        name: "Test",
+        version: "1.0.0",
+        colophonyVersion: "2.0.0",
+        description: "Test plugin",
+        author: "Test",
+        license: "MIT",
+        category: "integration",
+      },
+      register: vi.fn(async () => {
+        order.push("register");
+      }),
+      bootstrap: vi.fn(async () => {
+        order.push("bootstrap");
+      }),
+      destroy: vi.fn(),
+    };
+
+    await loadConfig({
+      config: { plugins: [plugin] },
+      logger: createNoopLogger(),
+    });
+
+    expect(order).toEqual(["register", "bootstrap"]);
+    expect(plugin.register).toHaveBeenCalledOnce();
+    expect(plugin.bootstrap).toHaveBeenCalledOnce();
+  });
+
+  it("loadConfig processes multiple adapters", async () => {
+    const EmailCls = createAdapterClass({
+      id: "email-adapter",
+      configSchema: z.object({}).passthrough(),
+    });
+    const StorageCls = createAdapterClass({
+      id: "storage-adapter",
+      configSchema: z.object({}).passthrough(),
+    });
+
+    const result = await loadConfig({
+      config: { adapters: { email: EmailCls, storage: StorageCls } },
+      logger: createNoopLogger(),
+    });
+
+    expect(result.registry.has("email")).toBe(true);
+    expect(result.registry.has("storage")).toBe(true);
+  });
+
+  it("loadConfig propagates adapter initialization errors", async () => {
+    const Cls = createAdapterClass({
+      id: "broken",
+      configSchema: z.object({}).passthrough(),
+      initialize: vi.fn().mockRejectedValue(new Error("connection refused")),
+    });
+
+    await expect(
+      loadConfig({
+        config: { adapters: { email: Cls } },
+        logger: createNoopLogger(),
+      }),
+    ).rejects.toThrow(AdapterInitializationError);
+  });
+});

--- a/packages/plugin-sdk/src/__tests__/hook-engine.spec.ts
+++ b/packages/plugin-sdk/src/__tests__/hook-engine.spec.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { HookEngine } from "../hooks/engine.js";
+import { createNoopLogger } from "../testing/noop-logger.js";
+
+describe("HookEngine", () => {
+  let engine: HookEngine;
+
+  beforeEach(() => {
+    engine = new HookEngine(createNoopLogger());
+  });
+
+  it("executes action hook handlers in priority order", async () => {
+    const order: number[] = [];
+
+    engine.on(
+      "submission.created",
+      async () => {
+        order.push(2);
+      },
+      { priority: 200 },
+    );
+    engine.on(
+      "submission.created",
+      async () => {
+        order.push(1);
+      },
+      { priority: 50 },
+    );
+
+    await engine.executeAction("submission.created", {
+      orgId: "org1",
+      submissionId: "s1",
+      submitterId: "u1",
+      formId: "f1",
+    });
+
+    expect(order).toEqual([1, 2]);
+  });
+
+  it("action hook swallows handler errors", async () => {
+    const handler1 = vi.fn().mockRejectedValue(new Error("boom"));
+    const handler2 = vi.fn().mockResolvedValue(undefined);
+
+    engine.on("submission.created", handler1);
+    engine.on("submission.created", handler2);
+
+    await engine.executeAction("submission.created", {
+      orgId: "org1",
+      submissionId: "s1",
+      submitterId: "u1",
+      formId: "f1",
+    });
+
+    expect(handler1).toHaveBeenCalledOnce();
+    expect(handler2).toHaveBeenCalledOnce();
+  });
+
+  it("action hook with no handlers is a no-op", async () => {
+    await expect(
+      engine.executeAction("submission.created", {
+        orgId: "org1",
+        submissionId: "s1",
+        submitterId: "u1",
+        formId: "f1",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("executes filter hook handlers in chain", async () => {
+    engine.on("submission.validate", async (payload) => ({
+      ...payload,
+      errors: [...payload.errors, "err1"],
+    }));
+    engine.on("submission.validate", async (payload) => ({
+      ...payload,
+      errors: [...payload.errors, "err2"],
+    }));
+
+    const result = await engine.executeFilter("submission.validate", {
+      orgId: "org1",
+      submissionId: "s1",
+      data: {},
+      errors: [],
+    });
+
+    expect(result.errors).toEqual(["err1", "err2"]);
+  });
+
+  it("filter hook passes through on handler error", async () => {
+    engine.on("submission.validate", () => {
+      throw new Error("filter boom");
+    });
+
+    const payload = {
+      orgId: "org1",
+      submissionId: "s1",
+      data: {},
+      errors: ["existing"],
+    };
+
+    const result = await engine.executeFilter("submission.validate", payload);
+    expect(result.errors).toEqual(["existing"]);
+  });
+
+  it("on() returns unsubscribe function", async () => {
+    const handler = vi.fn();
+    const unsub = engine.on("submission.created", handler);
+
+    expect(engine.getListenerCount("submission.created")).toBe(1);
+    unsub();
+    expect(engine.getListenerCount("submission.created")).toBe(0);
+  });
+
+  it("getListenerCount returns correct count", () => {
+    engine.on("submission.created", async () => {});
+    engine.on("submission.created", async () => {});
+    engine.on("submission.submitted", async () => {});
+
+    expect(engine.getListenerCount("submission.created")).toBe(2);
+    expect(engine.getListenerCount("submission.submitted")).toBe(1);
+    expect(engine.getListenerCount("payment.completed")).toBe(0);
+  });
+
+  it("removeAll clears all handlers for a hook", () => {
+    engine.on("submission.created", async () => {});
+    engine.on("submission.created", async () => {});
+    engine.on("submission.submitted", async () => {});
+
+    engine.removeAll("submission.created");
+
+    expect(engine.getListenerCount("submission.created")).toBe(0);
+    expect(engine.getListenerCount("submission.submitted")).toBe(1);
+  });
+
+  it("removeAll with no args clears everything", () => {
+    engine.on("submission.created", async () => {});
+    engine.on("submission.submitted", async () => {});
+
+    engine.removeAll();
+
+    expect(engine.getListenerCount("submission.created")).toBe(0);
+    expect(engine.getListenerCount("submission.submitted")).toBe(0);
+  });
+
+  it("default priority is 100", async () => {
+    const order: string[] = [];
+
+    engine.on("submission.created", async () => {
+      order.push("default");
+    });
+    engine.on(
+      "submission.created",
+      async () => {
+        order.push("low");
+      },
+      { priority: 50 },
+    );
+    engine.on(
+      "submission.created",
+      async () => {
+        order.push("high");
+      },
+      { priority: 200 },
+    );
+
+    await engine.executeAction("submission.created", {
+      orgId: "org1",
+      submissionId: "s1",
+      submitterId: "u1",
+      formId: "f1",
+    });
+
+    expect(order).toEqual(["low", "default", "high"]);
+  });
+});

--- a/packages/plugin-sdk/src/__tests__/plugin-manifest.spec.ts
+++ b/packages/plugin-sdk/src/__tests__/plugin-manifest.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+
+import { pluginManifestSchema } from "../plugin.js";
+
+const validManifest = {
+  id: "my-plugin",
+  name: "My Plugin",
+  version: "1.0.0",
+  colophonyVersion: "2.0.0",
+  description: "A test plugin",
+  author: "Test Author",
+  license: "MIT",
+  category: "adapter" as const,
+};
+
+describe("pluginManifestSchema", () => {
+  it("validates a valid manifest", () => {
+    const result = pluginManifestSchema.safeParse(validManifest);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects manifest with missing required fields", () => {
+    const { id: _, ...incomplete } = validManifest;
+    const result = pluginManifestSchema.safeParse(incomplete);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects manifest with invalid version format", () => {
+    const result = pluginManifestSchema.safeParse({
+      ...validManifest,
+      version: "not-semver",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts manifest without optional fields", () => {
+    const result = pluginManifestSchema.safeParse(validManifest);
+    expect(result.success).toBe(true);
+  });
+
+  it("validates adapter type enum", () => {
+    const valid = pluginManifestSchema.safeParse({
+      ...validManifest,
+      adapters: ["email", "storage"],
+    });
+    expect(valid.success).toBe(true);
+
+    const invalid = pluginManifestSchema.safeParse({
+      ...validManifest,
+      adapters: ["nonexistent"],
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it("validates permission enum", () => {
+    const valid = pluginManifestSchema.safeParse({
+      ...validManifest,
+      permissions: ["submissions:read", "email:send"],
+    });
+    expect(valid.success).toBe(true);
+
+    const invalid = pluginManifestSchema.safeParse({
+      ...validManifest,
+      permissions: ["invalid:perm"],
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it("validates category enum", () => {
+    const valid = pluginManifestSchema.safeParse(validManifest);
+    expect(valid.success).toBe(true);
+
+    const invalid = pluginManifestSchema.safeParse({
+      ...validManifest,
+      category: "nonexistent",
+    });
+    expect(invalid.success).toBe(false);
+  });
+});

--- a/packages/plugin-sdk/src/__tests__/registry.spec.ts
+++ b/packages/plugin-sdk/src/__tests__/registry.spec.ts
@@ -75,6 +75,25 @@ describe("AdapterRegistry", () => {
     expect(registry.has("email")).toBe(false);
   });
 
+  it("destroyAll completes even if one adapter throws", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const a1 = createStubAdapter({
+      id: "a1",
+      destroy: vi.fn().mockRejectedValue(new Error("destroy failed")),
+    });
+    const a2 = createStubAdapter({ id: "a2" });
+    registry.register("email", a1);
+    registry.register("storage", a2);
+
+    await registry.destroyAll();
+
+    expect(a1.destroy).toHaveBeenCalledOnce();
+    expect(a2.destroy).toHaveBeenCalledOnce();
+    expect(registry.has("email")).toBe(false);
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    consoleSpy.mockRestore();
+  });
+
   it("listAllTypes returns types with registrations", () => {
     registry.register("email", createStubAdapter());
     registry.register("search", createStubAdapter());

--- a/packages/plugin-sdk/src/__tests__/registry.spec.ts
+++ b/packages/plugin-sdk/src/__tests__/registry.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { z } from "zod";
+
+import { AdapterNotFoundError } from "../errors.js";
+import { AdapterRegistry } from "../registry.js";
+import type { BaseAdapter } from "../adapters/common.js";
+
+function createStubAdapter(overrides?: Partial<BaseAdapter>): BaseAdapter {
+  return {
+    id: "stub",
+    name: "Stub Adapter",
+    version: "1.0.0",
+    configSchema: z.object({}).passthrough(),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue({ healthy: true, message: "ok" }),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("AdapterRegistry", () => {
+  let registry: AdapterRegistry;
+
+  beforeEach(() => {
+    registry = new AdapterRegistry();
+  });
+
+  it("registers and resolves an adapter", () => {
+    const adapter = createStubAdapter({ id: "smtp" });
+    registry.register("email", adapter);
+    expect(registry.resolve("email")).toBe(adapter);
+  });
+
+  it("throws AdapterNotFoundError for unregistered type", () => {
+    expect(() => registry.resolve("payment")).toThrow(AdapterNotFoundError);
+  });
+
+  it("tryResolve returns null for unregistered type", () => {
+    expect(registry.tryResolve("storage")).toBeNull();
+  });
+
+  it("has() returns true for registered type", () => {
+    registry.register("email", createStubAdapter());
+    expect(registry.has("email")).toBe(true);
+    expect(registry.has("payment")).toBe(false);
+  });
+
+  it("listRegistered returns adapter info", () => {
+    registry.register(
+      "email",
+      createStubAdapter({ id: "smtp", name: "SMTP", version: "2.0.0" }),
+    );
+    const list = registry.listRegistered("email");
+    expect(list).toHaveLength(1);
+    expect(list[0]).toEqual({
+      id: "smtp",
+      name: "SMTP",
+      version: "2.0.0",
+      type: "email",
+      active: true,
+    });
+    expect(registry.listRegistered("payment")).toHaveLength(0);
+  });
+
+  it("destroyAll calls destroy on all adapters", async () => {
+    const a1 = createStubAdapter({ id: "a1" });
+    const a2 = createStubAdapter({ id: "a2" });
+    registry.register("email", a1);
+    registry.register("storage", a2);
+
+    await registry.destroyAll();
+
+    expect(a1.destroy).toHaveBeenCalledOnce();
+    expect(a2.destroy).toHaveBeenCalledOnce();
+    expect(registry.has("email")).toBe(false);
+  });
+
+  it("listAllTypes returns types with registrations", () => {
+    registry.register("email", createStubAdapter());
+    registry.register("search", createStubAdapter());
+    const types = registry.listAllTypes();
+    expect(types).toContain("email");
+    expect(types).toContain("search");
+    expect(types).toHaveLength(2);
+  });
+});

--- a/packages/plugin-sdk/src/__tests__/testing-utils.spec.ts
+++ b/packages/plugin-sdk/src/__tests__/testing-utils.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest";
+
+import type { PluginManifest } from "../plugin.js";
+import type { ColophonyPlugin } from "../plugin-base.js";
+import { MockEmailAdapter } from "../testing/mock-adapters.js";
+import { createMockRegisterContext } from "../testing/mock-context.js";
+import { createNoopLogger } from "../testing/noop-logger.js";
+import { createTestHarness } from "../testing/test-harness.js";
+
+function createTestPlugin(
+  overrides?: Partial<ColophonyPlugin>,
+): ColophonyPlugin {
+  return {
+    manifest: {
+      id: "test-plugin",
+      name: "Test",
+      version: "1.0.0",
+      colophonyVersion: "2.0.0",
+      description: "Test",
+      author: "Test",
+      license: "MIT",
+      category: "integration",
+    } satisfies PluginManifest,
+    register: vi.fn().mockResolvedValue(undefined),
+    bootstrap: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("testing utilities", () => {
+  it("MockEmailAdapter records sent emails", async () => {
+    const adapter = new MockEmailAdapter();
+    await adapter.send({
+      to: "user@example.com",
+      subject: "Hello",
+      html: "<p>Hi</p>",
+    });
+
+    expect(adapter.sentEmails).toHaveLength(1);
+    expect(adapter.getLastEmail()?.to).toBe("user@example.com");
+  });
+
+  it("MockEmailAdapter.reset clears history", async () => {
+    const adapter = new MockEmailAdapter();
+    await adapter.send({
+      to: "user@example.com",
+      subject: "Test",
+      html: "<p>Test</p>",
+    });
+    adapter.reset();
+    expect(adapter.sentEmails).toHaveLength(0);
+    expect(adapter.getLastEmail()).toBeUndefined();
+  });
+
+  it("createMockRegisterContext tracks registrations", () => {
+    const ctx = createMockRegisterContext();
+    const adapter = new MockEmailAdapter();
+
+    ctx.registerAdapter("email", adapter);
+    ctx.registerHook("submission.created", async () => {});
+    ctx.registerUIExtension({
+      point: "dashboard.widget",
+      id: "test-widget",
+      label: "Test",
+      component: "TestWidget",
+    });
+
+    expect(ctx.registeredAdapters).toHaveLength(1);
+    expect(ctx.registeredHooks).toHaveLength(1);
+    expect(ctx.registeredUIExtensions).toHaveLength(1);
+  });
+
+  it("createTestHarness loadPlugin calls lifecycle", async () => {
+    const harness = createTestHarness();
+    const plugin = createTestPlugin();
+
+    await harness.loadPlugin(plugin);
+
+    expect(plugin.register).toHaveBeenCalledOnce();
+    expect(plugin.bootstrap).toHaveBeenCalledOnce();
+  });
+
+  it("createTestHarness teardown calls destroy", async () => {
+    const harness = createTestHarness();
+    const plugin = createTestPlugin();
+
+    await harness.loadPlugin(plugin);
+    await harness.teardown();
+
+    expect(plugin.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("createNoopLogger does not throw", () => {
+    const logger = createNoopLogger();
+    expect(() => {
+      logger.info("test");
+      logger.warn("test");
+      logger.error("test");
+      logger.debug("test");
+      logger.child({ key: "value" }).info("child");
+    }).not.toThrow();
+  });
+});

--- a/packages/plugin-sdk/src/adapters/common.ts
+++ b/packages/plugin-sdk/src/adapters/common.ts
@@ -1,0 +1,33 @@
+import type { z } from "zod";
+
+export interface AdapterHealthResult {
+  healthy: boolean;
+  message: string;
+  latencyMs?: number;
+}
+
+export type AdapterType =
+  | "email"
+  | "payment"
+  | "storage"
+  | "search"
+  | "auth"
+  | "newsletter";
+
+export interface AdapterInfo {
+  id: string;
+  name: string;
+  version: string;
+  type: AdapterType;
+  active: boolean;
+}
+
+export interface BaseAdapter {
+  readonly id: string;
+  readonly name: string;
+  readonly version: string;
+  readonly configSchema: z.ZodType<Record<string, unknown>>;
+  initialize(config: Record<string, unknown>): Promise<void>;
+  healthCheck(): Promise<AdapterHealthResult>;
+  destroy(): Promise<void>;
+}

--- a/packages/plugin-sdk/src/adapters/email.ts
+++ b/packages/plugin-sdk/src/adapters/email.ts
@@ -1,0 +1,32 @@
+import type { BaseAdapter } from "./common.js";
+
+export interface EmailAttachment {
+  filename: string;
+  content: Buffer | string;
+  contentType?: string;
+}
+
+export interface SendEmailOptions {
+  to: string | string[];
+  subject: string;
+  html: string;
+  text?: string;
+  from?: string;
+  replyTo?: string;
+  attachments?: EmailAttachment[];
+  metadata?: Record<string, string>;
+}
+
+export interface SendEmailResult {
+  success: boolean;
+  messageId?: string;
+  error?: string;
+}
+
+export interface EmailAdapter extends BaseAdapter {
+  send(options: SendEmailOptions): Promise<SendEmailResult>;
+  sendBulk?(
+    recipients: string[],
+    options: Omit<SendEmailOptions, "to">,
+  ): Promise<SendEmailResult[]>;
+}

--- a/packages/plugin-sdk/src/adapters/index.ts
+++ b/packages/plugin-sdk/src/adapters/index.ts
@@ -1,0 +1,28 @@
+export type {
+  AdapterHealthResult,
+  AdapterInfo,
+  AdapterType,
+  BaseAdapter,
+} from "./common.js";
+export type {
+  EmailAdapter,
+  EmailAttachment,
+  SendEmailOptions,
+  SendEmailResult,
+} from "./email.js";
+export type {
+  CheckoutSessionParams,
+  CheckoutSessionResult,
+  PaymentAdapter,
+  PaymentWebhookEvent,
+  RefundResult,
+  WebhookHandleResult,
+} from "./payment.js";
+export type {
+  SearchAdapter,
+  SearchDocument,
+  SearchHit,
+  SearchQuery,
+  SearchResult,
+} from "./search.js";
+export type { StorageAdapter, UploadOptions, UploadResult } from "./storage.js";

--- a/packages/plugin-sdk/src/adapters/payment.ts
+++ b/packages/plugin-sdk/src/adapters/payment.ts
@@ -1,0 +1,45 @@
+import type { BaseAdapter } from "./common.js";
+
+export interface CheckoutSessionParams {
+  amount: number;
+  currency: string;
+  description?: string;
+  metadata?: Record<string, string>;
+  successUrl: string;
+  cancelUrl: string;
+  customerId?: string;
+}
+
+export interface CheckoutSessionResult {
+  sessionId: string;
+  url: string;
+}
+
+export interface PaymentWebhookEvent {
+  id: string;
+  type: string;
+  data: Record<string, unknown>;
+}
+
+export interface WebhookHandleResult {
+  handled: boolean;
+  action?: string;
+}
+
+export interface RefundResult {
+  refundId: string;
+  status: "succeeded" | "pending" | "failed";
+  amount: number;
+}
+
+export interface PaymentAdapter extends BaseAdapter {
+  createCheckoutSession(
+    params: CheckoutSessionParams,
+  ): Promise<CheckoutSessionResult>;
+  verifyWebhook(
+    headers: Record<string, string>,
+    body: string,
+  ): Promise<PaymentWebhookEvent>;
+  handleWebhookEvent(event: PaymentWebhookEvent): Promise<WebhookHandleResult>;
+  refund(paymentId: string, amount?: number): Promise<RefundResult>;
+}

--- a/packages/plugin-sdk/src/adapters/payment.ts
+++ b/packages/plugin-sdk/src/adapters/payment.ts
@@ -36,6 +36,10 @@ export interface PaymentAdapter extends BaseAdapter {
   createCheckoutSession(
     params: CheckoutSessionParams,
   ): Promise<CheckoutSessionResult>;
+  /**
+   * Verify and parse a webhook payload. Callers must pass the raw request
+   * body (before any JSON parsing) to ensure signature verification succeeds.
+   */
   verifyWebhook(
     headers: Record<string, string>,
     body: string,

--- a/packages/plugin-sdk/src/adapters/search.ts
+++ b/packages/plugin-sdk/src/adapters/search.ts
@@ -1,0 +1,34 @@
+import type { BaseAdapter } from "./common.js";
+
+export interface SearchDocument {
+  id: string;
+  index: string;
+  fields: Record<string, unknown>;
+}
+
+export interface SearchQuery {
+  index: string;
+  query: string;
+  filters?: Record<string, unknown>;
+  limit?: number;
+  offset?: number;
+}
+
+export interface SearchHit {
+  id: string;
+  score: number;
+  fields: Record<string, unknown>;
+}
+
+export interface SearchResult {
+  hits: SearchHit[];
+  total: number;
+  took: number;
+}
+
+export interface SearchAdapter extends BaseAdapter {
+  index(document: SearchDocument): Promise<void>;
+  indexBulk(documents: SearchDocument[]): Promise<void>;
+  search(query: SearchQuery): Promise<SearchResult>;
+  remove(documentId: string, index: string): Promise<void>;
+}

--- a/packages/plugin-sdk/src/adapters/storage.ts
+++ b/packages/plugin-sdk/src/adapters/storage.ts
@@ -1,0 +1,25 @@
+import type { Readable } from "node:stream";
+
+import type { BaseAdapter } from "./common.js";
+
+export interface UploadOptions {
+  key: string;
+  body: Buffer | Readable;
+  contentType?: string;
+  metadata?: Record<string, string>;
+}
+
+export interface UploadResult {
+  key: string;
+  size: number;
+  etag?: string;
+}
+
+export interface StorageAdapter extends BaseAdapter {
+  upload(options: UploadOptions): Promise<UploadResult>;
+  download(key: string): Promise<Readable>;
+  delete(key: string): Promise<void>;
+  exists(key: string): Promise<boolean>;
+  getSignedUrl(key: string, expiresInSeconds?: number): Promise<string>;
+  move(sourceKey: string, destinationKey: string): Promise<void>;
+}

--- a/packages/plugin-sdk/src/config.ts
+++ b/packages/plugin-sdk/src/config.ts
@@ -1,0 +1,115 @@
+import type { AdapterType, BaseAdapter } from "./adapters/common.js";
+import { AdapterInitializationError, ConfigValidationError } from "./errors.js";
+import { HookEngine } from "./hooks/engine.js";
+import type { Logger } from "./logger.js";
+import type { ColophonyPlugin } from "./plugin-base.js";
+import { AdapterRegistry } from "./registry.js";
+
+export type AdapterConstructor<T extends BaseAdapter = BaseAdapter> =
+  new () => T;
+
+export interface ColophonyConfig {
+  adapters?: Partial<Record<AdapterType, AdapterConstructor>>;
+  plugins?: ColophonyPlugin[];
+}
+
+export interface LoadConfigOptions {
+  config: ColophonyConfig;
+  adapterConfigs?: Partial<Record<AdapterType, Record<string, unknown>>>;
+  logger: Logger;
+  audit?: (params: {
+    action: string;
+    resourceType: string;
+    resourceId?: string;
+    newValue?: unknown;
+  }) => Promise<void>;
+}
+
+export interface LoadConfigResult {
+  registry: AdapterRegistry;
+  hookEngine: HookEngine;
+  plugins: ColophonyPlugin[];
+}
+
+export function defineConfig(config: ColophonyConfig): ColophonyConfig {
+  return config;
+}
+
+export async function loadConfig(
+  options: LoadConfigOptions,
+): Promise<LoadConfigResult> {
+  const { config, adapterConfigs, logger, audit } = options;
+  const registry = new AdapterRegistry();
+  const hookEngine = new HookEngine(logger);
+  const plugins = config.plugins ?? [];
+
+  // Phase 1: Initialize adapters
+  if (config.adapters) {
+    for (const [type, Ctor] of Object.entries(config.adapters) as [
+      AdapterType,
+      AdapterConstructor,
+    ][]) {
+      const adapter = new Ctor();
+      const rawConfig = adapterConfigs?.[type] ?? {};
+
+      // Validate config against adapter schema
+      const result = adapter.configSchema.safeParse(rawConfig);
+      if (!result.success) {
+        throw new ConfigValidationError(
+          `Config validation failed for adapter "${adapter.id}": ${
+            "error" in result ? String(result.error) : "Invalid configuration"
+          }`,
+        );
+      }
+
+      try {
+        await adapter.initialize(result.data as Record<string, unknown>);
+      } catch (err) {
+        throw new AdapterInitializationError(adapter.id, err);
+      }
+
+      registry.register(type, adapter);
+      logger.info(`Adapter "${adapter.id}" (${type}) initialized`);
+    }
+  }
+
+  const noopAudit = async () => {};
+  const auditFn = audit ?? noopAudit;
+
+  // Phase 2: Plugin register
+  const uiExtensions: unknown[] = [];
+  for (const plugin of plugins) {
+    await plugin.register({
+      registerAdapter: (type, adapter) => registry.register(type, adapter),
+      registerHook: (hookId, handler, hookOptions) => {
+        hookEngine.on(hookId, handler, {
+          ...hookOptions,
+          pluginId: plugin.manifest.id,
+        });
+      },
+      registerUIExtension: (ext) => uiExtensions.push(ext),
+      logger: logger.child({ plugin: plugin.manifest.id }),
+    });
+  }
+
+  // Phase 3: Plugin bootstrap
+  for (const plugin of plugins) {
+    await plugin.bootstrap({
+      registerAdapter: (type, adapter) => registry.register(type, adapter),
+      registerHook: (hookId, handler, hookOptions) => {
+        hookEngine.on(hookId, handler, {
+          ...hookOptions,
+          pluginId: plugin.manifest.id,
+        });
+      },
+      registerUIExtension: (ext) => uiExtensions.push(ext),
+      resolveAdapter: <T extends BaseAdapter>(type: AdapterType) =>
+        registry.resolve<T>(type),
+      config: {},
+      audit: auditFn,
+      logger: logger.child({ plugin: plugin.manifest.id }),
+    });
+  }
+
+  return { registry, hookEngine, plugins };
+}

--- a/packages/plugin-sdk/src/errors.ts
+++ b/packages/plugin-sdk/src/errors.ts
@@ -1,0 +1,54 @@
+export type PluginSdkErrorCode =
+  | "ADAPTER_NOT_FOUND"
+  | "ADAPTER_INIT_FAILED"
+  | "CONFIG_VALIDATION_FAILED"
+  | "HOOK_EXECUTION_FAILED";
+
+export class PluginSdkError extends Error {
+  readonly code: PluginSdkErrorCode;
+
+  constructor(message: string, code: PluginSdkErrorCode) {
+    super(message);
+    this.name = "PluginSdkError";
+    this.code = code;
+  }
+}
+
+export class AdapterNotFoundError extends PluginSdkError {
+  constructor(type: string) {
+    super(`No adapter registered for type "${type}"`, "ADAPTER_NOT_FOUND");
+    this.name = "AdapterNotFoundError";
+  }
+}
+
+export class AdapterInitializationError extends PluginSdkError {
+  readonly cause: unknown;
+
+  constructor(adapterId: string, cause: unknown) {
+    const msg = cause instanceof Error ? cause.message : String(cause);
+    super(
+      `Failed to initialize adapter "${adapterId}": ${msg}`,
+      "ADAPTER_INIT_FAILED",
+    );
+    this.name = "AdapterInitializationError";
+    this.cause = cause;
+  }
+}
+
+export class ConfigValidationError extends PluginSdkError {
+  constructor(message: string) {
+    super(message, "CONFIG_VALIDATION_FAILED");
+    this.name = "ConfigValidationError";
+  }
+}
+
+export class HookExecutionError extends PluginSdkError {
+  readonly cause: unknown;
+
+  constructor(hookId: string, cause: unknown) {
+    const msg = cause instanceof Error ? cause.message : String(cause);
+    super(`Hook "${hookId}" execution failed: ${msg}`, "HOOK_EXECUTION_FAILED");
+    this.name = "HookExecutionError";
+    this.cause = cause;
+  }
+}

--- a/packages/plugin-sdk/src/hooks/definitions.ts
+++ b/packages/plugin-sdk/src/hooks/definitions.ts
@@ -1,0 +1,76 @@
+import type { HookDefinition } from "./types.js";
+
+export const HOOKS = {
+  "submission.created": {
+    id: "submission.created",
+    type: "action",
+    description: "Fires after a new submission is created",
+  },
+  "submission.submitted": {
+    id: "submission.submitted",
+    type: "action",
+    description: "Fires after a submission is finalized and submitted",
+  },
+  "submission.status_changed": {
+    id: "submission.status_changed",
+    type: "action",
+    description: "Fires when a submission status changes",
+  },
+  "submission.assigned": {
+    id: "submission.assigned",
+    type: "action",
+    description: "Fires when a submission is assigned to a reader",
+  },
+  "pipeline.stage_changed": {
+    id: "pipeline.stage_changed",
+    type: "action",
+    description: "Fires when a pipeline item moves to a new stage",
+  },
+  "pipeline.completed": {
+    id: "pipeline.completed",
+    type: "action",
+    description: "Fires when a pipeline item reaches completion",
+  },
+  "issue.published": {
+    id: "issue.published",
+    type: "action",
+    description: "Fires when an issue is published",
+  },
+  "review.assigned": {
+    id: "review.assigned",
+    type: "action",
+    description: "Fires when a reviewer is assigned to a submission",
+  },
+  "review.completed": {
+    id: "review.completed",
+    type: "action",
+    description: "Fires when a review is completed",
+  },
+  "payment.completed": {
+    id: "payment.completed",
+    type: "action",
+    description: "Fires when a payment is completed",
+  },
+  "member.joined": {
+    id: "member.joined",
+    type: "action",
+    description: "Fires when a new member joins an organization",
+  },
+  "submission.validate": {
+    id: "submission.validate",
+    type: "filter",
+    description: "Filters submission validation — handlers can add errors",
+  },
+  "email.before_send": {
+    id: "email.before_send",
+    type: "filter",
+    description: "Filters email options before sending",
+  },
+  "submission.export": {
+    id: "submission.export",
+    type: "filter",
+    description: "Filters submission export content",
+  },
+} as const satisfies Record<string, HookDefinition>;
+
+export type HookId = keyof typeof HOOKS;

--- a/packages/plugin-sdk/src/hooks/engine.ts
+++ b/packages/plugin-sdk/src/hooks/engine.ts
@@ -1,0 +1,110 @@
+import type { Logger } from "../logger.js";
+import { HOOKS, type HookId } from "./definitions.js";
+import type { HookPayloadMap } from "./payloads.js";
+
+interface HookHandler {
+  pluginId?: string;
+  priority: number;
+  handler: (payload: unknown) => unknown | Promise<unknown>;
+}
+
+export interface HookHandlerOptions {
+  priority?: number;
+  pluginId?: string;
+}
+
+export class HookEngine {
+  private listeners = new Map<HookId, HookHandler[]>();
+  private logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  on<T extends HookId>(
+    hookId: T,
+    handler: (
+      payload: HookPayloadMap[T],
+    ) => HookPayloadMap[T] | void | Promise<HookPayloadMap[T]> | Promise<void>,
+    options?: HookHandlerOptions,
+  ): () => void {
+    const entry: HookHandler = {
+      pluginId: options?.pluginId,
+      priority: options?.priority ?? 100,
+      handler: handler as (payload: unknown) => unknown,
+    };
+
+    const existing = this.listeners.get(hookId) ?? [];
+    existing.push(entry);
+    existing.sort((a, b) => a.priority - b.priority);
+    this.listeners.set(hookId, existing);
+
+    return () => {
+      const list = this.listeners.get(hookId);
+      if (!list) return;
+      const idx = list.indexOf(entry);
+      if (idx !== -1) list.splice(idx, 1);
+    };
+  }
+
+  async executeAction<T extends HookId>(
+    hookId: T,
+    payload: HookPayloadMap[T],
+  ): Promise<void> {
+    const handlers = this.listeners.get(hookId);
+    if (!handlers?.length) return;
+
+    for (const entry of handlers) {
+      try {
+        await entry.handler(payload);
+      } catch (err) {
+        this.logger.error(
+          `Hook "${hookId}" handler${entry.pluginId ? ` (plugin: ${entry.pluginId})` : ""} threw an error`,
+          err,
+        );
+      }
+    }
+  }
+
+  async executeFilter<T extends HookId>(
+    hookId: T,
+    payload: HookPayloadMap[T],
+  ): Promise<HookPayloadMap[T]> {
+    const handlers = this.listeners.get(hookId);
+    if (!handlers?.length) return payload;
+
+    let current = payload;
+    for (const entry of handlers) {
+      try {
+        const result = await entry.handler(current);
+        if (result !== undefined && result !== null) {
+          current = result as HookPayloadMap[T];
+        }
+      } catch (err) {
+        this.logger.error(
+          `Filter "${hookId}" handler${entry.pluginId ? ` (plugin: ${entry.pluginId})` : ""} threw an error — passing through`,
+          err,
+        );
+      }
+    }
+
+    return current;
+  }
+
+  getListenerCount(hookId: HookId): number {
+    return this.listeners.get(hookId)?.length ?? 0;
+  }
+
+  removeAll(hookId?: HookId): void {
+    if (hookId) {
+      this.listeners.delete(hookId);
+    } else {
+      this.listeners.clear();
+    }
+  }
+
+  /** Returns all registered hook definitions. */
+  getHookDefinitions(): typeof HOOKS {
+    return HOOKS;
+  }
+}

--- a/packages/plugin-sdk/src/hooks/engine.ts
+++ b/packages/plugin-sdk/src/hooks/engine.ts
@@ -77,6 +77,8 @@ export class HookEngine {
     for (const entry of handlers) {
       try {
         const result = await entry.handler(current);
+        // Void/undefined return means "no modification" — pass through current payload.
+        // Null is not a valid filter result; treat as no-op to avoid wiping the payload.
         if (result !== undefined && result !== null) {
           current = result as HookPayloadMap[T];
         }
@@ -95,6 +97,11 @@ export class HookEngine {
     return this.listeners.get(hookId)?.length ?? 0;
   }
 
+  /**
+   * Remove all handlers for a specific hook, or all hooks if no hookId given.
+   * Note: previously returned unsubscribe functions from `on()` become no-ops
+   * after removal (they check the array reference which is now deleted).
+   */
   removeAll(hookId?: HookId): void {
     if (hookId) {
       this.listeners.delete(hookId);

--- a/packages/plugin-sdk/src/hooks/index.ts
+++ b/packages/plugin-sdk/src/hooks/index.ts
@@ -1,0 +1,20 @@
+export { HOOKS, type HookId } from "./definitions.js";
+export { HookEngine, type HookHandlerOptions } from "./engine.js";
+export type {
+  EmailBeforeSendPayload,
+  HookPayloadMap,
+  IssuePublishedPayload,
+  MemberJoinedPayload,
+  PaymentCompletedPayload,
+  PipelineCompletedPayload,
+  PipelineStageChangedPayload,
+  ReviewAssignedPayload,
+  ReviewCompletedPayload,
+  SubmissionAssignedPayload,
+  SubmissionCreatedPayload,
+  SubmissionExportPayload,
+  SubmissionStatusChangedPayload,
+  SubmissionSubmittedPayload,
+  SubmissionValidationPayload,
+} from "./payloads.js";
+export type { HookDefinition, HookType } from "./types.js";

--- a/packages/plugin-sdk/src/hooks/payloads.ts
+++ b/packages/plugin-sdk/src/hooks/payloads.ts
@@ -1,0 +1,119 @@
+// ── Action payloads ──
+
+export interface SubmissionCreatedPayload {
+  orgId: string;
+  submissionId: string;
+  submitterId: string;
+  formId: string;
+}
+
+export interface SubmissionSubmittedPayload {
+  orgId: string;
+  submissionId: string;
+  submitterId: string;
+}
+
+export interface SubmissionStatusChangedPayload {
+  orgId: string;
+  submissionId: string;
+  previousStatus: string;
+  newStatus: string;
+  changedBy?: string;
+}
+
+export interface SubmissionAssignedPayload {
+  orgId: string;
+  submissionId: string;
+  assigneeId: string;
+  assignedBy: string;
+}
+
+export interface PipelineStageChangedPayload {
+  orgId: string;
+  pipelineItemId: string;
+  previousStage: string;
+  newStage: string;
+}
+
+export interface PipelineCompletedPayload {
+  orgId: string;
+  pipelineItemId: string;
+  submissionId: string;
+}
+
+export interface IssuePublishedPayload {
+  orgId: string;
+  issueId: string;
+  publicationId: string;
+}
+
+export interface ReviewAssignedPayload {
+  orgId: string;
+  submissionId: string;
+  reviewerId: string;
+  assignedBy: string;
+}
+
+export interface ReviewCompletedPayload {
+  orgId: string;
+  submissionId: string;
+  reviewerId: string;
+  recommendation: string;
+}
+
+export interface PaymentCompletedPayload {
+  orgId: string;
+  submissionId: string;
+  paymentId: string;
+  amount: number;
+  currency: string;
+}
+
+export interface MemberJoinedPayload {
+  orgId: string;
+  userId: string;
+  role: string;
+}
+
+// ── Filter payloads ──
+
+export interface SubmissionValidationPayload {
+  orgId: string;
+  submissionId: string;
+  data: Record<string, unknown>;
+  errors: string[];
+}
+
+export interface EmailBeforeSendPayload {
+  to: string | string[];
+  subject: string;
+  html: string;
+  text?: string;
+  metadata?: Record<string, string>;
+}
+
+export interface SubmissionExportPayload {
+  orgId: string;
+  submissionId: string;
+  format: string;
+  content: string;
+}
+
+// ── Payload map ──
+
+export interface HookPayloadMap {
+  "submission.created": SubmissionCreatedPayload;
+  "submission.submitted": SubmissionSubmittedPayload;
+  "submission.status_changed": SubmissionStatusChangedPayload;
+  "submission.assigned": SubmissionAssignedPayload;
+  "pipeline.stage_changed": PipelineStageChangedPayload;
+  "pipeline.completed": PipelineCompletedPayload;
+  "issue.published": IssuePublishedPayload;
+  "review.assigned": ReviewAssignedPayload;
+  "review.completed": ReviewCompletedPayload;
+  "payment.completed": PaymentCompletedPayload;
+  "member.joined": MemberJoinedPayload;
+  "submission.validate": SubmissionValidationPayload;
+  "email.before_send": EmailBeforeSendPayload;
+  "submission.export": SubmissionExportPayload;
+}

--- a/packages/plugin-sdk/src/hooks/types.ts
+++ b/packages/plugin-sdk/src/hooks/types.ts
@@ -1,0 +1,9 @@
+export type HookType = "action" | "filter";
+
+export interface HookDefinition<TPayload = unknown> {
+  id: string;
+  type: HookType;
+  description: string;
+  /** Phantom field for TypeScript inference only. */
+  _payload?: TPayload;
+}

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -1,0 +1,96 @@
+// Adapters
+export type {
+  AdapterHealthResult,
+  AdapterInfo,
+  AdapterType,
+  BaseAdapter,
+  CheckoutSessionParams,
+  CheckoutSessionResult,
+  EmailAdapter,
+  EmailAttachment,
+  PaymentAdapter,
+  PaymentWebhookEvent,
+  RefundResult,
+  SearchAdapter,
+  SearchDocument,
+  SearchHit,
+  SearchQuery,
+  SearchResult,
+  SendEmailOptions,
+  SendEmailResult,
+  StorageAdapter,
+  UploadOptions,
+  UploadResult,
+  WebhookHandleResult,
+} from "./adapters/index.js";
+
+// Registry
+export { AdapterRegistry } from "./registry.js";
+
+// Hooks
+export { HOOKS, type HookId } from "./hooks/definitions.js";
+export { HookEngine, type HookHandlerOptions } from "./hooks/engine.js";
+export type {
+  EmailBeforeSendPayload,
+  HookPayloadMap,
+  IssuePublishedPayload,
+  MemberJoinedPayload,
+  PaymentCompletedPayload,
+  PipelineCompletedPayload,
+  PipelineStageChangedPayload,
+  ReviewAssignedPayload,
+  ReviewCompletedPayload,
+  SubmissionAssignedPayload,
+  SubmissionCreatedPayload,
+  SubmissionExportPayload,
+  SubmissionStatusChangedPayload,
+  SubmissionSubmittedPayload,
+  SubmissionValidationPayload,
+} from "./hooks/payloads.js";
+export type { HookDefinition, HookType } from "./hooks/types.js";
+
+// Plugin
+export {
+  pluginManifestSchema,
+  type PluginCategory,
+  type PluginManifest,
+  type PluginPermission,
+} from "./plugin.js";
+export {
+  ColophonyPlugin,
+  type AuditFn,
+  type PluginBootstrapContext,
+  type PluginRegisterContext,
+} from "./plugin-base.js";
+
+// UI
+export type {
+  UIContributionPoint,
+  UIExtensionDeclaration,
+} from "./ui/types.js";
+
+// Config
+export {
+  defineConfig,
+  loadConfig,
+  type AdapterConstructor,
+  type ColophonyConfig,
+  type LoadConfigOptions,
+  type LoadConfigResult,
+} from "./config.js";
+
+// Errors
+export {
+  AdapterInitializationError,
+  AdapterNotFoundError,
+  ConfigValidationError,
+  HookExecutionError,
+  PluginSdkError,
+  type PluginSdkErrorCode,
+} from "./errors.js";
+
+// Logger
+export type { Logger } from "./logger.js";
+
+// Version
+export { MIN_COLOPHONY_VERSION, SDK_VERSION } from "./version.js";

--- a/packages/plugin-sdk/src/logger.ts
+++ b/packages/plugin-sdk/src/logger.ts
@@ -1,0 +1,8 @@
+/** Minimal logger interface (Pino-compatible). SDK has no Fastify/Pino dependency. */
+export interface Logger {
+  info(msg: string, ...args: unknown[]): void;
+  warn(msg: string, ...args: unknown[]): void;
+  error(msg: string, ...args: unknown[]): void;
+  debug(msg: string, ...args: unknown[]): void;
+  child(bindings: Record<string, unknown>): Logger;
+}

--- a/packages/plugin-sdk/src/plugin-base.ts
+++ b/packages/plugin-sdk/src/plugin-base.ts
@@ -1,0 +1,47 @@
+import type { AdapterType, BaseAdapter } from "./adapters/common.js";
+import type { HookHandlerOptions } from "./hooks/engine.js";
+import type { HookId } from "./hooks/definitions.js";
+import type { HookPayloadMap } from "./hooks/payloads.js";
+import type { Logger } from "./logger.js";
+import type { PluginManifest } from "./plugin.js";
+import type { UIExtensionDeclaration } from "./ui/types.js";
+
+export type AuditFn = (params: {
+  action: string;
+  resourceType: string;
+  resourceId?: string;
+  newValue?: unknown;
+}) => Promise<void>;
+
+export interface PluginRegisterContext {
+  registerAdapter(type: AdapterType, adapter: BaseAdapter): void;
+  registerHook<T extends HookId>(
+    hookId: T,
+    handler: (
+      payload: HookPayloadMap[T],
+    ) => HookPayloadMap[T] | void | Promise<HookPayloadMap[T]> | Promise<void>,
+    options?: HookHandlerOptions,
+  ): void;
+  registerUIExtension(extension: UIExtensionDeclaration): void;
+  logger: Logger;
+}
+
+export interface PluginBootstrapContext extends PluginRegisterContext {
+  resolveAdapter<T extends BaseAdapter>(type: AdapterType): T;
+  config: Record<string, unknown>;
+  audit: AuditFn;
+}
+
+export abstract class ColophonyPlugin {
+  abstract readonly manifest: PluginManifest;
+
+  abstract register(context: PluginRegisterContext): Promise<void>;
+
+  async bootstrap(_context: PluginBootstrapContext): Promise<void> {
+    // Optional — override in subclass
+  }
+
+  async destroy(): Promise<void> {
+    // Optional — override in subclass
+  }
+}

--- a/packages/plugin-sdk/src/plugin.ts
+++ b/packages/plugin-sdk/src/plugin.ts
@@ -1,0 +1,107 @@
+import { z } from "zod";
+
+import type { AdapterType } from "./adapters/common.js";
+
+export type PluginCategory =
+  | "adapter"
+  | "integration"
+  | "workflow"
+  | "import-export"
+  | "report"
+  | "theme"
+  | "block"
+  | "notification";
+
+export type PluginPermission =
+  | "submissions:read"
+  | "submissions:write"
+  | "files:read"
+  | "files:write"
+  | "email:send"
+  | "http:outbound"
+  | "storage:read"
+  | "storage:write"
+  | "search:read"
+  | "search:write"
+  | "payment:read"
+  | "payment:write"
+  | "pipeline:read"
+  | "pipeline:write"
+  | "publications:read"
+  | "publications:write"
+  | "members:read"
+  | "database:read"
+  | "database:write";
+
+export interface PluginManifest {
+  id: string;
+  name: string;
+  version: string;
+  colophonyVersion: string;
+  description: string;
+  author: string;
+  license: string;
+  category: PluginCategory;
+  homepage?: string;
+  adapters?: AdapterType[];
+  ui?: string[];
+  permissions?: PluginPermission[];
+  dependencies?: Record<string, string>;
+}
+
+const semverPattern = /^\d+\.\d+\.\d+(?:-[\w.]+)?$/;
+
+export const pluginManifestSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  version: z.string().regex(semverPattern, "Must be a valid semver version"),
+  colophonyVersion: z
+    .string()
+    .regex(semverPattern, "Must be a valid semver version"),
+  description: z.string().min(1),
+  author: z.string().min(1),
+  license: z.string().min(1),
+  category: z.enum([
+    "adapter",
+    "integration",
+    "workflow",
+    "import-export",
+    "report",
+    "theme",
+    "block",
+    "notification",
+  ]),
+  homepage: z.string().url().optional(),
+  adapters: z
+    .array(
+      z.enum(["email", "payment", "storage", "search", "auth", "newsletter"]),
+    )
+    .optional(),
+  ui: z.array(z.string()).optional(),
+  permissions: z
+    .array(
+      z.enum([
+        "submissions:read",
+        "submissions:write",
+        "files:read",
+        "files:write",
+        "email:send",
+        "http:outbound",
+        "storage:read",
+        "storage:write",
+        "search:read",
+        "search:write",
+        "payment:read",
+        "payment:write",
+        "pipeline:read",
+        "pipeline:write",
+        "publications:read",
+        "publications:write",
+        "members:read",
+        "database:read",
+        "database:write",
+      ]),
+    )
+    .optional(),
+  dependencies: z.record(z.string(), z.string()).optional(),
+});

--- a/packages/plugin-sdk/src/registry.ts
+++ b/packages/plugin-sdk/src/registry.ts
@@ -1,0 +1,55 @@
+import type {
+  AdapterInfo,
+  AdapterType,
+  BaseAdapter,
+} from "./adapters/common.js";
+import { AdapterNotFoundError } from "./errors.js";
+
+export class AdapterRegistry {
+  private adapters = new Map<AdapterType, BaseAdapter>();
+
+  register<T extends BaseAdapter>(type: AdapterType, adapter: T): void {
+    this.adapters.set(type, adapter);
+  }
+
+  resolve<T extends BaseAdapter>(type: AdapterType): T {
+    const adapter = this.adapters.get(type);
+    if (!adapter) {
+      throw new AdapterNotFoundError(type);
+    }
+    return adapter as T;
+  }
+
+  tryResolve<T extends BaseAdapter>(type: AdapterType): T | null {
+    const adapter = this.adapters.get(type);
+    return (adapter as T) ?? null;
+  }
+
+  has(type: AdapterType): boolean {
+    return this.adapters.has(type);
+  }
+
+  listRegistered(type: AdapterType): AdapterInfo[] {
+    const adapter = this.adapters.get(type);
+    if (!adapter) return [];
+    return [
+      {
+        id: adapter.id,
+        name: adapter.name,
+        version: adapter.version,
+        type,
+        active: true,
+      },
+    ];
+  }
+
+  listAllTypes(): AdapterType[] {
+    return [...this.adapters.keys()];
+  }
+
+  async destroyAll(): Promise<void> {
+    const adapters = [...this.adapters.values()];
+    this.adapters.clear();
+    await Promise.all(adapters.map((a) => a.destroy()));
+  }
+}

--- a/packages/plugin-sdk/src/registry.ts
+++ b/packages/plugin-sdk/src/registry.ts
@@ -50,6 +50,12 @@ export class AdapterRegistry {
   async destroyAll(): Promise<void> {
     const adapters = [...this.adapters.values()];
     this.adapters.clear();
-    await Promise.all(adapters.map((a) => a.destroy()));
+    const results = await Promise.allSettled(adapters.map((a) => a.destroy()));
+    for (const result of results) {
+      if (result.status === "rejected") {
+        // Best-effort cleanup — log but don't throw so all adapters get destroyed
+        console.error("Adapter destroy failed:", result.reason);
+      }
+    }
   }
 }

--- a/packages/plugin-sdk/src/testing/index.ts
+++ b/packages/plugin-sdk/src/testing/index.ts
@@ -1,0 +1,13 @@
+export {
+  MockEmailAdapter,
+  MockPaymentAdapter,
+  MockSearchAdapter,
+  MockStorageAdapter,
+} from "./mock-adapters.js";
+export {
+  createMockBootstrapContext,
+  createMockRegisterContext,
+  type MockRegisterContext,
+} from "./mock-context.js";
+export { createNoopLogger } from "./noop-logger.js";
+export { createTestHarness, type TestHarness } from "./test-harness.js";

--- a/packages/plugin-sdk/src/testing/mock-adapters.ts
+++ b/packages/plugin-sdk/src/testing/mock-adapters.ts
@@ -233,7 +233,13 @@ export class MockSearchAdapter implements SearchAdapter {
 async function streamToBuffer(stream: Readable): Promise<Buffer> {
   const chunks: Buffer[] = [];
   for await (const chunk of stream) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+    chunks.push(
+      Buffer.isBuffer(chunk)
+        ? chunk
+        : Buffer.from(
+            typeof chunk === "string" ? chunk : (chunk as Uint8Array),
+          ),
+    );
   }
   return Buffer.concat(chunks);
 }

--- a/packages/plugin-sdk/src/testing/mock-adapters.ts
+++ b/packages/plugin-sdk/src/testing/mock-adapters.ts
@@ -1,0 +1,239 @@
+import type { Readable } from "node:stream";
+
+import { z } from "zod";
+
+import type { AdapterHealthResult } from "../adapters/common.js";
+import type {
+  EmailAdapter,
+  SendEmailOptions,
+  SendEmailResult,
+} from "../adapters/email.js";
+import type {
+  CheckoutSessionParams,
+  CheckoutSessionResult,
+  PaymentAdapter,
+  PaymentWebhookEvent,
+  RefundResult,
+  WebhookHandleResult,
+} from "../adapters/payment.js";
+import type {
+  SearchAdapter,
+  SearchDocument,
+  SearchQuery,
+  SearchResult,
+} from "../adapters/search.js";
+import type {
+  StorageAdapter,
+  UploadOptions,
+  UploadResult,
+} from "../adapters/storage.js";
+
+// ── Mock Email ──
+
+export class MockEmailAdapter implements EmailAdapter {
+  readonly id = "mock-email";
+  readonly name = "Mock Email";
+  readonly version = "0.0.0";
+  readonly configSchema = z.object({}).passthrough();
+
+  sentEmails: SendEmailOptions[] = [];
+
+  async initialize(): Promise<void> {}
+  async healthCheck(): Promise<AdapterHealthResult> {
+    return { healthy: true, message: "Mock email OK" };
+  }
+  async destroy(): Promise<void> {}
+
+  async send(options: SendEmailOptions): Promise<SendEmailResult> {
+    this.sentEmails.push(options);
+    return { success: true, messageId: `mock-${Date.now()}` };
+  }
+
+  getLastEmail(): SendEmailOptions | undefined {
+    return this.sentEmails[this.sentEmails.length - 1];
+  }
+
+  reset(): void {
+    this.sentEmails = [];
+  }
+}
+
+// ── Mock Payment ──
+
+export class MockPaymentAdapter implements PaymentAdapter {
+  readonly id = "mock-payment";
+  readonly name = "Mock Payment";
+  readonly version = "0.0.0";
+  readonly configSchema = z.object({}).passthrough();
+
+  sessions: CheckoutSessionParams[] = [];
+  refunds: Array<{ paymentId: string; amount?: number }> = [];
+
+  async initialize(): Promise<void> {}
+  async healthCheck(): Promise<AdapterHealthResult> {
+    return { healthy: true, message: "Mock payment OK" };
+  }
+  async destroy(): Promise<void> {}
+
+  async createCheckoutSession(
+    params: CheckoutSessionParams,
+  ): Promise<CheckoutSessionResult> {
+    this.sessions.push(params);
+    return {
+      sessionId: `sess-${Date.now()}`,
+      url: "https://mock.pay/checkout",
+    };
+  }
+
+  async verifyWebhook(
+    _headers: Record<string, string>,
+    _body: string,
+  ): Promise<PaymentWebhookEvent> {
+    return { id: "evt-mock", type: "payment.completed", data: {} };
+  }
+
+  async handleWebhookEvent(
+    _event: PaymentWebhookEvent,
+  ): Promise<WebhookHandleResult> {
+    return { handled: true };
+  }
+
+  async refund(paymentId: string, amount?: number): Promise<RefundResult> {
+    this.refunds.push({ paymentId, amount });
+    return {
+      refundId: `ref-${Date.now()}`,
+      status: "succeeded",
+      amount: amount ?? 0,
+    };
+  }
+
+  reset(): void {
+    this.sessions = [];
+    this.refunds = [];
+  }
+}
+
+// ── Mock Storage ──
+
+export class MockStorageAdapter implements StorageAdapter {
+  readonly id = "mock-storage";
+  readonly name = "Mock Storage";
+  readonly version = "0.0.0";
+  readonly configSchema = z.object({}).passthrough();
+
+  files = new Map<string, Buffer>();
+
+  async initialize(): Promise<void> {}
+  async healthCheck(): Promise<AdapterHealthResult> {
+    return { healthy: true, message: "Mock storage OK" };
+  }
+  async destroy(): Promise<void> {}
+
+  async upload(options: UploadOptions): Promise<UploadResult> {
+    const buf =
+      options.body instanceof Buffer
+        ? options.body
+        : await streamToBuffer(options.body as Readable);
+    this.files.set(options.key, buf);
+    return { key: options.key, size: buf.length };
+  }
+
+  async download(key: string): Promise<Readable> {
+    const buf = this.files.get(key);
+    if (!buf) throw new Error(`Key not found: ${key}`);
+    const { Readable: ReadableStream } = await import("node:stream");
+    return ReadableStream.from(buf);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.files.delete(key);
+  }
+
+  async exists(key: string): Promise<boolean> {
+    return this.files.has(key);
+  }
+
+  async getSignedUrl(key: string): Promise<string> {
+    return `https://mock.storage/${key}?signed=true`;
+  }
+
+  async move(sourceKey: string, destinationKey: string): Promise<void> {
+    const buf = this.files.get(sourceKey);
+    if (!buf) throw new Error(`Key not found: ${sourceKey}`);
+    this.files.set(destinationKey, buf);
+    this.files.delete(sourceKey);
+  }
+
+  reset(): void {
+    this.files.clear();
+  }
+}
+
+// ── Mock Search ──
+
+export class MockSearchAdapter implements SearchAdapter {
+  readonly id = "mock-search";
+  readonly name = "Mock Search";
+  readonly version = "0.0.0";
+  readonly configSchema = z.object({}).passthrough();
+
+  documents = new Map<string, SearchDocument>();
+
+  async initialize(): Promise<void> {}
+  async healthCheck(): Promise<AdapterHealthResult> {
+    return { healthy: true, message: "Mock search OK" };
+  }
+  async destroy(): Promise<void> {}
+
+  async index(document: SearchDocument): Promise<void> {
+    this.documents.set(`${document.index}:${document.id}`, document);
+  }
+
+  async indexBulk(documents: SearchDocument[]): Promise<void> {
+    for (const doc of documents) {
+      await this.index(doc);
+    }
+  }
+
+  async search(query: SearchQuery): Promise<SearchResult> {
+    const start = Date.now();
+    const hits = [...this.documents.values()]
+      .filter((doc) => {
+        if (doc.index !== query.index) return false;
+        const text = JSON.stringify(doc.fields).toLowerCase();
+        return text.includes(query.query.toLowerCase());
+      })
+      .map((doc) => ({
+        id: doc.id,
+        score: 1,
+        fields: doc.fields,
+      }));
+
+    return {
+      hits: hits.slice(
+        query.offset ?? 0,
+        (query.offset ?? 0) + (query.limit ?? 10),
+      ),
+      total: hits.length,
+      took: Date.now() - start,
+    };
+  }
+
+  async remove(documentId: string, index: string): Promise<void> {
+    this.documents.delete(`${index}:${documentId}`);
+  }
+
+  reset(): void {
+    this.documents.clear();
+  }
+}
+
+// ── Helpers ──
+
+async function streamToBuffer(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+  }
+  return Buffer.concat(chunks);
+}

--- a/packages/plugin-sdk/src/testing/mock-context.ts
+++ b/packages/plugin-sdk/src/testing/mock-context.ts
@@ -1,0 +1,69 @@
+import type { AdapterType, BaseAdapter } from "../adapters/common.js";
+import type { HookHandlerOptions } from "../hooks/engine.js";
+import type { HookId } from "../hooks/definitions.js";
+import type { HookPayloadMap } from "../hooks/payloads.js";
+import type {
+  AuditFn,
+  PluginBootstrapContext,
+  PluginRegisterContext,
+} from "../plugin-base.js";
+import type { UIExtensionDeclaration } from "../ui/types.js";
+import { createNoopLogger } from "./noop-logger.js";
+
+export interface MockRegisterContext extends PluginRegisterContext {
+  registeredAdapters: Array<{ type: AdapterType; adapter: BaseAdapter }>;
+  registeredHooks: Array<{
+    hookId: HookId;
+    handler: (payload: unknown) => unknown;
+    options?: HookHandlerOptions;
+  }>;
+  registeredUIExtensions: UIExtensionDeclaration[];
+}
+
+export function createMockRegisterContext(): MockRegisterContext {
+  const ctx: MockRegisterContext = {
+    registeredAdapters: [],
+    registeredHooks: [],
+    registeredUIExtensions: [],
+    logger: createNoopLogger(),
+
+    registerAdapter(type: AdapterType, adapter: BaseAdapter) {
+      ctx.registeredAdapters.push({ type, adapter });
+    },
+
+    registerHook<T extends HookId>(
+      hookId: T,
+      handler: (payload: HookPayloadMap[T]) => void | Promise<void>,
+      options?: HookHandlerOptions,
+    ) {
+      ctx.registeredHooks.push({
+        hookId,
+        handler: handler as (payload: unknown) => unknown,
+        options,
+      });
+    },
+
+    registerUIExtension(extension: UIExtensionDeclaration) {
+      ctx.registeredUIExtensions.push(extension);
+    },
+  };
+
+  return ctx;
+}
+
+export function createMockBootstrapContext(
+  overrides?: Partial<PluginBootstrapContext>,
+): PluginBootstrapContext {
+  const registerCtx = createMockRegisterContext();
+  const noopAudit: AuditFn = async () => {};
+
+  return {
+    ...registerCtx,
+    resolveAdapter: (_type: AdapterType) => {
+      throw new Error("No adapter registered in mock context");
+    },
+    config: {},
+    audit: noopAudit,
+    ...overrides,
+  } as PluginBootstrapContext;
+}

--- a/packages/plugin-sdk/src/testing/noop-logger.ts
+++ b/packages/plugin-sdk/src/testing/noop-logger.ts
@@ -1,0 +1,13 @@
+import type { Logger } from "../logger.js";
+
+export function createNoopLogger(): Logger {
+  const noop = () => {};
+  const logger: Logger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    child: () => logger,
+  };
+  return logger;
+}

--- a/packages/plugin-sdk/src/testing/test-harness.ts
+++ b/packages/plugin-sdk/src/testing/test-harness.ts
@@ -1,0 +1,65 @@
+import type { AdapterType, BaseAdapter } from "../adapters/common.js";
+import { HookEngine } from "../hooks/engine.js";
+import type { ColophonyPlugin } from "../plugin-base.js";
+import { AdapterRegistry } from "../registry.js";
+import { createNoopLogger } from "./noop-logger.js";
+
+export interface TestHarness {
+  registry: AdapterRegistry;
+  hookEngine: HookEngine;
+  loadPlugin(plugin: ColophonyPlugin): Promise<void>;
+  teardown(): Promise<void>;
+}
+
+export function createTestHarness(): TestHarness {
+  const logger = createNoopLogger();
+  const registry = new AdapterRegistry();
+  const hookEngine = new HookEngine(logger);
+  const loadedPlugins: ColophonyPlugin[] = [];
+
+  return {
+    registry,
+    hookEngine,
+
+    async loadPlugin(plugin: ColophonyPlugin) {
+      await plugin.register({
+        registerAdapter: (type, adapter) => registry.register(type, adapter),
+        registerHook: (hookId, handler, options) => {
+          hookEngine.on(hookId, handler, {
+            ...options,
+            pluginId: plugin.manifest.id,
+          });
+        },
+        registerUIExtension: () => {},
+        logger: logger.child({ plugin: plugin.manifest.id }),
+      });
+
+      await plugin.bootstrap({
+        registerAdapter: (type, adapter) => registry.register(type, adapter),
+        registerHook: (hookId, handler, options) => {
+          hookEngine.on(hookId, handler, {
+            ...options,
+            pluginId: plugin.manifest.id,
+          });
+        },
+        registerUIExtension: () => {},
+        resolveAdapter: <T extends BaseAdapter>(type: AdapterType) =>
+          registry.resolve<T>(type),
+        config: {},
+        audit: async () => {},
+        logger: logger.child({ plugin: plugin.manifest.id }),
+      });
+
+      loadedPlugins.push(plugin);
+    },
+
+    async teardown() {
+      for (const plugin of loadedPlugins) {
+        await plugin.destroy();
+      }
+      loadedPlugins.length = 0;
+      hookEngine.removeAll();
+      await registry.destroyAll();
+    },
+  };
+}

--- a/packages/plugin-sdk/src/ui/types.ts
+++ b/packages/plugin-sdk/src/ui/types.ts
@@ -1,0 +1,19 @@
+export type UIContributionPoint =
+  | "dashboard.widget"
+  | "submission.detail.section"
+  | "submission.list.action"
+  | "pipeline.stage.action"
+  | "settings.section"
+  | "navigation.item"
+  | "form.field"
+  | "publication.preview";
+
+export interface UIExtensionDeclaration {
+  point: UIContributionPoint;
+  id: string;
+  label: string;
+  icon?: string;
+  requiredPermissions?: string[];
+  component: string;
+  order?: number;
+}

--- a/packages/plugin-sdk/src/version.ts
+++ b/packages/plugin-sdk/src/version.ts
@@ -1,0 +1,2 @@
+export const SDK_VERSION = "0.0.0";
+export const MIN_COLOPHONY_VERSION = "2.0.0";

--- a/packages/plugin-sdk/tsconfig.json
+++ b/packages/plugin-sdk/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@colophony/typescript-config/library.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/plugin-sdk/vitest.config.ts
+++ b/packages/plugin-sdk/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.{test,spec}.ts"],
+    globals: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -526,6 +526,25 @@ importers:
         specifier: ^2.29.0
         version: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
 
+  packages/plugin-sdk:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@colophony/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^25.3.0
+        version: 25.3.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/types:
     dependencies:
       zod:


### PR DESCRIPTION
## Summary

- New `@colophony/plugin-sdk` package with adapter interfaces (email, payment, storage, search), `AdapterRegistry`, `HookEngine` (14 typed hooks: 11 action + 3 filter), `PluginManifest` with Zod validation, `ColophonyPlugin` abstract class with two-phase lifecycle, `defineConfig`/`loadConfig` config loader, UI contribution point types, and testing utilities (mock adapters, test harness)
- 37 tests across 5 test files — registry, hook engine, config loader, manifest validation, testing utils
- SDK-only package in `packages/plugin-sdk/` — no changes to existing app code (PR2 will refactor existing adapters and wire into `main.ts`)

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `src/hooks/engine.ts` | `on()` handler returns `void \| Promise<void>` | Returns `HookPayloadMap[T] \| void \| Promise<...>` | Filter handlers must return modified payload; single `on()` method (plan noted this as [exploratory]) |

## Test plan

- [x] `pnpm install` — registers new workspace package
- [x] `pnpm --filter @colophony/plugin-sdk build` — compiles to `dist/`
- [x] `pnpm --filter @colophony/plugin-sdk test` — all 37 tests pass
- [x] `pnpm type-check` — no regressions (12/12 packages)
- [x] `pnpm lint` — passes
- [x] OpenCode branch review — LGTM, all findings addressed