### PR TITLE
feat(api): Sentry error tracking + Prometheus metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,3 +92,17 @@ RATE_LIMIT_KEY_PREFIX=colophony:rl
 CLAMAV_HOST=
 CLAMAV_PORT=3310
 CLAMAV_TIMEOUT=30000
+
+# =============================================================================
+# MONITORING (optional)
+# =============================================================================
+# Sentry error tracking — set DSN to enable
+# SENTRY_DSN=https://your-dsn@sentry.io/project
+# SENTRY_ENVIRONMENT=development
+# SENTRY_TRACES_SAMPLE_RATE=0
+# SENTRY_RELEASE=
+
+# Prometheus metrics — set to true to enable /metrics endpoint
+# METRICS_ENABLED=false
+# Start monitoring stack: docker compose --profile monitoring up -d
+# Grafana: http://localhost:3001 (admin/admin)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,10 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **TypeScript SDK**       | `sdks/typescript/` (`@colophony/sdk` — openapi-fetch + generated types)          |
 | **Python SDK**           | `sdks/python/` (`colophony` — openapi-python-client generated)                   |
 | **SDK generation**       | `scripts/generate-sdks.ts` (regenerate both SDKs from committed spec)            |
+| **Sentry config**        | `apps/api/src/config/sentry.ts` (init, captureException, isSentryEnabled)        |
+| **Metrics registry**     | `apps/api/src/config/metrics.ts` (Prometheus counters, histograms, gauges)       |
+| **Metrics plugin**       | `apps/api/src/hooks/metrics.ts` (Fastify plugin — HTTP request instrumentation)  |
+| **Instrumented worker**  | `apps/api/src/config/instrumented-worker.ts` (BullMQ wrapper with metrics)       |
 | **Backlog**              | `docs/backlog.md` (track-organized, drives session focus)                        |
 
 Full project structure: [docs/architecture-v2-planning.md](docs/architecture-v2-planning.md)
@@ -183,7 +187,7 @@ All other version pins are in their respective per-directory CLAUDE.md files.
 - [ ] `pg_stat_statements` for query monitoring
 - [ ] Rotate credentials quarterly
 - [ ] AGPL license boundary documented (Zitadel is AGPL; Colophony code is unaffected)
-- [ ] Monitoring: Prometheus + Grafana + Loki
+- [x] Monitoring: Prometheus + Grafana (Sentry error tracking, `/metrics` endpoint, `--profile monitoring`)
 - [ ] Verify RLS in production — see `packages/db/CLAUDE.md` for verification queries
 
 ---
@@ -428,6 +432,11 @@ Canonical env definition with Zod validation: `apps/api/src/config/env.ts`
 | `NEXT_PUBLIC_ZITADEL_AUTHORITY` / `NEXT_PUBLIC_ZITADEL_CLIENT_ID` | —        | —                            | Web            |
 | `API_URL`                                                         | —        | —                            | Web (SSR only) |
 | `PLUGIN_REGISTRY_URL`                                             | No       | —                            | API            |
+| `SENTRY_DSN`                                                      | No       | —                            | API            |
+| `SENTRY_ENVIRONMENT`                                              | No       | `development`                | API            |
+| `SENTRY_TRACES_SAMPLE_RATE`                                       | No       | `0`                          | API            |
+| `SENTRY_RELEASE`                                                  | No       | —                            | API            |
+| `METRICS_ENABLED`                                                 | No       | `false`                      | API            |
 
 ---
 

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -255,18 +255,23 @@ Workers and queues are started in `main.ts` and closed during graceful shutdown.
 
 ### Env Vars
 
-| Variable             | Default     | Purpose                                     |
-| -------------------- | ----------- | ------------------------------------------- |
-| `CLAMAV_HOST`        | `localhost` | ClamAV daemon TCP host                      |
-| `CLAMAV_PORT`        | `3310`      | ClamAV daemon TCP port                      |
-| `VIRUS_SCAN_ENABLED` | `true`      | Enable/disable virus scans                  |
-| `DEV_AUTH_BYPASS`    | `false`     | Allow unauthed requests in dev (no Zitadel) |
-| `EMAIL_PROVIDER`     | `none`      | Email provider: `smtp`, `sendgrid`, `none`  |
-| `SMTP_HOST`          | —           | SMTP server hostname                        |
-| `SMTP_PORT`          | `587`       | SMTP server port                            |
-| `SMTP_FROM`          | —           | SMTP sender address                         |
-| `SENDGRID_API_KEY`   | —           | SendGrid API key                            |
-| `SENDGRID_FROM`      | —           | SendGrid sender address                     |
+| Variable                    | Default       | Purpose                                     |
+| --------------------------- | ------------- | ------------------------------------------- |
+| `CLAMAV_HOST`               | `localhost`   | ClamAV daemon TCP host                      |
+| `CLAMAV_PORT`               | `3310`        | ClamAV daemon TCP port                      |
+| `VIRUS_SCAN_ENABLED`        | `true`        | Enable/disable virus scans                  |
+| `DEV_AUTH_BYPASS`           | `false`       | Allow unauthed requests in dev (no Zitadel) |
+| `EMAIL_PROVIDER`            | `none`        | Email provider: `smtp`, `sendgrid`, `none`  |
+| `SMTP_HOST`                 | —             | SMTP server hostname                        |
+| `SMTP_PORT`                 | `587`         | SMTP server port                            |
+| `SMTP_FROM`                 | —             | SMTP sender address                         |
+| `SENDGRID_API_KEY`          | —             | SendGrid API key                            |
+| `SENDGRID_FROM`             | —             | SendGrid sender address                     |
+| `SENTRY_DSN`                | —             | Sentry DSN (enables error tracking)         |
+| `SENTRY_ENVIRONMENT`        | `development` | Sentry environment label                    |
+| `SENTRY_TRACES_SAMPLE_RATE` | `0`           | Sentry tracing sample rate (0-1)            |
+| `SENTRY_RELEASE`            | —             | Sentry release tag                          |
+| `METRICS_ENABLED`           | `false`       | Enable Prometheus `/metrics` endpoint       |
 
 ---
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -44,6 +44,7 @@
     "@pothos/core": "^4.3",
     "@pothos/plugin-relay": "^4.3",
     "@sendgrid/mail": "^8.1.6",
+    "@sentry/node": "^10.40.0",
     "@trpc/server": "^11.0.0",
     "archiver": "^7.0.1",
     "bullmq": "^5.70.1",
@@ -60,6 +61,7 @@
     "jose": "^6.0.0",
     "mjml": "^4.18.0",
     "nodemailer": "^8.0.1",
+    "prom-client": "^15.1.3",
     "stripe": "^20.3.1",
     "zod": "^4.3.6"
   },

--- a/apps/api/src/__tests__/webhooks/helpers/webhook-app.ts
+++ b/apps/api/src/__tests__/webhooks/helpers/webhook-app.ts
@@ -54,6 +54,9 @@ export function createTestEnv(overrides?: Partial<Env>): Env {
     INNGEST_DEV: false,
     EMAIL_PROVIDER: 'none' as const,
     SMTP_SECURE: false,
+    SENTRY_ENVIRONMENT: 'test',
+    SENTRY_TRACES_SAMPLE_RATE: 0,
+    METRICS_ENABLED: false,
     ...overrides,
   };
 }

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -120,6 +120,18 @@ const envSchema = z.object({
 
   // Plugin registry
   PLUGIN_REGISTRY_URL: z.string().url().optional(),
+
+  // Monitoring — Sentry
+  SENTRY_DSN: z.string().url().optional(),
+  SENTRY_ENVIRONMENT: z.string().default('development'),
+  SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0),
+  SENTRY_RELEASE: z.string().optional(),
+
+  // Monitoring — Prometheus
+  METRICS_ENABLED: z
+    .enum(['true', 'false'])
+    .default('false')
+    .transform((v) => v === 'true'),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/config/instrumented-worker.spec.ts
+++ b/apps/api/src/config/instrumented-worker.spec.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock metrics
+const mockObserve = vi.fn();
+const mockInc = vi.fn();
+vi.mock('./metrics.js', () => ({
+  bullmqJobDuration: { observe: (...args: unknown[]) => mockObserve(...args) },
+  bullmqJobTotal: { inc: (...args: unknown[]) => mockInc(...args) },
+}));
+
+// Mock sentry
+const mockCaptureException = vi.fn();
+vi.mock('./sentry.js', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
+// Mock logger
+vi.mock('./logger.js', () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+  }),
+}));
+
+// Mock BullMQ Worker
+const mockOn = vi.fn();
+vi.mock('bullmq', () => ({
+  Worker: function MockWorker(
+    _name: string,
+    processor: unknown,
+    _opts: unknown,
+  ) {
+    (this as { processor: unknown }).processor = processor;
+    (this as { on: unknown }).on = mockOn;
+    return this;
+  },
+}));
+
+import { createInstrumentedWorker } from './instrumented-worker.js';
+
+describe('createInstrumentedWorker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createTestWorker(opts?: {
+    processor?: (job: unknown) => Promise<unknown>;
+    onFailed?: (job: unknown, err: Error) => void | Promise<void>;
+  }) {
+    const processor = opts?.processor ?? (async () => 'result');
+    const worker = createInstrumentedWorker({
+      name: 'test-queue',
+      processor,
+      workerOpts: {
+        connection: { host: 'localhost', port: 6379 },
+        concurrency: 1,
+      },
+      onFailed: opts?.onFailed,
+    });
+    return worker;
+  }
+
+  it('records completed job duration', async () => {
+    const worker = createTestWorker();
+    const instrumentedProcessor = (
+      worker as unknown as {
+        processor: (job: unknown, token?: string) => Promise<unknown>;
+      }
+    ).processor;
+
+    await instrumentedProcessor({ id: 'job-1', attemptsMade: 0 });
+
+    expect(mockObserve).toHaveBeenCalledWith(
+      { queue: 'test-queue', status: 'completed' },
+      expect.any(Number),
+    );
+    expect(mockInc).toHaveBeenCalledWith({
+      queue: 'test-queue',
+      status: 'completed',
+    });
+  });
+
+  it('records failed job duration', async () => {
+    const worker = createTestWorker({
+      processor: async () => {
+        throw new Error('job failed');
+      },
+    });
+    const instrumentedProcessor = (
+      worker as unknown as {
+        processor: (job: unknown, token?: string) => Promise<unknown>;
+      }
+    ).processor;
+
+    await expect(
+      instrumentedProcessor({ id: 'job-2', attemptsMade: 1 }),
+    ).rejects.toThrow('job failed');
+
+    expect(mockObserve).toHaveBeenCalledWith(
+      { queue: 'test-queue', status: 'failed' },
+      expect.any(Number),
+    );
+    expect(mockInc).toHaveBeenCalledWith({
+      queue: 'test-queue',
+      status: 'failed',
+    });
+  });
+
+  it('calls captureException on failure with job context', async () => {
+    const worker = createTestWorker({
+      processor: async () => {
+        throw new Error('crash');
+      },
+    });
+    const instrumentedProcessor = (
+      worker as unknown as {
+        processor: (job: unknown, token?: string) => Promise<unknown>;
+      }
+    ).processor;
+
+    await expect(
+      instrumentedProcessor({ id: 'job-3', attemptsMade: 2 }),
+    ).rejects.toThrow('crash');
+
+    expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error), {
+      queue: 'test-queue',
+      jobId: 'job-3',
+      attemptsMade: 2,
+    });
+  });
+
+  it('re-throws error for BullMQ retry logic', async () => {
+    const worker = createTestWorker({
+      processor: async () => {
+        throw new Error('retry me');
+      },
+    });
+    const instrumentedProcessor = (
+      worker as unknown as {
+        processor: (job: unknown, token?: string) => Promise<unknown>;
+      }
+    ).processor;
+
+    await expect(
+      instrumentedProcessor({ id: 'job-4', attemptsMade: 0 }),
+    ).rejects.toThrow('retry me');
+  });
+
+  it('registers failed event handler', () => {
+    createTestWorker();
+    expect(mockOn).toHaveBeenCalledWith('failed', expect.any(Function));
+  });
+
+  it('invokes onFailed callback on failure event', async () => {
+    const onFailed = vi.fn();
+    createTestWorker({ onFailed });
+
+    // Extract the 'failed' handler
+    const failedHandler = mockOn.mock.calls.find(
+      (call: unknown[]) => call[0] === 'failed',
+    )?.[1] as (job: unknown, err: Error) => Promise<void>;
+
+    const mockJob = { id: 'job-5', attemptsMade: 3, opts: { attempts: 5 } };
+    const error = new Error('test failure');
+
+    await failedHandler(mockJob, error);
+
+    expect(onFailed).toHaveBeenCalledWith(mockJob, error);
+  });
+});

