### PR TITLE
feat(register): Track 8 schema — writer workspace & CSR foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **Metrics registry**     | `apps/api/src/config/metrics.ts` (Prometheus counters, histograms, gauges)       |
 | **Metrics plugin**       | `apps/api/src/hooks/metrics.ts` (Fastify plugin — HTTP request instrumentation)  |
 | **Instrumented worker**  | `apps/api/src/config/instrumented-worker.ts` (BullMQ wrapper with metrics)       |
+| **Writer workspace**     | `packages/db/src/schema/writer-workspace.ts`                                     |
+| **CSR types**            | `packages/types/src/csr.ts`                                                      |
 | **Backlog**              | `docs/backlog.md` (track-organized, drives session focus)                        |
 
 Full project structure: [docs/architecture-v2-planning.md](docs/architecture-v2-planning.md)

--- a/apps/api/src/__tests__/rls/helpers/db-setup.ts
+++ b/apps/api/src/__tests__/rls/helpers/db-setup.ts
@@ -130,6 +130,12 @@ export async function globalSetup(): Promise<void> {
     'REVOKE INSERT, UPDATE, DELETE ON "audit_events" FROM app_user',
   );
 
+  // Revoke DML on journal_directory (migration 0036 grants SELECT only,
+  // but the broad GRANT above re-grants it — must revoke after)
+  await admin.query(
+    'REVOKE INSERT, UPDATE, DELETE ON "journal_directory" FROM app_user',
+  );
+
   // Verify app_user is NOSUPERUSER and NOBYPASSRLS
   const { rows } = await admin.query<{
     usesuper: boolean;

--- a/apps/api/src/__tests__/rls/helpers/factories.ts
+++ b/apps/api/src/__tests__/rls/helpers/factories.ts
@@ -15,6 +15,10 @@ import {
   auditEvents,
   retentionPolicies,
   userConsents,
+  journalDirectory,
+  externalSubmissions,
+  correspondence,
+  writerProfiles,
   type Organization,
   type User,
   type OrganizationMember,
@@ -28,6 +32,10 @@ import {
   type AuditEvent,
   type RetentionPolicy,
   type UserConsent,
+  type JournalDirectoryEntry,
+  type ExternalSubmission,
+  type CorrespondenceRecord,
+  type WriterProfile,
 } from '@colophony/db';
 
 // (different optional peer dep contexts); runtime is single copy, types diverge. Cast to unify.
@@ -250,6 +258,84 @@ export async function createUserConsent(
     })
     .returning();
   return consent;
+}
+
+export async function createJournalDirectoryEntry(
+  overrides?: Partial<JournalDirectoryEntry>,
+): Promise<JournalDirectoryEntry> {
+  const db = adminDb();
+  const name = overrides?.name ?? faker.company.name();
+  const [entry] = await db
+    .insert(journalDirectory)
+    .values({
+      name,
+      normalizedName:
+        overrides?.normalizedName ??
+        name.toLowerCase().replace(/[^a-z0-9]+/g, '_'),
+      ...overrides,
+    })
+    .returning();
+  return entry;
+}
+
+export async function createExternalSubmission(
+  userId: string,
+  overrides?: Partial<ExternalSubmission>,
+): Promise<ExternalSubmission> {
+  const db = adminDb();
+  const [extSub] = await db
+    .insert(externalSubmissions)
+    .values({
+      userId,
+      journalName: faker.company.name(),
+      status: 'sent',
+      ...overrides,
+    })
+    .returning();
+  return extSub;
+}
+
+export async function createCorrespondence(
+  userId: string,
+  overrides?: Partial<CorrespondenceRecord>,
+): Promise<CorrespondenceRecord> {
+  const db = adminDb();
+  const [corr] = await db
+    .insert(correspondence)
+    .values({
+      userId,
+      direction: 'inbound',
+      channel: 'email',
+      sentAt: new Date(),
+      body: faker.lorem.paragraph(),
+      source: 'manual',
+      ...overrides,
+    })
+    .returning();
+  return corr;
+}
+
+export async function createWriterProfile(
+  userId: string,
+  overrides?: Partial<WriterProfile>,
+): Promise<WriterProfile> {
+  const db = adminDb();
+  const [profile] = await db
+    .insert(writerProfiles)
+    .values({
+      userId,
+      platform:
+        overrides?.platform ??
+        faker.helpers.arrayElement([
+          'submittable',
+          'duotrope',
+          'chillsubs',
+          'moksha',
+        ]),
+      ...overrides,
+    })
+    .returning();
+  return profile;
 }
 
 export interface TwoOrgScenario {

--- a/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
+++ b/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
@@ -20,10 +20,16 @@ const RLS_TABLES = [
   'embed_tokens',
   'piece_transfers',
   'identity_migrations',
+  'journal_directory',
+  'external_submissions',
+  'correspondence',
+  'writer_profiles',
 ];
 
-/** RLS tables where app_user has full DML (excludes audit_events which is SELECT-only + function). */
-const RLS_TABLES_FULL_DML = RLS_TABLES.filter((t) => t !== 'audit_events');
+/** RLS tables where app_user has full DML (excludes audit_events which is SELECT-only + function, journal_directory which is SELECT-only). */
+const RLS_TABLES_FULL_DML = RLS_TABLES.filter(
+  (t) => t !== 'audit_events' && t !== 'journal_directory',
+);
 
 const NON_RLS_TABLES = [
   'organizations',
@@ -146,6 +152,34 @@ describe('RLS Infrastructure', () => {
           true,
         );
       }
+    });
+
+    it('should have SELECT-only on journal_directory (writes via superuser)', async () => {
+      const admin = getAdminPool();
+
+      // SELECT: yes
+      const { rows: selRows } = await admin.query<{ has_priv: boolean }>(
+        `SELECT has_table_privilege('app_user', 'journal_directory', 'SELECT') as has_priv`,
+      );
+      expect(selRows[0].has_priv).toBe(true);
+
+      // INSERT: no
+      const { rows: insRows } = await admin.query<{ has_priv: boolean }>(
+        `SELECT has_table_privilege('app_user', 'journal_directory', 'INSERT') as has_priv`,
+      );
+      expect(insRows[0].has_priv).toBe(false);
+
+      // UPDATE: no
+      const { rows: updRows } = await admin.query<{ has_priv: boolean }>(
+        `SELECT has_table_privilege('app_user', 'journal_directory', 'UPDATE') as has_priv`,
+      );
+      expect(updRows[0].has_priv).toBe(false);
+
+      // DELETE: no
+      const { rows: delRows } = await admin.query<{ has_priv: boolean }>(
+        `SELECT has_table_privilege('app_user', 'journal_directory', 'DELETE') as has_priv`,
+      );
+      expect(delRows[0].has_priv).toBe(false);
     });
 
     it('should have SELECT-only on audit_events (INSERT via function)', async () => {

--- a/apps/api/src/__tests__/rls/rls-writer-workspace.test.ts
+++ b/apps/api/src/__tests__/rls/rls-writer-workspace.test.ts
@@ -1,0 +1,435 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { globalSetup, getAdminPool, getAppPool } from './helpers/db-setup';
+import { truncateAllTables } from './helpers/cleanup';
+import { withTestRls } from './helpers/rls-context';
+import {
+  createUser,
+  createOrganization,
+  createOrgMember,
+  createSubmission,
+  createSubmissionPeriod,
+  createJournalDirectoryEntry,
+  createExternalSubmission,
+  createCorrespondence,
+  createWriterProfile,
+} from './helpers/factories';
+import {
+  externalSubmissions,
+  correspondence,
+  journalDirectory,
+  writerProfiles,
+} from '@colophony/db';
+import type {
+  User,
+  Organization,
+  Submission,
+  ExternalSubmission,
+} from '@colophony/db';
+
+let userA: User;
+let userB: User;
+let orgX: Organization;
+let orgY: Organization;
+let submissionInOrgX: Submission;
+let extSubA: ExternalSubmission;
+
+describe('RLS Writer Workspace', () => {
+  beforeAll(async () => {
+    await globalSetup();
+    await truncateAllTables();
+
+    // Create users and orgs
+    [userA, userB] = await Promise.all([createUser(), createUser()]);
+    [orgX, orgY] = await Promise.all([
+      createOrganization(),
+      createOrganization(),
+    ]);
+
+    // userA is member of orgX, userB is member of orgY
+    await Promise.all([
+      createOrgMember(orgX.id, userA.id),
+      createOrgMember(orgY.id, userB.id),
+    ]);
+
+    // Create a submission period + submission in orgX for correspondence tests
+    const periodX = await createSubmissionPeriod(orgX.id);
+    submissionInOrgX = await createSubmission(orgX.id, userA.id, {
+      submissionPeriodId: periodX.id,
+    });
+
+    // Create external submissions for each user
+    extSubA = await createExternalSubmission(userA.id);
+    await createExternalSubmission(userB.id);
+
+    // Seed journal directory entries (via admin — app_user can't INSERT)
+    await createJournalDirectoryEntry({ name: 'The Paris Review' });
+    await createJournalDirectoryEntry({ name: 'Ploughshares' });
+  });
+
+  afterAll(async () => {
+    await truncateAllTables();
+  });
+
+  // =========================================================================
+  // external_submissions
+  // =========================================================================
+
+  describe('external_submissions', () => {
+    it('user can CRUD their own external submissions', async () => {
+      // INSERT
+      const [inserted] = await withTestRls({ userId: userA.id }, (tx) =>
+        tx
+          .insert(externalSubmissions)
+          .values({
+            userId: userA.id,
+            journalName: 'Test Journal',
+            status: 'draft',
+          })
+          .returning(),
+      );
+      expect(inserted).toBeDefined();
+
+      // SELECT
+      const rows = await withTestRls({ userId: userA.id }, (tx) =>
+        tx
+          .select()
+          .from(externalSubmissions)
+          .where(eq(externalSubmissions.id, inserted.id)),
+      );
+      expect(rows).toHaveLength(1);
+
+      // UPDATE
+      const [updated] = await withTestRls({ userId: userA.id }, (tx) =>
+        tx
+          .update(externalSubmissions)
+          .set({ status: 'sent' })
+          .where(eq(externalSubmissions.id, inserted.id))
+          .returning(),
+      );
+      expect(updated.status).toBe('sent');
+
+      // DELETE
+      const [deleted] = await withTestRls({ userId: userA.id }, (tx) =>
+        tx
+          .delete(externalSubmissions)
+          .where(eq(externalSubmissions.id, inserted.id))
+          .returning(),
+      );
+      expect(deleted).toBeDefined();
+    });
+
+    it("user cannot see another user's external submissions", async () => {
+      const rows = await withTestRls({ userId: userB.id }, (tx) =>
+        tx
+          .select()
+          .from(externalSubmissions)
+          .where(eq(externalSubmissions.id, extSubA.id)),
+      );
+      expect(rows).toHaveLength(0);
+    });
+
+    it("user cannot update another user's external submissions", async () => {
+      const rows = await withTestRls({ userId: userB.id }, (tx) =>
+        tx
+          .update(externalSubmissions)
+          .set({ status: 'accepted' })
+          .where(eq(externalSubmissions.id, extSubA.id))
+          .returning(),
+      );
+      expect(rows).toHaveLength(0);
+    });
+
+    it('cascade deletes on user deletion', async () => {
+      const tempUser = await createUser();
+      const extSub = await createExternalSubmission(tempUser.id);
+      const admin = getAdminPool();
+
+      // Delete the user — should cascade to external submissions
+      await admin.query('DELETE FROM users WHERE id = $1', [tempUser.id]);
+
+      const { rows } = await admin.query(
+        'SELECT id FROM external_submissions WHERE id = $1',
+        [extSub.id],
+      );
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  // =========================================================================
+  // correspondence
+  // =========================================================================
+
+  describe('correspondence', () => {
+    it('writer can CRUD their own correspondence', async () => {
+      // INSERT linked to external submission
+      const [inserted] = await withTestRls({ userId: userA.id }, (tx) =>
+        tx
+          .insert(correspondence)
+          .values({
+            userId: userA.id,
+            externalSubmissionId: extSubA.id,
+            direction: 'inbound',
+            channel: 'email',
+            sentAt: new Date(),
+            body: 'Thank you for your submission.',
+            source: 'manual',
+          })
+          .returning(),
+      );
+      expect(inserted).toBeDefined();
+
+      // SELECT
+      const rows = await withTestRls({ userId: userA.id }, (tx) =>
+        tx
+          .select()
+          .from(correspondence)
+          .where(eq(correspondence.id, inserted.id)),
+      );
+      expect(rows).toHaveLength(1);
+
+      // UPDATE
+      const [updated] = await withTestRls({ userId: userA.id }, (tx) =>
+        tx
+          .update(correspondence)
+          .set({ body: 'Updated body' })
+          .where(eq(correspondence.id, inserted.id))
+          .returning(),
+      );
+      expect(updated.body).toBe('Updated body');
+
+      // DELETE
+      const [deleted] = await withTestRls({ userId: userA.id }, (tx) =>
+        tx
+          .delete(correspondence)
+          .where(eq(correspondence.id, inserted.id))
+          .returning(),
+      );
+      expect(deleted).toBeDefined();
+    });
+
+    it("writer cannot see another writer's correspondence", async () => {
+      const corrA = await createCorrespondence(userA.id, {
+        externalSubmissionId: extSubA.id,
+      });
+
+      const rows = await withTestRls({ userId: userB.id }, (tx) =>
+        tx.select().from(correspondence).where(eq(correspondence.id, corrA.id)),
+      );
+      expect(rows).toHaveLength(0);
+    });
+
+    it("org editor can READ correspondence on their org's submissions", async () => {
+      // userA creates correspondence on a submission in orgX
+      const corrOnOrgSub = await createCorrespondence(userA.id, {
+        submissionId: submissionInOrgX.id,
+      });
+
+      // userB (editor in orgY) cannot see it, but let's create a member in orgX
+      // to test positive case — use a third user who is member of orgX
+      const editorUser = await createUser();
+      await createOrgMember(orgX.id, editorUser.id, { role: 'EDITOR' });
+
+      const rows = await withTestRls(
+        { userId: editorUser.id, orgId: orgX.id },
+        (tx) =>
+          tx
+            .select()
+            .from(correspondence)
+            .where(eq(correspondence.id, corrOnOrgSub.id)),
+      );
+      expect(rows).toHaveLength(1);
+    });
+
+    it('org editor cannot READ correspondence on external submissions', async () => {
+      // Correspondence linked to external_submission_id (not submission_id)
+      const corrOnExtSub = await createCorrespondence(userA.id, {
+        externalSubmissionId: extSubA.id,
+      });
+
+      const editorUser = await createUser();
+      await createOrgMember(orgX.id, editorUser.id, { role: 'EDITOR' });
+
+      // Editor in orgX should NOT see this — it's linked to external submission, not org submission
+      const rows = await withTestRls(
+        { userId: editorUser.id, orgId: orgX.id },
+        (tx) =>
+          tx
+            .select()
+            .from(correspondence)
+            .where(eq(correspondence.id, corrOnExtSub.id)),
+      );
+      expect(rows).toHaveLength(0);
+    });
+
+    it('org editor from different org cannot READ correspondence', async () => {
+      const corrOnOrgSub = await createCorrespondence(userA.id, {
+        submissionId: submissionInOrgX.id,
+      });
+
+      // userB is in orgY — should not see orgX correspondence
+      const rows = await withTestRls(
+        { userId: userB.id, orgId: orgY.id },
+        (tx) =>
+          tx
+            .select()
+            .from(correspondence)
+            .where(eq(correspondence.id, corrOnOrgSub.id)),
+      );
+      expect(rows).toHaveLength(0);
+    });
+
+    it('XOR constraint: rejects both FKs null', async () => {
+      const admin = getAdminPool();
+      await expect(
+        admin.query(
+          `INSERT INTO correspondence (
+            user_id, direction, channel, sent_at, body, source
+          ) VALUES ($1, 'inbound', 'email', now(), 'test body', 'manual')`,
+          [userA.id],
+        ),
+      ).rejects.toThrow(/correspondence_submission_xor/);
+    });
+
+    it('XOR constraint: rejects both FKs non-null', async () => {
+      const admin = getAdminPool();
+      await expect(
+        admin.query(
+          `INSERT INTO correspondence (
+            user_id, submission_id, external_submission_id,
+            direction, channel, sent_at, body, source
+          ) VALUES ($1, $2, $3, 'inbound', 'email', now(), 'test body', 'manual')`,
+          [userA.id, submissionInOrgX.id, extSubA.id],
+        ),
+      ).rejects.toThrow(/correspondence_submission_xor/);
+    });
+  });
+
+  // =========================================================================
+  // journal_directory
+  // =========================================================================
+
+  describe('journal_directory', () => {
+    it('authenticated user can read journal directory', async () => {
+      const rows = await withTestRls({ userId: userA.id }, (tx) =>
+        tx.select().from(journalDirectory),
+      );
+      expect(rows.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('app_user cannot insert into journal directory', async () => {
+      const app = getAppPool();
+      const client = await app.connect();
+      try {
+        await client.query('BEGIN');
+        await client.query("SELECT set_config('app.user_id', $1, true)", [
+          userA.id,
+        ]);
+        await expect(
+          client.query(
+            `INSERT INTO journal_directory (name, normalized_name)
+             VALUES ('Test Journal', 'test_journal')`,
+          ),
+        ).rejects.toThrow();
+        await client.query('ROLLBACK');
+      } finally {
+        client.release();
+      }
+    });
+
+    it('superuser can insert into journal directory', async () => {
+      const admin = getAdminPool();
+      const { rows } = await admin.query(
+        `INSERT INTO journal_directory (name, normalized_name)
+         VALUES ('Admin-Created Journal', 'admin_created_journal')
+         RETURNING id`,
+      );
+      expect(rows).toHaveLength(1);
+      // Clean up
+      await admin.query('DELETE FROM journal_directory WHERE id = $1', [
+        rows[0].id,
+      ]);
+    });
+  });
+
+  // =========================================================================
+  // writer_profiles
+  // =========================================================================
+
+  describe('writer_profiles', () => {
+    it('user can CRUD their own profiles', async () => {
+      // INSERT
+      const [inserted] = await withTestRls({ userId: userA.id }, (tx) =>
+        tx
+          .insert(writerProfiles)
+          .values({
+            userId: userA.id,
+            platform: 'submittable',
+            externalId: 'user123',
+          })
+          .returning(),
+      );
+      expect(inserted).toBeDefined();
+
+      // SELECT
+      const rows = await withTestRls({ userId: userA.id }, (tx) =>
+        tx
+          .select()
+          .from(writerProfiles)
+          .where(eq(writerProfiles.id, inserted.id)),
+      );
+      expect(rows).toHaveLength(1);
+
+      // UPDATE
+      const [updated] = await withTestRls({ userId: userA.id }, (tx) =>
+        tx
+          .update(writerProfiles)
+          .set({ externalId: 'user456' })
+          .where(eq(writerProfiles.id, inserted.id))
+          .returning(),
+      );
+      expect(updated.externalId).toBe('user456');
+
+      // DELETE
+      const [deleted] = await withTestRls({ userId: userA.id }, (tx) =>
+        tx
+          .delete(writerProfiles)
+          .where(eq(writerProfiles.id, inserted.id))
+          .returning(),
+      );
+      expect(deleted).toBeDefined();
+    });
+
+    it("user cannot see another user's profiles", async () => {
+      const profileA = await createWriterProfile(userA.id, {
+        platform: 'duotrope',
+      });
+
+      const rows = await withTestRls({ userId: userB.id }, (tx) =>
+        tx
+          .select()
+          .from(writerProfiles)
+          .where(eq(writerProfiles.id, profileA.id)),
+      );
+      expect(rows).toHaveLength(0);
+    });
+
+    it('unique constraint on (user_id, platform)', async () => {
+      const admin = getAdminPool();
+      // First insert should succeed
+      await admin.query(
+        `INSERT INTO writer_profiles (user_id, platform)
+         VALUES ($1, 'chillsubs')`,
+        [userA.id],
+      );
+      // Second insert with same user + platform should fail
+      await expect(
+        admin.query(
+          `INSERT INTO writer_profiles (user_id, platform)
+           VALUES ($1, 'chillsubs')`,
+          [userA.id],
+        ),
+      ).rejects.toThrow(/writer_profiles_user_platform_unique/);
+    });
+  });
+});

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -301,6 +301,148 @@
 
 ---
 
+## Track 7 — Editorial Experience (Pre-Launch)
+
+> **Status:** Not started. Addresses gaps in the editor-to-writer relationship and editorial workflow that are critical for Write or Die launch and early adopter credibility.
+
+### Correspondence & Communication
+
+- [ ] [P0] Editor-to-writer personalized correspondence — compose and send messages to individual submitters from the submission detail view; editor comments on status transitions should optionally be included in the notification email to the writer — (persona gap analysis 2026-02-27)
+- [ ] [P0] Customizable email templates — admin UI for editing MJML templates per org (acceptance, rejection, under review, custom); replace hardcoded boilerplate with org-branded voice — (persona gap analysis 2026-02-27)
+- [ ] [P1] "Revise and resubmit" status — add R&R to SubmissionStatus enum + transition map; editor sends revision notes, writer resubmits against the same submission record — (persona gap analysis 2026-02-27)
+- [ ] [P2] Embed submitter confirmation email — send a receipt email to the address provided in the embed identity step; include submission title, journal name, and a status-check token/link — (persona gap analysis 2026-02-27)
+- [ ] [P2] Embed submitter status check — public page at `/embed/status/:token` where embed submitters (no account) can check their submission status — (persona gap analysis 2026-02-27)
+
+### Editorial Workflow
+
+- [ ] [P1] Reviewer assignment per submission — assign one or more org members as readers on a submission; track who has read it; show assignment in submission detail — (persona gap analysis 2026-02-27)
+- [ ] [P1] Internal discussion threads on submissions — comment system on Hopper submissions (pre-acceptance), separate from the Slate pipeline comments (post-acceptance) — (persona gap analysis 2026-02-27)
+- [ ] [P2] Voting / scoring on submissions — readers cast votes (accept/reject/maybe + optional score); configurable per org; summary visible to editors making final decisions — (persona gap analysis 2026-02-27)
+- [ ] [P2] Blind / anonymous review mode — hide submitter identity from reviewers; admin toggle per submission period — (persona gap analysis 2026-02-27)
+- [ ] [P2] Batch operations — checkbox selection in submission queue; bulk status transitions (reject, move to review); bulk assignment — (persona gap analysis 2026-02-27)
+- [ ] [P3] Submission reading mode — distraction-free view for reading the submitted work; "next unread" navigation within the queue — (persona gap analysis 2026-02-27)
+
+### Analytics & Reporting
+
+- [ ] [P1] Submission analytics dashboard — acceptance rate, response time distribution, submissions per period, funnel (submitted → reviewed → accepted/rejected), aging submissions — (persona gap analysis 2026-02-27)
+- [ ] [P2] Publication data export — CSV/JSON export of all org submissions, with filters (date range, status, period); admin-only — (persona gap analysis 2026-02-27)
+- [ ] [P3] Response time tracking and reminders — flag submissions pending over N days (configurable); optional email reminder to editors — (persona gap analysis 2026-02-27)
+
+### UI Polish
+
+- [ ] [P1] Mobile navigation — hamburger menu or bottom nav for `< md` breakpoints; sidebar is currently `hidden md:flex` with no mobile alternative — (persona gap analysis 2026-02-27)
+- [ ] [P2] Column sorting in submission queue — sortable by title, submitter, date, status; currently hardcoded `DESC createdAt` — (persona gap analysis 2026-02-27)
+- [ ] [P2] Submission period filter in editor queue — the API supports `submissionPeriodId` filter but the UI doesn't expose a period dropdown — (persona gap analysis 2026-02-27)
+- [ ] [P3] Saved filter presets / views — editors can save named filter+sort combos for their queue — (persona gap analysis 2026-02-27)
+
+---
+
+## Track 8 — Register Data Standard & Writer Tools (Pre-Launch)
+
+> **Status:** Spec drafted (`docs/research/register-data-standard.md`). Defines the Colophony Submission Record (CSR) format, writer-as-top-level-entity architecture, correspondence tracking, and import pipeline. Prerequisite for Chill Subs integration (Track 11) and writer-side demand generation.
+
+### Data Standard
+
+- [x] [P0] Define CSR Zod schemas in `packages/types/src/csr.ts` — core CSR type hierarchy (Genre, CSRStatus, JournalRef, Correspondence, ExternalSubmission, WriterProfile, create/update schemas); full CSR v1.0 export envelope deferred to export endpoint work — (register-data-standard.md Section 2; done 2026-02-27 PR pending)
+- [x] [P0] Genre enum + schema migration — `genre` JSONB column on manuscripts + PrimaryGenre enum + Zod schema; API surface updates deferred — (register-data-standard.md Section 2.4, 4.2; done 2026-02-27 PR pending)
+- [ ] [P0] Align MigrationBundle with CSR — refactor `MigrationBundle` and `MigrationSubmissionHistory` in `packages/types/src/migration.ts` to use CSR types; fix gaps: derive `decidedAt` from submission_history, fetch `periodName` via JOIN, populate `genre` from manuscript, include `statusHistory` array — (register-data-standard.md Section 4.1; 2026-02-27)
+- [ ] [P1] CSR export endpoint — tRPC + REST endpoint for writers to download their full CSR as JSON; aggregates Colophony-native submissions (cross-org), external submissions, correspondence, and piece groupings — replaces GDPR export placeholder — (register-data-standard.md Section 2.1; 2026-02-27)
+- [ ] [P1] CSR import endpoint — ingest external submission records from JSON/CSV; flexible column mapping for CSV; piece grouping by normalized title; source tagging (`importedFrom` field) — (register-data-standard.md Section 3; 2026-02-27)
+- [ ] [P2] CSR format documentation — human-readable spec with field descriptions, examples, status mapping table, and extension points; publishable as part of project docs — (register-data-standard.md; 2026-02-27)
+
+### Correspondence Tracking
+
+- [x] [P0] `correspondence` DB table — new table for editor-writer messages linked to submissions; fields: direction (inbound/outbound), channel (email/portal/in_app), body, senderName, senderEmail, isPersonalized flag; RLS scoped to submission owner + org editors; XOR CHECK on submission_id/external_submission_id — (register-data-standard.md Section 2.8, 4.2; done 2026-02-27 PR pending)
+- [ ] [P1] Auto-capture Colophony correspondence — when Track 7 personalized correspondence ships, auto-insert records into the correspondence table; also capture status transition comments that are shared with writers — (register-data-standard.md Section 2.8; 2026-02-27)
+- [ ] [P2] Manual correspondence logging — writers can paste/enter notable editor messages (personalized rejections, encouragement letters) for external submissions; lightweight form: paste text, mark as personalized, save — (register-data-standard.md Section 2.8; 2026-02-27)
+- [ ] [P2] Correspondence in CSR export — include all correspondence records in the writer's CSR download, linked to submission records — (register-data-standard.md Section 2.8; 2026-02-27)
+
+### Writer as Top-Level Entity
+
+- [x] [P0] `external_submissions` DB table — manually-tracked non-Colophony submissions; mirrors CSR SubmissionRecord fields; scoped by `user_id` (not org); linked to `manuscripts` for piece grouping — (register-data-standard.md Section 4.2, 4.3; done 2026-02-27 PR pending)
+- [x] [P0] `journal_directory` DB table — local cache of known journals with name, externalUrl, directoryIds (JSONB), optional colophonyDomain; SELECT-only for app_user, writes via superuser pool — (register-data-standard.md Section 4.2; done 2026-02-27 PR pending)
+- [x] [P1] `writer_profiles` DB table — external platform links (Chill Subs ID, Submittable ID, etc.) per user; unique on (user_id, platform) — (register-data-standard.md Section 2.2, 4.2; done 2026-02-27 PR pending)
+- [ ] [P1] Writer workspace UI — new top-level nav section ("My Writing" or "Portfolio"); unified cross-org + external submission view, correspondence archive, piece library with submission history per piece — (register-data-standard.md Section 4.3; 2026-02-27)
+- [ ] [P1] External submission tracking UI — form to log submissions to non-Colophony journals (journal name via directory autocomplete or freetext, date sent, status, method, notes); table/kanban view matching Chill Subs UX patterns — (register-data-standard.md Section 3; 2026-02-27)
+- [ ] [P2] Cross-org submission portfolio — aggregated view: Colophony-native submissions from all orgs + external tracked submissions, unified by piece grouping — (persona gap analysis 2026-02-27)
+- [ ] [P2] Writer-facing analytics — personal response time stats, submissions pending, acceptance rate, submissions per month; derived from both native and manually-tracked records — (persona gap analysis 2026-02-27)
+- [ ] [P2] Import flows — Submittable CSV import, Chill Subs import (via directoryIds mapping), generic CSV with column mapping UI — (register-data-standard.md Section 3; 2026-02-27)
+
+### Design Decisions
+
+- [x] Personal workspace architecture — **Resolved:** Writers as top-level entities. New user-scoped tables (external_submissions, correspondence, writer_profiles, journal_directory) with RLS matching manuscripts pattern. No pseudo-org needed. — (2026-02-27)
+- [x] CSR field set — **Resolved:** Layered format (core/extended/identity/metadata) with correspondence as first-class. Genre as structured enum (primary + sub + hybrid). Piece grouping via manuscriptId. See `docs/research/register-data-standard.md` — (2026-02-27)
+- [x] External journal identity — **Resolved:** JournalRef type with freetext name (always present) + optional colophonyDomain + optional directoryIds map (keyed by platform: chillsubs, duotrope, etc.). Degrades gracefully from full federation to freetext. — (2026-02-27)
+- [x] Genre model — **Resolved:** Structured enum with primary (10 values), freetext sub for subgenres, and hybrid array for cross-genre work. Lives on manuscripts (the work), not submissions (the act of sending). — (2026-02-27)
+- [x] Community stats model — **Resolved:** Carried in CSR, distinguished as "community" (aggregated from tracker users, may over-report acceptances) vs. "editor_reported" (journal's own stats, authoritative). Following Chill Subs model. — (2026-02-27)
+
+---
+
+## Track 9 — Governance & Community Readiness (Pre-Launch)
+
+> **Status:** Not started. Non-code deliverables required for community publisher evaluation and open-source credibility.
+
+- [ ] [P0] AGPL license boundary documentation — clearly document what is AGPL (Zitadel), what license Colophony uses, obligations for self-hosters, and how the boundary works — (CLAUDE.md security checklist + persona gap analysis 2026-02-27)
+- [ ] [P0] Choose and document Colophony's own license — (persona gap analysis 2026-02-27)
+- [ ] [P1] CONTRIBUTING.md — how to contribute, development setup, PR process, code of conduct reference — (persona gap analysis 2026-02-27)
+- [ ] [P1] CODE_OF_CONDUCT.md — (persona gap analysis 2026-02-27)
+- [ ] [P1] README.md rewrite — project description in brand voice, architecture overview, quick start, screenshots, link to docs — (persona gap analysis 2026-02-27)
+- [ ] [P2] Governance model documentation — who makes decisions, how contributions are evaluated, roadmap transparency — (persona gap analysis 2026-02-27)
+- [ ] [P2] Fix deployment docs NestJS reference — deployment guide references NestJS but the system is Fastify — (persona gap analysis 2026-02-27)
+- [ ] [P3] Public instance identity page — human-readable page showing federation status, trust relationships, and governance commitments (the `.well-known/colophony` endpoint is machine-only) — (persona gap analysis 2026-02-27)
+
+---
+
+## Track 10 — Federation Admin UI (Pre-Launch)
+
+> **Status:** Not started. All federation management is currently API-only. Required before any instance other than Write or Die joins the network.
+
+- [ ] [P1] Trust management dashboard — list trusted peers with status, capabilities, last-verified; initiate/accept/reject/revoke trust relationships; preview remote instance metadata before trusting — (persona gap analysis 2026-02-27)
+- [ ] [P1] Federation status overview — current instance mode (allowlist/open/managed_hub), capabilities enabled, instance public key, DID document link — (persona gap analysis 2026-02-27)
+- [ ] [P2] Sim-sub admin UI — view sim-sub check history per submission, grant overrides, see conflict details — (persona gap analysis 2026-02-27)
+- [ ] [P2] Transfer management UI — list inbound/outbound transfers, view status, cancel pending — (persona gap analysis 2026-02-27)
+- [ ] [P2] Migration management UI — list pending migrations, approve/reject outbound, view history — (persona gap analysis 2026-02-27)
+- [ ] [P3] Hub admin UI (managed hosting only) — list registered instances, suspend/revoke, view attestation status — (persona gap analysis 2026-02-27)
+- [ ] [P3] Audit log viewer — browse audit events with filters (actor, action, resource, date range) — (persona gap analysis 2026-02-27)
+
+---
+
+## Track 11 — Chill Subs Integration (Post-Launch)
+
+> **Status:** Conceptual. Depends on Track 8 (CSR format) and the Chill Subs relationship timeline. Sequencing: relationship → data format alignment → technical integration.
+
+- [ ] CSR ↔ Chill Subs tracker data mapping — document field-level mapping between CSR format and Chill Subs submission tracker fields (title, journal, date sent, date responded, status, notes, submission method) — (strategy session 2026-02-27)
+- [ ] Chill Subs journal directory integration — if Chill Subs exposes a journal API or data feed, use it to populate the external journal identity field in CSR records; writers who track in Chill Subs and submit via Colophony get auto-linked records — (strategy session 2026-02-27)
+- [ ] Bidirectional sync protocol — define how a writer's Chill Subs tracker and Colophony submission history stay in sync; CSR as the interchange format — (strategy session 2026-02-27)
+- [ ] Partnership scope definition — technical partnership vs. data integration vs. deeper structural relationship; depends on Slushpile (Chill Subs submissions manager) architecture — (strategy session 2026-02-27)
+
+---
+
+## Track 12 — Slate & Pipeline Polish (Post-Launch)
+
+> **Status:** Not started. Quality-of-life improvements for the post-acceptance pipeline.
+
+- [ ] [P2] Contract signer auto-population — populate Documenso signers from submission/author data instead of passing `signers: []` — (codebase audit 2026-02-27)
+- [ ] [P2] Author name in CMS publish payload — `CmsPiecePayload.author` is always `null`; fetch submitter name from user record — (codebase audit 2026-02-27)
+- [ ] [P2] CMS external ID tracking — store `externalId`/`externalUrl` returned from CMS publish back on the issue/items — (codebase audit 2026-02-27)
+- [ ] [P3] Additional CMS adapters — Substack, Contentful, or other targets based on early adopter needs — (codebase audit 2026-02-27)
+- [ ] [P3] In-browser copyediting or diff view between manuscript versions — (persona gap analysis 2026-02-27)
+- [ ] [P3] READER role enforcement — define what READER can and cannot do distinct from EDITOR; currently decorative — (persona gap analysis 2026-02-27)
+- [ ] [P3] Email invitation workflow — invite by email link/token instead of requiring pre-existing Zitadel account — (persona gap analysis 2026-02-27)
+- [ ] [P3] Custom org roles beyond ADMIN/EDITOR/READER — named roles with configurable permission scopes — (persona gap analysis 2026-02-27)
+
+---
+
+## Accessibility (Cross-Cutting, Pre-Launch)
+
+- [ ] [P2] Status badges: add icons alongside color to support color-blind users — (persona gap analysis 2026-02-27)
+- [ ] [P2] File drop zones: add keyboard focus handling, `role="button"`, `tabIndex` — (persona gap analysis 2026-02-27)
+- [ ] [P2] Scan status: add `aria-live` region for screen reader announcements during file scanning — (persona gap analysis 2026-02-27)
+- [ ] [P2] Sidebar: add `aria-label` to `<nav>` element — (persona gap analysis 2026-02-27)
+- [ ] [P3] Sim-sub error message: show human-readable explanation ("This manuscript appears to be under consideration at another publication that prohibits simultaneous submissions") instead of generic tRPC error — (persona gap analysis 2026-02-27)
+
+---
+
 ## Production Deployment Checklist
 
 ### Infrastructure Setup

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-27 — Track 8 Schema: Writer Workspace & CSR Foundation
+
+### Done
+
+- **4 new enums:** `PrimaryGenre`, `CsrStatus`, `CorrespondenceDirection`, `CorrespondenceChannel` in `packages/db/src/schema/enums.ts`
+- **4 new tables:** `journal_directory` (global, SELECT-only for app_user), `external_submissions` (user-scoped), `correspondence` (user-scoped + org read for editors), `writer_profiles` (user-scoped with unique constraint on user+platform)
+- **Genre column on manuscripts:** Nullable JSONB column with `{ primary, sub, hybrid }` structure
+- **Migration 0036:** Full DDL with RLS, GRANTs, triggers, indexes, and XOR CHECK constraint on correspondence (exactly one of submission_id or external_submission_id)
+- **Drizzle relations:** 4 new relation blocks + extended `users`, `manuscripts`, `submissions` relations
+- **Zod types:** `packages/types/src/csr.ts` — Genre, CSRStatus, JournalRef, Correspondence, ExternalSubmission, WriterProfile schemas plus create/update schemas
+- **RLS tests:** 17 test cases in `rls-writer-workspace.test.ts` covering CRUD isolation, org editor read, XOR constraint, cascade deletes, unique constraints, journal_directory permissions
+- **Infrastructure updates:** RLS_TABLES array, journal_directory SELECT-only permission test, db-setup DML revoke, 4 factory functions
+- Type-check clean (14/14 packages), migration journal validated (37/37 consistent)
+
+### Decisions
+
+- XOR CHECK in migration SQL — Drizzle DSL cannot express table-level CHECK constraints
+- journal_directory SELECT-only for app_user — writes via superuser pool for normalization/dedup
+- writer_profiles as separate table (one row per platform per user), not JSONB on users
+- Genre column nullable — existing manuscripts have no genre; no index needed until analytics
+
+---
+
 ## 2026-02-27 — Frontend Performance Sweep
 
 ### Done

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -11,9 +11,9 @@
 | Type exports   | `src/types.ts`                           |
 | Migrations     | `migrations/`                            |
 
-### Schema Files (21 domain files + barrel)
+### Schema Files (22 domain files + barrel)
 
-`api-keys.ts`, `audit.ts`, `cms.ts`, `compliance.ts`, `contracts.ts`, `enums.ts`, `federation.ts`, `issues.ts`, `manuscripts.ts`, `members.ts`, `messaging.ts`, `notifications.ts`, `organizations.ts`, `payments.ts`, `pipeline.ts`, `publications.ts`, `relations.ts`, `submissions.ts`, `user-keys.ts`, `users.ts`, `webhooks.ts`, `index.ts`
+`api-keys.ts`, `audit.ts`, `cms.ts`, `compliance.ts`, `contracts.ts`, `enums.ts`, `federation.ts`, `issues.ts`, `manuscripts.ts`, `members.ts`, `messaging.ts`, `notifications.ts`, `organizations.ts`, `payments.ts`, `pipeline.ts`, `publications.ts`, `relations.ts`, `submissions.ts`, `user-keys.ts`, `users.ts`, `webhooks.ts`, `writer-workspace.ts`, `index.ts`
 
 ---
 

--- a/packages/db/migrations/0036_writer_workspace.sql
+++ b/packages/db/migrations/0036_writer_workspace.sql
@@ -1,0 +1,252 @@
+-- 0036_writer_workspace.sql
+-- Track 8: Writer workspace tables — journal directory, external submissions,
+-- correspondence, writer profiles, and genre column on manuscripts.
+
+-- 1. New enum types
+CREATE TYPE "PrimaryGenre" AS ENUM (
+  'poetry', 'fiction', 'creative_nonfiction', 'nonfiction', 'drama',
+  'translation', 'visual_art', 'comics', 'audio', 'other'
+);
+--> statement-breakpoint
+
+CREATE TYPE "CsrStatus" AS ENUM (
+  'draft', 'sent', 'in_review', 'hold', 'accepted', 'rejected',
+  'withdrawn', 'no_response', 'revise', 'unknown'
+);
+--> statement-breakpoint
+
+CREATE TYPE "CorrespondenceDirection" AS ENUM ('inbound', 'outbound');
+--> statement-breakpoint
+
+CREATE TYPE "CorrespondenceChannel" AS ENUM ('email', 'portal', 'in_app', 'other');
+--> statement-breakpoint
+
+-- 2. Add genre column to manuscripts
+ALTER TABLE "manuscripts" ADD COLUMN "genre" jsonb;
+--> statement-breakpoint
+
+-- 3. journal_directory — global shared, system-only writes
+CREATE TABLE "journal_directory" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "name" varchar(500) NOT NULL,
+  "normalized_name" varchar(500) NOT NULL,
+  "external_url" varchar(1000),
+  "colophony_domain" varchar(512),
+  "colophony_org_id" uuid,
+  "directory_ids" jsonb DEFAULT '{}'::jsonb NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+
+ALTER TABLE "journal_directory" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "journal_directory" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+
+ALTER TABLE "journal_directory"
+  ADD CONSTRAINT "journal_directory_normalized_name_unique"
+  UNIQUE ("normalized_name");
+--> statement-breakpoint
+
+CREATE INDEX "journal_directory_colophony_domain_idx"
+  ON "journal_directory" USING btree ("colophony_domain");
+--> statement-breakpoint
+
+CREATE POLICY "journal_directory_read" ON "journal_directory"
+  AS PERMISSIVE FOR SELECT TO public
+  USING (current_user_id() IS NOT NULL);
+--> statement-breakpoint
+
+-- SELECT only — writes via superuser pool
+GRANT SELECT ON "journal_directory" TO app_user;
+--> statement-breakpoint
+
+CREATE TRIGGER "trg_journal_directory_set_updated_at"
+  BEFORE UPDATE ON "journal_directory"
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+--> statement-breakpoint
+
+-- 4. external_submissions — user-scoped
+CREATE TABLE "external_submissions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" uuid NOT NULL,
+  "manuscript_id" uuid,
+  "journal_directory_id" uuid,
+  "journal_name" varchar(500) NOT NULL,
+  "status" "CsrStatus" DEFAULT 'sent' NOT NULL,
+  "sent_at" timestamp with time zone,
+  "responded_at" timestamp with time zone,
+  "method" varchar(100),
+  "notes" text,
+  "imported_from" varchar(100),
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+
+ALTER TABLE "external_submissions" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "external_submissions" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+
+ALTER TABLE "external_submissions"
+  ADD CONSTRAINT "external_submissions_user_id_users_id_fk"
+  FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+
+ALTER TABLE "external_submissions"
+  ADD CONSTRAINT "external_submissions_manuscript_id_manuscripts_id_fk"
+  FOREIGN KEY ("manuscript_id") REFERENCES "public"."manuscripts"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+
+ALTER TABLE "external_submissions"
+  ADD CONSTRAINT "external_submissions_journal_directory_id_fk"
+  FOREIGN KEY ("journal_directory_id") REFERENCES "public"."journal_directory"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+
+CREATE INDEX "external_submissions_user_id_idx"
+  ON "external_submissions" USING btree ("user_id");
+CREATE INDEX "external_submissions_user_status_idx"
+  ON "external_submissions" USING btree ("user_id", "status");
+CREATE INDEX "external_submissions_manuscript_id_idx"
+  ON "external_submissions" USING btree ("manuscript_id");
+CREATE INDEX "external_submissions_journal_directory_id_idx"
+  ON "external_submissions" USING btree ("journal_directory_id");
+--> statement-breakpoint
+
+CREATE POLICY "external_submissions_owner" ON "external_submissions"
+  AS PERMISSIVE FOR ALL TO public
+  USING (user_id = current_user_id());
+--> statement-breakpoint
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON "external_submissions" TO app_user;
+--> statement-breakpoint
+
+CREATE TRIGGER "trg_external_submissions_set_updated_at"
+  BEFORE UPDATE ON "external_submissions"
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+--> statement-breakpoint
+
+-- 5. correspondence — user-scoped with org read for editors
+CREATE TABLE "correspondence" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" uuid NOT NULL,
+  "submission_id" uuid,
+  "external_submission_id" uuid,
+  "direction" "CorrespondenceDirection" NOT NULL,
+  "channel" "CorrespondenceChannel" DEFAULT 'email' NOT NULL,
+  "sent_at" timestamp with time zone NOT NULL,
+  "subject" varchar(500),
+  "body" text NOT NULL,
+  "sender_name" varchar(255),
+  "sender_email" varchar(255),
+  "is_personalized" boolean DEFAULT false NOT NULL,
+  "source" varchar(50) DEFAULT 'manual' NOT NULL,
+  "captured_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+
+ALTER TABLE "correspondence" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "correspondence" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+
+ALTER TABLE "correspondence"
+  ADD CONSTRAINT "correspondence_user_id_users_id_fk"
+  FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+
+ALTER TABLE "correspondence"
+  ADD CONSTRAINT "correspondence_submission_id_submissions_id_fk"
+  FOREIGN KEY ("submission_id") REFERENCES "public"."submissions"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+
+ALTER TABLE "correspondence"
+  ADD CONSTRAINT "correspondence_external_submission_id_fk"
+  FOREIGN KEY ("external_submission_id") REFERENCES "public"."external_submissions"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+
+-- XOR constraint: exactly one of submission_id or external_submission_id must be non-null
+ALTER TABLE "correspondence"
+  ADD CONSTRAINT "correspondence_submission_xor"
+  CHECK (
+    (submission_id IS NOT NULL AND external_submission_id IS NULL)
+    OR
+    (submission_id IS NULL AND external_submission_id IS NOT NULL)
+  );
+--> statement-breakpoint
+
+CREATE INDEX "correspondence_user_id_idx"
+  ON "correspondence" USING btree ("user_id");
+CREATE INDEX "correspondence_submission_id_idx"
+  ON "correspondence" USING btree ("submission_id");
+CREATE INDEX "correspondence_external_submission_id_idx"
+  ON "correspondence" USING btree ("external_submission_id");
+--> statement-breakpoint
+
+-- Owner CRUD
+CREATE POLICY "correspondence_owner" ON "correspondence"
+  AS PERMISSIVE FOR ALL TO public
+  USING (user_id = current_user_id());
+--> statement-breakpoint
+
+-- Org editors can read correspondence on their org's submissions
+CREATE POLICY "correspondence_org_read" ON "correspondence"
+  AS PERMISSIVE FOR SELECT TO public
+  USING (submission_id IN (
+    SELECT id FROM submissions
+    WHERE organization_id = current_org_id()
+  ));
+--> statement-breakpoint
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON "correspondence" TO app_user;
+--> statement-breakpoint
+
+CREATE TRIGGER "trg_correspondence_set_updated_at"
+  BEFORE UPDATE ON "correspondence"
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+--> statement-breakpoint
+
+-- 6. writer_profiles — user-scoped
+CREATE TABLE "writer_profiles" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" uuid NOT NULL,
+  "platform" varchar(100) NOT NULL,
+  "external_id" varchar(500),
+  "profile_url" varchar(1000),
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+
+ALTER TABLE "writer_profiles" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "writer_profiles" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+
+ALTER TABLE "writer_profiles"
+  ADD CONSTRAINT "writer_profiles_user_id_users_id_fk"
+  FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+
+ALTER TABLE "writer_profiles"
+  ADD CONSTRAINT "writer_profiles_user_platform_unique"
+  UNIQUE ("user_id", "platform");
+--> statement-breakpoint
+
+CREATE INDEX "writer_profiles_user_id_idx"
+  ON "writer_profiles" USING btree ("user_id");
+CREATE INDEX "writer_profiles_platform_external_id_idx"
+  ON "writer_profiles" USING btree ("platform", "external_id");
+--> statement-breakpoint
+
+CREATE POLICY "writer_profiles_owner" ON "writer_profiles"
+  AS PERMISSIVE FOR ALL TO public
+  USING (user_id = current_user_id());
+--> statement-breakpoint
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON "writer_profiles" TO app_user;
+--> statement-breakpoint
+
+CREATE TRIGGER "trg_writer_profiles_set_updated_at"
+  BEFORE UPDATE ON "writer_profiles"
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1776200000000,
       "tag": "0035_issue_items_section_idx",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1776400000000,
+      "tag": "0036_writer_workspace",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -204,3 +204,45 @@ export const contractStatusEnum = pgEnum("ContractStatus", [
   "COMPLETED",
   "VOIDED",
 ]);
+
+// ---------------------------------------------------------------------------
+// Register — Writer Workspace (CSR)
+// ---------------------------------------------------------------------------
+
+export const primaryGenreEnum = pgEnum("PrimaryGenre", [
+  "poetry",
+  "fiction",
+  "creative_nonfiction",
+  "nonfiction",
+  "drama",
+  "translation",
+  "visual_art",
+  "comics",
+  "audio",
+  "other",
+]);
+
+export const csrStatusEnum = pgEnum("CsrStatus", [
+  "draft",
+  "sent",
+  "in_review",
+  "hold",
+  "accepted",
+  "rejected",
+  "withdrawn",
+  "no_response",
+  "revise",
+  "unknown",
+]);
+
+export const correspondenceDirectionEnum = pgEnum("CorrespondenceDirection", [
+  "inbound",
+  "outbound",
+]);
+
+export const correspondenceChannelEnum = pgEnum("CorrespondenceChannel", [
+  "email",
+  "portal",
+  "in_app",
+  "other",
+]);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -27,4 +27,5 @@ export * from "./hub";
 export * from "./notifications";
 export * from "./notifications-inbox";
 export * from "./webhook-endpoints";
+export * from "./writer-workspace";
 export * from "./relations";

--- a/packages/db/src/schema/manuscripts.ts
+++ b/packages/db/src/schema/manuscripts.ts
@@ -7,6 +7,7 @@ import {
   timestamp,
   integer,
   bigint,
+  jsonb,
   index,
   unique,
 } from "drizzle-orm/pg-core";
@@ -30,6 +31,11 @@ export const manuscripts = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
+    genre: jsonb("genre").$type<{
+      primary: string;
+      sub: string | null;
+      hybrid: string[];
+    }>(),
     updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .notNull()

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -19,6 +19,12 @@ import { contractTemplates, contracts } from "./contracts";
 import { issues, issueSections, issueItems } from "./issues";
 import { cmsConnections } from "./cms";
 import { trustedPeers } from "./trusted-peers";
+import {
+  journalDirectory,
+  externalSubmissions,
+  correspondence,
+  writerProfiles,
+} from "./writer-workspace";
 
 // --- organizations ---
 
@@ -52,6 +58,9 @@ export const usersRelations = relations(users, ({ many }) => ({
   dsarRequests: many(dsarRequests),
   userConsents: many(userConsents),
   apiKeys: many(apiKeys),
+  externalSubmissions: many(externalSubmissions),
+  correspondence: many(correspondence),
+  writerProfiles: many(writerProfiles),
 }));
 
 // --- organization_members ---
@@ -121,6 +130,7 @@ export const manuscriptsRelations = relations(manuscripts, ({ one, many }) => ({
     references: [users.id],
   }),
   versions: many(manuscriptVersions),
+  externalSubmissions: many(externalSubmissions),
 }));
 
 // --- manuscript_versions ---
@@ -193,6 +203,7 @@ export const submissionsRelations = relations(submissions, ({ one, many }) => ({
   history: many(submissionHistory),
   payments: many(payments),
   pipelineItems: many(pipelineItems),
+  correspondence: many(correspondence),
 }));
 
 // --- submission_history ---
@@ -454,5 +465,61 @@ export const cmsConnectionsRelations = relations(cmsConnections, ({ one }) => ({
   publication: one(publications, {
     fields: [cmsConnections.publicationId],
     references: [publications.id],
+  }),
+}));
+
+// --- journal_directory ---
+
+export const journalDirectoryRelations = relations(
+  journalDirectory,
+  ({ many }) => ({
+    externalSubmissions: many(externalSubmissions),
+  }),
+);
+
+// --- external_submissions ---
+
+export const externalSubmissionsRelations = relations(
+  externalSubmissions,
+  ({ one, many }) => ({
+    user: one(users, {
+      fields: [externalSubmissions.userId],
+      references: [users.id],
+    }),
+    manuscript: one(manuscripts, {
+      fields: [externalSubmissions.manuscriptId],
+      references: [manuscripts.id],
+    }),
+    journal: one(journalDirectory, {
+      fields: [externalSubmissions.journalDirectoryId],
+      references: [journalDirectory.id],
+    }),
+    correspondence: many(correspondence),
+  }),
+);
+
+// --- correspondence ---
+
+export const correspondenceRelations = relations(correspondence, ({ one }) => ({
+  user: one(users, {
+    fields: [correspondence.userId],
+    references: [users.id],
+  }),
+  submission: one(submissions, {
+    fields: [correspondence.submissionId],
+    references: [submissions.id],
+  }),
+  externalSubmission: one(externalSubmissions, {
+    fields: [correspondence.externalSubmissionId],
+    references: [externalSubmissions.id],
+  }),
+}));
+
+// --- writer_profiles ---
+
+export const writerProfilesRelations = relations(writerProfiles, ({ one }) => ({
+  user: one(users, {
+    fields: [writerProfiles.userId],
+    references: [users.id],
   }),
 }));

--- a/packages/db/src/schema/writer-workspace.ts
+++ b/packages/db/src/schema/writer-workspace.ts
@@ -1,0 +1,206 @@
+import {
+  boolean,
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  text,
+  timestamp,
+  jsonb,
+  index,
+  unique,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import {
+  csrStatusEnum,
+  correspondenceDirectionEnum,
+  correspondenceChannelEnum,
+} from "./enums";
+import { users } from "./users";
+import { manuscripts } from "./manuscripts";
+import { submissions } from "./submissions";
+
+// ---------------------------------------------------------------------------
+// journal_directory — Global shared journal registry
+// Read-only for authenticated users. Writes via superuser pool only.
+// ---------------------------------------------------------------------------
+
+export const journalDirectory = pgTable(
+  "journal_directory",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    name: varchar("name", { length: 500 }).notNull(),
+    normalizedName: varchar("normalized_name", { length: 500 }).notNull(),
+    externalUrl: varchar("external_url", { length: 1000 }),
+    colophonyDomain: varchar("colophony_domain", { length: 512 }),
+    colophonyOrgId: uuid("colophony_org_id"),
+    directoryIds: jsonb("directory_ids")
+      .$type<Record<string, string>>()
+      .notNull()
+      .default(sql`'{}'::jsonb`),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    unique("journal_directory_normalized_name_unique").on(table.normalizedName),
+    index("journal_directory_colophony_domain_idx").on(table.colophonyDomain),
+    pgPolicy("journal_directory_read", {
+      for: "select",
+      using: sql`current_user_id() IS NOT NULL`,
+    }),
+  ],
+).enableRLS();
+
+// ---------------------------------------------------------------------------
+// external_submissions — User-scoped external submission tracking
+// ---------------------------------------------------------------------------
+
+export const externalSubmissions = pgTable(
+  "external_submissions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    manuscriptId: uuid("manuscript_id").references(() => manuscripts.id, {
+      onDelete: "set null",
+    }),
+    journalDirectoryId: uuid("journal_directory_id").references(
+      () => journalDirectory.id,
+      { onDelete: "set null" },
+    ),
+    journalName: varchar("journal_name", { length: 500 }).notNull(),
+    status: csrStatusEnum("status").notNull().default("sent"),
+    sentAt: timestamp("sent_at", { withTimezone: true }),
+    respondedAt: timestamp("responded_at", { withTimezone: true }),
+    method: varchar("method", { length: 100 }),
+    notes: text("notes"),
+    importedFrom: varchar("imported_from", { length: 100 }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("external_submissions_user_id_idx").on(table.userId),
+    index("external_submissions_user_status_idx").on(
+      table.userId,
+      table.status,
+    ),
+    index("external_submissions_manuscript_id_idx").on(table.manuscriptId),
+    index("external_submissions_journal_directory_id_idx").on(
+      table.journalDirectoryId,
+    ),
+    pgPolicy("external_submissions_owner", {
+      for: "all",
+      using: sql`user_id = current_user_id()`,
+    }),
+  ],
+).enableRLS();
+
+// ---------------------------------------------------------------------------
+// correspondence — Editor-writer messages
+// NOTE: XOR CHECK constraint on (submission_id, external_submission_id)
+// enforced in migration SQL — Drizzle DSL does not support table-level CHECK.
+// ---------------------------------------------------------------------------
+
+export const correspondence = pgTable(
+  "correspondence",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    submissionId: uuid("submission_id").references(() => submissions.id, {
+      onDelete: "cascade",
+    }),
+    externalSubmissionId: uuid("external_submission_id").references(
+      () => externalSubmissions.id,
+      { onDelete: "cascade" },
+    ),
+    direction: correspondenceDirectionEnum("direction").notNull(),
+    channel: correspondenceChannelEnum("channel").notNull().default("email"),
+    sentAt: timestamp("sent_at", { withTimezone: true }).notNull(),
+    subject: varchar("subject", { length: 500 }),
+    body: text("body").notNull(),
+    senderName: varchar("sender_name", { length: 255 }),
+    senderEmail: varchar("sender_email", { length: 255 }),
+    isPersonalized: boolean("is_personalized").notNull().default(false),
+    source: varchar("source", { length: 50 }).notNull().default("manual"),
+    capturedAt: timestamp("captured_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("correspondence_user_id_idx").on(table.userId),
+    index("correspondence_submission_id_idx").on(table.submissionId),
+    index("correspondence_external_submission_id_idx").on(
+      table.externalSubmissionId,
+    ),
+    pgPolicy("correspondence_owner", {
+      for: "all",
+      using: sql`user_id = current_user_id()`,
+    }),
+    pgPolicy("correspondence_org_read", {
+      for: "select",
+      using: sql`submission_id IN (
+        SELECT id FROM submissions
+        WHERE organization_id = current_org_id()
+      )`,
+    }),
+  ],
+).enableRLS();
+
+// ---------------------------------------------------------------------------
+// writer_profiles — External platform links
+// ---------------------------------------------------------------------------
+
+export const writerProfiles = pgTable(
+  "writer_profiles",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    platform: varchar("platform", { length: 100 }).notNull(),
+    externalId: varchar("external_id", { length: 500 }),
+    profileUrl: varchar("profile_url", { length: 1000 }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    unique("writer_profiles_user_platform_unique").on(
+      table.userId,
+      table.platform,
+    ),
+    index("writer_profiles_user_id_idx").on(table.userId),
+    index("writer_profiles_platform_external_id_idx").on(
+      table.platform,
+      table.externalId,
+    ),
+    pgPolicy("writer_profiles_owner", {
+      for: "all",
+      using: sql`user_id = current_user_id()`,
+    }),
+  ],
+).enableRLS();

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -26,6 +26,12 @@ import type {
 } from "./schema/pipeline";
 import type { contractTemplates, contracts } from "./schema/contracts";
 import type { issues, issueSections, issueItems } from "./schema/issues";
+import type {
+  journalDirectory,
+  externalSubmissions,
+  correspondence,
+  writerProfiles,
+} from "./schema/writer-workspace";
 
 // --- Select types (what you get back from queries) ---
 
@@ -58,6 +64,10 @@ export type Contract = InferSelectModel<typeof contracts>;
 export type Issue = InferSelectModel<typeof issues>;
 export type IssueSection = InferSelectModel<typeof issueSections>;
 export type IssueItem = InferSelectModel<typeof issueItems>;
+export type JournalDirectoryEntry = InferSelectModel<typeof journalDirectory>;
+export type ExternalSubmission = InferSelectModel<typeof externalSubmissions>;
+export type CorrespondenceRecord = InferSelectModel<typeof correspondence>;
+export type WriterProfile = InferSelectModel<typeof writerProfiles>;
 
 /** @deprecated Use File instead — submission_files has been replaced by the files table */
 export type SubmissionFile = File;
@@ -101,6 +111,14 @@ export type NewContract = InferInsertModel<typeof contracts>;
 export type NewIssue = InferInsertModel<typeof issues>;
 export type NewIssueSection = InferInsertModel<typeof issueSections>;
 export type NewIssueItem = InferInsertModel<typeof issueItems>;
+export type NewJournalDirectoryEntry = InferInsertModel<
+  typeof journalDirectory
+>;
+export type NewExternalSubmission = InferInsertModel<
+  typeof externalSubmissions
+>;
+export type NewCorrespondenceRecord = InferInsertModel<typeof correspondence>;
+export type NewWriterProfile = InferInsertModel<typeof writerProfiles>;
 
 /** @deprecated Use NewFile instead */
 export type NewSubmissionFile = NewFile;

--- a/packages/types/src/csr.ts
+++ b/packages/types/src/csr.ts
@@ -1,0 +1,180 @@
+import { z } from "zod";
+
+// --- Genre ---
+
+export const primaryGenreSchema = z
+  .enum([
+    "poetry",
+    "fiction",
+    "creative_nonfiction",
+    "nonfiction",
+    "drama",
+    "translation",
+    "visual_art",
+    "comics",
+    "audio",
+    "other",
+  ])
+  .describe("Primary genre classification");
+
+export type PrimaryGenre = z.infer<typeof primaryGenreSchema>;
+
+export const genreSchema = z
+  .object({
+    primary: primaryGenreSchema,
+    sub: z
+      .string()
+      .nullable()
+      .describe("Freetext subgenre (e.g., 'flash', 'lyric essay')"),
+    hybrid: z
+      .array(primaryGenreSchema)
+      .describe("Additional primary genres for hybrid work"),
+  })
+  .describe("Structured genre classification with hybrid support");
+
+export type Genre = z.infer<typeof genreSchema>;
+
+// --- CSR Status ---
+
+export const csrStatusSchema = z
+  .enum([
+    "draft",
+    "sent",
+    "in_review",
+    "hold",
+    "accepted",
+    "rejected",
+    "withdrawn",
+    "no_response",
+    "revise",
+    "unknown",
+  ])
+  .describe("Harmonized submission status across systems");
+
+export type CSRStatus = z.infer<typeof csrStatusSchema>;
+
+// --- Journal Reference ---
+
+export const journalRefSchema = z
+  .object({
+    id: z.string().uuid().optional(),
+    name: z.string().min(1).max(500),
+    colophonyDomain: z.string().max(512).nullable().optional(),
+    colophonyOrgId: z.string().uuid().nullable().optional(),
+    externalUrl: z.string().url().max(1000).nullable().optional(),
+    directoryIds: z.record(z.string(), z.string()).nullable().optional(),
+  })
+  .describe(
+    "Journal identity reference — may be freetext-only or fully linked",
+  );
+
+export type JournalRef = z.infer<typeof journalRefSchema>;
+
+// --- Correspondence ---
+
+export const correspondenceDirectionSchema = z.enum(["inbound", "outbound"]);
+export const correspondenceChannelSchema = z.enum([
+  "email",
+  "portal",
+  "in_app",
+  "other",
+]);
+
+export const correspondenceSchema = z
+  .object({
+    id: z.string().uuid(),
+    submissionId: z.string().uuid().nullable(),
+    externalSubmissionId: z.string().uuid().nullable(),
+    direction: correspondenceDirectionSchema,
+    channel: correspondenceChannelSchema,
+    sentAt: z.string().datetime(),
+    subject: z.string().max(500).nullable(),
+    body: z.string().min(1),
+    senderName: z.string().max(255).nullable(),
+    senderEmail: z.string().email().max(255).nullable(),
+    isPersonalized: z.boolean(),
+    source: z.enum(["colophony", "manual"]),
+    capturedAt: z.string().datetime(),
+  })
+  .describe("Editor-writer correspondence record");
+
+export type Correspondence = z.infer<typeof correspondenceSchema>;
+
+// --- External Submission ---
+
+export const externalSubmissionSchema = z
+  .object({
+    id: z.string().uuid(),
+    manuscriptId: z.string().uuid().nullable(),
+    journalDirectoryId: z.string().uuid().nullable(),
+    journalName: z.string().min(1).max(500),
+    status: csrStatusSchema,
+    sentAt: z.string().datetime().nullable(),
+    respondedAt: z.string().datetime().nullable(),
+    method: z.string().max(100).nullable(),
+    notes: z.string().nullable(),
+    importedFrom: z.string().max(100).nullable(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+  .describe("Manually-tracked external submission record");
+
+export type ExternalSubmission = z.infer<typeof externalSubmissionSchema>;
+
+// --- Writer Profile ---
+
+export const writerProfileSchema = z
+  .object({
+    id: z.string().uuid(),
+    platform: z.string().min(1).max(100),
+    externalId: z.string().max(500).nullable(),
+    profileUrl: z.string().url().max(1000).nullable(),
+  })
+  .describe("External platform profile link");
+
+export type WriterProfile = z.infer<typeof writerProfileSchema>;
+
+// --- Create/Update schemas (for service layer) ---
+
+export const createExternalSubmissionSchema = z.object({
+  manuscriptId: z.string().uuid().optional(),
+  journalName: z.string().min(1).max(500),
+  journalDirectoryId: z.string().uuid().optional(),
+  status: csrStatusSchema.default("sent"),
+  sentAt: z.string().datetime().optional(),
+  respondedAt: z.string().datetime().optional(),
+  method: z.string().max(100).optional(),
+  notes: z.string().optional(),
+});
+
+export const updateExternalSubmissionSchema =
+  createExternalSubmissionSchema.partial();
+
+export const createCorrespondenceSchema = z
+  .object({
+    submissionId: z.string().uuid().optional(),
+    externalSubmissionId: z.string().uuid().optional(),
+    direction: correspondenceDirectionSchema,
+    channel: correspondenceChannelSchema.default("email"),
+    sentAt: z.string().datetime(),
+    subject: z.string().max(500).optional(),
+    body: z.string().min(1),
+    senderName: z.string().max(255).optional(),
+    senderEmail: z.string().email().max(255).optional(),
+    isPersonalized: z.boolean().default(false),
+    source: z.enum(["colophony", "manual"]).default("manual"),
+  })
+  .refine(
+    (data) =>
+      (data.submissionId != null) !== (data.externalSubmissionId != null),
+    {
+      message:
+        "Exactly one of submissionId or externalSubmissionId must be provided",
+    },
+  );
+
+export const createWriterProfileSchema = z.object({
+  platform: z.string().min(1).max(100),
+  externalId: z.string().max(500).optional(),
+  profileUrl: z.string().url().max(1000).optional(),
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -24,3 +24,4 @@ export * from "./hub";
 export * from "./notification-preferences";
 export * from "./notification";
 export * from "./webhook";
+export * from "./csr";


### PR DESCRIPTION
## Summary

- **4 new tables:** `journal_directory` (global, SELECT-only for app_user), `external_submissions` (user-scoped), `correspondence` (user-scoped + org read for editors), `writer_profiles` (user-scoped with unique constraint)
- **4 new enums:** `PrimaryGenre`, `CsrStatus`, `CorrespondenceDirection`, `CorrespondenceChannel`
- **Genre column:** Nullable JSONB on manuscripts (`{ primary, sub, hybrid }`)
- **Migration 0036:** Full DDL with RLS, GRANTs, triggers, indexes, XOR CHECK constraint
- **Zod types:** `packages/types/src/csr.ts` — Genre, CSRStatus, JournalRef, Correspondence, ExternalSubmission, WriterProfile schemas
- **17 RLS test cases** covering CRUD isolation, org editor read, XOR constraint, cascade deletes, unique constraints, journal_directory permissions
- **No service layer or UI** — schema + types + migration + tests only

Full spec: `docs/research/register-data-standard.md`

## Test plan

- [ ] `pnpm type-check` — all 14 packages pass
- [ ] `pnpm db:validate-migrations` — 37/37 consistent
- [ ] `pnpm db:reset` — migration applies cleanly
- [ ] `pnpm --filter @colophony/api test -- rls-writer-workspace` — 17 RLS tests pass
- [ ] `pnpm --filter @colophony/api test -- rls-infrastructure` — infrastructure tests pass with new tables
- [ ] Verify FORCE RLS on all 4 new tables
- [ ] Verify journal_directory is SELECT-only for app_user
- [ ] Verify XOR CHECK constraint on correspondence

## Code Review

OpenCode branch review: **LGTM** — no blocking issues. Plan drift: 11/11 items matched, 0 drift.