### PR TITLE
feat(relay): customizable email templates with WYSIWYG editor

### DIFF
--- a/apps/api/src/services/email-template.service.spec.ts
+++ b/apps/api/src/services/email-template.service.spec.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuditActions, AuditResources } from '@colophony/types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockInsert = vi.fn();
+const mockSelect = vi.fn();
+const mockDelete = vi.fn();
+const mockValues = vi.fn();
+const mockReturning = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockLimit = vi.fn();
+const mockOnConflictDoUpdate = vi.fn();
+
+vi.mock('@colophony/db', () => ({
+  emailTemplates: {
+    id: 'id',
+    organizationId: 'organization_id',
+    templateName: 'template_name',
+    subjectTemplate: 'subject_template',
+    bodyHtml: 'body_html',
+    isActive: 'is_active',
+  },
+  eq: vi.fn((_col: unknown, val: unknown) => val),
+  and: vi.fn((...args: unknown[]) => args),
+}));
+
+import {
+  emailTemplateService,
+  EmailTemplateNotFoundError,
+  InvalidMergeFieldError,
+  sanitizeTemplateHtml,
+  validateMergeFields,
+  interpolateMergeFields,
+} from './email-template.service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTx() {
+  mockReturning.mockReturnValue([]);
+  mockOnConflictDoUpdate.mockReturnValue({ returning: mockReturning });
+  mockValues.mockReturnValue({
+    onConflictDoUpdate: mockOnConflictDoUpdate,
+  });
+  mockInsert.mockReturnValue({ values: mockValues });
+  mockLimit.mockReturnValue([]);
+  mockWhere.mockReturnValue({ limit: mockLimit });
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockSelect.mockReturnValue({ from: mockFrom });
+  mockDelete.mockReturnValue({
+    where: vi.fn().mockReturnValue({ returning: mockReturning }),
+  });
+
+  return {
+    insert: mockInsert,
+    select: mockSelect,
+    delete: mockDelete,
+  } as unknown as Parameters<typeof emailTemplateService.list>[0];
+}
+
+function makeCtx(role = 'ADMIN') {
+  const tx = makeTx();
+  return {
+    tx,
+    actor: { userId: 'user-1', orgId: 'org-1', role },
+    audit: vi.fn(),
+  } as unknown as Parameters<typeof emailTemplateService.upsertWithAudit>[0];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Pure function tests
+// ---------------------------------------------------------------------------
+
+describe('sanitizeTemplateHtml', () => {
+  it('strips disallowed tags', () => {
+    const result = sanitizeTemplateHtml(
+      '<p>Hello</p><script>alert(1)</script>',
+    );
+    expect(result).toBe('<p>Hello</p>');
+  });
+
+  it('allows safe formatting tags', () => {
+    const html = '<p><strong>Bold</strong> and <em>italic</em></p>';
+    expect(sanitizeTemplateHtml(html)).toBe(html);
+  });
+});
+
+describe('validateMergeFields', () => {
+  it('allows valid merge fields', () => {
+    expect(() =>
+      validateMergeFields(
+        '{{submissionTitle}} by {{submitterName}}',
+        'submission-received',
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects invalid merge field in subject', () => {
+    expect(() =>
+      validateMergeFields('{{invalidField}}', 'submission-received'),
+    ).toThrow(InvalidMergeFieldError);
+  });
+
+  it('rejects invalid merge field in body', () => {
+    expect(() =>
+      validateMergeFields('<p>{{badField}}</p>', 'submission-accepted'),
+    ).toThrow(InvalidMergeFieldError);
+  });
+});
+
+describe('interpolateMergeFields', () => {
+  it('replaces merge fields with values', () => {
+    const result = interpolateMergeFields(
+      'Hello {{name}}, welcome to {{org}}',
+      {
+        name: 'Alice',
+        org: 'Acme',
+      },
+    );
+    expect(result).toBe('Hello Alice, welcome to Acme');
+  });
+
+  it('replaces missing fields with empty string', () => {
+    const result = interpolateMergeFields('Hello {{name}}', {});
+    expect(result).toBe('Hello ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Service method tests
+// ---------------------------------------------------------------------------
+
+describe('emailTemplateService', () => {
+  describe('list', () => {
+    it('returns customized template names', async () => {
+      const tx = makeTx();
+      const rows = [
+        { id: 't1', templateName: 'submission-received' },
+        { id: 't2', templateName: 'submission-accepted' },
+      ];
+      mockWhere.mockReturnValue(rows);
+
+      const result = await emailTemplateService.list(tx);
+      expect(result).toEqual(rows);
+    });
+  });
+
+  describe('getByName', () => {
+    it('returns template when exists', async () => {
+      const tx = makeTx();
+      const row = {
+        id: 't1',
+        templateName: 'submission-received',
+        subjectTemplate: 'New: {{submissionTitle}}',
+        bodyHtml: '<p>Received</p>',
+      };
+      mockLimit.mockReturnValue([row]);
+
+      const result = await emailTemplateService.getByName(
+        tx,
+        'submission-received',
+      );
+      expect(result).toEqual(row);
+    });
+
+    it('returns null when no override', async () => {
+      const tx = makeTx();
+      mockLimit.mockReturnValue([]);
+
+      const result = await emailTemplateService.getByName(
+        tx,
+        'submission-received',
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getActiveTemplate', () => {
+    it('returns subjectTemplate and bodyHtml', async () => {
+      const tx = makeTx();
+      const row = {
+        subjectTemplate: 'Subject: {{submissionTitle}}',
+        bodyHtml: '<p>Body</p>',
+      };
+      mockLimit.mockReturnValue([row]);
+
+      const result = await emailTemplateService.getActiveTemplate(
+        tx,
+        'submission-received',
+      );
+      expect(result).toEqual(row);
+    });
+
+    it('returns null when no override', async () => {
+      const tx = makeTx();
+      mockLimit.mockReturnValue([]);
+
+      const result = await emailTemplateService.getActiveTemplate(
+        tx,
+        'submission-received',
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('upsert', () => {
+    it('sanitizes HTML body', async () => {
+      const tx = makeTx();
+      const row = {
+        id: 't1',
+        templateName: 'submission-received',
+        subjectTemplate: 'New: {{submissionTitle}}',
+        bodyHtml: '<p>Received</p>',
+      };
+      mockReturning.mockReturnValue([row]);
+
+      await emailTemplateService.upsert(tx, 'org-1', {
+        templateName: 'submission-received',
+        subjectTemplate: 'New: {{submissionTitle}}',
+        bodyHtml: '<p>Received</p><script>alert(1)</script>',
+      });
+
+      expect(mockValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bodyHtml: '<p>Received</p>',
+        }),
+      );
+    });
+
+    it('rejects invalid merge field in subject', async () => {
+      const tx = makeTx();
+
+      await expect(
+        emailTemplateService.upsert(tx, 'org-1', {
+          templateName: 'submission-received',
+          subjectTemplate: '{{invalidField}}',
+          bodyHtml: '<p>Body</p>',
+        }),
+      ).rejects.toThrow(InvalidMergeFieldError);
+    });
+
+    it('rejects invalid merge field in body', async () => {
+      const tx = makeTx();
+
+      await expect(
+        emailTemplateService.upsert(tx, 'org-1', {
+          templateName: 'submission-received',
+          subjectTemplate: 'Subject',
+          bodyHtml: '<p>{{badField}}</p>',
+        }),
+      ).rejects.toThrow(InvalidMergeFieldError);
+    });
+
+    it('allows valid merge fields', async () => {
+      const tx = makeTx();
+      const row = {
+        id: 't1',
+        templateName: 'submission-received',
+        subjectTemplate: '{{submissionTitle}} {{orgName}}',
+        bodyHtml: '<p>By {{submitterName}}</p>',
+      };
+      mockReturning.mockReturnValue([row]);
+
+      await expect(
+        emailTemplateService.upsert(tx, 'org-1', {
+          templateName: 'submission-received',
+          subjectTemplate: '{{submissionTitle}} {{orgName}}',
+          bodyHtml: '<p>By {{submitterName}}</p>',
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('upsertWithAudit', () => {
+    it('logs CREATED for new template', async () => {
+      const ctx = makeCtx();
+      // getByName returns null (no existing)
+      mockLimit.mockReturnValue([]);
+      const newRow = {
+        id: 't1',
+        templateName: 'submission-received',
+        subjectTemplate: 'Subject',
+        bodyHtml: '<p>Body</p>',
+      };
+      mockReturning.mockReturnValue([newRow]);
+
+      await emailTemplateService.upsertWithAudit(ctx, {
+        templateName: 'submission-received',
+        subjectTemplate: 'Subject',
+        bodyHtml: '<p>Body</p>',
+      });
+
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: AuditResources.EMAIL_TEMPLATE,
+          action: AuditActions.EMAIL_TEMPLATE_CREATED,
+          resourceId: 't1',
+        }),
+      );
+    });
+
+    it('logs UPDATED for existing template', async () => {
+      const ctx = makeCtx();
+      // getByName returns existing row
+      const existing = {
+        id: 't1',
+        templateName: 'submission-received',
+        subjectTemplate: 'Old Subject',
+        bodyHtml: '<p>Old</p>',
+      };
+      mockLimit.mockReturnValueOnce([existing]);
+      mockReturning.mockReturnValue([{ ...existing, subjectTemplate: 'New' }]);
+
+      await emailTemplateService.upsertWithAudit(ctx, {
+        templateName: 'submission-received',
+        subjectTemplate: 'New',
+        bodyHtml: '<p>Old</p>',
+      });
+
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: AuditResources.EMAIL_TEMPLATE,
+          action: AuditActions.EMAIL_TEMPLATE_UPDATED,
+          resourceId: 't1',
+        }),
+      );
+    });
+  });
+
+  describe('deleteWithAudit', () => {
+    it('throws EmailTemplateNotFoundError when not found', async () => {
+      const ctx = makeCtx();
+      mockReturning.mockReturnValue([]);
+
+      await expect(
+        emailTemplateService.deleteWithAudit(ctx, 'submission-received'),
+      ).rejects.toThrow(EmailTemplateNotFoundError);
+    });
+
+    it('deletes and logs audit', async () => {
+      const ctx = makeCtx();
+      const row = {
+        id: 't1',
+        templateName: 'submission-received',
+      };
+      // delete mock returns the row
+      const deleteWhere = vi
+        .fn()
+        .mockReturnValue({ returning: vi.fn().mockReturnValue([row]) });
+      (ctx.tx as unknown as Record<string, unknown>).delete = vi
+        .fn()
+        .mockReturnValue({ where: deleteWhere });
+
+      const result = await emailTemplateService.deleteWithAudit(
+        ctx,
+        'submission-received',
+      );
+
+      expect(result).toEqual(row);
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: AuditResources.EMAIL_TEMPLATE,
+          action: AuditActions.EMAIL_TEMPLATE_DELETED,
+          resourceId: 't1',
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/services/email-template.service.ts
+++ b/apps/api/src/services/email-template.service.ts
@@ -1,0 +1,235 @@
+import sanitizeHtml from 'sanitize-html';
+import { emailTemplates, eq, and, type DrizzleDb } from '@colophony/db';
+import {
+  AuditActions,
+  AuditResources,
+  TEMPLATE_MERGE_FIELDS,
+  type EmailTemplateName,
+  type UpsertEmailTemplateInput,
+} from '@colophony/types';
+import type { ServiceContext } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class EmailTemplateNotFoundError extends Error {
+  constructor(templateName: string) {
+    super(`Email template "${templateName}" not found`);
+    this.name = 'EmailTemplateNotFoundError';
+  }
+}
+
+export class InvalidMergeFieldError extends Error {
+  constructor(field: string, templateName: string) {
+    super(`Invalid merge field "{{${field}}}" for template "${templateName}"`);
+    this.name = 'InvalidMergeFieldError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: [
+    'p',
+    'br',
+    'strong',
+    'b',
+    'em',
+    'i',
+    'u',
+    'a',
+    'ul',
+    'ol',
+    'li',
+    'blockquote',
+    'h1',
+    'h2',
+    'h3',
+  ],
+  allowedAttributes: {
+    a: ['href', 'target', 'rel'],
+  },
+  allowedSchemes: ['http', 'https', 'mailto'],
+};
+
+/** Sanitize HTML to the same allowlist as Tiptap content in templates.ts. */
+export function sanitizeTemplateHtml(html: string): string {
+  return sanitizeHtml(html, SANITIZE_OPTIONS);
+}
+
+const MERGE_FIELD_RE = /\{\{(\w+)\}\}/g;
+
+/**
+ * Validate that all `{{field}}` placeholders in `text` are allowed for the
+ * given template. Throws {@link InvalidMergeFieldError} on the first invalid
+ * field.
+ */
+export function validateMergeFields(
+  text: string,
+  templateName: EmailTemplateName,
+): void {
+  const allowed = TEMPLATE_MERGE_FIELDS[templateName];
+  const re = /\{\{(\w+)\}\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    if (!allowed.includes(match[1])) {
+      throw new InvalidMergeFieldError(match[1], templateName);
+    }
+  }
+}
+
+/**
+ * Replace `{{field}}` placeholders with values from `data`. Missing fields
+ * are replaced with an empty string.
+ */
+export function interpolateMergeFields(
+  template: string,
+  data: Record<string, unknown>,
+): string {
+  return template.replace(MERGE_FIELD_RE, (_, field: string) => {
+    const value = data[field];
+    return value != null ? String(value) : '';
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const emailTemplateService = {
+  /**
+   * List active custom template overrides for the current org (RLS-scoped).
+   * Returns only the id and templateName — the caller builds the full list
+   * by cross-referencing with the static template catalog.
+   */
+  async list(tx: DrizzleDb) {
+    return tx
+      .select({
+        id: emailTemplates.id,
+        templateName: emailTemplates.templateName,
+      })
+      .from(emailTemplates)
+      .where(eq(emailTemplates.isActive, true));
+  },
+
+  /** Get a single template override by name (RLS-scoped, active only). */
+  async getByName(tx: DrizzleDb, templateName: string) {
+    const [row] = await tx
+      .select()
+      .from(emailTemplates)
+      .where(
+        and(
+          eq(emailTemplates.templateName, templateName),
+          eq(emailTemplates.isActive, true),
+        ),
+      )
+      .limit(1);
+
+    return row ?? null;
+  },
+
+  /** Get subject + body for a template (worker use — no full row needed). */
+  async getActiveTemplate(tx: DrizzleDb, templateName: string) {
+    const [row] = await tx
+      .select({
+        subjectTemplate: emailTemplates.subjectTemplate,
+        bodyHtml: emailTemplates.bodyHtml,
+      })
+      .from(emailTemplates)
+      .where(
+        and(
+          eq(emailTemplates.templateName, templateName),
+          eq(emailTemplates.isActive, true),
+        ),
+      )
+      .limit(1);
+
+    return row ?? null;
+  },
+
+  /**
+   * Insert or update a template override. Validates merge fields and
+   * sanitizes the HTML body.
+   */
+  async upsert(tx: DrizzleDb, orgId: string, input: UpsertEmailTemplateInput) {
+    const { templateName, subjectTemplate, bodyHtml } = input;
+
+    // Validate merge fields in both subject and body
+    validateMergeFields(subjectTemplate, templateName);
+    validateMergeFields(bodyHtml, templateName);
+
+    // Sanitize body HTML
+    const sanitizedBody = sanitizeTemplateHtml(bodyHtml);
+
+    const [row] = await tx
+      .insert(emailTemplates)
+      .values({
+        organizationId: orgId,
+        templateName,
+        subjectTemplate,
+        bodyHtml: sanitizedBody,
+      })
+      .onConflictDoUpdate({
+        target: [emailTemplates.organizationId, emailTemplates.templateName],
+        set: {
+          subjectTemplate,
+          bodyHtml: sanitizedBody,
+          isActive: true,
+        },
+      })
+      .returning();
+
+    return row;
+  },
+
+  /** Upsert with audit logging (CREATED or UPDATED). */
+  async upsertWithAudit(ctx: ServiceContext, input: UpsertEmailTemplateInput) {
+    const existing = await this.getByName(ctx.tx, input.templateName);
+    const row = await this.upsert(ctx.tx, ctx.actor.orgId, input);
+
+    await ctx.audit({
+      resource: AuditResources.EMAIL_TEMPLATE,
+      action: existing
+        ? AuditActions.EMAIL_TEMPLATE_UPDATED
+        : AuditActions.EMAIL_TEMPLATE_CREATED,
+      resourceId: row.id,
+      newValue: {
+        templateName: input.templateName,
+        subjectTemplate: input.subjectTemplate,
+      },
+    });
+
+    return row;
+  },
+
+  /** Delete a template override (resets to built-in default). */
+  async delete(tx: DrizzleDb, templateName: string) {
+    const [row] = await tx
+      .delete(emailTemplates)
+      .where(eq(emailTemplates.templateName, templateName))
+      .returning();
+
+    return row ?? null;
+  },
+
+  /** Delete with audit logging. Throws if the template doesn't exist. */
+  async deleteWithAudit(ctx: ServiceContext, templateName: string) {
+    const row = await this.delete(ctx.tx, templateName);
+
+    if (!row) {
+      throw new EmailTemplateNotFoundError(templateName);
+    }
+
+    await ctx.audit({
+      resource: AuditResources.EMAIL_TEMPLATE,
+      action: AuditActions.EMAIL_TEMPLATE_DELETED,
+      resourceId: row.id,
+      newValue: { templateName },
+    });
+
+    return row;
+  },
+};

--- a/apps/api/src/templates/email/__tests__/custom-render.spec.ts
+++ b/apps/api/src/templates/email/__tests__/custom-render.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { renderCustomTemplate } from '../render.js';
+
+describe('renderCustomTemplate', () => {
+  const orgName = 'The Paris Review';
+
+  it('interpolates merge fields in subject', () => {
+    const result = renderCustomTemplate(
+      {
+        subjectTemplate: 'New submission: {{submissionTitle}}',
+        bodyHtml: '<p>A new submission has been received.</p>',
+      },
+      { submissionTitle: 'My Poem' },
+      orgName,
+    );
+
+    expect(result.subject).toBe('New submission: My Poem');
+  });
+
+  it('interpolates merge fields in body', () => {
+    const result = renderCustomTemplate(
+      {
+        subjectTemplate: 'Update',
+        bodyHtml: '<p>Welcome to {{orgName}}.</p>',
+      },
+      { orgName: 'The Paris Review' },
+      orgName,
+    );
+
+    expect(result.html).toContain('Welcome to The Paris Review.');
+  });
+
+  it('sanitizes script tags from body', () => {
+    const result = renderCustomTemplate(
+      {
+        subjectTemplate: 'Test',
+        bodyHtml: '<p>Hello</p><script>alert(1)</script>',
+      },
+      {},
+      orgName,
+    );
+
+    expect(result.html).not.toContain('<script>');
+    expect(result.html).toContain('Hello');
+  });
+
+  it('generates plain text from HTML', () => {
+    const result = renderCustomTemplate(
+      {
+        subjectTemplate: 'Test',
+        bodyHtml: '<p>Hello <strong>World</strong></p>',
+      },
+      {},
+      orgName,
+    );
+
+    expect(result.text).toBe('Hello World');
+  });
+
+  it('wraps body in MJML layout with orgName', () => {
+    const result = renderCustomTemplate(
+      {
+        subjectTemplate: 'Test',
+        bodyHtml: '<p>Content</p>',
+      },
+      {},
+      orgName,
+    );
+
+    expect(result.html).toContain('<!doctype html>');
+    expect(result.html).toContain('The Paris Review');
+  });
+
+  it('replaces missing fields with empty string', () => {
+    const result = renderCustomTemplate(
+      {
+        subjectTemplate: 'Hello {{unknownField}}',
+        bodyHtml: '<p>Greeting {{anotherMissing}}</p>',
+      },
+      {},
+      orgName,
+    );
+
+    expect(result.subject).toBe('Hello ');
+    expect(result.text).toContain('Greeting');
+  });
+});

--- a/apps/api/src/templates/email/index.ts
+++ b/apps/api/src/templates/email/index.ts
@@ -7,6 +7,7 @@ export type {
 } from './types.js';
 export {
   renderEmailTemplate,
+  renderCustomTemplate,
   renderMjml,
   type RenderedEmail,
 } from './render.js';

--- a/apps/api/src/templates/email/render.ts
+++ b/apps/api/src/templates/email/render.ts
@@ -1,6 +1,12 @@
+import sanitizeHtml from 'sanitize-html';
 import mjml2html from 'mjml';
 import type { TemplateName } from './types.js';
 import { templates } from './templates.js';
+import { wrapInLayout } from './layout.js';
+import {
+  sanitizeTemplateHtml,
+  interpolateMergeFields,
+} from '../../services/email-template.service.js';
 
 export interface RenderedEmail {
   html: string;
@@ -24,6 +30,43 @@ export function renderEmailTemplate(
 
   const { mjml, text, subject } = renderer(data);
   const { html } = renderMjml(mjml);
+
+  return { html, text, subject };
+}
+
+/**
+ * Render a custom (user-defined) email template with merge field
+ * interpolation, HTML sanitization, and MJML layout wrapping.
+ */
+export function renderCustomTemplate(
+  customTemplate: { subjectTemplate: string; bodyHtml: string },
+  data: Record<string, unknown>,
+  orgName: string,
+): RenderedEmail {
+  // Interpolate merge fields in subject
+  const subject = interpolateMergeFields(customTemplate.subjectTemplate, data);
+
+  // Interpolate + sanitize body HTML
+  const interpolatedBody = interpolateMergeFields(
+    customTemplate.bodyHtml,
+    data,
+  );
+  const sanitizedBody = sanitizeTemplateHtml(interpolatedBody);
+
+  // Wrap in MJML layout and render
+  const mjmlString = wrapInLayout(
+    `<mj-text>${sanitizedBody}</mj-text>`,
+    orgName,
+  );
+  const { html } = renderMjml(mjmlString);
+
+  // Generate plain text by stripping HTML
+  const text = sanitizeHtml(sanitizedBody, {
+    allowedTags: [],
+    allowedAttributes: {},
+  })
+    .replace(/&nbsp;/g, ' ')
+    .trim();
 
   return { html, text, subject };
 }

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -64,6 +64,10 @@ import {
   MigrationAlreadyActiveError,
   MigrationUserNotFoundError,
 } from '../services/migration.service.js';
+import {
+  EmailTemplateNotFoundError,
+  InvalidMergeFieldError,
+} from '../services/email-template.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -125,6 +129,9 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [MigrationCapabilityError, 'BAD_REQUEST'],
   [MigrationAlreadyActiveError, 'CONFLICT'],
   [MigrationUserNotFoundError, 'NOT_FOUND'],
+  // Email template errors
+  [EmailTemplateNotFoundError, 'NOT_FOUND'],
+  [InvalidMergeFieldError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -22,6 +22,7 @@ import { notificationsRouter } from './routers/notifications.js';
 import { pluginsRouter } from './routers/plugins.js';
 import { webhooksRouter } from './routers/webhooks.js';
 import { correspondenceRouter } from './routers/correspondence.js';
+import { emailTemplatesRouter } from './routers/email-templates.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -65,6 +66,7 @@ export const appRouter = t.router({
   webhooks: webhooksRouter,
   plugins: pluginsRouter,
   correspondence: correspondenceRouter,
+  emailTemplates: emailTemplatesRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/email-templates.ts
+++ b/apps/api/src/trpc/routers/email-templates.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod';
+import {
+  upsertEmailTemplateSchema,
+  getEmailTemplateSchema,
+  previewEmailTemplateSchema,
+  emailTemplateSchema,
+  emailTemplatePreviewSchema,
+  emailTemplateListItemSchema,
+  templateNameValues,
+  TEMPLATE_LABELS,
+  TEMPLATE_MERGE_FIELDS,
+  TEMPLATE_SAMPLE_DATA,
+  type EmailTemplateName,
+} from '@colophony/types';
+import {
+  orgProcedure,
+  adminProcedure,
+  createRouter,
+  requireScopes,
+} from '../init.js';
+import { toServiceContext } from '../../services/context.js';
+import { emailTemplateService } from '../../services/email-template.service.js';
+import { renderCustomTemplate } from '../../templates/email/render.js';
+import { mapServiceError } from '../error-mapper.js';
+
+export const emailTemplatesRouter = createRouter({
+  /** List all 7 template names with customization status. */
+  list: orgProcedure
+    .use(requireScopes('email_templates:read'))
+    .output(z.array(emailTemplateListItemSchema))
+    .query(async ({ ctx }) => {
+      try {
+        const customized = await emailTemplateService.list(ctx.dbTx);
+        const customizedNames = new Set(customized.map((r) => r.templateName));
+
+        return templateNameValues.map((name) => ({
+          templateName: name,
+          label: TEMPLATE_LABELS[name].label,
+          description: TEMPLATE_LABELS[name].description,
+          isCustomized: customizedNames.has(name),
+          mergeFields: [...TEMPLATE_MERGE_FIELDS[name]],
+        }));
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Get a single template override by name. */
+  getByName: orgProcedure
+    .use(requireScopes('email_templates:read'))
+    .input(getEmailTemplateSchema)
+    .output(emailTemplateSchema.nullable())
+    .query(async ({ ctx, input }) => {
+      try {
+        const row = await emailTemplateService.getByName(
+          ctx.dbTx,
+          input.templateName,
+        );
+        if (!row) return null;
+        return {
+          ...row,
+          templateName: row.templateName as EmailTemplateName,
+        };
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Create or update a template override. */
+  upsert: adminProcedure
+    .use(requireScopes('email_templates:write'))
+    .input(upsertEmailTemplateSchema)
+    .output(emailTemplateSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const row = await emailTemplateService.upsertWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+        return {
+          ...row,
+          templateName: row.templateName as EmailTemplateName,
+        };
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Delete a template override (reset to built-in default). */
+  delete: adminProcedure
+    .use(requireScopes('email_templates:write'))
+    .input(getEmailTemplateSchema)
+    .output(emailTemplateSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const row = await emailTemplateService.deleteWithAudit(
+          toServiceContext(ctx),
+          input.templateName,
+        );
+        return {
+          ...row,
+          templateName: row.templateName as EmailTemplateName,
+        };
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Preview a template with sample data (renders full HTML). */
+  preview: orgProcedure
+    .use(requireScopes('email_templates:read'))
+    .input(previewEmailTemplateSchema)
+    .output(emailTemplatePreviewSchema)
+    .mutation(async ({ input }) => {
+      const sampleData =
+        TEMPLATE_SAMPLE_DATA[input.templateName as EmailTemplateName];
+      const rendered = renderCustomTemplate(
+        {
+          subjectTemplate: input.subjectTemplate,
+          bodyHtml: input.bodyHtml,
+        },
+        sampleData,
+        sampleData.orgName ?? 'Your Magazine',
+      );
+
+      return {
+        html: rendered.html,
+        text: rendered.text,
+        subject: rendered.subject,
+      };
+    }),
+});

--- a/apps/api/src/trpc/routers/email-templates.ts
+++ b/apps/api/src/trpc/routers/email-templates.ts
@@ -112,8 +112,7 @@ export const emailTemplatesRouter = createRouter({
     .input(previewEmailTemplateSchema)
     .output(emailTemplatePreviewSchema)
     .mutation(async ({ input }) => {
-      const sampleData =
-        TEMPLATE_SAMPLE_DATA[input.templateName as EmailTemplateName];
+      const sampleData = TEMPLATE_SAMPLE_DATA[input.templateName];
       const rendered = renderCustomTemplate(
         {
           subjectTemplate: input.subjectTemplate,

--- a/apps/api/src/workers/__tests__/email.worker.spec.ts
+++ b/apps/api/src/workers/__tests__/email.worker.spec.ts
@@ -47,19 +47,24 @@ vi.mock('../../services/email-template.service.js', () => ({
   },
 }));
 
-const mockRenderCustomTemplate = vi.fn(
-  () =>
-    ({
-      html: '<p>Custom</p>',
-      text: 'Custom',
-      subject: 'Custom Subject',
-    }) as { html: string; text: string; subject: string },
-);
+const mockRenderCustomTemplate = vi
+  .fn<
+    (
+      template: unknown,
+      data: unknown,
+      orgName: unknown,
+    ) => { html: string; text: string; subject: string }
+  >()
+  .mockReturnValue({
+    html: '<p>Custom</p>',
+    text: 'Custom',
+    subject: 'Custom Subject',
+  });
 vi.mock('../../templates/email/index.js', () => ({
   renderEmailTemplate: (name: unknown, data: unknown) =>
     mockRenderEmailTemplate(name, data),
-  renderCustomTemplate: (...args: unknown[]) =>
-    mockRenderCustomTemplate(...args),
+  renderCustomTemplate: (template: unknown, data: unknown, orgName: unknown) =>
+    mockRenderCustomTemplate(template, data, orgName),
 }));
 
 let workerCallback: (job: unknown) => Promise<unknown>;

--- a/apps/api/src/workers/__tests__/email.worker.spec.ts
+++ b/apps/api/src/workers/__tests__/email.worker.spec.ts
@@ -40,9 +40,26 @@ const mockRenderEmailTemplate = vi.fn(
       subject: 'Test Subject',
     }) as { html: string; text: string; subject: string },
 );
+const mockGetActiveTemplate = vi.fn();
+vi.mock('../../services/email-template.service.js', () => ({
+  emailTemplateService: {
+    getActiveTemplate: (...args: unknown[]) => mockGetActiveTemplate(...args),
+  },
+}));
+
+const mockRenderCustomTemplate = vi.fn(
+  () =>
+    ({
+      html: '<p>Custom</p>',
+      text: 'Custom',
+      subject: 'Custom Subject',
+    }) as { html: string; text: string; subject: string },
+);
 vi.mock('../../templates/email/index.js', () => ({
   renderEmailTemplate: (name: unknown, data: unknown) =>
     mockRenderEmailTemplate(name, data),
+  renderCustomTemplate: (...args: unknown[]) =>
+    mockRenderCustomTemplate(...args),
 }));
 
 let workerCallback: (job: unknown) => Promise<unknown>;
@@ -93,6 +110,8 @@ describe('email worker', () => {
       async (_ctx: unknown, fn: (tx: unknown) => Promise<unknown>) =>
         fn('mock-tx'),
     );
+    // Default: no custom template override
+    mockGetActiveTemplate.mockResolvedValue(null);
   });
 
   it('starts worker and processes job successfully', async () => {

--- a/apps/api/src/workers/email.worker.ts
+++ b/apps/api/src/workers/email.worker.ts
@@ -7,7 +7,11 @@ import type { Env } from '../config/env.js';
 import type { EmailJobData } from '../queues/email.queue.js';
 import { emailService } from '../services/email.service.js';
 import { auditService } from '../services/audit.service.js';
-import { renderEmailTemplate } from '../templates/email/index.js';
+import { emailTemplateService } from '../services/email-template.service.js';
+import {
+  renderEmailTemplate,
+  renderCustomTemplate,
+} from '../templates/email/index.js';
 import type { TemplateName } from '../templates/email/types.js';
 import { createInstrumentedWorker } from '../config/instrumented-worker.js';
 
@@ -36,12 +40,34 @@ export function startEmailWorker(
       });
 
       // Phase 2: Render template (non-retryable — fail immediately on error)
+      // Check for a custom org template override first; fall back to built-in.
       let rendered: { html: string; text: string; subject: string };
       try {
-        rendered = renderEmailTemplate(
-          templateName as TemplateName,
-          templateData,
-        );
+        let customTemplate: {
+          subjectTemplate: string;
+          bodyHtml: string;
+        } | null = null;
+        await withRls({ orgId }, async (tx: DrizzleDb) => {
+          customTemplate = await emailTemplateService.getActiveTemplate(
+            tx,
+            templateName,
+          );
+        });
+
+        if (customTemplate) {
+          const orgNameVal =
+            (templateData as Record<string, unknown>).orgName ?? '';
+          rendered = renderCustomTemplate(
+            customTemplate,
+            templateData,
+            String(orgNameVal),
+          );
+        } else {
+          rendered = renderEmailTemplate(
+            templateName as TemplateName,
+            templateData,
+          );
+        }
       } catch (renderErr) {
         await withRls({ orgId }, async (tx: DrizzleDb) => {
           await emailService.markFailed(

--- a/apps/api/src/workers/email.worker.ts
+++ b/apps/api/src/workers/email.worker.ts
@@ -55,8 +55,7 @@ export function startEmailWorker(
         });
 
         if (customTemplate) {
-          const orgNameVal =
-            (templateData as Record<string, unknown>).orgName ?? '';
+          const orgNameVal = templateData.orgName ?? '';
           rendered = renderCustomTemplate(
             customTemplate,
             templateData,

--- a/apps/web/src/components/organizations/__tests__/email-template-editor.spec.tsx
+++ b/apps/web/src/components/organizations/__tests__/email-template-editor.spec.tsx
@@ -1,0 +1,186 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { EmailTemplateEditor } from "../email-template-editor";
+import "../../../../test/setup";
+
+// --- Mutable mock state ---
+let mockUpsertMutate: jest.Mock;
+let mockUpsertIsPending: boolean;
+let mockDeleteMutate: jest.Mock;
+let mockDeleteIsPending: boolean;
+let mockPreviewMutate: jest.Mock;
+let mockPreviewIsPending: boolean;
+let mockExistingData: Record<string, unknown> | null;
+let mockInsertContent: jest.Mock;
+
+function resetMocks() {
+  mockUpsertMutate = jest.fn();
+  mockUpsertIsPending = false;
+  mockDeleteMutate = jest.fn();
+  mockDeleteIsPending = false;
+  mockPreviewMutate = jest.fn();
+  mockPreviewIsPending = false;
+  mockExistingData = null;
+  mockInsertContent = jest.fn();
+}
+
+jest.mock("@tiptap/react", () => ({
+  useEditor: () => ({
+    getHTML: () => "<p>Test body</p>",
+    commands: {
+      clearContent: jest.fn(),
+      setContent: jest.fn(),
+    },
+    chain: () => ({
+      focus: () => ({
+        toggleBold: () => ({ run: jest.fn() }),
+        toggleItalic: () => ({ run: jest.fn() }),
+        toggleBulletList: () => ({ run: jest.fn() }),
+        toggleOrderedList: () => ({ run: jest.fn() }),
+        setLink: () => ({ run: jest.fn() }),
+        unsetLink: () => ({ run: jest.fn() }),
+        insertContent: () => ({ run: mockInsertContent }),
+      }),
+    }),
+    isActive: () => false,
+  }),
+  EditorContent: ({ editor }: { editor: unknown }) =>
+    editor ? <div data-testid="editor-content">Editor</div> : null,
+}));
+
+jest.mock("@tiptap/starter-kit", () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock("@tiptap/extension-placeholder", () => ({
+  __esModule: true,
+  default: { configure: () => ({}) },
+}));
+
+jest.mock("@tiptap/extension-link", () => ({
+  __esModule: true,
+  default: { configure: () => ({}) },
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+const mockInvalidateList = jest.fn();
+const mockInvalidateGetByName = jest.fn();
+
+jest.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({ isAdmin: true }),
+}));
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    emailTemplates: {
+      getByName: {
+        useQuery: () => ({
+          data: mockExistingData,
+          isPending: false,
+        }),
+      },
+      upsert: {
+        useMutation: (opts: {
+          onSuccess?: () => void;
+          onError?: (err: { message: string }) => void;
+        }) => ({
+          mutate: (...args: unknown[]) => {
+            mockUpsertMutate(...args);
+            if (!mockUpsertIsPending) opts.onSuccess?.();
+          },
+          isPending: mockUpsertIsPending,
+        }),
+      },
+      delete: {
+        useMutation: (opts: {
+          onSuccess?: () => void;
+          onError?: (err: { message: string }) => void;
+        }) => ({
+          mutate: (...args: unknown[]) => {
+            mockDeleteMutate(...args);
+            if (!mockDeleteIsPending) opts.onSuccess?.();
+          },
+          isPending: mockDeleteIsPending,
+        }),
+      },
+      preview: {
+        useMutation: (opts: {
+          onSuccess?: (data: { html: string }) => void;
+          onError?: (err: { message: string }) => void;
+        }) => ({
+          mutate: (...args: unknown[]) => {
+            mockPreviewMutate(...args);
+            opts.onSuccess?.({ html: "<html>preview</html>" });
+          },
+          isPending: mockPreviewIsPending,
+        }),
+      },
+    },
+    useUtils: () => ({
+      emailTemplates: {
+        list: { invalidate: mockInvalidateList },
+        getByName: { invalidate: mockInvalidateGetByName },
+      },
+    }),
+  },
+}));
+
+beforeEach(() => {
+  resetMocks();
+});
+
+describe("EmailTemplateEditor", () => {
+  const defaultProps = {
+    templateName: "submission-received",
+    mergeFields: ["submissionTitle", "submitterName", "orgName"],
+    onClose: jest.fn(),
+  };
+
+  it("renders subject input and body editor", () => {
+    render(<EmailTemplateEditor {...defaultProps} />);
+    expect(screen.getByLabelText("Subject")).toBeInTheDocument();
+    expect(screen.getByTestId("editor-content")).toBeInTheDocument();
+  });
+
+  it("save button calls upsert mutation", () => {
+    render(<EmailTemplateEditor {...defaultProps} />);
+    const subjectInput = screen.getByLabelText("Subject");
+    fireEvent.change(subjectInput, {
+      target: { value: "New: {{submissionTitle}}" },
+    });
+    const saveButton = screen.getByRole("button", { name: /save/i });
+    fireEvent.click(saveButton);
+    expect(mockUpsertMutate).toHaveBeenCalled();
+  });
+
+  it("reset to default shows confirmation dialog", () => {
+    mockExistingData = {
+      id: "t1",
+      templateName: "submission-received",
+      subjectTemplate: "Old Subject",
+      bodyHtml: "<p>Old Body</p>",
+    };
+    render(<EmailTemplateEditor {...defaultProps} />);
+    const resetButton = screen.getByRole("button", {
+      name: /reset to default/i,
+    });
+    fireEvent.click(resetButton);
+    expect(screen.getByText("Reset to default?")).toBeInTheDocument();
+  });
+
+  it("preview button renders template", () => {
+    render(<EmailTemplateEditor {...defaultProps} />);
+    const previewButton = screen.getByRole("button", { name: /preview/i });
+    fireEvent.click(previewButton);
+    expect(mockPreviewMutate).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/organizations/email-template-editor.tsx
+++ b/apps/web/src/components/organizations/email-template-editor.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Placeholder from "@tiptap/extension-placeholder";
+import Link from "@tiptap/extension-link";
+import type { EmailTemplateName } from "@colophony/types";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import {
+  ArrowLeft,
+  Bold,
+  Italic,
+  List,
+  ListOrdered,
+  Link as LinkIcon,
+  Eye,
+  Loader2,
+  RotateCcw,
+} from "lucide-react";
+
+interface EmailTemplateEditorProps {
+  templateName: string;
+  mergeFields: string[];
+  onClose: () => void;
+}
+
+export function EmailTemplateEditor({
+  templateName,
+  mergeFields,
+  onClose,
+}: EmailTemplateEditorProps) {
+  const { isAdmin } = useOrganization();
+  const utils = trpc.useUtils();
+  const [subject, setSubject] = useState("");
+  const [showResetDialog, setShowResetDialog] = useState(false);
+  const [previewHtml, setPreviewHtml] = useState<string | null>(null);
+
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit,
+      Placeholder.configure({ placeholder: "Write your email template..." }),
+      Link.configure({ openOnClick: false }),
+    ],
+    content: "",
+    editable: isAdmin,
+  });
+
+  // Load existing template if customized
+  const { data: existing, isPending: isLoadingTemplate } =
+    trpc.emailTemplates.getByName.useQuery({
+      templateName: templateName as EmailTemplateName,
+    });
+
+  // Sync subject from server data once loaded
+  const [hasSynced, setHasSynced] = useState(false);
+  if (existing && !hasSynced) {
+    setHasSynced(true);
+    setSubject(existing.subjectTemplate);
+  }
+
+  // Sync editor content when existing data loads (editor is async)
+  useEffect(() => {
+    if (existing && editor) {
+      editor.commands.setContent(existing.bodyHtml);
+    }
+  }, [existing, editor]);
+
+  const upsertMutation = trpc.emailTemplates.upsert.useMutation({
+    onSuccess: () => {
+      toast.success("Template saved");
+      utils.emailTemplates.list.invalidate();
+      utils.emailTemplates.getByName.invalidate({
+        templateName: templateName as EmailTemplateName,
+      });
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const deleteMutation = trpc.emailTemplates.delete.useMutation({
+    onSuccess: () => {
+      toast.success("Template reset to default");
+      utils.emailTemplates.list.invalidate();
+      utils.emailTemplates.getByName.invalidate({
+        templateName: templateName as EmailTemplateName,
+      });
+      setShowResetDialog(false);
+      onClose();
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const previewMutation = trpc.emailTemplates.preview.useMutation({
+    onSuccess: (data) => {
+      setPreviewHtml(data.html);
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const handleSave = () => {
+    if (!editor) return;
+    const bodyHtml = editor.getHTML();
+    if (!subject.trim() || !bodyHtml.trim() || bodyHtml === "<p></p>") {
+      toast.error("Subject and body are required");
+      return;
+    }
+
+    upsertMutation.mutate({
+      templateName: templateName as EmailTemplateName,
+      subjectTemplate: subject.trim(),
+      bodyHtml,
+    });
+  };
+
+  const handlePreview = () => {
+    if (!editor) return;
+    const bodyHtml = editor.getHTML();
+    previewMutation.mutate({
+      templateName: templateName as EmailTemplateName,
+      subjectTemplate: subject || "Preview",
+      bodyHtml: bodyHtml || "<p></p>",
+    });
+  };
+
+  const insertMergeField = (field: string) => {
+    if (!editor) return;
+    editor.chain().focus().insertContent(`{{${field}}}`).run();
+  };
+
+  const toggleLink = () => {
+    if (!editor) return;
+    if (editor.isActive("link")) {
+      editor.chain().focus().unsetLink().run();
+      return;
+    }
+    const url = window.prompt("Enter URL:");
+    if (url) {
+      editor.chain().focus().setLink({ href: url }).run();
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="icon" onClick={onClose}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <h3 className="text-lg font-medium">Edit Email Template</h3>
+      </div>
+
+      {/* Subject */}
+      <div className="space-y-2">
+        <Label htmlFor="template-subject">Subject</Label>
+        <div className="flex gap-2">
+          <Input
+            id="template-subject"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            placeholder="Email subject line..."
+            maxLength={512}
+            disabled={!isAdmin}
+          />
+          <Select
+            onValueChange={(field) => setSubject((s) => `${s}{{${field}}}`)}
+          >
+            <SelectTrigger className="w-48">
+              <SelectValue placeholder="Insert field" />
+            </SelectTrigger>
+            <SelectContent>
+              {mergeFields.map((field) => (
+                <SelectItem key={field} value={field}>
+                  {`{{${field}}}`}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Body editor */}
+      <div className="space-y-2">
+        <Label>Body</Label>
+        <div className="border rounded-md">
+          <div className="flex items-center gap-1 border-b p-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => editor?.chain().focus().toggleBold().run()}
+              data-active={editor?.isActive("bold")}
+              disabled={!isAdmin}
+            >
+              <Bold className="h-4 w-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => editor?.chain().focus().toggleItalic().run()}
+              data-active={editor?.isActive("italic")}
+              disabled={!isAdmin}
+            >
+              <Italic className="h-4 w-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => editor?.chain().focus().toggleBulletList().run()}
+              data-active={editor?.isActive("bulletList")}
+              disabled={!isAdmin}
+            >
+              <List className="h-4 w-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => editor?.chain().focus().toggleOrderedList().run()}
+              data-active={editor?.isActive("orderedList")}
+              disabled={!isAdmin}
+            >
+              <ListOrdered className="h-4 w-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={toggleLink}
+              data-active={editor?.isActive("link")}
+              disabled={!isAdmin}
+            >
+              <LinkIcon className="h-4 w-4" />
+            </Button>
+            <div className="ml-auto">
+              <Select onValueChange={insertMergeField} disabled={!isAdmin}>
+                <SelectTrigger className="h-8 w-40 text-xs">
+                  <SelectValue placeholder="Insert field" />
+                </SelectTrigger>
+                <SelectContent>
+                  {mergeFields.map((field) => (
+                    <SelectItem key={field} value={field}>
+                      {`{{${field}}}`}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <EditorContent
+            editor={editor}
+            className="prose prose-sm max-w-none p-3 min-h-[200px] focus-within:outline-none [&_.tiptap]:outline-none"
+          />
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2">
+        {isAdmin && (
+          <>
+            <Button onClick={handleSave} disabled={upsertMutation.isPending}>
+              {upsertMutation.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Save
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handlePreview}
+              disabled={previewMutation.isPending}
+            >
+              {previewMutation.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Eye className="mr-2 h-4 w-4" />
+              )}
+              Preview
+            </Button>
+            {existing && (
+              <Button
+                variant="ghost"
+                className="text-destructive"
+                onClick={() => setShowResetDialog(true)}
+              >
+                <RotateCcw className="mr-2 h-4 w-4" />
+                Reset to Default
+              </Button>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Preview pane */}
+      {previewHtml && (
+        <div className="border rounded-md">
+          <div className="flex items-center justify-between border-b p-2">
+            <span className="text-sm font-medium">Preview</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setPreviewHtml(null)}
+            >
+              Close
+            </Button>
+          </div>
+          <iframe
+            sandbox=""
+            srcDoc={previewHtml}
+            className="w-full min-h-[400px] border-0"
+            title="Email preview"
+          />
+        </div>
+      )}
+
+      {/* Reset confirmation dialog */}
+      <Dialog open={showResetDialog} onOpenChange={setShowResetDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Reset to default?</DialogTitle>
+            <DialogDescription>
+              This will delete your custom template and revert to the built-in
+              default. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowResetDialog(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() =>
+                deleteMutation.mutate({
+                  templateName: templateName as EmailTemplateName,
+                })
+              }
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Reset
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/components/organizations/email-template-editor.tsx
+++ b/apps/web/src/components/organizations/email-template-editor.tsx
@@ -68,10 +68,9 @@ export function EmailTemplateEditor({
   });
 
   // Load existing template if customized
-  const { data: existing, isPending: isLoadingTemplate } =
-    trpc.emailTemplates.getByName.useQuery({
-      templateName: templateName as EmailTemplateName,
-    });
+  const { data: existing } = trpc.emailTemplates.getByName.useQuery({
+    templateName: templateName as EmailTemplateName,
+  });
 
   // Sync subject from server data once loaded
   const [hasSynced, setHasSynced] = useState(false);

--- a/apps/web/src/components/organizations/email-template-settings.tsx
+++ b/apps/web/src/components/organizations/email-template-settings.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmailTemplateEditor } from "./email-template-editor";
+
+export function EmailTemplateSettings() {
+  const { isAdmin } = useOrganization();
+  const [editingTemplate, setEditingTemplate] = useState<string | null>(null);
+
+  const { data: templates, isPending: isLoading } =
+    trpc.emailTemplates.list.useQuery();
+
+  if (editingTemplate) {
+    const tpl = templates?.find((t) => t.templateName === editingTemplate);
+    return (
+      <EmailTemplateEditor
+        templateName={editingTemplate}
+        mergeFields={tpl?.mergeFields ?? []}
+        onClose={() => setEditingTemplate(null)}
+      />
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {templates?.map((tpl) => (
+        <Card
+          key={tpl.templateName}
+          className="cursor-pointer hover:bg-muted/50 transition-colors"
+          onClick={() => setEditingTemplate(tpl.templateName)}
+        >
+          <CardHeader className="py-4">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-base">{tpl.label}</CardTitle>
+              <Badge variant={tpl.isCustomized ? "default" : "secondary"}>
+                {tpl.isCustomized ? "Customized" : "Default"}
+              </Badge>
+            </div>
+            <CardDescription>{tpl.description}</CardDescription>
+          </CardHeader>
+        </Card>
+      ))}
+      {!isAdmin && (
+        <p className="text-sm text-muted-foreground">
+          Only admins can customize email templates.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/organizations/org-settings.tsx
+++ b/apps/web/src/components/organizations/org-settings.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/navigation";
 import { trpc } from "@/lib/trpc";
 import { useOrganization } from "@/hooks/use-organization";
 import { MemberList } from "./member-list";
+import { EmailTemplateSettings } from "./email-template-settings";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -136,6 +137,7 @@ export function OrgSettings() {
         <TabsList>
           <TabsTrigger value="general">General</TabsTrigger>
           <TabsTrigger value="members">Members</TabsTrigger>
+          <TabsTrigger value="email-templates">Email Templates</TabsTrigger>
         </TabsList>
 
         <TabsContent value="general" className="mt-6">
@@ -214,6 +216,22 @@ export function OrgSettings() {
             </CardHeader>
             <CardContent>
               <MemberList />
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="email-templates" className="mt-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Email Templates</CardTitle>
+              <CardDescription>
+                {isAdmin
+                  ? "Customize the email notifications sent by your magazine."
+                  : "Email notification templates (admin access required to customize)."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <EmailTemplateSettings />
             </CardContent>
           </Card>
         </TabsContent>

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -303,12 +303,12 @@
 
 ## Track 7 — Editorial Experience (Pre-Launch)
 
-> **Status:** In progress. PR1 (correspondence) shipped.
+> **Status:** In progress. PR1 (correspondence) shipped. PR2 (email templates) pending.
 
 ### Correspondence & Communication
 
 - [x] [P0] Editor-to-writer personalized correspondence — compose and send messages to individual submitters from the submission detail view; editor comments on status transitions included in notification emails — (persona gap analysis 2026-02-27; done 2026-02-27 PR pending)
-- [ ] [P0] Customizable email templates — admin UI for editing MJML templates per org (acceptance, rejection, under review, custom); replace hardcoded boilerplate with org-branded voice — (persona gap analysis 2026-02-27)
+- [x] [P0] Customizable email templates — admin UI for editing MJML templates per org (acceptance, rejection, under review, custom); replace hardcoded boilerplate with org-branded voice — (persona gap analysis 2026-02-27; done 2026-02-27 PR pending)
 - [ ] [P1] "Revise and resubmit" status — add R&R to SubmissionStatus enum + transition map; editor sends revision notes, writer resubmits against the same submission record — (persona gap analysis 2026-02-27)
 - [ ] [P2] Embed submitter confirmation email — send a receipt email to the address provided in the embed identity step; include submission title, journal name, and a status-check token/link — (persona gap analysis 2026-02-27)
 - [ ] [P2] Embed submitter status check — public page at `/embed/status/:token` where embed submitters (no account) can check their submission status — (persona gap analysis 2026-02-27)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-27 — Track 7 PR2: Customizable Email Templates
+
+### Done
+
+- **Shared types:** `packages/types/src/email-templates.ts` — template names, merge fields catalog, sample data for preview, UI labels, Zod input/output schemas
+- **Audit types:** `EMAIL_TEMPLATE_CREATED/UPDATED/DELETED` actions, `EMAIL_TEMPLATE` resource in audit union
+- **API key scopes:** `email_templates:read` and `email_templates:write` added to scope enum
+- **DB schema:** `email_templates` table with org FK, unique `(org_id, template_name)` index, RLS via `current_org_id()`, `updatedAt` trigger (migration 0038)
+- **Service layer:** `emailTemplateService` with list, getByName, getActiveTemplate, upsert, delete + audit variants; `sanitizeTemplateHtml`, `validateMergeFields`, `interpolateMergeFields` helpers
+- **Custom rendering:** `renderCustomTemplate()` — interpolates merge fields, sanitizes HTML, wraps in MJML layout, generates plain text
+- **Email worker integration:** Phase 2 now checks for custom org template via `withRls` before falling back to built-in `renderEmailTemplate()`
+- **tRPC router:** `emailTemplates.list/getByName/upsert/delete/preview` with scope enforcement and admin-only writes
+- **Frontend:** Template settings list (clickable cards with Customized/Default badges), Tiptap WYSIWYG editor with merge field dropdown inserter, live preview via sandboxed iframe, reset-to-default with confirmation dialog, integrated as new "Email Templates" tab in org settings
+- **Tests:** 20 service tests + 6 render tests + 4 frontend tests, all passing; existing 1284 API tests + email worker tests unbroken
+
+### Decisions
+
+- `templateName` stored as varchar(64) not Postgres enum — simpler migration, TypeScript enum enforced at Zod/router boundary via cast
+- Stateful regex (`/g` flag) replaced with local regex in `validateMergeFields` — module-level `lastIndex` caused cross-call bugs
+- Subject synced from query data using render-time `setState` pattern (not `useEffect`) to satisfy `react-hooks/set-state-in-effect` lint rule
+
+---
+
 ## 2026-02-27 — Track 7 PR1: Editor-to-Writer Correspondence
 
 ### Done

--- a/packages/db/migrations/0038_email_templates.sql
+++ b/packages/db/migrations/0038_email_templates.sql
@@ -40,7 +40,7 @@ CREATE POLICY "email_templates_modify" ON "email_templates"
 GRANT ALL ON "email_templates" TO "app_user";
 
 --> statement-breakpoint
-CREATE TRIGGER email_templates_updated_at
+CREATE TRIGGER "trg_email_templates_set_updated_at"
   BEFORE UPDATE ON "email_templates"
   FOR EACH ROW
-  EXECUTE FUNCTION update_updated_at();
+  EXECUTE FUNCTION set_updated_at();

--- a/packages/db/migrations/0038_email_templates.sql
+++ b/packages/db/migrations/0038_email_templates.sql
@@ -1,0 +1,46 @@
+-- Email Templates — per-org customizable email template overrides
+-- Manual migration (drizzle-kit TUI blocked in non-interactive shell)
+
+--> statement-breakpoint
+CREATE TABLE "email_templates" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "template_name" varchar(64) NOT NULL,
+  "subject_template" varchar(512) NOT NULL,
+  "body_html" text NOT NULL,
+  "is_active" boolean DEFAULT true NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+CREATE UNIQUE INDEX "email_templates_org_name_idx" ON "email_templates" ("organization_id", "template_name");
+
+--> statement-breakpoint
+CREATE INDEX "email_templates_organization_id_idx" ON "email_templates" ("organization_id");
+
+--> statement-breakpoint
+ALTER TABLE "email_templates" ENABLE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+ALTER TABLE "email_templates" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+CREATE POLICY "email_templates_select" ON "email_templates"
+  FOR SELECT
+  USING (organization_id = current_org_id());
+
+--> statement-breakpoint
+CREATE POLICY "email_templates_modify" ON "email_templates"
+  FOR ALL
+  USING (organization_id = current_org_id())
+  WITH CHECK (organization_id = current_org_id());
+
+--> statement-breakpoint
+GRANT ALL ON "email_templates" TO "app_user";
+
+--> statement-breakpoint
+CREATE TRIGGER email_templates_updated_at
+  BEFORE UPDATE ON "email_templates"
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1776600000000,
       "tag": "0037_correspondence_org_insert",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1776800000000,
+      "tag": "0038_email_templates",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/email-templates.ts
+++ b/packages/db/src/schema/email-templates.ts
@@ -1,0 +1,49 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  text,
+  boolean,
+  timestamp,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { organizations } from "./organizations";
+
+export const emailTemplates = pgTable(
+  "email_templates",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    templateName: varchar("template_name", { length: 64 }).notNull(),
+    subjectTemplate: varchar("subject_template", { length: 512 }).notNull(),
+    bodyHtml: text("body_html").notNull(),
+    isActive: boolean("is_active").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("email_templates_org_name_idx").on(
+      table.organizationId,
+      table.templateName,
+    ),
+    index("email_templates_organization_id_idx").on(table.organizationId),
+    pgPolicy("email_templates_select", {
+      for: "select",
+      using: sql`organization_id = current_org_id()`,
+    }),
+    pgPolicy("email_templates_modify", {
+      for: "all",
+      using: sql`organization_id = current_org_id()`,
+      withCheck: sql`organization_id = current_org_id()`,
+    }),
+  ],
+).enableRLS();

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -28,4 +28,5 @@ export * from "./notifications";
 export * from "./notifications-inbox";
 export * from "./webhook-endpoints";
 export * from "./writer-workspace";
+export * from "./email-templates";
 export * from "./relations";

--- a/packages/types/src/api-key.ts
+++ b/packages/types/src/api-key.ts
@@ -33,6 +33,8 @@ export const apiKeyScopeSchema = z
     "issues:write",
     "cms:read",
     "cms:write",
+    "email_templates:read",
+    "email_templates:write",
     "audit:read",
   ])
   .describe("Permission scope for the API key");

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -211,6 +211,11 @@ export const AuditActions = {
   CORRESPONDENCE_SENT: "CORRESPONDENCE_SENT",
   CORRESPONDENCE_AUTO_CAPTURED: "CORRESPONDENCE_AUTO_CAPTURED",
 
+  // Email template lifecycle
+  EMAIL_TEMPLATE_CREATED: "EMAIL_TEMPLATE_CREATED",
+  EMAIL_TEMPLATE_UPDATED: "EMAIL_TEMPLATE_UPDATED",
+  EMAIL_TEMPLATE_DELETED: "EMAIL_TEMPLATE_DELETED",
+
   // Audit access
   AUDIT_ACCESSED: "AUDIT_ACCESSED",
 } as const;
@@ -247,6 +252,7 @@ export const AuditResources = {
   WEBHOOK_ENDPOINT: "webhook_endpoint",
   WEBHOOK_DELIVERY: "webhook_delivery",
   CORRESPONDENCE: "correspondence",
+  EMAIL_TEMPLATE: "email_template",
   AUDIT: "audit",
 } as const;
 
@@ -554,6 +560,14 @@ export interface CorrespondenceAuditParams extends BaseAuditParams {
     | typeof AuditActions.CORRESPONDENCE_AUTO_CAPTURED;
 }
 
+export interface EmailTemplateAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.EMAIL_TEMPLATE;
+  action:
+    | typeof AuditActions.EMAIL_TEMPLATE_CREATED
+    | typeof AuditActions.EMAIL_TEMPLATE_UPDATED
+    | typeof AuditActions.EMAIL_TEMPLATE_DELETED;
+}
+
 export interface AuditAccessAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.AUDIT;
   action: typeof AuditActions.AUDIT_ACCESSED;
@@ -596,6 +610,7 @@ export type AuditLogParams =
   | WebhookEndpointAuditParams
   | WebhookDeliveryAuditParams
   | CorrespondenceAuditParams
+  | EmailTemplateAuditParams
   | AuditAccessAuditParams
   | SystemAuditParams;
 

--- a/packages/types/src/email-templates.ts
+++ b/packages/types/src/email-templates.ts
@@ -1,0 +1,221 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Template names — source of truth for all email template identifiers
+// ---------------------------------------------------------------------------
+
+export const templateNameValues = [
+  "submission-received",
+  "submission-accepted",
+  "submission-rejected",
+  "submission-withdrawn",
+  "contract-ready",
+  "copyeditor-assigned",
+  "editor-message",
+] as const;
+
+export const templateNameSchema = z.enum(templateNameValues);
+export type EmailTemplateName = z.infer<typeof templateNameSchema>;
+
+// ---------------------------------------------------------------------------
+// Merge fields — allowed {{field}} placeholders per template
+// ---------------------------------------------------------------------------
+
+export const TEMPLATE_MERGE_FIELDS: Record<
+  EmailTemplateName,
+  readonly string[]
+> = {
+  "submission-received": [
+    "submissionTitle",
+    "submitterName",
+    "submitterEmail",
+    "orgName",
+    "submissionUrl",
+  ],
+  "submission-accepted": [
+    "submissionTitle",
+    "submitterName",
+    "submitterEmail",
+    "orgName",
+    "editorComment",
+  ],
+  "submission-rejected": [
+    "submissionTitle",
+    "submitterName",
+    "submitterEmail",
+    "orgName",
+    "editorComment",
+  ],
+  "submission-withdrawn": [
+    "submissionTitle",
+    "submitterName",
+    "submitterEmail",
+    "orgName",
+  ],
+  "contract-ready": ["submissionTitle", "signerName", "orgName", "contractUrl"],
+  "copyeditor-assigned": [
+    "submissionTitle",
+    "copyeditorName",
+    "orgName",
+    "pipelineUrl",
+  ],
+  "editor-message": [
+    "submissionTitle",
+    "orgName",
+    "editorName",
+    "messageSubject",
+    "messageBody",
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Sample data — used for live preview rendering
+// ---------------------------------------------------------------------------
+
+export const TEMPLATE_SAMPLE_DATA: Record<
+  EmailTemplateName,
+  Record<string, string>
+> = {
+  "submission-received": {
+    submissionTitle: "The Garden of Forking Paths",
+    submitterName: "Jorge Luis Borges",
+    submitterEmail: "borges@example.com",
+    orgName: "The Paris Review",
+    submissionUrl: "https://example.com/submissions/123",
+  },
+  "submission-accepted": {
+    submissionTitle: "The Garden of Forking Paths",
+    submitterName: "Jorge Luis Borges",
+    submitterEmail: "borges@example.com",
+    orgName: "The Paris Review",
+    editorComment:
+      "We loved your piece and would like to feature it in our spring issue.",
+  },
+  "submission-rejected": {
+    submissionTitle: "The Garden of Forking Paths",
+    submitterName: "Jorge Luis Borges",
+    submitterEmail: "borges@example.com",
+    orgName: "The Paris Review",
+    editorComment:
+      "While we admired the craft, it wasn't the right fit for our current issue.",
+  },
+  "submission-withdrawn": {
+    submissionTitle: "The Garden of Forking Paths",
+    submitterName: "Jorge Luis Borges",
+    submitterEmail: "borges@example.com",
+    orgName: "The Paris Review",
+  },
+  "contract-ready": {
+    submissionTitle: "The Garden of Forking Paths",
+    signerName: "Jorge Luis Borges",
+    orgName: "The Paris Review",
+    contractUrl: "https://example.com/contracts/456",
+  },
+  "copyeditor-assigned": {
+    submissionTitle: "The Garden of Forking Paths",
+    copyeditorName: "Maxwell Perkins",
+    orgName: "The Paris Review",
+    pipelineUrl: "https://example.com/pipeline/789",
+  },
+  "editor-message": {
+    submissionTitle: "The Garden of Forking Paths",
+    orgName: "The Paris Review",
+    editorName: "George Plimpton",
+    messageSubject: "A note about your submission",
+    messageBody: "<p>We have a few questions about your piece.</p>",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Labels — human-readable names and descriptions for each template
+// ---------------------------------------------------------------------------
+
+export const TEMPLATE_LABELS: Record<
+  EmailTemplateName,
+  { label: string; description: string }
+> = {
+  "submission-received": {
+    label: "Submission Received",
+    description:
+      "Sent to editors when a new submission is received by the magazine.",
+  },
+  "submission-accepted": {
+    label: "Submission Accepted",
+    description: "Sent to the writer when their submission is accepted.",
+  },
+  "submission-rejected": {
+    label: "Submission Rejected",
+    description: "Sent to the writer when their submission is declined.",
+  },
+  "submission-withdrawn": {
+    label: "Submission Withdrawn",
+    description: "Sent to editors when a writer withdraws their submission.",
+  },
+  "contract-ready": {
+    label: "Contract Ready",
+    description: "Sent to the writer when a contract is ready to sign.",
+  },
+  "copyeditor-assigned": {
+    label: "Copyeditor Assigned",
+    description: "Sent to the copyeditor when they are assigned a submission.",
+  },
+  "editor-message": {
+    label: "Editor Message",
+    description: "Wrapper for personalized messages from editors to writers.",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Input schemas
+// ---------------------------------------------------------------------------
+
+export const upsertEmailTemplateSchema = z.object({
+  templateName: templateNameSchema,
+  subjectTemplate: z.string().trim().min(1).max(512),
+  bodyHtml: z.string().trim().min(1).max(65535),
+});
+
+export type UpsertEmailTemplateInput = z.infer<
+  typeof upsertEmailTemplateSchema
+>;
+
+export const getEmailTemplateSchema = z.object({
+  templateName: templateNameSchema,
+});
+
+export const previewEmailTemplateSchema = z.object({
+  templateName: templateNameSchema,
+  subjectTemplate: z.string().trim().min(1).max(512),
+  bodyHtml: z.string().trim().min(1).max(65535),
+});
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+export const emailTemplateSchema = z.object({
+  id: z.string().uuid(),
+  organizationId: z.string().uuid(),
+  templateName: templateNameSchema,
+  subjectTemplate: z.string(),
+  bodyHtml: z.string(),
+  isActive: z.boolean(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type EmailTemplateResponse = z.infer<typeof emailTemplateSchema>;
+
+export const emailTemplatePreviewSchema = z.object({
+  html: z.string(),
+  text: z.string(),
+  subject: z.string(),
+});
+
+export const emailTemplateListItemSchema = z.object({
+  templateName: templateNameSchema,
+  label: z.string(),
+  description: z.string(),
+  isCustomized: z.boolean(),
+  mergeFields: z.array(z.string()),
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -27,3 +27,4 @@ export * from "./webhook";
 export * from "./correspondence";
 export * from "./csr";
 export * from "./status-mapping";
+export * from "./email-templates";


### PR DESCRIPTION
## Summary

- Full-stack per-org email template customization: DB schema, service layer, tRPC router, Tiptap WYSIWYG editor
- 7 template types (submission-received through editor-message) with merge field validation and live preview
- Email worker transparently checks for custom templates before falling back to built-in defaults
- 30 new tests (20 service + 6 render + 4 frontend), all existing tests unbroken

## Test plan

- [ ] `pnpm type-check` passes all 14 packages
- [ ] `pnpm test` — 1284 API tests + 4 frontend tests pass
- [ ] `pnpm lint` — 0 errors
- [ ] Apply migration on dev DB (`pnpm db:migrate`)
- [ ] Navigate to Org Settings → Email Templates tab
- [ ] Click a template → editor loads
- [ ] Type subject with merge fields, write body, click Preview → rendered HTML in iframe
- [ ] Save → toast success, return to list with "Customized" badge
- [ ] Reset to Default → confirmation → template deleted → badge reverts
- [ ] Trigger a notification → email uses custom template when set, built-in when not