--- a/apps/api/src/config/instrumented-worker.ts
+++ b/apps/api/src/config/instrumented-worker.ts
@@ -1,0 +1,87 @@
+import { Worker, type Processor, type WorkerOptions, type Job } from 'bullmq';
+import { bullmqJobDuration, bullmqJobTotal } from './metrics.js';
+import { captureException } from './sentry.js';
+import { getLogger } from './logger.js';
+
+export interface InstrumentedWorkerOptions<T> {
+  /** Queue name — used as metric label and log prefix. */
+  name: string;
+  /** Job processor function. */
+  processor: Processor<T>;
+  /** BullMQ worker options (connection, concurrency, settings, etc.). */
+  workerOpts: Omit<WorkerOptions, 'connection'> & {
+    connection: { host: string; port: number; password?: string };
+  };
+  /**
+   * Optional callback invoked on job failure (after logging + metrics).
+   * Use this for final-failure audit logic (e.g., marking records as FAILED).
+   * The wrapper already calls getLogger().error() — don't duplicate that.
+   */
+  onFailed?: (job: Job<T> | undefined, err: Error) => void | Promise<void>;
+}
+
+/**
+ * Creates a BullMQ Worker instrumented with Prometheus metrics and Sentry error tracking.
+ *
+ * - Records job duration in `bullmq_job_duration_seconds` histogram
+ * - Increments `bullmq_jobs_total` counter (completed/failed)
+ * - Calls `captureException()` on failure with job context
+ * - Re-throws errors for BullMQ retry logic
+ * - Logs failures via `getLogger().error()`
+ */
+export function createInstrumentedWorker<T>(
+  opts: InstrumentedWorkerOptions<T>,
+): Worker<T> {
+  const { name, processor, workerOpts, onFailed } = opts;
+
+  const instrumentedProcessor: Processor<T> = async (job, token) => {
+    const start = process.hrtime();
+    try {
+      const result = await processor(job, token);
+      const [seconds, nanoseconds] = process.hrtime(start);
+      const duration = seconds + nanoseconds / 1e9;
+      bullmqJobDuration.observe({ queue: name, status: 'completed' }, duration);
+      bullmqJobTotal.inc({ queue: name, status: 'completed' });
+      return result;
+    } catch (err) {
+      const [seconds, nanoseconds] = process.hrtime(start);
+      const duration = seconds + nanoseconds / 1e9;
+      bullmqJobDuration.observe({ queue: name, status: 'failed' }, duration);
+      bullmqJobTotal.inc({ queue: name, status: 'failed' });
+      captureException(err, {
+        queue: name,
+        jobId: job.id,
+        attemptsMade: job.attemptsMade,
+      });
+      throw err;
+    }
+  };
+
+  const worker = new Worker<T>(name, instrumentedProcessor, workerOpts);
+
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  worker.on('failed', async (job, err) => {
+    getLogger().error(
+      {
+        jobId: job?.id,
+        attempt: job?.attemptsMade,
+        maxAttempts: job?.opts.attempts,
+        err,
+      },
+      `[${name}] Job failed`,
+    );
+
+    if (onFailed) {
+      try {
+        await onFailed(job, err);
+      } catch (callbackErr) {
+        getLogger().error(
+          { jobId: job?.id, err: callbackErr },
+          `[${name}] onFailed callback error`,
+        );
+      }
+    }
+  });
+
+  return worker;
+}

--- a/apps/api/src/config/metrics.spec.ts
+++ b/apps/api/src/config/metrics.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import client from 'prom-client';
+import {
+  httpRequestDuration,
+  httpRequestTotal,
+  httpActiveConnections,
+  bullmqJobDuration,
+  bullmqJobTotal,
+  getMetricsOutput,
+  getContentType,
+  stopMetricsPolling,
+} from './metrics.js';
+
+afterEach(() => {
+  // Reset all metrics between tests to avoid cross-contamination
+  client.register.resetMetrics();
+  stopMetricsPolling();
+});
+
+describe('metrics', () => {
+  it('records HTTP request duration histogram', () => {
+    httpRequestDuration.observe(
+      { method: 'GET', route: '/test', status_code: '200' },
+      0.05,
+    );
+    // No throw = success. The observation is recorded in the histogram.
+    expect(true).toBe(true);
+  });
+
+  it('increments HTTP request counter', () => {
+    httpRequestTotal.inc({
+      method: 'POST',
+      route: '/v1/submissions',
+      status_code: '201',
+    });
+    expect(true).toBe(true);
+  });
+
+  it('tracks active connections gauge', () => {
+    httpActiveConnections.inc();
+    httpActiveConnections.inc();
+    httpActiveConnections.dec();
+    // Gauge should be at 1
+    expect(true).toBe(true);
+  });
+
+  it('records BullMQ job duration histogram', () => {
+    bullmqJobDuration.observe({ queue: 'email', status: 'completed' }, 1.234);
+    expect(true).toBe(true);
+  });
+
+  it('increments BullMQ job counter', () => {
+    bullmqJobTotal.inc({ queue: 'file-scan', status: 'failed' });
+    expect(true).toBe(true);
+  });
+
+  it('getMetricsOutput returns valid Prometheus text format', async () => {
+    httpRequestTotal.inc({
+      method: 'GET',
+      route: '/health',
+      status_code: '200',
+    });
+
+    const output = await getMetricsOutput();
+    expect(output).toContain('http_requests_total');
+    expect(output).toContain('method="GET"');
+    expect(output).toContain('route="/health"');
+    expect(output).toContain('status_code="200"');
+  });
+
+  it('getContentType returns correct MIME type', () => {
+    const contentType = getContentType();
+    expect(contentType).toContain('text/plain');
+  });
+});

--- a/apps/api/src/config/metrics.ts
+++ b/apps/api/src/config/metrics.ts
@@ -1,0 +1,126 @@
+import client from 'prom-client';
+import type { Pool } from 'pg';
+import type { Queue } from 'bullmq';
+
+// HTTP metrics
+export const httpRequestDuration = new client.Histogram({
+  name: 'http_request_duration_seconds',
+  help: 'HTTP request duration in seconds',
+  labelNames: ['method', 'route', 'status_code'] as const,
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+});
+
+export const httpRequestTotal = new client.Counter({
+  name: 'http_requests_total',
+  help: 'Total number of HTTP requests',
+  labelNames: ['method', 'route', 'status_code'] as const,
+});
+
+export const httpActiveConnections = new client.Gauge({
+  name: 'http_active_connections',
+  help: 'Number of active HTTP connections',
+});
+
+// BullMQ metrics
+export const bullmqJobDuration = new client.Histogram({
+  name: 'bullmq_job_duration_seconds',
+  help: 'BullMQ job processing duration in seconds',
+  labelNames: ['queue', 'status'] as const,
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
+});
+
+export const bullmqJobTotal = new client.Counter({
+  name: 'bullmq_jobs_total',
+  help: 'Total number of BullMQ jobs processed',
+  labelNames: ['queue', 'status'] as const,
+});
+
+export const bullmqQueueDepth = new client.Gauge({
+  name: 'bullmq_queue_depth',
+  help: 'Number of jobs in queue by state',
+  labelNames: ['queue', 'state'] as const,
+});
+
+// DB pool metrics
+export const dbPoolTotal = new client.Gauge({
+  name: 'db_pool_total_connections',
+  help: 'Total number of connections in the DB pool',
+  labelNames: ['pool'] as const,
+});
+
+export const dbPoolIdle = new client.Gauge({
+  name: 'db_pool_idle_connections',
+  help: 'Number of idle connections in the DB pool',
+  labelNames: ['pool'] as const,
+});
+
+export const dbPoolWaiting = new client.Gauge({
+  name: 'db_pool_waiting_clients',
+  help: 'Number of clients waiting for a connection',
+  labelNames: ['pool'] as const,
+});
+
+let poolInterval: ReturnType<typeof setInterval> | null = null;
+let queueInterval: ReturnType<typeof setInterval> | null = null;
+
+export function initMetrics(pools: { admin: Pool; app: Pool }): void {
+  client.collectDefaultMetrics();
+
+  // Poll DB pool stats every 15 seconds
+  poolInterval = setInterval(() => {
+    dbPoolTotal.set({ pool: 'admin' }, pools.admin.totalCount);
+    dbPoolIdle.set({ pool: 'admin' }, pools.admin.idleCount);
+    dbPoolWaiting.set({ pool: 'admin' }, pools.admin.waitingCount);
+
+    dbPoolTotal.set({ pool: 'app' }, pools.app.totalCount);
+    dbPoolIdle.set({ pool: 'app' }, pools.app.idleCount);
+    dbPoolWaiting.set({ pool: 'app' }, pools.app.waitingCount);
+  }, 15_000);
+  poolInterval.unref();
+}
+
+export function startQueueDepthPolling(
+  queues: Array<{ name: string; queue: Queue }>,
+): void {
+  queueInterval = setInterval(() => {
+    void (async () => {
+      for (const { name, queue } of queues) {
+        try {
+          const counts = await queue.getJobCounts(
+            'waiting',
+            'active',
+            'delayed',
+            'failed',
+          );
+          const labels = { queue: name };
+          bullmqQueueDepth.set({ ...labels, state: 'waiting' }, counts.waiting);
+          bullmqQueueDepth.set({ ...labels, state: 'active' }, counts.active);
+          bullmqQueueDepth.set({ ...labels, state: 'delayed' }, counts.delayed);
+          bullmqQueueDepth.set({ ...labels, state: 'failed' }, counts.failed);
+        } catch {
+          // Swallow errors — queue might be closing
+        }
+      }
+    })();
+  }, 30_000);
+  queueInterval.unref();
+}
+
+export function stopMetricsPolling(): void {
+  if (poolInterval) {
+    clearInterval(poolInterval);
+    poolInterval = null;
+  }
+  if (queueInterval) {
+    clearInterval(queueInterval);
+    queueInterval = null;
+  }
+}
+
+export async function getMetricsOutput(): Promise<string> {
+  return client.register.metrics();
+}
+
+export function getContentType(): string {
+  return client.register.contentType;
+}

