### PR TITLE
feat(plugins): add @colophony/create-plugin scaffolding CLI

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -195,11 +195,14 @@
 
 - [x] UI contribution point system (dashboard widgets, settings pages, submission detail sections) — (plugin research Section 11; done 2026-02-26 PR3)
 - [x] In-app Plugin Gallery (JSON registry, browse + install instructions) — (plugin research Section 11; done 2026-02-26 PR4)
-- [ ] `@colophony/create-plugin` scaffolding CLI — (plugin research Section 11)
-- [ ] Evaluate n8n / Activepieces as recommended external automation target — security: must be network-isolated — (decision 2026-02-15)
+- [x] `@colophony/create-plugin` scaffolding CLI — (plugin research Section 11; done 2026-02-26)
+- [x] Evaluate n8n / Activepieces as recommended external automation target — **Resolved:** Recommend n8n (no privileged container, mature webhooks, 5800+ nodes); Activepieces as MIT-licensed alternative. Deliverables (docs, custom n8n node, Docker profile) deferred post-v2.0. See `docs/research/automation-platform-evaluation.md` — (decision 2026-02-15; resolved 2026-02-26)
 
 ### Phase 5-6 (v2.3+)
 
+- [ ] `n8n-nodes-colophony` custom node — API credential type, webhook triggers for Tier 0 events, common API actions — (automation eval 2026-02-26)
+- [ ] Docker Compose `--profile automation` — n8n sidecar on internal network, pre-configured webhook URL — (automation eval 2026-02-26)
+- [ ] "Automation with n8n" documentation — sidecar setup, webhook config, example workflows, Activepieces alternative note — (automation eval 2026-02-26)
 - [ ] Plugin signing via npm trusted publishing + Sigstore Cosign — (plugin research Section 6, decision 2026-02-15)
 - [ ] OPA load-time permission policy for managed hosting — (plugin research Section 6, decision 2026-02-15)
 - [ ] Frontend sandboxing for community UI plugins — (plugin research Section 11)
@@ -208,12 +211,12 @@
 
 ### Design Decisions
 
