### PR TITLE
chore: code quality polish — type safety, structured logging, cleanup

### DIFF
--- a/apps/api/src/config/logger.ts
+++ b/apps/api/src/config/logger.ts
@@ -9,7 +9,6 @@ import type { FastifyBaseLogger } from 'fastify';
  */
 let _logger: FastifyBaseLogger | null = null;
 
-/* eslint-disable no-console */
 const _fallback = {
   fatal: console.error.bind(console),
   error: console.error.bind(console),
@@ -21,7 +20,6 @@ const _fallback = {
   child: () => _fallback,
   level: 'info',
 } as unknown as FastifyBaseLogger;
-/* eslint-enable no-console */
 
 export function setWorkerLogger(logger: FastifyBaseLogger): void {
   _logger = logger;

--- a/apps/api/src/config/logger.ts
+++ b/apps/api/src/config/logger.ts
@@ -4,19 +4,29 @@ import type { FastifyBaseLogger } from 'fastify';
  * Shared logger reference for BullMQ workers and other non-request code.
  *
  * Initialized from `main.ts` after the Fastify instance is created.
- * Workers call `getLogger()` instead of `console.error()`.
+ * Falls back to console-based logging if called before initialization
+ * (e.g., during tests or unusual startup sequences).
  */
 let _logger: FastifyBaseLogger | null = null;
+
+/* eslint-disable no-console */
+const _fallback = {
+  fatal: console.error.bind(console),
+  error: console.error.bind(console),
+  warn: console.warn.bind(console),
+  info: console.info.bind(console),
+  debug: console.debug.bind(console),
+  trace: console.debug.bind(console),
+  silent: () => {},
+  child: () => _fallback,
+  level: 'info',
+} as unknown as FastifyBaseLogger;
+/* eslint-enable no-console */
 
 export function setWorkerLogger(logger: FastifyBaseLogger): void {
   _logger = logger;
 }
 
 export function getLogger(): FastifyBaseLogger {
-  if (!_logger) {
-    throw new Error(
-      'Worker logger not initialized — call setWorkerLogger() from main.ts first',
-    );
-  }
-  return _logger;
+  return _logger ?? _fallback;
 }

--- a/apps/api/src/config/logger.ts
+++ b/apps/api/src/config/logger.ts
@@ -1,0 +1,22 @@
+import type { FastifyBaseLogger } from 'fastify';
+
+/**
+ * Shared logger reference for BullMQ workers and other non-request code.
+ *
+ * Initialized from `main.ts` after the Fastify instance is created.
+ * Workers call `getLogger()` instead of `console.error()`.
+ */
+let _logger: FastifyBaseLogger | null = null;
+
+export function setWorkerLogger(logger: FastifyBaseLogger): void {
+  _logger = logger;
+}
+
+export function getLogger(): FastifyBaseLogger {
+  if (!_logger) {
+    throw new Error(
+      'Worker logger not initialized — call setWorkerLogger() from main.ts first',
+    );
+  }
+  return _logger;
+}

--- a/apps/api/src/federation/federation-auth.ts
+++ b/apps/api/src/federation/federation-auth.ts
@@ -150,7 +150,7 @@ export default fp(
         // Reconstruct full URL for signature verification.
         // Use request.host (not hostname) to preserve the port for non-default ports.
         const fullUrl = `${request.protocol}://${request.host}${request.url}`;
-        const rawBody = (request as any).rawBody as string | undefined;
+        const rawBody = request.rawBody;
 
         try {
           const result = await verifyFederationSignature(

--- a/apps/api/src/federation/hub-auth.ts
+++ b/apps/api/src/federation/hub-auth.ts
@@ -104,7 +104,7 @@ export default fp(
 
         // Reconstruct full URL for signature verification
         const fullUrl = `${request.protocol}://${request.host}${request.url}`;
-        const rawBody = (request as any).rawBody as string | undefined;
+        const rawBody = request.rawBody;
 
         try {
           const result = await verifyFederationSignature(

--- a/apps/api/src/federation/trust.routes.ts
+++ b/apps/api/src/federation/trust.routes.ts
@@ -47,7 +47,7 @@ export async function registerFederationTrustRoutes(
     }
 
     try {
-      const rawBody = (request as any).rawBody as string;
+      const rawBody = request.rawBody as string;
       const result = await trustService.handleInboundTrustRequest(
         env,
         parsed.data,
@@ -87,7 +87,7 @@ export async function registerFederationTrustRoutes(
     }
 
     try {
-      const rawBody = (request as any).rawBody as string;
+      const rawBody = request.rawBody as string;
       await trustService.handleInboundTrustAccept(
         env,
         parsed.data,

--- a/apps/api/src/federation/trust.routes.ts
+++ b/apps/api/src/federation/trust.routes.ts
@@ -47,6 +47,8 @@ export async function registerFederationTrustRoutes(
     }
 
     try {
+      // rawBody is string (not Buffer) because fastify-raw-body is registered
+      // with encoding: 'utf8' in this scope (see plugin registration above).
       const rawBody = request.rawBody as string;
       const result = await trustService.handleInboundTrustRequest(
         env,
@@ -87,6 +89,7 @@ export async function registerFederationTrustRoutes(
     }
 
     try {
+      // rawBody is string — see encoding note above.
       const rawBody = request.rawBody as string;
       await trustService.handleInboundTrustAccept(
         env,

--- a/apps/api/src/graphql/types/file.ts
+++ b/apps/api/src/graphql/types/file.ts
@@ -35,6 +35,3 @@ export const FileType = builder.objectRef<File>('File').implement({
     }),
   }),
 });
-
-/** @deprecated Use FileType — aliased for backwards compat */
-export const SubmissionFileType = FileType;

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -3,7 +3,7 @@ export { SubmissionStatusEnum, ScanStatusEnum, RoleEnum } from './enums.js';
 export { UserType } from './user.js';
 export { OrganizationType, OrganizationMemberType } from './organization.js';
 export { SubmissionType, SubmissionHistoryType } from './submission.js';
-export { FileType, SubmissionFileType } from './file.js';
+export { FileType } from './file.js';
 export { ManuscriptType, ManuscriptVersionType } from './manuscript.js';
 export { AuditEventType } from './audit.js';
 export { ApiKeyType } from './api-key.js';

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -387,7 +387,10 @@ async function start(): Promise<void> {
       await closePublisher();
       await closeSubscriber();
       await registry.destroyAll();
-      await Promise.all([pool.end(), appPool.end()]);
+      await Promise.all([
+        pool.end().catch(() => {}),
+        appPool.end().catch(() => {}),
+      ]);
       app.log.info('Server closed');
     } finally {
       clearTimeout(forceExit);

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,7 +1,7 @@
 import Fastify, { type FastifyInstance } from 'fastify';
 import cors from '@fastify/cors';
 import helmet from '@fastify/helmet';
-import { pool } from '@colophony/db';
+import { pool, appPool } from '@colophony/db';
 import { loadConfig } from '@colophony/plugin-sdk';
 import { type Env, validateEnv } from './config/env.js';
 import { buildColophonyConfig } from './colophony.config.js';
@@ -317,6 +317,10 @@ async function start(): Promise<void> {
   setGlobalExtensions(uiExtensions);
   setGlobalPluginManifests(plugins.map((p) => p.manifest));
 
+  // Initialize shared logger for BullMQ workers
+  const { setWorkerLogger } = await import('./config/logger.js');
+  setWorkerLogger(app.log);
+
   // Start BullMQ workers
   if (env.VIRUS_SCAN_ENABLED) {
     startFileScanWorker(env, registry);
@@ -383,7 +387,7 @@ async function start(): Promise<void> {
       await closePublisher();
       await closeSubscriber();
       await registry.destroyAll();
-      // TODO: Close DB pool when connection management is centralized
+      await Promise.all([pool.end(), appPool.end()]);
       app.log.info('Server closed');
     } finally {
       clearTimeout(forceExit);

--- a/apps/api/src/services/transfer.service.ts
+++ b/apps/api/src/services/transfer.service.ts
@@ -31,6 +31,7 @@ import { signFederationRequest } from '../federation/http-signatures.js';
 import { getGlobalRegistry } from '../adapters/registry-accessor.js';
 import type { S3StorageAdapter } from '../adapters/storage/index.js';
 import { enqueueTransferFetch } from '../queues/transfer-fetch.queue.js';
+import { getLogger } from '../config/logger.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -596,7 +597,10 @@ export const transferService = {
             result.transferId,
             orgId,
           ).catch((err) => {
-            console.error('Background file fetch failed:', err);
+            getLogger().error(
+              { err },
+              '[transfer] Background file fetch failed',
+            );
           });
         }
       }
@@ -644,8 +648,9 @@ export const transferService = {
         });
 
         if (!response.ok) {
-          console.error(
-            `File fetch failed for ${entry.fileId}: ${response.status}`,
+          getLogger().error(
+            { fileId: entry.fileId, status: response.status },
+            '[transfer] File fetch failed',
           );
           continue;
         }
@@ -662,7 +667,10 @@ export const transferService = {
 
         storedFiles.push({ fileId: entry.fileId, storageKey });
       } catch (err) {
-        console.error(`File fetch error for ${entry.fileId}:`, err);
+        getLogger().error(
+          { fileId: entry.fileId, err },
+          '[transfer] File fetch error',
+        );
       }
     }
 

--- a/apps/api/src/workers/__tests__/email.worker.spec.ts
+++ b/apps/api/src/workers/__tests__/email.worker.spec.ts
@@ -23,6 +23,15 @@ vi.mock('../../services/audit.service.js', () => ({
   },
 }));
 
+vi.mock('../../config/logger.js', () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
 const mockRenderEmailTemplate = vi.fn(
   (_name: unknown, _data: unknown) =>
     ({

--- a/apps/api/src/workers/__tests__/file-scan.worker.spec.ts
+++ b/apps/api/src/workers/__tests__/file-scan.worker.spec.ts
@@ -4,6 +4,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mocks — must be set up before imports
 // ---------------------------------------------------------------------------
 
+vi.mock('../../config/logger.js', () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
 const mockWithRls = vi.fn();
 vi.mock('@colophony/db', () => ({
   withRls: (...args: unknown[]) => mockWithRls(...args),

--- a/apps/api/src/workers/__tests__/transfer-fetch.worker.spec.ts
+++ b/apps/api/src/workers/__tests__/transfer-fetch.worker.spec.ts
@@ -4,6 +4,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mocks — must be set up before imports
 // ---------------------------------------------------------------------------
 
+vi.mock('../../config/logger.js', () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
 const mockWithRls = vi.fn();
 vi.mock('@colophony/db', () => ({
   withRls: (...args: unknown[]) => mockWithRls(...args),

--- a/apps/api/src/workers/__tests__/webhook.worker.spec.ts
+++ b/apps/api/src/workers/__tests__/webhook.worker.spec.ts
@@ -60,6 +60,15 @@ vi.mock('@colophony/types', () => ({
   },
 }));
 
+vi.mock('../../config/logger.js', () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
 const mockGetWebhookBackoffDelay = vi.fn().mockReturnValue(1000);
 vi.mock('../../queues/webhook.queue.js', () => ({
   getWebhookBackoffDelay: (...args: unknown[]) =>

--- a/apps/api/src/workers/email.worker.ts
+++ b/apps/api/src/workers/email.worker.ts
@@ -9,6 +9,7 @@ import { emailService } from '../services/email.service.js';
 import { auditService } from '../services/audit.service.js';
 import { renderEmailTemplate } from '../templates/email/index.js';
 import type { TemplateName } from '../templates/email/types.js';
+import { getLogger } from '../config/logger.js';
 
 let worker: Worker<EmailJobData> | null = null;
 
@@ -107,9 +108,14 @@ export function startEmailWorker(
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   worker.on('failed', async (job, err) => {
-    console.error(
-      `[email] Job ${job?.id} failed (attempt ${job?.attemptsMade}/${job?.opts.attempts}):`,
-      err.message,
+    getLogger().error(
+      {
+        jobId: job?.id,
+        attempt: job?.attemptsMade,
+        maxAttempts: job?.opts.attempts,
+        err,
+      },
+      '[email] Job failed',
     );
 
     // On final failure, mark as FAILED + audit
@@ -132,9 +138,9 @@ export function startEmailWorker(
           });
         });
       } catch (auditErr) {
-        console.error(
-          `[email] Failed to record failure for job ${job.id}:`,
-          auditErr,
+        getLogger().error(
+          { jobId: job.id, err: auditErr },
+          '[email] Failed to record failure audit',
         );
       }
     }

--- a/apps/api/src/workers/file-scan.worker.ts
+++ b/apps/api/src/workers/file-scan.worker.ts
@@ -9,6 +9,7 @@ import type { FileScanJobData } from '../queues/file-scan.queue.js';
 import { fileService } from '../services/file.service.js';
 import { auditService } from '../services/audit.service.js';
 import type { S3StorageAdapter } from '../adapters/storage/index.js';
+import { getLogger } from '../config/logger.js';
 
 let worker: Worker<FileScanJobData> | null = null;
 let clamInstance: NodeClam | null = null;
@@ -152,9 +153,14 @@ export function startFileScanWorker(
   );
 
   worker.on('failed', (job, err) => {
-    console.error(
-      `[file-scan] Job ${job?.id} failed (attempt ${job?.attemptsMade}/${job?.opts.attempts}):`,
-      err.message,
+    getLogger().error(
+      {
+        jobId: job?.id,
+        attempt: job?.attemptsMade,
+        maxAttempts: job?.opts.attempts,
+        err,
+      },
+      '[file-scan] Job failed',
     );
   });
 

--- a/apps/api/src/workers/outbox-poller.worker.ts
+++ b/apps/api/src/workers/outbox-poller.worker.ts
@@ -3,6 +3,7 @@ import { db, outboxEvents, eq, sql, isNull, asc } from '@colophony/db';
 import type { Env } from '../config/env.js';
 import type { OutboxPollerJobData } from '../queues/outbox-poller.queue.js';
 import { inngest } from '../inngest/client.js';
+import { getLogger } from '../config/logger.js';
 
 let worker: Worker<OutboxPollerJobData> | null = null;
 
@@ -99,7 +100,7 @@ export function startOutboxPollerWorker(env: Env): void {
   );
 
   worker.on('failed', (job, err) => {
-    console.error(`Outbox poller job ${job?.id} failed:`, err.message);
+    getLogger().error({ jobId: job?.id, err }, '[outbox-poller] Job failed');
   });
 }
 

--- a/apps/api/src/workers/s3-cleanup.worker.ts
+++ b/apps/api/src/workers/s3-cleanup.worker.ts
@@ -5,6 +5,7 @@ import type { Env } from '../config/env.js';
 import type { S3CleanupJobData } from '../queues/s3-cleanup.queue.js';
 import type { S3StorageAdapter } from '../adapters/storage/index.js';
 import { auditService } from '../services/audit.service.js';
+import { getLogger } from '../config/logger.js';
 
 let worker: Worker<S3CleanupJobData> | null = null;
 
@@ -70,9 +71,14 @@ export function startS3CleanupWorker(
   );
 
   worker.on('failed', (job, err) => {
-    console.error(
-      `[s3-cleanup] Job ${job?.id} failed (attempt ${job?.attemptsMade}/${job?.opts.attempts}):`,
-      err.message,
+    getLogger().error(
+      {
+        jobId: job?.id,
+        attempt: job?.attemptsMade,
+        maxAttempts: job?.opts.attempts,
+        err,
+      },
+      '[s3-cleanup] Job failed',
     );
   });
 

--- a/apps/api/src/workers/transfer-fetch.worker.ts
+++ b/apps/api/src/workers/transfer-fetch.worker.ts
@@ -14,6 +14,7 @@ import type { Env } from '../config/env.js';
 import type { TransferFetchJobData } from '../queues/transfer-fetch.queue.js';
 import { auditService } from '../services/audit.service.js';
 import type { S3StorageAdapter } from '../adapters/storage/index.js';
+import { getLogger } from '../config/logger.js';
 
 let worker: Worker<TransferFetchJobData> | null = null;
 
@@ -249,9 +250,14 @@ export function startTransferFetchWorker(
   );
 
   worker.on('failed', (job, err) => {
-    console.error(
-      `[transfer-fetch] Job ${job?.id} failed (attempt ${job?.attemptsMade}/${job?.opts.attempts}):`,
-      err.message,
+    getLogger().error(
+      {
+        jobId: job?.id,
+        attempt: job?.attemptsMade,
+        maxAttempts: job?.opts.attempts,
+        err,
+      },
+      '[transfer-fetch] Job failed',
     );
   });
 

--- a/apps/api/src/workers/webhook.worker.ts
+++ b/apps/api/src/workers/webhook.worker.ts
@@ -8,6 +8,7 @@ import type { WebhookJobData } from '../queues/webhook.queue.js';
 import { getWebhookBackoffDelay } from '../queues/webhook.queue.js';
 import { webhookService } from '../services/webhook.service.js';
 import { auditService } from '../services/audit.service.js';
+import { getLogger } from '../config/logger.js';
 
 const AUTO_DISABLE_THRESHOLD = 5;
 const DELIVERY_TIMEOUT_MS = 30_000;
@@ -137,9 +138,14 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   worker.on('failed', async (job, err) => {
-    console.error(
-      `[webhook] Job ${job?.id} failed (attempt ${job?.attemptsMade}/${job?.opts.attempts}):`,
-      err.message,
+    getLogger().error(
+      {
+        jobId: job?.id,
+        attempt: job?.attemptsMade,
+        maxAttempts: job?.opts.attempts,
+        err,
+      },
+      '[webhook] Job failed',
     );
 
     // On final failure, mark as FAILED + audit + auto-disable check
@@ -196,9 +202,9 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
           }
         });
       } catch (auditErr) {
-        console.error(
-          `[webhook] Failed to record failure for job ${job.id}:`,
-          auditErr,
+        getLogger().error(
+          { jobId: job.id, err: auditErr },
+          '[webhook] Failed to record failure audit',
         );
       }
     }

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,23 @@ Newest entries first.
 
 ---
 
+## 2026-02-27 — Code Quality Polish
+
+### Done
+
+- **Fastify rawBody type safety:** Removed 4 `as any` casts in federation auth files (`federation-auth.ts`, `hub-auth.ts`, `trust.routes.ts`) by leveraging the existing type declarations from `fastify-raw-body` plugin. Zero production `as any` remaining in federation code.
+- **Structured logging in workers:** Replaced `console.error` with pino structured logger (`getLogger().error({ ...context }, 'message')`) in all 6 BullMQ workers (email, file-scan, s3-cleanup, webhook, transfer-fetch, outbox-poller) and transfer service. Created shared `config/logger.ts` module initialized from Fastify's pino instance.
+- **Removed deprecated alias:** Deleted unused `SubmissionFileType` export from GraphQL types (renamed to `FileType` during manuscript refactor, no consumers).
+- **DB pool graceful shutdown:** Wired `pool.end()` + `appPool.end()` into Fastify shutdown handler, replacing TODO comment at `main.ts:386`.
+- **Codebase audit:** Ran 4-way parallel audit (TODOs, console.log, type anti-patterns, dead code). Findings: 1 production TODO (fixed), 0 FIXME/HACK/XXX, 0 `@ts-ignore`, 0 empty catch blocks, 0 significant dead code.
+
+### Decisions
+
+- Used shared logger singleton (`setWorkerLogger`/`getLogger`) rather than passing logger as parameter to worker functions — minimizes signature churn across 6 workers
+- rawBody type narrowing uses `as string` (not `as any`) since plugin is configured with `encoding: 'utf8'`
+
+---
+
 ## 2026-02-27 — Track 2: SDK Generation (TypeScript + Python)
 
 ### Done


### PR DESCRIPTION
## Summary

- **Fastify rawBody type safety:** Removed 4 `as any` casts in federation auth files by leveraging existing `fastify-raw-body` plugin type declarations
- **Structured logging in workers:** Replaced `console.error` with pino structured logger in all 6 BullMQ workers + transfer service via shared `config/logger.ts` module
- **Removed deprecated alias:** Deleted unused `SubmissionFileType` GraphQL export (no consumers)
- **DB pool graceful shutdown:** Wired `pool.end()` + `appPool.end()` into Fastify shutdown handler

## Test plan

- [x] Type-check passes (14/14 packages)
- [x] All 1212 unit tests pass (112 test files)
- [x] Lint clean
- [x] Pre-push hooks pass (type-check + lint)
- [ ] CI passes