--- a/apps/api/src/config/sentry.spec.ts
+++ b/apps/api/src/config/sentry.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock @sentry/node
+const mockInit = vi.fn();
+const mockCaptureException = vi.fn();
+vi.mock('@sentry/node', () => ({
+  init: (...args: unknown[]) => mockInit(...args),
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  onUncaughtExceptionIntegration: vi.fn(() => 'uncaught-integration'),
+  onUnhandledRejectionIntegration: vi.fn(() => 'unhandled-integration'),
+}));
+
+// Dynamic import to ensure fresh module state per describe block
+async function loadModule() {
+  const mod = await import('./sentry.js');
+  return mod;
+}
+
+describe('sentry', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockInit.mockReset();
+    mockCaptureException.mockReset();
+  });
+
+  it('does not init when SENTRY_DSN is undefined', async () => {
+    const { initSentry, isSentryEnabled } = await loadModule();
+    initSentry({
+      SENTRY_ENVIRONMENT: 'test',
+      SENTRY_TRACES_SAMPLE_RATE: 0,
+    } as never);
+    expect(mockInit).not.toHaveBeenCalled();
+    expect(isSentryEnabled()).toBe(false);
+  });
+
+  it('initializes with DSN', async () => {
+    const { initSentry, isSentryEnabled } = await loadModule();
+    initSentry({
+      SENTRY_DSN: 'https://key@sentry.io/123',
+      SENTRY_ENVIRONMENT: 'test',
+      SENTRY_TRACES_SAMPLE_RATE: 0.5,
+      SENTRY_RELEASE: 'v1.0.0',
+    } as never);
+    expect(mockInit).toHaveBeenCalledOnce();
+    expect(mockInit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dsn: 'https://key@sentry.io/123',
+        environment: 'test',
+        release: 'v1.0.0',
+        tracesSampleRate: 0.5,
+      }),
+    );
+    expect(isSentryEnabled()).toBe(true);
+  });
+
+  it('is idempotent — second init is a no-op', async () => {
+    const { initSentry } = await loadModule();
+    const env = {
+      SENTRY_DSN: 'https://key@sentry.io/123',
+      SENTRY_ENVIRONMENT: 'test',
+      SENTRY_TRACES_SAMPLE_RATE: 0,
+    } as never;
+    initSentry(env);
+    initSentry(env);
+    expect(mockInit).toHaveBeenCalledOnce();
+  });
+
+  it('captureException is a no-op when not initialized', async () => {
+    const { captureException } = await loadModule();
+    captureException(new Error('test'));
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('captureException forwards with context when initialized', async () => {
+    const { initSentry, captureException } = await loadModule();
+    initSentry({
+      SENTRY_DSN: 'https://key@sentry.io/123',
+      SENTRY_ENVIRONMENT: 'test',
+      SENTRY_TRACES_SAMPLE_RATE: 0,
+    } as never);
+
+    const error = new Error('test error');
+    captureException(error, { url: '/test', method: 'GET' });
+
+    expect(mockCaptureException).toHaveBeenCalledWith(error, {
+      extra: { url: '/test', method: 'GET' },
+    });
+  });
+
+  it('beforeSend scrubs authorization headers from breadcrumbs', async () => {
+    const { initSentry } = await loadModule();
+    initSentry({
+      SENTRY_DSN: 'https://key@sentry.io/123',
+      SENTRY_ENVIRONMENT: 'test',
+      SENTRY_TRACES_SAMPLE_RATE: 0,
+    } as never);
+
+    const { beforeSend } = mockInit.mock.calls[0][0] as {
+      beforeSend: (event: {
+        breadcrumbs?: Array<{
+          data?: { headers?: Record<string, unknown> };
+        }>;
+      }) => unknown;
+    };
+
+    const event = {
+      breadcrumbs: [
+        {
+          data: {
+            headers: {
+              authorization: 'Bearer secret',
+              'x-api-key': 'col_live_abc',
+              'content-type': 'application/json',
+            },
+          },
+        },
+      ],
+    };
+
+    const result = beforeSend(event) as typeof event;
+    const headers = result.breadcrumbs?.[0]?.data?.headers;
+    expect(headers?.authorization).toBeUndefined();
+    expect(headers?.['x-api-key']).toBeUndefined();
+    expect(headers?.['content-type']).toBe('application/json');
+  });
+});

--- a/apps/api/src/config/sentry.ts
+++ b/apps/api/src/config/sentry.ts
@@ -1,0 +1,49 @@
+import * as Sentry from '@sentry/node';
+import type { Env } from './env.js';
+
+let initialized = false;
+
+export function initSentry(env: Env): void {
+  if (initialized) return;
+  if (!env.SENTRY_DSN) return;
+
+  Sentry.init({
+    dsn: env.SENTRY_DSN,
+    environment: env.SENTRY_ENVIRONMENT,
+    release: env.SENTRY_RELEASE,
+    tracesSampleRate: env.SENTRY_TRACES_SAMPLE_RATE,
+    integrations: [
+      Sentry.onUncaughtExceptionIntegration(),
+      Sentry.onUnhandledRejectionIntegration(),
+    ],
+    beforeSend(event) {
+      // Scrub authorization headers from breadcrumbs
+      if (event.breadcrumbs) {
+        for (const breadcrumb of event.breadcrumbs) {
+          const headers = breadcrumb.data?.headers as
+            | Record<string, unknown>
+            | undefined;
+          if (headers) {
+            delete headers.authorization;
+            delete headers['x-api-key'];
+          }
+        }
+      }
+      return event;
+    },
+  });
+
+  initialized = true;
+}
+
+export function captureException(
+  error: unknown,
+  context?: Record<string, unknown>,
+): void {
+  if (!initialized) return;
+  Sentry.captureException(error, context ? { extra: context } : undefined);
+}
+
+export function isSentryEnabled(): boolean {
+  return initialized;
+}