-- [ ] Plugin configuration storage: database per-org (encrypted) vs env vars per-deployment — (plugin research Open Question #1)
-- [ ] Hot-reload in production: loadable without restart vs requires restart — (plugin research Open Question #2)
-- [ ] Plugin marketplace governance: review criteria, signing key management — (plugin research Open Question #3)
-- [ ] Database access for Tier 4 plugins: direct DB (with RLS) vs service API — (plugin research Open Question #4)
-- [ ] Frontend plugin bundling: runtime dynamic import vs compile-time — (plugin research Open Question #5)
-- [ ] Webhook vs event bus for Tier 0: webhooks only vs Redis pub/sub or NATS — (plugin research Open Question #6)
+- [x] Plugin configuration storage: env vars only per-deployment for v2.0; per-org DB deferred to managed-hosting milestone — (plugin research Open Question #1; resolved 2026-02-26)
+- [x] Hot-reload in production: restart required for v2.0; `destroy()` lifecycle exists for future support — (plugin research Open Question #2; resolved 2026-02-26)
+- [x] Plugin marketplace governance: define criteria spec now, defer enforcement to v2.3+ — (plugin research Open Question #3; resolved 2026-02-26)
+- [x] Database access for Tier 4 plugins: plugin data namespace (`ctx.store`) + read-only service API for v2.0 — (plugin research Open Question #4; resolved 2026-02-26)
+- [x] Frontend plugin bundling: build-time only for v2.0; runtime loading deferred to v2.3+ — (plugin research Open Question #5; resolved 2026-02-26)
+- [x] Webhook vs event bus for Tier 0: webhooks only for v2.0; pub/sub deferred post-launch — (plugin research Open Question #6; resolved 2026-02-26)
 
 ---
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,26 @@ Newest entries first.
 
 ---
 
+## 2026-02-26 — Track 6: `@colophony/create-plugin` Scaffolding CLI
+
+### Done
+
+- **`packages/create-plugin/` package:** npm-publishable `@colophony/create-plugin` v0.1.0 invokable via `npm create @colophony/plugin`
+- **Interactive prompts:** Plugin name (validated), description, author, license, category (8 `PluginCategory` values), scaffold type (integration/adapter/full), adapter type (email/payment/storage/search)
+- **8 template generators:** package.json (ESM, SDK dep), tsconfig (standalone, strict, NodeNext, declaration), plugin class (extends `ColophonyPlugin`), adapter class (correct SDK interface stubs per type), test file (SDK testing utils), README (registration example), .gitignore, LICENSE (MIT full text, placeholder for others)
+- **Scaffold types:** Integration (plugin + hook stubs), Adapter (plugin + adapter impl), Full (both)
+- **38 tests across 3 suites:** utils (12), templates (20), integration (6) — all passing
+- **TypeScript:** builds and type-checks cleanly; standalone tsconfig (doesn't extend `@colophony/typescript-config` since it's unpublished)
+
+### Decisions
+
+- `prompts` library for interactive CLI — lightweight, stable, zero-dep
+- `pluginType` is CLI-internal scaffold concept (what files to generate), separate from `PluginCategory` (manifest `category` field)
+- Standalone tsconfig in generated projects — `@colophony/typescript-config` is workspace-only/unpublished
+- Assertion casts for discriminated union narrowing where TypeScript couldn't narrow after boolean OR check
+
+---
+
 ## 2026-02-26 — Track 6: In-App Plugin Gallery (PR4)
 
 ### Done

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@colophony/create-plugin",
+  "version": "0.1.0",
+  "description": "Scaffold a new Colophony plugin project",
+  "type": "module",
+  "bin": {
+    "create-plugin": "./dist/cli.js"
+  },
+  "main": "./dist/run.js",
+  "types": "./dist/run.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/run.d.ts",
+      "default": "./dist/run.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "prompts": "^2.4.2"
+  },
+  "devDependencies": {
+    "@colophony/typescript-config": "workspace:*",
+    "@types/prompts": "^2.4.9",
+    "typescript": "^5.7.2",
+    "vitest": "^4.0.18"
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "MIT"
+}

--- a/packages/create-plugin/src/__tests__/run.spec.ts
+++ b/packages/create-plugin/src/__tests__/run.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildFileMap, scaffoldProject } from "../write.js";
+import type { IntegrationAnswers, AdapterAnswers } from "../prompts.js";
+
+const integrationAnswers: IntegrationAnswers = {
+  name: "test-plugin",
+  description: "A test plugin",
+  author: "Test",
+  license: "MIT",
+  category: "integration",
+  pluginType: "integration",
+};
+
+const adapterAnswers: AdapterAnswers = {
+  name: "test-email",
+  description: "A test email adapter",
+  author: "Test",
+  license: "MIT",
+  category: "adapter",
+  pluginType: "adapter",
+  adapterType: "email",
+};
+
+describe("run integration", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "create-plugin-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates the output directory", async () => {
+    const input = buildFileMap(integrationAnswers, { cwd: tmpDir });
+    await scaffoldProject(input);
+
+    const stat = await fs.stat(input.outputDir);
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it("generates all required files for integration type", async () => {
+    const input = buildFileMap(integrationAnswers, { cwd: tmpDir });
+    await scaffoldProject(input);
+
+    const files = await fs.readdir(input.outputDir, { recursive: true });
+    expect(files).toContain("package.json");
+    expect(files).toContain("tsconfig.json");
+    expect(files).toContain("README.md");
+    expect(files).toContain(".gitignore");
+    expect(files).toContain("LICENSE");
+  });
+
+  it("generates package.json with correct name", async () => {
+    const input = buildFileMap(integrationAnswers, { cwd: tmpDir });
+    await scaffoldProject(input);
+
+    const pkgJson = JSON.parse(
+      await fs.readFile(path.join(input.outputDir, "package.json"), "utf-8"),
+    );
+    expect(pkgJson.name).toBe("colophony-plugin-test-plugin");
+  });
+
+  it("generates adapter file for adapter type", async () => {
+    const input = buildFileMap(adapterAnswers, { cwd: tmpDir });
+    await scaffoldProject(input);
+
+    const adapterPath = path.join(
+      input.outputDir,
+      "src",
+      "adapters",
+      "email.adapter.ts",
+    );
+    const content = await fs.readFile(adapterPath, "utf-8");
+    expect(content).toContain("implements EmailAdapter");
+  });
+
+  it("does NOT generate adapter file for integration type", async () => {
+    const input = buildFileMap(integrationAnswers, { cwd: tmpDir });
+    await scaffoldProject(input);
+
+    const adaptersDir = path.join(input.outputDir, "src", "adapters");
+    const exists = await fs
+      .access(adaptersDir)
+      .then(() => true)
+      .catch(() => false);
+    expect(exists).toBe(false);
+  });
+
+  it("throws if directory already exists", async () => {
+    const input = buildFileMap(integrationAnswers, { cwd: tmpDir });
+    await fs.mkdir(input.outputDir, { recursive: true });
+
+    await expect(scaffoldProject(input)).rejects.toThrow(
+      "Directory already exists",
+    );
+  });
+});

--- a/packages/create-plugin/src/__tests__/templates.spec.ts
+++ b/packages/create-plugin/src/__tests__/templates.spec.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import { generatePackageJson } from "../templates/package-json.js";
+import { generateTsConfig } from "../templates/tsconfig.js";
+import { generatePluginClass } from "../templates/plugin-class.js";
+import { generateAdapterClass } from "../templates/adapter-class.js";
+import { generateTestFile } from "../templates/test-file.js";
+import { generateReadme } from "../templates/readme.js";
+import type {
+  IntegrationAnswers,
+  AdapterAnswers,
+  FullAnswers,
+} from "../prompts.js";
+
+const integrationAnswers: IntegrationAnswers = {
+  name: "my-notifier",
+  description: "A notification plugin",
+  author: "Test Author",
+  license: "MIT",
+  category: "notification",
+  pluginType: "integration",
+};
+
+const adapterAnswers: AdapterAnswers = {
+  name: "custom-email",
+  description: "A custom email adapter",
+  author: "Test Author",
+  license: "MIT",
+  category: "adapter",
+  pluginType: "adapter",
+  adapterType: "email",
+};
+
+const fullAnswers: FullAnswers = {
+  name: "full-plugin",
+  description: "A full plugin",
+  author: "Test Author",
+  license: "MIT",
+  category: "integration",
+  pluginType: "full",
+  adapterType: "storage",
+};
+
+describe("generatePackageJson", () => {
+  it("generates correct package name", () => {
+    const result = JSON.parse(generatePackageJson(integrationAnswers));
+    expect(result.name).toBe("colophony-plugin-my-notifier");
+  });
+
+  it("includes plugin-sdk dependency", () => {
+    const result = JSON.parse(generatePackageJson(integrationAnswers));
+    expect(result.dependencies["@colophony/plugin-sdk"]).toBeDefined();
+  });
+
+  it("is not private", () => {
+    const result = JSON.parse(generatePackageJson(integrationAnswers));
+    expect(result.private).toBeUndefined();
+  });
+
+  it("uses ESM type module", () => {
+    const result = JSON.parse(generatePackageJson(integrationAnswers));
+    expect(result.type).toBe("module");
+  });
+});
+
+describe("generateTsConfig", () => {
+  it("enables strict mode", () => {
+    const result = JSON.parse(generateTsConfig());
+    expect(result.compilerOptions.strict).toBe(true);
+  });
+
+  it("uses NodeNext module", () => {
+    const result = JSON.parse(generateTsConfig());
+    expect(result.compilerOptions.module).toBe("NodeNext");
+  });
+
+  it("does not extend shared config", () => {
+    const result = JSON.parse(generateTsConfig());
+    expect(result.extends).toBeUndefined();
+  });
+
+  it("enables declaration output", () => {
+    const result = JSON.parse(generateTsConfig());
+    expect(result.compilerOptions.declaration).toBe(true);
+  });
+});
+
+describe("generatePluginClass", () => {
+  it("generates integration class with register method", () => {
+    const result = generatePluginClass(integrationAnswers);
+    expect(result).toContain("class MyNotifierPlugin extends ColophonyPlugin");
+    expect(result).toContain("async register(context");
+  });
+
+  it("includes adapter import for adapter type", () => {
+    const result = generatePluginClass(adapterAnswers);
+    expect(result).toContain("import { CustomEmailAdapter }");
+    expect(result).toContain('registerAdapter("email"');
+  });
+
+  it("generates full plugin with adapter and hook stubs", () => {
+    const result = generatePluginClass(fullAnswers);
+    expect(result).toContain("import { FullPluginAdapter }");
+    expect(result).toContain('registerAdapter("storage"');
+    expect(result).toContain("TODO: Register hooks");
+  });
+
+  it("includes correct manifest category", () => {
+    const result = generatePluginClass(integrationAnswers);
+    expect(result).toContain('category: "notification"');
+  });
+});
+
+describe("generateAdapterClass", () => {
+  it("generates email adapter with send method", () => {
+    const result = generateAdapterClass({
+      name: "my-mailer",
+      adapterType: "email",
+    });
+    expect(result).toContain("implements EmailAdapter");
+    expect(result).toContain("async send(");
+    expect(result).toContain("configSchema");
+  });
+
+  it("generates payment adapter with required methods", () => {
+    const result = generateAdapterClass({
+      name: "pay",
+      adapterType: "payment",
+    });
+    expect(result).toContain("implements PaymentAdapter");
+    expect(result).toContain("createCheckoutSession");
+    expect(result).toContain("verifyWebhook");
+    expect(result).toContain("refund");
+  });
+
+  it("generates storage adapter with required methods", () => {
+    const result = generateAdapterClass({
+      name: "store",
+      adapterType: "storage",
+    });
+    expect(result).toContain("implements StorageAdapter");
+    expect(result).toContain("upload");
+    expect(result).toContain("download");
+    expect(result).toContain("getSignedUrl");
+    expect(result).toContain("move");
+  });
+
+  it("generates search adapter with required methods", () => {
+    const result = generateAdapterClass({
+      name: "finder",
+      adapterType: "search",
+    });
+    expect(result).toContain("implements SearchAdapter");
+    expect(result).toContain("index(");
+    expect(result).toContain("indexBulk");
+    expect(result).toContain("search(");
+    expect(result).toContain("remove(");
+  });
+});
+
+describe("generateTestFile", () => {
+  it("uses createTestHarness for integration type", () => {
+    const result = generateTestFile(integrationAnswers);
+    expect(result).toContain("createTestHarness");
+    expect(result).not.toContain("createMockRegisterContext");
+  });
+
+  it("uses createMockRegisterContext for adapter type", () => {
+    const result = generateTestFile(adapterAnswers);
+    expect(result).toContain("createMockRegisterContext");
+    expect(result).not.toContain("createTestHarness");
+  });
+});
+
+describe("generateReadme", () => {
+  it("includes plugin name as heading", () => {
+    const result = generateReadme(integrationAnswers);
+    expect(result).toContain("# my-notifier");
+  });
+
+  it("includes installation section", () => {
+    const result = generateReadme(integrationAnswers);
+    expect(result).toContain("## Installation");
+    expect(result).toContain("npm install colophony-plugin-my-notifier");
+  });
+});

--- a/packages/create-plugin/src/__tests__/utils.spec.ts
+++ b/packages/create-plugin/src/__tests__/utils.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import {
+  toKebabCase,
+  toPascalCase,
+  toPluginId,
+  validatePluginName,
+} from "../utils.js";
+
+describe("toKebabCase", () => {
+  it("converts spaces to hyphens", () => {
+    expect(toKebabCase("My Plugin")).toBe("my-plugin");
+  });
+
+  it("converts PascalCase to kebab-case", () => {
+    expect(toKebabCase("MyPlugin")).toBe("my-plugin");
+  });
+
+  it("returns lowercase as-is", () => {
+    expect(toKebabCase("simple")).toBe("simple");
+  });
+});
+
+describe("toPascalCase", () => {
+  it("converts kebab-case to PascalCase", () => {
+    expect(toPascalCase("my-plugin")).toBe("MyPlugin");
+  });
+
+  it("converts spaces to PascalCase", () => {
+    expect(toPascalCase("my cool plugin")).toBe("MyCoolPlugin");
+  });
+});
+
+describe("toPluginId", () => {
+  it("strips special characters and converts to kebab", () => {
+    expect(toPluginId("My Plugin!@#")).toBe("my-plugin");
+  });
+
+  it("handles already clean input", () => {
+    expect(toPluginId("my-plugin")).toBe("my-plugin");
+  });
+});
+
+describe("validatePluginName", () => {
+  it("returns true for valid names", () => {
+    expect(validatePluginName("my-plugin")).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    expect(validatePluginName("")).not.toBe(true);
+  });
+
+  it("rejects too-long names", () => {
+    expect(validatePluginName("a".repeat(51))).not.toBe(true);
+  });
+
+  it("rejects names starting with a hyphen", () => {
+    expect(validatePluginName("-bad")).not.toBe(true);
+  });
+
+  it("rejects single character names", () => {
+    expect(validatePluginName("a")).not.toBe(true);
+  });
+});

--- a/packages/create-plugin/src/cli.ts
+++ b/packages/create-plugin/src/cli.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { run } from "./run.js";
+
+run().catch((err: Error) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/packages/create-plugin/src/prompts.ts
+++ b/packages/create-plugin/src/prompts.ts
@@ -51,11 +51,19 @@ export async function collectAnswers(): Promise<PluginAnswers> {
         type: "text",
         name: "description",
         message: "Description",
+        validate: (v: string) =>
+          v.length > 200 ? "Description must be at most 200 characters" : true,
       },
       {
         type: "text",
         name: "author",
         message: "Author",
+        validate: (v: string) =>
+          !v.trim()
+            ? "Author is required"
+            : v.length > 100
+              ? "Author must be at most 100 characters"
+              : true,
       },
       {
         type: "text",

--- a/packages/create-plugin/src/prompts.ts
+++ b/packages/create-plugin/src/prompts.ts
@@ -1,0 +1,129 @@
+import prompts from "prompts";
+import { validatePluginName } from "./utils.js";
+
+export type PluginCategory =
+  | "adapter"
+  | "integration"
+  | "workflow"
+  | "import-export"
+  | "report"
+  | "theme"
+  | "block"
+  | "notification";
+
+export type PluginType = "integration" | "adapter" | "full";
+export type AdapterKind = "email" | "payment" | "storage" | "search";
+
+interface BaseAnswers {
+  name: string;
+  description: string;
+  author: string;
+  license: string;
+  category: PluginCategory;
+}
+
+export interface IntegrationAnswers extends BaseAnswers {
+  pluginType: "integration";
+}
+
+export interface AdapterAnswers extends BaseAnswers {
+  pluginType: "adapter";
+  adapterType: AdapterKind;
+}
+
+export interface FullAnswers extends BaseAnswers {
+  pluginType: "full";
+  adapterType: AdapterKind;
+}
+
+export type PluginAnswers = IntegrationAnswers | AdapterAnswers | FullAnswers;
+
+export async function collectAnswers(): Promise<PluginAnswers> {
+  const base = await prompts(
+    [
+      {
+        type: "text",
+        name: "name",
+        message: "Plugin name",
+        validate: (value: string) => validatePluginName(value),
+      },
+      {
+        type: "text",
+        name: "description",
+        message: "Description",
+      },
+      {
+        type: "text",
+        name: "author",
+        message: "Author",
+      },
+      {
+        type: "text",
+        name: "license",
+        message: "License",
+        initial: "MIT",
+      },
+      {
+        type: "select",
+        name: "category",
+        message: "Plugin category",
+        choices: [
+          { title: "Adapter", value: "adapter" },
+          { title: "Integration", value: "integration" },
+          { title: "Workflow", value: "workflow" },
+          { title: "Import/Export", value: "import-export" },
+          { title: "Report", value: "report" },
+          { title: "Theme", value: "theme" },
+          { title: "Block", value: "block" },
+          { title: "Notification", value: "notification" },
+        ],
+      },
+      {
+        type: "select",
+        name: "pluginType",
+        message: "Plugin type (what to scaffold)",
+        choices: [
+          {
+            title: "Integration",
+            value: "integration",
+            description: "Plugin class with hook stubs",
+          },
+          {
+            title: "Adapter",
+            value: "adapter",
+            description: "Plugin class + adapter implementation",
+          },
+          {
+            title: "Full",
+            value: "full",
+            description: "Plugin class + adapter + hook stubs",
+          },
+        ],
+      },
+    ],
+    { onCancel: () => process.exit(1) },
+  );
+
+  if (base.pluginType === "integration") {
+    return base as IntegrationAnswers;
+  }
+
+  const { adapterType } = await prompts(
+    [
+      {
+        type: "select",
+        name: "adapterType",
+        message: "Adapter type",
+        choices: [
+          { title: "Email", value: "email" },
+          { title: "Payment", value: "payment" },
+          { title: "Storage", value: "storage" },
+          { title: "Search", value: "search" },
+        ],
+      },
+    ],
+    { onCancel: () => process.exit(1) },
+  );
+
+  return { ...base, adapterType } as PluginAnswers;
+}

--- a/packages/create-plugin/src/run.ts
+++ b/packages/create-plugin/src/run.ts
@@ -1,0 +1,24 @@
+import { collectAnswers } from "./prompts.js";
+import { buildFileMap, scaffoldProject } from "./write.js";
+
+export async function run(options?: {
+  cwd?: string;
+}): Promise<{ outputDir: string; files: string[] }> {
+  console.log("\nColophony Plugin Scaffolder\n");
+
+  const answers = await collectAnswers();
+  const input = buildFileMap(answers, options);
+
+  await scaffoldProject(input);
+
+  const files = Object.keys(input.files);
+
+  console.log(`\nCreated ${files.length} files in ${input.outputDir}\n`);
+  console.log("Next steps:");
+  console.log(`  cd ${input.outputDir}`);
+  console.log("  npm install");
+  console.log("  npm run build");
+  console.log("  npm test\n");
+
+  return { outputDir: input.outputDir, files };
+}

--- a/packages/create-plugin/src/templates/adapter-class.ts
+++ b/packages/create-plugin/src/templates/adapter-class.ts
@@ -1,0 +1,228 @@
+import { toPascalCase } from "../utils.js";
+import type { AdapterKind } from "../prompts.js";
+
+interface AdapterInput {
+  name: string;
+  adapterType: AdapterKind;
+}
+
+const ADAPTER_TEMPLATES: Record<AdapterKind, (pascal: string) => string> = {
+  email: (
+    pascal,
+  ) => `import type { EmailAdapter, SendEmailOptions, SendEmailResult, AdapterHealthResult } from "@colophony/plugin-sdk";
+import { z } from "zod";
+
+export const configSchema = z.object({
+  // TODO: Define your adapter configuration
+  apiKey: z.string().describe("API key for the email service"),
+});
+
+export class ${pascal}Adapter implements EmailAdapter {
+  readonly id = "${pascal.toLowerCase()}-email";
+  readonly name = "${pascal} Email Adapter";
+  readonly version = "0.1.0";
+  readonly configSchema = configSchema;
+
+  async initialize(config: Record<string, unknown>): Promise<void> {
+    const _validated = configSchema.parse(config);
+    // TODO: Initialize email client
+  }
+
+  async send(options: SendEmailOptions): Promise<SendEmailResult> {
+    // TODO: Implement email sending
+    throw new Error("Not implemented: send()");
+  }
+
+  // Optional: implement sendBulk for batch email sending
+  // async sendBulk(recipients: string[], options: Omit<SendEmailOptions, "to">): Promise<SendEmailResult[]> { }
+
+  async healthCheck(): Promise<AdapterHealthResult> {
+    return { healthy: true, message: "OK" };
+  }
+
+  async destroy(): Promise<void> {
+    // TODO: Cleanup resources
+  }
+}
+`,
+
+  payment: (pascal) => `import type {
+  PaymentAdapter,
+  CheckoutSessionParams,
+  CheckoutSessionResult,
+  PaymentWebhookEvent,
+  WebhookHandleResult,
+  RefundResult,
+  AdapterHealthResult,
+} from "@colophony/plugin-sdk";
+import { z } from "zod";
+
+export const configSchema = z.object({
+  // TODO: Define your adapter configuration
+  secretKey: z.string().describe("Secret key for the payment provider"),
+});
+
+export class ${pascal}Adapter implements PaymentAdapter {
+  readonly id = "${pascal.toLowerCase()}-payment";
+  readonly name = "${pascal} Payment Adapter";
+  readonly version = "0.1.0";
+  readonly configSchema = configSchema;
+
+  async initialize(config: Record<string, unknown>): Promise<void> {
+    const _validated = configSchema.parse(config);
+    // TODO: Initialize payment client
+  }
+
+  async createCheckoutSession(params: CheckoutSessionParams): Promise<CheckoutSessionResult> {
+    // TODO: Implement checkout session creation
+    throw new Error("Not implemented: createCheckoutSession()");
+  }
+
+  async verifyWebhook(headers: Record<string, string>, body: string): Promise<PaymentWebhookEvent> {
+    // TODO: Verify webhook signature and parse event
+    throw new Error("Not implemented: verifyWebhook()");
+  }
+
+  async handleWebhookEvent(event: PaymentWebhookEvent): Promise<WebhookHandleResult> {
+    // TODO: Handle payment events
+    throw new Error("Not implemented: handleWebhookEvent()");
+  }
+
+  async refund(paymentId: string, amount?: number): Promise<RefundResult> {
+    // TODO: Implement refund
+    throw new Error("Not implemented: refund()");
+  }
+
+  async healthCheck(): Promise<AdapterHealthResult> {
+    return { healthy: true, message: "OK" };
+  }
+
+  async destroy(): Promise<void> {
+    // TODO: Cleanup resources
+  }
+}
+`,
+
+  storage: (
+    pascal,
+  ) => `import type { StorageAdapter, UploadOptions, UploadResult, AdapterHealthResult } from "@colophony/plugin-sdk";
+import type { Readable } from "node:stream";
+import { z } from "zod";
+
+export const configSchema = z.object({
+  // TODO: Define your adapter configuration
+  bucket: z.string().describe("Storage bucket name"),
+});
+
+export class ${pascal}Adapter implements StorageAdapter {
+  readonly id = "${pascal.toLowerCase()}-storage";
+  readonly name = "${pascal} Storage Adapter";
+  readonly version = "0.1.0";
+  readonly configSchema = configSchema;
+
+  async initialize(config: Record<string, unknown>): Promise<void> {
+    const _validated = configSchema.parse(config);
+    // TODO: Initialize storage client
+  }
+
+  async upload(options: UploadOptions): Promise<UploadResult> {
+    // TODO: Implement file upload
+    throw new Error("Not implemented: upload()");
+  }
+
+  async download(key: string): Promise<Readable> {
+    // TODO: Implement file download
+    throw new Error("Not implemented: download()");
+  }
+
+  async delete(key: string): Promise<void> {
+    // TODO: Implement file deletion
+    throw new Error("Not implemented: delete()");
+  }
+
+  async exists(key: string): Promise<boolean> {
+    // TODO: Implement existence check
+    throw new Error("Not implemented: exists()");
+  }
+
+  async getSignedUrl(key: string, expiresInSeconds?: number): Promise<string> {
+    // TODO: Implement signed URL generation
+    throw new Error("Not implemented: getSignedUrl()");
+  }
+
+  async move(sourceKey: string, destinationKey: string): Promise<void> {
+    // TODO: Implement file move
+    throw new Error("Not implemented: move()");
+  }
+
+  async healthCheck(): Promise<AdapterHealthResult> {
+    return { healthy: true, message: "OK" };
+  }
+
+  async destroy(): Promise<void> {
+    // TODO: Cleanup resources
+  }
+}
+`,
+
+  search: (pascal) => `import type {
+  SearchAdapter,
+  SearchDocument,
+  SearchQuery,
+  SearchResult,
+  AdapterHealthResult,
+} from "@colophony/plugin-sdk";
+import { z } from "zod";
+
+export const configSchema = z.object({
+  // TODO: Define your adapter configuration
+  endpoint: z.string().describe("Search service endpoint URL"),
+});
+
+export class ${pascal}Adapter implements SearchAdapter {
+  readonly id = "${pascal.toLowerCase()}-search";
+  readonly name = "${pascal} Search Adapter";
+  readonly version = "0.1.0";
+  readonly configSchema = configSchema;
+
+  async initialize(config: Record<string, unknown>): Promise<void> {
+    const _validated = configSchema.parse(config);
+    // TODO: Initialize search client
+  }
+
+  async index(document: SearchDocument): Promise<void> {
+    // TODO: Implement document indexing
+    throw new Error("Not implemented: index()");
+  }
+
+  async indexBulk(documents: SearchDocument[]): Promise<void> {
+    // TODO: Implement bulk indexing
+    throw new Error("Not implemented: indexBulk()");
+  }
+
+  async search(query: SearchQuery): Promise<SearchResult> {
+    // TODO: Implement search
+    throw new Error("Not implemented: search()");
+  }
+
+  async remove(documentId: string, index: string): Promise<void> {
+    // TODO: Implement document removal
+    throw new Error("Not implemented: remove()");
+  }
+
+  async healthCheck(): Promise<AdapterHealthResult> {
+    return { healthy: true, message: "OK" };
+  }
+
+  async destroy(): Promise<void> {
+    // TODO: Cleanup resources
+  }
+}
+`,
+};
+
+export function generateAdapterClass(input: AdapterInput): string {
+  const pascal = toPascalCase(input.name);
+  const template = ADAPTER_TEMPLATES[input.adapterType];
+  return template(pascal);
+}

--- a/packages/create-plugin/src/templates/adapter-class.ts
+++ b/packages/create-plugin/src/templates/adapter-class.ts
@@ -6,6 +6,15 @@ interface AdapterInput {
   adapterType: AdapterKind;
 }
 
+const NOT_IMPLEMENTED_ERROR = `
+class NotImplementedError extends Error {
+  constructor(method: string) {
+    super(\`Not implemented: \${method}\`);
+    this.name = "NotImplementedError";
+  }
+}
+`;
+
 const ADAPTER_TEMPLATES: Record<AdapterKind, (pascal: string) => string> = {
   email: (
     pascal,
@@ -30,7 +39,7 @@ export class ${pascal}Adapter implements EmailAdapter {
 
   async send(options: SendEmailOptions): Promise<SendEmailResult> {
     // TODO: Implement email sending
-    throw new Error("Not implemented: send()");
+    throw new NotImplementedError(" send()");
   }
 
   // Optional: implement sendBulk for batch email sending
@@ -75,22 +84,22 @@ export class ${pascal}Adapter implements PaymentAdapter {
 
   async createCheckoutSession(params: CheckoutSessionParams): Promise<CheckoutSessionResult> {
     // TODO: Implement checkout session creation
-    throw new Error("Not implemented: createCheckoutSession()");
+    throw new NotImplementedError(" createCheckoutSession()");
   }
 
   async verifyWebhook(headers: Record<string, string>, body: string): Promise<PaymentWebhookEvent> {
     // TODO: Verify webhook signature and parse event
-    throw new Error("Not implemented: verifyWebhook()");
+    throw new NotImplementedError(" verifyWebhook()");
   }
 
   async handleWebhookEvent(event: PaymentWebhookEvent): Promise<WebhookHandleResult> {
     // TODO: Handle payment events
-    throw new Error("Not implemented: handleWebhookEvent()");
+    throw new NotImplementedError(" handleWebhookEvent()");
   }
 
   async refund(paymentId: string, amount?: number): Promise<RefundResult> {
     // TODO: Implement refund
-    throw new Error("Not implemented: refund()");
+    throw new NotImplementedError(" refund()");
   }
 
   async healthCheck(): Promise<AdapterHealthResult> {
@@ -127,32 +136,32 @@ export class ${pascal}Adapter implements StorageAdapter {
 
   async upload(options: UploadOptions): Promise<UploadResult> {
     // TODO: Implement file upload
-    throw new Error("Not implemented: upload()");
+    throw new NotImplementedError(" upload()");
   }
 
   async download(key: string): Promise<Readable> {
     // TODO: Implement file download
-    throw new Error("Not implemented: download()");
+    throw new NotImplementedError(" download()");
   }
 
   async delete(key: string): Promise<void> {
     // TODO: Implement file deletion
-    throw new Error("Not implemented: delete()");
+    throw new NotImplementedError(" delete()");
   }
 
   async exists(key: string): Promise<boolean> {
     // TODO: Implement existence check
-    throw new Error("Not implemented: exists()");
+    throw new NotImplementedError(" exists()");
   }
 
   async getSignedUrl(key: string, expiresInSeconds?: number): Promise<string> {
     // TODO: Implement signed URL generation
-    throw new Error("Not implemented: getSignedUrl()");
+    throw new NotImplementedError(" getSignedUrl()");
   }
 
   async move(sourceKey: string, destinationKey: string): Promise<void> {
     // TODO: Implement file move
-    throw new Error("Not implemented: move()");
+    throw new NotImplementedError(" move()");
   }
 
   async healthCheck(): Promise<AdapterHealthResult> {
@@ -192,22 +201,22 @@ export class ${pascal}Adapter implements SearchAdapter {
 
   async index(document: SearchDocument): Promise<void> {
     // TODO: Implement document indexing
-    throw new Error("Not implemented: index()");
+    throw new NotImplementedError(" index()");
   }
 
   async indexBulk(documents: SearchDocument[]): Promise<void> {
     // TODO: Implement bulk indexing
-    throw new Error("Not implemented: indexBulk()");
+    throw new NotImplementedError(" indexBulk()");
   }
 
   async search(query: SearchQuery): Promise<SearchResult> {
     // TODO: Implement search
-    throw new Error("Not implemented: search()");
+    throw new NotImplementedError(" search()");
   }
 
   async remove(documentId: string, index: string): Promise<void> {
     // TODO: Implement document removal
-    throw new Error("Not implemented: remove()");
+    throw new NotImplementedError(" remove()");
   }
 
   async healthCheck(): Promise<AdapterHealthResult> {
@@ -224,5 +233,11 @@ export class ${pascal}Adapter implements SearchAdapter {
 export function generateAdapterClass(input: AdapterInput): string {
   const pascal = toPascalCase(input.name);
   const template = ADAPTER_TEMPLATES[input.adapterType];
-  return template(pascal);
+  const code = template(pascal);
+  // Inject NotImplementedError after the last import line
+  const lastImportIdx = code.lastIndexOf("import ");
+  const insertIdx = code.indexOf("\n", lastImportIdx) + 1;
+  return (
+    code.slice(0, insertIdx) + NOT_IMPLEMENTED_ERROR + code.slice(insertIdx)
+  );
 }

--- a/packages/create-plugin/src/templates/gitignore.ts
+++ b/packages/create-plugin/src/templates/gitignore.ts
@@ -1,0 +1,7 @@
+export function generateGitignore(): string {
+  return `node_modules/
+dist/
+*.tsbuildinfo
+.DS_Store
+`;
+}

--- a/packages/create-plugin/src/templates/license.ts
+++ b/packages/create-plugin/src/templates/license.ts
@@ -3,13 +3,18 @@ interface LicenseInput {
   license: string;
 }
 
+function sanitizeAuthor(author: string): string {
+  return author.replace(/[<>]/g, "").trim();
+}
+
 export function generateLicense(input: LicenseInput): string {
   const year = new Date().getFullYear();
+  const author = sanitizeAuthor(input.author);
 
   if (input.license === "MIT") {
     return `MIT License
 
-Copyright (c) ${year} ${input.author}
+Copyright (c) ${year} ${author}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +38,6 @@ SOFTWARE.
 
   return `TODO: Add ${input.license} license text here.
 
-Copyright (c) ${year} ${input.author}
+Copyright (c) ${year} ${author}
 `;
 }

--- a/packages/create-plugin/src/templates/license.ts
+++ b/packages/create-plugin/src/templates/license.ts
@@ -1,0 +1,38 @@
+interface LicenseInput {
+  author: string;
+  license: string;
+}
+
+export function generateLicense(input: LicenseInput): string {
+  const year = new Date().getFullYear();
+
+  if (input.license === "MIT") {
+    return `MIT License
+
+Copyright (c) ${year} ${input.author}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`;
+  }
+
+  return `TODO: Add ${input.license} license text here.
+
+Copyright (c) ${year} ${input.author}
+`;
+}

--- a/packages/create-plugin/src/templates/package-json.ts
+++ b/packages/create-plugin/src/templates/package-json.ts
@@ -1,0 +1,38 @@
+import { toKebabCase } from "../utils.js";
+import type { PluginAnswers } from "../prompts.js";
+
+export function generatePackageJson(answers: PluginAnswers): string {
+  const kebab = toKebabCase(answers.name);
+  const pkg = {
+    name: `colophony-plugin-${kebab}`,
+    version: "0.1.0",
+    description: answers.description || `A Colophony plugin: ${answers.name}`,
+    type: "module",
+    main: "./dist/index.js",
+    types: "./dist/index.d.ts",
+    exports: {
+      ".": {
+        types: "./dist/index.d.ts",
+        default: "./dist/index.js",
+      },
+    },
+    scripts: {
+      build: "tsc",
+      clean: "rm -rf dist",
+      "type-check": "tsc --noEmit",
+      test: "vitest run",
+      "test:watch": "vitest",
+    },
+    dependencies: {
+      "@colophony/plugin-sdk": "^0.0.0",
+      zod: "^4.0.0",
+    },
+    devDependencies: {
+      typescript: "^5.7.0",
+      vitest: "^4.0.0",
+    },
+    license: answers.license || "MIT",
+  };
+
+  return JSON.stringify(pkg, null, 2) + "\n";
+}

--- a/packages/create-plugin/src/templates/plugin-class.ts
+++ b/packages/create-plugin/src/templates/plugin-class.ts
@@ -1,0 +1,63 @@
+import { toKebabCase, toPascalCase, toPluginId } from "../utils.js";
+import type { PluginAnswers } from "../prompts.js";
+
+export function generatePluginClass(answers: PluginAnswers): string {
+  const pascal = toPascalCase(answers.name);
+  const pluginId = toPluginId(answers.name);
+  const hasAdapter =
+    answers.pluginType === "adapter" || answers.pluginType === "full";
+  const hasHooks =
+    answers.pluginType === "integration" || answers.pluginType === "full";
+
+  let adapterImport = "";
+  let adapterTypes = "";
+  if (hasAdapter) {
+    const adapterType = (answers as { adapterType: string }).adapterType;
+    adapterImport = `import { ${pascal}Adapter } from "./adapters/${toKebabCase(adapterType)}.adapter.js";\n`;
+    adapterTypes = `\n    adapters: ["${adapterType}"],`;
+  }
+
+  const imports = [
+    "ColophonyPlugin",
+    "type PluginManifest",
+    "type PluginRegisterContext",
+  ];
+
+  const registerBody: string[] = [];
+  if (hasAdapter) {
+    const adapterType = (answers as { adapterType: string }).adapterType;
+    registerBody.push(
+      `    context.registerAdapter("${adapterType}", new ${pascal}Adapter());`,
+    );
+  }
+  if (hasHooks) {
+    registerBody.push(
+      `    // TODO: Register hooks`,
+      `    // context.registerHook("submission.created", async (payload) => {`,
+      `    //   context.logger.info("Submission created", { submissionId: payload.submissionId });`,
+      `    // });`,
+    );
+  }
+
+  return `import { ${imports.join(", ")} } from "@colophony/plugin-sdk";
+${adapterImport}
+export class ${pascal}Plugin extends ColophonyPlugin {
+  readonly manifest: PluginManifest = {
+    id: "${pluginId}",
+    name: "${answers.name}",
+    version: "0.1.0",
+    colophonyVersion: "2.0.0",
+    description: "${answers.description || `A Colophony plugin: ${answers.name}`}",
+    author: "${answers.author}",
+    license: "${answers.license}",
+    category: "${answers.category}",${adapterTypes}
+  };
+
+  async register(context: PluginRegisterContext): Promise<void> {
+${registerBody.length > 0 ? registerBody.join("\n") : "    // TODO: Register adapters, hooks, or UI extensions"}
+  }
+}
+
+export default ${pascal}Plugin;
+`;
+}

--- a/packages/create-plugin/src/templates/readme.ts
+++ b/packages/create-plugin/src/templates/readme.ts
@@ -1,8 +1,9 @@
-import { toKebabCase } from "../utils.js";
+import { toKebabCase, toPascalCase } from "../utils.js";
 import type { PluginAnswers } from "../prompts.js";
 
 export function generateReadme(answers: PluginAnswers): string {
   const kebab = toKebabCase(answers.name);
+  const pascal = toPascalCase(answers.name);
   const pkgName = `colophony-plugin-${kebab}`;
 
   return `# ${answers.name}
@@ -21,16 +22,10 @@ Add the plugin to your \`colophony.config.ts\`:
 
 \`\`\`typescript
 import { defineConfig } from "@colophony/plugin-sdk";
-import { ${kebab
-    .split("-")
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join("")}Plugin } from "${pkgName}";
+import { ${pascal}Plugin } from "${pkgName}";
 
 export default defineConfig({
-  plugins: [new ${kebab
-    .split("-")
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join("")}Plugin()],
+  plugins: [new ${pascal}Plugin()],
 });
 \`\`\`
 

--- a/packages/create-plugin/src/templates/readme.ts
+++ b/packages/create-plugin/src/templates/readme.ts
@@ -1,0 +1,49 @@
+import { toKebabCase } from "../utils.js";
+import type { PluginAnswers } from "../prompts.js";
+
+export function generateReadme(answers: PluginAnswers): string {
+  const kebab = toKebabCase(answers.name);
+  const pkgName = `colophony-plugin-${kebab}`;
+
+  return `# ${answers.name}
+
+${answers.description || `A Colophony plugin: ${answers.name}`}
+
+## Installation
+
+\`\`\`bash
+npm install ${pkgName}
+\`\`\`
+
+## Usage
+
+Add the plugin to your \`colophony.config.ts\`:
+
+\`\`\`typescript
+import { defineConfig } from "@colophony/plugin-sdk";
+import { ${kebab
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join("")}Plugin } from "${pkgName}";
+
+export default defineConfig({
+  plugins: [new ${kebab
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join("")}Plugin()],
+});
+\`\`\`
+
+## Development
+
+\`\`\`bash
+npm install
+npm run build
+npm test
+\`\`\`
+
+## License
+
+${answers.license || "MIT"}
+`;
+}

--- a/packages/create-plugin/src/templates/test-file.ts
+++ b/packages/create-plugin/src/templates/test-file.ts
@@ -1,0 +1,53 @@
+import { toPascalCase, toPluginId } from "../utils.js";
+import type { PluginAnswers } from "../prompts.js";
+
+export function generateTestFile(answers: PluginAnswers): string {
+  const pascal = toPascalCase(answers.name);
+  const pluginId = toPluginId(answers.name);
+  const hasAdapter =
+    answers.pluginType === "adapter" || answers.pluginType === "full";
+
+  if (hasAdapter) {
+    return `import { describe, it, expect } from "vitest";
+import { createMockRegisterContext } from "@colophony/plugin-sdk/testing";
+import { ${pascal}Plugin } from "./index.js";
+
+describe("${pascal}Plugin", () => {
+  it("has the correct manifest id", () => {
+    const plugin = new ${pascal}Plugin();
+    expect(plugin.manifest.id).toBe("${pluginId}");
+  });
+
+  it("registers the ${answers.adapterType} adapter", async () => {
+    const plugin = new ${pascal}Plugin();
+    const context = createMockRegisterContext();
+
+    await plugin.register(context);
+
+    expect(context.registeredAdapters).toHaveLength(1);
+    expect(context.registeredAdapters[0].type).toBe("${answers.adapterType}");
+  });
+});
+`;
+  }
+
+  return `import { describe, it, expect } from "vitest";
+import { createTestHarness } from "@colophony/plugin-sdk/testing";
+import { ${pascal}Plugin } from "./index.js";
+
+describe("${pascal}Plugin", () => {
+  it("has the correct manifest id", () => {
+    const plugin = new ${pascal}Plugin();
+    expect(plugin.manifest.id).toBe("${pluginId}");
+  });
+
+  it("registers without error", async () => {
+    const harness = createTestHarness();
+    const plugin = new ${pascal}Plugin();
+
+    await harness.loadPlugin(plugin);
+    await harness.teardown();
+  });
+});
+`;
+}

--- a/packages/create-plugin/src/templates/tsconfig.ts
+++ b/packages/create-plugin/src/templates/tsconfig.ts
@@ -1,0 +1,22 @@
+export function generateTsConfig(): string {
+  const config = {
+    compilerOptions: {
+      target: "ES2022",
+      module: "NodeNext",
+      moduleResolution: "NodeNext",
+      strict: true,
+      esModuleInterop: true,
+      skipLibCheck: true,
+      forceConsistentCasingInFileNames: true,
+      declaration: true,
+      declarationMap: true,
+      sourceMap: true,
+      outDir: "./dist",
+      rootDir: "./src",
+    },
+    include: ["src/**/*"],
+    exclude: ["node_modules", "dist"],
+  };
+
+  return JSON.stringify(config, null, 2) + "\n";
+}

--- a/packages/create-plugin/src/utils.ts
+++ b/packages/create-plugin/src/utils.ts
@@ -1,0 +1,41 @@
+export function toKebabCase(str: string): string {
+  return str
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .replace(/[\s_]+/g, "-")
+    .toLowerCase();
+}
+
+export function toPascalCase(str: string): string {
+  return str
+    .replace(/[-_\s]+(.)?/g, (_, c: string | undefined) =>
+      c ? c.toUpperCase() : "",
+    )
+    .replace(/^(.)/, (_, c: string) => c.toUpperCase());
+}
+
+export function toPluginId(name: string): string {
+  return name
+    .replace(/[^a-zA-Z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .toLowerCase()
+    .replace(/^-+|-+$/g, "");
+}
+
+export function validatePluginName(name: string): string | true {
+  if (!name || name.trim().length === 0) {
+    return "Plugin name is required";
+  }
+  if (name.length < 2) {
+    return "Plugin name must be at least 2 characters";
+  }
+  if (name.length > 50) {
+    return "Plugin name must be at most 50 characters";
+  }
+  if (/^-/.test(name)) {
+    return "Plugin name cannot start with a hyphen";
+  }
+  if (!/^[a-z0-9][a-z0-9 -]*$/.test(name)) {
+    return "Plugin name must contain only lowercase letters, numbers, spaces, and hyphens";
+  }
+  return true;
+}

--- a/packages/create-plugin/src/write.ts
+++ b/packages/create-plugin/src/write.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { toKebabCase } from "./utils.js";
+import { toKebabCase, toPluginId } from "./utils.js";
 import type { PluginAnswers } from "./prompts.js";
 import { generatePackageJson } from "./templates/package-json.js";
 import { generateTsConfig } from "./templates/tsconfig.js";
@@ -20,8 +20,8 @@ export function buildFileMap(
   answers: PluginAnswers,
   options?: { cwd?: string },
 ): ScaffoldInput {
-  const kebab = toKebabCase(answers.name);
-  const dirName = `colophony-plugin-${kebab}`;
+  const safeId = toPluginId(answers.name);
+  const dirName = `colophony-plugin-${safeId}`;
   const cwd = options?.cwd ?? process.cwd();
   const outputDir = path.join(cwd, dirName);
 
@@ -67,9 +67,18 @@ export async function scaffoldProject(input: ScaffoldInput): Promise<void> {
     throw new Error(`Directory already exists: ${input.outputDir}`);
   }
 
-  for (const [relativePath, content] of Object.entries(input.files)) {
-    const fullPath = path.join(input.outputDir, relativePath);
-    await fs.mkdir(path.dirname(fullPath), { recursive: true });
-    await fs.writeFile(fullPath, content, "utf-8");
+  const dirs = new Set(
+    Object.keys(input.files).map((p) =>
+      path.dirname(path.join(input.outputDir, p)),
+    ),
+  );
+  for (const dir of dirs) {
+    await fs.mkdir(dir, { recursive: true });
   }
+
+  await Promise.all(
+    Object.entries(input.files).map(([relativePath, content]) =>
+      fs.writeFile(path.join(input.outputDir, relativePath), content, "utf-8"),
+    ),
+  );
 }

--- a/packages/create-plugin/src/write.ts
+++ b/packages/create-plugin/src/write.ts
@@ -1,0 +1,75 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { toKebabCase } from "./utils.js";
+import type { PluginAnswers } from "./prompts.js";
+import { generatePackageJson } from "./templates/package-json.js";
+import { generateTsConfig } from "./templates/tsconfig.js";
+import { generatePluginClass } from "./templates/plugin-class.js";
+import { generateAdapterClass } from "./templates/adapter-class.js";
+import { generateTestFile } from "./templates/test-file.js";
+import { generateReadme } from "./templates/readme.js";
+import { generateGitignore } from "./templates/gitignore.js";
+import { generateLicense } from "./templates/license.js";
+
+export interface ScaffoldInput {
+  outputDir: string;
+  files: Record<string, string>;
+}
+
+export function buildFileMap(
+  answers: PluginAnswers,
+  options?: { cwd?: string },
+): ScaffoldInput {
+  const kebab = toKebabCase(answers.name);
+  const dirName = `colophony-plugin-${kebab}`;
+  const cwd = options?.cwd ?? process.cwd();
+  const outputDir = path.join(cwd, dirName);
+
+  const files: Record<string, string> = {
+    "package.json": generatePackageJson(answers),
+    "tsconfig.json": generateTsConfig(),
+    "README.md": generateReadme(answers),
+    ".gitignore": generateGitignore(),
+    LICENSE: generateLicense({
+      author: answers.author,
+      license: answers.license,
+    }),
+    "src/index.ts": generatePluginClass(answers),
+    "src/index.spec.ts": generateTestFile(answers),
+  };
+
+  const hasAdapter =
+    answers.pluginType === "adapter" || answers.pluginType === "full";
+
+  if (hasAdapter) {
+    const adapterKebab = toKebabCase(
+      (answers as { adapterType: string }).adapterType,
+    );
+    const adapterType = (
+      answers as { adapterType: "email" | "payment" | "storage" | "search" }
+    ).adapterType;
+    files[`src/adapters/${adapterKebab}.adapter.ts`] = generateAdapterClass({
+      name: answers.name,
+      adapterType,
+    });
+  }
+
+  return { outputDir, files };
+}
+
+export async function scaffoldProject(input: ScaffoldInput): Promise<void> {
+  const exists = await fs
+    .access(input.outputDir)
+    .then(() => true)
+    .catch(() => false);
+
+  if (exists) {
+    throw new Error(`Directory already exists: ${input.outputDir}`);
+  }
+
+  for (const [relativePath, content] of Object.entries(input.files)) {
+    const fullPath = path.join(input.outputDir, relativePath);
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    await fs.writeFile(fullPath, content, "utf-8");
+  }
+}

--- a/packages/create-plugin/tsconfig.json
+++ b/packages/create-plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@colophony/typescript-config/library.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/create-plugin/vitest.config.ts
+++ b/packages/create-plugin/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.{test,spec}.ts"],
+    globals: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -480,6 +480,25 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/create-plugin:
+    dependencies:
+      prompts:
+        specifier: ^2.4.2
+        version: 2.4.2
+    devDependencies:
+      '@colophony/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/prompts':
+        specifier: ^2.4.9
+        version: 2.4.9
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/db:
     dependencies:
       drizzle-orm:
@@ -3825,6 +3844,9 @@ packages:
   '@types/pg@8.16.0':
     resolution: {integrity: sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==}
 
+  '@types/prompts@2.4.9':
+    resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -6026,6 +6048,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
 
@@ -6798,6 +6824,10 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -7208,6 +7238,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -11939,6 +11972,11 @@ snapshots:
       pg-protocol: 1.11.0
       pg-types: 2.2.0
 
+  '@types/prompts@2.4.9':
+    dependencies:
+      '@types/node': 25.3.0
+      kleur: 3.0.3
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -14580,6 +14618,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  kleur@3.0.3: {}
+
   language-subtag-registry@0.3.23: {}
 
   language-tags@1.0.9:
@@ -15522,6 +15562,11 @@ snapshots:
 
   process@0.11.10: {}
 
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -16054,6 +16099,8 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 


### PR DESCRIPTION
## Summary

- New `packages/create-plugin/` package — npm-publishable `@colophony/create-plugin` v0.1.0
- Interactive CLI scaffolds standalone Colophony plugin projects with correct SDK dependency, TypeScript config, plugin class, tests, and README
- Supports 3 scaffold types: integration (hooks only), adapter (SDK interface impl), full (both)
- 4 adapter types: email, payment, storage, search — generates correct interface stubs
- 38 tests across 3 suites (utils, templates, integration)

Track 6 Phase 3-4 scaffolding CLI item.

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `src/__tests__/utils.spec.ts` | 10 tests | 12 tests | Extra edge cases for `validatePluginName` and `toPluginId` |
| `src/templates/adapter-class.ts` | Generic `Error` in stubs | `NotImplementedError` class | code review finding — more descriptive errors |
| `src/write.ts` | Sequential file writes | `Promise.all` parallel writes | code review finding — performance |
| `src/prompts.ts` | No length limits on description/author | 200/100 char limits | code review finding — input validation |

## Test plan

- [x] `pnpm --filter @colophony/create-plugin build` — compiles cleanly
- [x] `pnpm --filter @colophony/create-plugin type-check` — no errors
- [x] `pnpm --filter @colophony/create-plugin test` — 38/38 tests pass
- [x] OpenCode branch review — all findings addressed
- [ ] CI passes (quality, unit-tests, build)