### PR TITLE
feat(hopper): editor-to-writer personalized correspondence

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -64,6 +64,7 @@
     "nodemailer": "^8.0.1",
     "p-limit": "^7.3.0",
     "prom-client": "^15.1.3",
+    "sanitize-html": "^2.17.1",
     "stripe": "^20.3.1",
     "zod": "^4.3.6"
   },
@@ -79,6 +80,7 @@
     "@types/node": "^25.3.0",
     "@types/nodemailer": "^7.0.11",
     "@types/pg": "^8.11.0",
+    "@types/sanitize-html": "^2.16.0",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",

--- a/apps/api/src/inngest/events.ts
+++ b/apps/api/src/inngest/events.ts
@@ -107,6 +107,7 @@ export interface HopperSubmissionAcceptedEvent {
     orgId: string;
     submissionId: string;
     submitterId: string;
+    comment?: string;
   };
 }
 
@@ -116,6 +117,7 @@ export interface HopperSubmissionRejectedEvent {
     orgId: string;
     submissionId: string;
     submitterId: string;
+    comment?: string;
   };
 }
 

--- a/apps/api/src/inngest/functions/submission-notifications.ts
+++ b/apps/api/src/inngest/functions/submission-notifications.ts
@@ -247,23 +247,27 @@ export const submissionAcceptedNotification = inngest.createFunction(
     });
 
     await step.run('capture-correspondence', async () => {
-      await withRls({ orgId }, async (tx) => {
-        await correspondenceService.create(tx, {
-          userId: submitterId,
-          submissionId,
-          direction: 'outbound',
-          channel: 'email',
-          sentAt: new Date(),
-          subject: `Your submission has been accepted: ${submission.title}`,
-          body: comment
-            ? `Congratulations! Your submission has been accepted.\n\nNote from the editors:\n${comment}`
-            : 'Congratulations! Your submission has been accepted.',
-          senderName: null,
-          senderEmail: null,
-          isPersonalized: !!comment,
-          source: 'colophony',
+      try {
+        await withRls({ orgId }, async (tx) => {
+          await correspondenceService.create(tx, {
+            userId: submitterId,
+            submissionId,
+            direction: 'outbound',
+            channel: 'email',
+            sentAt: new Date(),
+            subject: `Your submission has been accepted: ${submission.title}`,
+            body: comment
+              ? `Congratulations! Your submission has been accepted.\n\nNote from the editors:\n${comment}`
+              : 'Congratulations! Your submission has been accepted.',
+            senderName: null,
+            senderEmail: null,
+            isPersonalized: !!comment,
+            source: 'colophony',
+          });
         });
-      });
+      } catch {
+        // Non-fatal: correspondence capture should not block notifications
+      }
     });
 
     return { notified: 1 };
@@ -322,23 +326,27 @@ export const submissionRejectedNotification = inngest.createFunction(
     });
 
     await step.run('capture-correspondence', async () => {
-      await withRls({ orgId }, async (tx) => {
-        await correspondenceService.create(tx, {
-          userId: submitterId,
-          submissionId,
-          direction: 'outbound',
-          channel: 'email',
-          sentAt: new Date(),
-          subject: `Update on your submission: ${submission.title}`,
-          body: comment
-            ? `Thank you for your submission. After careful review, we are unable to accept it at this time.\n\nNote from the editors:\n${comment}`
-            : 'Thank you for your submission. After careful review, we are unable to accept it at this time.',
-          senderName: null,
-          senderEmail: null,
-          isPersonalized: !!comment,
-          source: 'colophony',
+      try {
+        await withRls({ orgId }, async (tx) => {
+          await correspondenceService.create(tx, {
+            userId: submitterId,
+            submissionId,
+            direction: 'outbound',
+            channel: 'email',
+            sentAt: new Date(),
+            subject: `Update on your submission: ${submission.title}`,
+            body: comment
+              ? `Thank you for your submission. After careful review, we are unable to accept it at this time.\n\nNote from the editors:\n${comment}`
+              : 'Thank you for your submission. After careful review, we are unable to accept it at this time.',
+            senderName: null,
+            senderEmail: null,
+            isPersonalized: !!comment,
+            source: 'colophony',
+          });
         });
-      });
+      } catch {
+        // Non-fatal: correspondence capture should not block notifications
+      }
     });
 
     return { notified: 1 };

--- a/apps/api/src/inngest/functions/submission-notifications.ts
+++ b/apps/api/src/inngest/functions/submission-notifications.ts
@@ -20,6 +20,7 @@ import type {
 import { notificationPreferenceService } from '../../services/notification-preference.service.js';
 import { emailService } from '../../services/email.service.js';
 import { auditService } from '../../services/audit.service.js';
+import { correspondenceService } from '../../services/correspondence.service.js';
 import { enqueueEmail } from '../../queues/email.queue.js';
 import { validateEnv } from '../../config/env.js';
 import { queueInAppNotification } from '../helpers/queue-in-app-notification.js';
@@ -202,7 +203,7 @@ export const submissionAcceptedNotification = inngest.createFunction(
   },
   { event: 'hopper/submission.accepted' },
   async ({ event, step }) => {
-    const { orgId, submissionId, submitterId } =
+    const { orgId, submissionId, submitterId, comment } =
       event.data as HopperSubmissionAcceptedEvent['data'];
 
     const { submission, orgName } = await step.run('resolve-data', async () =>
@@ -229,6 +230,7 @@ export const submissionAcceptedNotification = inngest.createFunction(
           submitterName: submitter.email,
           submitterEmail: submitter.email,
           orgName,
+          editorComment: comment,
         },
         subject: `Your submission has been accepted: ${submission.title}`,
       });
@@ -244,6 +246,26 @@ export const submissionAcceptedNotification = inngest.createFunction(
       });
     });
 
+    await step.run('capture-correspondence', async () => {
+      await withRls({ orgId }, async (tx) => {
+        await correspondenceService.create(tx, {
+          userId: submitterId,
+          submissionId,
+          direction: 'outbound',
+          channel: 'email',
+          sentAt: new Date(),
+          subject: `Your submission has been accepted: ${submission.title}`,
+          body: comment
+            ? `Congratulations! Your submission has been accepted.\n\nNote from the editors:\n${comment}`
+            : 'Congratulations! Your submission has been accepted.',
+          senderName: null,
+          senderEmail: null,
+          isPersonalized: !!comment,
+          source: 'colophony',
+        });
+      });
+    });
+
     return { notified: 1 };
   },
 );
@@ -256,7 +278,7 @@ export const submissionRejectedNotification = inngest.createFunction(
   },
   { event: 'hopper/submission.rejected' },
   async ({ event, step }) => {
-    const { orgId, submissionId, submitterId } =
+    const { orgId, submissionId, submitterId, comment } =
       event.data as HopperSubmissionRejectedEvent['data'];
 
     const { submission, orgName } = await step.run('resolve-data', async () =>
@@ -283,6 +305,7 @@ export const submissionRejectedNotification = inngest.createFunction(
           submitterName: submitter.email,
           submitterEmail: submitter.email,
           orgName,
+          editorComment: comment,
         },
         subject: `Update on your submission: ${submission.title}`,
       });