--- a/apps/api/src/federation/did.routes.spec.ts
+++ b/apps/api/src/federation/did.routes.spec.ts
@@ -59,6 +59,9 @@ const testEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 const sampleInstanceDoc = {

--- a/apps/api/src/federation/discovery.routes.spec.ts
+++ b/apps/api/src/federation/discovery.routes.spec.ts
@@ -62,6 +62,9 @@ const testEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 describe('Federation Discovery Routes', () => {

--- a/apps/api/src/federation/migration.routes.spec.ts
+++ b/apps/api/src/federation/migration.routes.spec.ts
@@ -119,6 +119,9 @@ const testEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 describe('migration.routes (S2S)', () => {

--- a/apps/api/src/federation/simsub-admin.routes.spec.ts
+++ b/apps/api/src/federation/simsub-admin.routes.spec.ts
@@ -63,6 +63,9 @@ const testEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 const validUuid = '00000000-0000-4000-a000-000000000001';

--- a/apps/api/src/federation/simsub.routes.spec.ts
+++ b/apps/api/src/federation/simsub.routes.spec.ts
@@ -73,6 +73,9 @@ const testEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 describe('simsub.routes (S2S)', () => {

--- a/apps/api/src/federation/transfer-admin.routes.spec.ts
+++ b/apps/api/src/federation/transfer-admin.routes.spec.ts
@@ -68,6 +68,9 @@ const testEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 function buildApp(authContext: any): FastifyInstance {

--- a/apps/api/src/federation/transfer.routes.spec.ts
+++ b/apps/api/src/federation/transfer.routes.spec.ts
@@ -99,6 +99,9 @@ const testEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 describe('transfer.routes (S2S)', () => {

--- a/apps/api/src/federation/trust-admin.routes.spec.ts
+++ b/apps/api/src/federation/trust-admin.routes.spec.ts
@@ -92,6 +92,9 @@ const testEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 const testOrgId = '10000000-0000-4000-a000-000000000010';

--- a/apps/api/src/federation/trust.routes.spec.ts
+++ b/apps/api/src/federation/trust.routes.spec.ts
@@ -57,6 +57,9 @@ const testEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 describe('trust.routes (public S2S)', () => {

--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -86,6 +86,9 @@ const baseEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 describe('auth plugin', () => {
@@ -142,6 +145,15 @@ describe('auth plugin', () => {
       const response = await app.inject({
         method: 'GET',
         url: '/trpc/health',
+      });
+      // 404 because no route registered, but auth hook didn't block
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('allows /metrics without auth', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/metrics',
       });
       // 404 because no route registered, but auth hook didn't block
       expect(response.statusCode).toBe(404);

--- a/apps/api/src/hooks/auth.ts
+++ b/apps/api/src/hooks/auth.ts
@@ -41,6 +41,7 @@ const PUBLIC_EXACT = [
   '/',
   '/health',
   '/ready',
+  '/metrics',
   '/trpc/health',
   '/v1/openapi.json',
   '/v1/docs',

--- a/apps/api/src/hooks/metrics.spec.ts
+++ b/apps/api/src/hooks/metrics.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import client from 'prom-client';
+import metricsPlugin from './metrics.js';
+
+describe('metrics plugin', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(metricsPlugin);
+
+    app.get('/test', async () => ({ ok: true }));
+    app.get('/items/:id', async () => ({ ok: true }));
+    app.post('/v1/submissions', async () => ({ created: true }));
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(() => {
+    client.register.resetMetrics();
+  });
+
+  it('records request duration on response', async () => {
+    const response = await app.inject({ method: 'GET', url: '/test' });
+    expect(response.statusCode).toBe(200);
+
+    const output = await client.register.metrics();
+    expect(output).toContain('http_request_duration_seconds');
+  });
+
+  it('increments request counter with correct labels', async () => {
+    await app.inject({ method: 'GET', url: '/test' });
+
+    const output = await client.register.metrics();
+    expect(output).toContain('http_requests_total');
+    expect(output).toContain('method="GET"');
+    expect(output).toContain('status_code="200"');
+  });
+
+  it('uses parameterized route pattern, not concrete path', async () => {
+    await app.inject({ method: 'GET', url: '/items/abc-123' });
+
+    const output = await client.register.metrics();
+    // Should use the pattern /items/:id, not /items/abc-123
+    expect(output).toContain('route="/items/:id"');
+    expect(output).not.toContain('route="/items/abc-123"');
+  });
+
+  it('active connections gauge returns to 0 after response', async () => {
+    await app.inject({ method: 'GET', url: '/test' });
+
+    const metrics = await client.register.getMetricsAsJSON();
+    const gauge = metrics.find((m) => m.name === 'http_active_connections');
+    expect(gauge).toBeDefined();
+    // After response completes, active connections should be 0
+    if (gauge && 'values' in gauge) {
+      const values = gauge.values as Array<{ value: number }>;
+      expect(values[0]?.value).toBe(0);
+    }
+  });
+
+  it('handles multiple concurrent requests', async () => {
+    await Promise.all([
+      app.inject({ method: 'GET', url: '/test' }),
+      app.inject({ method: 'POST', url: '/v1/submissions' }),
+      app.inject({ method: 'GET', url: '/items/1' }),
+    ]);
+
+    const output = await client.register.metrics();
+    expect(output).toContain('method="GET"');
+    expect(output).toContain('method="POST"');
+  });
+});

--- a/apps/api/src/hooks/metrics.ts
+++ b/apps/api/src/hooks/metrics.ts
@@ -1,0 +1,74 @@
+import fp from 'fastify-plugin';
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import {
+  httpRequestDuration,
+  httpRequestTotal,
+  httpActiveConnections,
+} from '../config/metrics.js';
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    _metricsStartTime: [number, number] | null;
+  }
+}
+
+/**
+ * Extracts a parameterized route label to prevent cardinality explosion.
+ * Uses Fastify's routeOptions.url (e.g., `/v1/submissions/:id`) when available.
+ * Falls back to the first 2 path segments.
+ */
+function getRouteLabel(request: FastifyRequest): string {
+  // Fastify's routeOptions.url gives the parameterized pattern
+  const pattern = request.routeOptions?.url;
+  if (pattern) return pattern;
+
+  // Fallback: first 2 segments to limit cardinality
+  const path = request.url.split('?')[0];
+  const segments = path.split('/').filter(Boolean);
+  if (segments.length <= 2) return path;
+  return '/' + segments.slice(0, 2).join('/');
+}
+
+export default fp(
+  async function metricsPlugin(app: FastifyInstance) {
+    app.decorateRequest('_metricsStartTime', null);
+
+    app.addHook(
+      'onRequest',
+      async function metricsOnRequest(request: FastifyRequest) {
+        request._metricsStartTime = process.hrtime();
+        httpActiveConnections.inc();
+      },
+    );
+
+    app.addHook(
+      'onResponse',
+      async function metricsOnResponse(
+        request: FastifyRequest,
+        reply: FastifyReply,
+      ) {
+        httpActiveConnections.dec();
+
+        if (!request._metricsStartTime) return;
+
+        const [seconds, nanoseconds] = process.hrtime(
+          request._metricsStartTime,
+        );
+        const duration = seconds + nanoseconds / 1e9;
+
+        const labels = {
+          method: request.method,
+          route: getRouteLabel(request),
+          status_code: reply.statusCode.toString(),
+        };
+
+        httpRequestDuration.observe(labels, duration);
+        httpRequestTotal.inc(labels);
+      },
+    );
+  },
+  {
+    name: 'colophony-metrics',
+    fastify: '5.x',
+  },
+);

--- a/apps/api/src/hooks/rate-limit-auth.spec.ts
+++ b/apps/api/src/hooks/rate-limit-auth.spec.ts
@@ -92,6 +92,9 @@ const testEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 async function buildApp(

--- a/apps/api/src/hooks/rate-limit.spec.ts
+++ b/apps/api/src/hooks/rate-limit.spec.ts
@@ -91,6 +91,9 @@ const testEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 async function buildApp(
@@ -125,6 +128,7 @@ describe('rate-limit plugin', () => {
       app.get('/health', async () => ({ status: 'ok' }));
       app.get('/ready', async () => ({ status: 'ready' }));
       app.get('/', async () => ({ name: 'API' }));
+      app.get('/metrics', async () => ({ metrics: 'ok' }));
       app.get('/.well-known/openid-configuration', async () => ({}));
     });
 
@@ -156,6 +160,12 @@ describe('rate-limit plugin', () => {
         method: 'GET',
         url: '/.well-known/openid-configuration',
       });
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['x-ratelimit-limit']).toBeUndefined();
+    });
+
+    it('skips /metrics', async () => {
+      const response = await app.inject({ method: 'GET', url: '/metrics' });
       expect(response.statusCode).toBe(200);
       expect(response.headers['x-ratelimit-limit']).toBeUndefined();
     });

--- a/apps/api/src/hooks/rate-limit.ts
+++ b/apps/api/src/hooks/rate-limit.ts
@@ -11,7 +11,7 @@ export interface RateLimitPluginOptions {
 
 /** Routes that skip rate limiting entirely. */
 const SKIP_PREFIXES = ['/health', '/ready', '/webhooks/', '/.well-known/'];
-const SKIP_EXACT = ['/', '/health', '/ready'];
+const SKIP_EXACT = ['/', '/health', '/ready', '/metrics'];
 
 function shouldSkip(request: FastifyRequest): boolean {
   if (request.method === 'OPTIONS') return true;

--- a/apps/api/src/main.spec.ts
+++ b/apps/api/src/main.spec.ts
@@ -94,6 +94,9 @@ const testEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 describe('Fastify app', () => {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,6 +4,15 @@ import helmet from '@fastify/helmet';
 import { pool, appPool } from '@colophony/db';
 import { loadConfig } from '@colophony/plugin-sdk';
 import { type Env, validateEnv } from './config/env.js';
+import { initSentry, captureException } from './config/sentry.js';
+import {
+  initMetrics,
+  startQueueDepthPolling,
+  stopMetricsPolling,
+  getMetricsOutput,
+  getContentType,
+} from './config/metrics.js';
+import metricsPlugin from './hooks/metrics.js';
 import { buildColophonyConfig } from './colophony.config.js';
 import { setGlobalExtensions } from './adapters/extensions-accessor.js';
 import { setGlobalPluginManifests } from './adapters/plugins-accessor.js';
@@ -46,6 +55,12 @@ import {
   closeTransferFetchQueue,
   closeEmailQueue,
   closeWebhookQueue,
+  getFileScanQueueInstance,
+  getS3CleanupQueueInstance,
+  getOutboxPollerQueueInstance,
+  getTransferFetchQueueInstance,
+  getEmailQueueInstance,
+  getWebhookQueueInstance,
 } from './queues/index.js';
 import { registerInngestRoutes } from './inngest/serve.js';
 import { registerFederationDiscoveryRoutes } from './federation/discovery.routes.js';
@@ -155,6 +170,11 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
     maxAge: 86400, // 24 hours
   });
 
+  // Metrics plugin — before rate limit so it measures full lifecycle including auth
+  if (env.METRICS_ENABLED) {
+    await app.register(metricsPlugin);
+  }
+
   // Rate limit (IP) → auth → rate limit (user) → org context → per-request RLS transaction
   // First-pass rate limit runs before auth so unauthenticated 401s are still throttled (DoS protection)
   // Second-pass rate limit runs after auth to apply higher per-user limits
@@ -184,6 +204,16 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
   await app.register(async (scope) => {
     await registerEmbedRoutes(scope, { env });
   });
+
+  // Prometheus metrics endpoint — isolated scope (public, no auth/rate-limit)
+  if (env.METRICS_ENABLED) {
+    await app.register(async (scope) => {
+      scope.get('/metrics', async (_request, reply) => {
+        const output = await getMetricsOutput();
+        return reply.type(getContentType()).send(output);
+      });
+    });
+  }
 
   // Inngest serve endpoint — isolated scope (Inngest handles its own auth)
   await app.register(async (scope) => {
@@ -242,8 +272,11 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
     trpcOptions: {
       router: appRouter,
       createContext,
-      onError({ error }: { error: { message: string } }) {
+      onError({ error }: { error: { message: string; code?: string } }) {
         app.log.error(error, 'tRPC error');
+        if (!error.code || error.code === 'INTERNAL_SERVER_ERROR') {
+          captureException(error, { source: 'trpc' });
+        }
       },
     },
   });
@@ -283,13 +316,21 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
   }));
 
   // Error handlers
-  app.setErrorHandler<Error>((error, _request, reply) => {
+  app.setErrorHandler<Error>((error, request, reply) => {
     app.log.error(error);
     const statusCode =
       'statusCode' in error &&
       typeof (error as Record<string, unknown>).statusCode === 'number'
         ? ((error as Record<string, unknown>).statusCode as number)
         : 500;
+    if (statusCode >= 500) {
+      captureException(error, {
+        url: request.url,
+        method: request.method,
+        userId: request.authContext?.userId,
+        orgId: request.authContext?.orgId,
+      });
+    }
     void reply.status(statusCode).send({
       error: statusCode >= 500 ? 'internal_error' : error.message,
     });
@@ -304,6 +345,10 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
 
 async function start(): Promise<void> {
   const env = validateEnv();
+
+  // Initialize Sentry early for global exception handlers
+  initSentry(env);
+
   const app = await buildApp(env);
 
   // Initialize plugin SDK adapters + registry
@@ -320,6 +365,12 @@ async function start(): Promise<void> {
   // Initialize shared logger for BullMQ workers
   const { setWorkerLogger } = await import('./config/logger.js');
   setWorkerLogger(app.log);
+
+  // Initialize Prometheus metrics (DB pool polling)
+  if (env.METRICS_ENABLED) {
+    initMetrics({ admin: pool, app: appPool });
+    app.log.info('Prometheus metrics enabled');
+  }
 
   // Start BullMQ workers
   if (env.VIRUS_SCAN_ENABLED) {
@@ -350,6 +401,23 @@ async function start(): Promise<void> {
   startWebhookWorker(env);
   app.log.info('Webhook delivery worker started');
 
+  // Start queue depth polling for Prometheus metrics
+  if (env.METRICS_ENABLED) {
+    const allQueues: Array<{ name: string; queue: unknown }> = [
+      { name: 'file-scan', queue: getFileScanQueueInstance() },
+      { name: 's3-cleanup', queue: getS3CleanupQueueInstance() },
+      { name: 'outbox-poller', queue: getOutboxPollerQueueInstance() },
+      { name: 'transfer-fetch', queue: getTransferFetchQueueInstance() },
+      { name: 'email', queue: getEmailQueueInstance() },
+      { name: 'webhook', queue: getWebhookQueueInstance() },
+    ];
+    const activeQueues = allQueues.filter((q) => q.queue !== null) as Array<{
+      name: string;
+      queue: import('bullmq').Queue;
+    }>;
+    startQueueDepthPolling(activeQueues);
+  }
+
   // Hub registration (fire-and-forget — don't block startup)
   if (env.HUB_DOMAIN && env.HUB_REGISTRATION_TOKEN) {
     hubClientService.registerWithHub(env).catch((err) => {
@@ -370,6 +438,7 @@ async function start(): Promise<void> {
     }, 10_000);
 
     try {
+      stopMetricsPolling();
       await app.close();
       await stopFileScanWorker();
       await stopS3CleanupWorker();

--- a/apps/api/src/queues/email.queue.ts
+++ b/apps/api/src/queues/email.queue.ts
@@ -40,6 +40,10 @@ export async function enqueueEmail(
   await getQueue(env).add('send', data, { jobId: data.emailSendId });
 }
 
+export function getEmailQueueInstance(): Queue<EmailJobData> | null {
+  return queue;
+}
+
 export async function closeEmailQueue(): Promise<void> {
   if (queue) {
     await queue.close();

--- a/apps/api/src/queues/file-scan.queue.ts
+++ b/apps/api/src/queues/file-scan.queue.ts
@@ -38,6 +38,10 @@ export async function enqueueFileScan(
   await getQueue(env).add('scan', data, { jobId: data.fileId });
 }
 
+export function getFileScanQueueInstance(): Queue<FileScanJobData> | null {
+  return queue;
+}
+
 export async function closeFileScanQueue(): Promise<void> {
   if (queue) {
     await queue.close();

--- a/apps/api/src/queues/index.ts
+++ b/apps/api/src/queues/index.ts
@@ -1,35 +1,41 @@
 export {
   enqueueFileScan,
   closeFileScanQueue,
+  getFileScanQueueInstance,
   type FileScanJobData,
 } from './file-scan.queue.js';
 
 export {
   enqueueS3Cleanup,
   closeS3CleanupQueue,
+  getS3CleanupQueueInstance,
   type S3CleanupJobData,
 } from './s3-cleanup.queue.js';
 
 export {
   startOutboxPoller,
   closeOutboxPollerQueue,
+  getOutboxPollerQueueInstance,
 } from './outbox-poller.queue.js';
 
 export {
   enqueueTransferFetch,
   closeTransferFetchQueue,
+  getTransferFetchQueueInstance,
   type TransferFetchJobData,
 } from './transfer-fetch.queue.js';
 
 export {
   enqueueEmail,
   closeEmailQueue,
+  getEmailQueueInstance,
   type EmailJobData,
 } from './email.queue.js';
 
 export {
   enqueueWebhook,
   closeWebhookQueue,
+  getWebhookQueueInstance,
   type WebhookJobData,
   type WebhookPayload,
 } from './webhook.queue.js';

--- a/apps/api/src/queues/outbox-poller.queue.ts
+++ b/apps/api/src/queues/outbox-poller.queue.ts
@@ -40,6 +40,10 @@ export async function startOutboxPoller(env: Env): Promise<void> {
   );
 }
 
+export function getOutboxPollerQueueInstance(): Queue<OutboxPollerJobData> | null {
+  return queue;
+}
+
 export async function closeOutboxPollerQueue(): Promise<void> {
   if (queue) {
     await queue.close();

--- a/apps/api/src/queues/s3-cleanup.queue.ts
+++ b/apps/api/src/queues/s3-cleanup.queue.ts
@@ -35,6 +35,10 @@ export async function enqueueS3Cleanup(
   await getQueue(env).add('cleanup', data);
 }
 
+export function getS3CleanupQueueInstance(): Queue<S3CleanupJobData> | null {
+  return queue;
+}
+
 export async function closeS3CleanupQueue(): Promise<void> {
   if (queue) {
     await queue.close();

--- a/apps/api/src/queues/transfer-fetch.queue.ts
+++ b/apps/api/src/queues/transfer-fetch.queue.ts
@@ -41,6 +41,10 @@ export async function enqueueTransferFetch(
   await getQueue(env).add('fetch', data, { jobId: data.transferId });
 }
 
+export function getTransferFetchQueueInstance(): Queue<TransferFetchJobData> | null {
+  return queue;
+}
+
 export async function closeTransferFetchQueue(): Promise<void> {
   if (queue) {
     await queue.close();

--- a/apps/api/src/queues/webhook.queue.ts
+++ b/apps/api/src/queues/webhook.queue.ts
@@ -58,6 +58,10 @@ export async function enqueueWebhook(
   await getQueue(env).add('deliver', data, { jobId: data.deliveryId });
 }
 
+export function getWebhookQueueInstance(): Queue<WebhookJobData> | null {
+  return queue;
+}
+
 export async function closeWebhookQueue(): Promise<void> {
   if (queue) {
     await queue.close();

--- a/apps/api/src/services/federation.service.spec.ts
+++ b/apps/api/src/services/federation.service.spec.ts
@@ -110,6 +110,9 @@ const baseEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 // Helper to build chained Drizzle mock

--- a/apps/api/src/webhooks/stripe.webhook.spec.ts
+++ b/apps/api/src/webhooks/stripe.webhook.spec.ts
@@ -146,6 +146,9 @@ const testEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
   STRIPE_SECRET_KEY: 'sk_test_xxx',
   STRIPE_WEBHOOK_SECRET: WEBHOOK_SECRET,
 };

--- a/apps/api/src/webhooks/zitadel.webhook.spec.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.spec.ts
@@ -150,6 +150,9 @@ const testEnv: Env = {
   INNGEST_DEV: false,
   EMAIL_PROVIDER: 'none' as const,
   SMTP_SECURE: false,
+  SENTRY_ENVIRONMENT: 'test',
+  SENTRY_TRACES_SAMPLE_RATE: 0,
+  METRICS_ENABLED: false,
 };
 
 function signPayload(body: string): string {

--- a/apps/api/src/workers/email.worker.ts
+++ b/apps/api/src/workers/email.worker.ts
@@ -1,4 +1,4 @@
-import { Worker } from 'bullmq';
+import type { Worker } from 'bullmq';
 import { withRls } from '@colophony/db';
 import type { DrizzleDb } from '@colophony/db';
 import type { AdapterRegistry, EmailAdapter } from '@colophony/plugin-sdk';
@@ -9,7 +9,7 @@ import { emailService } from '../services/email.service.js';
 import { auditService } from '../services/audit.service.js';
 import { renderEmailTemplate } from '../templates/email/index.js';
 import type { TemplateName } from '../templates/email/types.js';
-import { getLogger } from '../config/logger.js';
+import { createInstrumentedWorker } from '../config/instrumented-worker.js';
 
 let worker: Worker<EmailJobData> | null = null;
 
@@ -19,9 +19,9 @@ export function startEmailWorker(
 ): Worker<EmailJobData> {
   const emailAdapter = registry.resolve<EmailAdapter>('email');
 
-  worker = new Worker<EmailJobData>(
-    'email',
-    async (job) => {
+  worker = createInstrumentedWorker<EmailJobData>({
+    name: 'email',
+    processor: async (job) => {
       const { emailSendId, orgId, to, from, templateName, templateData } =
         job.data;
 
@@ -96,7 +96,7 @@ export function startEmailWorker(
         });
       });
     },
-    {
+    workerOpts: {
       connection: {
         host: env.REDIS_HOST,
         port: env.REDIS_PORT,
@@ -104,23 +104,9 @@ export function startEmailWorker(
       },
       concurrency: 5,
     },
-  );
-
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
-  worker.on('failed', async (job, err) => {
-    getLogger().error(
-      {
-        jobId: job?.id,
-        attempt: job?.attemptsMade,
-        maxAttempts: job?.opts.attempts,
-        err,
-      },
-      '[email] Job failed',
-    );
-
-    // On final failure, mark as FAILED + audit
-    if (job && job.attemptsMade >= (job.opts.attempts ?? 5)) {
-      try {
+    onFailed: async (job, err) => {
+      // On final failure, mark as FAILED + audit
+      if (job && job.attemptsMade >= (job.opts.attempts ?? 5)) {
         const { emailSendId, orgId, to, templateName } = job.data;
         await withRls({ orgId }, async (tx: DrizzleDb) => {
           await emailService.markFailed(tx, emailSendId, err.message);
@@ -137,13 +123,8 @@ export function startEmailWorker(
             },
           });
         });
-      } catch (auditErr) {
-        getLogger().error(
-          { jobId: job.id, err: auditErr },
-          '[email] Failed to record failure audit',
-        );
       }
-    }
+    },
   });
 
   return worker;

--- a/apps/api/src/workers/file-scan.worker.ts
+++ b/apps/api/src/workers/file-scan.worker.ts
@@ -1,4 +1,3 @@
-import { Worker } from 'bullmq';
 import NodeClam from 'clamscan';
 import { withRls } from '@colophony/db';
 import type { DrizzleDb } from '@colophony/db';
@@ -9,7 +8,8 @@ import type { FileScanJobData } from '../queues/file-scan.queue.js';
 import { fileService } from '../services/file.service.js';
 import { auditService } from '../services/audit.service.js';
 import type { S3StorageAdapter } from '../adapters/storage/index.js';
-import { getLogger } from '../config/logger.js';
+import { createInstrumentedWorker } from '../config/instrumented-worker.js';
+import type { Worker } from 'bullmq';
 
 let worker: Worker<FileScanJobData> | null = null;
 let clamInstance: NodeClam | null = null;
@@ -48,9 +48,9 @@ export function startFileScanWorker(
 ): Worker<FileScanJobData> {
   const storage = registry.resolve<S3StorageAdapter>('storage');
 
-  worker = new Worker<FileScanJobData>(
-    'file-scan',
-    async (job) => {
+  worker = createInstrumentedWorker<FileScanJobData>({
+    name: 'file-scan',
+    processor: async (job) => {
       const { fileId, storageKey } = job.data;
       const rlsCtx = buildRlsContext(job.data);
 
@@ -142,7 +142,7 @@ export function startFileScanWorker(
         throw err;
       }
     },
-    {
+    workerOpts: {
       connection: {
         host: env.REDIS_HOST,
         port: env.REDIS_PORT,
@@ -150,18 +150,6 @@ export function startFileScanWorker(
       },
       concurrency: 5,
     },
-  );
-
-  worker.on('failed', (job, err) => {
-    getLogger().error(
-      {
-        jobId: job?.id,
-        attempt: job?.attemptsMade,
-        maxAttempts: job?.opts.attempts,
-        err,
-      },
-      '[file-scan] Job failed',
-    );
   });
 
   return worker;

--- a/apps/api/src/workers/outbox-poller.worker.ts
+++ b/apps/api/src/workers/outbox-poller.worker.ts
@@ -1,9 +1,9 @@
-import { Worker } from 'bullmq';
 import { db, outboxEvents, eq, sql, isNull, asc } from '@colophony/db';
 import type { Env } from '../config/env.js';
 import type { OutboxPollerJobData } from '../queues/outbox-poller.queue.js';
 import { inngest } from '../inngest/client.js';
-import { getLogger } from '../config/logger.js';
+import { createInstrumentedWorker } from '../config/instrumented-worker.js';
+import type { Worker } from 'bullmq';
 
 let worker: Worker<OutboxPollerJobData> | null = null;
 
@@ -84,12 +84,12 @@ async function processOutboxEvents(): Promise<number> {
 export function startOutboxPollerWorker(env: Env): void {
   if (worker) return;
 
-  worker = new Worker<OutboxPollerJobData>(
-    'outbox-poller',
-    async () => {
+  worker = createInstrumentedWorker<OutboxPollerJobData>({
+    name: 'outbox-poller',
+    processor: async () => {
       await processOutboxEvents();
     },
-    {
+    workerOpts: {
       connection: {
         host: env.REDIS_HOST,
         port: env.REDIS_PORT,
@@ -97,10 +97,6 @@ export function startOutboxPollerWorker(env: Env): void {
       },
       concurrency: 1, // Single poller to avoid duplicate sends
     },
-  );
-
-  worker.on('failed', (job, err) => {
-    getLogger().error({ jobId: job?.id, err }, '[outbox-poller] Job failed');
   });
 }
 

--- a/apps/api/src/workers/s3-cleanup.worker.ts
+++ b/apps/api/src/workers/s3-cleanup.worker.ts
@@ -1,11 +1,11 @@
-import { Worker } from 'bullmq';
 import type { AdapterRegistry } from '@colophony/plugin-sdk';
 import { AuditActions, AuditResources } from '@colophony/types';
 import type { Env } from '../config/env.js';
 import type { S3CleanupJobData } from '../queues/s3-cleanup.queue.js';
 import type { S3StorageAdapter } from '../adapters/storage/index.js';
 import { auditService } from '../services/audit.service.js';
-import { getLogger } from '../config/logger.js';
+import { createInstrumentedWorker } from '../config/instrumented-worker.js';
+import type { Worker } from 'bullmq';
 
 let worker: Worker<S3CleanupJobData> | null = null;
 
@@ -15,9 +15,9 @@ export function startS3CleanupWorker(
 ): Worker<S3CleanupJobData> {
   const storage = registry.resolve<S3StorageAdapter>('storage');
 
-  worker = new Worker<S3CleanupJobData>(
-    's3-cleanup',
-    async (job) => {
+  worker = createInstrumentedWorker<S3CleanupJobData>({
+    name: 's3-cleanup',
+    processor: async (job) => {
       const { storageKeys, sourceId } = job.data;
       const errors: Array<{ storageKey: string; error: string }> = [];
 
@@ -60,7 +60,7 @@ export function startS3CleanupWorker(
         },
       });
     },
-    {
+    workerOpts: {
       connection: {
         host: env.REDIS_HOST,
         port: env.REDIS_PORT,
@@ -68,18 +68,6 @@ export function startS3CleanupWorker(
       },
       concurrency: 2,
     },
-  );
-
-  worker.on('failed', (job, err) => {
-    getLogger().error(
-      {
-        jobId: job?.id,
-        attempt: job?.attemptsMade,
-        maxAttempts: job?.opts.attempts,
-        err,
-      },
-      '[s3-cleanup] Job failed',
-    );
   });
 
   return worker;

--- a/apps/api/src/workers/transfer-fetch.worker.ts
+++ b/apps/api/src/workers/transfer-fetch.worker.ts
@@ -1,4 +1,5 @@
-import { Worker, UnrecoverableError } from 'bullmq';
+import { UnrecoverableError } from 'bullmq';
+import type { Worker } from 'bullmq';
 import {
   withRls,
   submissions,
@@ -14,7 +15,7 @@ import type { Env } from '../config/env.js';
 import type { TransferFetchJobData } from '../queues/transfer-fetch.queue.js';
 import { auditService } from '../services/audit.service.js';
 import type { S3StorageAdapter } from '../adapters/storage/index.js';
-import { getLogger } from '../config/logger.js';
+import { createInstrumentedWorker } from '../config/instrumented-worker.js';
 
 let worker: Worker<TransferFetchJobData> | null = null;
 
@@ -24,9 +25,9 @@ export function startTransferFetchWorker(
 ): Worker<TransferFetchJobData> {
   const storage = registry.resolve<S3StorageAdapter>('storage');
 
-  worker = new Worker<TransferFetchJobData>(
-    'transfer-fetch',
-    async (job) => {
+  worker = createInstrumentedWorker<TransferFetchJobData>({
+    name: 'transfer-fetch',
+    processor: async (job) => {
       const {
         transferId,
         orgId,
@@ -239,7 +240,7 @@ export function startTransferFetchWorker(
         `Partial failure: ${failedFiles.length}/${fileManifest.length} files failed for transfer ${transferId}`,
       );
     },
-    {
+    workerOpts: {
       connection: {
         host: env.REDIS_HOST,
         port: env.REDIS_PORT,
@@ -247,18 +248,6 @@ export function startTransferFetchWorker(
       },
       concurrency: 3,
     },
-  );
-
-  worker.on('failed', (job, err) => {
-    getLogger().error(
-      {
-        jobId: job?.id,
-        attempt: job?.attemptsMade,
-        maxAttempts: job?.opts.attempts,
-        err,
-      },
-      '[transfer-fetch] Job failed',
-    );
   });
 
   return worker;

--- a/apps/api/src/workers/webhook.worker.ts
+++ b/apps/api/src/workers/webhook.worker.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto';
-import { Worker } from 'bullmq';
+import type { Worker } from 'bullmq';
 import { withRls, webhookDeliveries, eq } from '@colophony/db';
 import type { DrizzleDb } from '@colophony/db';
 import { AuditActions, AuditResources } from '@colophony/types';
@@ -8,7 +8,7 @@ import type { WebhookJobData } from '../queues/webhook.queue.js';
 import { getWebhookBackoffDelay } from '../queues/webhook.queue.js';
 import { webhookService } from '../services/webhook.service.js';
 import { auditService } from '../services/audit.service.js';
-import { getLogger } from '../config/logger.js';
+import { createInstrumentedWorker } from '../config/instrumented-worker.js';
 
 const AUTO_DISABLE_THRESHOLD = 5;
 const DELIVERY_TIMEOUT_MS = 30_000;
@@ -16,9 +16,9 @@ const DELIVERY_TIMEOUT_MS = 30_000;
 let worker: Worker<WebhookJobData> | null = null;
 
 export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
-  worker = new Worker<WebhookJobData>(
-    'webhook',
-    async (job) => {
+  worker = createInstrumentedWorker<WebhookJobData>({
+    name: 'webhook',
+    processor: async (job) => {
       const { deliveryId, orgId, endpointUrl, secret, payload } = job.data;
 
       // Phase 1: Mark as DELIVERING + increment attempts
@@ -121,7 +121,7 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
         throw new Error(`Webhook delivery failed: HTTP ${response.status}`);
       }
     },
-    {
+    workerOpts: {
       connection: {
         host: env.REDIS_HOST,
         port: env.REDIS_PORT,
@@ -134,23 +134,9 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
         },
       },
     },
-  );
-
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
-  worker.on('failed', async (job, err) => {
-    getLogger().error(
-      {
-        jobId: job?.id,
-        attempt: job?.attemptsMade,
-        maxAttempts: job?.opts.attempts,
-        err,
-      },
-      '[webhook] Job failed',
-    );
-
-    // On final failure, mark as FAILED + audit + auto-disable check
-    if (job && job.attemptsMade >= (job.opts.attempts ?? 8)) {
-      try {
+    onFailed: async (job, err) => {
+      // On final failure, mark as FAILED + audit + auto-disable check
+      if (job && job.attemptsMade >= (job.opts.attempts ?? 8)) {
         const { deliveryId, orgId, endpointUrl, payload } = job.data;
         await withRls({ orgId }, async (tx: DrizzleDb) => {
           await webhookService.updateDeliveryStatus(tx, deliveryId, 'FAILED', {
@@ -201,13 +187,8 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
             }
           }
         });
-      } catch (auditErr) {
-        getLogger().error(
-          { jobId: job.id, err: auditErr },
-          '[webhook] Failed to record failure audit',
-        );
       }
-    }
+    },
   });
 
   return worker;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,6 +185,39 @@ services:
     profiles:
       - slate
 
+  # Prometheus metrics collection (optional — for monitoring)
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: colophony-prometheus
+    ports:
+      - '9090:9090'
+    volumes:
+      - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    profiles:
+      - monitoring
+
+  # Grafana dashboards (optional — for monitoring)
+  grafana:
+    image: grafana/grafana:latest
+    container_name: colophony-grafana
+    ports:
+      - '3001:3000'
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: 'false'
+    volumes:
+      - ./docker/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./docker/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    profiles:
+      - monitoring
+
   # ClamAV for virus scanning (optional in development)
   clamav:
     image: clamav/clamav:stable
@@ -210,3 +243,5 @@ volumes:
   redis_data:
   minio_data:
   clamav_data:
+  prometheus_data:
+  grafana_data:

--- a/docker/grafana/dashboards/colophony-api.json
+++ b/docker/grafana/dashboards/colophony-api.json
@@ -1,0 +1,167 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "title": "Request Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total[5m])) by (method)",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "title": "Error Rate (5xx)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status_code=~\"5..\"}[5m]))",
+          "legendFormat": "5xx errors/s",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "fixed", "fixedColor": "red" }
+        }
+      }
+    },
+    {
+      "title": "Request Latency (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" }
+      }
+    },
+    {
+      "title": "Active HTTP Connections",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "expr": "http_active_connections",
+          "legendFormat": "connections",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "BullMQ Queue Depth",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "expr": "bullmq_queue_depth{state=\"waiting\"}",
+          "legendFormat": "{{queue}} (waiting)",
+          "refId": "A"
+        },
+        {
+          "expr": "bullmq_queue_depth{state=\"active\"}",
+          "legendFormat": "{{queue}} (active)",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "title": "BullMQ Job Throughput",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "targets": [
+        {
+          "expr": "sum(rate(bullmq_jobs_total{status=\"completed\"}[5m])) by (queue)",
+          "legendFormat": "{{queue}} (completed)",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(bullmq_jobs_total{status=\"failed\"}[5m])) by (queue)",
+          "legendFormat": "{{queue}} (failed)",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "ops" }
+      }
+    },
+    {
+      "title": "DB Pool Utilization",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "targets": [
+        {
+          "expr": "db_pool_total_connections",
+          "legendFormat": "{{pool}} total",
+          "refId": "A"
+        },
+        {
+          "expr": "db_pool_idle_connections",
+          "legendFormat": "{{pool}} idle",
+          "refId": "B"
+        },
+        {
+          "expr": "db_pool_waiting_clients",
+          "legendFormat": "{{pool}} waiting",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "title": "Node.js Memory Usage",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes",
+          "legendFormat": "RSS",
+          "refId": "A"
+        },
+        {
+          "expr": "nodejs_heap_size_used_bytes",
+          "legendFormat": "Heap Used",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "bytes" }
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["colophony"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Colophony API",
+  "uid": "colophony-api",
+  "version": 1
+}

--- a/docker/grafana/provisioning/dashboards/dashboard.yml
+++ b/docker/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'Colophony'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'colophony-api'
+    static_configs:
+      - targets: ['host.docker.internal:4000']
+    metrics_path: /metrics
+    scrape_interval: 10s

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -306,7 +306,7 @@
 ### Infrastructure Setup
 
 - [ ] Coolify + Hetzner managed hosting setup — (architecture doc Track 1)
-- [ ] Monitoring stack: Prometheus + Grafana + Loki — (architecture doc Track 1)
+- [x] Monitoring stack: Prometheus + Grafana (Sentry for errors) — done 2026-02-27 PR pending; Loki deferred to production
 
 ### Database Hardening
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,28 @@ Newest entries first.
 
 ---
 
+## 2026-02-27 — Sentry + Prometheus Monitoring
+
+### Done
+
+- **Sentry error tracking:** Created `config/sentry.ts` — opt-in via `SENTRY_DSN` env var. SDK init with idempotency guard, `beforeSend` scrubs authorization/api-key headers from breadcrumbs, `captureException()` wired into Fastify global error handler (5xx) and tRPC `onError` (INTERNAL_SERVER_ERROR).
+- **Prometheus metrics:** Created `config/metrics.ts` — 9 metric singletons: HTTP request duration/count/active connections (histograms/counters/gauges), BullMQ job duration/count/queue depth, DB pool total/idle/waiting. Opt-in via `METRICS_ENABLED=true`.
+- **Fastify metrics plugin:** Created `hooks/metrics.ts` — measures full request lifecycle using `process.hrtime()`, parameterized route labels via `request.routeOptions.url` to prevent cardinality explosion.
+- **Instrumented worker wrapper:** Created `config/instrumented-worker.ts` — factory function wrapping BullMQ Worker with timing + Prometheus metrics + Sentry capture. All 6 workers migrated.
+- **Queue depth polling:** Added `get*QueueInstance()` exports to all 6 queue files; `startQueueDepthPolling()` in main.ts polls queue job counts every 30s.
+- **Docker monitoring stack:** Prometheus + Grafana behind `--profile monitoring`, Grafana on port 3001 with auto-provisioned datasource and pre-built 8-panel dashboard.
+- **Tests:** 24 new tests across 4 test files (sentry, metrics, hooks/metrics, instrumented-worker) + 16 existing test files updated with new env fields. All 1238 tests pass.
+
+### Decisions
+
+- Sentry + Prometheus shipped as single PR — both are opt-in monitoring with zero impact when env vars absent
+- `/metrics` endpoint exempt from auth and rate limiting — Prometheus scraper needs unauthenticated access
+- Used factory wrapper pattern for worker instrumentation instead of modifying each worker inline — cleaner separation, consistent metrics
+- Grafana on port 3001 to avoid Next.js 3000 conflict
+- Docker monitoring behind `profiles: [monitoring]` so `docker compose up` stays lightweight
+
+---
+
 ## 2026-02-27 — Code Quality Polish
 
 ### Done

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@sendgrid/mail':
         specifier: ^8.1.6
         version: 8.1.6
+      '@sentry/node':
+        specifier: ^10.40.0
+        version: 10.40.0
       '@trpc/server':
         specifier: ^11.0.0
         version: 11.10.0(typescript@5.9.3)
@@ -123,6 +126,9 @@ importers:
       nodemailer:
         specifier: ^8.0.1
         version: 8.0.1
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       stripe:
         specifier: ^20.3.1
         version: 20.3.1(@types/node@25.3.0)
@@ -1412,6 +1418,11 @@ packages:
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
 
+  '@fastify/otel@0.16.0':
+    resolution: {integrity: sha512-2304BdM5Q/kUvQC9qJO1KZq3Zn1WWsw+WWkVmFEaj1UE2hEIiuFqrPeglQOwEtw/ftngisqfQ3v70TWMmwhhHA==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
 
@@ -1895,6 +1906,18 @@ packages:
     resolution: {integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api-logs@0.207.0':
+    resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.208.0':
+    resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.211.0':
+    resolution: {integrity: sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.212.0':
     resolution: {integrity: sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==}
     engines: {node: '>=8.0.0'}
@@ -1918,6 +1941,12 @@ packages:
 
   '@opentelemetry/context-async-hooks@2.5.1':
     resolution: {integrity: sha512-MHbu8XxCHcBn6RwvCt2Vpn1WnLMNECfNKYB14LI5XypcgH4IE0/DiVifVR9tAkwPMyLXN8dOoPJfya3IryLQVw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.5.0':
+    resolution: {integrity: sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -1994,6 +2023,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
 
+  '@opentelemetry/instrumentation-amqplib@0.58.0':
+    resolution: {integrity: sha512-fjpQtH18J6GxzUZ+cwNhWUpb71u+DzT7rFkg5pLssDGaEber91Y2WNGdpVpwGivfEluMlNMZumzjEqfg8DeKXQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-amqplib@0.59.0':
     resolution: {integrity: sha512-xscSgOJA+GHphESDZxBHNk/zjNaEgoeufMwmiqYdL+qM27Xw3BbR9vN6Ucbq9dW6Y+oYUPgTTj17qf+Za4+uzg==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -2024,6 +2059,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-connect@0.54.0':
+    resolution: {integrity: sha512-43RmbhUhqt3uuPnc16cX6NsxEASEtn8z/cYV8Zpt6EP4p2h9s4FNuJ4Q9BbEQ2C0YlCCB/2crO1ruVz/hWt8fA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-connect@0.55.0':
     resolution: {integrity: sha512-UfGw7ubKKZBoTRjxi5KlfeECEaXZinS20RdRNlZE5tVF+O17hJOnrcGwAoQAHp6eYmxI2jW9IQ4t6450gnNF9g==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -2036,6 +2077,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
 
+  '@opentelemetry/instrumentation-dataloader@0.28.0':
+    resolution: {integrity: sha512-ExXGBp0sUj8yhm6Znhf9jmuOaGDsYfDES3gswZnKr4MCqoBWQdEFn6EoDdt5u+RdbxQER+t43FoUihEfTSqsjA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-dataloader@0.29.0':
     resolution: {integrity: sha512-220WjRb1G1UiAKbVblSMxwxxFdpyB4wj1XYIO9BJs5r62Azj2dL5fyZiXK3/WO6wB3uLul9R946iKI1bpPxktQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -2044,6 +2091,12 @@ packages:
 
   '@opentelemetry/instrumentation-dns@0.55.0':
     resolution: {integrity: sha512-cfWLaFi22V+sQrKY7t6QroYzT3kO9m3PpkN1OXYmuCyfwxQaXOVlF8NSAHtua/RQYw0aQl+2fe6JOWyJdEZiwA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-express@0.59.0':
+    resolution: {integrity: sha512-pMKV/qnHiW/Q6pmbKkxt0eIhuNEtvJ7sUAyee192HErlr+a1Jx+FZ3WjfmzhQL1geewyGEiPGkmjjAgNY8TgDA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2060,14 +2113,32 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-fs@0.30.0':
+    resolution: {integrity: sha512-n3Cf8YhG7reaj5dncGlRIU7iT40bxPOjsBEA5Bc1a1g6e9Qvb+JFJ7SEiMlPbUw4PBmxE3h40ltE8LZ3zVt6OA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-fs@0.31.0':
     resolution: {integrity: sha512-C7tdXGDnkMgLVlE79VSekB+Y+P345zKUigvFMs5M7U0GIYA8ERx3FS0aAcY/ICIq9YwRmH2uuMb++Br5M2vNUg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-generic-pool@0.54.0':
+    resolution: {integrity: sha512-8dXMBzzmEdXfH/wjuRvcJnUFeWzZHUnExkmFJ2uPfa31wmpyBCMxO59yr8f/OXXgSogNgi/uPo9KW9H7LMIZ+g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-generic-pool@0.55.0':
     resolution: {integrity: sha512-7hWiyLbEX/dIS4LZy/h8VaAQPs8oBeEqsrysDWbos0b9PF414L6Rsbi2um/omtxIs+GTvsbuqDscWigeaxyWdA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-graphql@0.58.0':
+    resolution: {integrity: sha512-+yWVVY7fxOs3j2RixCbvue8vUuJ1inHxN2q1sduqDB0Wnkr4vOzVKRYl/Zy7B31/dcPS72D9lo/kltdOTBM3bQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2084,8 +2155,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-hapi@0.57.0':
+    resolution: {integrity: sha512-Os4THbvls8cTQTVA8ApLfZZztuuqGEeqog0XUnyRW7QVF0d/vOVBEcBCk1pazPFmllXGEdNbbat8e2fYIWdFbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-hapi@0.58.0':
     resolution: {integrity: sha512-reuRApR2KHm2VsfyDgsrLhNE+IOy4uIU6n3oMjUleReHacEEZmf4vXxdt4/qcmJ6GoUXnRN2AOu3s5N3pMrgYA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-http@0.211.0':
+    resolution: {integrity: sha512-n0IaQ6oVll9PP84SjbOCwDjaJasWRHi6BLsbMLiT6tNj7QbVOkuA5sk/EfZczwI0j5uTKl1awQPivO/ldVtsqA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2096,8 +2179,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-ioredis@0.59.0':
+    resolution: {integrity: sha512-875UxzBHWkW+P4Y45SoFM2AR8f8TzBMD8eO7QXGCyFSCUMP5s9vtt/BS8b/r2kqLyaRPK6mLbdnZznK3XzQWvw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-ioredis@0.60.0':
     resolution: {integrity: sha512-R+nnbPD9l2ruzu248qM3YDWzpdmWVaFFFv08lQqsc0EP4pT/B1GGUg06/tHOSo3L5njB2eejwyzpkvJkjaQEMA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-kafkajs@0.20.0':
+    resolution: {integrity: sha512-yJXOuWZROzj7WmYCUiyT27tIfqBrVtl1/TwVbQyWPz7rL0r1Lu7kWjD0PiVeTCIL6CrIZ7M2s8eBxsTAOxbNvw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2108,17 +2203,35 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-knex@0.55.0':
+    resolution: {integrity: sha512-FtTL5DUx5Ka/8VK6P1VwnlUXPa3nrb7REvm5ddLUIeXXq4tb9pKd+/ThB1xM/IjefkRSN3z8a5t7epYw1JLBJQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-knex@0.56.0':
     resolution: {integrity: sha512-pKqtY5lbAQ70MC5K/BJeAA1t2gAUlRBZBAJ5ergRUNs5jw8zbdOXEZOLztiuNvQqD2z4a9N0Tkde9JMFm2pKMQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-koa@0.59.0':
+    resolution: {integrity: sha512-K9o2skADV20Skdu5tG2bogPKiSpXh4KxfLjz6FuqIVvDJNibwSdu5UvyyBzRVp1rQMV6UmoIk6d3PyPtJbaGSg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
   '@opentelemetry/instrumentation-koa@0.60.0':
     resolution: {integrity: sha512-UOmu2y2LHgPzKsm9xd0sCQJimr11YP4MKFc190Do1ufd8qds7Zd5BI3f6TudqYhH9dUIhojsQyUaS6K4nv5FsQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.55.0':
+    resolution: {integrity: sha512-FDBfT7yDGcspN0Cxbu/k8A0Pp1Jhv/m7BMTzXGpcb8ENl3tDj/51U65R5lWzUH15GaZA15HQ5A5wtafklxYj7g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
 
   '@opentelemetry/instrumentation-lru-memoizer@0.56.0':
     resolution: {integrity: sha512-vXtOValhKRgWA9tLAiTU3P37Q31OveRuM2N5iLSVHl4GzkMBQ5p50A9kSKvt5gReL6BzFDXPCM9ItJiAhSS2KQ==}
@@ -2132,8 +2245,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-mongodb@0.64.0':
+    resolution: {integrity: sha512-pFlCJjweTqVp7B220mCvCld1c1eYKZfQt1p3bxSbcReypKLJTwat+wbL2YZoX9jPi5X2O8tTKFEOahO5ehQGsA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-mongodb@0.65.0':
     resolution: {integrity: sha512-hOAJRs5vrY7fZolSYUXmf29Y+HFDHWrek0DeLq82uwMPjPSda7h6oumQnqEX5olzw357q/QG39/uJdkclJ/JUg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongoose@0.57.0':
+    resolution: {integrity: sha512-MthiekrU/BAJc5JZoZeJmo0OTX6ycJMiP6sMOSRTkvz5BrPMYDqaJos0OgsLPL/HpcgHP7eo5pduETuLguOqcg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2144,8 +2269,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-mysql2@0.57.0':
+    resolution: {integrity: sha512-nHSrYAwF7+aV1E1V9yOOP9TchOodb6fjn4gFvdrdQXiRE7cMuffyLLbCZlZd4wsspBzVwOXX8mpURdRserAhNA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-mysql2@0.58.0':
     resolution: {integrity: sha512-EubjV1XZb7XHrENqF7TW2lnah+KN0LddMneKNAB8PjGVKL5lJkVV/vhJ6EIcUNn9nCWmAwZ3GRcFVEDKCnyXfQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql@0.57.0':
+    resolution: {integrity: sha512-HFS/+FcZ6Q7piM7Il7CzQ4VHhJvGMJWjx7EgCkP5AnTntSN5rb5Xi3TkYJHBKeR27A0QqPlGaCITi93fUDs++Q==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2180,6 +2317,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-pg@0.63.0':
+    resolution: {integrity: sha512-dKm/ODNN3GgIQVlbD6ZPxwRc3kleLf95hrRWXM+l8wYo+vSeXtEpQPT53afEf6VFWDVzJK55VGn8KMLtSve/cg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-pg@0.64.0':
     resolution: {integrity: sha512-NbfB/rlfsRI3zpTjnbvJv3qwuoGLsN8FxR/XoI+ZTn1Rs62x1IenO+TSSvk4NO+7FlXpd2MiOe8LT/oNbydHGA==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -2188,6 +2331,12 @@ packages:
 
   '@opentelemetry/instrumentation-pino@0.58.0':
     resolution: {integrity: sha512-rgy+tA7cDjuSq6dXAO40OiYP25azIDHMBtxG3RzSmCBVEYdjggl6btyuLVasX6VkOOhP2gf6PBuLMNxVwaIqAw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-redis@0.59.0':
+    resolution: {integrity: sha512-JKv1KDDYA2chJ1PC3pLP+Q9ISMQk6h5ey+99mB57/ARk0vQPGZTTEb4h4/JlcEpy7AYT8HIGv7X6l+br03Neeg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2222,11 +2371,23 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-tedious@0.30.0':
+    resolution: {integrity: sha512-bZy9Q8jFdycKQ2pAsyuHYUHNmCxCOGdG6eg1Mn75RvQDccq832sU5OWOBnc12EFUELI6icJkhR7+EQKMBam2GA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-tedious@0.31.0':
     resolution: {integrity: sha512-HoF2EtcyP3JR4R3jLPHohZ9lFcj1QLJyGmFfLKDTvUUjPiFuK4XZ6L1OV9HhaqvN0xY+tWKfNdCPS3r33rd0Xw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-undici@0.21.0':
+    resolution: {integrity: sha512-gok0LPUOTz2FQ1YJMZzaHcOzDFyT64XJ8M9rNkugk923/p6lDGms/cRW1cqgqp6N6qcd6K6YdVHwPEhnx9BWbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
 
   '@opentelemetry/instrumentation-undici@0.22.0':
     resolution: {integrity: sha512-yb6vEWUPOrD5i7yR1XceEEqiVHbMgr5YnUPnom5eQVCjvrTkEVswyrf9i+vvJR+28wrNqILIIphWgOOx6BjnTQ==}
@@ -2242,6 +2403,24 @@ packages:
 
   '@opentelemetry/instrumentation@0.203.0':
     resolution: {integrity: sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.207.0':
+    resolution: {integrity: sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.208.0':
+    resolution: {integrity: sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.211.0':
+    resolution: {integrity: sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2482,6 +2661,11 @@ packages:
 
   '@prisma/get-platform@5.22.0':
     resolution: {integrity: sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==}
+
+  '@prisma/instrumentation@7.2.0':
+    resolution: {integrity: sha512-Rh9Z4x5kEj1OdARd7U18AtVrnL6rmLSI0qYShaB4W7Wx5BKbgzndWF+QnuzMb7GLfVdlT5aYCXoPQVYuYtVu0g==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.8
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -3171,6 +3355,51 @@ packages:
   '@sendgrid/mail@8.1.6':
     resolution: {integrity: sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==}
     engines: {node: '>=12.*'}
+
+  '@sentry/core@10.40.0':
+    resolution: {integrity: sha512-/wrcHPp9Avmgl6WBimPjS4gj810a1wU5oX9fF1bzJfeIIbF3jTsAbv0oMbgDp0cSDnkwv2+NvcPnn3+c5J6pBA==}
+    engines: {node: '>=18'}
+
+  '@sentry/node-core@10.40.0':
+    resolution: {integrity: sha512-ciZGOF54rJH9Fkg7V3v4gmWVufnJRqQQOrn0KStuo49vfPQAJLGePDx+crQv0iNVoLc6Hmrr6E7ebNHSb4NSAw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/resources': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/context-async-hooks':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/resources':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
+
+  '@sentry/node@10.40.0':
+    resolution: {integrity: sha512-HQETLoNZTUUM8PBxFPT4X0qepzk5NcyWg3jyKUmF7Hh/19KSJItBXXZXxx+8l3PC2eASXUn70utXi65PoXEHWA==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.40.0':
+    resolution: {integrity: sha512-Zx6T258qlEhQfdghIlazSTbK7uRO0pXWw4/4/VPR8pMOiRPh8dAoJg8AB0L55PYPMpVdXxNf7L9X0EZoDYibJw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
 
   '@sinclair/typebox@0.34.48':
     resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
@@ -4351,6 +4580,9 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -6314,6 +6546,10 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@9.0.1:
     resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -6823,6 +7059,10 @@ packages:
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -7462,6 +7702,9 @@ packages:
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   temporal-polyfill@0.2.5:
     resolution: {integrity: sha512-ye47xp8Cb0nDguAhrrDS1JT1SzwEV9e26sSsrWzVu+yPZ7LzceEcH0i2gci9jWfOfSCCgM3Qv5nOYShVUUFUXA==}
@@ -9062,6 +9305,16 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  '@fastify/otel@0.16.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      minimatch: 10.2.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@fastify/proxy-addr@5.1.0':
     dependencies:
       '@fastify/forwarded': 3.0.1
@@ -9596,6 +9849,18 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
 
+  '@opentelemetry/api-logs@0.207.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api-logs@0.208.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api-logs@0.211.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api-logs@0.212.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -9667,6 +9932,11 @@ snapshots:
   '@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.39.0
 
   '@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -9779,6 +10049,15 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
 
+  '@opentelemetry/instrumentation-amqplib@0.58.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-amqplib@0.59.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -9823,6 +10102,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-connect@0.54.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@types/connect': 3.4.38
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-connect@0.55.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -9841,6 +10130,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-dataloader@0.28.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-dataloader@0.29.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -9852,6 +10148,15 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-express@0.59.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9873,6 +10178,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-fs@0.30.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-fs@0.31.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -9881,10 +10194,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-generic-pool@0.54.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-generic-pool@0.55.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-graphql@0.58.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9903,12 +10230,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-hapi@0.57.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-hapi@0.58.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-http@0.211.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      forwarded-parse: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -9922,11 +10268,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-ioredis@0.59.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/redis-common': 0.38.2
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-ioredis@0.60.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/redis-common': 0.38.2
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-kafkajs@0.20.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
     transitivePeerDependencies:
       - supports-color
@@ -9939,10 +10302,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-knex@0.55.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-knex@0.56.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-koa@0.59.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
     transitivePeerDependencies:
       - supports-color
@@ -9953,6 +10333,13 @@ snapshots:
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.55.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9972,10 +10359,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-mongodb@0.64.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-mongodb@0.65.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongoose@0.57.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
     transitivePeerDependencies:
       - supports-color
@@ -9989,12 +10393,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-mysql2@0.57.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-mysql2@0.58.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
       '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql@0.57.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@types/mysql': 2.15.27
     transitivePeerDependencies:
       - supports-color
 
@@ -10041,6 +10463,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-pg@0.63.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
+      '@types/pg': 8.15.6
+      '@types/pg-pool': 2.0.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-pg@0.64.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -10059,6 +10493,15 @@ snapshots:
       '@opentelemetry/api-logs': 0.212.0
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-redis@0.59.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/redis-common': 0.38.2
+      '@opentelemetry/semantic-conventions': 1.39.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10102,12 +10545,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-tedious@0.30.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-tedious@0.31.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
       '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-undici@0.21.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10134,6 +10595,33 @@ snapshots:
       '@opentelemetry/api-logs': 0.203.0
       import-in-the-middle: 1.15.0
       require-in-the-middle: 7.5.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.207.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.211.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -10490,6 +10978,13 @@ snapshots:
     dependencies:
       '@prisma/debug': 5.22.0
     optional: true
+
+  '@prisma/instrumentation@7.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -11129,6 +11624,71 @@ snapshots:
       '@sendgrid/helpers': 8.0.0
     transitivePeerDependencies:
       - debug
+
+  '@sentry/core@10.40.0': {}
+
+  '@sentry/node-core@10.40.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)':
+    dependencies:
+      '@sentry/core': 10.40.0
+      '@sentry/opentelemetry': 10.40.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
+      import-in-the-middle: 2.0.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@sentry/node@10.40.0':
+    dependencies:
+      '@fastify/otel': 0.16.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-amqplib': 0.58.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-connect': 0.54.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-dataloader': 0.28.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-express': 0.59.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-fs': 0.30.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-generic-pool': 0.54.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-graphql': 0.58.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-hapi': 0.57.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-http': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-ioredis': 0.59.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-kafkajs': 0.20.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-knex': 0.55.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-koa': 0.59.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.55.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mongodb': 0.64.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mongoose': 0.57.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mysql': 0.57.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mysql2': 0.57.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-pg': 0.63.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-redis': 0.59.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-tedious': 0.30.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-undici': 0.21.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@prisma/instrumentation': 7.2.0(@opentelemetry/api@1.9.0)
+      '@sentry/core': 10.40.0
+      '@sentry/node-core': 10.40.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
+      '@sentry/opentelemetry': 10.40.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
+      import-in-the-middle: 2.0.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sentry/opentelemetry@10.40.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@sentry/core': 10.40.0
 
   '@sinclair/typebox@0.34.48': {}
 
@@ -12532,6 +13092,8 @@ snapshots:
   bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
+
+  bintrees@1.0.2: {}
 
   boolbase@1.0.0: {}
 
@@ -14855,6 +15417,10 @@ snapshots:
 
   minimalistic-assert@1.0.1: {}
 
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.3
+
   minimatch@9.0.1:
     dependencies:
       brace-expansion: 2.0.2
@@ -15561,6 +16127,11 @@ snapshots:
   process-warning@5.0.0: {}
 
   process@0.11.10: {}
+
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      tdigest: 0.1.2
 
   prompts@2.4.2:
     dependencies:
@@ -16327,6 +16898,10 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   temporal-polyfill@0.2.5:
     dependencies:


### PR DESCRIPTION
## Summary

- **Sentry error tracking** — opt-in via `SENTRY_DSN` env var. SDK init with header scrubbing, `captureException()` wired into Fastify error handler + tRPC `onError`
- **Prometheus metrics** — opt-in via `METRICS_ENABLED=true`. HTTP request duration/count/active connections, BullMQ job duration/count/queue depth, DB pool utilization. Exposed at `/metrics`
- **Instrumented worker wrapper** — factory function wrapping all 6 BullMQ workers with timing + metrics + Sentry error capture
- **Docker monitoring stack** — Prometheus + Grafana behind `--profile monitoring`, pre-built 8-panel dashboard

Both features are zero-impact when env vars are absent.

## Test plan

- [x] `pnpm type-check` — all types resolve
- [x] `pnpm lint` — clean (0 errors)
- [x] `pnpm test` — 1238 tests pass (116 files), including 24 new tests across 4 new test files
- [x] OpenCode branch review — LGTM, zero critical/important findings
- [x] Plan drift check — 26/26 items match, zero drift
- [ ] Manual: `METRICS_ENABLED=true` → curl `localhost:4000/metrics` returns Prometheus text
- [ ] Manual: `docker compose --profile monitoring up -d` → Grafana at `localhost:3001`