### PR TITLE
fix(web): stabilize withdraw E2E test + fix markRead race

### DIFF
--- a/apps/web/e2e/submissions/submission-detail.spec.ts
+++ b/apps/web/e2e/submissions/submission-detail.spec.ts
@@ -191,6 +191,9 @@ test.describe("Submission Detail & Edit", () => {
       authedPage.getByRole("heading", { name: "E2E Detail: Submit Flow" }),
     ).toBeVisible({ timeout: 10_000 });
 
+    // Wait for network to settle (listReviewers, getHistory etc.)
+    await authedPage.waitForLoadState("networkidle");
+
     // Click Withdraw
     await authedPage.getByRole("button", { name: "Withdraw" }).click();
 

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -130,11 +130,11 @@ export function SubmissionDetail({
 
   // Mark submission as read when a non-owner views it (fire-and-forget, idempotent)
   useEffect(() => {
-    if (submission && user?.id !== submission.submitterId) {
+    if (submission && user && user.id !== submission.submitterId) {
       markReadMutation.mutate({ submissionId });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [submission?.id]);
+  }, [submission?.id, user?.id]);
 
   const handleDownload = async (fileId: string) => {
     try {


### PR DESCRIPTION
## Summary

- **Fix race condition in reviewer read tracking** — `useEffect` for `markReadMutation` in `submission-detail.tsx` fired when `user` was still `undefined` (OIDC state not yet loaded), causing spurious `markRead` calls for submission owners
- **Stabilize flaky Playwright withdraw test** — add `waitForLoadState('networkidle')` before clicking Withdraw, allowing new reviewer queries (`listReviewers`, etc.) to settle

## Context

CI on `main` failed with `Playwright Submissions E2E` — the "withdraw dialog changes status to WITHDRAWN" test crashed with "Target page, context or browser has been closed" (Chromium crash). 19/20 tests passed. Root cause is likely CI resource pressure compounded by new API queries from reviewer assignment (#209).

## Test plan

- [ ] CI Playwright Submissions E2E passes (the fix target)
- [ ] All other CI jobs pass (no regressions)