### PR TITLE
perf: backend performance sweep (7 fixes)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -36,6 +36,7 @@
     "@colophony/db": "workspace:*",
     "@colophony/plugin-sdk": "workspace:^",
     "@colophony/types": "workspace:*",
+    "@fastify/compress": "^8.3.1",
     "@fastify/cors": "^11.0.0",
     "@fastify/helmet": "^13.0.0",
     "@orpc/openapi": "^1.13.5",
@@ -61,6 +62,7 @@
     "jose": "^6.0.0",
     "mjml": "^4.18.0",
     "nodemailer": "^8.0.1",
+    "p-limit": "^7.3.0",
     "prom-client": "^15.1.3",
     "stripe": "^20.3.1",
     "zod": "^4.3.6"

--- a/apps/api/src/config/metrics.spec.ts
+++ b/apps/api/src/config/metrics.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import client from 'prom-client';
 import {
   httpRequestDuration,
@@ -6,6 +6,7 @@ import {
   httpActiveConnections,
   bullmqJobDuration,
   bullmqJobTotal,
+  startQueueDepthPolling,
   getMetricsOutput,
   getContentType,
   stopMetricsPolling,
@@ -71,5 +72,56 @@ describe('metrics', () => {
   it('getContentType returns correct MIME type', () => {
     const contentType = getContentType();
     expect(contentType).toContain('text/plain');
+  });
+
+  it('skips overlapping queue depth polls when previous poll is still running', async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveFirst: (() => void) | null = null;
+      let callCount = 0;
+
+      const mockQueue = {
+        getJobCounts: vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            // First poll: block until resolved
+            return new Promise<Record<string, number>>((resolve) => {
+              resolveFirst = () =>
+                resolve({ waiting: 1, active: 0, delayed: 0, failed: 0 });
+            });
+          }
+          // Subsequent polls: resolve immediately
+          return Promise.resolve({
+            waiting: 0,
+            active: 0,
+            delayed: 0,
+            failed: 0,
+          });
+        }),
+      };
+
+      startQueueDepthPolling([{ name: 'test', queue: mockQueue as any }]);
+
+      // Trigger first poll
+      vi.advanceTimersByTime(30_000);
+      // First poll is in-flight (blocked)
+
+      // Trigger second poll while first is still running
+      vi.advanceTimersByTime(30_000);
+
+      // Only the first poll should have called getJobCounts
+      expect(callCount).toBe(1);
+
+      // Resolve first poll
+      resolveFirst!();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Now trigger third poll — should work since first completed
+      vi.advanceTimersByTime(30_000);
+      expect(callCount).toBe(2);
+    } finally {
+      stopMetricsPolling();
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/api/src/config/metrics.ts
+++ b/apps/api/src/config/metrics.ts
@@ -62,6 +62,7 @@ export const dbPoolWaiting = new client.Gauge({
 
 let poolInterval: ReturnType<typeof setInterval> | null = null;
 let queueInterval: ReturnType<typeof setInterval> | null = null;
+let isQueuePolling = false;
 
 export function initMetrics(pools: { admin: Pool; app: Pool }): void {
   client.collectDefaultMetrics();
@@ -83,23 +84,35 @@ export function startQueueDepthPolling(
   queues: Array<{ name: string; queue: Queue }>,
 ): void {
   queueInterval = setInterval(() => {
+    if (isQueuePolling) return;
+    isQueuePolling = true;
     void (async () => {
-      for (const { name, queue } of queues) {
-        try {
-          const counts = await queue.getJobCounts(
-            'waiting',
-            'active',
-            'delayed',
-            'failed',
-          );
-          const labels = { queue: name };
-          bullmqQueueDepth.set({ ...labels, state: 'waiting' }, counts.waiting);
-          bullmqQueueDepth.set({ ...labels, state: 'active' }, counts.active);
-          bullmqQueueDepth.set({ ...labels, state: 'delayed' }, counts.delayed);
-          bullmqQueueDepth.set({ ...labels, state: 'failed' }, counts.failed);
-        } catch {
-          // Swallow errors — queue might be closing
+      try {
+        for (const { name, queue } of queues) {
+          try {
+            const counts = await queue.getJobCounts(
+              'waiting',
+              'active',
+              'delayed',
+              'failed',
+            );
+            const labels = { queue: name };
+            bullmqQueueDepth.set(
+              { ...labels, state: 'waiting' },
+              counts.waiting,
+            );
+            bullmqQueueDepth.set({ ...labels, state: 'active' }, counts.active);
+            bullmqQueueDepth.set(
+              { ...labels, state: 'delayed' },
+              counts.delayed,
+            );
+            bullmqQueueDepth.set({ ...labels, state: 'failed' }, counts.failed);
+          } catch {
+            // Swallow errors — queue might be closing
+          }
         }
+      } finally {
+        isQueuePolling = false;
       }
     })();
   }, 30_000);
@@ -114,6 +127,7 @@ export function stopMetricsPolling(): void {
   if (queueInterval) {
     clearInterval(queueInterval);
     queueInterval = null;
+    isQueuePolling = false;
   }
 }
 

--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -1134,6 +1134,98 @@ describe('auth plugin', () => {
       }
     });
 
+    it('does not grow failureMap beyond 10,000 entries (fail-open for new IPs)', async () => {
+      const app = Fastify({ logger: false, trustProxy: true });
+      await app.register(authPlugin, {
+        env: {
+          ...baseEnv,
+          NODE_ENV: 'development' as const,
+          ZITADEL_AUTHORITY: 'http://localhost:8080',
+          ZITADEL_CLIENT_ID: 'my-client',
+          AUTH_FAILURE_THROTTLE_MAX: 100, // high enough that no IP gets throttled from a single failure
+          AUTH_FAILURE_THROTTLE_WINDOW_SECONDS: 300,
+        },
+      });
+      app.get('/protected', async (request) => ({
+        authContext: request.authContext,
+      }));
+
+      // Warm up the map with 10,000 unique IPs (one failure each)
+      for (let i = 0; i < 10_000; i++) {
+        await app.inject({
+          method: 'GET',
+          url: '/protected',
+          headers: {
+            'x-forwarded-for': `10.${Math.floor(i / 65536) % 256}.${Math.floor(i / 256) % 256}.${i % 256}`,
+          },
+        });
+      }
+
+      // New IP beyond cap — should get 401 (not 429), meaning fail-open
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { 'x-forwarded-for': '192.168.1.1' },
+      });
+      expect(response.statusCode).toBe(401);
+
+      await app.close();
+    });
+
+    it('still throttles existing IPs when map is at capacity', async () => {
+      const app = Fastify({ logger: false, trustProxy: true });
+      await app.register(authPlugin, {
+        env: {
+          ...baseEnv,
+          NODE_ENV: 'development' as const,
+          ZITADEL_AUTHORITY: 'http://localhost:8080',
+          ZITADEL_CLIENT_ID: 'my-client',
+          AUTH_FAILURE_THROTTLE_MAX: 2,
+          AUTH_FAILURE_THROTTLE_WINDOW_SECONDS: 300,
+        },
+      });
+      app.get('/protected', async (request) => ({
+        authContext: request.authContext,
+      }));
+
+      // Record an initial failure from a known IP
+      await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { 'x-forwarded-for': '10.0.0.1' },
+      });
+      await flushPromises();
+
+      // Fill to 10k with other IPs
+      for (let i = 1; i < 10_000; i++) {
+        await app.inject({
+          method: 'GET',
+          url: '/protected',
+          headers: {
+            'x-forwarded-for': `10.${Math.floor(i / 65536) % 256}.${Math.floor(i / 256) % 256}.${i % 256}`,
+          },
+        });
+      }
+
+      // One more failure for known IP — should still increment (existing entry)
+      await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { 'x-forwarded-for': '10.0.0.1' },
+      });
+      await flushPromises();
+
+      // Now known IP should be throttled (2 failures >= max of 2)
+      const blocked = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { 'x-forwarded-for': '10.0.0.1' },
+      });
+      expect(blocked.statusCode).toBe(429);
+
+      await app.close();
+    });
+
     it('does not throttle public routes', async () => {
       const app = Fastify({ logger: false });
       await app.register(authPlugin, {

--- a/apps/api/src/hooks/auth.ts
+++ b/apps/api/src/hooks/auth.ts
@@ -73,6 +73,7 @@ export default fp(
     // --- Per-IP auth failure throttle ---
     const throttleMax = env.AUTH_FAILURE_THROTTLE_MAX;
     const throttleWindowMs = env.AUTH_FAILURE_THROTTLE_WINDOW_SECONDS * 1000;
+    const FAILURE_MAP_MAX_SIZE = 10_000;
     const failureMap = new Map<
       string,
       { count: number; windowStart: number }
@@ -82,6 +83,12 @@ export default fp(
       const now = Date.now();
       const entry = failureMap.get(ip);
       if (!entry || now - entry.windowStart >= throttleWindowMs) {
+        // New entry or expired window — check capacity before inserting new IP
+        if (!entry && failureMap.size >= FAILURE_MAP_MAX_SIZE) {
+          // Fail-open: skip tracking for new IPs when map is at capacity.
+          // Redis rate-limit hook provides broader DDoS protection.
+          return;
+        }
         failureMap.set(ip, { count: 1, windowStart: now });
       } else {
         entry.count++;

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,5 +1,6 @@
 import Fastify, { type FastifyInstance } from 'fastify';
 import cors from '@fastify/cors';
+import compress from '@fastify/compress';
 import helmet from '@fastify/helmet';
 import { pool, appPool } from '@colophony/db';
 import { loadConfig } from '@colophony/plugin-sdk';
@@ -113,6 +114,9 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
     // CORP defaults to same-origin; no override needed for a JSON API
     // (cross-origin fetch/XHR is governed by CORS, not CORP)
   });
+
+  // Response compression (brotli + gzip, skip small payloads)
+  await app.register(compress, { threshold: 1024 });
 
   // Permissions-Policy — helmet v8 dropped support; set manually
   app.addHook('onSend', async (_request, reply) => {

--- a/apps/api/src/services/hub.service.ts
+++ b/apps/api/src/services/hub.service.ts
@@ -326,7 +326,8 @@ export const hubService = {
           .select()
           .from(hubRegisteredInstances)
           .where(eq(hubRegisteredInstances.status, filter.status))
-      : db.select().from(hubRegisteredInstances);
+          .limit(500)
+      : db.select().from(hubRegisteredInstances).limit(500);
 
     const rows = await query;
     return rows.map(mapInstanceRow);

--- a/apps/api/src/services/migration-bundle.service.spec.ts
+++ b/apps/api/src/services/migration-bundle.service.spec.ts
@@ -147,6 +147,7 @@ describe('migrationBundleService', () => {
       });
 
       // Call tracking: select calls resolve differently based on count
+      // New batch flow: 1. submissions, 2. orgs, 3. batch files, 4. batch versions
       mockDb.where.mockImplementation(() => {
         if (selectCallCount === 1) {
           // Submissions query
@@ -176,10 +177,10 @@ describe('migrationBundleService', () => {
           ];
         }
         if (selectCallCount === 2) {
-          // Orgs lookup
+          // Orgs lookup (inArray)
           return [{ id: validUuid2, name: 'Test Magazine' }];
         }
-        // Files for active submission
+        // Batch files fetch (all versions at once)
         if (selectCallCount === 3) {
           return [
             {
@@ -187,21 +188,16 @@ describe('migrationBundleService', () => {
               filename: 'story.docx',
               mimeType: 'application/docx',
               size: 12345,
+              manuscriptVersionId: validUuid,
             },
           ];
         }
-        // Manuscript version fingerprint
+        // Batch versions fetch (all versions at once)
         if (selectCallCount === 4) {
-          mockDb.limit.mockResolvedValueOnce([
-            { contentFingerprint: 'abc123' },
-          ]);
-          return mockDb;
+          return [{ id: validUuid, contentFingerprint: 'abc123' }];
         }
-        return mockDb;
+        return [];
       });
-
-      // For the limit() calls on specific queries
-      mockDb.limit.mockResolvedValue([{ contentFingerprint: 'abc123' }]);
 
       const bundle = await migrationBundleService.assembleBundleForUser(
         testEnv,
@@ -261,6 +257,146 @@ describe('migrationBundleService', () => {
         'remote.example.com',
       );
       expect(mockSignJWT.setJti).toHaveBeenCalledWith(validUuid2);
+    });
+
+    it('batch-fetches files and versions instead of per-submission queries', async () => {
+      let selectCallCount = 0;
+      mockDb.select.mockImplementation(() => {
+        selectCallCount++;
+        return mockDb;
+      });
+
+      // Two active submissions with different manuscriptVersionIds
+      const mvId1 = '00000000-0000-4000-a000-000000000010';
+      const mvId2 = '00000000-0000-4000-a000-000000000020';
+
+      mockDb.where.mockImplementation(() => {
+        if (selectCallCount === 1) {
+          // Submissions query
+          return [
+            {
+              id: validUuid,
+              title: 'Active 1',
+              coverLetter: null,
+              content: 'Text',
+              status: 'SUBMITTED',
+              formData: null,
+              submittedAt: new Date('2025-01-01'),
+              organizationId: validUuid2,
+              manuscriptVersionId: mvId1,
+            },
+            {
+              id: validUuid2,
+              title: 'Active 2',
+              coverLetter: null,
+              content: 'Text2',
+              status: 'UNDER_REVIEW',
+              formData: null,
+              submittedAt: new Date('2025-02-01'),
+              organizationId: validUuid2,
+              manuscriptVersionId: mvId2,
+            },
+          ];
+        }
+        if (selectCallCount === 2) {
+          // Orgs lookup (via inArray)
+          return [{ id: validUuid2, name: 'Test Mag' }];
+        }
+        if (selectCallCount === 3) {
+          // Batch files fetch (single query for both versions)
+          return [
+            {
+              id: 'f1',
+              filename: 'a.docx',
+              mimeType: 'application/docx',
+              size: 100,
+              manuscriptVersionId: mvId1,
+            },
+            {
+              id: 'f2',
+              filename: 'b.docx',
+              mimeType: 'application/docx',
+              size: 200,
+              manuscriptVersionId: mvId2,
+            },
+          ];
+        }
+        if (selectCallCount === 4) {
+          // Batch versions fetch
+          return [
+            { id: mvId1, contentFingerprint: 'fp-1' },
+            { id: mvId2, contentFingerprint: 'fp-2' },
+          ];
+        }
+        return [];
+      });
+
+      const bundle = await migrationBundleService.assembleBundleForUser(
+        testEnv,
+        {
+          userId: validUuid,
+          userEmail: 'user@test.com',
+          userDid: 'did:web:local.example.com:users:user',
+          destinationDomain: 'remote.example.com',
+          destinationUserDid: null,
+          migrationId: validUuid2,
+        },
+      );
+
+      // Should have made exactly 4 select calls:
+      // 1. submissions, 2. orgs, 3. batch files, 4. batch versions
+      expect(selectCallCount).toBe(4);
+      expect(bundle.activeSubmissions).toHaveLength(2);
+      expect(bundle.activeSubmissions[0].fileManifest).toHaveLength(1);
+      expect(bundle.activeSubmissions[1].fileManifest).toHaveLength(1);
+    });
+
+    it('handles submissions with no manuscriptVersionId (skips batch)', async () => {
+      let selectCallCount = 0;
+      mockDb.select.mockImplementation(() => {
+        selectCallCount++;
+        return mockDb;
+      });
+
+      mockDb.where.mockImplementation(() => {
+        if (selectCallCount === 1) {
+          return [
+            {
+              id: validUuid,
+              title: 'Draft No Version',
+              coverLetter: null,
+              content: 'Text',
+              status: 'DRAFT',
+              formData: null,
+              submittedAt: null,
+              organizationId: validUuid2,
+              manuscriptVersionId: null,
+            },
+          ];
+        }
+        if (selectCallCount === 2) {
+          return [{ id: validUuid2, name: 'Test Mag' }];
+        }
+        return [];
+      });
+
+      const bundle = await migrationBundleService.assembleBundleForUser(
+        testEnv,
+        {
+          userId: validUuid,
+          userEmail: 'user@test.com',
+          userDid: 'did:web:local.example.com:users:user',
+          destinationDomain: 'remote.example.com',
+          destinationUserDid: null,
+          migrationId: validUuid2,
+        },
+      );
+
+      // Only 2 select calls: submissions + orgs (no batch files/versions)
+      expect(selectCallCount).toBe(2);
+      expect(bundle.activeSubmissions).toHaveLength(1);
+      expect(bundle.activeSubmissions[0].fileManifest).toEqual([]);
+      expect(bundle.activeSubmissions[0].contentFingerprint).toBeNull();
     });
   });
 

--- a/apps/api/src/services/migration-bundle.service.ts
+++ b/apps/api/src/services/migration-bundle.service.ts
@@ -124,7 +124,7 @@ export const migrationBundleService = {
         );
 
       for (const f of fileRows) {
-        const key = f.manuscriptVersionId!;
+        const key = f.manuscriptVersionId;
         const entry: TransferFileManifestEntry = {
           fileId: f.id,
           filename: f.filename,

--- a/apps/api/src/services/migration-bundle.service.ts
+++ b/apps/api/src/services/migration-bundle.service.ts
@@ -94,6 +94,64 @@ export const migrationBundleService = {
       }
     }
 
+    // Batch-fetch files and versions for active submissions (avoids N+1)
+    const versionIds = allSubmissions
+      .filter(
+        (s) =>
+          (ACTIVE_STATUSES as readonly string[]).includes(s.status) &&
+          s.manuscriptVersionId,
+      )
+      .map((s) => s.manuscriptVersionId!);
+
+    const filesMap = new Map<string, TransferFileManifestEntry[]>();
+    const versionFingerprintMap = new Map<string, string | null>();
+
+    if (versionIds.length > 0) {
+      const fileRows = await db
+        .select({
+          id: files.id,
+          filename: files.filename,
+          mimeType: files.mimeType,
+          size: files.size,
+          manuscriptVersionId: files.manuscriptVersionId,
+        })
+        .from(files)
+        .where(
+          and(
+            inArray(files.manuscriptVersionId, versionIds),
+            eq(files.scanStatus, 'CLEAN'),
+          ),
+        );
+
+      for (const f of fileRows) {
+        const key = f.manuscriptVersionId!;
+        const entry: TransferFileManifestEntry = {
+          fileId: f.id,
+          filename: f.filename,
+          mimeType: f.mimeType,
+          size: Number(f.size),
+        };
+        const existing = filesMap.get(key);
+        if (existing) {
+          existing.push(entry);
+        } else {
+          filesMap.set(key, [entry]);
+        }
+      }
+
+      const versionRows = await db
+        .select({
+          id: manuscriptVersions.id,
+          contentFingerprint: manuscriptVersions.contentFingerprint,
+        })
+        .from(manuscriptVersions)
+        .where(inArray(manuscriptVersions.id, versionIds));
+
+      for (const v of versionRows) {
+        versionFingerprintMap.set(v.id, v.contentFingerprint);
+      }
+    }
+
     // Build closed submissions (metadata only)
     const submissionHistory: MigrationSubmissionHistory[] = [];
     const activeSubmissions: MigrationActiveSubmission[] = [];
@@ -116,46 +174,14 @@ export const migrationBundleService = {
           periodName: null,
         });
       } else if ((ACTIVE_STATUSES as readonly string[]).includes(sub.status)) {
-        // Get file manifest for active submissions
         let fileManifest: TransferFileManifestEntry[] = [];
         let contentFingerprint: string | null = null;
 
         if (sub.manuscriptVersionId) {
-          // CLEAN files only (same filter as transfer.service.ts)
-          const fileRows = await db
-            .select({
-              id: files.id,
-              filename: files.filename,
-              mimeType: files.mimeType,
-              size: files.size,
-            })
-            .from(files)
-            .where(
-              and(
-                eq(files.manuscriptVersionId, sub.manuscriptVersionId),
-                eq(files.scanStatus, 'CLEAN'),
-              ),
-            );
-
-          fileManifest = fileRows.map((f) => ({
-            fileId: f.id,
-            filename: f.filename,
-            mimeType: f.mimeType,
-            size: Number(f.size),
-          }));
-
+          fileManifest = filesMap.get(sub.manuscriptVersionId) ?? [];
           allFileIds.push(...fileManifest.map((f) => f.fileId));
-
-          // Content fingerprint from manuscript version
-          const [version] = await db
-            .select({
-              contentFingerprint: manuscriptVersions.contentFingerprint,
-            })
-            .from(manuscriptVersions)
-            .where(eq(manuscriptVersions.id, sub.manuscriptVersionId))
-            .limit(1);
-
-          contentFingerprint = version?.contentFingerprint ?? null;
+          contentFingerprint =
+            versionFingerprintMap.get(sub.manuscriptVersionId) ?? null;
         }
 
         activeSubmissions.push({

--- a/apps/api/src/workers/transfer-fetch.worker.spec.ts
+++ b/apps/api/src/workers/transfer-fetch.worker.spec.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('p-limit', () => ({
+  default: (concurrency: number) => {
+    // Track concurrency for testing
+    let active = 0;
+    let maxObserved = 0;
+    const limit = <T>(fn: () => Promise<T>): Promise<T> => {
+      active++;
+      if (active > maxObserved) maxObserved = active;
+      return fn().finally(() => {
+        active--;
+      });
+    };
+    limit.concurrency = concurrency;
+    limit.maxObserved = () => maxObserved;
+    return limit;
+  },
+}));
+
+const mockUploadToBucket = vi.fn().mockResolvedValue(undefined);
+const mockStorage = {
+  defaultBucket: 'test-bucket',
+  uploadToBucket: mockUploadToBucket,
+};
+
+const mockResolve = vi.fn().mockReturnValue(mockStorage);
+vi.mock('@colophony/plugin-sdk', () => ({
+  loadConfig: vi.fn(),
+}));
+
+const mockWithRls = vi
+  .fn()
+  .mockImplementation(
+    async (_ctx: unknown, fn: (tx: unknown) => Promise<unknown>) => fn(mockTx),
+  );
+const mockTx = {
+  update: vi.fn().mockReturnThis(),
+  set: vi.fn().mockReturnThis(),
+  where: vi.fn().mockResolvedValue(undefined),
+  select: vi.fn().mockReturnThis(),
+  from: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockResolvedValue([]),
+};
+
+vi.mock('@colophony/db', () => ({
+  withRls: (...args: unknown[]) => mockWithRls(...args),
+  submissions: { formData: 'formData', id: 'id' },
+  trustedPeers: {
+    instanceUrl: 'instanceUrl',
+    domain: 'domain',
+    status: 'status',
+  },
+  inboundTransfers: { id: 'id', status: 'status' },
+  eq: vi.fn(),
+  and: vi.fn(),
+}));
+
+vi.mock('@colophony/types', () => ({
+  AuditActions: {
+    TRANSFER_FILES_FETCH_STARTED: 'TRANSFER_FILES_FETCH_STARTED',
+    TRANSFER_FILES_FETCH_COMPLETED: 'TRANSFER_FILES_FETCH_COMPLETED',
+    TRANSFER_FILES_FETCH_FAILED: 'TRANSFER_FILES_FETCH_FAILED',
+  },
+  AuditResources: { TRANSFER: 'transfer' },
+}));
+
+const mockLogDirect = vi.fn().mockResolvedValue(undefined);
+vi.mock('../services/audit.service.js', () => ({
+  auditService: { logDirect: (...args: unknown[]) => mockLogDirect(...args) },
+}));
+
+vi.mock('../config/instrumented-worker.js', () => ({
+  createInstrumentedWorker: vi.fn(
+    (opts: { processor: (job: unknown) => Promise<void> }) => {
+      // Store the processor so tests can invoke it directly
+      (globalThis as any).__transferFetchProcessor = opts.processor;
+      return { close: vi.fn() };
+    },
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { startTransferFetchWorker } from './transfer-fetch.worker.js';
+
+const baseJobData = {
+  transferId: 'transfer-1',
+  orgId: 'org-1',
+  originDomain: 'origin.example.com',
+  transferToken: 'tok-123',
+  tokenExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  localSubmissionId: 'sub-1',
+  inboundTransferId: null,
+};
+
+function makeJob(overrides: Record<string, unknown> = {}) {
+  return {
+    data: { ...baseJobData, ...overrides },
+    attemptsMade: 0,
+    opts: { attempts: 3 },
+  };
+}
+
+describe('transfer-fetch worker', () => {
+  let processor: (job: unknown) => Promise<void>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // peer lookup + other RLS operations
+    mockWithRls.mockImplementation(
+      async (_ctx: unknown, fn: (tx: unknown) => Promise<unknown>) => {
+        // Build a mock tx where every method returns a chainable + thenable object
+        const defaultResult = [{ instanceUrl: 'https://origin.example.com' }];
+        function makeDrizzleChain(resolveWith: unknown = defaultResult): any {
+          const chain: any = {
+            then: (res: any, rej?: any) =>
+              Promise.resolve(resolveWith).then(res, rej),
+          };
+          chain.update = vi.fn().mockReturnValue(chain);
+          chain.set = vi.fn().mockReturnValue(chain);
+          chain.where = vi.fn().mockReturnValue(chain);
+          chain.select = vi.fn().mockReturnValue(chain);
+          chain.from = vi.fn().mockReturnValue(chain);
+          chain.limit = vi.fn().mockReturnValue(chain);
+          return chain;
+        }
+        return fn(makeDrizzleChain());
+      },
+    );
+
+    const registry = { resolve: mockResolve } as any;
+    const env = {
+      REDIS_HOST: 'localhost',
+      REDIS_PORT: 6379,
+      REDIS_PASSWORD: '',
+    } as any;
+    startTransferFetchWorker(env, registry);
+    processor = (globalThis as any).__transferFetchProcessor;
+  });
+
+  it('fetches files concurrently up to limit of 5', async () => {
+    const files = Array.from({ length: 8 }, (_, i) => ({
+      fileId: `file-${i}`,
+      filename: `doc-${i}.pdf`,
+      mimeType: 'application/pdf',
+      size: 1000,
+    }));
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => {
+        return new Response(Buffer.from('data'), { status: 200 });
+      });
+
+    await processor(
+      makeJob({
+        fileManifest: files,
+      }),
+    );
+
+    // All 8 files should have been fetched
+    expect(fetchSpy.mock.calls.length).toBe(8);
+    // All 8 files should have been uploaded
+    expect(mockUploadToBucket.mock.calls.length).toBe(8);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('tracks individual file failures separately from successes', async () => {
+    const files = [
+      {
+        fileId: 'file-ok',
+        filename: 'a.pdf',
+        mimeType: 'application/pdf',
+        size: 100,
+      },
+      {
+        fileId: 'file-fail',
+        filename: 'b.pdf',
+        mimeType: 'application/pdf',
+        size: 100,
+      },
+      {
+        fileId: 'file-ok2',
+        filename: 'c.pdf',
+        mimeType: 'application/pdf',
+        size: 100,
+      },
+    ];
+
+    let callIdx = 0;
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => {
+        callIdx++;
+        if (callIdx === 2) {
+          return new Response('Not Found', { status: 404 });
+        }
+        return new Response(Buffer.from('data'), { status: 200 });
+      });
+
+    // Partial failure → should throw for retry
+    await expect(processor(makeJob({ fileManifest: files }))).rejects.toThrow(
+      'Partial failure',
+    );
+
+    // 2 files uploaded (the successful ones)
+    expect(mockUploadToBucket.mock.calls.length).toBe(2);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('handles all files failing gracefully', async () => {
+    const files = [
+      {
+        fileId: 'file-1',
+        filename: 'a.pdf',
+        mimeType: 'application/pdf',
+        size: 100,
+      },
+      {
+        fileId: 'file-2',
+        filename: 'b.pdf',
+        mimeType: 'application/pdf',
+        size: 100,
+      },
+    ];
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => {
+        return new Response('Error', { status: 500 });
+      });
+
+    await expect(processor(makeJob({ fileManifest: files }))).rejects.toThrow(
+      'All 2 file fetches failed',
+    );
+
+    // No uploads should have happened
+    expect(mockUploadToBucket).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/apps/api/src/workers/transfer-fetch.worker.ts
+++ b/apps/api/src/workers/transfer-fetch.worker.ts
@@ -1,5 +1,6 @@
 import { UnrecoverableError } from 'bullmq';
 import type { Worker } from 'bullmq';
+import pLimit from 'p-limit';
 import {
   withRls,
   submissions,
@@ -100,34 +101,45 @@ export function startTransferFetchWorker(
         );
       }
 
-      // Phase 2: fetch files
+      // Phase 2: fetch files (concurrent with limit of 5)
       const storedFiles: Array<{ fileId: string; storageKey: string }> = [];
       const failedFiles: string[] = [];
+      const limit = pLimit(5);
 
-      for (const entry of fileManifest) {
-        try {
-          const url = `${peer.instanceUrl}/federation/v1/transfers/${transferId}/files/${entry.fileId}`;
-          const response = await fetch(url, {
-            headers: { authorization: `Bearer ${transferToken}` },
-            signal: AbortSignal.timeout(60_000),
-          });
+      const results = await Promise.allSettled(
+        fileManifest.map((entry) =>
+          limit(async () => {
+            const url = `${peer.instanceUrl}/federation/v1/transfers/${transferId}/files/${entry.fileId}`;
+            const response = await fetch(url, {
+              headers: { authorization: `Bearer ${transferToken}` },
+              signal: AbortSignal.timeout(60_000),
+            });
 
-          if (!response.ok) {
-            failedFiles.push(entry.fileId);
-            continue;
-          }
+            if (!response.ok) {
+              throw new Error(
+                `HTTP ${response.status} for file ${entry.fileId}`,
+              );
+            }
 
-          const storageKey = `transfers/${localSubmissionId}/${entry.fileId}/${entry.filename}`;
-          const buffer = Buffer.from(await response.arrayBuffer());
-          await storage.uploadToBucket(
-            storage.defaultBucket,
-            storageKey,
-            buffer,
-            entry.mimeType,
-          );
-          storedFiles.push({ fileId: entry.fileId, storageKey });
-        } catch {
-          failedFiles.push(entry.fileId);
+            const storageKey = `transfers/${localSubmissionId}/${entry.fileId}/${entry.filename}`;
+            const buffer = Buffer.from(await response.arrayBuffer());
+            await storage.uploadToBucket(
+              storage.defaultBucket,
+              storageKey,
+              buffer,
+              entry.mimeType,
+            );
+            return { fileId: entry.fileId, storageKey };
+          }),
+        ),
+      );
+
+      for (let i = 0; i < results.length; i++) {
+        const result = results[i];
+        if (result.status === 'fulfilled') {
+          storedFiles.push(result.value);
+        } else {
+          failedFiles.push(fileManifest[i].fileId);
         }
       }
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,26 @@ Newest entries first.
 
 ---
 
+## 2026-02-27 — Backend Performance Sweep
+
+### Done
+
+- **Parallel file downloads:** Replaced sequential for-loop in transfer-fetch worker with `Promise.allSettled` + `p-limit(5)` for concurrent federation file fetches. Per-file 60s timeout and error isolation preserved.
+- **Auth failure Map cap:** Added 10k entry cap on in-memory per-IP auth failure map (fail-open for new IPs). Prevents OOM under rotating-IP DDoS while Redis rate-limit hook provides broader protection.
+- **Batch N+1 queries:** Migration bundle assembly now batch-fetches files and manuscript versions with `inArray()` instead of per-submission queries. O(2N) → O(2) constant.
+- **Hub query limit:** Added `.limit(500)` to both branches of `hub.service.listInstances()` to prevent unbounded result sets.
+- **Response compression:** Registered `@fastify/compress` (brotli + gzip, threshold 1024 bytes) after helmet.
+- **Queue polling overlap guard:** Added boolean flag to prevent concurrent queue depth polls from stacking when Redis is slow.
+- **FK index:** Added missing index on `issueItems.issueSectionId` with manual migration (0035).
+- **Tests:** 8 new test cases across 4 files (1 new spec for transfer-fetch worker). All 1246 tests pass.
+
+### Decisions
+
+- Used manual migration for FK index — drizzle-kit TUI blocks in non-interactive shell
+- Fail-open strategy for auth map cap — better to miss tracking a new IP than to OOM; Redis rate-limit handles the real DDoS protection
+
+---
+
 ## 2026-02-27 — Sentry + Prometheus Monitoring
 
 ### Done

--- a/packages/db/migrations/0035_issue_items_section_idx.sql
+++ b/packages/db/migrations/0035_issue_items_section_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "issue_items_section_id_idx" ON "issue_items" USING btree ("issue_section_id");

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1776000000000,
       "tag": "0034_notifications_inbox",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1776200000000,
+      "tag": "0035_issue_items_section_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -118,6 +118,7 @@ export const issueItems = pgTable(
     ),
     index("issue_items_issue_id_idx").on(table.issueId),
     index("issue_items_pipeline_item_id_idx").on(table.pipelineItemId),
+    index("issue_items_section_id_idx").on(table.issueSectionId),
     issueItemRlsPolicy,
   ],
 ).enableRLS();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@colophony/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@fastify/compress':
+        specifier: ^8.3.1
+        version: 8.3.1
       '@fastify/cors':
         specifier: ^11.0.0
         version: 11.2.0
@@ -126,6 +129,9 @@ importers:
       nodemailer:
         specifier: ^8.0.1
         version: 8.0.1
+      p-limit:
+        specifier: ^7.3.0
+        version: 7.3.0
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -1394,11 +1400,17 @@ packages:
     resolution: {integrity: sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
 
+  '@fastify/accept-negotiator@2.0.1':
+    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
+
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
   '@fastify/busboy@3.2.0':
     resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
+  '@fastify/compress@8.3.1':
+    resolution: {integrity: sha512-BUpItLr6MUX9e9ukg5Y6xekyA/7pBFG8QWtFCrUDm9ctoBc3R2/nA16yOaOWtVoccpXGjdDEYA/MxAb5+8cxag==}
 
   '@fastify/cors@11.2.0':
     resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
@@ -5092,6 +5104,12 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexify@3.7.1:
+    resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
+
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -6857,6 +6875,10 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-limit@7.3.0:
+    resolution: {integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==}
+    engines: {node: '>=20'}
+
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -6910,6 +6932,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  peek-stream@1.1.3:
+    resolution: {integrity: sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -7149,6 +7174,9 @@ packages:
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
+  pumpify@2.0.1:
+    resolution: {integrity: sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==}
+
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
@@ -7233,6 +7261,10 @@ packages:
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readable-stream@4.7.0:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
@@ -7550,6 +7582,9 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
 
@@ -7727,6 +7762,9 @@ packages:
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
+
+  through2@2.0.5:
+    resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -8242,6 +8280,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
@@ -9275,6 +9317,8 @@ snapshots:
 
   '@faker-js/faker@8.4.1': {}
 
+  '@fastify/accept-negotiator@2.0.1': {}
+
   '@fastify/ajv-compiler@4.0.5':
     dependencies:
       ajv: 8.18.0
@@ -9282,6 +9326,17 @@ snapshots:
       fast-uri: 3.1.0
 
   '@fastify/busboy@3.2.0': {}
+
+  '@fastify/compress@8.3.1':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      fastify-plugin: 5.1.0
+      mime-db: 1.52.0
+      minipass: 7.1.2
+      peek-stream: 1.1.3
+      pump: 3.0.3
+      pumpify: 2.0.1
+      readable-stream: 4.7.0
 
   '@fastify/cors@11.2.0':
     dependencies:
@@ -13524,6 +13579,20 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexify@3.7.1:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 2.3.8
+      stream-shift: 1.0.3
+
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
   eastasianwidth@0.2.0: {}
 
   editorconfig@1.0.4:
@@ -15925,6 +15994,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@7.3.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
@@ -15975,6 +16048,12 @@ snapshots:
       minipass: 7.1.2
 
   pathe@2.0.3: {}
+
+  peek-stream@1.1.3:
+    dependencies:
+      buffer-from: 1.1.2
+      duplexify: 3.7.1
+      through2: 2.0.5
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -16292,6 +16371,12 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  pumpify@2.0.1:
+    dependencies:
+      duplexify: 4.1.3
+      inherits: 2.0.4
+      pump: 3.0.3
+
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
@@ -16365,6 +16450,12 @@ snapshots:
       process-nextick-args: 2.0.1
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
   readable-stream@4.7.0:
@@ -16730,6 +16821,8 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  stream-shift@1.0.3: {}
+
   streamx@2.23.0:
     dependencies:
       events-universal: 1.0.1
@@ -16932,6 +17025,11 @@ snapshots:
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
+
+  through2@2.0.5:
+    dependencies:
+      readable-stream: 2.3.8
+      xtend: 4.0.2
 
   tinybench@2.9.0: {}
 
@@ -17442,6 +17540,8 @@ snapshots:
     optional: true
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.2: {}
 
   zip-stream@6.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- **Parallel file downloads:** Transfer-fetch worker uses `p-limit(5)` + `Promise.allSettled()` instead of sequential loop
- **Auth failure Map cap:** 10k entry limit on in-memory per-IP failure tracking (fail-open for new IPs under DDoS)
- **Batch N+1 queries:** Migration bundle assembly batch-fetches files and versions with `inArray()` — O(2N) → O(2)
- **Hub query limit:** `.limit(500)` on `listInstances()` to prevent unbounded result sets
- **Response compression:** `@fastify/compress` (brotli + gzip, threshold 1024 bytes)
- **Queue polling overlap guard:** Prevents concurrent queue depth polls from stacking
- **FK index:** Missing index on `issueItems.issueSectionId` (migration 0035)

## Test plan

- [x] All 1246 existing tests pass
- [x] 8 new test cases added (3 transfer-fetch, 2 auth map cap, 2 migration bundle batch, 1 metrics overlap)
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean
- [ ] Manual: start dev server with `METRICS_ENABLED=true`, verify `/metrics` queue metrics update without overlap
- [ ] Manual: verify `Accept-Encoding: gzip` responses return `Content-Encoding` header
- [ ] Run `pnpm db:migrate` to apply FK index migration (0035)