@@ -295,6 +318,26 @@ export const submissionRejectedNotification = inngest.createFunction(
         eventType: 'submission.rejected',
         title: `Update on your submission: ${submission.title}`,
         link: `/submissions/${submissionId}`,
+      });
+    });
+
+    await step.run('capture-correspondence', async () => {
+      await withRls({ orgId }, async (tx) => {
+        await correspondenceService.create(tx, {
+          userId: submitterId,
+          submissionId,
+          direction: 'outbound',
+          channel: 'email',
+          sentAt: new Date(),
+          subject: `Update on your submission: ${submission.title}`,
+          body: comment
+            ? `Thank you for your submission. After careful review, we are unable to accept it at this time.\n\nNote from the editors:\n${comment}`
+            : 'Thank you for your submission. After careful review, we are unable to accept it at this time.',
+          senderName: null,
+          senderEmail: null,
+          isPersonalized: !!comment,
+          source: 'colophony',
+        });
       });
     });
 

--- a/apps/api/src/services/correspondence.service.spec.ts
+++ b/apps/api/src/services/correspondence.service.spec.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuditActions, AuditResources } from '@colophony/types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockInsert = vi.fn();
+const mockSelect = vi.fn();
+const mockValues = vi.fn();
+const mockReturning = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockLimit = vi.fn();
+const mockOrderBy = vi.fn();
+
+vi.mock('@colophony/db', () => ({
+  correspondence: { submissionId: 'submission_id', sentAt: 'sent_at' },
+  submissions: { id: 'id' },
+  users: { id: 'id', email: 'email', displayName: 'display_name' },
+  organizations: { id: 'id', name: 'name' },
+  eq: vi.fn((_col: unknown, val: unknown) => val),
+  desc: vi.fn(),
+}));
+
+vi.mock('./submission.service.js', () => ({
+  submissionService: {
+    getById: vi.fn(),
+  },
+}));
+
+vi.mock('./email.service.js', () => ({
+  emailService: {
+    create: vi.fn(),
+  },
+}));
+
+vi.mock('../queues/email.queue.js', () => ({
+  enqueueEmail: vi.fn(),
+}));
+
+vi.mock('../config/env.js', () => ({
+  validateEnv: vi.fn(() => ({
+    EMAIL_PROVIDER: 'smtp',
+    SMTP_FROM: 'noreply@test.com',
+  })),
+}));
+
+import { correspondenceService } from './correspondence.service.js';
+import { submissionService } from './submission.service.js';
+import { emailService } from './email.service.js';
+import { enqueueEmail } from '../queues/email.queue.js';
+import { ForbiddenError, NotFoundError } from './errors.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTx() {
+  mockReturning.mockReturnValue([
+    {
+      id: 'corr-1',
+      userId: 'user-1',
+      submissionId: 'sub-1',
+      direction: 'outbound',
+      channel: 'email',
+      sentAt: new Date(),
+      subject: 'Test',
+      body: '<p>Hello</p>',
+      senderName: 'Editor',
+      senderEmail: 'editor@test.com',
+      isPersonalized: true,
+      source: 'colophony',
+    },
+  ]);
+  mockValues.mockReturnValue({ returning: mockReturning });
+  mockInsert.mockReturnValue({ values: mockValues });
+  mockLimit.mockReturnValue([]);
+  mockWhere.mockReturnValue({ limit: mockLimit, orderBy: mockOrderBy });
+  mockOrderBy.mockReturnValue([]);
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockSelect.mockReturnValue({ from: mockFrom });
+
+  return {
+    insert: mockInsert,
+    select: mockSelect,
+  } as unknown as Parameters<typeof correspondenceService.create>[0];
+}
+
+function makeSvc(role = 'EDITOR') {
+  const tx = makeTx();
+  return {
+    tx,
+    actor: { userId: 'editor-1', orgId: 'org-1', role },
+    audit: vi.fn(),
+  } as unknown as Parameters<typeof correspondenceService.sendEditorMessage>[0];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('correspondenceService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('inserts and returns row', async () => {
+      const tx = makeTx();
+      const result = await correspondenceService.create(tx, {
+        userId: 'user-1',
+        submissionId: 'sub-1',
+        direction: 'outbound',
+        channel: 'email',
+        sentAt: new Date(),
+        subject: 'Test',
+        body: '<p>Hello</p>',
+        senderName: 'Editor',
+        senderEmail: 'editor@test.com',
+        isPersonalized: true,
+        source: 'colophony',
+      });
+
+      expect(mockInsert).toHaveBeenCalled();
+      expect(result).toMatchObject({ id: 'corr-1' });
+    });
+  });
+
+  describe('listBySubmission', () => {
+    it('returns rows ordered by sentAt desc', async () => {
+      const rows = [
+        { id: 'c1', sentAt: new Date('2026-01-02') },
+        { id: 'c2', sentAt: new Date('2026-01-01') },
+      ];
+      const svc = makeSvc('EDITOR');
+      // Override the chain for list: select().from().where().orderBy()
+      const localOrderBy = vi.fn().mockReturnValue(rows);
+      const localWhere = vi.fn().mockReturnValue({ orderBy: localOrderBy });
+      const localFrom = vi.fn().mockReturnValue({ where: localWhere });
+      const localSelect = vi.fn().mockReturnValue({ from: localFrom });
+      (svc.tx as unknown as Record<string, unknown>).select = localSelect;
+
+      const result = await correspondenceService.listBySubmission(svc, 'sub-1');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('c1');
+    });
+
+    it('throws ForbiddenError for non-editor', async () => {
+      const svc = makeSvc('READER');
+
+      await expect(
+        correspondenceService.listBySubmission(svc, 'sub-1'),
+      ).rejects.toThrow(ForbiddenError);
+    });
+  });
+
+  describe('sendEditorMessage', () => {
+    function setupMocks() {
+      vi.mocked(submissionService.getById).mockResolvedValue({
+        id: 'sub-1',
+        submitterId: 'writer-1',
+        title: 'My Poem',
+      } as Awaited<ReturnType<typeof submissionService.getById>>);
+
+      // submitter lookup
+      mockLimit
+        .mockReturnValueOnce([
+          { email: 'writer@test.com', displayName: 'Writer' },
+        ])
+        // editor lookup
+        .mockReturnValueOnce([
+          { email: 'editor@test.com', displayName: 'Editor' },
+        ])
+        // org lookup
+        .mockReturnValueOnce([{ name: 'Test Mag' }]);
+
+      vi.mocked(emailService.create).mockResolvedValue({
+        id: 'email-1',
+      } as Awaited<ReturnType<typeof emailService.create>>);
+    }
+
+    it('creates correspondence with correct fields', async () => {
+      setupMocks();
+      const svc = makeSvc();
+
+      await correspondenceService.sendEditorMessage(svc, {
+        submissionId: 'sub-1',
+        subject: 'Re: My Poem',
+        body: '<p>Thanks for submitting</p>',
+      });
+
+      expect(mockInsert).toHaveBeenCalled();
+      expect(mockValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          direction: 'outbound',
+          isPersonalized: true,
+          source: 'colophony',
+          channel: 'email',
+        }),
+      );
+    });
+
+    it('enqueues email with editor-message template', async () => {
+      setupMocks();
+      const svc = makeSvc();
+
+      await correspondenceService.sendEditorMessage(svc, {
+        submissionId: 'sub-1',
+        subject: 'Re: My Poem',
+        body: '<p>Thanks</p>',
+      });
+
+      expect(enqueueEmail).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          templateName: 'editor-message',
+          replyTo: 'editor@test.com',
+        }),
+      );
+    });
+
+    it('audits CORRESPONDENCE_SENT', async () => {
+      setupMocks();
+      const svc = makeSvc();
+
+      await correspondenceService.sendEditorMessage(svc, {
+        submissionId: 'sub-1',
+        subject: 'Re: My Poem',
+        body: '<p>Thanks</p>',
+      });
+
+      expect(svc.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditActions.CORRESPONDENCE_SENT,
+          resource: AuditResources.CORRESPONDENCE,
+        }),
+      );
+    });
+
+    it('throws NotFoundError for missing submission', async () => {
+      vi.mocked(submissionService.getById).mockResolvedValue(null);
+      const svc = makeSvc();
+
+      await expect(
+        correspondenceService.sendEditorMessage(svc, {
+          submissionId: 'missing',
+          subject: 'Test',
+          body: 'Test',
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('throws ForbiddenError for non-editor', async () => {
+      const svc = makeSvc('READER');
+
+      await expect(
+        correspondenceService.sendEditorMessage(svc, {
+          submissionId: 'sub-1',
+          subject: 'Test',
+          body: 'Test',
+        }),
+      ).rejects.toThrow(ForbiddenError);
+    });
+  });
+});

--- a/apps/api/src/services/correspondence.service.spec.ts
+++ b/apps/api/src/services/correspondence.service.spec.ts
@@ -158,7 +158,8 @@ describe('correspondenceService', () => {
 
   describe('sendEditorMessage', () => {
     function setupMocks() {
-      vi.mocked(submissionService.getById).mockResolvedValue({
+      const mockedGetById = vi.mocked(submissionService.getById);
+      mockedGetById.mockResolvedValue({
         id: 'sub-1',
         submitterId: 'writer-1',
         title: 'My Poem',
@@ -176,7 +177,8 @@ describe('correspondenceService', () => {
         // org lookup
         .mockReturnValueOnce([{ name: 'Test Mag' }]);
 
-      vi.mocked(emailService.create).mockResolvedValue({
+      const mockedEmailCreate = vi.mocked(emailService.create);
+      mockedEmailCreate.mockResolvedValue({
         id: 'email-1',
       } as Awaited<ReturnType<typeof emailService.create>>);
     }
@@ -240,7 +242,8 @@ describe('correspondenceService', () => {
     });
 
     it('throws NotFoundError for missing submission', async () => {
-      vi.mocked(submissionService.getById).mockResolvedValue(null);
+      const mockedGetById = vi.mocked(submissionService.getById);
+      mockedGetById.mockResolvedValue(null);
       const svc = makeSvc();
 
       await expect(

--- a/apps/api/src/services/correspondence.service.spec.ts
+++ b/apps/api/src/services/correspondence.service.spec.ts
@@ -158,8 +158,8 @@ describe('correspondenceService', () => {
 
   describe('sendEditorMessage', () => {
     function setupMocks() {
-      const mockedGetById = vi.mocked(submissionService.getById);
-      mockedGetById.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValue({
         id: 'sub-1',
         submitterId: 'writer-1',
         title: 'My Poem',
@@ -177,8 +177,8 @@ describe('correspondenceService', () => {
         // org lookup
         .mockReturnValueOnce([{ name: 'Test Mag' }]);
 
-      const mockedEmailCreate = vi.mocked(emailService.create);
-      mockedEmailCreate.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(emailService.create).mockResolvedValue({
         id: 'email-1',
       } as Awaited<ReturnType<typeof emailService.create>>);
     }
@@ -242,8 +242,8 @@ describe('correspondenceService', () => {
     });
 
     it('throws NotFoundError for missing submission', async () => {
-      const mockedGetById = vi.mocked(submissionService.getById);
-      mockedGetById.mockResolvedValue(null);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(submissionService.getById).mockResolvedValue(null);
       const svc = makeSvc();
 
       await expect(

--- a/apps/api/src/services/correspondence.service.ts
+++ b/apps/api/src/services/correspondence.service.ts
@@ -1,0 +1,175 @@
+import {
+  correspondence,
+  users,
+  organizations,
+  eq,
+  desc,
+  type DrizzleDb,
+} from '@colophony/db';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { SendEditorMessageInput } from '@colophony/types';
+import type { ServiceContext } from './types.js';
+import { assertEditorOrAdmin, NotFoundError } from './errors.js';
+import { submissionService } from './submission.service.js';
+import { emailService } from './email.service.js';
+import { enqueueEmail } from '../queues/email.queue.js';
+import { validateEnv } from '../config/env.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CreateCorrespondenceParams {
+  userId: string;
+  submissionId: string;
+  direction: 'inbound' | 'outbound';
+  channel: 'email' | 'portal' | 'in_app' | 'other';
+  sentAt: Date;
+  subject: string | null;
+  body: string;
+  senderName: string | null;
+  senderEmail: string | null;
+  isPersonalized: boolean;
+  source: string;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const correspondenceService = {
+  async create(tx: DrizzleDb, params: CreateCorrespondenceParams) {
+    const [row] = await tx
+      .insert(correspondence)
+      .values({
+        userId: params.userId,
+        submissionId: params.submissionId,
+        direction: params.direction,
+        channel: params.channel,
+        sentAt: params.sentAt,
+        subject: params.subject,
+        body: params.body,
+        senderName: params.senderName,
+        senderEmail: params.senderEmail,
+        isPersonalized: params.isPersonalized,
+        source: params.source,
+      })
+      .returning();
+    return row;
+  },
+
+  async listBySubmission(svc: ServiceContext, submissionId: string) {
+    assertEditorOrAdmin(svc.actor.role);
+
+    const rows = await svc.tx
+      .select()
+      .from(correspondence)
+      .where(eq(correspondence.submissionId, submissionId))
+      .orderBy(desc(correspondence.sentAt));
+
+    return rows;
+  },
+
+  async sendEditorMessage(
+    svc: ServiceContext,
+    input: SendEditorMessageInput,
+  ): Promise<{ correspondenceId: string }> {
+    assertEditorOrAdmin(svc.actor.role);
+
+    // Fetch the submission (RLS-scoped)
+    const submission = await submissionService.getById(
+      svc.tx,
+      input.submissionId,
+    );
+    if (!submission) throw new NotFoundError('Submission not found');
+
+    const submitterId = submission.submitterId;
+    if (!submitterId) throw new NotFoundError('Submitter not found');
+
+    // Fetch submitter email
+    const [submitter] = await svc.tx
+      .select({ email: users.email })
+      .from(users)
+      .where(eq(users.id, submitterId))
+      .limit(1);
+
+    if (!submitter) throw new NotFoundError('Submitter not found');
+
+    // Fetch editor email (for replyTo)
+    const [editor] = await svc.tx
+      .select({ email: users.email })
+      .from(users)
+      .where(eq(users.id, svc.actor.userId))
+      .limit(1);
+
+    // Fetch org name
+    const [org] = await svc.tx
+      .select({ name: organizations.name })
+      .from(organizations)
+      .where(eq(organizations.id, svc.actor.orgId))
+      .limit(1);
+
+    const orgName = org?.name ?? 'Unknown Organization';
+    const editorName = editor?.email ?? 'Editor';
+    const editorEmail: string | undefined = editor?.email;
+
+    // Create correspondence record
+    const record = await correspondenceService.create(svc.tx, {
+      userId: submitterId,
+      submissionId: input.submissionId,
+      direction: 'outbound',
+      channel: 'email',
+      sentAt: new Date(),
+      subject: input.subject,
+      body: input.body,
+      senderName: editorName,
+      senderEmail: editorEmail ?? null,
+      isPersonalized: true,
+      source: 'colophony',
+    });
+
+    // Create email_sends record
+    const emailSend = await emailService.create(svc.tx, {
+      organizationId: svc.actor.orgId,
+      recipientUserId: submitterId,
+      recipientEmail: submitter.email,
+      templateName: 'editor-message',
+      eventType: 'correspondence.editor_message',
+      subject: input.subject,
+    });
+
+    // Audit
+    await svc.audit({
+      action: AuditActions.CORRESPONDENCE_SENT,
+      resource: AuditResources.CORRESPONDENCE,
+      resourceId: record.id,
+      newValue: {
+        submissionId: input.submissionId,
+        recipientEmail: submitter.email,
+        subject: input.subject,
+      },
+    });
+
+    // Enqueue email for sending
+    const env = validateEnv();
+    if (env.EMAIL_PROVIDER !== 'none') {
+      await enqueueEmail(env, {
+        emailSendId: emailSend.id,
+        orgId: svc.actor.orgId,
+        to: submitter.email,
+        from: env.SMTP_FROM ?? env.SENDGRID_FROM ?? 'noreply@colophony.dev',
+        templateName: 'editor-message',
+        templateData: {
+          submissionTitle: submission.title ?? 'Untitled',
+          orgName,
+          editorName,
+          messageSubject: input.subject,
+          messageBody: input.body,
+        },
+        replyTo: editorEmail,
+      });
+    }
+
+    return { correspondenceId: record.id };
+  },
+};

--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -726,12 +726,14 @@ export const submissionService = {
         orgId: svc.actor.orgId,
         submissionId: id,
         submitterId: existing.submitterId,
+        comment,
       });
     } else if (status === 'REJECTED') {
       await enqueueOutboxEvent(svc.tx, 'hopper/submission.rejected', {
         orgId: svc.actor.orgId,
         submissionId: id,
         submitterId: existing.submitterId,
+        comment,
       });
     }
 

--- a/apps/api/src/templates/email/templates.ts
+++ b/apps/api/src/templates/email/templates.ts
@@ -1,3 +1,4 @@
+import sanitizeHtml from 'sanitize-html';
 import type {
   TemplateName,
   SubmissionTemplateData,
@@ -6,6 +7,33 @@ import type {
   EditorMessageTemplateData,
 } from './types.js';
 import { wrapInLayout } from './layout.js';
+
+/** Sanitize Tiptap HTML to only allow safe formatting tags */
+function sanitizeTiptapHtml(html: string): string {
+  return sanitizeHtml(html, {
+    allowedTags: [
+      'p',
+      'br',
+      'strong',
+      'b',
+      'em',
+      'i',
+      'u',
+      'a',
+      'ul',
+      'ol',
+      'li',
+      'blockquote',
+      'h1',
+      'h2',
+      'h3',
+    ],
+    allowedAttributes: {
+      a: ['href', 'target', 'rel'],
+    },
+    allowedSchemes: ['http', 'https', 'mailto'],
+  });
+}
 
 interface TemplateResult {
   mjml: string;
@@ -156,7 +184,7 @@ function editorMessage(data: Record<string, unknown>): TemplateResult {
       </mj-text>
       <mj-divider border-color="#e5e7eb" border-width="1px" padding="16px 0" />
       <mj-text>
-        ${d.messageBody}
+        ${sanitizeTiptapHtml(d.messageBody)}
       </mj-text>`,
       d.orgName,
     ),
@@ -164,7 +192,7 @@ function editorMessage(data: Record<string, unknown>): TemplateResult {
       `You have received a message from the editorial team at ${d.orgName}.`,
       `Regarding: ${d.submissionTitle}`,
       '',
-      stripHtml(d.messageBody),
+      stripHtml(sanitizeTiptapHtml(d.messageBody)),
     ].join('\n'),
   };
 }

--- a/apps/api/src/templates/email/templates.ts
+++ b/apps/api/src/templates/email/templates.ts
@@ -208,8 +208,7 @@ export const templates: Record<TemplateName, TemplateRenderer> = {
 };
 
 function stripHtml(html: string): string {
-  return html
-    .replace(/<[^>]*>/g, '')
+  return sanitizeHtml(html, { allowedTags: [], allowedAttributes: {} })
     .replace(/&nbsp;/g, ' ')
     .trim();
 }

--- a/apps/api/src/templates/email/templates.ts
+++ b/apps/api/src/templates/email/templates.ts
@@ -3,6 +3,7 @@ import type {
   SubmissionTemplateData,
   ContractTemplateData,
   CopyeditorAssignedData,
+  EditorMessageTemplateData,
 } from './types.js';
 import { wrapInLayout } from './layout.js';
 
@@ -46,13 +47,16 @@ function submissionAccepted(data: Record<string, unknown>): TemplateResult {
         <p>Congratulations! Your submission has been accepted.</p>
         <p><strong>Title:</strong> ${escapeHtml(d.submissionTitle)}</p>
         <p>The editorial team at ${escapeHtml(d.orgName)} will be in touch with next steps.</p>
-      </mj-text>`,
+      </mj-text>${d.editorComment ? `<mj-divider border-color="#e5e7eb" border-width="1px" padding="16px 0" /><mj-text><p><strong>Note from the editors:</strong></p><p>${escapeHtml(d.editorComment)}</p></mj-text>` : ''}`,
       d.orgName,
     ),
     text: [
       `Congratulations! Your submission "${d.submissionTitle}" has been accepted.`,
       `The editorial team at ${d.orgName} will be in touch with next steps.`,
-    ].join('\n'),
+      d.editorComment ? `\nNote from the editors:\n${d.editorComment}` : '',
+    ]
+      .filter(Boolean)
+      .join('\n'),
   };
 }
 
@@ -65,14 +69,17 @@ function submissionRejected(data: Record<string, unknown>): TemplateResult {
         <p>Thank you for your submission. After careful review, we are unable to accept it at this time.</p>
         <p><strong>Title:</strong> ${escapeHtml(d.submissionTitle)}</p>
         <p>We appreciate your interest in ${escapeHtml(d.orgName)} and encourage future submissions.</p>
-      </mj-text>`,
+      </mj-text>${d.editorComment ? `<mj-divider border-color="#e5e7eb" border-width="1px" padding="16px 0" /><mj-text><p><strong>Note from the editors:</strong></p><p>${escapeHtml(d.editorComment)}</p></mj-text>` : ''}`,
       d.orgName,
     ),
     text: [
       `Thank you for your submission "${d.submissionTitle}".`,
       `After careful review, we are unable to accept it at this time.`,
       `We appreciate your interest in ${d.orgName} and encourage future submissions.`,
-    ].join('\n'),
+      d.editorComment ? `\nNote from the editors:\n${d.editorComment}` : '',
+    ]
+      .filter(Boolean)
+      .join('\n'),
   };
 }
 
@@ -138,6 +145,30 @@ function copyeditorAssigned(data: Record<string, unknown>): TemplateResult {
   };
 }
 
+function editorMessage(data: Record<string, unknown>): TemplateResult {
+  const d = data as unknown as EditorMessageTemplateData;
+  return {
+    subject: d.messageSubject,
+    mjml: wrapInLayout(
+      `<mj-text>
+        <p>You have received a message from the editorial team at ${escapeHtml(d.orgName)}.</p>
+        <p><strong>Regarding:</strong> ${escapeHtml(d.submissionTitle)}</p>
+      </mj-text>
+      <mj-divider border-color="#e5e7eb" border-width="1px" padding="16px 0" />
+      <mj-text>
+        ${d.messageBody}
+      </mj-text>`,
+      d.orgName,
+    ),
+    text: [
+      `You have received a message from the editorial team at ${d.orgName}.`,
+      `Regarding: ${d.submissionTitle}`,
+      '',
+      stripHtml(d.messageBody),
+    ].join('\n'),
+  };
+}
+
 export const templates: Record<TemplateName, TemplateRenderer> = {
   'submission-received': submissionReceived,
   'submission-accepted': submissionAccepted,
@@ -145,7 +176,15 @@ export const templates: Record<TemplateName, TemplateRenderer> = {
   'submission-withdrawn': submissionWithdrawn,
   'contract-ready': contractReady,
   'copyeditor-assigned': copyeditorAssigned,
+  'editor-message': editorMessage,
 };
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .trim();
+}
 
 function escapeHtml(text: string): string {
   return text

--- a/apps/api/src/templates/email/types.ts
+++ b/apps/api/src/templates/email/types.ts
@@ -4,7 +4,8 @@ export type TemplateName =
   | 'submission-rejected'
   | 'submission-withdrawn'
   | 'contract-ready'
-  | 'copyeditor-assigned';
+  | 'copyeditor-assigned'
+  | 'editor-message';
 
 export interface SubmissionTemplateData {
   submissionTitle: string;
@@ -12,6 +13,7 @@ export interface SubmissionTemplateData {
   submitterEmail: string;
   orgName: string;
   submissionUrl?: string;
+  editorComment?: string;
 }
 
 export interface ContractTemplateData {
@@ -28,7 +30,16 @@ export interface CopyeditorAssignedData {
   pipelineUrl?: string;
 }
 
+export interface EditorMessageTemplateData {
+  submissionTitle: string;
+  orgName: string;
+  editorName: string;
+  messageSubject: string;
+  messageBody: string; // HTML from Tiptap
+}
+
 export type TemplateData =
   | SubmissionTemplateData
   | ContractTemplateData
-  | CopyeditorAssignedData;
+  | CopyeditorAssignedData
+  | EditorMessageTemplateData;

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -21,6 +21,7 @@ import { notificationPreferencesRouter } from './routers/notification-preference
 import { notificationsRouter } from './routers/notifications.js';
 import { pluginsRouter } from './routers/plugins.js';
 import { webhooksRouter } from './routers/webhooks.js';
+import { correspondenceRouter } from './routers/correspondence.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -63,6 +64,7 @@ export const appRouter = t.router({
   notifications: notificationsRouter,
   webhooks: webhooksRouter,
   plugins: pluginsRouter,
+  correspondence: correspondenceRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/correspondence.ts
+++ b/apps/api/src/trpc/routers/correspondence.ts
@@ -1,3 +1,4 @@
+import sanitizeHtml from 'sanitize-html';
 import { z } from 'zod';
 import {
   sendEditorMessageSchema,
@@ -9,10 +10,11 @@ import { correspondenceService } from '../../services/correspondence.service.js'
 import { mapServiceError } from '../error-mapper.js';
 
 function stripHtmlAndTruncate(html: string, maxLen: number): string {
-  const text = html
-    .replace(/<[^>]*>/g, '')
-    .replace(/&nbsp;/g, ' ')
-    .trim();
+  const sanitized = sanitizeHtml(html, {
+    allowedTags: [],
+    allowedAttributes: {},
+  });
+  const text = sanitized.replace(/&nbsp;/g, ' ').trim();
   return text.length > maxLen ? text.slice(0, maxLen - 1) + '\u2026' : text;
 }
 

--- a/apps/api/src/trpc/routers/correspondence.ts
+++ b/apps/api/src/trpc/routers/correspondence.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import {
+  sendEditorMessageSchema,
+  correspondenceListItemSchema,
+} from '@colophony/types';
+import { orgProcedure, createRouter, requireScopes } from '../init.js';
+import { toServiceContext } from '../../services/context.js';
+import { correspondenceService } from '../../services/correspondence.service.js';
+import { mapServiceError } from '../error-mapper.js';
+
+function stripHtmlAndTruncate(html: string, maxLen: number): string {
+  const text = html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .trim();
+  return text.length > maxLen ? text.slice(0, maxLen - 1) + '\u2026' : text;
+}
+
+export const correspondenceRouter = createRouter({
+  send: orgProcedure
+    .use(requireScopes('submissions:write'))
+    .input(sendEditorMessageSchema)
+    .output(z.object({ correspondenceId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await correspondenceService.sendEditorMessage(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  listBySubmission: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(z.object({ submissionId: z.string().uuid() }))
+    .output(z.array(correspondenceListItemSchema))
+    .query(async ({ ctx, input }) => {
+      try {
+        const rows = await correspondenceService.listBySubmission(
+          toServiceContext(ctx),
+          input.submissionId,
+        );
+        return rows.map((r) => ({
+          id: r.id,
+          direction: r.direction as 'inbound' | 'outbound',
+          channel: r.channel as 'email' | 'portal' | 'in_app' | 'other',
+          sentAt: r.sentAt.toISOString(),
+          subject: r.subject,
+          bodyPreview: stripHtmlAndTruncate(r.body, 200),
+          senderName: r.senderName,
+          senderEmail: r.senderEmail,
+          isPersonalized: r.isPersonalized,
+          source: r.source as 'colophony' | 'manual',
+        }));
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+});

--- a/apps/api/src/trpc/routers/correspondence.ts
+++ b/apps/api/src/trpc/routers/correspondence.ts
@@ -44,8 +44,8 @@ export const correspondenceRouter = createRouter({
         );
         return rows.map((r) => ({
           id: r.id,
-          direction: r.direction as 'inbound' | 'outbound',
-          channel: r.channel as 'email' | 'portal' | 'in_app' | 'other',
+          direction: r.direction,
+          channel: r.channel,
           sentAt: r.sentAt.toISOString(),
           subject: r.subject,
           bodyPreview: stripHtmlAndTruncate(r.body, 200),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,6 +45,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.0.0",
     "@tiptap/core": "^3.20.0",
+    "@tiptap/extension-link": "^3.20.0",
     "@tiptap/extension-placeholder": "^3.20.0",
     "@tiptap/pm": "^3.20.0",
     "@tiptap/react": "^3.20.0",

--- a/apps/web/src/components/submissions/__tests__/compose-message-dialog.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/compose-message-dialog.spec.tsx
@@ -1,0 +1,130 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ComposeMessageDialog } from "../compose-message-dialog";
+import "../../../../test/setup";
+
+// --- Mutable mock state ---
+let mockMutate: jest.Mock;
+let mockIsPending: boolean;
+
+function resetMocks() {
+  mockMutate = jest.fn();
+  mockIsPending = false;
+}
+
+jest.mock("@tiptap/react", () => ({
+  useEditor: () => ({
+    getHTML: () => "<p>Test message</p>",
+    commands: { clearContent: jest.fn() },
+    chain: () => ({
+      focus: () => ({
+        toggleBold: () => ({ run: jest.fn() }),
+        toggleItalic: () => ({ run: jest.fn() }),
+        toggleBulletList: () => ({ run: jest.fn() }),
+        toggleOrderedList: () => ({ run: jest.fn() }),
+        setLink: () => ({ run: jest.fn() }),
+        unsetLink: () => ({ run: jest.fn() }),
+      }),
+    }),
+    isActive: () => false,
+  }),
+  EditorContent: ({ editor }: { editor: unknown }) =>
+    editor ? <div data-testid="editor-content">Editor</div> : null,
+}));
+
+jest.mock("@tiptap/starter-kit", () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock("@tiptap/extension-placeholder", () => ({
+  __esModule: true,
+  default: { configure: () => ({}) },
+}));
+
+jest.mock("@tiptap/extension-link", () => ({
+  __esModule: true,
+  default: { configure: () => ({}) },
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+const mockInvalidate = jest.fn();
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    correspondence: {
+      send: {
+        useMutation: (opts: {
+          onSuccess?: () => void;
+          onError?: (err: { message: string }) => void;
+        }) => ({
+          mutate: (...args: unknown[]) => {
+            mockMutate(...args);
+            if (!mockIsPending) opts.onSuccess?.();
+          },
+          isPending: mockIsPending,
+        }),
+      },
+    },
+    useUtils: () => ({
+      correspondence: {
+        listBySubmission: { invalidate: mockInvalidate },
+      },
+    }),
+  },
+}));
+
+beforeEach(() => {
+  resetMocks();
+});
+
+describe("ComposeMessageDialog", () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: jest.fn(),
+    submissionId: "sub-1",
+    submissionTitle: "My Poem",
+  };
+
+  it("pre-fills subject with Re: submission title", () => {
+    render(<ComposeMessageDialog {...defaultProps} />);
+    const input = screen.getByLabelText("Subject") as HTMLInputElement;
+    expect(input.value).toBe("Re: My Poem");
+  });
+
+  it("calls send mutation on submit", () => {
+    render(<ComposeMessageDialog {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    expect(mockMutate).toHaveBeenCalledWith({
+      submissionId: "sub-1",
+      subject: "Re: My Poem",
+      body: "<p>Test message</p>",
+    });
+  });
+
+  it("disables send button while pending", () => {
+    mockIsPending = true;
+    render(<ComposeMessageDialog {...defaultProps} />);
+    const sendBtn = screen.getByRole("button", { name: /send/i });
+    expect(sendBtn).toBeDisabled();
+  });
+
+  it("shows error toast on failure", () => {
+    expect(mockToastError).toBeDefined();
+  });
+
+  it("closes dialog and shows success toast on success", () => {
+    render(<ComposeMessageDialog {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    expect(mockToastSuccess).toHaveBeenCalledWith("Message sent");
+    expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/src/components/submissions/compose-message-dialog.tsx
+++ b/apps/web/src/components/submissions/compose-message-dialog.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState } from "react";
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Placeholder from "@tiptap/extension-placeholder";
+import Link from "@tiptap/extension-link";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import {
+  Bold,
+  Italic,
+  List,
+  ListOrdered,
+  Link as LinkIcon,
+  Loader2,
+} from "lucide-react";
+
+interface ComposeMessageDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  submissionId: string;
+  submissionTitle: string;
+}
+
+export function ComposeMessageDialog({
+  open,
+  onOpenChange,
+  submissionId,
+  submissionTitle,
+}: ComposeMessageDialogProps) {
+  const [subject, setSubject] = useState(`Re: ${submissionTitle}`);
+  const utils = trpc.useUtils();
+
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit,
+      Placeholder.configure({ placeholder: "Write your message..." }),
+      Link.configure({ openOnClick: false }),
+    ],
+    content: "",
+  });
+
+  const sendMutation = trpc.correspondence.send.useMutation({
+    onSuccess: () => {
+      toast.success("Message sent");
+      editor?.commands.clearContent();
+      setSubject(`Re: ${submissionTitle}`);
+      onOpenChange(false);
+      utils.correspondence.listBySubmission.invalidate({ submissionId });
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const handleSubmit = () => {
+    if (!editor) return;
+    const body = editor.getHTML();
+    if (!subject.trim() || !body.trim() || body === "<p></p>") return;
+
+    sendMutation.mutate({
+      submissionId,
+      subject: subject.trim(),
+      body,
+    });
+  };
+
+  const toggleLink = () => {
+    if (!editor) return;
+    if (editor.isActive("link")) {
+      editor.chain().focus().unsetLink().run();
+      return;
+    }
+    const url = window.prompt("Enter URL:");
+    if (url) {
+      editor.chain().focus().setLink({ href: url }).run();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>Send Message</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="subject">Subject</Label>
+            <Input
+              id="subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              maxLength={500}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Message</Label>
+            <div className="border rounded-md">
+              <div className="flex items-center gap-1 border-b p-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => editor?.chain().focus().toggleBold().run()}
+                  data-active={editor?.isActive("bold")}
+                >
+                  <Bold className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => editor?.chain().focus().toggleItalic().run()}
+                  data-active={editor?.isActive("italic")}
+                >
+                  <Italic className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() =>
+                    editor?.chain().focus().toggleBulletList().run()
+                  }
+                  data-active={editor?.isActive("bulletList")}
+                >
+                  <List className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() =>
+                    editor?.chain().focus().toggleOrderedList().run()
+                  }
+                  data-active={editor?.isActive("orderedList")}
+                >
+                  <ListOrdered className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={toggleLink}
+                  data-active={editor?.isActive("link")}
+                >
+                  <LinkIcon className="h-4 w-4" />
+                </Button>
+              </div>
+              <EditorContent
+                editor={editor}
+                className="prose prose-sm max-w-none p-3 min-h-[150px] focus-within:outline-none [&_.tiptap]:outline-none"
+              />
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={sendMutation.isPending}>
+            {sendMutation.isPending && (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            )}
+            Send
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/submissions/correspondence-history.tsx
+++ b/apps/web/src/components/submissions/correspondence-history.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { format } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowUpRight, ArrowDownLeft, Mail } from "lucide-react";
+
+interface CorrespondenceHistoryProps {
+  submissionId: string;
+}
+
+export function CorrespondenceHistory({
+  submissionId,
+}: CorrespondenceHistoryProps) {
+  const { data: items, isPending: isLoading } =
+    trpc.correspondence.listBySubmission.useQuery({ submissionId });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Correspondence</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-16 w-full" />
+          </div>
+        ) : items && items.length > 0 ? (
+          <div className="space-y-4">
+            {items.map((item) => {
+              const DirectionIcon =
+                item.direction === "outbound" ? ArrowUpRight : ArrowDownLeft;
+              return (
+                <div
+                  key={item.id}
+                  className="flex gap-3 text-sm border-b pb-3 last:border-0 last:pb-0"
+                >
+                  <DirectionIcon className="h-4 w-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
+                  <div className="flex-1 min-w-0 space-y-1">
+                    <div className="flex items-center gap-2">
+                      {item.subject && (
+                        <span className="font-medium truncate">
+                          {item.subject}
+                        </span>
+                      )}
+                      {item.isPersonalized && (
+                        <Badge variant="secondary" className="text-xs">
+                          Personalized
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="text-muted-foreground truncate">
+                      {item.bodyPreview}
+                    </p>
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <span>{format(new Date(item.sentAt), "PPp")}</span>
+                      {item.senderName && (
+                        <span>&middot; {item.senderName}</span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-2 py-6 text-muted-foreground">
+            <Mail className="h-8 w-8" />
+            <p className="text-sm">No correspondence yet</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -9,6 +9,8 @@ import { useOrganization } from "@/hooks/use-organization";
 import { PluginSlot } from "@/components/plugins/plugin-slot";
 import { StatusBadge } from "./status-badge";
 import { StatusTransition } from "./status-transition";
+import { ComposeMessageDialog } from "./compose-message-dialog";
+import { CorrespondenceHistory } from "./correspondence-history";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -39,6 +41,7 @@ import {
   AlertCircle,
   Loader2,
   BookOpen,
+  Mail,
 } from "lucide-react";
 import {
   EDITOR_ALLOWED_TRANSITIONS,
@@ -77,6 +80,7 @@ export function SubmissionDetail({
   const { user, isEditor, isAdmin } = useOrganization();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showWithdrawDialog, setShowWithdrawDialog] = useState(false);
+  const [showComposeDialog, setShowComposeDialog] = useState(false);
   const utils = trpc.useUtils();
 
   const { data: submission, isPending: isLoading } =
@@ -221,6 +225,16 @@ export function SubmissionDetail({
                 submissionId={submissionId}
                 currentStatus={submission.status as SubmissionStatus}
               />
+              <div className="mt-4 pt-4 border-t">
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => setShowComposeDialog(true)}
+                >
+                  <Mail className="mr-2 h-4 w-4" />
+                  Send Message
+                </Button>
+              </div>
             </CardContent>
           </Card>
         )}
@@ -420,8 +434,20 @@ export function SubmissionDetail({
               )}
             </CardContent>
           </Card>
+
+          {(isEditor || isAdmin) && (
+            <CorrespondenceHistory submissionId={submissionId} />
+          )}
         </div>
       </div>
+
+      {/* Compose message dialog */}
+      <ComposeMessageDialog
+        open={showComposeDialog}
+        onOpenChange={setShowComposeDialog}
+        submissionId={submissionId}
+        submissionTitle={submission.title ?? "Untitled"}
+      />
 
       {/* Delete confirmation dialog */}
       <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -303,11 +303,11 @@
 
 ## Track 7 — Editorial Experience (Pre-Launch)
 
-> **Status:** Not started. Addresses gaps in the editor-to-writer relationship and editorial workflow that are critical for Write or Die launch and early adopter credibility.
+> **Status:** In progress. PR1 (correspondence) shipped.
 
 ### Correspondence & Communication
 
-- [ ] [P0] Editor-to-writer personalized correspondence — compose and send messages to individual submitters from the submission detail view; editor comments on status transitions should optionally be included in the notification email to the writer — (persona gap analysis 2026-02-27)
+- [x] [P0] Editor-to-writer personalized correspondence — compose and send messages to individual submitters from the submission detail view; editor comments on status transitions included in notification emails — (persona gap analysis 2026-02-27; done 2026-02-27 PR pending)
 - [ ] [P0] Customizable email templates — admin UI for editing MJML templates per org (acceptance, rejection, under review, custom); replace hardcoded boilerplate with org-branded voice — (persona gap analysis 2026-02-27)
 - [ ] [P1] "Revise and resubmit" status — add R&R to SubmissionStatus enum + transition map; editor sends revision notes, writer resubmits against the same submission record — (persona gap analysis 2026-02-27)
 - [ ] [P2] Embed submitter confirmation email — send a receipt email to the address provided in the embed identity step; include submission title, journal name, and a status-check token/link — (persona gap analysis 2026-02-27)
@@ -356,7 +356,7 @@
 ### Correspondence Tracking
 
 - [x] [P0] `correspondence` DB table — new table for editor-writer messages linked to submissions; fields: direction (inbound/outbound), channel (email/portal/in_app), body, senderName, senderEmail, isPersonalized flag; RLS scoped to submission owner + org editors; XOR CHECK on submission_id/external_submission_id — (register-data-standard.md Section 2.8, 4.2; done 2026-02-27 PR pending)
-- [ ] [P1] Auto-capture Colophony correspondence — when Track 7 personalized correspondence ships, auto-insert records into the correspondence table; also capture status transition comments that are shared with writers — (register-data-standard.md Section 2.8; 2026-02-27)
+- [x] [P1] Auto-capture Colophony correspondence — auto-insert correspondence records on acceptance/rejection notifications + editor messages; captures status transition comments — (register-data-standard.md Section 2.8; done 2026-02-27 PR pending)
 - [ ] [P2] Manual correspondence logging — writers can paste/enter notable editor messages (personalized rejections, encouragement letters) for external submissions; lightweight form: paste text, mark as personalized, save — (register-data-standard.md Section 2.8; 2026-02-27)
 - [ ] [P2] Correspondence in CSR export — include all correspondence records in the writer's CSR download, linked to submission records — (register-data-standard.md Section 2.8; 2026-02-27)
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,31 @@ Newest entries first.
 
 ---
 
+## 2026-02-27 — Track 7 PR1: Editor-to-Writer Correspondence
+
+### Done
+
+- **Correspondence service:** `create`, `listBySubmission`, `sendEditorMessage` methods with audit logging and email queuing
+- **tRPC router:** `correspondence.send` (mutation) and `correspondence.listBySubmission` (query) with scope enforcement
+- **Editor-message email template:** MJML + text variant, passes Tiptap HTML body from compose dialog
+- **Transition comments:** Acceptance/rejection notification emails now include optional "Note from the editors" section via `editorComment` field
+- **Auto-capture:** Inngest notification functions create correspondence records after sending acceptance/rejection emails
+- **RLS migration (0037):** `correspondence_org_insert` policy — allows editors to INSERT correspondence for submissions in their org
+- **Compose message dialog:** Tiptap WYSIWYG with StarterKit + Link + Placeholder, toolbar (bold/italic/list/link), subject pre-fill
+- **Correspondence history:** Timeline card in submission detail sidebar showing direction icons, personalized badges, body preview, sender info
+- **Submission detail integration:** Send Message button in Editor Actions card, correspondence history in sidebar
+- **Types:** `sendEditorMessageSchema`, `correspondenceListItemSchema` in `packages/types/src/correspondence.ts`; `CORRESPONDENCE_SENT`, `CORRESPONDENCE_AUTO_CAPTURED` audit actions
+- **Tests:** 8 API service tests + 5 frontend component tests, all passing; 14/14 packages type-check clean
+
+### Decisions
+
+- No `displayName` column on users table — used email as editor name in correspondence records and templates
+- Editor message HTML from Tiptap passed directly to MJML template (trusted internal source, not raw user HTML)
+- No REST/GraphQL surface for correspondence — dashboard-only feature, tRPC sufficient for now
+- RLS `correspondence_org_insert` needed because existing `correspondence_owner` policy requires `user_id = current_user_id()`, but the record's `userId` is the submitter, not the editor
+
+---
+
 ## 2026-02-27 — Align MigrationBundle with CSR Types
 
 ### Done

--- a/packages/db/migrations/0037_correspondence_org_insert.sql
+++ b/packages/db/migrations/0037_correspondence_org_insert.sql
@@ -1,0 +1,8 @@
+CREATE POLICY "correspondence_org_insert" ON "correspondence"
+  AS PERMISSIVE FOR INSERT TO public
+  WITH CHECK (
+    submission_id IN (
+      SELECT id FROM submissions
+      WHERE organization_id = current_org_id()
+    )
+  );

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1776400000000,
       "tag": "0036_writer_workspace",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1776600000000,
+      "tag": "0037_correspondence_org_insert",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/writer-workspace.ts
+++ b/packages/db/src/schema/writer-workspace.ts
@@ -163,6 +163,13 @@ export const correspondence = pgTable(
         WHERE organization_id = current_org_id()
       )`,
     }),
+    pgPolicy("correspondence_org_insert", {
+      for: "insert",
+      withCheck: sql`submission_id IN (
+        SELECT id FROM submissions
+        WHERE organization_id = current_org_id()
+      )`,
+    }),
   ],
 ).enableRLS();
 

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -207,6 +207,10 @@ export const AuditActions = {
   WEBHOOK_DELIVERY_RETRIED: "WEBHOOK_DELIVERY_RETRIED",
   WEBHOOK_ENDPOINT_AUTO_DISABLED: "WEBHOOK_ENDPOINT_AUTO_DISABLED",
 
+  // Correspondence lifecycle
+  CORRESPONDENCE_SENT: "CORRESPONDENCE_SENT",
+  CORRESPONDENCE_AUTO_CAPTURED: "CORRESPONDENCE_AUTO_CAPTURED",
+
   // Audit access
   AUDIT_ACCESSED: "AUDIT_ACCESSED",
 } as const;
@@ -242,6 +246,7 @@ export const AuditResources = {
   NOTIFICATION_PREFERENCE: "notification_preference",
   WEBHOOK_ENDPOINT: "webhook_endpoint",
   WEBHOOK_DELIVERY: "webhook_delivery",
+  CORRESPONDENCE: "correspondence",
   AUDIT: "audit",
 } as const;
 
@@ -542,6 +547,13 @@ export interface WebhookDeliveryAuditParams extends BaseAuditParams {
     | typeof AuditActions.WEBHOOK_DELIVERY_RETRIED;
 }
 
+export interface CorrespondenceAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.CORRESPONDENCE;
+  action:
+    | typeof AuditActions.CORRESPONDENCE_SENT
+    | typeof AuditActions.CORRESPONDENCE_AUTO_CAPTURED;
+}
+
 export interface AuditAccessAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.AUDIT;
   action: typeof AuditActions.AUDIT_ACCESSED;
@@ -583,6 +595,7 @@ export type AuditLogParams =
   | NotificationPreferenceAuditParams
   | WebhookEndpointAuditParams
   | WebhookDeliveryAuditParams
+  | CorrespondenceAuditParams
   | AuditAccessAuditParams
   | SystemAuditParams;
 

--- a/packages/types/src/correspondence.ts
+++ b/packages/types/src/correspondence.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Editor-to-writer correspondence — shared schemas
+// ---------------------------------------------------------------------------
+
+export const sendEditorMessageSchema = z.object({
+  submissionId: z.string().uuid(),
+  subject: z.string().min(1).max(500),
+  body: z.string().min(1).max(50_000), // HTML from Tiptap
+});
+
+export type SendEditorMessageInput = z.infer<typeof sendEditorMessageSchema>;
+
+export const correspondenceListItemSchema = z.object({
+  id: z.string().uuid(),
+  direction: z.enum(["inbound", "outbound"]),
+  channel: z.enum(["email", "portal", "in_app", "other"]),
+  sentAt: z.string().datetime(),
+  subject: z.string().max(500).nullable(),
+  bodyPreview: z.string().max(200),
+  senderName: z.string().max(255).nullable(),
+  senderEmail: z.string().email().max(255).nullable(),
+  isPersonalized: z.boolean(),
+  source: z.enum(["colophony", "manual"]),
+});
+
+export type CorrespondenceListItem = z.infer<
+  typeof correspondenceListItemSchema
+>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -24,5 +24,6 @@ export * from "./hub";
 export * from "./notification-preferences";
 export * from "./notification";
 export * from "./webhook";
+export * from "./correspondence";
 export * from "./csr";
 export * from "./status-mapping";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
       '@tiptap/core':
         specifier: ^3.20.0
         version: 3.20.0(@tiptap/pm@3.20.0)
+      '@tiptap/extension-link':
+        specifier: ^3.20.0
+        version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
       '@tiptap/extension-placeholder':
         specifier: ^3.20.0
         version: 3.20.0(@tiptap/extensions@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
+      sanitize-html:
+        specifier: ^2.17.1
+        version: 2.17.1
       stripe:
         specifier: ^20.3.1
         version: 20.3.1(@types/node@25.3.0)
@@ -175,6 +178,9 @@ importers:
       '@types/pg':
         specifier: ^8.11.0
         version: 8.16.0
+      '@types/sanitize-html':
+        specifier: ^2.16.0
+        version: 2.16.0
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -4102,6 +4108,9 @@ packages:
   '@types/readdir-glob@1.1.5':
     resolution: {integrity: sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==}
 
+  '@types/sanitize-html@2.16.0':
+    resolution: {integrity: sha512-l6rX1MUXje5ztPT0cAFtUayXF06DqPhRyfVXareEN5gGCFaP/iwsxIyKODr9XDhfxPpN6vXUFNfo5kZMXCxBtw==}
+
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
@@ -5978,6 +5987,10 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
@@ -6908,6 +6921,9 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
 
@@ -7422,6 +7438,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-html@2.17.1:
+    resolution: {integrity: sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -12607,6 +12626,10 @@ snapshots:
     dependencies:
       '@types/node': 25.3.0
 
+  '@types/sanitize-html@2.16.0':
+    dependencies:
+      htmlparser2: 8.0.2
+
   '@types/stack-utils@2.0.3': {}
 
   '@types/tedious@4.0.14':
@@ -14718,6 +14741,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-plain-object@5.0.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
 
   is-regex@1.2.1:
@@ -16028,6 +16053,8 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse-srcset@1.0.2: {}
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
       domhandler: 5.0.3
@@ -16645,6 +16672,15 @@ snapshots:
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
+
+  sanitize-html@2.17.1:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 8.0.2
+      is-plain-object: 5.0.0
+      parse-srcset: 1.0.2
+      postcss: 8.5.6
 
   saxes@6.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- **Compose & send** personalized messages from the submission detail view (Tiptap WYSIWYG editor with link support)
- **Correspondence history** timeline displayed on the submission detail page for editors/admins
- **Transition comments** included in acceptance/rejection notification emails
- **Auto-capture** of system correspondence records (accepted/rejected notifications) for the writer's portfolio
- New `correspondence` tRPC router with `send` mutation and `listBySubmission` query
- RLS `correspondence_org_insert` policy to allow editor INSERT on writer-owned correspondence records
- `editor-message` MJML email template with HTML body pass-through
- 8 API unit tests (correspondence service) + 5 frontend tests (compose dialog)

## Plan Overrides

| File | Planned | Actual | Rationale |
|---|---|---|---|
| `correspondence.service.ts` | Use `users.displayName` for editor name | Use `users.email` | `users` table has no `displayName` column |
| `correspondence.service.ts` | `submitterId` always string | Added null check for nullable `submitterId` | Schema allows null |

## Test plan

- [ ] `pnpm --filter @colophony/api test -- correspondence` — 8 tests pass
- [ ] `pnpm --filter @colophony/web test -- compose-message-dialog` — 5 tests pass
- [ ] `pnpm type-check` — 14/14 packages clean
- [ ] Manual: Login as editor → submission detail → "Send Message" → compose with formatting → send → verify toast + correspondence history entry
- [ ] Manual: Accept submission with comment → verify notification email includes "Note from the editors" section
- [ ] Manual: Verify `correspondence` table has auto-captured records after accept/reject