### PR TITLE
feat(plugins): in-app plugin gallery (Track 6, PR4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **Inngest functions**    | `apps/api/src/inngest/`                                                          |
 | **Adapter registry**     | `apps/api/src/adapters/registry-accessor.ts` (module-level singleton)            |
 | **Extensions store**     | `apps/api/src/adapters/extensions-accessor.ts` (UI extension singleton)          |
+| **Plugins store**        | `apps/api/src/adapters/plugins-accessor.ts` (plugin manifest singleton)          |
+| **Plugin registry svc**  | `apps/api/src/services/plugin-registry.service.ts` (remote registry fetch+cache) |
 | **Config builder**       | `apps/api/src/colophony.config.ts` (maps env → adapter configs + plugins)        |
 | **Built-in plugins**     | `apps/api/src/plugins/` (plugin classes registered in config)                    |
 | **SDK adapters**         | `apps/api/src/adapters/{email,storage,payment}/` (SDK-compatible)                |
@@ -413,6 +415,7 @@ Canonical env definition with Zod validation: `apps/api/src/config/env.ts`
 | `NEXT_PUBLIC_API_URL`                                             | No       | `http://localhost:4000`      | Web            |
 | `NEXT_PUBLIC_ZITADEL_AUTHORITY` / `NEXT_PUBLIC_ZITADEL_CLIENT_ID` | —        | —                            | Web            |
 | `API_URL`                                                         | —        | —                            | Web (SSR only) |
+| `PLUGIN_REGISTRY_URL`                                             | No       | —                            | API            |
 
 ---
 

--- a/apps/api/src/adapters/__tests__/plugins-accessor.spec.ts
+++ b/apps/api/src/adapters/__tests__/plugins-accessor.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { PluginManifest } from '@colophony/plugin-sdk';
+import {
+  getGlobalPluginManifests,
+  setGlobalPluginManifests,
+} from '../plugins-accessor.js';
+
+function makeManifest(id: string): PluginManifest {
+  return {
+    id,
+    name: `Plugin ${id}`,
+    version: '1.0.0',
+    colophonyVersion: '2.0.0',
+    description: 'Test plugin',
+    author: 'Test',
+    license: 'MIT',
+    category: 'adapter',
+  };
+}
+
+describe('plugins-accessor', () => {
+  beforeEach(() => {
+    setGlobalPluginManifests([]);
+  });
+
+  it('returns empty array before init', () => {
+    expect(getGlobalPluginManifests()).toEqual([]);
+  });
+
+  it('set then get returns manifests', () => {
+    const manifests = [makeManifest('foo'), makeManifest('bar')];
+    setGlobalPluginManifests(manifests);
+    expect(getGlobalPluginManifests()).toEqual(manifests);
+  });
+
+  it('set replaces previous', () => {
+    setGlobalPluginManifests([makeManifest('first')]);
+    setGlobalPluginManifests([makeManifest('second')]);
+    const result = getGlobalPluginManifests();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('second');
+  });
+});

--- a/apps/api/src/adapters/plugins-accessor.ts
+++ b/apps/api/src/adapters/plugins-accessor.ts
@@ -1,0 +1,11 @@
+import type { PluginManifest } from '@colophony/plugin-sdk';
+
+let _manifests: PluginManifest[] = [];
+
+export function setGlobalPluginManifests(manifests: PluginManifest[]): void {
+  _manifests = manifests;
+}
+
+export function getGlobalPluginManifests(): PluginManifest[] {
+  return _manifests;
+}

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -117,6 +117,9 @@ const envSchema = z.object({
     .transform((v) => v === 'true'),
   SENDGRID_API_KEY: z.string().optional(),
   SENDGRID_FROM: z.string().optional(),
+
+  // Plugin registry
+  PLUGIN_REGISTRY_URL: z.string().url().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -6,6 +6,7 @@ import { loadConfig } from '@colophony/plugin-sdk';
 import { type Env, validateEnv } from './config/env.js';
 import { buildColophonyConfig } from './colophony.config.js';
 import { setGlobalExtensions } from './adapters/extensions-accessor.js';
+import { setGlobalPluginManifests } from './adapters/plugins-accessor.js';
 import { setGlobalRegistry } from './adapters/registry-accessor.js';
 import authPlugin from './hooks/auth.js';
 import rateLimitPlugin from './hooks/rate-limit.js';
@@ -307,13 +308,14 @@ async function start(): Promise<void> {
 
   // Initialize plugin SDK adapters + registry
   const { config, adapterConfigs } = buildColophonyConfig(env);
-  const { registry, uiExtensions } = await loadConfig({
+  const { registry, plugins, uiExtensions } = await loadConfig({
     config,
     adapterConfigs,
     logger: app.log,
   });
   setGlobalRegistry(registry);
   setGlobalExtensions(uiExtensions);
+  setGlobalPluginManifests(plugins.map((p) => p.manifest));
 
   // Start BullMQ workers
   if (env.VIRUS_SCAN_ENABLED) {

--- a/apps/api/src/services/__tests__/plugin-registry.service.spec.ts
+++ b/apps/api/src/services/__tests__/plugin-registry.service.spec.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  fetchPluginRegistry,
+  listRegistryEntries,
+  getRegistryEntry,
+  clearRegistryCache,
+} from '../plugin-registry.service.js';
+
+vi.mock('../../adapters/plugins-accessor.js', () => ({
+  getGlobalPluginManifests: vi.fn(() => []),
+}));
+
+import { getGlobalPluginManifests } from '../../adapters/plugins-accessor.js';
+const mockGetManifests = vi.mocked(getGlobalPluginManifests);
+
+function makeRegistryEntry(id: string, overrides?: Record<string, unknown>) {
+  return {
+    id,
+    name: `Plugin ${id}`,
+    version: '1.0.0',
+    colophonyVersion: '2.0.0',
+    description: `Description for ${id}`,
+    author: 'Test Author',
+    license: 'MIT',
+    category: 'adapter',
+    npmPackage: `@colophony/plugin-${id}`,
+    ...overrides,
+  };
+}
+
+describe('plugin-registry.service', () => {
+  beforeEach(() => {
+    clearRegistryCache();
+    vi.restoreAllMocks();
+    mockGetManifests.mockReturnValue([]);
+  });
+
+  it('fetches and parses valid registry', async () => {
+    const entries = [makeRegistryEntry('foo'), makeRegistryEntry('bar')];
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(entries), { status: 200 }),
+    );
+
+    const result = await fetchPluginRegistry(
+      'https://example.com/registry.json',
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('foo');
+    expect(result[1].id).toBe('bar');
+  });
+
+  it('returns cached data within TTL', async () => {
+    const entries = [makeRegistryEntry('cached')];
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify(entries), { status: 200 }),
+      );
+
+    await fetchPluginRegistry('https://example.com/registry.json');
+    await fetchPluginRegistry('https://example.com/registry.json');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches after cache expiry', async () => {
+    const entries = [makeRegistryEntry('fresh')];
+    const json = JSON.stringify(entries);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => new Response(json, { status: 200 }));
+
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValueOnce(now);
+    await fetchPluginRegistry('https://example.com/registry.json');
+
+    // Advance past TTL (1 hour + 1ms)
+    vi.spyOn(Date, 'now').mockReturnValueOnce(now + 3_600_001);
+    await fetchPluginRegistry('https://example.com/registry.json');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws on non-OK response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Not Found', { status: 404, statusText: 'Not Found' }),
+    );
+
+    await expect(
+      fetchPluginRegistry('https://example.com/registry.json'),
+    ).rejects.toThrow('Failed to fetch plugin registry: 404 Not Found');
+  });
+
+  it('throws on invalid schema', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify([{ invalid: true }]), { status: 200 }),
+    );
+
+    await expect(
+      fetchPluginRegistry('https://example.com/registry.json'),
+    ).rejects.toThrow();
+  });
+
+  it('marks installed plugins correctly', async () => {
+    const entries = [makeRegistryEntry('foo'), makeRegistryEntry('bar')];
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(entries), { status: 200 }),
+    );
+    mockGetManifests.mockReturnValue([
+      {
+        id: 'foo',
+        name: 'Plugin foo',
+        version: '1.0.0',
+        colophonyVersion: '2.0.0',
+        description: 'Test',
+        author: 'Test',
+        license: 'MIT',
+        category: 'adapter',
+      },
+    ]);
+
+    const result = await listRegistryEntries(
+      'https://example.com/registry.json',
+    );
+    expect(result.find((e) => e.id === 'foo')?.installed).toBe(true);
+    expect(result.find((e) => e.id === 'bar')?.installed).toBe(false);
+  });
+
+  it('getRegistryEntry returns entry with status', async () => {
+    const entries = [makeRegistryEntry('target')];
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(entries), { status: 200 }),
+    );
+
+    const result = await getRegistryEntry(
+      'https://example.com/registry.json',
+      'target',
+    );
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('target');
+    expect(result!.installed).toBe(false);
+  });
+
+  it('getRegistryEntry returns null for unknown', async () => {
+    const entries = [makeRegistryEntry('known')];
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(entries), { status: 200 }),
+    );
+
+    const result = await getRegistryEntry(
+      'https://example.com/registry.json',
+      'nonexistent',
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/apps/api/src/services/__tests__/plugin-registry.service.spec.ts
+++ b/apps/api/src/services/__tests__/plugin-registry.service.spec.ts
@@ -98,7 +98,7 @@ describe('plugin-registry.service', () => {
 
     await expect(
       fetchPluginRegistry('https://example.com/registry.json'),
-    ).rejects.toThrow();
+    ).rejects.toThrow('Plugin registry response failed validation');
   });
 
   it('marks installed plugins correctly', async () => {

--- a/apps/api/src/services/plugin-registry.service.ts
+++ b/apps/api/src/services/plugin-registry.service.ts
@@ -11,6 +11,7 @@ export type RegistryEntryWithStatus = PluginRegistryEntry & {
 // In-memory cache
 let _cache: { entries: PluginRegistryEntry[]; fetchedAt: number } | null = null;
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const FETCH_TIMEOUT_MS = 10_000; // 10 seconds
 
 export async function fetchPluginRegistry(
   registryUrl: string,
@@ -20,7 +21,9 @@ export async function fetchPluginRegistry(
     return _cache.entries;
   }
 
-  const response = await fetch(registryUrl);
+  const response = await fetch(registryUrl, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(
       `Failed to fetch plugin registry: ${response.status} ${response.statusText}`,
@@ -28,9 +31,16 @@ export async function fetchPluginRegistry(
   }
 
   const json: unknown = await response.json();
-  const entries = pluginRegistrySchema.parse(json);
-  _cache = { entries, fetchedAt: now };
-  return entries;
+
+  const result = pluginRegistrySchema.safeParse(json);
+  if (!result.success) {
+    throw new Error(
+      `Plugin registry response failed validation: ${result.error.issues.map((i) => i.message).join(', ')}`,
+    );
+  }
+
+  _cache = { entries: result.data, fetchedAt: now };
+  return result.data;
 }
 
 export async function listRegistryEntries(

--- a/apps/api/src/services/plugin-registry.service.ts
+++ b/apps/api/src/services/plugin-registry.service.ts
@@ -1,0 +1,58 @@
+import {
+  pluginRegistrySchema,
+  type PluginRegistryEntry,
+} from '@colophony/plugin-sdk';
+import { getGlobalPluginManifests } from '../adapters/plugins-accessor.js';
+
+export type RegistryEntryWithStatus = PluginRegistryEntry & {
+  installed: boolean;
+};
+
+// In-memory cache
+let _cache: { entries: PluginRegistryEntry[]; fetchedAt: number } | null = null;
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export async function fetchPluginRegistry(
+  registryUrl: string,
+): Promise<PluginRegistryEntry[]> {
+  const now = Date.now();
+  if (_cache && now - _cache.fetchedAt < CACHE_TTL_MS) {
+    return _cache.entries;
+  }
+
+  const response = await fetch(registryUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch plugin registry: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const json: unknown = await response.json();
+  const entries = pluginRegistrySchema.parse(json);
+  _cache = { entries, fetchedAt: now };
+  return entries;
+}
+
+export async function listRegistryEntries(
+  registryUrl: string,
+): Promise<RegistryEntryWithStatus[]> {
+  const entries = await fetchPluginRegistry(registryUrl);
+  const installedIds = new Set(getGlobalPluginManifests().map((m) => m.id));
+
+  return entries.map((entry) => ({
+    ...entry,
+    installed: installedIds.has(entry.id),
+  }));
+}
+
+export async function getRegistryEntry(
+  registryUrl: string,
+  pluginId: string,
+): Promise<RegistryEntryWithStatus | null> {
+  const entries = await listRegistryEntries(registryUrl);
+  return entries.find((e) => e.id === pluginId) ?? null;
+}
+
+export function clearRegistryCache(): void {
+  _cache = null;
+}

--- a/apps/api/src/trpc/routers/plugins.ts
+++ b/apps/api/src/trpc/routers/plugins.ts
@@ -1,7 +1,19 @@
 import { z } from 'zod';
-import type { UIExtensionDeclaration } from '@colophony/plugin-sdk';
-import { createRouter, orgProcedure } from '../init.js';
+import {
+  pluginRegistryEntrySchema,
+  type UIExtensionDeclaration,
+} from '@colophony/plugin-sdk';
+import { createRouter, adminProcedure, orgProcedure } from '../init.js';
 import { getGlobalExtensions } from '../../adapters/extensions-accessor.js';
+import { validateEnv } from '../../config/env.js';
+import {
+  listRegistryEntries,
+  getRegistryEntry,
+} from '../../services/plugin-registry.service.js';
+
+const registryEntryWithStatusSchema = pluginRegistryEntrySchema.extend({
+  installed: z.boolean(),
+});
 
 const uiExtensionPointEnum = z.enum([
   'dashboard.widget',
@@ -79,6 +91,23 @@ function extensionAllowed(
 }
 
 export const pluginsRouter = createRouter({
+  listRegistry: adminProcedure
+    .output(z.array(registryEntryWithStatusSchema))
+    .query(async () => {
+      const env = validateEnv();
+      if (!env.PLUGIN_REGISTRY_URL) return [];
+      return listRegistryEntries(env.PLUGIN_REGISTRY_URL);
+    }),
+
+  getRegistryEntry: adminProcedure
+    .input(z.object({ pluginId: z.string().min(1) }))
+    .output(registryEntryWithStatusSchema.nullable())
+    .query(async ({ input }) => {
+      const env = validateEnv();
+      if (!env.PLUGIN_REGISTRY_URL) return null;
+      return getRegistryEntry(env.PLUGIN_REGISTRY_URL, input.pluginId);
+    }),
+
   listExtensions: orgProcedure
     .input(
       z

--- a/apps/web/src/app/(dashboard)/plugins/page.tsx
+++ b/apps/web/src/app/(dashboard)/plugins/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { PluginGallery } from "@/components/plugins/plugin-gallery";
+
+export default function PluginsPage() {
+  return <PluginGallery />;
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Inbox,
   LayoutDashboard,
   Library,
+  Puzzle,
   Settings,
   Webhook,
 } from "lucide-react";
@@ -56,6 +57,11 @@ const adminNavigation = [
     name: "Webhooks",
     href: "/webhooks",
     icon: Webhook,
+  },
+  {
+    name: "Plugins",
+    href: "/plugins",
+    icon: Puzzle,
   },
 ];
 

--- a/apps/web/src/components/plugins/__tests__/plugin-detail-dialog.spec.tsx
+++ b/apps/web/src/components/plugins/__tests__/plugin-detail-dialog.spec.tsx
@@ -1,0 +1,163 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PluginDetailDialog } from "../plugin-detail-dialog";
+
+// --- Mutable mock state ---
+type MockRegistryEntry = {
+  id: string;
+  name: string;
+  description: string;
+  author: string;
+  category: string;
+  version: string;
+  installed: boolean;
+  verified?: boolean;
+  npmPackage: string;
+  license: string;
+  colophonyVersion: string;
+  installCommand?: string;
+  configExample?: string;
+  permissions?: string[];
+  repository?: string;
+  homepage?: string;
+  readme?: string;
+};
+
+let mockPlugin: MockRegistryEntry | null = null;
+let mockIsLoading = false;
+
+jest.mock("@/hooks/use-plugin-registry", () => ({
+  usePluginRegistryEntry: () => ({
+    plugin: mockPlugin,
+    isLoading: mockIsLoading,
+    error: null,
+  }),
+}));
+
+function makeEntry(overrides?: Partial<MockRegistryEntry>): MockRegistryEntry {
+  return {
+    id: "test-plugin",
+    name: "Test Plugin",
+    description: "A test plugin description.",
+    author: "Test Author",
+    category: "adapter",
+    version: "1.2.3",
+    installed: false,
+    npmPackage: "@colophony/plugin-test",
+    license: "MIT",
+    colophonyVersion: "2.0.0",
+    ...overrides,
+  };
+}
+
+describe("PluginDetailDialog", () => {
+  const onOpenChange = jest.fn();
+
+  beforeEach(() => {
+    mockPlugin = null;
+    mockIsLoading = false;
+    onOpenChange.mockClear();
+  });
+
+  it("renders plugin details", () => {
+    mockPlugin = makeEntry({
+      name: "My Plugin",
+      version: "3.0.0",
+      description: "Full description here.",
+    });
+    render(
+      <PluginDetailDialog
+        pluginId="test-plugin"
+        open={true}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    expect(screen.getByText("My Plugin")).toBeInTheDocument();
+    expect(screen.getByText("v3.0.0")).toBeInTheDocument();
+    expect(screen.getByText("Full description here.")).toBeInTheDocument();
+  });
+
+  it("shows install section when not installed", () => {
+    mockPlugin = makeEntry({
+      installed: false,
+      installCommand: "pnpm add @colophony/plugin-test",
+    });
+    render(
+      <PluginDetailDialog
+        pluginId="test-plugin"
+        open={true}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    expect(screen.getByText("Install")).toBeInTheDocument();
+    expect(
+      screen.getByText("pnpm add @colophony/plugin-test"),
+    ).toBeInTheDocument();
+  });
+
+  it("hides install section when installed", () => {
+    mockPlugin = makeEntry({
+      installed: true,
+      installCommand: "pnpm add @colophony/plugin-test",
+    });
+    render(
+      <PluginDetailDialog
+        pluginId="test-plugin"
+        open={true}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    expect(screen.getByText("Installed")).toBeInTheDocument();
+    expect(screen.queryByText("Install")).not.toBeInTheDocument();
+  });
+
+  it("copy button copies to clipboard", async () => {
+    const user = userEvent.setup();
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    mockPlugin = makeEntry({
+      installed: false,
+      installCommand: "pnpm add @colophony/plugin-test",
+    });
+    render(
+      <PluginDetailDialog
+        pluginId="test-plugin"
+        open={true}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    // Find the copy button next to install command
+    const installSection = screen.getByText("Install").parentElement!;
+    const copyButton = installSection.querySelector("button")!;
+    await user.click(copyButton);
+
+    expect(writeText).toHaveBeenCalledWith("pnpm add @colophony/plugin-test");
+  });
+
+  it("renders permission badges", () => {
+    mockPlugin = makeEntry({
+      permissions: ["email:send", "http:outbound", "storage:read"],
+    });
+    render(
+      <PluginDetailDialog
+        pluginId="test-plugin"
+        open={true}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    expect(screen.getByText("Permissions")).toBeInTheDocument();
+    expect(screen.getByText("email:send")).toBeInTheDocument();
+    expect(screen.getByText("http:outbound")).toBeInTheDocument();
+    expect(screen.getByText("storage:read")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/plugins/__tests__/plugin-gallery.spec.tsx
+++ b/apps/web/src/components/plugins/__tests__/plugin-gallery.spec.tsx
@@ -1,0 +1,136 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PluginGallery } from "../plugin-gallery";
+
+// --- Mutable mock state ---
+type MockPlugin = {
+  id: string;
+  name: string;
+  description: string;
+  author: string;
+  category: string;
+  version: string;
+  installed: boolean;
+  verified?: boolean;
+  tags?: string[];
+  npmPackage: string;
+  license: string;
+  colophonyVersion: string;
+};
+
+let mockPlugins: MockPlugin[] = [];
+let mockIsLoading = false;
+let mockError: Error | null = null;
+const mockRefetch = jest.fn();
+
+jest.mock("@/hooks/use-plugin-registry", () => ({
+  usePluginRegistry: () => ({
+    plugins: mockPlugins,
+    isLoading: mockIsLoading,
+    error: mockError,
+    refetch: mockRefetch,
+  }),
+  usePluginRegistryEntry: () => ({
+    plugin: null,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+function makePlugin(id: string, overrides?: Partial<MockPlugin>): MockPlugin {
+  return {
+    id,
+    name: `Plugin ${id}`,
+    description: `Description for ${id}`,
+    author: "Test Author",
+    category: "adapter",
+    version: "1.0.0",
+    installed: false,
+    npmPackage: `@colophony/plugin-${id}`,
+    license: "MIT",
+    colophonyVersion: "2.0.0",
+    ...overrides,
+  };
+}
+
+describe("PluginGallery", () => {
+  beforeEach(() => {
+    mockPlugins = [];
+    mockIsLoading = false;
+    mockError = null;
+  });
+
+  it("renders loading skeletons", () => {
+    mockIsLoading = true;
+    const { container } = render(<PluginGallery />);
+    // Skeleton cards use animate-pulse class
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders plugin cards", () => {
+    mockPlugins = [
+      makePlugin("alpha"),
+      makePlugin("beta"),
+      makePlugin("gamma"),
+    ];
+    render(<PluginGallery />);
+    expect(screen.getByText("Plugin alpha")).toBeInTheDocument();
+    expect(screen.getByText("Plugin beta")).toBeInTheDocument();
+    expect(screen.getByText("Plugin gamma")).toBeInTheDocument();
+  });
+
+  it("filters by search text", async () => {
+    const user = userEvent.setup();
+    mockPlugins = [
+      makePlugin("email-adapter", { name: "Email Adapter" }),
+      makePlugin("storage-adapter", { name: "Storage Adapter" }),
+    ];
+    render(<PluginGallery />);
+
+    const searchInput = screen.getByPlaceholderText("Search plugins...");
+    await user.type(searchInput, "Email");
+
+    expect(screen.getByText("Email Adapter")).toBeInTheDocument();
+    expect(screen.queryByText("Storage Adapter")).not.toBeInTheDocument();
+  });
+
+  it("filters by category tab", async () => {
+    const user = userEvent.setup();
+    mockPlugins = [
+      makePlugin("adapter-plugin", {
+        name: "My Adapter",
+        category: "adapter",
+      }),
+      makePlugin("workflow-plugin", {
+        name: "My Workflow",
+        category: "workflow",
+      }),
+    ];
+    render(<PluginGallery />);
+
+    const workflowTab = screen.getByRole("tab", { name: "Workflow" });
+    await user.click(workflowTab);
+
+    expect(screen.getByText("My Workflow")).toBeInTheDocument();
+    expect(screen.queryByText("My Adapter")).not.toBeInTheDocument();
+  });
+
+  it("opens detail dialog on card click", async () => {
+    const user = userEvent.setup();
+    mockPlugins = [makePlugin("clickable", { name: "Clickable Plugin" })];
+    render(<PluginGallery />);
+
+    const card = screen.getByText("Clickable Plugin");
+    await user.click(card);
+
+    // Dialog should open (DialogContent renders with role="dialog")
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("renders empty state", () => {
+    mockPlugins = [];
+    render(<PluginGallery />);
+    expect(screen.getByText("No plugins found.")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/plugins/__tests__/plugin-gallery.spec.tsx
+++ b/apps/web/src/components/plugins/__tests__/plugin-gallery.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PluginGallery } from "../plugin-gallery";
 

--- a/apps/web/src/components/plugins/plugin-card.tsx
+++ b/apps/web/src/components/plugins/plugin-card.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ShieldCheck } from "lucide-react";
+
+export interface PluginCardData {
+  id: string;
+  name: string;
+  description: string;
+  author: string;
+  category: string;
+  version: string;
+  installed: boolean;
+  verified?: boolean;
+  tags?: string[];
+}
+
+interface PluginCardProps {
+  plugin: PluginCardData;
+  onClick: (pluginId: string) => void;
+}
+
+export function PluginCard({ plugin, onClick }: PluginCardProps) {
+  return (
+    <button
+      type="button"
+      className="text-left w-full"
+      onClick={() => onClick(plugin.id)}
+    >
+      <Card className="h-full transition-colors hover:border-primary/50 hover:shadow-sm">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">{plugin.name}</CardTitle>
+          <CardDescription>{plugin.author}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
+            {plugin.description}
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            <Badge variant="outline">{plugin.category}</Badge>
+            {plugin.installed && (
+              <Badge variant="default" className="bg-green-600">
+                Installed
+              </Badge>
+            )}
+            {plugin.verified && (
+              <Badge variant="secondary" className="gap-1">
+                <ShieldCheck className="h-3 w-3" />
+                Verified
+              </Badge>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </button>
+  );
+}

--- a/apps/web/src/components/plugins/plugin-detail-dialog.tsx
+++ b/apps/web/src/components/plugins/plugin-detail-dialog.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { usePluginRegistryEntry } from "@/hooks/use-plugin-registry";
+import { toast } from "sonner";
+import { Check, Copy, ExternalLink, ShieldCheck } from "lucide-react";
+import { useState } from "react";
+
+interface PluginDetailDialogProps {
+  pluginId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    toast.success("Copied!");
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-6 w-6 shrink-0"
+      onClick={handleCopy}
+    >
+      {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+    </Button>
+  );
+}
+
+export function PluginDetailDialog({
+  pluginId,
+  open,
+  onOpenChange,
+}: PluginDetailDialogProps) {
+  const { plugin, isLoading } = usePluginRegistryEntry(pluginId);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
+        {isLoading && (
+          <div className="space-y-4 p-4">
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+          </div>
+        )}
+
+        {plugin && (
+          <>
+            <DialogHeader>
+              <div className="flex items-center gap-2">
+                <DialogTitle>{plugin.name}</DialogTitle>
+                <Badge variant="outline">v{plugin.version}</Badge>
+              </div>
+              <DialogDescription>{plugin.author}</DialogDescription>
+              <div className="flex flex-wrap gap-1.5 pt-1">
+                {plugin.installed && (
+                  <Badge variant="default" className="bg-green-600">
+                    Installed
+                  </Badge>
+                )}
+                {plugin.verified && (
+                  <Badge variant="secondary" className="gap-1">
+                    <ShieldCheck className="h-3 w-3" />
+                    Verified
+                  </Badge>
+                )}
+              </div>
+            </DialogHeader>
+
+            <div className="space-y-4">
+              {/* Description */}
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  {plugin.readme ?? plugin.description}
+                </p>
+              </div>
+
+              {/* Install section */}
+              {!plugin.installed && plugin.installCommand && (
+                <div className="space-y-2">
+                  <h4 className="text-sm font-medium">Install</h4>
+                  <div className="flex items-center gap-2 rounded-md bg-muted p-2">
+                    <code className="flex-1 text-xs break-all">
+                      {plugin.installCommand}
+                    </code>
+                    <CopyButton text={plugin.installCommand} />
+                  </div>
+                </div>
+              )}
+
+              {!plugin.installed && plugin.configExample && (
+                <div className="space-y-2">
+                  <h4 className="text-sm font-medium">Configuration Example</h4>
+                  <div className="relative rounded-md bg-muted p-2">
+                    <div className="absolute right-2 top-2">
+                      <CopyButton text={plugin.configExample} />
+                    </div>
+                    <pre className="text-xs overflow-x-auto whitespace-pre-wrap pr-8">
+                      {plugin.configExample}
+                    </pre>
+                  </div>
+                </div>
+              )}
+
+              {/* Permissions */}
+              {plugin.permissions && plugin.permissions.length > 0 && (
+                <div className="space-y-2">
+                  <h4 className="text-sm font-medium">Permissions</h4>
+                  <div className="flex flex-wrap gap-1.5">
+                    {plugin.permissions.map((perm) => (
+                      <Badge key={perm} variant="outline">
+                        {perm}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Details */}
+              <div className="space-y-1 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Category</span>
+                  <span>{plugin.category}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">License</span>
+                  <span>{plugin.license}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">
+                    Colophony Version
+                  </span>
+                  <span>{plugin.colophonyVersion}</span>
+                </div>
+                {plugin.adapters && plugin.adapters.length > 0 && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Adapters</span>
+                    <span>{plugin.adapters.join(", ")}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <DialogFooter className="gap-2 sm:gap-0">
+              {plugin.repository && (
+                <Button variant="outline" size="sm" asChild>
+                  <a
+                    href={plugin.repository}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                    Repository
+                  </a>
+                </Button>
+              )}
+              {plugin.homepage && (
+                <Button variant="outline" size="sm" asChild>
+                  <a
+                    href={plugin.homepage}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                    Homepage
+                  </a>
+                </Button>
+              )}
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/plugins/plugin-gallery.tsx
+++ b/apps/web/src/components/plugins/plugin-gallery.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card } from "@/components/ui/card";
+import { Search } from "lucide-react";
+import { usePluginRegistry } from "@/hooks/use-plugin-registry";
+import { PluginCard } from "./plugin-card";
+import { PluginDetailDialog } from "./plugin-detail-dialog";
+
+const CATEGORIES = [
+  { value: "all", label: "All" },
+  { value: "adapter", label: "Adapters" },
+  { value: "integration", label: "Integrations" },
+  { value: "workflow", label: "Workflow" },
+  { value: "import-export", label: "Import/Export" },
+  { value: "report", label: "Reports" },
+  { value: "theme", label: "Themes" },
+  { value: "block", label: "Blocks" },
+  { value: "notification", label: "Notifications" },
+] as const;
+
+export function PluginGallery() {
+  const { plugins, isLoading, error } = usePluginRegistry();
+  const [search, setSearch] = useState("");
+  const [category, setCategory] = useState("all");
+  const [selectedPluginId, setSelectedPluginId] = useState<string | null>(null);
+
+  const filtered = useMemo(() => {
+    let result = plugins;
+
+    if (category !== "all") {
+      result = result.filter((p) => p.category === category);
+    }
+
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        (p) =>
+          p.name.toLowerCase().includes(q) ||
+          p.description.toLowerCase().includes(q) ||
+          p.tags?.some((t) => t.toLowerCase().includes(q)),
+      );
+    }
+
+    return result;
+  }, [plugins, search, category]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Plugins</h1>
+        <p className="text-muted-foreground">
+          Browse and discover plugins for your Colophony instance.
+        </p>
+      </div>
+
+      {/* Search */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder="Search plugins..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      {/* Category tabs */}
+      <Tabs value={category} onValueChange={setCategory}>
+        <TabsList className="flex-wrap h-auto gap-1">
+          {CATEGORIES.map((cat) => (
+            <TabsTrigger key={cat.value} value={cat.value}>
+              {cat.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      {/* Error state */}
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>
+            Failed to load plugin registry: {error.message}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Loading state */}
+      {isLoading && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Card key={i} className="p-6 space-y-3">
+              <Skeleton className="h-5 w-32" />
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Plugin grid */}
+      {!isLoading && !error && filtered.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filtered.map((plugin) => (
+            <PluginCard
+              key={plugin.id}
+              plugin={plugin}
+              onClick={setSelectedPluginId}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && !error && filtered.length === 0 && (
+        <div className="text-center py-12">
+          <p className="text-muted-foreground">No plugins found.</p>
+        </div>
+      )}
+
+      {/* Detail dialog */}
+      <PluginDetailDialog
+        pluginId={selectedPluginId}
+        open={!!selectedPluginId}
+        onOpenChange={(open) => {
+          if (!open) setSelectedPluginId(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-plugin-registry.ts
+++ b/apps/web/src/hooks/use-plugin-registry.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { trpc } from "@/lib/trpc";
+
+export function usePluginRegistry() {
+  const { data, isPending, error, refetch } =
+    trpc.plugins.listRegistry.useQuery(undefined, {
+      staleTime: 5 * 60 * 1000,
+    });
+
+  return {
+    plugins: data ?? [],
+    isLoading: isPending,
+    error: error ?? null,
+    refetch,
+  };
+}
+
+export function usePluginRegistryEntry(pluginId: string | null) {
+  const { data, isPending, error } = trpc.plugins.getRegistryEntry.useQuery(
+    { pluginId: pluginId! },
+    {
+      enabled: !!pluginId,
+      staleTime: 5 * 60 * 1000,
+    },
+  );
+
+  return {
+    plugin: data ?? null,
+    isLoading: isPending,
+    error: error ?? null,
+  };
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -194,7 +194,7 @@
 ### Phase 3-4 (v2.1-v2.2)
 
 - [x] UI contribution point system (dashboard widgets, settings pages, submission detail sections) — (plugin research Section 11; done 2026-02-26 PR3)
-- [ ] In-app Plugin Gallery (JSON registry, one-click install) — (plugin research Section 11)
+- [x] In-app Plugin Gallery (JSON registry, browse + install instructions) — (plugin research Section 11; done 2026-02-26 PR4)
 - [ ] `@colophony/create-plugin` scaffolding CLI — (plugin research Section 11)
 - [ ] Evaluate n8n / Activepieces as recommended external automation target — security: must be network-isolated — (decision 2026-02-15)
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-26 — Track 6: In-App Plugin Gallery (PR4)
+
+### Done
+
+- **Plugin SDK registry types:** `pluginRegistryEntrySchema` extending `pluginManifestSchema` with gallery fields (npmPackage, readme, repository, downloads, tags, verified, iconUrl, configExample, installCommand); exported from `@colophony/plugin-sdk`
+- **Plugins accessor singleton:** `plugins-accessor.ts` stores loaded plugin manifests globally; wired in `main.ts` from `loadConfig()` result
+- **`PLUGIN_REGISTRY_URL` env var:** Optional URL for remote JSON registry; gallery disabled when not set
+- **Plugin registry service:** `fetchPluginRegistry()` with 1-hour in-memory cache; `listRegistryEntries()` enriches with installed status by comparing against global manifests; `getRegistryEntry()` for single lookup
+- **tRPC procedures:** `plugins.listRegistry` + `plugins.getRegistryEntry` — both `adminProcedure` (ADMIN-only); return empty/null when env var not configured
+- **Frontend hooks:** `usePluginRegistry()` + `usePluginRegistryEntry()` wrapping tRPC queries with 5-min staleTime
+- **3 frontend components:** `PluginCard` (clickable card with badges), `PluginDetailDialog` (full details + copy-to-clipboard install command + config example), `PluginGallery` (search input, category tabs, responsive grid, loading/empty/error states)
+- **`/plugins` page:** Dashboard route, admin-only via sidebar nav item (Puzzle icon in admin section)
+- **27 new tests** across 5 files: SDK schema 5, accessor 3, service 8, gallery 6, dialog 5
+- **Verification:** type-check passes, all tests pass, production build succeeds
+
+### Decisions
+
+- Informational gallery only — no runtime install/uninstall (would require config mutation rearchitecture)
+- Admin-only access via `adminProcedure` — non-admins can't browse registry
+- Types inferred from tRPC router output on frontend — web doesn't import from plugin-sdk
+
+---
+
 ## 2026-02-26 — Track 6: UI Contribution Point System (PR3)
 
 ### Done

--- a/packages/plugin-sdk/src/__tests__/registry-types.spec.ts
+++ b/packages/plugin-sdk/src/__tests__/registry-types.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  pluginRegistryEntrySchema,
+  pluginRegistrySchema,
+} from "../registry-types.js";
+
+function makeValidEntry(overrides?: Record<string, unknown>) {
+  return {
+    id: "colophony-plugin-example",
+    name: "Example Plugin",
+    version: "1.0.0",
+    colophonyVersion: "2.0.0",
+    description: "An example plugin for testing.",
+    author: "Test Author",
+    license: "MIT",
+    category: "adapter",
+    npmPackage: "@colophony/plugin-example",
+    ...overrides,
+  };
+}
+
+describe("pluginRegistryEntrySchema", () => {
+  it("validates a complete registry entry", () => {
+    const entry = makeValidEntry({
+      readme: "# Example\n\nA full readme.",
+      repository: "https://github.com/example/plugin",
+      downloads: 1500,
+      tags: ["email", "adapter"],
+      verified: true,
+      iconUrl: "https://example.com/icon.png",
+      configExample: 'new ExamplePlugin({ key: "value" })',
+      installCommand: "pnpm add @colophony/plugin-example",
+      homepage: "https://example.com",
+      permissions: ["email:send", "http:outbound"],
+    });
+
+    const result = pluginRegistryEntrySchema.safeParse(entry);
+    expect(result.success).toBe(true);
+  });
+
+  it("requires npmPackage field", () => {
+    const { npmPackage: _, ...entry } = makeValidEntry();
+    const result = pluginRegistryEntrySchema.safeParse(entry);
+    expect(result.success).toBe(false);
+  });
+
+  it("inherits PluginManifest validation", () => {
+    const entry = makeValidEntry({ version: "not-semver" });
+    const result = pluginRegistryEntrySchema.safeParse(entry);
+    expect(result.success).toBe(false);
+  });
+
+  it("validates array via pluginRegistrySchema", () => {
+    const entries = [
+      makeValidEntry({ id: "plugin-a" }),
+      makeValidEntry({ id: "plugin-b" }),
+    ];
+    const result = pluginRegistrySchema.safeParse(entries);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(2);
+    }
+  });
+
+  it("allows minimal entry with only manifest + npmPackage", () => {
+    const entry = makeValidEntry();
+    const result = pluginRegistryEntrySchema.safeParse(entry);
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -69,6 +69,14 @@ export type {
   UIExtensionDeclaration,
 } from "./ui/types.js";
 
+// Registry types
+export {
+  pluginRegistryEntrySchema,
+  pluginRegistrySchema,
+  type PluginRegistryEntry,
+  type PluginRegistry,
+} from "./registry-types.js";
+
 // Config
 export {
   defineConfig,

--- a/packages/plugin-sdk/src/registry-types.ts
+++ b/packages/plugin-sdk/src/registry-types.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { pluginManifestSchema } from "./plugin.js";
+
+export const pluginRegistryEntrySchema = pluginManifestSchema.extend({
+  npmPackage: z.string().min(1),
+  readme: z.string().optional(),
+  repository: z.string().url().optional(),
+  downloads: z.number().int().nonnegative().optional(),
+  tags: z.array(z.string()).optional(),
+  verified: z.boolean().optional(),
+  iconUrl: z.string().url().optional(),
+  configExample: z.string().optional(),
+  installCommand: z.string().optional(),
+});
+
+export type PluginRegistryEntry = z.infer<typeof pluginRegistryEntrySchema>;
+
+export const pluginRegistrySchema = z.array(pluginRegistryEntrySchema);
+export type PluginRegistry = z.infer<typeof pluginRegistrySchema>;


### PR DESCRIPTION
## Summary

- Add an admin-only plugin gallery page (`/plugins`) for browsing available plugins from a remote JSON registry
- Backend: registry types in plugin-sdk, plugins-accessor singleton, plugin-registry service with fetch + 1h cache + installed-status enrichment, two admin tRPC procedures (`listRegistry`, `getRegistryEntry`)
- Frontend: `usePluginRegistry`/`usePluginRegistryEntry` hooks, `PluginCard`, `PluginDetailDialog` (with copy-to-clipboard install instructions), `PluginGallery` (search, category tabs, responsive grid), `/plugins` page, sidebar nav item
- Informational only — no runtime install/uninstall (browse + copy install command)

## Test plan

- [ ] 27 new unit tests pass (5 SDK schema, 3 accessor, 8 service, 6 gallery, 5 dialog)
- [ ] `pnpm type-check` passes
- [ ] `pnpm build` succeeds
- [ ] Set `PLUGIN_REGISTRY_URL` to a test JSON file, navigate to `/plugins` as ADMIN, verify gallery renders
- [ ] Verify search/filter works, detail dialog shows install instructions with copy
- [ ] Verify `/plugins` nav item hidden for EDITOR/READER roles

## Review findings addressed

- Added 10s `AbortSignal.timeout` on registry fetch (prevents hanging)
- Changed `pluginRegistrySchema.parse()` to `safeParse()` with contextual error message