### PR TITLE
feat: UI contribution points — SDK, tRPC, PluginSlot (Track 6, PR3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,9 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **Documenso webhook**    | `apps/api/src/webhooks/documenso.webhook.ts`                                     |
 | **Inngest functions**    | `apps/api/src/inngest/`                                                          |
 | **Adapter registry**     | `apps/api/src/adapters/registry-accessor.ts` (module-level singleton)            |
-| **Config builder**       | `apps/api/src/colophony.config.ts` (maps env → adapter configs)                  |
+| **Extensions store**     | `apps/api/src/adapters/extensions-accessor.ts` (UI extension singleton)          |
+| **Config builder**       | `apps/api/src/colophony.config.ts` (maps env → adapter configs + plugins)        |
+| **Built-in plugins**     | `apps/api/src/plugins/` (plugin classes registered in config)                    |
 | **SDK adapters**         | `apps/api/src/adapters/{email,storage,payment}/` (SDK-compatible)                |
 | **CMS adapters**         | `apps/api/src/adapters/cms/`                                                     |
 | **Federation discovery** | `apps/api/src/federation/discovery.routes.ts`                                    |
@@ -68,6 +70,8 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **Hub client service**   | `apps/api/src/services/hub-client.service.ts`                                    |
 | **Next.js frontend**     | `apps/web/`                                                                      |
 | **tRPC client**          | `apps/web/src/lib/trpc.ts`                                                       |
+| **Plugin components**    | `apps/web/src/components/plugins/` (PluginSlot, extensions, error boundary)      |
+| **Component registry**   | `apps/web/src/lib/plugin-components.ts` (build-time Map registry)                |
 | **Env config (Zod)**     | `apps/api/src/config/env.ts`                                                     |
 | **Plugin SDK**           | `packages/plugin-sdk/src/` (adapters, hooks, config, plugin-base, testing)       |
 | **Backlog**              | `docs/backlog.md` (track-organized, drives session focus)                        |

--- a/apps/api/src/adapters/__tests__/extensions-accessor.spec.ts
+++ b/apps/api/src/adapters/__tests__/extensions-accessor.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { UIExtensionDeclaration } from '@colophony/plugin-sdk';
+import {
+  getGlobalExtensions,
+  setGlobalExtensions,
+} from '../extensions-accessor.js';
+
+describe('extensions-accessor', () => {
+  beforeEach(() => {
+    setGlobalExtensions([]);
+  });
+
+  it('getGlobalExtensions returns empty array before init', () => {
+    expect(getGlobalExtensions()).toEqual([]);
+  });
+
+  it('set then get returns same extensions', () => {
+    const exts: UIExtensionDeclaration[] = [
+      {
+        point: 'dashboard.widget',
+        id: 'test-widget',
+        label: 'Test',
+        component: 'test.widget',
+      },
+    ];
+    setGlobalExtensions(exts);
+    expect(getGlobalExtensions()).toBe(exts);
+  });
+
+  it('set replaces previous extensions', () => {
+    const first: UIExtensionDeclaration[] = [
+      {
+        point: 'dashboard.widget',
+        id: 'first',
+        label: 'First',
+        component: 'first.widget',
+      },
+    ];
+    const second: UIExtensionDeclaration[] = [
+      {
+        point: 'settings.section',
+        id: 'second',
+        label: 'Second',
+        component: 'second.section',
+      },
+    ];
+
+    setGlobalExtensions(first);
+    setGlobalExtensions(second);
+
+    const result = getGlobalExtensions();
+    expect(result).toBe(second);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('second');
+  });
+});

--- a/apps/api/src/adapters/extensions-accessor.ts
+++ b/apps/api/src/adapters/extensions-accessor.ts
@@ -1,0 +1,13 @@
+import type { UIExtensionDeclaration } from '@colophony/plugin-sdk';
+
+let _extensions: UIExtensionDeclaration[] = [];
+
+export function setGlobalExtensions(
+  extensions: UIExtensionDeclaration[],
+): void {
+  _extensions = extensions;
+}
+
+export function getGlobalExtensions(): UIExtensionDeclaration[] {
+  return _extensions;
+}

--- a/apps/api/src/colophony.config.ts
+++ b/apps/api/src/colophony.config.ts
@@ -4,12 +4,16 @@ import { SmtpEmailAdapter } from './adapters/email/smtp-sdk.adapter.js';
 import { SendGridEmailAdapter } from './adapters/email/sendgrid-sdk.adapter.js';
 import { S3StorageAdapter } from './adapters/storage/index.js';
 import { StripePaymentAdapter } from './adapters/payment/index.js';
+import { BuiltInExtensionsPlugin } from './plugins/built-in-extensions.plugin.js';
 
 export function buildColophonyConfig(env: Env): {
   config: ColophonyConfig;
   adapterConfigs: Partial<Record<AdapterType, Record<string, unknown>>>;
 } {
-  const config: ColophonyConfig = { adapters: {} };
+  const config: ColophonyConfig = {
+    adapters: {},
+    plugins: [new BuiltInExtensionsPlugin()],
+  };
   const adapterConfigs: Partial<Record<AdapterType, Record<string, unknown>>> =
     {};
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,6 +5,7 @@ import { pool } from '@colophony/db';
 import { loadConfig } from '@colophony/plugin-sdk';
 import { type Env, validateEnv } from './config/env.js';
 import { buildColophonyConfig } from './colophony.config.js';
+import { setGlobalExtensions } from './adapters/extensions-accessor.js';
 import { setGlobalRegistry } from './adapters/registry-accessor.js';
 import authPlugin from './hooks/auth.js';
 import rateLimitPlugin from './hooks/rate-limit.js';
@@ -306,12 +307,13 @@ async function start(): Promise<void> {
 
   // Initialize plugin SDK adapters + registry
   const { config, adapterConfigs } = buildColophonyConfig(env);
-  const { registry } = await loadConfig({
+  const { registry, uiExtensions } = await loadConfig({
     config,
     adapterConfigs,
     logger: app.log,
   });
   setGlobalRegistry(registry);
+  setGlobalExtensions(uiExtensions);
 
   // Start BullMQ workers
   if (env.VIRUS_SCAN_ENABLED) {

--- a/apps/api/src/plugins/built-in-extensions.plugin.ts
+++ b/apps/api/src/plugins/built-in-extensions.plugin.ts
@@ -1,0 +1,29 @@
+import {
+  ColophonyPlugin,
+  type PluginManifest,
+  type PluginRegisterContext,
+} from '@colophony/plugin-sdk';
+
+export class BuiltInExtensionsPlugin extends ColophonyPlugin {
+  readonly manifest: PluginManifest = {
+    id: 'colophony-built-in-extensions',
+    name: 'Built-in Extensions',
+    version: '1.0.0',
+    colophonyVersion: '2.0.0',
+    description: 'Demo UI extensions bundled with Colophony',
+    author: 'Colophony',
+    license: 'MIT',
+    category: 'integration',
+  };
+
+  async register(ctx: PluginRegisterContext): Promise<void> {
+    ctx.registerUIExtension({
+      point: 'dashboard.widget',
+      id: 'colophony-word-count-widget',
+      label: 'Word Count Stats',
+      icon: 'BarChart3',
+      component: 'colophony.word-count-widget',
+      order: 100,
+    });
+  }
+}

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -19,6 +19,7 @@ import { issuesRouter } from './routers/issues.js';
 import { cmsConnectionsRouter } from './routers/cms-connections.js';
 import { notificationPreferencesRouter } from './routers/notification-preferences.js';
 import { notificationsRouter } from './routers/notifications.js';
+import { pluginsRouter } from './routers/plugins.js';
 import { webhooksRouter } from './routers/webhooks.js';
 
 // Re-export procedure builders for convenience
@@ -61,6 +62,7 @@ export const appRouter = t.router({
   notificationPreferences: notificationPreferencesRouter,
   notifications: notificationsRouter,
   webhooks: webhooksRouter,
+  plugins: pluginsRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/plugins.spec.ts
+++ b/apps/api/src/trpc/routers/plugins.spec.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { UIExtensionDeclaration } from '@colophony/plugin-sdk';
+import type { TRPCContext } from '../context.js';
+
+const { mockGetGlobalExtensions } = vi.hoisted(() => {
+  const mockGetGlobalExtensions = vi.fn(() => [] as UIExtensionDeclaration[]);
+  return { mockGetGlobalExtensions };
+});
+
+vi.mock('../../adapters/extensions-accessor.js', () => ({
+  getGlobalExtensions: mockGetGlobalExtensions,
+}));
+
+import { appRouter } from '../router.js';
+
+function makeContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
+  return {
+    authContext: null,
+    dbTx: null,
+    audit: vi.fn(),
+    ...overrides,
+  };
+}
+
+function orgContext(
+  role: 'ADMIN' | 'EDITOR' | 'READER' = 'ADMIN',
+  overrides: Partial<TRPCContext> = {},
+): TRPCContext {
+  const mockTx = {} as never;
+  return makeContext({
+    authContext: {
+      userId: 'user-1',
+      zitadelUserId: 'zid-1',
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+      orgId: 'org-1',
+      role,
+    },
+    dbTx: mockTx,
+    audit: vi.fn(),
+    ...overrides,
+  });
+}
+
+const createCaller = (appRouter as any).createCaller as (
+  ctx: TRPCContext,
+) => any;
+
+const sampleExtensions: UIExtensionDeclaration[] = [
+  {
+    point: 'dashboard.widget',
+    id: 'widget-1',
+    label: 'Widget 1',
+    component: 'test.widget',
+    order: 10,
+  },
+  {
+    point: 'settings.section',
+    id: 'settings-1',
+    label: 'Settings 1',
+    component: 'test.settings',
+    requiredPermissions: ['settings:read'],
+    order: 20,
+  },
+  {
+    point: 'dashboard.widget',
+    id: 'widget-2',
+    label: 'Widget 2',
+    component: 'test.widget2',
+    requiredPermissions: ['database:write'],
+    order: 5,
+  },
+];
+
+describe('plugins router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGlobalExtensions.mockReturnValue(sampleExtensions);
+  });
+
+  describe('listExtensions', () => {
+    it('returns all extensions for ADMIN', async () => {
+      const caller = createCaller(orgContext('ADMIN'));
+      const result = await caller.plugins.listExtensions({});
+
+      expect(result).toHaveLength(3);
+    });
+
+    it('filters by requiredPermissions for READER', async () => {
+      const caller = createCaller(orgContext('READER'));
+      const result = await caller.plugins.listExtensions({});
+
+      // READER has no settings:read or database:write
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('widget-1');
+    });
+
+    it('filters by point', async () => {
+      const caller = createCaller(orgContext('ADMIN'));
+      const result = await caller.plugins.listExtensions({
+        point: 'dashboard.widget',
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result.every((e: any) => e.point === 'dashboard.widget')).toBe(
+        true,
+      );
+    });
+
+    it('sorts by order ascending, nullish last', async () => {
+      mockGetGlobalExtensions.mockReturnValue([
+        {
+          point: 'dashboard.widget',
+          id: 'no-order',
+          label: 'No Order',
+          component: 'a',
+        },
+        {
+          point: 'dashboard.widget',
+          id: 'order-50',
+          label: 'Order 50',
+          component: 'b',
+          order: 50,
+        },
+        {
+          point: 'dashboard.widget',
+          id: 'order-10',
+          label: 'Order 10',
+          component: 'c',
+          order: 10,
+        },
+      ]);
+
+      const caller = createCaller(orgContext('ADMIN'));
+      const result = await caller.plugins.listExtensions({});
+
+      expect(result.map((e: any) => e.id)).toEqual([
+        'order-10',
+        'order-50',
+        'no-order',
+      ]);
+    });
+
+    it('returns empty when no extensions', async () => {
+      mockGetGlobalExtensions.mockReturnValue([]);
+      const caller = createCaller(orgContext('ADMIN'));
+      const result = await caller.plugins.listExtensions({});
+
+      expect(result).toEqual([]);
+    });
+
+    it('requires org context', async () => {
+      const caller = createCaller(
+        makeContext({
+          authContext: {
+            userId: 'user-1',
+            zitadelUserId: 'zid-1',
+            email: 'test@example.com',
+            emailVerified: true,
+            authMethod: 'test',
+            orgId: undefined as any,
+            role: undefined as any,
+          },
+        }),
+      );
+
+      await expect(caller.plugins.listExtensions({})).rejects.toThrow(
+        /Organization/i,
+      );
+    });
+
+    it('rejects unauthenticated', async () => {
+      const caller = createCaller(makeContext());
+
+      await expect(caller.plugins.listExtensions({})).rejects.toThrow(
+        /authenticated/i,
+      );
+    });
+  });
+});

--- a/apps/api/src/trpc/routers/plugins.spec.ts
+++ b/apps/api/src/trpc/routers/plugins.spec.ts
@@ -96,6 +96,16 @@ describe('plugins router', () => {
       expect(result[0].id).toBe('widget-1');
     });
 
+    it('filters by requiredPermissions for EDITOR', async () => {
+      const caller = createCaller(orgContext('EDITOR'));
+      const result = await caller.plugins.listExtensions({});
+
+      // EDITOR has database:write but not settings:read
+      expect(result).toHaveLength(2);
+      // widget-2 (order=5) sorts before widget-1 (order=10)
+      expect(result.map((e: any) => e.id)).toEqual(['widget-2', 'widget-1']);
+    });
+
     it('filters by point', async () => {
       const caller = createCaller(orgContext('ADMIN'));
       const result = await caller.plugins.listExtensions({

--- a/apps/api/src/trpc/routers/plugins.ts
+++ b/apps/api/src/trpc/routers/plugins.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod';
+import type { UIExtensionDeclaration } from '@colophony/plugin-sdk';
+import { createRouter, orgProcedure } from '../init.js';
+import { getGlobalExtensions } from '../../adapters/extensions-accessor.js';
+
+const uiExtensionPointEnum = z.enum([
+  'dashboard.widget',
+  'submission.detail.section',
+  'submission.list.action',
+  'pipeline.stage.action',
+  'settings.section',
+  'navigation.item',
+  'form.field',
+  'publication.preview',
+]);
+
+const uiExtensionSchema = z.object({
+  point: uiExtensionPointEnum,
+  id: z.string(),
+  label: z.string(),
+  icon: z.string().optional(),
+  requiredPermissions: z.array(z.string()).optional(),
+  component: z.string(),
+  order: z.number().optional(),
+});
+
+/**
+ * Build the set of granted permissions for an org role.
+ * ADMIN gets everything; EDITOR gets read + write; READER gets read-only.
+ */
+function buildPermissionsForRole(
+  role: 'ADMIN' | 'EDITOR' | 'READER',
+): Set<string> {
+  const perms = new Set<string>();
+
+  // Read permissions for all roles
+  perms.add('submissions:read');
+  perms.add('forms:read');
+  perms.add('files:read');
+  perms.add('publications:read');
+  perms.add('pipeline:read');
+  perms.add('issues:read');
+  perms.add('contracts:read');
+
+  if (role === 'EDITOR' || role === 'ADMIN') {
+    perms.add('submissions:write');
+    perms.add('forms:write');
+    perms.add('files:write');
+    perms.add('publications:write');
+    perms.add('pipeline:write');
+    perms.add('issues:write');
+    perms.add('contracts:write');
+    perms.add('database:write');
+  }
+
+  if (role === 'ADMIN') {
+    perms.add('settings:read');
+    perms.add('settings:write');
+    perms.add('members:read');
+    perms.add('members:write');
+    perms.add('audit:read');
+    perms.add('api-keys:read');
+    perms.add('api-keys:write');
+    perms.add('webhooks:read');
+    perms.add('webhooks:write');
+  }
+
+  return perms;
+}
+
+function extensionAllowed(
+  ext: UIExtensionDeclaration,
+  grantedPermissions: Set<string>,
+): boolean {
+  if (!ext.requiredPermissions || ext.requiredPermissions.length === 0) {
+    return true;
+  }
+  return ext.requiredPermissions.every((p) => grantedPermissions.has(p));
+}
+
+export const pluginsRouter = createRouter({
+  listExtensions: orgProcedure
+    .input(
+      z
+        .object({ point: uiExtensionPointEnum.optional() })
+        .optional()
+        .default({}),
+    )
+    .output(z.array(uiExtensionSchema))
+    .query(({ ctx, input }) => {
+      const extensions = getGlobalExtensions();
+      const granted = buildPermissionsForRole(ctx.authContext.role);
+
+      let filtered = extensions.filter((ext) => extensionAllowed(ext, granted));
+
+      if (input.point) {
+        filtered = filtered.filter((ext) => ext.point === input.point);
+      }
+
+      // Sort by order ascending, nullish last
+      filtered.sort((a, b) => {
+        const aOrder = a.order ?? Number.MAX_SAFE_INTEGER;
+        const bOrder = b.order ?? Number.MAX_SAFE_INTEGER;
+        return aOrder - bOrder;
+      });
+
+      return filtered;
+    }),
+});

--- a/apps/web/src/app/(dashboard)/editor/dashboard-plugin-slot.tsx
+++ b/apps/web/src/app/(dashboard)/editor/dashboard-plugin-slot.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { PluginSlot } from "@/components/plugins/plugin-slot";
+
+export function DashboardPluginSlot() {
+  return (
+    <PluginSlot
+      point="dashboard.widget"
+      className="grid gap-4 md:grid-cols-2 lg:grid-cols-3"
+    />
+  );
+}

--- a/apps/web/src/app/(dashboard)/editor/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/page.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { ClipboardList, Inbox } from "lucide-react";
+import { DashboardPluginSlot } from "./dashboard-plugin-slot";
 
 export default function EditorPage() {
   return (
@@ -66,6 +67,8 @@ export default function EditorPage() {
           </Card>
         </Link>
       </div>
+
+      <DashboardPluginSlot />
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/page.tsx
@@ -37,6 +37,7 @@ import {
   Settings as SettingsIcon,
 } from "lucide-react";
 import { NotificationPreferencesCard } from "@/components/settings/notification-preferences-card";
+import { PluginSlot } from "@/components/plugins/plugin-slot";
 
 export default function SettingsPage() {
   const { user } = useAuth();
@@ -200,6 +201,8 @@ export default function SettingsPage() {
 
       {/* Notification Preferences */}
       <NotificationPreferencesCard />
+
+      <PluginSlot point="settings.section" className="space-y-6" />
 
       {/* Privacy & Data */}
       <Card>

--- a/apps/web/src/components/layout/__tests__/sidebar.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/sidebar.spec.tsx
@@ -7,6 +7,10 @@ let mockIsEditor = false;
 let mockIsAdmin = false;
 let mockPathname = "/";
 
+jest.mock("@/components/plugins/plugin-slot", () => ({
+  PluginSlot: () => null,
+}));
+
 jest.mock("@/hooks/use-organization", () => ({
   useOrganization: () => ({
     isEditor: mockIsEditor,

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { useOrganization } from "@/hooks/use-organization";
+import { PluginSlot } from "@/components/plugins/plugin-slot";
 import {
   BookCopy,
   BookMarked,
@@ -182,6 +183,8 @@ export function Sidebar() {
             })}
           </>
         )}
+
+        <PluginSlot point="navigation.item" className="space-y-1" />
       </nav>
     </div>
   );

--- a/apps/web/src/components/plugins/__tests__/plugin-slot.spec.tsx
+++ b/apps/web/src/components/plugins/__tests__/plugin-slot.spec.tsx
@@ -1,0 +1,164 @@
+import { render, screen } from "@testing-library/react";
+import { PluginSlot } from "../plugin-slot";
+import {
+  registerComponent,
+  type PluginComponentProps,
+} from "@/lib/plugin-components";
+
+// --- Mutable mock state ---
+let mockExtensions: any[] = [];
+let mockIsLoading = false;
+let mockError: Error | null = null;
+
+let mockCurrentOrg: any = {
+  id: "org-1",
+  name: "Test Org",
+  role: "ADMIN",
+};
+let mockUser: any = { id: "user-1", email: "test@example.com" };
+
+jest.mock("@/hooks/use-plugin-extensions", () => ({
+  usePluginExtensions: () => ({
+    extensions: mockExtensions,
+    isLoading: mockIsLoading,
+    error: mockError,
+  }),
+}));
+
+jest.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({ currentOrg: mockCurrentOrg }),
+}));
+
+jest.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ user: mockUser }),
+}));
+
+describe("PluginSlot", () => {
+  beforeEach(() => {
+    mockExtensions = [];
+    mockIsLoading = false;
+    mockError = null;
+    mockCurrentOrg = {
+      id: "org-1",
+      name: "Test Org",
+      role: "ADMIN",
+    };
+    mockUser = { id: "user-1", email: "test@example.com" };
+  });
+
+  it("renders nothing when no extensions", () => {
+    const { container } = render(<PluginSlot point="dashboard.widget" />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders resolved plugin components", () => {
+    const TestWidget = (props: PluginComponentProps) => (
+      <div data-testid="test-widget">Widget: {props.extensionId}</div>
+    );
+    registerComponent("test.render-widget", TestWidget);
+
+    mockExtensions = [
+      {
+        point: "dashboard.widget",
+        id: "render-widget",
+        label: "Render Widget",
+        component: "test.render-widget",
+      },
+    ];
+
+    render(<PluginSlot point="dashboard.widget" />);
+
+    expect(screen.getByTestId("test-widget")).toHaveTextContent(
+      "Widget: render-widget",
+    );
+  });
+
+  it("catches errors with error boundary", () => {
+    const ErrorWidget = () => {
+      throw new Error("Widget crashed");
+    };
+    registerComponent("test.error-widget", ErrorWidget as any);
+
+    mockExtensions = [
+      {
+        point: "dashboard.widget",
+        id: "error-widget",
+        label: "Error Widget",
+        component: "test.error-widget",
+      },
+    ];
+
+    // Suppress React error boundary console.error
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    render(<PluginSlot point="dashboard.widget" />);
+
+    expect(screen.getByText(/Plugin Error/)).toBeInTheDocument();
+    expect(screen.getByText(/Widget crashed/)).toBeInTheDocument();
+
+    errorSpy.mockRestore();
+  });
+
+  it("passes context to plugin components", () => {
+    const ContextWidget = (props: PluginComponentProps) => (
+      <div data-testid="ctx-widget">{JSON.stringify(props.context)}</div>
+    );
+    registerComponent("test.ctx-widget", ContextWidget);
+
+    mockExtensions = [
+      {
+        point: "submission.detail.section",
+        id: "ctx-ext",
+        label: "Ctx",
+        component: "test.ctx-widget",
+      },
+    ];
+
+    render(
+      <PluginSlot
+        point="submission.detail.section"
+        context={{ submissionId: "sub-1" }}
+      />,
+    );
+
+    expect(screen.getByTestId("ctx-widget")).toHaveTextContent(
+      '{"submissionId":"sub-1"}',
+    );
+  });
+
+  it("renders nothing when no org", () => {
+    mockCurrentOrg = null;
+    mockExtensions = [
+      {
+        point: "dashboard.widget",
+        id: "any",
+        label: "Any",
+        component: "test.any",
+      },
+    ];
+
+    const { container } = render(<PluginSlot point="dashboard.widget" />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("sets data-plugin-slot attribute", () => {
+    const SlotWidget = () => <div>Slot</div>;
+    registerComponent("test.slot-attr-widget", SlotWidget as any);
+
+    mockExtensions = [
+      {
+        point: "settings.section",
+        id: "attr-ext",
+        label: "Attr",
+        component: "test.slot-attr-widget",
+      },
+    ];
+
+    const { container } = render(<PluginSlot point="settings.section" />);
+
+    const slot = container.querySelector(
+      "[data-plugin-slot='settings.section']",
+    );
+    expect(slot).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/plugins/__tests__/plugin-slot.spec.tsx
+++ b/apps/web/src/components/plugins/__tests__/plugin-slot.spec.tsx
@@ -1,3 +1,4 @@
+import type { ComponentType } from "react";
 import { render, screen } from "@testing-library/react";
 import { PluginSlot } from "../plugin-slot";
 import {
@@ -6,16 +7,29 @@ import {
 } from "@/lib/plugin-components";
 
 // --- Mutable mock state ---
-let mockExtensions: any[] = [];
+let mockExtensions: {
+  point: string;
+  id: string;
+  label: string;
+  component: string;
+  order?: number;
+}[] = [];
 let mockIsLoading = false;
 let mockError: Error | null = null;
 
-let mockCurrentOrg: any = {
+let mockCurrentOrg: {
+  id: string;
+  name: string;
+  role: string;
+} | null = {
   id: "org-1",
   name: "Test Org",
   role: "ADMIN",
 };
-let mockUser: any = { id: "user-1", email: "test@example.com" };
+let mockUser: { id: string; email: string } | null = {
+  id: "user-1",
+  email: "test@example.com",
+};
 
 jest.mock("@/hooks/use-plugin-extensions", () => ({
   usePluginExtensions: () => ({
@@ -77,7 +91,10 @@ describe("PluginSlot", () => {
     const ErrorWidget = () => {
       throw new Error("Widget crashed");
     };
-    registerComponent("test.error-widget", ErrorWidget as any);
+    registerComponent(
+      "test.error-widget",
+      ErrorWidget as unknown as ComponentType<PluginComponentProps>,
+    );
 
     mockExtensions = [
       {
@@ -143,7 +160,10 @@ describe("PluginSlot", () => {
 
   it("sets data-plugin-slot attribute", () => {
     const SlotWidget = () => <div>Slot</div>;
-    registerComponent("test.slot-attr-widget", SlotWidget as any);
+    registerComponent(
+      "test.slot-attr-widget",
+      SlotWidget as unknown as ComponentType<PluginComponentProps>,
+    );
 
     mockExtensions = [
       {

--- a/apps/web/src/components/plugins/extensions/index.ts
+++ b/apps/web/src/components/plugins/extensions/index.ts
@@ -1,0 +1,4 @@
+import { registerComponent } from "@/lib/plugin-components";
+import { WordCountWidget } from "./word-count-widget";
+
+registerComponent("colophony.word-count-widget", WordCountWidget);

--- a/apps/web/src/components/plugins/extensions/word-count-widget.tsx
+++ b/apps/web/src/components/plugins/extensions/word-count-widget.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { PluginComponentProps } from "@/lib/plugin-components";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { BarChart3 } from "lucide-react";
+
+export function WordCountWidget(_props: PluginComponentProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <BarChart3 className="h-4 w-4 text-muted-foreground" />
+          Word Count Stats
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <p className="text-2xl font-bold">12,847</p>
+            <p className="text-xs text-muted-foreground">Total Words</p>
+          </div>
+          <div>
+            <p className="text-2xl font-bold">42</p>
+            <p className="text-xs text-muted-foreground">Submissions</p>
+          </div>
+          <div>
+            <p className="text-2xl font-bold">306</p>
+            <p className="text-xs text-muted-foreground">Avg per Piece</p>
+          </div>
+          <div>
+            <p className="text-2xl font-bold">3,201</p>
+            <p className="text-xs text-muted-foreground">Longest Piece</p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/plugins/plugin-slot.tsx
+++ b/apps/web/src/components/plugins/plugin-slot.tsx
@@ -107,7 +107,17 @@ export function PluginSlot({
       ): entry is {
         ext: (typeof extensions)[number];
         Component: React.ComponentType<PluginComponentProps>;
-      } => entry.Component !== null,
+      } => {
+        if (entry.Component === null) {
+          if (process.env.NODE_ENV === "development") {
+            console.warn(
+              `[PluginSlot] No component registered for key "${entry.ext.component}" (extension "${entry.ext.id}")`,
+            );
+          }
+          return false;
+        }
+        return true;
+      },
     );
 
   if (resolved.length === 0 && hideEmpty) {

--- a/apps/web/src/components/plugins/plugin-slot.tsx
+++ b/apps/web/src/components/plugins/plugin-slot.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import {
+  usePluginExtensions,
+  type UIContributionPoint,
+} from "@/hooks/use-plugin-extensions";
+import { useOrganization } from "@/hooks/use-organization";
+import { useAuth } from "@/hooks/use-auth";
+import {
+  resolveComponent,
+  type PluginComponentProps,
+} from "@/lib/plugin-components";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { AlertTriangle } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Error boundary
+// ---------------------------------------------------------------------------
+
+interface ErrorBoundaryProps {
+  extensionId: string;
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+class PluginErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(
+      `[PluginSlot] Extension "${this.props.extensionId}" crashed:`,
+      error,
+      info,
+    );
+  }
+
+  override render(): ReactNode {
+    if (this.state.error) {
+      return (
+        <Card className="border-destructive">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-sm text-destructive">
+              <AlertTriangle className="h-4 w-4" />
+              Plugin Error
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-xs text-muted-foreground">
+              Extension &quot;{this.props.extensionId}&quot; encountered an
+              error: {this.state.error.message}
+            </p>
+          </CardContent>
+        </Card>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PluginSlot
+// ---------------------------------------------------------------------------
+
+export interface PluginSlotProps {
+  point: UIContributionPoint;
+  context?: Record<string, unknown>;
+  className?: string;
+  hideEmpty?: boolean;
+}
+
+export function PluginSlot({
+  point,
+  context,
+  className,
+  hideEmpty = true,
+}: PluginSlotProps) {
+  const { extensions, isLoading } = usePluginExtensions(point);
+  const { currentOrg } = useOrganization();
+  const { user } = useAuth();
+
+  if (isLoading || !currentOrg || !user) {
+    return null;
+  }
+
+  const resolved = extensions
+    .map((ext) => ({
+      ext,
+      Component: resolveComponent(ext.component),
+    }))
+    .filter(
+      (
+        entry,
+      ): entry is {
+        ext: (typeof extensions)[number];
+        Component: React.ComponentType<PluginComponentProps>;
+      } => entry.Component !== null,
+    );
+
+  if (resolved.length === 0 && hideEmpty) {
+    return null;
+  }
+
+  return (
+    <div data-plugin-slot={point} className={className}>
+      {resolved.map(({ ext, Component }) => (
+        <PluginErrorBoundary key={ext.id} extensionId={ext.id}>
+          <Component
+            orgId={currentOrg.id}
+            userId={user.id}
+            role={currentOrg.role}
+            extensionId={ext.id}
+            context={context}
+          />
+        </PluginErrorBoundary>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -4,6 +4,9 @@ import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { trpc, getTrpcClient } from "@/lib/trpc";
 
+// Side-effect: registers built-in plugin components at module parse time
+import "@/components/plugins/extensions";
+
 /**
  * Root providers component
  * Wraps the app with tRPC and TanStack Query providers.

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { formatDistanceToNow, format } from "date-fns";
 import { trpc } from "@/lib/trpc";
 import { useOrganization } from "@/hooks/use-organization";
+import { PluginSlot } from "@/components/plugins/plugin-slot";
 import { StatusBadge } from "./status-badge";
 import { StatusTransition } from "./status-transition";
 import { Button } from "@/components/ui/button";
@@ -354,6 +355,12 @@ export function SubmissionDetail({
               </CardContent>
             </Card>
           )}
+
+          <PluginSlot
+            point="submission.detail.section"
+            context={{ submissionId: submission.id }}
+            className="space-y-4"
+          />
         </div>
 
         {/* Sidebar */}

--- a/apps/web/src/hooks/__tests__/use-plugin-extensions.spec.ts
+++ b/apps/web/src/hooks/__tests__/use-plugin-extensions.spec.ts
@@ -2,17 +2,23 @@ import { renderHook } from "@testing-library/react";
 import { usePluginExtensions } from "../use-plugin-extensions";
 
 // --- Mutable mock state ---
-let mockData: any[] | undefined;
+interface MockExtension {
+  point: string;
+  id: string;
+  label: string;
+  component: string;
+}
+let mockData: MockExtension[] | undefined;
 let mockIsPending = false;
 let mockError: Error | null = null;
-let lastQueryArgs: any;
-let lastQueryOptions: any;
+let lastQueryArgs: { point: string } | undefined;
+let lastQueryOptions: { staleTime: number } | undefined;
 
 jest.mock("@/lib/trpc", () => ({
   trpc: {
     plugins: {
       listExtensions: {
-        useQuery: (args: any, opts: any) => {
+        useQuery: (args: { point: string }, opts: { staleTime: number }) => {
           lastQueryArgs = args;
           lastQueryOptions = opts;
           return { data: mockData, isPending: mockIsPending, error: mockError };

--- a/apps/web/src/hooks/__tests__/use-plugin-extensions.spec.ts
+++ b/apps/web/src/hooks/__tests__/use-plugin-extensions.spec.ts
@@ -1,0 +1,72 @@
+import { renderHook } from "@testing-library/react";
+import { usePluginExtensions } from "../use-plugin-extensions";
+
+// --- Mutable mock state ---
+let mockData: any[] | undefined;
+let mockIsPending = false;
+let mockError: Error | null = null;
+let lastQueryArgs: any;
+let lastQueryOptions: any;
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    plugins: {
+      listExtensions: {
+        useQuery: (args: any, opts: any) => {
+          lastQueryArgs = args;
+          lastQueryOptions = opts;
+          return { data: mockData, isPending: mockIsPending, error: mockError };
+        },
+      },
+    },
+  },
+}));
+
+describe("usePluginExtensions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockData = undefined;
+    mockIsPending = false;
+    mockError = null;
+    lastQueryArgs = undefined;
+    lastQueryOptions = undefined;
+  });
+
+  it("returns empty extensions while loading", () => {
+    mockIsPending = true;
+    mockData = undefined;
+
+    const { result } = renderHook(() =>
+      usePluginExtensions("dashboard.widget"),
+    );
+
+    expect(result.current.extensions).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("returns extensions from tRPC query", () => {
+    mockData = [
+      {
+        point: "dashboard.widget",
+        id: "test-widget",
+        label: "Test",
+        component: "test.widget",
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      usePluginExtensions("dashboard.widget"),
+    );
+
+    expect(result.current.extensions).toHaveLength(1);
+    expect(result.current.extensions[0].id).toBe("test-widget");
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("passes point parameter to query", () => {
+    renderHook(() => usePluginExtensions("settings.section"));
+
+    expect(lastQueryArgs).toEqual({ point: "settings.section" });
+    expect(lastQueryOptions).toEqual({ staleTime: 5 * 60 * 1000 });
+  });
+});

--- a/apps/web/src/hooks/use-plugin-extensions.ts
+++ b/apps/web/src/hooks/use-plugin-extensions.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { trpc } from "@/lib/trpc";
+
+export type UIContributionPoint =
+  | "dashboard.widget"
+  | "submission.detail.section"
+  | "submission.list.action"
+  | "pipeline.stage.action"
+  | "settings.section"
+  | "navigation.item"
+  | "form.field"
+  | "publication.preview";
+
+export function usePluginExtensions(point: UIContributionPoint) {
+  const { data, isPending, error } = trpc.plugins.listExtensions.useQuery(
+    { point },
+    { staleTime: 5 * 60 * 1000 },
+  );
+
+  return {
+    extensions: data ?? [],
+    isLoading: isPending,
+    error: error ?? null,
+  };
+}

--- a/apps/web/src/hooks/use-plugin-extensions.ts
+++ b/apps/web/src/hooks/use-plugin-extensions.ts
@@ -2,6 +2,8 @@
 
 import { trpc } from "@/lib/trpc";
 
+// Keep in sync with packages/plugin-sdk/src/ui/types.ts UIContributionPoint
+// and apps/api/src/trpc/routers/plugins.ts uiExtensionPointEnum
 export type UIContributionPoint =
   | "dashboard.widget"
   | "submission.detail.section"

--- a/apps/web/src/lib/__tests__/plugin-components.spec.ts
+++ b/apps/web/src/lib/__tests__/plugin-components.spec.ts
@@ -1,19 +1,17 @@
+import type { ComponentType } from "react";
 import {
   registerComponent,
   resolveComponent,
   listRegisteredKeys,
+  type PluginComponentProps,
 } from "../plugin-components";
 
-// Reset registry between tests — since it's a module-level Map, we clear it
-beforeEach(() => {
-  // Re-register nothing; resolveComponent returns null for unregistered
-  // We need to clear by re-importing or just testing in order
-});
+const stub = (() => null) as unknown as ComponentType<PluginComponentProps>;
 
 describe("plugin-components registry", () => {
   it("registerComponent stores and resolveComponent retrieves", () => {
-    const TestComponent = () => null;
-    registerComponent("test.component", TestComponent as any);
+    const TestComponent = stub;
+    registerComponent("test.component", TestComponent);
     expect(resolveComponent("test.component")).toBe(TestComponent);
   });
 
@@ -23,11 +21,12 @@ describe("plugin-components registry", () => {
 
   it("registerComponent warns on duplicate and overwrites", () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-    const First = () => null;
-    const Second = () => null;
+    const First = stub;
+    const Second = (() =>
+      null) as unknown as ComponentType<PluginComponentProps>;
 
-    registerComponent("dup.key", First as any);
-    registerComponent("dup.key", Second as any);
+    registerComponent("dup.key", First);
+    registerComponent("dup.key", Second);
 
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("Overwriting"),
@@ -37,8 +36,8 @@ describe("plugin-components registry", () => {
   });
 
   it("listRegisteredKeys returns all keys", () => {
-    registerComponent("key.a", (() => null) as any);
-    registerComponent("key.b", (() => null) as any);
+    registerComponent("key.a", stub);
+    registerComponent("key.b", stub);
 
     const keys = listRegisteredKeys();
     expect(keys).toContain("key.a");

--- a/apps/web/src/lib/__tests__/plugin-components.spec.ts
+++ b/apps/web/src/lib/__tests__/plugin-components.spec.ts
@@ -1,0 +1,47 @@
+import {
+  registerComponent,
+  resolveComponent,
+  listRegisteredKeys,
+} from "../plugin-components";
+
+// Reset registry between tests — since it's a module-level Map, we clear it
+beforeEach(() => {
+  // Re-register nothing; resolveComponent returns null for unregistered
+  // We need to clear by re-importing or just testing in order
+});
+
+describe("plugin-components registry", () => {
+  it("registerComponent stores and resolveComponent retrieves", () => {
+    const TestComponent = () => null;
+    registerComponent("test.component", TestComponent as any);
+    expect(resolveComponent("test.component")).toBe(TestComponent);
+  });
+
+  it("resolveComponent returns null for unregistered key", () => {
+    expect(resolveComponent("nonexistent.key")).toBeNull();
+  });
+
+  it("registerComponent warns on duplicate and overwrites", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const First = () => null;
+    const Second = () => null;
+
+    registerComponent("dup.key", First as any);
+    registerComponent("dup.key", Second as any);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Overwriting"),
+    );
+    expect(resolveComponent("dup.key")).toBe(Second);
+    warnSpy.mockRestore();
+  });
+
+  it("listRegisteredKeys returns all keys", () => {
+    registerComponent("key.a", (() => null) as any);
+    registerComponent("key.b", (() => null) as any);
+
+    const keys = listRegisteredKeys();
+    expect(keys).toContain("key.a");
+    expect(keys).toContain("key.b");
+  });
+});

--- a/apps/web/src/lib/plugin-components.ts
+++ b/apps/web/src/lib/plugin-components.ts
@@ -1,0 +1,33 @@
+import type { ComponentType } from "react";
+
+export interface PluginComponentProps {
+  orgId: string;
+  userId: string;
+  role: "ADMIN" | "EDITOR" | "READER";
+  extensionId: string;
+  context?: Record<string, unknown>;
+}
+
+const registry = new Map<string, ComponentType<PluginComponentProps>>();
+
+export function registerComponent(
+  key: string,
+  component: ComponentType<PluginComponentProps>,
+): void {
+  if (registry.has(key)) {
+    console.warn(
+      `[plugin-components] Overwriting existing component for key "${key}"`,
+    );
+  }
+  registry.set(key, component);
+}
+
+export function resolveComponent(
+  key: string,
+): ComponentType<PluginComponentProps> | null {
+  return registry.get(key) ?? null;
+}
+
+export function listRegisteredKeys(): string[] {
+  return Array.from(registry.keys());
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -193,7 +193,7 @@
 
 ### Phase 3-4 (v2.1-v2.2)
 
-- [ ] UI contribution point system (dashboard widgets, settings pages, submission detail sections) — (plugin research Section 11)
+- [x] UI contribution point system (dashboard widgets, settings pages, submission detail sections) — (plugin research Section 11; done 2026-02-26 PR3)
 - [ ] In-app Plugin Gallery (JSON registry, one-click install) — (plugin research Section 11)
 - [ ] `@colophony/create-plugin` scaffolding CLI — (plugin research Section 11)
 - [ ] Evaluate n8n / Activepieces as recommended external automation target — security: must be network-isolated — (decision 2026-02-15)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,30 @@ Newest entries first.
 
 ---
 
+## 2026-02-26 — Track 6: UI Contribution Point System (PR3)
+
+### Done
+
+- **SDK:** Typed `uiExtensions` as `UIExtensionDeclaration[]` in `LoadConfigResult`, returned from `loadConfig()` (previously collected but discarded)
+- **Backend extensions store:** Module-level singleton (`extensions-accessor.ts`) following registry-accessor pattern; wired in `main.ts` after `loadConfig()`
+- **tRPC plugins router:** `plugins.listExtensions` query with role-based permission filtering (ADMIN=all, EDITOR=read+write, READER=read-only), optional point filter, order sorting
+- **Frontend component registry:** `plugin-components.ts` — `registerComponent()`/`resolveComponent()` Map-based registry for build-time component resolution
+- **`usePluginExtensions` hook:** Wraps `trpc.plugins.listExtensions.useQuery` with 5-min stale time
+- **`<PluginSlot>` component:** Generic slot with class-based error boundary, permission-aware rendering, `data-plugin-slot` attribute; uses `useOrganization` + `useAuth` for context
+- **Demo plugin:** `BuiltInExtensionsPlugin` registers `dashboard.widget` → word-count stats card; frontend component registered via side-effect import in `providers.tsx`
+- **4 contribution points wired:** Editor dashboard, submission detail, settings page, sidebar navigation
+- **27 new tests** across 6 test files (SDK 4, API 10, Web 13); all existing tests updated/passing
+- **Verification:** 13/13 type-check, 1638 total tests pass, production build succeeds
+
+### Decisions
+
+- `UIContributionPoint` type defined locally in web app (not importing from `@colophony/plugin-sdk`) — web doesn't have plugin-sdk as dependency; avoids coupling frontend to backend SDK
+- Editor page uses thin client wrapper (`dashboard-plugin-slot.tsx`) since editor page is a server component but PluginSlot uses hooks
+- Permission model is role-based: `buildPermissionsForRole()` returns a `Set<string>` of granted permissions; extensions with `requiredPermissions` are filtered against it
+- Side-effect import in `providers.tsx` for component registration — runs at module parse time before child mount
+
+---
+
 ## 2026-02-26 — Track 6: Adapter SDK Refactor + Config Loader (PR2 of 2)
 
 ### Done

--- a/packages/plugin-sdk/src/__tests__/config-ui-extensions.spec.ts
+++ b/packages/plugin-sdk/src/__tests__/config-ui-extensions.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { loadConfig } from "../config.js";
+import type { ColophonyPlugin } from "../plugin-base.js";
+import type { PluginManifest } from "../plugin.js";
+import { createNoopLogger } from "../testing/noop-logger.js";
+
+function makeManifest(id: string): PluginManifest {
+  return {
+    id,
+    name: id,
+    version: "1.0.0",
+    colophonyVersion: "2.0.0",
+    description: "Test",
+    author: "Test",
+    license: "MIT",
+    category: "integration",
+  };
+}
+
+describe("loadConfig — UI extensions", () => {
+  it("returns empty uiExtensions when no plugins", async () => {
+    const result = await loadConfig({
+      config: {},
+      logger: createNoopLogger(),
+    });
+    expect(result.uiExtensions).toEqual([]);
+  });
+
+  it("collects UI extensions from plugin register phase", async () => {
+    const plugin: ColophonyPlugin = {
+      manifest: makeManifest("ext-plugin"),
+      register: vi.fn(async (ctx) => {
+        ctx.registerUIExtension({
+          point: "dashboard.widget",
+          id: "test-widget",
+          label: "Test Widget",
+          component: "test.widget",
+          order: 10,
+        });
+      }),
+      bootstrap: vi.fn(),
+      destroy: vi.fn(),
+    };
+
+    const result = await loadConfig({
+      config: { plugins: [plugin] },
+      logger: createNoopLogger(),
+    });
+
+    expect(result.uiExtensions).toHaveLength(1);
+    expect(result.uiExtensions[0]).toMatchObject({
+      point: "dashboard.widget",
+      id: "test-widget",
+      component: "test.widget",
+    });
+  });
+
+  it("collects UI extensions from multiple plugins", async () => {
+    const plugin1: ColophonyPlugin = {
+      manifest: makeManifest("plugin-1"),
+      register: vi.fn(async (ctx) => {
+        ctx.registerUIExtension({
+          point: "dashboard.widget",
+          id: "widget-1",
+          label: "Widget 1",
+          component: "p1.widget",
+        });
+      }),
+      bootstrap: vi.fn(),
+      destroy: vi.fn(),
+    };
+
+    const plugin2: ColophonyPlugin = {
+      manifest: makeManifest("plugin-2"),
+      register: vi.fn(async (ctx) => {
+        ctx.registerUIExtension({
+          point: "settings.section",
+          id: "settings-ext",
+          label: "Settings Extension",
+          component: "p2.settings",
+        });
+      }),
+      bootstrap: vi.fn(),
+      destroy: vi.fn(),
+    };
+
+    const result = await loadConfig({
+      config: { plugins: [plugin1, plugin2] },
+      logger: createNoopLogger(),
+    });
+
+    expect(result.uiExtensions).toHaveLength(2);
+    expect(result.uiExtensions.map((e) => e.id)).toEqual([
+      "widget-1",
+      "settings-ext",
+    ]);
+  });
+
+  it("includes extensions from bootstrap phase", async () => {
+    const plugin: ColophonyPlugin = {
+      manifest: makeManifest("bootstrap-plugin"),
+      register: vi.fn(),
+      bootstrap: vi.fn(async (ctx) => {
+        ctx.registerUIExtension({
+          point: "navigation.item",
+          id: "nav-ext",
+          label: "Nav Extension",
+          component: "boot.nav",
+        });
+      }),
+      destroy: vi.fn(),
+    };
+
+    const result = await loadConfig({
+      config: { plugins: [plugin] },
+      logger: createNoopLogger(),
+    });
+
+    expect(result.uiExtensions).toHaveLength(1);
+    expect(result.uiExtensions[0].id).toBe("nav-ext");
+  });
+});

--- a/packages/plugin-sdk/src/config.ts
+++ b/packages/plugin-sdk/src/config.ts
@@ -4,6 +4,7 @@ import { HookEngine } from "./hooks/engine.js";
 import type { Logger } from "./logger.js";
 import type { ColophonyPlugin } from "./plugin-base.js";
 import { AdapterRegistry } from "./registry.js";
+import type { UIExtensionDeclaration } from "./ui/types.js";
 
 export type AdapterConstructor<T extends BaseAdapter = BaseAdapter> =
   new () => T;
@@ -29,6 +30,7 @@ export interface LoadConfigResult {
   registry: AdapterRegistry;
   hookEngine: HookEngine;
   plugins: ColophonyPlugin[];
+  uiExtensions: UIExtensionDeclaration[];
 }
 
 export function defineConfig(config: ColophonyConfig): ColophonyConfig {
@@ -77,7 +79,7 @@ export async function loadConfig(
   const auditFn = audit ?? noopAudit;
 
   // Phase 2: Plugin register
-  const uiExtensions: unknown[] = [];
+  const uiExtensions: UIExtensionDeclaration[] = [];
   for (const plugin of plugins) {
     await plugin.register({
       registerAdapter: (type, adapter) => registry.register(type, adapter),
@@ -111,5 +113,5 @@ export async function loadConfig(
     });
   }
 
-  return { registry, hookEngine, plugins };
+  return { registry, hookEngine, plugins, uiExtensions };
 }


### PR DESCRIPTION
## Summary

- **SDK**: `loadConfig()` now returns `uiExtensions: UIExtensionDeclaration[]` (previously collected but discarded)
- **Backend**: New `plugins.listExtensions` tRPC query with role-based permission filtering (ADMIN=all, EDITOR=read+write, READER=read-only), sorted by `order` ascending
- **Frontend**: Build-time component registry (`registerComponent`/`resolveComponent`), `usePluginExtensions` hook, `<PluginSlot>` component with per-extension error boundaries
- **Demo**: `BuiltInExtensionsPlugin` registers a "Word Count Stats" dashboard widget, rendered via `<PluginSlot point="dashboard.widget">`
- **Page integration**: PluginSlots wired into editor dashboard, submission detail, settings, and sidebar
- **Tests**: 28 new tests across 6 files (SDK config, extensions accessor, plugins router, component registry, hook, PluginSlot)

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `apps/web/src/hooks/use-plugin-extensions.ts` | Import `UIContributionPoint` from plugin-sdk | Defined locally with sync comment | Web app doesn't depend on `@colophony/plugin-sdk`; avoids adding cross-layer dependency |
| `apps/web/src/app/(dashboard)/editor/page.tsx` | Add `"use client"` or evaluate | Created `dashboard-plugin-slot.tsx` thin wrapper | Editor page stays as server component; wrapper isolates client boundary |

## Test plan

- [x] `pnpm type-check` — all 13 packages pass
- [x] `pnpm test` — 1638 tests pass (SDK 41, API 1200, Web 397)
- [x] `pnpm build` — API + Web production build succeeds
- [ ] Manual: start dev servers, navigate to `/editor` as admin, confirm Word Count Stats widget renders
- [ ] Manual: check DevTools Network for `trpc/plugins.listExtensions` call