### PR TITLE
feat(hopper): reviewer assignment + revise-and-resubmit

### DIFF
--- a/apps/api/src/graphql/error-mapper.ts
+++ b/apps/api/src/graphql/error-mapper.ts
@@ -54,6 +54,11 @@ import {
 } from '../services/issue.service.js';
 import { CmsConnectionNotFoundError } from '../services/cms-connection.service.js';
 import { SimSubConflictError } from '../services/simsub.service.js';
+import {
+  ReviewerAlreadyAssignedError,
+  ReviewerNotAssignedError,
+  ReviewerNotOrgMemberError,
+} from '../services/submission-reviewer.service.js';
 
 type GraphQLErrorCode = string;
 
@@ -107,6 +112,10 @@ const errorCodeMap: [new (...args: never[]) => Error, GraphQLErrorCode][] = [
   [IssueItemAlreadyExistsError, 'CONFLICT'],
   // CMS errors
   [CmsConnectionNotFoundError, 'NOT_FOUND'],
+  // Reviewer errors
+  [ReviewerAlreadyAssignedError, 'CONFLICT'],
+  [ReviewerNotAssignedError, 'NOT_FOUND'],
+  [ReviewerNotOrgMemberError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/graphql/resolvers/submissions.ts
+++ b/apps/api/src/graphql/resolvers/submissions.ts
@@ -11,10 +11,15 @@ import { requireOrgContext, requireScopes } from '../guards.js';
 import { toServiceContext } from '../../services/context.js';
 import { assertEditorOrAdmin } from '../../services/errors.js';
 import { submissionService } from '../../services/submission.service.js';
+import { submissionReviewerService } from '../../services/submission-reviewer.service.js';
 import { simsubService } from '../../services/simsub.service.js';
 import { mapServiceError } from '../error-mapper.js';
 import { validateEnv } from '../../config/env.js';
-import { SubmissionType, SubmissionHistoryType } from '../types/index.js';
+import {
+  SubmissionType,
+  SubmissionHistoryType,
+  SubmissionReviewerType,
+} from '../types/index.js';
 import {
   SubmissionStatusChangePayload,
   SuccessPayload,
@@ -165,6 +170,36 @@ builder.queryFields((t) => ({
         return await submissionService.getByIdWithAccess(
           toServiceContext(orgCtx),
           id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * List reviewers assigned to a submission.
+   */
+  submissionReviewers: t.field({
+    type: [SubmissionReviewerType],
+    description:
+      'List reviewers assigned to a submission. Visible to submitter and editors/admins.',
+    args: {
+      submissionId: t.arg.string({
+        required: true,
+        description: 'Submission ID.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'submissions:read');
+      const { id: submissionId } = idParamSchema.parse({
+        id: args.submissionId,
+      });
+      try {
+        return await submissionReviewerService.listBySubmissionWithAccess(
+          toServiceContext(orgCtx),
+          submissionId,
         );
       } catch (e) {
         mapServiceError(e);
@@ -400,6 +435,107 @@ builder.mutationFields((t) => ({
           toServiceContext(orgCtx),
           id,
           args.manuscriptVersionId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Assign reviewers to a submission (editor/admin only).
+   */
+  assignReviewers: t.field({
+    type: [SubmissionReviewerType],
+    description:
+      'Assign one or more org members as reviewers on a submission. Requires EDITOR or ADMIN role.',
+    args: {
+      submissionId: t.arg.string({
+        required: true,
+        description: 'Submission ID.',
+      }),
+      reviewerUserIds: t.arg.stringList({
+        required: true,
+        description: 'User IDs to assign as reviewers.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'submissions:write');
+      const { id: submissionId } = idParamSchema.parse({
+        id: args.submissionId,
+      });
+      try {
+        return await submissionReviewerService.assignWithAudit(
+          toServiceContext(orgCtx),
+          submissionId,
+          args.reviewerUserIds,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Unassign a reviewer from a submission (editor/admin only).
+   */
+  unassignReviewer: t.field({
+    type: SuccessPayload,
+    description:
+      'Remove a reviewer from a submission. Requires EDITOR or ADMIN role.',
+    args: {
+      submissionId: t.arg.string({
+        required: true,
+        description: 'Submission ID.',
+      }),
+      reviewerUserId: t.arg.string({
+        required: true,
+        description: 'User ID to unassign.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'submissions:write');
+      const { id: submissionId } = idParamSchema.parse({
+        id: args.submissionId,
+      });
+      try {
+        await submissionReviewerService.unassignWithAudit(
+          toServiceContext(orgCtx),
+          submissionId,
+          args.reviewerUserId,
+        );
+        return { success: true };
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Mark a submission as read by the current reviewer.
+   */
+  markSubmissionRead: t.field({
+    type: SuccessPayload,
+    description:
+      'Mark the current user as having read the submission. Idempotent.',
+    args: {
+      submissionId: t.arg.string({
+        required: true,
+        description: 'Submission ID.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'submissions:read');
+      const { id: submissionId } = idParamSchema.parse({
+        id: args.submissionId,
+      });
+      try {
+        return await submissionReviewerService.markReadWithAudit(
+          toServiceContext(orgCtx),
+          submissionId,
         );
       } catch (e) {
         mapServiceError(e);

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -3,6 +3,7 @@ export { SubmissionStatusEnum, ScanStatusEnum, RoleEnum } from './enums.js';
 export { UserType } from './user.js';
 export { OrganizationType, OrganizationMemberType } from './organization.js';
 export { SubmissionType, SubmissionHistoryType } from './submission.js';
+export { SubmissionReviewerType } from './submission-reviewer.js';
 export { FileType } from './file.js';
 export { ManuscriptType, ManuscriptVersionType } from './manuscript.js';
 export { AuditEventType } from './audit.js';

--- a/apps/api/src/graphql/types/submission-reviewer.ts
+++ b/apps/api/src/graphql/types/submission-reviewer.ts
@@ -1,0 +1,40 @@
+import type { SubmissionReviewer } from '@colophony/types';
+import { builder } from '../builder.js';
+import { RoleEnum } from './enums.js';
+
+export const SubmissionReviewerType = builder
+  .objectRef<SubmissionReviewer>('SubmissionReviewer')
+  .implement({
+    description:
+      'A reviewer assignment on a submission, tracking who has been assigned and whether they have read it.',
+    fields: (t) => ({
+      id: t.exposeString('id', { description: 'Assignment record ID.' }),
+      submissionId: t.exposeString('submissionId', {
+        description: 'ID of the submission.',
+      }),
+      reviewerUserId: t.exposeString('reviewerUserId', {
+        description: 'ID of the reviewer user.',
+      }),
+      reviewerEmail: t.exposeString('reviewerEmail', {
+        description: "Reviewer's email address.",
+      }),
+      reviewerRole: t.expose('reviewerRole', {
+        type: RoleEnum,
+        description: "Reviewer's role in the organization.",
+      }),
+      assignedBy: t.exposeString('assignedBy', {
+        nullable: true,
+        description: 'ID of the user who assigned this reviewer.',
+      }),
+      assignedAt: t.expose('assignedAt', {
+        type: 'DateTime',
+        description: 'When the reviewer was assigned.',
+      }),
+      readAt: t.expose('readAt', {
+        type: 'DateTime',
+        nullable: true,
+        description:
+          'When the reviewer first viewed the submission (null = unread).',
+      }),
+    }),
+  });

--- a/apps/api/src/inngest/events.ts
+++ b/apps/api/src/inngest/events.ts
@@ -140,12 +140,23 @@ export interface HopperSubmissionReviseAndResubmitEvent {
   };
 }
 
+export interface HopperReviewerAssignedEvent {
+  name: 'hopper/reviewer.assigned';
+  data: {
+    orgId: string;
+    submissionId: string;
+    reviewerUserId: string;
+    assignedBy: string;
+  };
+}
+
 export type HopperEvent =
   | HopperSubmissionSubmittedEvent
   | HopperSubmissionAcceptedEvent
   | HopperSubmissionRejectedEvent
   | HopperSubmissionWithdrawnEvent
-  | HopperSubmissionReviseAndResubmitEvent;
+  | HopperSubmissionReviseAndResubmitEvent
+  | HopperReviewerAssignedEvent;
 
 // ---------------------------------------------------------------------------
 // Union type for all Slate events

--- a/apps/api/src/inngest/functions/index.ts
+++ b/apps/api/src/inngest/functions/index.ts
@@ -12,4 +12,5 @@ export {
   contractReadyNotification,
   copyeditorAssignedNotification,
 } from './slate-notifications.js';
+export { reviewerAssignedNotification } from './reviewer-notifications.js';
 export { webhookDelivery } from './webhook-delivery.js';

--- a/apps/api/src/inngest/functions/reviewer-notifications.ts
+++ b/apps/api/src/inngest/functions/reviewer-notifications.ts
@@ -1,0 +1,165 @@
+import {
+  withRls,
+  db,
+  submissions,
+  organizations,
+  users,
+  eq,
+} from '@colophony/db';
+import { inngest } from '../client.js';
+import type { HopperReviewerAssignedEvent } from '../events.js';
+import { notificationPreferenceService } from '../../services/notification-preference.service.js';
+import { emailService } from '../../services/email.service.js';
+import { auditService } from '../../services/audit.service.js';
+import { enqueueEmail } from '../../queues/email.queue.js';
+import { validateEnv } from '../../config/env.js';
+import { AuditActions, AuditResources } from '@colophony/types';
+import { queueInAppNotification } from '../helpers/queue-in-app-notification.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getSubmissionAndOrg(orgId: string, submissionId: string) {
+  return withRls({ orgId }, async (tx) => {
+    const [submission] = await tx
+      .select({ id: submissions.id, title: submissions.title })
+      .from(submissions)
+      .where(eq(submissions.id, submissionId))
+      .limit(1);
+
+    const [org] = await tx
+      .select({ name: organizations.name })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+
+    return { submission, orgName: org?.name ?? 'Unknown Organization' };
+  });
+}
+
+async function getUserEmail(userId: string) {
+  const [user] = await db
+    .select({ email: users.email })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return user ?? null;
+}
+
+async function queueEmailForRecipient(params: {
+  orgId: string;
+  userId: string;
+  email: string;
+  eventType: string;
+  templateName: string;
+  templateData: Record<string, unknown>;
+  subject: string;
+}) {
+  const env = validateEnv();
+  if (env.EMAIL_PROVIDER === 'none') return;
+
+  const enabled = await withRls({ orgId: params.orgId }, async (tx) => {
+    return notificationPreferenceService.isEmailEnabled(
+      tx,
+      params.orgId,
+      params.userId,
+      params.eventType,
+    );
+  });
+
+  if (!enabled) return;
+
+  const emailSend = await withRls({ orgId: params.orgId }, async (tx) => {
+    const row = await emailService.create(tx, {
+      organizationId: params.orgId,
+      recipientUserId: params.userId,
+      recipientEmail: params.email,
+      templateName: params.templateName,
+      eventType: params.eventType,
+      subject: params.subject,
+    });
+    await auditService.log(tx, {
+      resource: AuditResources.EMAIL,
+      action: AuditActions.EMAIL_QUEUED,
+      resourceId: row.id,
+      organizationId: params.orgId,
+      newValue: {
+        to: params.email,
+        templateName: params.templateName,
+        eventType: params.eventType,
+      },
+    });
+    return row;
+  });
+
+  await enqueueEmail(env, {
+    emailSendId: emailSend.id,
+    orgId: params.orgId,
+    to: params.email,
+    from: env.SMTP_FROM ?? env.SENDGRID_FROM ?? 'noreply@colophony.dev',
+    templateName: params.templateName,
+    templateData: params.templateData,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Inngest function
+// ---------------------------------------------------------------------------
+
+export const reviewerAssignedNotification = inngest.createFunction(
+  {
+    id: 'reviewer-assigned-notification',
+    name: 'Reviewer Assigned Notification',
+    retries: 3,
+  },
+  { event: 'hopper/reviewer.assigned' },
+  async ({ event, step }) => {
+    const { orgId, submissionId, reviewerUserId, assignedBy } =
+      event.data as HopperReviewerAssignedEvent['data'];
+
+    const { submission, orgName } = await step.run('resolve-data', async () =>
+      getSubmissionAndOrg(orgId, submissionId),
+    );
+
+    if (!submission) return { skipped: true, reason: 'submission-not-found' };
+
+    const reviewer = await step.run('get-reviewer', async () =>
+      getUserEmail(reviewerUserId),
+    );
+
+    if (!reviewer) return { skipped: true, reason: 'reviewer-not-found' };
+
+    const assigner = await step.run('get-assigner', async () =>
+      getUserEmail(assignedBy),
+    );
+
+    await step.run('queue-email', async () => {
+      await queueEmailForRecipient({
+        orgId,
+        userId: reviewerUserId,
+        email: reviewer.email,
+        eventType: 'reviewer.assigned',
+        templateName: 'reviewer-assigned',
+        templateData: {
+          submissionTitle: submission.title,
+          orgName,
+          assignedByName: assigner?.email ?? 'An editor',
+        },
+        subject: `You've been assigned to review: ${submission.title}`,
+      });
+    });
+
+    await step.run('queue-in-app', async () => {
+      await queueInAppNotification({
+        orgId,
+        userId: reviewerUserId,
+        eventType: 'reviewer.assigned',
+        title: `You've been assigned to review: ${submission.title}`,
+        link: `/submissions/${submissionId}`,
+      });
+    });
+
+    return { notified: 1 };
+  },
+);

--- a/apps/api/src/inngest/serve.ts
+++ b/apps/api/src/inngest/serve.ts
@@ -12,6 +12,7 @@ import {
   submissionWithdrawnNotification,
   contractReadyNotification,
   copyeditorAssignedNotification,
+  reviewerAssignedNotification,
   webhookDelivery,
 } from './functions/index.js';
 
@@ -38,6 +39,7 @@ export async function registerInngestRoutes(
       submissionWithdrawnNotification,
       contractReadyNotification,
       copyeditorAssignedNotification,
+      reviewerAssignedNotification,
       webhookDelivery,
     ],
   });

--- a/apps/api/src/rest/error-mapper.ts
+++ b/apps/api/src/rest/error-mapper.ts
@@ -66,6 +66,11 @@ import {
   MigrationAlreadyActiveError,
   MigrationUserNotFoundError,
 } from '../services/migration.service.js';
+import {
+  ReviewerAlreadyAssignedError,
+  ReviewerNotAssignedError,
+  ReviewerNotOrgMemberError,
+} from '../services/submission-reviewer.service.js';
 
 type ORPCErrorCode = ConstructorParameters<typeof ORPCError>[0];
 
@@ -129,6 +134,10 @@ const errorCodeMap: [new (...args: never[]) => Error, ORPCErrorCode][] = [
   [MigrationCapabilityError, 'BAD_REQUEST'],
   [MigrationAlreadyActiveError, 'CONFLICT'],
   [MigrationUserNotFoundError, 'NOT_FOUND'],
+  // Reviewer errors
+  [ReviewerAlreadyAssignedError, 'CONFLICT'],
+  [ReviewerNotAssignedError, 'NOT_FOUND'],
+  [ReviewerNotOrgMemberError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/rest/routers/submissions.ts
+++ b/apps/api/src/rest/routers/submissions.ts
@@ -11,9 +11,11 @@ import {
   fileSchema,
   paginatedResponseSchema,
   successResponseSchema,
+  submissionReviewerSchema,
 } from '@colophony/types';
 import { restPaginationQuery } from '@colophony/api-contracts';
 import { submissionService } from '../../services/submission.service.js';
+import { submissionReviewerService } from '../../services/submission-reviewer.service.js';
 import { simsubService } from '../../services/simsub.service.js';
 import { toServiceContext } from '../../services/context.js';
 import { assertEditorOrAdmin } from '../../services/errors.js';
@@ -316,6 +318,121 @@ const history = orgProcedure
   });
 
 // ---------------------------------------------------------------------------
+// Reviewer routes
+// ---------------------------------------------------------------------------
+
+const listReviewers = orgProcedure
+  .use(requireScopes('submissions:read'))
+  .route({
+    method: 'GET',
+    path: '/submissions/{id}/reviewers',
+    summary: 'List submission reviewers',
+    description:
+      'Returns reviewers assigned to a submission. Visible to the submitter and editors/admins.',
+    operationId: 'listSubmissionReviewers',
+    tags: ['Submissions'],
+  })
+  .input(idParamSchema)
+  .output(z.array(submissionReviewerSchema))
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionReviewerService.listBySubmissionWithAccess(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const assignReviewers = orgProcedure
+  .use(requireScopes('submissions:write'))
+  .route({
+    method: 'POST',
+    path: '/submissions/{id}/reviewers',
+    successStatus: 201,
+    summary: 'Assign reviewers',
+    description:
+      'Assign one or more org members as reviewers on a submission. Requires EDITOR or ADMIN role.',
+    operationId: 'assignSubmissionReviewers',
+    tags: ['Submissions'],
+  })
+  .input(
+    idParamSchema.merge(
+      z.object({
+        reviewerUserIds: z.array(z.string().uuid()).min(1).max(20),
+      }),
+    ),
+  )
+  .output(z.array(submissionReviewerSchema))
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionReviewerService.assignWithAudit(
+        toServiceContext(context),
+        input.id,
+        input.reviewerUserIds,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const unassignReviewer = orgProcedure
+  .use(requireScopes('submissions:write'))
+  .route({
+    method: 'DELETE',
+    path: '/submissions/{id}/reviewers/{reviewerUserId}',
+    summary: 'Unassign a reviewer',
+    description:
+      'Remove a reviewer from a submission. Requires EDITOR or ADMIN role.',
+    operationId: 'unassignSubmissionReviewer',
+    tags: ['Submissions'],
+  })
+  .input(
+    z.object({
+      id: z.string().uuid(),
+      reviewerUserId: z.string().uuid(),
+    }),
+  )
+  .output(successResponseSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      await submissionReviewerService.unassignWithAudit(
+        toServiceContext(context),
+        input.id,
+        input.reviewerUserId,
+      );
+      return { success: true as const };
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const markReviewerRead = orgProcedure
+  .use(requireScopes('submissions:read'))
+  .route({
+    method: 'POST',
+    path: '/submissions/{id}/reviewers/mark-read',
+    summary: 'Mark submission as read',
+    description:
+      'Mark the current user as having read the submission. Idempotent — no-op if not a reviewer or already read.',
+    operationId: 'markSubmissionReviewerRead',
+    tags: ['Submissions'],
+  })
+  .input(idParamSchema)
+  .output(successResponseSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionReviewerService.markReadWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+// ---------------------------------------------------------------------------
 // Assembled router
 // ---------------------------------------------------------------------------
 
@@ -331,4 +448,8 @@ export const submissionsRouter = {
   withdraw,
   updateStatus,
   history,
+  listReviewers,
+  assignReviewers,
+  unassignReviewer,
+  markReviewerRead,
 };

--- a/apps/api/src/services/submission-reviewer.service.ts
+++ b/apps/api/src/services/submission-reviewer.service.ts
@@ -1,0 +1,306 @@
+import {
+  submissionReviewers,
+  submissions,
+  organizationMembers,
+  users,
+  eq,
+  and,
+  isNull,
+  type DrizzleDb,
+} from '@colophony/db';
+import { inArray } from 'drizzle-orm';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { SubmissionReviewer } from '@colophony/types';
+import { enqueueOutboxEvent } from './outbox.js';
+import type { ServiceContext } from './types.js';
+import { assertEditorOrAdmin, assertOwnerOrEditor } from './errors.js';
+import { SubmissionNotFoundError } from './submission.service.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class ReviewerAlreadyAssignedError extends Error {
+  constructor(reviewerUserId: string) {
+    super(
+      `Reviewer "${reviewerUserId}" is already assigned to this submission`,
+    );
+    this.name = 'ReviewerAlreadyAssignedError';
+  }
+}
+
+export class ReviewerNotAssignedError extends Error {
+  constructor(reviewerUserId: string) {
+    super(`Reviewer "${reviewerUserId}" is not assigned to this submission`);
+    this.name = 'ReviewerNotAssignedError';
+  }
+}
+
+export class ReviewerNotOrgMemberError extends Error {
+  constructor(reviewerUserId: string) {
+    super(`User "${reviewerUserId}" is not a member of this organization`);
+    this.name = 'ReviewerNotOrgMemberError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure data methods (accept DrizzleDb tx)
+// ---------------------------------------------------------------------------
+
+async function assign(
+  tx: DrizzleDb,
+  orgId: string,
+  submissionId: string,
+  reviewerUserId: string,
+  assignedBy: string,
+) {
+  try {
+    const [row] = await tx
+      .insert(submissionReviewers)
+      .values({
+        organizationId: orgId,
+        submissionId,
+        reviewerUserId,
+        assignedBy,
+      })
+      .returning();
+    return row;
+  } catch (error: unknown) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as { code: string }).code === '23505'
+    ) {
+      throw new ReviewerAlreadyAssignedError(reviewerUserId);
+    }
+    throw error;
+  }
+}
+
+async function unassign(
+  tx: DrizzleDb,
+  submissionId: string,
+  reviewerUserId: string,
+): Promise<void> {
+  const deleted = await tx
+    .delete(submissionReviewers)
+    .where(
+      and(
+        eq(submissionReviewers.submissionId, submissionId),
+        eq(submissionReviewers.reviewerUserId, reviewerUserId),
+      ),
+    )
+    .returning({ id: submissionReviewers.id });
+
+  if (deleted.length === 0) {
+    throw new ReviewerNotAssignedError(reviewerUserId);
+  }
+}
+
+async function listBySubmission(
+  tx: DrizzleDb,
+  submissionId: string,
+): Promise<SubmissionReviewer[]> {
+  const rows = await tx
+    .select({
+      id: submissionReviewers.id,
+      submissionId: submissionReviewers.submissionId,
+      reviewerUserId: submissionReviewers.reviewerUserId,
+      reviewerEmail: users.email,
+      reviewerRole: organizationMembers.role,
+      assignedBy: submissionReviewers.assignedBy,
+      assignedAt: submissionReviewers.assignedAt,
+      readAt: submissionReviewers.readAt,
+    })
+    .from(submissionReviewers)
+    .innerJoin(users, eq(users.id, submissionReviewers.reviewerUserId))
+    .innerJoin(
+      organizationMembers,
+      and(
+        eq(organizationMembers.userId, submissionReviewers.reviewerUserId),
+        eq(
+          organizationMembers.organizationId,
+          submissionReviewers.organizationId,
+        ),
+      ),
+    )
+    .where(eq(submissionReviewers.submissionId, submissionId));
+
+  return rows;
+}
+
+async function markRead(
+  tx: DrizzleDb,
+  submissionId: string,
+  userId: string,
+): Promise<boolean> {
+  const updated = await tx
+    .update(submissionReviewers)
+    .set({ readAt: new Date() })
+    .where(
+      and(
+        eq(submissionReviewers.submissionId, submissionId),
+        eq(submissionReviewers.reviewerUserId, userId),
+        isNull(submissionReviewers.readAt),
+      ),
+    )
+    .returning({ id: submissionReviewers.id });
+
+  return updated.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getSubmissionOrThrow(tx: DrizzleDb, submissionId: string) {
+  const [submission] = await tx
+    .select({
+      id: submissions.id,
+      submitterId: submissions.submitterId,
+      organizationId: submissions.organizationId,
+    })
+    .from(submissions)
+    .where(eq(submissions.id, submissionId))
+    .limit(1);
+
+  if (!submission) throw new SubmissionNotFoundError(submissionId);
+  return submission;
+}
+
+async function validateOrgMembership(
+  tx: DrizzleDb,
+  orgId: string,
+  userIds: string[],
+): Promise<void> {
+  const members = await tx
+    .select({ userId: organizationMembers.userId })
+    .from(organizationMembers)
+    .where(
+      and(
+        eq(organizationMembers.organizationId, orgId),
+        inArray(organizationMembers.userId, userIds),
+      ),
+    );
+
+  const memberSet = new Set(members.map((m) => m.userId));
+  for (const userId of userIds) {
+    if (!memberSet.has(userId)) {
+      throw new ReviewerNotOrgMemberError(userId);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Access-aware methods (accept ServiceContext)
+// ---------------------------------------------------------------------------
+
+async function assignWithAudit(
+  svc: ServiceContext,
+  submissionId: string,
+  reviewerUserIds: string[],
+): Promise<SubmissionReviewer[]> {
+  assertEditorOrAdmin(svc.actor.role);
+
+  await getSubmissionOrThrow(svc.tx, submissionId);
+  await validateOrgMembership(svc.tx, svc.actor.orgId, reviewerUserIds);
+
+  const results: SubmissionReviewer[] = [];
+  for (const reviewerUserId of reviewerUserIds) {
+    const row = await assign(
+      svc.tx,
+      svc.actor.orgId,
+      submissionId,
+      reviewerUserId,
+      svc.actor.userId,
+    );
+
+    await svc.audit({
+      resource: AuditResources.SUBMISSION,
+      action: AuditActions.REVIEWER_ASSIGNED,
+      resourceId: submissionId,
+      newValue: { reviewerUserId },
+    });
+
+    await enqueueOutboxEvent(svc.tx, 'hopper/reviewer.assigned', {
+      orgId: svc.actor.orgId,
+      submissionId,
+      reviewerUserId,
+      assignedBy: svc.actor.userId,
+    });
+
+    // Build the full result with email/role via a re-read
+    results.push({
+      ...row,
+      submissionId: row.submissionId,
+      reviewerUserId: row.reviewerUserId,
+      reviewerEmail: '', // will be filled below
+      reviewerRole: 'READER' as const,
+      assignedBy: row.assignedBy,
+      assignedAt: row.assignedAt,
+      readAt: row.readAt,
+    });
+  }
+
+  // Re-read full list with JOINs for complete data
+  return listBySubmission(svc.tx, submissionId);
+}
+
+async function unassignWithAudit(
+  svc: ServiceContext,
+  submissionId: string,
+  reviewerUserId: string,
+): Promise<void> {
+  assertEditorOrAdmin(svc.actor.role);
+  await getSubmissionOrThrow(svc.tx, submissionId);
+  await unassign(svc.tx, submissionId, reviewerUserId);
+
+  await svc.audit({
+    resource: AuditResources.SUBMISSION,
+    action: AuditActions.REVIEWER_UNASSIGNED,
+    resourceId: submissionId,
+    newValue: { reviewerUserId },
+  });
+}
+
+async function listBySubmissionWithAccess(
+  svc: ServiceContext,
+  submissionId: string,
+): Promise<SubmissionReviewer[]> {
+  const submission = await getSubmissionOrThrow(svc.tx, submissionId);
+  assertOwnerOrEditor(svc.actor.userId, svc.actor.role, submission.submitterId);
+  return listBySubmission(svc.tx, submissionId);
+}
+
+async function markReadWithAudit(
+  svc: ServiceContext,
+  submissionId: string,
+): Promise<{ success: true }> {
+  const updated = await markRead(svc.tx, submissionId, svc.actor.userId);
+
+  if (updated) {
+    await svc.audit({
+      resource: AuditResources.SUBMISSION,
+      action: AuditActions.REVIEWER_READ,
+      resourceId: submissionId,
+    });
+  }
+
+  return { success: true };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export const submissionReviewerService = {
+  assign,
+  unassign,
+  listBySubmission,
+  markRead,
+  assignWithAudit,
+  unassignWithAudit,
+  listBySubmissionWithAccess,
+  markReadWithAudit,
+};

--- a/apps/api/src/templates/email/templates.ts
+++ b/apps/api/src/templates/email/templates.ts
@@ -5,6 +5,7 @@ import type {
   ContractTemplateData,
   CopyeditorAssignedData,
   EditorMessageTemplateData,
+  ReviewerAssignedTemplateData,
 } from './types.js';
 import { wrapInLayout } from './layout.js';
 
@@ -222,6 +223,29 @@ function editorMessage(data: Record<string, unknown>): TemplateResult {
   };
 }
 
+function reviewerAssigned(data: Record<string, unknown>): TemplateResult {
+  const d = data as unknown as ReviewerAssignedTemplateData;
+  return {
+    subject: `You've been assigned to review: ${d.submissionTitle}`,
+    mjml: wrapInLayout(
+      `<mj-text>
+        <p>You have been assigned as a reviewer for a submission.</p>
+        <p><strong>Title:</strong> ${escapeHtml(d.submissionTitle)}</p>
+        <p><strong>Assigned by:</strong> ${escapeHtml(d.assignedByName)}</p>
+        ${d.submissionUrl ? `<p><a href="${escapeHtml(d.submissionUrl)}">View Submission</a></p>` : ''}
+      </mj-text>`,
+      d.orgName,
+    ),
+    text: [
+      `You have been assigned as a reviewer for "${d.submissionTitle}".`,
+      `Assigned by: ${d.assignedByName}`,
+      d.submissionUrl ? `View: ${d.submissionUrl}` : '',
+    ]
+      .filter(Boolean)
+      .join('\n'),
+  };
+}
+
 export const templates: Record<TemplateName, TemplateRenderer> = {
   'submission-received': submissionReceived,
   'submission-accepted': submissionAccepted,
@@ -231,6 +255,7 @@ export const templates: Record<TemplateName, TemplateRenderer> = {
   'contract-ready': contractReady,
   'copyeditor-assigned': copyeditorAssigned,
   'editor-message': editorMessage,
+  'reviewer-assigned': reviewerAssigned,
 };
 
 function stripHtml(html: string): string {

--- a/apps/api/src/templates/email/types.ts
+++ b/apps/api/src/templates/email/types.ts
@@ -6,7 +6,8 @@ export type TemplateName =
   | 'submission-withdrawn'
   | 'contract-ready'
   | 'copyeditor-assigned'
-  | 'editor-message';
+  | 'editor-message'
+  | 'reviewer-assigned';
 
 export interface SubmissionTemplateData {
   submissionTitle: string;
@@ -39,8 +40,16 @@ export interface EditorMessageTemplateData {
   messageBody: string; // HTML from Tiptap
 }
 
+export interface ReviewerAssignedTemplateData {
+  submissionTitle: string;
+  orgName: string;
+  assignedByName: string;
+  submissionUrl?: string;
+}
+
 export type TemplateData =
   | SubmissionTemplateData
   | ContractTemplateData
   | CopyeditorAssignedData
-  | EditorMessageTemplateData;
+  | EditorMessageTemplateData
+  | ReviewerAssignedTemplateData;

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -70,6 +70,11 @@ import {
   EmailTemplateNotFoundError,
   InvalidMergeFieldError,
 } from '../services/email-template.service.js';
+import {
+  ReviewerAlreadyAssignedError,
+  ReviewerNotAssignedError,
+  ReviewerNotOrgMemberError,
+} from '../services/submission-reviewer.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -136,6 +141,10 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   // Email template errors
   [EmailTemplateNotFoundError, 'NOT_FOUND'],
   [InvalidMergeFieldError, 'BAD_REQUEST'],
+  // Reviewer errors
+  [ReviewerAlreadyAssignedError, 'CONFLICT'],
+  [ReviewerNotAssignedError, 'NOT_FOUND'],
+  [ReviewerNotOrgMemberError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];

--- a/apps/api/src/trpc/routers/submissions.ts
+++ b/apps/api/src/trpc/routers/submissions.ts
@@ -19,6 +19,10 @@ import {
   requestMigrationInputSchema,
   migrationIdParamSchema,
   migrationListQuerySchema,
+  assignReviewerInputSchema,
+  unassignReviewerInputSchema,
+  markReviewerReadInputSchema,
+  submissionReviewerSchema,
 } from '@colophony/types';
 import {
   orgProcedure,
@@ -27,6 +31,7 @@ import {
   requireScopes,
 } from '../init.js';
 import { submissionService } from '../../services/submission.service.js';
+import { submissionReviewerService } from '../../services/submission-reviewer.service.js';
 import { simsubService } from '../../services/simsub.service.js';
 import { transferService } from '../../services/transfer.service.js';
 import { migrationService } from '../../services/migration.service.js';
@@ -264,6 +269,75 @@ export const submissionsRouter = createRouter({
           input.transferId,
         );
         return { success: true };
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  // ─── Reviewer assignment procedures ───
+
+  /** Assign reviewers to a submission — editor/admin only. */
+  assignReviewers: orgProcedure
+    .use(requireScopes('submissions:write'))
+    .input(assignReviewerInputSchema)
+    .output(z.array(submissionReviewerSchema))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await submissionReviewerService.assignWithAudit(
+          toServiceContext(ctx),
+          input.submissionId,
+          input.reviewerUserIds,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Unassign a reviewer from a submission — editor/admin only. */
+  unassignReviewer: orgProcedure
+    .use(requireScopes('submissions:write'))
+    .input(unassignReviewerInputSchema)
+    .output(successResponseSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        await submissionReviewerService.unassignWithAudit(
+          toServiceContext(ctx),
+          input.submissionId,
+          input.reviewerUserId,
+        );
+        return { success: true as const };
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** List reviewers for a submission — owner or editor/admin. */
+  listReviewers: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(submissionIdParamSchema)
+    .output(z.array(submissionReviewerSchema))
+    .query(async ({ ctx, input }) => {
+      try {
+        return await submissionReviewerService.listBySubmissionWithAccess(
+          toServiceContext(ctx),
+          input.submissionId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Mark a submission as read by the current user (reviewer). */
+  markReviewerRead: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(markReviewerReadInputSchema)
+    .output(successResponseSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await submissionReviewerService.markReadWithAudit(
+          toServiceContext(ctx),
+          input.submissionId,
+        );
       } catch (e) {
         mapServiceError(e);
       }

--- a/apps/web/src/components/submissions/reviewer-list.tsx
+++ b/apps/web/src/components/submissions/reviewer-list.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { formatDistanceToNow } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { X, Eye, EyeOff } from "lucide-react";
+import { toast } from "sonner";
+
+interface ReviewerListProps {
+  submissionId: string;
+}
+
+export function ReviewerList({ submissionId }: ReviewerListProps) {
+  const { isEditor, isAdmin } = useOrganization();
+  const utils = trpc.useUtils();
+
+  const { data: reviewers, isPending: isLoading } =
+    trpc.submissions.listReviewers.useQuery({ submissionId });
+
+  const unassignMutation = trpc.submissions.unassignReviewer.useMutation({
+    onSuccess: () => {
+      toast.success("Reviewer removed");
+      utils.submissions.listReviewers.invalidate({ submissionId });
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
+  }
+
+  if (!reviewers || reviewers.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">No reviewers assigned</p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {reviewers.map((reviewer) => (
+        <div
+          key={reviewer.id}
+          className="flex items-center gap-3 p-2 border rounded-lg"
+        >
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium truncate">
+              {reviewer.reviewerEmail}
+            </p>
+            <div className="flex items-center gap-1.5 mt-0.5">
+              <Badge variant="outline" className="text-xs">
+                {reviewer.reviewerRole}
+              </Badge>
+              {reviewer.readAt ? (
+                <Badge variant="default" className="text-xs gap-1 bg-green-600">
+                  <Eye className="h-3 w-3" />
+                  Read{" "}
+                  {formatDistanceToNow(new Date(reviewer.readAt), {
+                    addSuffix: true,
+                  })}
+                </Badge>
+              ) : (
+                <Badge variant="secondary" className="text-xs gap-1">
+                  <EyeOff className="h-3 w-3" />
+                  Unread
+                </Badge>
+              )}
+            </div>
+          </div>
+          {(isEditor || isAdmin) && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 shrink-0"
+              onClick={() =>
+                unassignMutation.mutate({
+                  submissionId,
+                  reviewerUserId: reviewer.reviewerUserId,
+                })
+              }
+              disabled={unassignMutation.isPending}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/submissions/reviewer-picker.tsx
+++ b/apps/web/src/components/submissions/reviewer-picker.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Badge } from "@/components/ui/badge";
+import { Check, UserPlus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+
+interface ReviewerPickerProps {
+  submissionId: string;
+  existingReviewerIds: string[];
+  onAssigned?: () => void;
+}
+
+export function ReviewerPicker({
+  submissionId,
+  existingReviewerIds,
+  onAssigned,
+}: ReviewerPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<string[]>([]);
+  const utils = trpc.useUtils();
+
+  const { data: membersData } = trpc.organizations.members.list.useQuery(
+    { page: 1, limit: 100 },
+    { enabled: open },
+  );
+
+  const assignMutation = trpc.submissions.assignReviewers.useMutation({
+    onSuccess: () => {
+      toast.success("Reviewers assigned");
+      setSelected([]);
+      setOpen(false);
+      utils.submissions.listReviewers.invalidate({ submissionId });
+      onAssigned?.();
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const availableMembers = (membersData?.items ?? []).filter(
+    (m) => !existingReviewerIds.includes(m.userId),
+  );
+
+  const toggleSelect = (userId: string) => {
+    setSelected((prev) =>
+      prev.includes(userId)
+        ? prev.filter((id) => id !== userId)
+        : [...prev, userId],
+    );
+  };
+
+  const handleAssign = () => {
+    if (selected.length === 0) return;
+    assignMutation.mutate({
+      submissionId,
+      reviewerUserIds: selected,
+    });
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-1.5">
+          <UserPlus className="h-4 w-4" />
+          Add Reviewer
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-0" align="start">
+        <Command shouldFilter={false}>
+          <CommandInput placeholder="Search members..." />
+          <CommandList>
+            <CommandEmpty>No members available</CommandEmpty>
+            <CommandGroup>
+              {availableMembers.map((member) => (
+                <CommandItem
+                  key={member.userId}
+                  value={member.userId}
+                  onSelect={() => toggleSelect(member.userId)}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      selected.includes(member.userId)
+                        ? "opacity-100"
+                        : "opacity-0",
+                    )}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <span className="text-sm truncate">{member.email}</span>
+                  </div>
+                  <Badge variant="outline" className="text-xs ml-2">
+                    {member.role}
+                  </Badge>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+        {selected.length > 0 && (
+          <div className="border-t p-2">
+            <Button
+              size="sm"
+              className="w-full"
+              onClick={handleAssign}
+              disabled={assignMutation.isPending}
+            >
+              {assignMutation.isPending
+                ? "Assigning..."
+                : `Assign ${selected.length} reviewer${selected.length > 1 ? "s" : ""}`}
+            </Button>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { formatDistanceToNow, format } from "date-fns";
@@ -12,6 +12,8 @@ import { StatusTransition } from "./status-transition";
 import { ReviseAndResubmitCard } from "./revise-and-resubmit-card";
 import { ComposeMessageDialog } from "./compose-message-dialog";
 import { CorrespondenceHistory } from "./correspondence-history";
+import { ReviewerList } from "./reviewer-list";
+import { ReviewerPicker } from "./reviewer-picker";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -99,6 +101,12 @@ export function SubmissionDetail({
     submissionId,
   });
 
+  const { data: reviewers } = trpc.submissions.listReviewers.useQuery({
+    submissionId,
+  });
+
+  const markReadMutation = trpc.submissions.markReviewerRead.useMutation();
+
   const deleteMutation = trpc.submissions.delete.useMutation({
     onSuccess: () => {
       toast.success("Submission deleted");
@@ -119,6 +127,14 @@ export function SubmissionDetail({
       toast.error(err.message);
     },
   });
+
+  // Mark submission as read when a non-owner views it (fire-and-forget, idempotent)
+  useEffect(() => {
+    if (submission && user?.id !== submission.submitterId) {
+      markReadMutation.mutate({ submissionId });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [submission?.id]);
 
   const handleDownload = async (fileId: string) => {
     try {
@@ -256,6 +272,33 @@ export function SubmissionDetail({
             }
           />
         )}
+
+      {/* Reviewers */}
+      {(isEditor || isAdmin || isOwner) && (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle>Reviewers</CardTitle>
+                <CardDescription>
+                  Assigned reviewers and read status
+                </CardDescription>
+              </div>
+              {(isEditor || isAdmin) && (
+                <ReviewerPicker
+                  submissionId={submissionId}
+                  existingReviewerIds={
+                    reviewers?.map((r) => r.reviewerUserId) ?? []
+                  }
+                />
+              )}
+            </div>
+          </CardHeader>
+          <CardContent>
+            <ReviewerList submissionId={submissionId} />
+          </CardContent>
+        </Card>
+      )}
 
       {/* Content */}
       <div className="grid gap-6 md:grid-cols-3">

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -315,7 +315,7 @@
 
 ### Editorial Workflow
 
-- [ ] [P1] Reviewer assignment per submission — assign one or more org members as readers on a submission; track who has read it; show assignment in submission detail — (persona gap analysis 2026-02-27)
+- [x] [P1] Reviewer assignment per submission — assign one or more org members as readers on a submission; track who has read it; show assignment in submission detail — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [ ] [P1] Internal discussion threads on submissions — comment system on Hopper submissions (pre-acceptance), separate from the Slate pipeline comments (post-acceptance) — (persona gap analysis 2026-02-27)
 - [ ] [P2] Voting / scoring on submissions — readers cast votes (accept/reject/maybe + optional score); configurable per org; summary visible to editors making final decisions — (persona gap analysis 2026-02-27)
 - [ ] [P2] Blind / anonymous review mode — hide submitter identity from reviewers; admin toggle per submission period — (persona gap analysis 2026-02-27)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-28 — Track 7 PR4: Reviewer Assignment per Submission
+
+### Done
+
+- **DB:** `submission_reviewers` junction table (migration 0040) with direct `organization_id` for fast RLS, unique `(submission_id, reviewer_user_id)` index, CASCADE on submission/user delete, SET NULL on assigner delete
+- **Shared types:** `submissionReviewerSchema`, `assignReviewerInputSchema`, `unassignReviewerInputSchema`, `markReviewerReadInputSchema` Zod schemas; 3 audit actions (REVIEWER_ASSIGNED/UNASSIGNED/READ)
+- **Service layer:** `submission-reviewer.service.ts` — pure data methods (assign, unassign, listBySubmission, markRead) + access-aware wrappers (assignWithAudit, unassignWithAudit, listBySubmissionWithAccess, markReadWithAudit); 3 error classes; org membership validation
+- **Inngest:** `hopper/reviewer.assigned` event + `reviewerAssignedNotification` function (email + in-app notification)
+- **Email template:** `reviewer-assigned` with MJML + plain text (submission title, assigner name, link)
+- **API surfaces:** 4 endpoints on tRPC (assignReviewers, unassignReviewer, listReviewers, markReviewerRead), REST (`GET/POST /submissions/{id}/reviewers`, `DELETE /submissions/{id}/reviewers/{reviewerUserId}`, `POST /submissions/{id}/reviewers/mark-read`), and GraphQL (submissionReviewers query, assignReviewers/unassignReviewer/markSubmissionRead mutations)
+- **Error mappers:** ReviewerAlreadyAssignedError (CONFLICT), ReviewerNotAssignedError (NOT_FOUND), ReviewerNotOrgMemberError (BAD_REQUEST) across all 3 API surfaces
+- **Frontend:** `ReviewerList` (read/unread badges, unassign button for editors), `ReviewerPicker` (Popover + Command multi-select), submission-detail integration with read tracking useEffect
+- **Tests:** All 1290 API tests + 38 types tests passing; type-checks clean across all packages
+
+### Decisions
+
+- Direct `organization_id` on junction table for fast RLS (equality check vs subquery on submissions)
+- `assigned_by` nullable (SET NULL on user delete) — assignment persists even if assigner account is deleted
+- Read tracking fires on any non-owner view (idempotent, fire-and-forget via markRead)
+- Re-read full list with JOINs after assignment for complete reviewer data (email + role)
+
+---
+
 ## 2026-02-27 — Track 7 PR3: Revise and Resubmit (R&R) Status
 
 ### Done

--- a/packages/db/migrations/0040_submission_reviewers.sql
+++ b/packages/db/migrations/0040_submission_reviewers.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS "submission_reviewers" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "submission_id" uuid NOT NULL,
+  "reviewer_user_id" uuid NOT NULL,
+  "assigned_by" uuid,
+  "assigned_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "read_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "submission_reviewers" ADD CONSTRAINT "submission_reviewers_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "submission_reviewers" ADD CONSTRAINT "submission_reviewers_submission_id_submissions_id_fk" FOREIGN KEY ("submission_id") REFERENCES "submissions"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "submission_reviewers" ADD CONSTRAINT "submission_reviewers_reviewer_user_id_users_id_fk" FOREIGN KEY ("reviewer_user_id") REFERENCES "users"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "submission_reviewers" ADD CONSTRAINT "submission_reviewers_assigned_by_users_id_fk" FOREIGN KEY ("assigned_by") REFERENCES "users"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "submission_reviewers_sub_user_idx" ON "submission_reviewers" ("submission_id", "reviewer_user_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "submission_reviewers_org_id_idx" ON "submission_reviewers" ("organization_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "submission_reviewers_submission_id_idx" ON "submission_reviewers" ("submission_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "submission_reviewers_reviewer_user_id_idx" ON "submission_reviewers" ("reviewer_user_id");
+--> statement-breakpoint
+ALTER TABLE "submission_reviewers" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "submission_reviewers" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE POLICY "org_isolation" ON "submission_reviewers" FOR ALL USING (organization_id = current_org_id());
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON "submission_reviewers" TO app_user;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1777000000000,
       "tag": "0039_revise_and_resubmit",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1777200000000,
+      "tag": "0040_submission_reviewers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/submissions.ts
+++ b/packages/db/src/schema/submissions.ts
@@ -10,6 +10,7 @@ import {
   numeric,
   jsonb,
   index,
+  uniqueIndex,
   customType,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
@@ -239,5 +240,40 @@ export const simSubChecks = pgTable(
         WHERE organization_id = current_org_id()
       )`,
     }),
+  ],
+).enableRLS();
+
+// --- submission_reviewers ---
+
+export const submissionReviewers = pgTable(
+  "submission_reviewers",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    submissionId: uuid("submission_id")
+      .notNull()
+      .references(() => submissions.id, { onDelete: "cascade" }),
+    reviewerUserId: uuid("reviewer_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    assignedBy: uuid("assigned_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    assignedAt: timestamp("assigned_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    readAt: timestamp("read_at", { withTimezone: true }),
+  },
+  (table) => [
+    uniqueIndex("submission_reviewers_sub_user_idx").on(
+      table.submissionId,
+      table.reviewerUserId,
+    ),
+    index("submission_reviewers_org_id_idx").on(table.organizationId),
+    index("submission_reviewers_submission_id_idx").on(table.submissionId),
+    index("submission_reviewers_reviewer_user_id_idx").on(table.reviewerUserId),
+    orgIsolationPolicy,
   ],
 ).enableRLS();

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -29,6 +29,9 @@ export const AuditActions = {
   SUBMISSION_STATUS_CHANGED: "SUBMISSION_STATUS_CHANGED",
   SUBMISSION_DELETED: "SUBMISSION_DELETED",
   SUBMISSION_WITHDRAWN: "SUBMISSION_WITHDRAWN",
+  REVIEWER_ASSIGNED: "REVIEWER_ASSIGNED",
+  REVIEWER_UNASSIGNED: "REVIEWER_UNASSIGNED",
+  REVIEWER_READ: "REVIEWER_READ",
 
   // File lifecycle
   FILE_UPLOADED: "FILE_UPLOADED",
@@ -308,7 +311,10 @@ export interface SubmissionAuditParams extends BaseAuditParams {
     | typeof AuditActions.SUBMISSION_SUBMITTED
     | typeof AuditActions.SUBMISSION_STATUS_CHANGED
     | typeof AuditActions.SUBMISSION_DELETED
-    | typeof AuditActions.SUBMISSION_WITHDRAWN;
+    | typeof AuditActions.SUBMISSION_WITHDRAWN
+    | typeof AuditActions.REVIEWER_ASSIGNED
+    | typeof AuditActions.REVIEWER_UNASSIGNED
+    | typeof AuditActions.REVIEWER_READ;
 }
 
 export interface FileAuditParams extends BaseAuditParams {

--- a/packages/types/src/submission.ts
+++ b/packages/types/src/submission.ts
@@ -441,3 +441,36 @@ export function isEditorAllowedTransition(
 ): boolean {
   return EDITOR_ALLOWED_TRANSITIONS[from].includes(to);
 }
+
+// ---------------------------------------------------------------------------
+// Reviewer assignment schemas
+// ---------------------------------------------------------------------------
+
+export const submissionReviewerSchema = z.object({
+  id: z.string().uuid(),
+  submissionId: z.string().uuid(),
+  reviewerUserId: z.string().uuid(),
+  reviewerEmail: z.string().email(),
+  reviewerRole: z.enum(["ADMIN", "EDITOR", "READER"]),
+  assignedBy: z.string().uuid().nullable(),
+  assignedAt: z.coerce.date(),
+  readAt: z.coerce.date().nullable(),
+});
+export type SubmissionReviewer = z.infer<typeof submissionReviewerSchema>;
+
+export const assignReviewerInputSchema = z.object({
+  submissionId: z.string().uuid(),
+  reviewerUserIds: z.array(z.string().uuid()).min(1).max(20),
+});
+export type AssignReviewerInput = z.infer<typeof assignReviewerInputSchema>;
+
+export const unassignReviewerInputSchema = z.object({
+  submissionId: z.string().uuid(),
+  reviewerUserId: z.string().uuid(),
+});
+export type UnassignReviewerInput = z.infer<typeof unassignReviewerInputSchema>;
+
+export const markReviewerReadInputSchema = z.object({
+  submissionId: z.string().uuid(),
+});
+export type MarkReviewerReadInput = z.infer<typeof markReviewerReadInputSchema>;


### PR DESCRIPTION
## Summary

- Adds `REVISE_AND_RESUBMIT` status to the submission workflow (PR3 from previous session)
- Adds **reviewer assignment** per submission — editors assign org members as reviewers, track read status, display in submission detail (PR4 from this session)

## Changes

### PR3: Revise and Resubmit (R&R)
- **DB:** `REVISE_AND_RESUBMIT` added to `SubmissionStatus` enum (migration 0039)
- **Types:** Zod enum, transition maps, status mapping, `resubmitSchema`
- **Service:** R&R error classes, comment guard, `resubmitAsOwner()` with scan validation
- **Inngest:** R&R event + notification function (email + in-app + correspondence)
- **Email:** `submission-revise-resubmit` MJML template
- **API surfaces:** `resubmit` on tRPC, REST, GraphQL
- **Frontend:** Amber R&R badge, "Request Revisions" dialog, `ReviseAndResubmitCard`, `canWithdraw` update

### PR4: Reviewer Assignment
- **DB:** `submission_reviewers` junction table (migration 0040) with RLS, unique constraint, CASCADE deletes
- **Types:** `submissionReviewerSchema`, input schemas, 3 audit actions (REVIEWER_ASSIGNED/UNASSIGNED/READ)
- **Service:** `submission-reviewer.service.ts` — assign, unassign, list, markRead + access-aware wrappers with audit + outbox events
- **Inngest:** `hopper/reviewer.assigned` event + notification function
- **Email:** `reviewer-assigned` MJML template
- **API surfaces:** 4 endpoints on tRPC, REST, and GraphQL (assign, unassign, list, mark-read)
- **Error mappers:** 3 reviewer errors (CONFLICT, NOT_FOUND, BAD_REQUEST) across all surfaces
- **Frontend:** `ReviewerList` (read/unread badges, unassign), `ReviewerPicker` (Popover + Command multi-select), submission-detail integration with read tracking

### Tests
- All 1290 API tests + 38 types tests passing
- Type-checks clean across all packages

## Test plan

- [ ] Run `pnpm db:migrate` and verify both migrations apply cleanly
- [ ] As editor: set submission to R&R — verify required notes dialog and amber badge
- [ ] As writer: resubmit from R&R with new manuscript version
- [ ] As editor: assign reviewers via picker — verify list updates
- [ ] As reviewer: open submission — verify read badge updates (idempotent)
- [ ] As editor: unassign a reviewer — verify removal
- [ ] Verify notification emails sent for both R&R and reviewer assignment