### PR TITLE
feat(hopper): internal discussion threads on submissions

### DIFF
--- a/apps/api/src/graphql/error-mapper.ts
+++ b/apps/api/src/graphql/error-mapper.ts
@@ -59,6 +59,10 @@ import {
   ReviewerNotAssignedError,
   ReviewerNotOrgMemberError,
 } from '../services/submission-reviewer.service.js';
+import {
+  DiscussionCommentNotFoundError,
+  DiscussionParentNotFoundError,
+} from '../services/submission-discussion.service.js';
 
 type GraphQLErrorCode = string;
 
@@ -116,6 +120,9 @@ const errorCodeMap: [new (...args: never[]) => Error, GraphQLErrorCode][] = [
   [ReviewerAlreadyAssignedError, 'CONFLICT'],
   [ReviewerNotAssignedError, 'NOT_FOUND'],
   [ReviewerNotOrgMemberError, 'BAD_REQUEST'],
+  // Discussion errors
+  [DiscussionCommentNotFoundError, 'NOT_FOUND'],
+  [DiscussionParentNotFoundError, 'NOT_FOUND'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/graphql/resolvers/submissions.ts
+++ b/apps/api/src/graphql/resolvers/submissions.ts
@@ -12,6 +12,7 @@ import { toServiceContext } from '../../services/context.js';
 import { assertEditorOrAdmin } from '../../services/errors.js';
 import { submissionService } from '../../services/submission.service.js';
 import { submissionReviewerService } from '../../services/submission-reviewer.service.js';
+import { submissionDiscussionService } from '../../services/submission-discussion.service.js';
 import { simsubService } from '../../services/simsub.service.js';
 import { mapServiceError } from '../error-mapper.js';
 import { validateEnv } from '../../config/env.js';
@@ -19,6 +20,7 @@ import {
   SubmissionType,
   SubmissionHistoryType,
   SubmissionReviewerType,
+  SubmissionDiscussionType,
 } from '../types/index.js';
 import {
   SubmissionStatusChangePayload,
@@ -227,6 +229,36 @@ builder.queryFields((t) => ({
       });
       try {
         return await submissionService.getHistoryWithAccess(
+          toServiceContext(orgCtx),
+          submissionId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * List internal discussion comments on a submission.
+   */
+  submissionDiscussions: t.field({
+    type: [SubmissionDiscussionType],
+    description:
+      'List internal discussion comments. Only accessible to editors, admins, and assigned reviewers.',
+    args: {
+      submissionId: t.arg.string({
+        required: true,
+        description: 'Submission ID.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'submissions:read');
+      const { id: submissionId } = idParamSchema.parse({
+        id: args.submissionId,
+      });
+      try {
+        return await submissionDiscussionService.listWithAccess(
           toServiceContext(orgCtx),
           submissionId,
         );
@@ -575,6 +607,48 @@ builder.mutationFields((t) => ({
           id,
           status,
           comment,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Add a discussion comment on a submission.
+   */
+  addSubmissionDiscussion: t.field({
+    type: SubmissionDiscussionType,
+    description:
+      'Add an internal discussion comment. Only accessible to editors, admins, and assigned reviewers.',
+    args: {
+      submissionId: t.arg.string({
+        required: true,
+        description: 'Submission ID.',
+      }),
+      parentId: t.arg.string({
+        required: false,
+        description: 'Parent comment ID for threaded replies.',
+      }),
+      content: t.arg.string({
+        required: true,
+        description: 'HTML content of the comment.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'submissions:write');
+      const { id: submissionId } = idParamSchema.parse({
+        id: args.submissionId,
+      });
+      try {
+        return await submissionDiscussionService.createWithAudit(
+          toServiceContext(orgCtx),
+          {
+            submissionId,
+            parentId: args.parentId ?? undefined,
+            content: args.content,
+          },
         );
       } catch (e) {
         mapServiceError(e);

--- a/apps/api/src/graphql/types/discussion.ts
+++ b/apps/api/src/graphql/types/discussion.ts
@@ -1,0 +1,39 @@
+import type { SubmissionDiscussion } from '@colophony/types';
+import { builder } from '../builder.js';
+
+export const SubmissionDiscussionType = builder
+  .objectRef<SubmissionDiscussion>('SubmissionDiscussion')
+  .implement({
+    description:
+      'An internal discussion comment on a submission, visible only to editors, admins, and assigned reviewers.',
+    fields: (t) => ({
+      id: t.exposeString('id', { description: 'Comment ID.' }),
+      submissionId: t.exposeString('submissionId', {
+        description: 'ID of the submission.',
+      }),
+      authorId: t.exposeString('authorId', {
+        nullable: true,
+        description: 'ID of the comment author.',
+      }),
+      authorEmail: t.exposeString('authorEmail', {
+        nullable: true,
+        description: "Author's email address.",
+      }),
+      parentId: t.exposeString('parentId', {
+        nullable: true,
+        description: 'ID of the parent comment (null for top-level comments).',
+      }),
+      content: t.exposeString('content', {
+        description: 'HTML content of the comment.',
+      }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the comment was created.',
+      }),
+      updatedAt: t.expose('updatedAt', {
+        type: 'DateTime',
+        nullable: true,
+        description: 'When the comment was last updated.',
+      }),
+    }),
+  });

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -35,6 +35,7 @@ export {
   IssueStatusEnum,
 } from './issue.js';
 export { CmsConnectionType, CmsAdapterTypeEnum } from './cms-connection.js';
+export { SubmissionDiscussionType } from './discussion.js';
 export {
   SubmissionStatusChangePayload,
   CreateOrganizationPayload,

--- a/apps/api/src/inngest/events.ts
+++ b/apps/api/src/inngest/events.ts
@@ -150,13 +150,25 @@ export interface HopperReviewerAssignedEvent {
   };
 }
 
+export interface HopperDiscussionCommentEvent {
+  name: 'hopper/discussion.comment_added';
+  data: {
+    orgId: string;
+    submissionId: string;
+    commentId: string;
+    authorId: string;
+    recipientUserIds: string[];
+  };
+}
+
 export type HopperEvent =
   | HopperSubmissionSubmittedEvent
   | HopperSubmissionAcceptedEvent
   | HopperSubmissionRejectedEvent
   | HopperSubmissionWithdrawnEvent
   | HopperSubmissionReviseAndResubmitEvent
-  | HopperReviewerAssignedEvent;
+  | HopperReviewerAssignedEvent
+  | HopperDiscussionCommentEvent;
 
 // ---------------------------------------------------------------------------
 // Union type for all Slate events

--- a/apps/api/src/inngest/functions/discussion-notifications.ts
+++ b/apps/api/src/inngest/functions/discussion-notifications.ts
@@ -1,0 +1,174 @@
+import {
+  withRls,
+  db,
+  submissions,
+  organizations,
+  users,
+  eq,
+} from '@colophony/db';
+import { inngest } from '../client.js';
+import type { HopperDiscussionCommentEvent } from '../events.js';
+import { notificationPreferenceService } from '../../services/notification-preference.service.js';
+import { emailService } from '../../services/email.service.js';
+import { auditService } from '../../services/audit.service.js';
+import { enqueueEmail } from '../../queues/email.queue.js';
+import { validateEnv } from '../../config/env.js';
+import { AuditActions, AuditResources } from '@colophony/types';
+import { queueInAppNotification } from '../helpers/queue-in-app-notification.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getSubmissionAndOrg(orgId: string, submissionId: string) {
+  return withRls({ orgId }, async (tx) => {
+    const [submission] = await tx
+      .select({ id: submissions.id, title: submissions.title })
+      .from(submissions)
+      .where(eq(submissions.id, submissionId))
+      .limit(1);
+
+    const [org] = await tx
+      .select({ name: organizations.name })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+
+    return { submission, orgName: org?.name ?? 'Unknown Organization' };
+  });
+}
+
+async function getUserEmail(userId: string) {
+  const [user] = await db
+    .select({ email: users.email })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return user ?? null;
+}
+
+async function queueEmailForRecipient(params: {
+  orgId: string;
+  userId: string;
+  email: string;
+  eventType: string;
+  templateName: string;
+  templateData: Record<string, unknown>;
+  subject: string;
+}) {
+  const env = validateEnv();
+  if (env.EMAIL_PROVIDER === 'none') return;
+
+  const enabled = await withRls({ orgId: params.orgId }, async (tx) => {
+    return notificationPreferenceService.isEmailEnabled(
+      tx,
+      params.orgId,
+      params.userId,
+      params.eventType,
+    );
+  });
+
+  if (!enabled) return;
+
+  const emailSend = await withRls({ orgId: params.orgId }, async (tx) => {
+    const row = await emailService.create(tx, {
+      organizationId: params.orgId,
+      recipientUserId: params.userId,
+      recipientEmail: params.email,
+      templateName: params.templateName,
+      eventType: params.eventType,
+      subject: params.subject,
+    });
+    await auditService.log(tx, {
+      resource: AuditResources.EMAIL,
+      action: AuditActions.EMAIL_QUEUED,
+      resourceId: row.id,
+      organizationId: params.orgId,
+      newValue: {
+        to: params.email,
+        templateName: params.templateName,
+        eventType: params.eventType,
+      },
+    });
+    return row;
+  });
+
+  await enqueueEmail(env, {
+    emailSendId: emailSend.id,
+    orgId: params.orgId,
+    to: params.email,
+    from: env.SMTP_FROM ?? env.SENDGRID_FROM ?? 'noreply@colophony.dev',
+    templateName: params.templateName,
+    templateData: params.templateData,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Inngest function
+// ---------------------------------------------------------------------------
+
+export const discussionCommentNotification = inngest.createFunction(
+  {
+    id: 'discussion-comment-notification',
+    name: 'Discussion Comment Notification',
+    retries: 3,
+  },
+  { event: 'hopper/discussion.comment_added' },
+  async ({ event, step }) => {
+    const { orgId, submissionId, authorId, recipientUserIds } =
+      event.data as HopperDiscussionCommentEvent['data'];
+
+    const { submission, orgName } = await step.run('resolve-data', async () =>
+      getSubmissionAndOrg(orgId, submissionId),
+    );
+
+    if (!submission) return { skipped: true, reason: 'submission-not-found' };
+
+    const author = await step.run('get-author', async () =>
+      getUserEmail(authorId),
+    );
+
+    const authorName = author?.email ?? 'A team member';
+
+    let notified = 0;
+
+    for (const recipientId of recipientUserIds) {
+      const recipient = await step.run(
+        `get-recipient-${recipientId}`,
+        async () => getUserEmail(recipientId),
+      );
+
+      if (!recipient) continue;
+
+      await step.run(`queue-email-${recipientId}`, async () => {
+        await queueEmailForRecipient({
+          orgId,
+          userId: recipientId,
+          email: recipient.email,
+          eventType: 'discussion.comment_added',
+          templateName: 'discussion-comment',
+          templateData: {
+            submissionTitle: submission.title,
+            orgName,
+            authorName,
+          },
+          subject: `New discussion comment on: ${submission.title}`,
+        });
+      });
+
+      await step.run(`queue-in-app-${recipientId}`, async () => {
+        await queueInAppNotification({
+          orgId,
+          userId: recipientId,
+          eventType: 'discussion.comment_added',
+          title: `${authorName} commented on the discussion for: ${submission.title}`,
+          link: `/submissions/${submissionId}`,
+        });
+      });
+
+      notified++;
+    }
+
+    return { notified };
+  },
+);

--- a/apps/api/src/inngest/functions/index.ts
+++ b/apps/api/src/inngest/functions/index.ts
@@ -13,4 +13,5 @@ export {
   copyeditorAssignedNotification,
 } from './slate-notifications.js';
 export { reviewerAssignedNotification } from './reviewer-notifications.js';
+export { discussionCommentNotification } from './discussion-notifications.js';
 export { webhookDelivery } from './webhook-delivery.js';

--- a/apps/api/src/inngest/serve.ts
+++ b/apps/api/src/inngest/serve.ts
@@ -13,6 +13,7 @@ import {
   contractReadyNotification,
   copyeditorAssignedNotification,
   reviewerAssignedNotification,
+  discussionCommentNotification,
   webhookDelivery,
 } from './functions/index.js';
 
@@ -40,6 +41,7 @@ export async function registerInngestRoutes(
       contractReadyNotification,
       copyeditorAssignedNotification,
       reviewerAssignedNotification,
+      discussionCommentNotification,
       webhookDelivery,
     ],
   });

--- a/apps/api/src/rest/error-mapper.ts
+++ b/apps/api/src/rest/error-mapper.ts
@@ -71,6 +71,10 @@ import {
   ReviewerNotAssignedError,
   ReviewerNotOrgMemberError,
 } from '../services/submission-reviewer.service.js';
+import {
+  DiscussionCommentNotFoundError,
+  DiscussionParentNotFoundError,
+} from '../services/submission-discussion.service.js';
 
 type ORPCErrorCode = ConstructorParameters<typeof ORPCError>[0];
 
@@ -138,6 +142,9 @@ const errorCodeMap: [new (...args: never[]) => Error, ORPCErrorCode][] = [
   [ReviewerAlreadyAssignedError, 'CONFLICT'],
   [ReviewerNotAssignedError, 'NOT_FOUND'],
   [ReviewerNotOrgMemberError, 'BAD_REQUEST'],
+  // Discussion errors
+  [DiscussionCommentNotFoundError, 'NOT_FOUND'],
+  [DiscussionParentNotFoundError, 'NOT_FOUND'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/rest/routers/submissions.ts
+++ b/apps/api/src/rest/routers/submissions.ts
@@ -12,10 +12,13 @@ import {
   paginatedResponseSchema,
   successResponseSchema,
   submissionReviewerSchema,
+  createDiscussionCommentSchema,
+  submissionDiscussionSchema,
 } from '@colophony/types';
 import { restPaginationQuery } from '@colophony/api-contracts';
 import { submissionService } from '../../services/submission.service.js';
 import { submissionReviewerService } from '../../services/submission-reviewer.service.js';
+import { submissionDiscussionService } from '../../services/submission-discussion.service.js';
 import { simsubService } from '../../services/simsub.service.js';
 import { toServiceContext } from '../../services/context.js';
 import { assertEditorOrAdmin } from '../../services/errors.js';
@@ -432,6 +435,62 @@ const markReviewerRead = orgProcedure
     }
   });
 
+const listDiscussions = orgProcedure
+  .use(requireScopes('submissions:read'))
+  .route({
+    method: 'GET',
+    path: '/submissions/{id}/discussions',
+    summary: 'List internal discussion comments',
+    description:
+      'List all internal discussion comments on a submission. Only accessible to editors, admins, and assigned reviewers.',
+    operationId: 'listSubmissionDiscussions',
+    tags: ['Submissions'],
+  })
+  .input(idParamSchema)
+  .output(z.array(submissionDiscussionSchema))
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionDiscussionService.listWithAccess(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const addDiscussion = orgProcedure
+  .use(requireScopes('submissions:write'))
+  .route({
+    method: 'POST',
+    path: '/submissions/{id}/discussions',
+    summary: 'Add a discussion comment',
+    description:
+      'Add an internal discussion comment on a submission. Only accessible to editors, admins, and assigned reviewers.',
+    operationId: 'addSubmissionDiscussion',
+    tags: ['Submissions'],
+  })
+  .input(
+    idParamSchema.merge(
+      createDiscussionCommentSchema.pick({ parentId: true, content: true }),
+    ),
+  )
+  .output(submissionDiscussionSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionDiscussionService.createWithAudit(
+        toServiceContext(context),
+        {
+          submissionId: input.id,
+          parentId: input.parentId,
+          content: input.content,
+        },
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
 // ---------------------------------------------------------------------------
 // Assembled router
 // ---------------------------------------------------------------------------
@@ -452,4 +511,6 @@ export const submissionsRouter = {
   assignReviewers,
   unassignReviewer,
   markReviewerRead,
+  listDiscussions,
+  addDiscussion,
 };

--- a/apps/api/src/services/submission-discussion.service.spec.ts
+++ b/apps/api/src/services/submission-discussion.service.spec.ts
@@ -1,0 +1,420 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuditActions, AuditResources } from '@colophony/types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockInsert = vi.fn();
+const mockSelect = vi.fn();
+const mockValues = vi.fn();
+const mockReturning = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockLimit = vi.fn();
+const mockOrderBy = vi.fn();
+const mockLeftJoin = vi.fn();
+const mockExecute = vi.fn();
+
+vi.mock('@colophony/db', () => ({
+  submissionDiscussions: {
+    id: 'id',
+    organizationId: 'organization_id',
+    submissionId: 'submission_id',
+    authorId: 'author_id',
+    parentId: 'parent_id',
+    content: 'content',
+    createdAt: 'created_at',
+    updatedAt: 'updated_at',
+  },
+  submissionReviewers: {
+    id: 'id',
+    submissionId: 'submission_id',
+    reviewerUserId: 'reviewer_user_id',
+  },
+  submissions: {
+    id: 'id',
+    submitterId: 'submitter_id',
+    organizationId: 'organization_id',
+  },
+  users: { id: 'id', email: 'email' },
+  eq: vi.fn((_col: unknown, val: unknown) => val),
+  and: vi.fn((...args: unknown[]) => args),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  sql: vi.fn(),
+}));
+
+vi.mock('sanitize-html', () => ({
+  default: vi.fn((html: string) => html),
+}));
+
+vi.mock('./outbox.js', () => ({
+  enqueueOutboxEvent: vi.fn(),
+}));
+
+vi.mock('./submission.service.js', () => ({
+  SubmissionNotFoundError: class SubmissionNotFoundError extends Error {
+    constructor(id: string) {
+      super(`Submission "${id}" not found`);
+      this.name = 'SubmissionNotFoundError';
+    }
+  },
+}));
+
+import { submissionDiscussionService } from './submission-discussion.service.js';
+import { ForbiddenError } from './errors.js';
+import { DiscussionParentNotFoundError } from './submission-discussion.service.js';
+import type { ServiceContext } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTx() {
+  mockReturning.mockReturnValue([{ id: 'comment-1' }]);
+  mockValues.mockReturnValue({ returning: mockReturning });
+  mockInsert.mockReturnValue({ values: mockValues });
+  mockLimit.mockReturnValue([]);
+  mockWhere.mockReturnValue({
+    limit: mockLimit,
+    orderBy: mockOrderBy,
+  });
+  mockOrderBy.mockReturnValue([]);
+  mockLeftJoin.mockReturnValue({ where: mockWhere });
+  mockFrom.mockReturnValue({
+    leftJoin: mockLeftJoin,
+    innerJoin: vi.fn().mockReturnValue({ where: mockWhere }),
+    where: mockWhere,
+  });
+  mockSelect.mockReturnValue({ from: mockFrom });
+  mockExecute.mockResolvedValue({ rows: [] });
+
+  return {
+    insert: mockInsert,
+    select: mockSelect,
+    execute: mockExecute,
+  } as unknown as import('@colophony/db').DrizzleDb;
+}
+
+function makeSvc(
+  role: string = 'EDITOR',
+  userId: string = 'user-editor',
+): ServiceContext {
+  return {
+    tx: makeTx(),
+    actor: {
+      userId,
+      orgId: 'org-1',
+      role: role as 'ADMIN' | 'EDITOR' | 'READER',
+    },
+    audit: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('submissionDiscussionService', () => {
+  describe('listBySubmission', () => {
+    it('returns empty array for no comments', async () => {
+      const tx = makeTx();
+      mockOrderBy.mockReturnValue([]);
+
+      const result = await submissionDiscussionService.listBySubmission(
+        tx,
+        'sub-1',
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('returns comments with author email joined', async () => {
+      const tx = makeTx();
+      const comments = [
+        {
+          id: 'c1',
+          submissionId: 'sub-1',
+          authorId: 'user-1',
+          authorEmail: 'user@test.com',
+          parentId: null,
+          content: '<p>Hello</p>',
+          createdAt: new Date(),
+          updatedAt: null,
+        },
+      ];
+      mockOrderBy.mockReturnValue(comments);
+
+      const result = await submissionDiscussionService.listBySubmission(
+        tx,
+        'sub-1',
+      );
+      expect(result).toEqual(comments);
+      expect(mockSelect).toHaveBeenCalled();
+    });
+  });
+
+  describe('create', () => {
+    it('inserts and returns id', async () => {
+      const tx = makeTx();
+      mockReturning.mockReturnValue([{ id: 'new-comment-1' }]);
+
+      const result = await submissionDiscussionService.create(tx, {
+        organizationId: 'org-1',
+        submissionId: 'sub-1',
+        authorId: 'user-1',
+        content: '<p>Test</p>',
+      });
+
+      expect(result).toEqual({ id: 'new-comment-1' });
+      expect(mockInsert).toHaveBeenCalled();
+    });
+  });
+
+  describe('createWithAudit', () => {
+    it('rejects READER not assigned as reviewer', async () => {
+      const svc = makeSvc('READER', 'user-reader');
+      // Mock submission exists with a different submitter
+      mockLimit
+        .mockReturnValueOnce([
+          {
+            id: 'sub-1',
+            submitterId: 'user-submitter',
+            organizationId: 'org-1',
+          },
+        ])
+        // Mock reviewer check returns empty
+        .mockReturnValueOnce([]);
+
+      await expect(
+        submissionDiscussionService.createWithAudit(svc, {
+          submissionId: 'sub-1',
+          content: '<p>Test</p>',
+        }),
+      ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('allows assigned READER reviewer', async () => {
+      const svc = makeSvc('READER', 'user-reviewer');
+      // Mock submission exists
+      mockLimit
+        .mockReturnValueOnce([
+          {
+            id: 'sub-1',
+            submitterId: 'user-submitter',
+            organizationId: 'org-1',
+          },
+        ])
+        // Mock reviewer exists
+        .mockReturnValueOnce([{ id: 'rev-1' }]);
+
+      // Mock create returning
+      mockReturning.mockReturnValue([{ id: 'comment-1' }]);
+      // Mock the final re-read to get full comment
+      mockLimit.mockReturnValueOnce([
+        {
+          id: 'comment-1',
+          submissionId: 'sub-1',
+          authorId: 'user-reviewer',
+          authorEmail: 'reviewer@test.com',
+          parentId: null,
+          content: '<p>Test</p>',
+          createdAt: new Date(),
+          updatedAt: null,
+        },
+      ]);
+
+      const result = await submissionDiscussionService.createWithAudit(svc, {
+        submissionId: 'sub-1',
+        content: '<p>Test</p>',
+      });
+
+      expect(result.id).toBe('comment-1');
+      expect(svc.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: AuditResources.SUBMISSION,
+          action: AuditActions.DISCUSSION_COMMENT_ADDED,
+        }),
+      );
+    });
+
+    it('allows EDITOR', async () => {
+      const svc = makeSvc('EDITOR', 'user-editor');
+      // Mock submission exists
+      mockLimit.mockReturnValueOnce([
+        {
+          id: 'sub-1',
+          submitterId: 'user-submitter',
+          organizationId: 'org-1',
+        },
+      ]);
+
+      // Mock create
+      mockReturning.mockReturnValue([{ id: 'comment-1' }]);
+      // Mock re-read
+      mockLimit.mockReturnValueOnce([
+        {
+          id: 'comment-1',
+          submissionId: 'sub-1',
+          authorId: 'user-editor',
+          authorEmail: 'editor@test.com',
+          parentId: null,
+          content: '<p>Test</p>',
+          createdAt: new Date(),
+          updatedAt: null,
+        },
+      ]);
+
+      const result = await submissionDiscussionService.createWithAudit(svc, {
+        submissionId: 'sub-1',
+        content: '<p>Test</p>',
+      });
+
+      expect(result.id).toBe('comment-1');
+    });
+
+    it('allows ADMIN', async () => {
+      const svc = makeSvc('ADMIN', 'user-admin');
+      mockLimit.mockReturnValueOnce([
+        {
+          id: 'sub-1',
+          submitterId: 'user-submitter',
+          organizationId: 'org-1',
+        },
+      ]);
+
+      mockReturning.mockReturnValue([{ id: 'comment-1' }]);
+      mockLimit.mockReturnValueOnce([
+        {
+          id: 'comment-1',
+          submissionId: 'sub-1',
+          authorId: 'user-admin',
+          authorEmail: 'admin@test.com',
+          parentId: null,
+          content: '<p>Test</p>',
+          createdAt: new Date(),
+          updatedAt: null,
+        },
+      ]);
+
+      const result = await submissionDiscussionService.createWithAudit(svc, {
+        submissionId: 'sub-1',
+        content: '<p>Test</p>',
+      });
+
+      expect(result.id).toBe('comment-1');
+    });
+
+    it('rejects nonexistent parentId', async () => {
+      const svc = makeSvc('EDITOR', 'user-editor');
+      // Mock submission exists
+      mockLimit
+        .mockReturnValueOnce([
+          {
+            id: 'sub-1',
+            submitterId: 'user-submitter',
+            organizationId: 'org-1',
+          },
+        ])
+        // Mock parent comment not found
+        .mockReturnValueOnce([]);
+
+      await expect(
+        submissionDiscussionService.createWithAudit(svc, {
+          submissionId: 'sub-1',
+          parentId: 'nonexistent-parent',
+          content: '<p>Test</p>',
+        }),
+      ).rejects.toThrow(DiscussionParentNotFoundError);
+    });
+
+    it('collapses depth > 1 replies to root parent', async () => {
+      const svc = makeSvc('EDITOR', 'user-editor');
+      // Mock submission exists
+      mockLimit
+        .mockReturnValueOnce([
+          {
+            id: 'sub-1',
+            submitterId: 'user-submitter',
+            organizationId: 'org-1',
+          },
+        ])
+        // Mock parent comment has its own parent (depth > 1)
+        .mockReturnValueOnce([
+          {
+            id: 'child-comment',
+            parentId: 'root-comment',
+            submissionId: 'sub-1',
+          },
+        ]);
+
+      // Mock create
+      mockReturning.mockReturnValue([{ id: 'new-comment' }]);
+      // Mock re-read
+      mockLimit.mockReturnValueOnce([
+        {
+          id: 'new-comment',
+          submissionId: 'sub-1',
+          authorId: 'user-editor',
+          authorEmail: 'editor@test.com',
+          parentId: 'root-comment', // collapsed to root
+          content: '<p>Test</p>',
+          createdAt: new Date(),
+          updatedAt: null,
+        },
+      ]);
+
+      const result = await submissionDiscussionService.createWithAudit(svc, {
+        submissionId: 'sub-1',
+        parentId: 'child-comment',
+        content: '<p>Test</p>',
+      });
+
+      expect(result.parentId).toBe('root-comment');
+      // Verify the insert was called (the values mock will have the collapsed parentId)
+      expect(mockInsert).toHaveBeenCalled();
+    });
+
+    it('rejects submitter even if they have an org role', async () => {
+      const svc = makeSvc('EDITOR', 'user-submitter');
+      mockLimit.mockReturnValueOnce([
+        {
+          id: 'sub-1',
+          submitterId: 'user-submitter',
+          organizationId: 'org-1',
+        },
+      ]);
+
+      await expect(
+        submissionDiscussionService.createWithAudit(svc, {
+          submissionId: 'sub-1',
+          content: '<p>Test</p>',
+        }),
+      ).rejects.toThrow(ForbiddenError);
+    });
+  });
+
+  describe('getNotificationRecipients', () => {
+    it('de-duplicates and excludes author', async () => {
+      const tx = makeTx();
+      mockExecute.mockResolvedValue({
+        rows: [{ user_id: 'reviewer-1' }, { user_id: 'commenter-1' }],
+      });
+
+      const result =
+        await submissionDiscussionService.getNotificationRecipients(
+          tx,
+          'sub-1',
+          'author-1',
+        );
+
+      expect(result).toEqual(['reviewer-1', 'commenter-1']);
+      expect(mockExecute).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/services/submission-discussion.service.ts
+++ b/apps/api/src/services/submission-discussion.service.ts
@@ -1,0 +1,316 @@
+import sanitizeHtml from 'sanitize-html';
+import {
+  submissionDiscussions,
+  submissionReviewers,
+  submissions,
+  users,
+  eq,
+  and,
+  type DrizzleDb,
+} from '@colophony/db';
+import { sql } from 'drizzle-orm';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { SubmissionDiscussion } from '@colophony/types';
+import { enqueueOutboxEvent } from './outbox.js';
+import type { ServiceContext } from './types.js';
+import { ForbiddenError } from './errors.js';
+import { SubmissionNotFoundError } from './submission.service.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class DiscussionCommentNotFoundError extends Error {
+  constructor(commentId: string) {
+    super(`Discussion comment "${commentId}" not found`);
+    this.name = 'DiscussionCommentNotFoundError';
+  }
+}
+
+export class DiscussionParentNotFoundError extends Error {
+  constructor(parentId: string) {
+    super(`Discussion parent comment "${parentId}" not found`);
+    this.name = 'DiscussionParentNotFoundError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HTML sanitization (same allowlist as Tiptap templates)
+// ---------------------------------------------------------------------------
+
+function sanitizeContent(html: string): string {
+  return sanitizeHtml(html, {
+    allowedTags: [
+      'p',
+      'br',
+      'strong',
+      'b',
+      'em',
+      'i',
+      'u',
+      'a',
+      'ul',
+      'ol',
+      'li',
+      'blockquote',
+      'h1',
+      'h2',
+      'h3',
+    ],
+    allowedAttributes: {
+      a: ['href', 'target', 'rel'],
+    },
+    allowedSchemes: ['http', 'https', 'mailto'],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getSubmissionOrThrow(tx: DrizzleDb, submissionId: string) {
+  const [submission] = await tx
+    .select({
+      id: submissions.id,
+      submitterId: submissions.submitterId,
+      organizationId: submissions.organizationId,
+    })
+    .from(submissions)
+    .where(eq(submissions.id, submissionId))
+    .limit(1);
+
+  if (!submission) throw new SubmissionNotFoundError(submissionId);
+  return submission;
+}
+
+/**
+ * Assert the caller is an EDITOR, ADMIN, or an assigned reviewer for the
+ * submission. Submitters (owners) are explicitly rejected.
+ */
+async function assertEditorAdminOrReviewer(
+  tx: DrizzleDb,
+  actorRole: string,
+  actorUserId: string,
+  submissionId: string,
+  submitterId: string | null,
+): Promise<void> {
+  // Owners must not access internal discussion
+  if (submitterId && actorUserId === submitterId) {
+    throw new ForbiddenError(
+      'Submitters cannot access the internal discussion',
+    );
+  }
+
+  if (actorRole === 'ADMIN' || actorRole === 'EDITOR') return;
+
+  if (actorRole === 'READER') {
+    const [reviewer] = await tx
+      .select({ id: submissionReviewers.id })
+      .from(submissionReviewers)
+      .where(
+        and(
+          eq(submissionReviewers.submissionId, submissionId),
+          eq(submissionReviewers.reviewerUserId, actorUserId),
+        ),
+      )
+      .limit(1);
+
+    if (reviewer) return;
+  }
+
+  throw new ForbiddenError(
+    'Only editors, admins, and assigned reviewers can access the discussion',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pure data methods (accept DrizzleDb tx)
+// ---------------------------------------------------------------------------
+
+async function listBySubmission(
+  tx: DrizzleDb,
+  submissionId: string,
+): Promise<SubmissionDiscussion[]> {
+  const rows = await tx
+    .select({
+      id: submissionDiscussions.id,
+      submissionId: submissionDiscussions.submissionId,
+      authorId: submissionDiscussions.authorId,
+      authorEmail: users.email,
+      parentId: submissionDiscussions.parentId,
+      content: submissionDiscussions.content,
+      createdAt: submissionDiscussions.createdAt,
+      updatedAt: submissionDiscussions.updatedAt,
+    })
+    .from(submissionDiscussions)
+    .leftJoin(users, eq(users.id, submissionDiscussions.authorId))
+    .where(eq(submissionDiscussions.submissionId, submissionId))
+    .orderBy(submissionDiscussions.createdAt);
+
+  return rows;
+}
+
+async function create(
+  tx: DrizzleDb,
+  params: {
+    organizationId: string;
+    submissionId: string;
+    authorId: string;
+    parentId?: string | null;
+    content: string;
+  },
+): Promise<{ id: string }> {
+  const [row] = await tx
+    .insert(submissionDiscussions)
+    .values({
+      organizationId: params.organizationId,
+      submissionId: params.submissionId,
+      authorId: params.authorId,
+      parentId: params.parentId ?? null,
+      content: params.content,
+    })
+    .returning({ id: submissionDiscussions.id });
+
+  return row;
+}
+
+async function getNotificationRecipients(
+  tx: DrizzleDb,
+  submissionId: string,
+  authorId: string,
+): Promise<string[]> {
+  // Union of reviewer userIds + distinct commenter authorIds, minus the author
+  const rows = await tx.execute(sql`
+    SELECT DISTINCT user_id FROM (
+      SELECT reviewer_user_id AS user_id
+      FROM submission_reviewers
+      WHERE submission_id = ${submissionId}
+      UNION
+      SELECT author_id AS user_id
+      FROM submission_discussions
+      WHERE submission_id = ${submissionId} AND author_id IS NOT NULL
+    ) AS combined
+    WHERE user_id != ${authorId}
+  `);
+
+  return (rows.rows as Array<{ user_id: string }>).map((r) => r.user_id);
+}
+
+// ---------------------------------------------------------------------------
+// Access-aware methods (accept ServiceContext)
+// ---------------------------------------------------------------------------
+
+async function listWithAccess(
+  svc: ServiceContext,
+  submissionId: string,
+): Promise<SubmissionDiscussion[]> {
+  const submission = await getSubmissionOrThrow(svc.tx, submissionId);
+  await assertEditorAdminOrReviewer(
+    svc.tx,
+    svc.actor.role,
+    svc.actor.userId,
+    submissionId,
+    submission.submitterId,
+  );
+  return listBySubmission(svc.tx, submissionId);
+}
+
+async function createWithAudit(
+  svc: ServiceContext,
+  params: { submissionId: string; parentId?: string; content: string },
+): Promise<SubmissionDiscussion> {
+  const submission = await getSubmissionOrThrow(svc.tx, params.submissionId);
+  await assertEditorAdminOrReviewer(
+    svc.tx,
+    svc.actor.role,
+    svc.actor.userId,
+    params.submissionId,
+    submission.submitterId,
+  );
+
+  // Validate + collapse parentId if provided
+  let resolvedParentId: string | null = null;
+  if (params.parentId) {
+    const [parent] = await svc.tx
+      .select({
+        id: submissionDiscussions.id,
+        parentId: submissionDiscussions.parentId,
+        submissionId: submissionDiscussions.submissionId,
+      })
+      .from(submissionDiscussions)
+      .where(eq(submissionDiscussions.id, params.parentId))
+      .limit(1);
+
+    if (!parent || parent.submissionId !== params.submissionId) {
+      throw new DiscussionParentNotFoundError(params.parentId);
+    }
+
+    // Collapse depth > 1: if parent itself has a parent, reply to the root
+    resolvedParentId = parent.parentId ?? parent.id;
+  }
+
+  const sanitizedContent = sanitizeContent(params.content);
+
+  const { id } = await create(svc.tx, {
+    organizationId: svc.actor.orgId,
+    submissionId: params.submissionId,
+    authorId: svc.actor.userId,
+    parentId: resolvedParentId,
+    content: sanitizedContent,
+  });
+
+  await svc.audit({
+    resource: AuditResources.SUBMISSION,
+    action: AuditActions.DISCUSSION_COMMENT_ADDED,
+    resourceId: params.submissionId,
+    newValue: { commentId: id },
+  });
+
+  // Get notification recipients and enqueue outbox event
+  const recipientUserIds = await getNotificationRecipients(
+    svc.tx,
+    params.submissionId,
+    svc.actor.userId,
+  );
+
+  if (recipientUserIds.length > 0) {
+    await enqueueOutboxEvent(svc.tx, 'hopper/discussion.comment_added', {
+      orgId: svc.actor.orgId,
+      submissionId: params.submissionId,
+      commentId: id,
+      authorId: svc.actor.userId,
+      recipientUserIds,
+    });
+  }
+
+  // Return the full comment with author email
+  const [comment] = await svc.tx
+    .select({
+      id: submissionDiscussions.id,
+      submissionId: submissionDiscussions.submissionId,
+      authorId: submissionDiscussions.authorId,
+      authorEmail: users.email,
+      parentId: submissionDiscussions.parentId,
+      content: submissionDiscussions.content,
+      createdAt: submissionDiscussions.createdAt,
+      updatedAt: submissionDiscussions.updatedAt,
+    })
+    .from(submissionDiscussions)
+    .leftJoin(users, eq(users.id, submissionDiscussions.authorId))
+    .where(eq(submissionDiscussions.id, id))
+    .limit(1);
+
+  return comment;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export const submissionDiscussionService = {
+  listBySubmission,
+  create,
+  getNotificationRecipients,
+  listWithAccess,
+  createWithAudit,
+};

--- a/apps/api/src/templates/email/templates.ts
+++ b/apps/api/src/templates/email/templates.ts
@@ -6,6 +6,7 @@ import type {
   CopyeditorAssignedData,
   EditorMessageTemplateData,
   ReviewerAssignedTemplateData,
+  DiscussionCommentTemplateData,
 } from './types.js';
 import { wrapInLayout } from './layout.js';
 
@@ -246,6 +247,29 @@ function reviewerAssigned(data: Record<string, unknown>): TemplateResult {
   };
 }
 
+function discussionComment(data: Record<string, unknown>): TemplateResult {
+  const d = data as unknown as DiscussionCommentTemplateData;
+  return {
+    subject: `New discussion comment on: ${d.submissionTitle}`,
+    mjml: wrapInLayout(
+      `<mj-text>
+        <p>A team member commented on the internal discussion for a submission.</p>
+        <p><strong>Title:</strong> ${escapeHtml(d.submissionTitle)}</p>
+        <p><strong>Comment by:</strong> ${escapeHtml(d.authorName)}</p>
+        ${d.submissionUrl ? `<p><a href="${escapeHtml(d.submissionUrl)}">View Submission</a></p>` : ''}
+      </mj-text>`,
+      d.orgName,
+    ),
+    text: [
+      `A team member commented on the internal discussion for "${d.submissionTitle}".`,
+      `Comment by: ${d.authorName}`,
+      d.submissionUrl ? `View: ${d.submissionUrl}` : '',
+    ]
+      .filter(Boolean)
+      .join('\n'),
+  };
+}
+
 export const templates: Record<TemplateName, TemplateRenderer> = {
   'submission-received': submissionReceived,
   'submission-accepted': submissionAccepted,
@@ -256,6 +280,7 @@ export const templates: Record<TemplateName, TemplateRenderer> = {
   'copyeditor-assigned': copyeditorAssigned,
   'editor-message': editorMessage,
   'reviewer-assigned': reviewerAssigned,
+  'discussion-comment': discussionComment,
 };
 
 function stripHtml(html: string): string {

--- a/apps/api/src/templates/email/types.ts
+++ b/apps/api/src/templates/email/types.ts
@@ -7,7 +7,8 @@ export type TemplateName =
   | 'contract-ready'
   | 'copyeditor-assigned'
   | 'editor-message'
-  | 'reviewer-assigned';
+  | 'reviewer-assigned'
+  | 'discussion-comment';
 
 export interface SubmissionTemplateData {
   submissionTitle: string;
@@ -47,9 +48,17 @@ export interface ReviewerAssignedTemplateData {
   submissionUrl?: string;
 }
 
+export interface DiscussionCommentTemplateData {
+  submissionTitle: string;
+  orgName: string;
+  authorName: string;
+  submissionUrl?: string;
+}
+
 export type TemplateData =
   | SubmissionTemplateData
   | ContractTemplateData
   | CopyeditorAssignedData
   | EditorMessageTemplateData
-  | ReviewerAssignedTemplateData;
+  | ReviewerAssignedTemplateData
+  | DiscussionCommentTemplateData;

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -75,6 +75,10 @@ import {
   ReviewerNotAssignedError,
   ReviewerNotOrgMemberError,
 } from '../services/submission-reviewer.service.js';
+import {
+  DiscussionCommentNotFoundError,
+  DiscussionParentNotFoundError,
+} from '../services/submission-discussion.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -145,6 +149,9 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [ReviewerAlreadyAssignedError, 'CONFLICT'],
   [ReviewerNotAssignedError, 'NOT_FOUND'],
   [ReviewerNotOrgMemberError, 'BAD_REQUEST'],
+  // Discussion errors
+  [DiscussionCommentNotFoundError, 'NOT_FOUND'],
+  [DiscussionParentNotFoundError, 'NOT_FOUND'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];

--- a/apps/api/src/trpc/routers/submissions.ts
+++ b/apps/api/src/trpc/routers/submissions.ts
@@ -23,6 +23,9 @@ import {
   unassignReviewerInputSchema,
   markReviewerReadInputSchema,
   submissionReviewerSchema,
+  listDiscussionCommentsSchema,
+  createDiscussionCommentSchema,
+  submissionDiscussionSchema,
 } from '@colophony/types';
 import {
   orgProcedure,
@@ -32,6 +35,7 @@ import {
 } from '../init.js';
 import { submissionService } from '../../services/submission.service.js';
 import { submissionReviewerService } from '../../services/submission-reviewer.service.js';
+import { submissionDiscussionService } from '../../services/submission-discussion.service.js';
 import { simsubService } from '../../services/simsub.service.js';
 import { transferService } from '../../services/transfer.service.js';
 import { migrationService } from '../../services/migration.service.js';
@@ -405,6 +409,38 @@ export const submissionsRouter = createRouter({
       try {
         return await migrationService.listMigrationsForUser(
           ctx.authContext.userId,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** List internal discussion comments on a submission. */
+  listDiscussionComments: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(listDiscussionCommentsSchema)
+    .output(z.array(submissionDiscussionSchema))
+    .query(async ({ ctx, input }) => {
+      try {
+        return await submissionDiscussionService.listWithAccess(
+          toServiceContext(ctx),
+          input.submissionId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Add a comment to the internal discussion on a submission. */
+  addDiscussionComment: orgProcedure
+    .use(requireScopes('submissions:write'))
+    .input(createDiscussionCommentSchema)
+    .output(submissionDiscussionSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await submissionDiscussionService.createWithAudit(
+          toServiceContext(ctx),
           input,
         );
       } catch (e) {

--- a/apps/web/src/components/submissions/discussion-thread.tsx
+++ b/apps/web/src/components/submissions/discussion-thread.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { useState } from "react";
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Placeholder from "@tiptap/extension-placeholder";
+import TiptapLink from "@tiptap/extension-link";
+import { formatDistanceToNow } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "sonner";
+import {
+  Bold,
+  Italic,
+  List,
+  ListOrdered,
+  Link as LinkIcon,
+  Loader2,
+  Reply,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+
+interface DiscussionThreadProps {
+  submissionId: string;
+}
+
+function TiptapToolbar({
+  editor,
+}: {
+  editor: ReturnType<typeof useEditor> | null;
+}) {
+  if (!editor) return null;
+
+  const toggleLink = () => {
+    if (editor.isActive("link")) {
+      editor.chain().focus().unsetLink().run();
+      return;
+    }
+    const url = window.prompt("Enter URL:");
+    if (url) {
+      editor.chain().focus().setLink({ href: url }).run();
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-1 border-b p-2">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8"
+        onClick={() => editor.chain().focus().toggleBold().run()}
+        data-active={editor.isActive("bold")}
+      >
+        <Bold className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8"
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+        data-active={editor.isActive("italic")}
+      >
+        <Italic className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8"
+        onClick={() => editor.chain().focus().toggleBulletList().run()}
+        data-active={editor.isActive("bulletList")}
+      >
+        <List className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8"
+        onClick={() => editor.chain().focus().toggleOrderedList().run()}
+        data-active={editor.isActive("orderedList")}
+      >
+        <ListOrdered className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8"
+        onClick={toggleLink}
+        data-active={editor.isActive("link")}
+      >
+        <LinkIcon className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+function CommentEditor({
+  onSubmit,
+  isPending,
+  placeholder = "Write a comment...",
+  autoFocus = false,
+}: {
+  onSubmit: (html: string) => void;
+  isPending: boolean;
+  placeholder?: string;
+  autoFocus?: boolean;
+}) {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit,
+      Placeholder.configure({ placeholder }),
+      TiptapLink.configure({ openOnClick: false }),
+    ],
+    content: "",
+    autofocus: autoFocus,
+  });
+
+  const handleSubmit = () => {
+    if (!editor) return;
+    const html = editor.getHTML();
+    if (!html.trim() || html === "<p></p>") return;
+    onSubmit(html);
+    editor.commands.clearContent();
+  };
+
+  return (
+    <div className="border rounded-md">
+      <TiptapToolbar editor={editor} />
+      <EditorContent
+        editor={editor}
+        className="prose prose-sm max-w-none p-3 min-h-[100px] focus-within:outline-none [&_.tiptap]:outline-none"
+      />
+      <div className="flex justify-end p-2 border-t">
+        <Button size="sm" onClick={handleSubmit} disabled={isPending}>
+          {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Comment
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function CommentItem({
+  comment,
+  replies,
+  onReply,
+}: {
+  comment: {
+    id: string;
+    authorEmail: string | null;
+    content: string;
+    createdAt: string | Date;
+    parentId: string | null;
+  };
+  replies: Array<{
+    id: string;
+    authorEmail: string | null;
+    content: string;
+    createdAt: string | Date;
+    parentId: string | null;
+  }>;
+  onReply: (parentId: string) => void;
+}) {
+  const [showReplies, setShowReplies] = useState(true);
+  const isTopLevel = comment.parentId === null;
+
+  return (
+    <div className={isTopLevel ? "" : "ml-6 border-l-2 border-muted pl-4"}>
+      <div className="space-y-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">
+            {comment.authorEmail ?? "Unknown"}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {formatDistanceToNow(new Date(comment.createdAt), {
+              addSuffix: true,
+            })}
+          </span>
+        </div>
+        <div
+          className="prose prose-sm max-w-none text-sm"
+          dangerouslySetInnerHTML={{ __html: comment.content }}
+        />
+        {isTopLevel && (
+          <div className="flex items-center gap-2 pt-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs text-muted-foreground"
+              onClick={() => onReply(comment.id)}
+            >
+              <Reply className="mr-1 h-3 w-3" />
+              Reply
+            </Button>
+            {replies.length > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs text-muted-foreground"
+                onClick={() => setShowReplies(!showReplies)}
+              >
+                {showReplies ? (
+                  <ChevronDown className="mr-1 h-3 w-3" />
+                ) : (
+                  <ChevronRight className="mr-1 h-3 w-3" />
+                )}
+                {replies.length} {replies.length === 1 ? "reply" : "replies"}
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+      {isTopLevel && showReplies && replies.length > 0 && (
+        <div className="mt-2 space-y-3">
+          {replies.map((reply) => (
+            <CommentItem
+              key={reply.id}
+              comment={reply}
+              replies={[]}
+              onReply={onReply}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function DiscussionThread({ submissionId }: DiscussionThreadProps) {
+  const [replyingTo, setReplyingTo] = useState<string | null>(null);
+  const utils = trpc.useUtils();
+
+  const { data: comments, isPending: isLoading } =
+    trpc.submissions.listDiscussionComments.useQuery({ submissionId });
+
+  const addComment = trpc.submissions.addDiscussionComment.useMutation({
+    onSuccess: () => {
+      toast.success("Comment posted");
+      setReplyingTo(null);
+      utils.submissions.listDiscussionComments.invalidate({ submissionId });
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const handleSubmit = (content: string, parentId?: string) => {
+    addComment.mutate({ submissionId, parentId, content });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-20 w-full" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+    );
+  }
+
+  // Group comments by threading
+  const topLevel = (comments ?? []).filter((c) => c.parentId === null);
+  const repliesByParent = new Map<string, typeof comments>();
+  for (const c of comments ?? []) {
+    if (c.parentId) {
+      const existing = repliesByParent.get(c.parentId) ?? [];
+      existing.push(c);
+      repliesByParent.set(c.parentId, existing);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {topLevel.length === 0 && !replyingTo && (
+        <p className="text-sm text-muted-foreground">No discussion yet.</p>
+      )}
+
+      {topLevel.map((comment) => (
+        <div key={comment.id}>
+          <CommentItem
+            comment={comment}
+            replies={repliesByParent.get(comment.id) ?? []}
+            onReply={setReplyingTo}
+          />
+          {replyingTo === comment.id && (
+            <div className="ml-6 mt-2">
+              <CommentEditor
+                onSubmit={(html) => handleSubmit(html, comment.id)}
+                isPending={addComment.isPending}
+                placeholder="Write a reply..."
+                autoFocus
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                className="mt-1 text-xs"
+                onClick={() => setReplyingTo(null)}
+              >
+                Cancel
+              </Button>
+            </div>
+          )}
+        </div>
+      ))}
+
+      <CommentEditor
+        onSubmit={(html) => handleSubmit(html)}
+        isPending={addComment.isPending}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -14,6 +14,7 @@ import { ComposeMessageDialog } from "./compose-message-dialog";
 import { CorrespondenceHistory } from "./correspondence-history";
 import { ReviewerList } from "./reviewer-list";
 import { ReviewerPicker } from "./reviewer-picker";
+import { DiscussionThread } from "./discussion-thread";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -45,6 +46,7 @@ import {
   Loader2,
   BookOpen,
   Mail,
+  MessageSquare,
 } from "lucide-react";
 import {
   EDITOR_ALLOWED_TRANSITIONS,
@@ -299,6 +301,27 @@ export function SubmissionDetail({
           </CardContent>
         </Card>
       )}
+
+      {/* Internal Discussion — editors, admins, and assigned reviewers only */}
+      {(isEditor ||
+        isAdmin ||
+        (reviewers ?? []).some((r) => r.reviewerUserId === user?.id)) &&
+        !isOwner && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <MessageSquare className="h-5 w-5" />
+                Internal Discussion
+              </CardTitle>
+              <CardDescription>
+                Visible to editors, admins, and assigned reviewers only.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <DiscussionThread submissionId={submissionId} />
+            </CardContent>
+          </Card>
+        )}
 
       {/* Content */}
       <div className="grid gap-6 md:grid-cols-3">

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -316,7 +316,7 @@
 ### Editorial Workflow
 
 - [x] [P1] Reviewer assignment per submission — assign one or more org members as readers on a submission; track who has read it; show assignment in submission detail — (persona gap analysis 2026-02-27; done 2026-02-28)
-- [ ] [P1] Internal discussion threads on submissions — comment system on Hopper submissions (pre-acceptance), separate from the Slate pipeline comments (post-acceptance) — (persona gap analysis 2026-02-27)
+- [x] [P1] Internal discussion threads on submissions — comment system on Hopper submissions (pre-acceptance), separate from the Slate pipeline comments (post-acceptance) — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [ ] [P2] Voting / scoring on submissions — readers cast votes (accept/reject/maybe + optional score); configurable per org; summary visible to editors making final decisions — (persona gap analysis 2026-02-27)
 - [ ] [P2] Blind / anonymous review mode — hide submitter identity from reviewers; admin toggle per submission period — (persona gap analysis 2026-02-27)
 - [ ] [P2] Batch operations — checkbox selection in submission queue; bulk status transitions (reject, move to review); bulk assignment — (persona gap analysis 2026-02-27)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-28 — Track 7 PR5: Internal Discussion Threads on Submissions
+
+### Done
+
+- **DB:** `submission_discussions` table (migration 0041) with org isolation RLS, self-referencing `parent_id` FK for threading, 4 indexes (org, submission, parent, author)
+- **Shared types:** `submissionDiscussionSchema`, `createDiscussionCommentSchema`, `listDiscussionCommentsSchema` Zod schemas; `DISCUSSION_COMMENT_ADDED` audit action on `SubmissionAuditParams`
+- **Service layer:** `submission-discussion.service.ts` — `assertEditorAdminOrReviewer` (ADMIN/EDITOR pass; READER must be assigned reviewer; submitters explicitly rejected); depth-1 thread collapsing; HTML sanitization via `sanitize-html`; notification recipient union (reviewers + prior commenters, minus author)
+- **Inngest:** `hopper/discussion.comment_added` event + `discussionCommentNotification` function (loops recipients: email + in-app per recipient)
+- **Email template:** `discussion-comment` with MJML + plain text (submission title, author name)
+- **API surfaces:** 2 endpoints on tRPC (`listDiscussionComments`, `addDiscussionComment`), REST (`GET/POST /submissions/{id}/discussions`), and GraphQL (`submissionDiscussions` query, `addSubmissionDiscussion` mutation)
+- **Error mappers:** `DiscussionCommentNotFoundError` (NOT_FOUND), `DiscussionParentNotFoundError` (NOT_FOUND) across all 3 API surfaces
+- **Frontend:** `DiscussionThread` component with Tiptap rich text editor (Bold, Italic, BulletList, OrderedList, Link), threaded comment display, reply/collapse controls; integrated into `submission-detail.tsx` with conditional rendering for editors/admins/assigned reviewers (hidden from submitters)
+- **Tests:** 11 service unit tests + 4 type validation tests; all 1301 tests passing; type-checks and lint clean
+
+### Decisions
+
+- Threading max depth 1 — replies to replies collapse to the root parent (keeps UI simple)
+- Submitters explicitly rejected from `assertEditorAdminOrReviewer` even if they have an org role (owner edge case from code review)
+- `DISCUSSION_COMMENT_ADDED` on existing `SubmissionAuditParams` (not a new audit resource) — consistent with reviewer actions
+- Notification recipients: union of assigned reviewers + distinct prior commenters, de-duplicated, excluding comment author
+
+---
+
 ## 2026-02-28 — Track 7 PR4: Reviewer Assignment per Submission
 
 ### Done

--- a/packages/db/migrations/0041_submission_discussions.sql
+++ b/packages/db/migrations/0041_submission_discussions.sql
@@ -1,0 +1,35 @@
+-- submission_discussions: internal staff discussion threads on submissions
+CREATE TABLE IF NOT EXISTS "submission_discussions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "submission_id" uuid NOT NULL REFERENCES "submissions"("id") ON DELETE CASCADE,
+  "author_id" uuid REFERENCES "users"("id") ON DELETE SET NULL,
+  "parent_id" uuid REFERENCES "submission_discussions"("id") ON DELETE SET NULL,
+  "content" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone
+);
+
+--> statement-breakpoint
+
+ALTER TABLE "submission_discussions" ENABLE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+
+CREATE POLICY "org_isolation" ON "submission_discussions" AS PERMISSIVE FOR ALL TO public USING (organization_id = current_org_id());
+
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "submission_discussions_org_id_idx" ON "submission_discussions" USING btree ("organization_id");
+
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "submission_discussions_submission_id_idx" ON "submission_discussions" USING btree ("submission_id");
+
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "submission_discussions_parent_id_idx" ON "submission_discussions" USING btree ("parent_id");
+
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "submission_discussions_author_id_idx" ON "submission_discussions" USING btree ("author_id");

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1777200000000,
       "tag": "0040_submission_reviewers",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1777400000000,
+      "tag": "0041_submission_discussions",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/submissions.ts
+++ b/packages/db/src/schema/submissions.ts
@@ -277,3 +277,34 @@ export const submissionReviewers = pgTable(
     orgIsolationPolicy,
   ],
 ).enableRLS();
+
+// --- submission_discussions ---
+
+export const submissionDiscussions = pgTable(
+  "submission_discussions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    submissionId: uuid("submission_id")
+      .notNull()
+      .references(() => submissions.id, { onDelete: "cascade" }),
+    authorId: uuid("author_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    parentId: uuid("parent_id"),
+    content: text("content").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("submission_discussions_org_id_idx").on(table.organizationId),
+    index("submission_discussions_submission_id_idx").on(table.submissionId),
+    index("submission_discussions_parent_id_idx").on(table.parentId),
+    index("submission_discussions_author_id_idx").on(table.authorId),
+    orgIsolationPolicy,
+  ],
+).enableRLS();

--- a/packages/types/src/__tests__/discussion.spec.ts
+++ b/packages/types/src/__tests__/discussion.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  submissionDiscussionSchema,
+  createDiscussionCommentSchema,
+} from "../discussion";
+
+describe("submissionDiscussionSchema", () => {
+  it("validates complete data", () => {
+    const data = {
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      submissionId: "550e8400-e29b-41d4-a716-446655440001",
+      authorId: "550e8400-e29b-41d4-a716-446655440002",
+      authorEmail: "user@example.com",
+      parentId: null,
+      content: "<p>Test comment</p>",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: null,
+    };
+
+    const result = submissionDiscussionSchema.parse(data);
+    expect(result.id).toBe(data.id);
+    expect(result.authorEmail).toBe(data.authorEmail);
+    expect(result.createdAt).toBeInstanceOf(Date);
+  });
+});
+
+describe("createDiscussionCommentSchema", () => {
+  it("rejects empty content", () => {
+    const result = createDiscussionCommentSchema.safeParse({
+      submissionId: "550e8400-e29b-41d4-a716-446655440000",
+      content: "",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects content over 50000 characters", () => {
+    const result = createDiscussionCommentSchema.safeParse({
+      submissionId: "550e8400-e29b-41d4-a716-446655440000",
+      content: "x".repeat(50001),
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts without parentId", () => {
+    const result = createDiscussionCommentSchema.safeParse({
+      submissionId: "550e8400-e29b-41d4-a716-446655440000",
+      content: "Valid comment",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts with parentId", () => {
+    const result = createDiscussionCommentSchema.safeParse({
+      submissionId: "550e8400-e29b-41d4-a716-446655440000",
+      parentId: "550e8400-e29b-41d4-a716-446655440001",
+      content: "Valid reply",
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -214,6 +214,9 @@ export const AuditActions = {
   CORRESPONDENCE_SENT: "CORRESPONDENCE_SENT",
   CORRESPONDENCE_AUTO_CAPTURED: "CORRESPONDENCE_AUTO_CAPTURED",
 
+  // Discussion lifecycle
+  DISCUSSION_COMMENT_ADDED: "DISCUSSION_COMMENT_ADDED",
+
   // Email template lifecycle
   EMAIL_TEMPLATE_CREATED: "EMAIL_TEMPLATE_CREATED",
   EMAIL_TEMPLATE_UPDATED: "EMAIL_TEMPLATE_UPDATED",
@@ -314,7 +317,8 @@ export interface SubmissionAuditParams extends BaseAuditParams {
     | typeof AuditActions.SUBMISSION_WITHDRAWN
     | typeof AuditActions.REVIEWER_ASSIGNED
     | typeof AuditActions.REVIEWER_UNASSIGNED
-    | typeof AuditActions.REVIEWER_READ;
+    | typeof AuditActions.REVIEWER_READ
+    | typeof AuditActions.DISCUSSION_COMMENT_ADDED;
 }
 
 export interface FileAuditParams extends BaseAuditParams {

--- a/packages/types/src/discussion.ts
+++ b/packages/types/src/discussion.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Submission discussion comment schema
+// ---------------------------------------------------------------------------
+
+export const submissionDiscussionSchema = z.object({
+  id: z.string().uuid(),
+  submissionId: z.string().uuid(),
+  authorId: z.string().uuid().nullable(),
+  authorEmail: z.string().nullable(),
+  parentId: z.string().uuid().nullable(),
+  content: z.string(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date().nullable(),
+});
+
+export type SubmissionDiscussion = z.infer<typeof submissionDiscussionSchema>;
+
+// ---------------------------------------------------------------------------
+// Input schemas
+// ---------------------------------------------------------------------------
+
+export const createDiscussionCommentSchema = z.object({
+  submissionId: z.string().uuid(),
+  parentId: z.string().uuid().optional(),
+  content: z.string().trim().min(1).max(50000),
+});
+
+export type CreateDiscussionCommentInput = z.infer<
+  typeof createDiscussionCommentSchema
+>;
+
+export const listDiscussionCommentsSchema = z.object({
+  submissionId: z.string().uuid(),
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -28,3 +28,4 @@ export * from "./correspondence";
 export * from "./csr";
 export * from "./status-mapping";
 export * from "./email-templates";
+export * from "./discussion";


### PR DESCRIPTION
## Summary

- Adds staff-only threaded discussion system on Hopper submissions (pre-acceptance)
- Editors, admins, and assigned reviewers can post and view discussion comments; submitters cannot access
- Rich text editing via Tiptap with threading (max depth 1, replies collapse to root parent)
- Full API coverage: tRPC, REST, and GraphQL endpoints
- Inngest-powered email + in-app notifications to assigned reviewers and prior commenters

## Changes

### Database
- New `submission_discussions` table with RLS via `orgIsolationPolicy`
- Self-referencing `parent_id` FK for threading
- Migration `0041_submission_discussions.sql`

### Backend
- `submission-discussion.service.ts` — access control (`assertEditorAdminOrReviewer`), CRUD, HTML sanitization, audit logging, notification dispatch
- `discussion-notifications.ts` — Inngest function for email + in-app notifications
- `discussion-comment` email template
- All three API surfaces: tRPC procedures, REST routes, GraphQL query/mutation
- Error mappers for all API surfaces

### Frontend
- `discussion-thread.tsx` — Tiptap rich text editor, threaded comment display with reply/collapse
- Integrated into `submission-detail.tsx` behind role-based visibility

### Tests
- 11 service unit tests (access control, threading, notifications)
- 4 type validation tests

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `apps/api/src/services/submission-discussion.service.spec.ts` | In `__tests__/` subdir | In `services/` directly | Matches codebase convention for service specs |

## Test plan

- [x] `pnpm test` — 1301 pass, 0 fail (15 new)
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean (pre-existing warnings only)
- [ ] Manual QA: log in as editor, post discussion comment, verify threading
- [ ] Manual QA: verify submitter view does NOT show discussion section
- [ ] Playwright E2E submissions suite — no regressions