### PR TITLE
feat(hopper): submission analytics dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,8 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **Hub auth**             | `apps/api/src/federation/hub-auth.ts` (S2S hub auth middleware)                  |
 | **Hub service**          | `apps/api/src/services/hub.service.ts`                                           |
 | **Hub client service**   | `apps/api/src/services/hub-client.service.ts`                                    |
+| **Analytics service**    | `apps/api/src/services/submission-analytics.service.ts`                          |
+| **Analytics components** | `apps/web/src/components/analytics/` (charts, filters, dashboard page)           |
 | **Next.js frontend**     | `apps/web/`                                                                      |
 | **tRPC client**          | `apps/web/src/lib/trpc.ts`                                                       |
 | **Plugin components**    | `apps/web/src/components/plugins/` (PluginSlot, extensions, error boundary)      |

--- a/apps/api/src/graphql/resolvers/index.ts
+++ b/apps/api/src/graphql/resolvers/index.ts
@@ -13,3 +13,4 @@ import './pipeline.js';
 import './contracts.js';
 import './issues.js';
 import './cms-connections.js';
+import './submission-analytics.js';

--- a/apps/api/src/graphql/resolvers/submission-analytics.ts
+++ b/apps/api/src/graphql/resolvers/submission-analytics.ts
@@ -1,0 +1,178 @@
+import { builder } from '../builder.js';
+import { requireOrgContext, requireScopes } from '../guards.js';
+import { assertEditorOrAdmin } from '../../services/errors.js';
+import { submissionAnalyticsService } from '../../services/submission-analytics.service.js';
+import { mapServiceError } from '../error-mapper.js';
+import {
+  SubmissionOverviewStatsType,
+  SubmissionStatusBreakdownType,
+  SubmissionFunnelType,
+  SubmissionTimeSeriesType,
+  ResponseTimeDistributionType,
+  AgingSubmissionsType,
+} from '../types/index.js';
+
+// ---------------------------------------------------------------------------
+// Helper to extract filter from args
+// ---------------------------------------------------------------------------
+
+function extractFilter(args: {
+  startDate?: Date | null;
+  endDate?: Date | null;
+  submissionPeriodId?: string | null;
+}) {
+  return {
+    startDate: args.startDate ?? undefined,
+    endDate: args.endDate ?? undefined,
+    submissionPeriodId: args.submissionPeriodId ?? undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Query fields
+// ---------------------------------------------------------------------------
+
+builder.queryFields((t) => {
+  const filterArgs = {
+    startDate: t.arg({ type: 'DateTime', required: false }),
+    endDate: t.arg({ type: 'DateTime', required: false }),
+    submissionPeriodId: t.arg.string({ required: false }),
+  } as const;
+
+  return {
+    submissionAnalyticsOverview: t.field({
+      type: SubmissionOverviewStatsType,
+      description:
+        'Key submission statistics: totals, acceptance rate, avg response time.',
+      args: filterArgs,
+      resolve: async (_root, args, ctx) => {
+        try {
+          const orgCtx = requireOrgContext(ctx);
+          await requireScopes(ctx, 'submissions:read');
+          assertEditorOrAdmin(orgCtx.authContext.role);
+          return await submissionAnalyticsService.getOverviewStats(
+            orgCtx.dbTx,
+            extractFilter(args),
+          );
+        } catch (e) {
+          mapServiceError(e);
+        }
+      },
+    }),
+
+    submissionAnalyticsStatusBreakdown: t.field({
+      type: SubmissionStatusBreakdownType,
+      description: 'Submission counts grouped by status.',
+      args: filterArgs,
+      resolve: async (_root, args, ctx) => {
+        try {
+          const orgCtx = requireOrgContext(ctx);
+          await requireScopes(ctx, 'submissions:read');
+          assertEditorOrAdmin(orgCtx.authContext.role);
+          return await submissionAnalyticsService.getStatusBreakdown(
+            orgCtx.dbTx,
+            extractFilter(args),
+          );
+        } catch (e) {
+          mapServiceError(e);
+        }
+      },
+    }),
+
+    submissionAnalyticsFunnel: t.field({
+      type: SubmissionFunnelType,
+      description: 'Submission workflow funnel — count at each stage.',
+      args: filterArgs,
+      resolve: async (_root, args, ctx) => {
+        try {
+          const orgCtx = requireOrgContext(ctx);
+          await requireScopes(ctx, 'submissions:read');
+          assertEditorOrAdmin(orgCtx.authContext.role);
+          return await submissionAnalyticsService.getFunnel(
+            orgCtx.dbTx,
+            extractFilter(args),
+          );
+        } catch (e) {
+          mapServiceError(e);
+        }
+      },
+    }),
+
+    submissionAnalyticsTimeSeries: t.field({
+      type: SubmissionTimeSeriesType,
+      description: 'Submission counts over time by granularity.',
+      args: {
+        ...filterArgs,
+        granularity: t.arg.string({
+          required: false,
+          description: 'Time series granularity: daily, weekly, monthly.',
+        }),
+      },
+      resolve: async (_root, args, ctx) => {
+        try {
+          const orgCtx = requireOrgContext(ctx);
+          await requireScopes(ctx, 'submissions:read');
+          assertEditorOrAdmin(orgCtx.authContext.role);
+          const granularity =
+            args.granularity === 'daily' || args.granularity === 'weekly'
+              ? args.granularity
+              : ('monthly' as const);
+          return await submissionAnalyticsService.getTimeSeries(orgCtx.dbTx, {
+            ...extractFilter(args),
+            granularity,
+          });
+        } catch (e) {
+          mapServiceError(e);
+        }
+      },
+    }),
+
+    submissionAnalyticsResponseTime: t.field({
+      type: ResponseTimeDistributionType,
+      description: 'Response time histogram buckets and median.',
+      args: filterArgs,
+      resolve: async (_root, args, ctx) => {
+        try {
+          const orgCtx = requireOrgContext(ctx);
+          await requireScopes(ctx, 'submissions:read');
+          assertEditorOrAdmin(orgCtx.authContext.role);
+          return await submissionAnalyticsService.getResponseTimeDistribution(
+            orgCtx.dbTx,
+            extractFilter(args),
+          );
+        } catch (e) {
+          mapServiceError(e);
+        }
+      },
+    }),
+
+    submissionAnalyticsAging: t.field({
+      type: AgingSubmissionsType,
+      description: 'Non-terminal submissions older than threshold.',
+      args: {
+        ...filterArgs,
+        thresholdDays: t.arg.int({
+          required: false,
+          defaultValue: 14,
+          description: 'Age threshold in days.',
+        }),
+      },
+      resolve: async (_root, args, ctx) => {
+        try {
+          const orgCtx = requireOrgContext(ctx);
+          await requireScopes(ctx, 'submissions:read');
+          assertEditorOrAdmin(orgCtx.authContext.role);
+          return await submissionAnalyticsService.getAgingSubmissions(
+            orgCtx.dbTx,
+            {
+              ...extractFilter(args),
+              thresholdDays: args.thresholdDays ?? 14,
+            },
+          );
+        } catch (e) {
+          mapServiceError(e);
+        }
+      },
+    }),
+  };
+});

--- a/apps/api/src/graphql/types/analytics.ts
+++ b/apps/api/src/graphql/types/analytics.ts
@@ -1,0 +1,180 @@
+import type {
+  SubmissionOverviewStats,
+  SubmissionStatusBreakdown,
+  SubmissionFunnel,
+  SubmissionTimeSeries,
+  ResponseTimeDistribution,
+  AgingSubmissions,
+} from '@colophony/types';
+import { builder } from '../builder.js';
+
+// ---------------------------------------------------------------------------
+// Nested object types
+// ---------------------------------------------------------------------------
+
+const StatusBreakdownItem = builder
+  .objectRef<{ status: string; count: number }>('StatusBreakdownItem')
+  .implement({
+    fields: (t) => ({
+      status: t.exposeString('status'),
+      count: t.exposeInt('count'),
+    }),
+  });
+
+const FunnelStage = builder
+  .objectRef<{ stage: string; count: number }>('FunnelStage')
+  .implement({
+    fields: (t) => ({
+      stage: t.exposeString('stage'),
+      count: t.exposeInt('count'),
+    }),
+  });
+
+const TimeSeriesPoint = builder
+  .objectRef<{ date: string; count: number }>('TimeSeriesPoint')
+  .implement({
+    fields: (t) => ({
+      date: t.exposeString('date'),
+      count: t.exposeInt('count'),
+    }),
+  });
+
+const ResponseTimeBucket = builder
+  .objectRef<{
+    label: string;
+    count: number;
+    minDays: number;
+    maxDays: number;
+  }>('ResponseTimeBucket')
+  .implement({
+    fields: (t) => ({
+      label: t.exposeString('label'),
+      count: t.exposeInt('count'),
+      minDays: t.exposeFloat('minDays'),
+      maxDays: t.exposeFloat('maxDays'),
+    }),
+  });
+
+const AgingSubmissionItem = builder
+  .objectRef<{
+    id: string;
+    title: string | null;
+    status: string;
+    submittedAt: Date | null;
+    daysPending: number;
+  }>('AgingSubmissionItem')
+  .implement({
+    fields: (t) => ({
+      id: t.exposeString('id'),
+      title: t.exposeString('title', { nullable: true }),
+      status: t.exposeString('status'),
+      submittedAt: t.expose('submittedAt', {
+        type: 'DateTime',
+        nullable: true,
+      }),
+      daysPending: t.exposeInt('daysPending'),
+    }),
+  });
+
+const AgingBracket = builder
+  .objectRef<{
+    label: string;
+    count: number;
+    submissions: Array<{
+      id: string;
+      title: string | null;
+      status: string;
+      submittedAt: Date | null;
+      daysPending: number;
+    }>;
+  }>('AgingBracket')
+  .implement({
+    fields: (t) => ({
+      label: t.exposeString('label'),
+      count: t.exposeInt('count'),
+      submissions: t.field({
+        type: [AgingSubmissionItem],
+        resolve: (r) => r.submissions,
+      }),
+    }),
+  });
+
+// ---------------------------------------------------------------------------
+// Top-level analytics types
+// ---------------------------------------------------------------------------
+
+export const SubmissionOverviewStatsType = builder
+  .objectRef<SubmissionOverviewStats>('SubmissionOverviewStats')
+  .implement({
+    description: 'Summary statistics for submissions.',
+    fields: (t) => ({
+      totalSubmissions: t.exposeInt('totalSubmissions'),
+      acceptanceRate: t.exposeFloat('acceptanceRate'),
+      avgResponseTimeDays: t.exposeFloat('avgResponseTimeDays', {
+        nullable: true,
+      }),
+      pendingCount: t.exposeInt('pendingCount'),
+      submissionsThisMonth: t.exposeInt('submissionsThisMonth'),
+      submissionsLastMonth: t.exposeInt('submissionsLastMonth'),
+    }),
+  });
+
+export const SubmissionStatusBreakdownType = builder
+  .objectRef<SubmissionStatusBreakdown>('SubmissionStatusBreakdown')
+  .implement({
+    description: 'Submission counts grouped by status.',
+    fields: (t) => ({
+      breakdown: t.field({
+        type: [StatusBreakdownItem],
+        resolve: (r) => r.breakdown,
+      }),
+    }),
+  });
+
+export const SubmissionFunnelType = builder
+  .objectRef<SubmissionFunnel>('SubmissionFunnel')
+  .implement({
+    description: 'Submission workflow funnel — count at each stage.',
+    fields: (t) => ({
+      stages: t.field({ type: [FunnelStage], resolve: (r) => r.stages }),
+    }),
+  });
+
+export const SubmissionTimeSeriesType = builder
+  .objectRef<SubmissionTimeSeries>('SubmissionTimeSeries')
+  .implement({
+    description: 'Submission counts over time.',
+    fields: (t) => ({
+      granularity: t.exposeString('granularity'),
+      points: t.field({
+        type: [TimeSeriesPoint],
+        resolve: (r) => r.points,
+      }),
+    }),
+  });
+
+export const ResponseTimeDistributionType = builder
+  .objectRef<ResponseTimeDistribution>('ResponseTimeDistribution')
+  .implement({
+    description: 'Distribution of response times with histogram buckets.',
+    fields: (t) => ({
+      buckets: t.field({
+        type: [ResponseTimeBucket],
+        resolve: (r) => r.buckets,
+      }),
+      medianDays: t.exposeFloat('medianDays', { nullable: true }),
+    }),
+  });
+
+export const AgingSubmissionsType = builder
+  .objectRef<AgingSubmissions>('AgingSubmissions')
+  .implement({
+    description: 'Non-terminal submissions grouped by age bracket.',
+    fields: (t) => ({
+      brackets: t.field({
+        type: [AgingBracket],
+        resolve: (r) => r.brackets,
+      }),
+      totalAging: t.exposeInt('totalAging'),
+    }),
+  });

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -37,6 +37,14 @@ export {
 export { CmsConnectionType, CmsAdapterTypeEnum } from './cms-connection.js';
 export { SubmissionDiscussionType } from './discussion.js';
 export {
+  SubmissionOverviewStatsType,
+  SubmissionStatusBreakdownType,
+  SubmissionFunnelType,
+  SubmissionTimeSeriesType,
+  ResponseTimeDistributionType,
+  AgingSubmissionsType,
+} from './analytics.js';
+export {
   SubmissionStatusChangePayload,
   CreateOrganizationPayload,
   CreateApiKeyPayload,

--- a/apps/api/src/rest/routers/submissions.ts
+++ b/apps/api/src/rest/routers/submissions.ts
@@ -14,11 +14,18 @@ import {
   submissionReviewerSchema,
   createDiscussionCommentSchema,
   submissionDiscussionSchema,
+  submissionOverviewStatsSchema,
+  submissionStatusBreakdownSchema,
+  submissionFunnelSchema,
+  submissionTimeSeriesSchema,
+  responseTimeDistributionSchema,
+  agingSubmissionsSchema,
 } from '@colophony/types';
 import { restPaginationQuery } from '@colophony/api-contracts';
 import { submissionService } from '../../services/submission.service.js';
 import { submissionReviewerService } from '../../services/submission-reviewer.service.js';
 import { submissionDiscussionService } from '../../services/submission-discussion.service.js';
+import { submissionAnalyticsService } from '../../services/submission-analytics.service.js';
 import { simsubService } from '../../services/simsub.service.js';
 import { toServiceContext } from '../../services/context.js';
 import { assertEditorOrAdmin } from '../../services/errors.js';
@@ -492,6 +499,170 @@ const addDiscussion = orgProcedure
   });
 
 // ---------------------------------------------------------------------------
+// Analytics routes
+// ---------------------------------------------------------------------------
+
+const restAnalyticsFilterSchema = z.object({
+  startDate: z.coerce.date().optional(),
+  endDate: z.coerce.date().optional(),
+  submissionPeriodId: z.string().uuid().optional(),
+});
+
+const restTimeSeriesFilterSchema = restAnalyticsFilterSchema.extend({
+  granularity: z.enum(['daily', 'weekly', 'monthly']).default('monthly'),
+});
+
+const restAgingFilterSchema = restAnalyticsFilterSchema.extend({
+  thresholdDays: z.coerce.number().int().min(1).default(14),
+});
+
+const analyticsOverview = orgProcedure
+  .use(requireScopes('submissions:read'))
+  .route({
+    method: 'GET',
+    path: '/submissions/analytics/overview',
+    summary: 'Submission analytics overview',
+    description:
+      'Returns key submission statistics: totals, acceptance rate, avg response time, and month-over-month counts.',
+    operationId: 'getSubmissionAnalyticsOverview',
+    tags: ['Submission Analytics'],
+  })
+  .input(restAnalyticsFilterSchema)
+  .output(submissionOverviewStatsSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      assertEditorOrAdmin(context.authContext.role);
+      return await submissionAnalyticsService.getOverviewStats(
+        context.dbTx,
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const analyticsStatusBreakdown = orgProcedure
+  .use(requireScopes('submissions:read'))
+  .route({
+    method: 'GET',
+    path: '/submissions/analytics/status-breakdown',
+    summary: 'Submission status breakdown',
+    description: 'Returns the count of submissions grouped by status.',
+    operationId: 'getSubmissionAnalyticsStatusBreakdown',
+    tags: ['Submission Analytics'],
+  })
+  .input(restAnalyticsFilterSchema)
+  .output(submissionStatusBreakdownSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      assertEditorOrAdmin(context.authContext.role);
+      return await submissionAnalyticsService.getStatusBreakdown(
+        context.dbTx,
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const analyticsFunnel = orgProcedure
+  .use(requireScopes('submissions:read'))
+  .route({
+    method: 'GET',
+    path: '/submissions/analytics/funnel',
+    summary: 'Submission funnel',
+    description:
+      'Returns distinct submission counts at each workflow stage for funnel visualization.',
+    operationId: 'getSubmissionAnalyticsFunnel',
+    tags: ['Submission Analytics'],
+  })
+  .input(restAnalyticsFilterSchema)
+  .output(submissionFunnelSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      assertEditorOrAdmin(context.authContext.role);
+      return await submissionAnalyticsService.getFunnel(context.dbTx, input);
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const analyticsTimeSeries = orgProcedure
+  .use(requireScopes('submissions:read'))
+  .route({
+    method: 'GET',
+    path: '/submissions/analytics/time-series',
+    summary: 'Submission time series',
+    description:
+      'Returns submission counts over time, grouped by the specified granularity.',
+    operationId: 'getSubmissionAnalyticsTimeSeries',
+    tags: ['Submission Analytics'],
+  })
+  .input(restTimeSeriesFilterSchema)
+  .output(submissionTimeSeriesSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      assertEditorOrAdmin(context.authContext.role);
+      return await submissionAnalyticsService.getTimeSeries(
+        context.dbTx,
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const analyticsResponseTime = orgProcedure
+  .use(requireScopes('submissions:read'))
+  .route({
+    method: 'GET',
+    path: '/submissions/analytics/response-time',
+    summary: 'Response time distribution',
+    description:
+      'Returns a histogram of response times (days to first ACCEPTED/REJECTED) and the median.',
+    operationId: 'getSubmissionAnalyticsResponseTime',
+    tags: ['Submission Analytics'],
+  })
+  .input(restAnalyticsFilterSchema)
+  .output(responseTimeDistributionSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      assertEditorOrAdmin(context.authContext.role);
+      return await submissionAnalyticsService.getResponseTimeDistribution(
+        context.dbTx,
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const analyticsAging = orgProcedure
+  .use(requireScopes('submissions:read'))
+  .route({
+    method: 'GET',
+    path: '/submissions/analytics/aging',
+    summary: 'Aging submissions',
+    description:
+      'Returns non-terminal submissions older than the threshold, grouped by age bracket.',
+    operationId: 'getSubmissionAnalyticsAging',
+    tags: ['Submission Analytics'],
+  })
+  .input(restAgingFilterSchema)
+  .output(agingSubmissionsSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      assertEditorOrAdmin(context.authContext.role);
+      return await submissionAnalyticsService.getAgingSubmissions(
+        context.dbTx,
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+// ---------------------------------------------------------------------------
 // Assembled router
 // ---------------------------------------------------------------------------
 
@@ -513,4 +684,10 @@ export const submissionsRouter = {
   markReviewerRead,
   listDiscussions,
   addDiscussion,
+  analyticsOverview,
+  analyticsStatusBreakdown,
+  analyticsFunnel,
+  analyticsTimeSeries,
+  analyticsResponseTime,
+  analyticsAging,
 };

--- a/apps/api/src/services/submission-analytics.service.spec.ts
+++ b/apps/api/src/services/submission-analytics.service.spec.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Drizzle mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  submissions: {},
+  submissionHistory: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: { raw: (s: string) => s },
+  desc: vi.fn(),
+  count: vi.fn(),
+}));
+
+import { submissionAnalyticsService } from './submission-analytics.service.js';
+import type { DrizzleDb } from '@colophony/db';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockTx(rows: Record<string, unknown>[]) {
+  return {
+    execute: vi.fn().mockResolvedValue({ rows }),
+  } as unknown as DrizzleDb;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('submissionAnalyticsService', () => {
+  describe('getOverviewStats', () => {
+    it('returns correct stats', async () => {
+      const tx = mockTx([
+        {
+          totalSubmissions: 50,
+          pendingCount: 10,
+          acceptanceRate: 40.0,
+          avgResponseTimeDays: 12.5,
+          submissionsThisMonth: 8,
+          submissionsLastMonth: 15,
+        },
+      ]);
+
+      const result = await submissionAnalyticsService.getOverviewStats(tx, {});
+
+      expect(result).toEqual({
+        totalSubmissions: 50,
+        pendingCount: 10,
+        acceptanceRate: 40.0,
+        avgResponseTimeDays: 12.5,
+        submissionsThisMonth: 8,
+        submissionsLastMonth: 15,
+      });
+    });
+
+    it('handles zero submissions', async () => {
+      const tx = mockTx([
+        {
+          totalSubmissions: 0,
+          pendingCount: 0,
+          acceptanceRate: 0,
+          avgResponseTimeDays: null,
+          submissionsThisMonth: 0,
+          submissionsLastMonth: 0,
+        },
+      ]);
+
+      const result = await submissionAnalyticsService.getOverviewStats(tx, {});
+
+      expect(result.acceptanceRate).toBe(0);
+      expect(result.avgResponseTimeDays).toBeNull();
+    });
+
+    it('applies date range filter', async () => {
+      const tx = mockTx([
+        {
+          totalSubmissions: 5,
+          pendingCount: 2,
+          acceptanceRate: 50,
+          avgResponseTimeDays: 10,
+          submissionsThisMonth: 3,
+          submissionsLastMonth: 0,
+        },
+      ]);
+
+      const result = await submissionAnalyticsService.getOverviewStats(tx, {
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-01-31'),
+      });
+
+      expect(result.totalSubmissions).toBe(5);
+      // Verify the execute was called (SQL includes date conditions)
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(tx.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('applies period filter', async () => {
+      const tx = mockTx([
+        {
+          totalSubmissions: 3,
+          pendingCount: 1,
+          acceptanceRate: 66.7,
+          avgResponseTimeDays: 7,
+          submissionsThisMonth: 1,
+          submissionsLastMonth: 2,
+        },
+      ]);
+
+      const result = await submissionAnalyticsService.getOverviewStats(tx, {
+        submissionPeriodId: '550e8400-e29b-41d4-a716-446655440000',
+      });
+
+      expect(result.totalSubmissions).toBe(3);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(tx.execute).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getStatusBreakdown', () => {
+    it('groups by status', async () => {
+      const tx = mockTx([
+        { status: 'SUBMITTED', count: 10 },
+        { status: 'UNDER_REVIEW', count: 5 },
+        { status: 'ACCEPTED', count: 3 },
+      ]);
+
+      const result = await submissionAnalyticsService.getStatusBreakdown(
+        tx,
+        {},
+      );
+
+      expect(result.breakdown).toHaveLength(3);
+      expect(result.breakdown[0]).toEqual({ status: 'SUBMITTED', count: 10 });
+    });
+  });
+
+  describe('getFunnel', () => {
+    it('orders stages correctly', async () => {
+      // Return unordered data
+      const tx = mockTx([
+        { stage: 'ACCEPTED', count: 2 },
+        { stage: 'SUBMITTED', count: 20 },
+        { stage: 'UNDER_REVIEW', count: 15 },
+        { stage: 'REJECTED', count: 3 },
+      ]);
+
+      const result = await submissionAnalyticsService.getFunnel(tx, {});
+
+      // Should be in funnel order regardless of DB order
+      expect(result.stages[0].stage).toBe('SUBMITTED');
+      expect(result.stages[1].stage).toBe('UNDER_REVIEW');
+      expect(result.stages[4].stage).toBe('ACCEPTED');
+      expect(result.stages[5].stage).toBe('REJECTED');
+      // Missing stages should have count 0
+      expect(result.stages[2]).toEqual({ stage: 'HOLD', count: 0 });
+    });
+  });
+
+  describe('getTimeSeries', () => {
+    it('returns daily points', async () => {
+      const tx = mockTx([
+        { date: '2026-01-01', count: 5 },
+        { date: '2026-01-02', count: 3 },
+        { date: '2026-01-03', count: 8 },
+      ]);
+
+      const result = await submissionAnalyticsService.getTimeSeries(tx, {
+        granularity: 'daily',
+      });
+
+      expect(result.granularity).toBe('daily');
+      expect(result.points).toHaveLength(3);
+      expect(result.points[0]).toEqual({ date: '2026-01-01', count: 5 });
+    });
+  });
+
+  describe('getResponseTimeDistribution', () => {
+    it('buckets correctly', async () => {
+      const tx = mockTx([
+        {
+          bucket_0_7: 10,
+          bucket_7_14: 8,
+          bucket_14_28: 5,
+          bucket_28_60: 2,
+          bucket_60_plus: 1,
+          medianDays: 9.5,
+        },
+      ]);
+
+      const result =
+        await submissionAnalyticsService.getResponseTimeDistribution(tx, {});
+
+      expect(result.buckets).toHaveLength(5);
+      expect(result.buckets[0]).toEqual({
+        label: '< 7 days',
+        count: 10,
+        minDays: 0,
+        maxDays: 7,
+      });
+      expect(result.medianDays).toBe(9.5);
+    });
+  });
+
+  describe('getAgingSubmissions', () => {
+    it('groups into brackets', async () => {
+      const tx = mockTx([
+        {
+          id: 'sub-1',
+          title: 'Old Story',
+          status: 'SUBMITTED',
+          submittedAt: '2026-01-01T00:00:00Z',
+          daysPending: 20,
+        },
+        {
+          id: 'sub-2',
+          title: 'Very Old Story',
+          status: 'UNDER_REVIEW',
+          submittedAt: '2025-12-01T00:00:00Z',
+          daysPending: 60,
+        },
+        {
+          id: 'sub-3',
+          title: 'Fresh',
+          status: 'SUBMITTED',
+          submittedAt: '2026-02-20T00:00:00Z',
+          daysPending: 5,
+        },
+      ]);
+
+      const result = await submissionAnalyticsService.getAgingSubmissions(tx, {
+        thresholdDays: 14,
+      });
+
+      // sub-3 (5 days) is below threshold, should not be counted
+      expect(result.totalAging).toBe(2);
+      // sub-1 (20 days) in 14-28 bracket, sub-2 (60 days) in 56+ bracket
+      expect(result.brackets[0].count).toBe(1); // 14-28
+      expect(result.brackets[2].count).toBe(1); // 56+
+    });
+
+    it('respects threshold', async () => {
+      const tx = mockTx([
+        {
+          id: 'sub-1',
+          title: 'Story',
+          status: 'SUBMITTED',
+          submittedAt: '2026-02-20T00:00:00Z',
+          daysPending: 10,
+        },
+      ]);
+
+      const result = await submissionAnalyticsService.getAgingSubmissions(tx, {
+        thresholdDays: 7,
+      });
+
+      // 10 days >= 7 threshold, should be in first bracket (7-14)
+      expect(result.totalAging).toBe(1);
+      expect(result.brackets[0].label).toBe('7-14 days');
+      expect(result.brackets[0].count).toBe(1);
+    });
+  });
+});

--- a/apps/api/src/services/submission-analytics.service.spec.ts
+++ b/apps/api/src/services/submission-analytics.service.spec.ts
@@ -14,13 +14,21 @@ vi.mock('@colophony/db', () => ({
   sql: vi.fn(),
 }));
 
-vi.mock('drizzle-orm', () => ({
-  eq: vi.fn(),
-  and: vi.fn(),
-  sql: { raw: (s: string) => s },
-  desc: vi.fn(),
-  count: vi.fn(),
-}));
+vi.mock('drizzle-orm', () => {
+  // sql is both a tagged template function AND has static methods
+  const sqlTag = (_strings: TemplateStringsArray, ..._values: unknown[]) =>
+    'sql-fragment';
+  sqlTag.raw = (s: string) => s;
+  sqlTag.join = (parts: unknown[], _sep: unknown) =>
+    parts.length > 0 ? 'joined-where' : '';
+  return {
+    eq: vi.fn(),
+    and: vi.fn(),
+    sql: sqlTag,
+    desc: vi.fn(),
+    count: vi.fn(),
+  };
+});
 
 import { submissionAnalyticsService } from './submission-analytics.service.js';
 import type { DrizzleDb } from '@colophony/db';

--- a/apps/api/src/services/submission-analytics.service.ts
+++ b/apps/api/src/services/submission-analytics.service.ts
@@ -1,0 +1,372 @@
+import { sql } from 'drizzle-orm';
+import type { DrizzleDb } from '@colophony/db';
+import type {
+  AnalyticsFilter,
+  TimeSeriesFilter,
+  AgingFilter,
+  SubmissionOverviewStats,
+  SubmissionStatusBreakdown,
+  SubmissionFunnel,
+  SubmissionTimeSeries,
+  ResponseTimeDistribution,
+  AgingSubmissions,
+} from '@colophony/types';
+
+// ---------------------------------------------------------------------------
+// Terminal and non-terminal status sets
+// ---------------------------------------------------------------------------
+
+const NON_TERMINAL_STATUSES = [
+  'SUBMITTED',
+  'UNDER_REVIEW',
+  'HOLD',
+  'REVISE_AND_RESUBMIT',
+] as const;
+
+/** Funnel stage ordering — matches the submission workflow progression. */
+const FUNNEL_STAGE_ORDER = [
+  'SUBMITTED',
+  'UNDER_REVIEW',
+  'HOLD',
+  'REVISE_AND_RESUBMIT',
+  'ACCEPTED',
+  'REJECTED',
+  'WITHDRAWN',
+] as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildFilterConditions(filter: AnalyticsFilter): string[] {
+  const conditions: string[] = [];
+  // Exclude DRAFTs from all analytics
+  conditions.push(`s.status != 'DRAFT'`);
+  if (filter.startDate) {
+    conditions.push(
+      `s.submitted_at >= '${filter.startDate.toISOString()}'::timestamptz`,
+    );
+  }
+  if (filter.endDate) {
+    conditions.push(
+      `s.submitted_at <= '${filter.endDate.toISOString()}'::timestamptz`,
+    );
+  }
+  if (filter.submissionPeriodId) {
+    conditions.push(
+      `s.submission_period_id = '${filter.submissionPeriodId}'::uuid`,
+    );
+  }
+  return conditions;
+}
+
+function whereClause(conditions: string[]): string {
+  return conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const submissionAnalyticsService = {
+  async getOverviewStats(
+    tx: DrizzleDb,
+    filter: AnalyticsFilter,
+  ): Promise<SubmissionOverviewStats> {
+    const conditions = buildFilterConditions(filter);
+    const where = whereClause(conditions);
+
+    const now = new Date();
+    const thisMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+
+    const result = await tx.execute(
+      sql.raw(`
+      SELECT
+        COUNT(*)::int AS "totalSubmissions",
+        COUNT(*) FILTER (WHERE s.status IN ('SUBMITTED', 'UNDER_REVIEW', 'HOLD', 'REVISE_AND_RESUBMIT'))::int AS "pendingCount",
+        COALESCE(
+          ROUND(
+            COUNT(*) FILTER (WHERE s.status = 'ACCEPTED')::numeric
+            / NULLIF(COUNT(*) FILTER (WHERE s.status IN ('ACCEPTED', 'REJECTED'))::numeric, 0)
+            * 100,
+            1
+          ),
+          0
+        )::float AS "acceptanceRate",
+        (
+          SELECT ROUND(AVG(EXTRACT(EPOCH FROM (h.changed_at - s2.submitted_at)) / 86400), 1)::float
+          FROM submissions s2
+          JOIN LATERAL (
+            SELECT MIN(changed_at) AS changed_at
+            FROM submission_history sh
+            WHERE sh.submission_id = s2.id
+              AND sh.to_status IN ('ACCEPTED', 'REJECTED')
+          ) h ON h.changed_at IS NOT NULL
+          ${where.replace(/\bs\./g, 's2.')}
+        ) AS "avgResponseTimeDays",
+        COUNT(*) FILTER (WHERE s.submitted_at >= '${thisMonthStart.toISOString()}'::timestamptz)::int AS "submissionsThisMonth",
+        COUNT(*) FILTER (WHERE s.submitted_at >= '${lastMonthStart.toISOString()}'::timestamptz AND s.submitted_at < '${thisMonthStart.toISOString()}'::timestamptz)::int AS "submissionsLastMonth"
+      FROM submissions s
+      ${where}
+    `),
+    );
+
+    const row = result.rows[0];
+    return {
+      totalSubmissions: (row.totalSubmissions as number) ?? 0,
+      acceptanceRate: (row.acceptanceRate as number) ?? 0,
+      avgResponseTimeDays: (row.avgResponseTimeDays as number) ?? null,
+      pendingCount: (row.pendingCount as number) ?? 0,
+      submissionsThisMonth: (row.submissionsThisMonth as number) ?? 0,
+      submissionsLastMonth: (row.submissionsLastMonth as number) ?? 0,
+    };
+  },
+
+  async getStatusBreakdown(
+    tx: DrizzleDb,
+    filter: AnalyticsFilter,
+  ): Promise<SubmissionStatusBreakdown> {
+    const conditions = buildFilterConditions(filter);
+    const where = whereClause(conditions);
+
+    const result = await tx.execute(
+      sql.raw(`
+      SELECT s.status, COUNT(*)::int AS count
+      FROM submissions s
+      ${where}
+      GROUP BY s.status
+      ORDER BY count DESC
+    `),
+    );
+
+    return {
+      breakdown: result.rows.map((row) => ({
+        status: row.status as string,
+        count: row.count as number,
+      })),
+    };
+  },
+
+  async getFunnel(
+    tx: DrizzleDb,
+    filter: AnalyticsFilter,
+  ): Promise<SubmissionFunnel> {
+    const conditions = buildFilterConditions(filter);
+    // For funnel, we count distinct submissions that have ever entered each stage
+    // via submission_history
+    const historyConditions = conditions.map((c) =>
+      c.replace(/\bs\./g, 'sub.'),
+    );
+    const historyWhere =
+      historyConditions.length > 0
+        ? `WHERE ${historyConditions.join(' AND ')}`
+        : '';
+
+    const result = await tx.execute(
+      sql.raw(`
+      SELECT sh.to_status AS stage, COUNT(DISTINCT sh.submission_id)::int AS count
+      FROM submission_history sh
+      JOIN submissions sub ON sub.id = sh.submission_id
+      ${historyWhere}
+      GROUP BY sh.to_status
+    `),
+    );
+
+    const countMap = new Map<string, number>();
+    for (const row of result.rows) {
+      countMap.set(row.stage as string, row.count as number);
+    }
+
+    const stages = FUNNEL_STAGE_ORDER.map((stage) => ({
+      stage,
+      count: countMap.get(stage) ?? 0,
+    }));
+
+    return { stages };
+  },
+
+  async getTimeSeries(
+    tx: DrizzleDb,
+    filter: TimeSeriesFilter,
+  ): Promise<SubmissionTimeSeries> {
+    const conditions = buildFilterConditions(filter);
+    const where = whereClause(conditions);
+
+    const result = await tx.execute(
+      sql.raw(`
+      SELECT
+        date_trunc('${filter.granularity === 'daily' ? 'day' : filter.granularity === 'weekly' ? 'week' : 'month'}', s.submitted_at)::date::text AS date,
+        COUNT(*)::int AS count
+      FROM submissions s
+      ${where}
+        AND s.submitted_at IS NOT NULL
+      GROUP BY 1
+      ORDER BY 1 ASC
+    `),
+    );
+
+    return {
+      granularity: filter.granularity,
+      points: result.rows.map((row) => ({
+        date: row.date as string,
+        count: row.count as number,
+      })),
+    };
+  },
+
+  async getResponseTimeDistribution(
+    tx: DrizzleDb,
+    filter: AnalyticsFilter,
+  ): Promise<ResponseTimeDistribution> {
+    const conditions = buildFilterConditions(filter);
+    const where = whereClause(conditions);
+
+    const result = await tx.execute(
+      sql.raw(`
+      WITH response_times AS (
+        SELECT
+          EXTRACT(EPOCH FROM (h.changed_at - s.submitted_at)) / 86400 AS response_days
+        FROM submissions s
+        JOIN LATERAL (
+          SELECT MIN(changed_at) AS changed_at
+          FROM submission_history sh
+          WHERE sh.submission_id = s.id
+            AND sh.to_status IN ('ACCEPTED', 'REJECTED')
+        ) h ON h.changed_at IS NOT NULL
+        ${where}
+      )
+      SELECT
+        COUNT(*) FILTER (WHERE response_days < 7)::int AS "bucket_0_7",
+        COUNT(*) FILTER (WHERE response_days >= 7 AND response_days < 14)::int AS "bucket_7_14",
+        COUNT(*) FILTER (WHERE response_days >= 14 AND response_days < 28)::int AS "bucket_14_28",
+        COUNT(*) FILTER (WHERE response_days >= 28 AND response_days < 60)::int AS "bucket_28_60",
+        COUNT(*) FILTER (WHERE response_days >= 60)::int AS "bucket_60_plus",
+        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY response_days)::float AS "medianDays"
+      FROM response_times
+    `),
+    );
+
+    const row = result.rows[0];
+
+    return {
+      buckets: [
+        {
+          label: '< 7 days',
+          count: (row.bucket_0_7 as number) ?? 0,
+          minDays: 0,
+          maxDays: 7,
+        },
+        {
+          label: '7-14 days',
+          count: (row.bucket_7_14 as number) ?? 0,
+          minDays: 7,
+          maxDays: 14,
+        },
+        {
+          label: '14-28 days',
+          count: (row.bucket_14_28 as number) ?? 0,
+          minDays: 14,
+          maxDays: 28,
+        },
+        {
+          label: '28-60 days',
+          count: (row.bucket_28_60 as number) ?? 0,
+          minDays: 28,
+          maxDays: 60,
+        },
+        {
+          label: '60+ days',
+          count: (row.bucket_60_plus as number) ?? 0,
+          minDays: 60,
+          maxDays: Infinity,
+        },
+      ],
+      medianDays: (row.medianDays as number) ?? null,
+    };
+  },
+
+  async getAgingSubmissions(
+    tx: DrizzleDb,
+    filter: AgingFilter,
+  ): Promise<AgingSubmissions> {
+    const conditions = buildFilterConditions(filter);
+    // Only non-terminal submissions
+    conditions.push(
+      `s.status IN (${NON_TERMINAL_STATUSES.map((s) => `'${s}'`).join(', ')})`,
+    );
+    conditions.push(`s.submitted_at IS NOT NULL`);
+    const where = whereClause(conditions);
+
+    const result = await tx.execute(
+      sql.raw(`
+      SELECT
+        s.id,
+        s.title,
+        s.status,
+        s.submitted_at AS "submittedAt",
+        EXTRACT(EPOCH FROM (NOW() - s.submitted_at)) / 86400 AS "daysPending"
+      FROM submissions s
+      ${where}
+      ORDER BY s.submitted_at ASC
+    `),
+    );
+
+    const threshold = filter.thresholdDays;
+
+    // Define age brackets relative to threshold
+    const bracketDefs = [
+      {
+        label: `${threshold}-${threshold * 2} days`,
+        min: threshold,
+        max: threshold * 2,
+      },
+      {
+        label: `${threshold * 2}-${threshold * 4} days`,
+        min: threshold * 2,
+        max: threshold * 4,
+      },
+      { label: `${threshold * 4}+ days`, min: threshold * 4, max: Infinity },
+    ];
+
+    const brackets = bracketDefs.map((def) => ({
+      label: def.label,
+      count: 0,
+      submissions: [] as Array<{
+        id: string;
+        title: string | null;
+        status: string;
+        submittedAt: Date | null;
+        daysPending: number;
+      }>,
+    }));
+
+    let totalAging = 0;
+
+    for (const row of result.rows) {
+      const daysPending = Math.floor(row.daysPending as number);
+      if (daysPending < threshold) continue;
+
+      totalAging++;
+      const sub = {
+        id: row.id as string,
+        title: row.title as string | null,
+        status: row.status as string,
+        submittedAt: row.submittedAt
+          ? new Date(row.submittedAt as string)
+          : null,
+        daysPending,
+      };
+
+      for (let i = brackets.length - 1; i >= 0; i--) {
+        if (daysPending >= bracketDefs[i].min) {
+          brackets[i].submissions.push(sub);
+          brackets[i].count++;
+          break;
+        }
+      }
+    }
+
+    return { brackets, totalAging };
+  },
+};

--- a/apps/api/src/services/submission-analytics.service.ts
+++ b/apps/api/src/services/submission-analytics.service.ts
@@ -13,15 +13,8 @@ import type {
 } from '@colophony/types';
 
 // ---------------------------------------------------------------------------
-// Terminal and non-terminal status sets
+// Status sets
 // ---------------------------------------------------------------------------
-
-const NON_TERMINAL_STATUSES = [
-  'SUBMITTED',
-  'UNDER_REVIEW',
-  'HOLD',
-  'REVISE_AND_RESUBMIT',
-] as const;
 
 /** Funnel stage ordering — matches the submission workflow progression. */
 const FUNNEL_STAGE_ORDER = [

--- a/apps/api/src/services/submission-analytics.service.ts
+++ b/apps/api/src/services/submission-analytics.service.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm';
+import { sql, type SQL } from 'drizzle-orm';
 import type { DrizzleDb } from '@colophony/db';
 import type {
   AnalyticsFilter,
@@ -35,33 +35,30 @@ const FUNNEL_STAGE_ORDER = [
 ] as const;
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Helpers — parameterized SQL fragments (defense-in-depth)
 // ---------------------------------------------------------------------------
 
-function buildFilterConditions(filter: AnalyticsFilter): string[] {
-  const conditions: string[] = [];
-  // Exclude DRAFTs from all analytics
-  conditions.push(`s.status != 'DRAFT'`);
+/**
+ * Build parameterized WHERE conditions from the analytics filter.
+ * Returns SQL fragments using Drizzle's tagged template for safe interpolation.
+ * The `alias` param controls the table alias (e.g., 's', 's2', 'sub').
+ */
+function buildFilterWhere(filter: AnalyticsFilter, alias = 's'): SQL {
+  const parts: SQL[] = [sql.raw(`${alias}.status != 'DRAFT'`)];
+
   if (filter.startDate) {
-    conditions.push(
-      `s.submitted_at >= '${filter.startDate.toISOString()}'::timestamptz`,
-    );
+    parts.push(sql`${sql.raw(`${alias}.submitted_at`)} >= ${filter.startDate}`);
   }
   if (filter.endDate) {
-    conditions.push(
-      `s.submitted_at <= '${filter.endDate.toISOString()}'::timestamptz`,
-    );
+    parts.push(sql`${sql.raw(`${alias}.submitted_at`)} <= ${filter.endDate}`);
   }
   if (filter.submissionPeriodId) {
-    conditions.push(
-      `s.submission_period_id = '${filter.submissionPeriodId}'::uuid`,
+    parts.push(
+      sql`${sql.raw(`${alias}.submission_period_id`)} = ${filter.submissionPeriodId}::uuid`,
     );
   }
-  return conditions;
-}
 
-function whereClause(conditions: string[]): string {
-  return conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+  return sql.join(parts, sql.raw(' AND '));
 }
 
 // ---------------------------------------------------------------------------
@@ -73,15 +70,14 @@ export const submissionAnalyticsService = {
     tx: DrizzleDb,
     filter: AnalyticsFilter,
   ): Promise<SubmissionOverviewStats> {
-    const conditions = buildFilterConditions(filter);
-    const where = whereClause(conditions);
+    const where = buildFilterWhere(filter);
+    const subWhere = buildFilterWhere(filter, 's2');
 
     const now = new Date();
     const thisMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
     const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
 
-    const result = await tx.execute(
-      sql.raw(`
+    const result = await tx.execute(sql`
       SELECT
         COUNT(*)::int AS "totalSubmissions",
         COUNT(*) FILTER (WHERE s.status IN ('SUBMITTED', 'UNDER_REVIEW', 'HOLD', 'REVISE_AND_RESUBMIT'))::int AS "pendingCount",
@@ -103,14 +99,13 @@ export const submissionAnalyticsService = {
             WHERE sh.submission_id = s2.id
               AND sh.to_status IN ('ACCEPTED', 'REJECTED')
           ) h ON h.changed_at IS NOT NULL
-          ${where.replace(/\bs\./g, 's2.')}
+          WHERE ${subWhere}
         ) AS "avgResponseTimeDays",
-        COUNT(*) FILTER (WHERE s.submitted_at >= '${thisMonthStart.toISOString()}'::timestamptz)::int AS "submissionsThisMonth",
-        COUNT(*) FILTER (WHERE s.submitted_at >= '${lastMonthStart.toISOString()}'::timestamptz AND s.submitted_at < '${thisMonthStart.toISOString()}'::timestamptz)::int AS "submissionsLastMonth"
+        COUNT(*) FILTER (WHERE s.submitted_at >= ${thisMonthStart})::int AS "submissionsThisMonth",
+        COUNT(*) FILTER (WHERE s.submitted_at >= ${lastMonthStart} AND s.submitted_at < ${thisMonthStart})::int AS "submissionsLastMonth"
       FROM submissions s
-      ${where}
-    `),
-    );
+      WHERE ${where}
+    `);
 
     const row = result.rows[0];
     return {
@@ -127,18 +122,15 @@ export const submissionAnalyticsService = {
     tx: DrizzleDb,
     filter: AnalyticsFilter,
   ): Promise<SubmissionStatusBreakdown> {
-    const conditions = buildFilterConditions(filter);
-    const where = whereClause(conditions);
+    const where = buildFilterWhere(filter);
 
-    const result = await tx.execute(
-      sql.raw(`
+    const result = await tx.execute(sql`
       SELECT s.status, COUNT(*)::int AS count
       FROM submissions s
-      ${where}
+      WHERE ${where}
       GROUP BY s.status
       ORDER BY count DESC
-    `),
-    );
+    `);
 
     return {
       breakdown: result.rows.map((row) => ({
@@ -152,26 +144,15 @@ export const submissionAnalyticsService = {
     tx: DrizzleDb,
     filter: AnalyticsFilter,
   ): Promise<SubmissionFunnel> {
-    const conditions = buildFilterConditions(filter);
-    // For funnel, we count distinct submissions that have ever entered each stage
-    // via submission_history
-    const historyConditions = conditions.map((c) =>
-      c.replace(/\bs\./g, 'sub.'),
-    );
-    const historyWhere =
-      historyConditions.length > 0
-        ? `WHERE ${historyConditions.join(' AND ')}`
-        : '';
+    const where = buildFilterWhere(filter, 'sub');
 
-    const result = await tx.execute(
-      sql.raw(`
+    const result = await tx.execute(sql`
       SELECT sh.to_status AS stage, COUNT(DISTINCT sh.submission_id)::int AS count
       FROM submission_history sh
       JOIN submissions sub ON sub.id = sh.submission_id
-      ${historyWhere}
+      WHERE ${where}
       GROUP BY sh.to_status
-    `),
-    );
+    `);
 
     const countMap = new Map<string, number>();
     for (const row of result.rows) {
@@ -190,21 +171,25 @@ export const submissionAnalyticsService = {
     tx: DrizzleDb,
     filter: TimeSeriesFilter,
   ): Promise<SubmissionTimeSeries> {
-    const conditions = buildFilterConditions(filter);
-    const where = whereClause(conditions);
+    const where = buildFilterWhere(filter);
+    // Granularity is validated by Zod enum — safe to use in sql.raw
+    const truncUnit =
+      filter.granularity === 'daily'
+        ? 'day'
+        : filter.granularity === 'weekly'
+          ? 'week'
+          : 'month';
 
-    const result = await tx.execute(
-      sql.raw(`
+    const result = await tx.execute(sql`
       SELECT
-        date_trunc('${filter.granularity === 'daily' ? 'day' : filter.granularity === 'weekly' ? 'week' : 'month'}', s.submitted_at)::date::text AS date,
+        date_trunc(${truncUnit}, s.submitted_at)::date::text AS date,
         COUNT(*)::int AS count
       FROM submissions s
-      ${where}
+      WHERE ${where}
         AND s.submitted_at IS NOT NULL
       GROUP BY 1
       ORDER BY 1 ASC
-    `),
-    );
+    `);
 
     return {
       granularity: filter.granularity,
@@ -219,11 +204,9 @@ export const submissionAnalyticsService = {
     tx: DrizzleDb,
     filter: AnalyticsFilter,
   ): Promise<ResponseTimeDistribution> {
-    const conditions = buildFilterConditions(filter);
-    const where = whereClause(conditions);
+    const where = buildFilterWhere(filter);
 
-    const result = await tx.execute(
-      sql.raw(`
+    const result = await tx.execute(sql`
       WITH response_times AS (
         SELECT
           EXTRACT(EPOCH FROM (h.changed_at - s.submitted_at)) / 86400 AS response_days
@@ -234,7 +217,7 @@ export const submissionAnalyticsService = {
           WHERE sh.submission_id = s.id
             AND sh.to_status IN ('ACCEPTED', 'REJECTED')
         ) h ON h.changed_at IS NOT NULL
-        ${where}
+        WHERE ${where}
       )
       SELECT
         COUNT(*) FILTER (WHERE response_days < 7)::int AS "bucket_0_7",
@@ -244,8 +227,7 @@ export const submissionAnalyticsService = {
         COUNT(*) FILTER (WHERE response_days >= 60)::int AS "bucket_60_plus",
         PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY response_days)::float AS "medianDays"
       FROM response_times
-    `),
-    );
+    `);
 
     const row = result.rows[0];
 
@@ -290,16 +272,9 @@ export const submissionAnalyticsService = {
     tx: DrizzleDb,
     filter: AgingFilter,
   ): Promise<AgingSubmissions> {
-    const conditions = buildFilterConditions(filter);
-    // Only non-terminal submissions
-    conditions.push(
-      `s.status IN (${NON_TERMINAL_STATUSES.map((s) => `'${s}'`).join(', ')})`,
-    );
-    conditions.push(`s.submitted_at IS NOT NULL`);
-    const where = whereClause(conditions);
+    const baseWhere = buildFilterWhere(filter);
 
-    const result = await tx.execute(
-      sql.raw(`
+    const result = await tx.execute(sql`
       SELECT
         s.id,
         s.title,
@@ -307,10 +282,11 @@ export const submissionAnalyticsService = {
         s.submitted_at AS "submittedAt",
         EXTRACT(EPOCH FROM (NOW() - s.submitted_at)) / 86400 AS "daysPending"
       FROM submissions s
-      ${where}
+      WHERE ${baseWhere}
+        AND s.status IN ('SUBMITTED', 'UNDER_REVIEW', 'HOLD', 'REVISE_AND_RESUBMIT')
+        AND s.submitted_at IS NOT NULL
       ORDER BY s.submitted_at ASC
-    `),
-    );
+    `);
 
     const threshold = filter.thresholdDays;
 

--- a/apps/api/src/trpc/routers/submissions.ts
+++ b/apps/api/src/trpc/routers/submissions.ts
@@ -26,6 +26,15 @@ import {
   listDiscussionCommentsSchema,
   createDiscussionCommentSchema,
   submissionDiscussionSchema,
+  analyticsFilterSchema,
+  timeSeriesFilterSchema,
+  agingFilterSchema,
+  submissionOverviewStatsSchema,
+  submissionStatusBreakdownSchema,
+  submissionFunnelSchema,
+  submissionTimeSeriesSchema,
+  responseTimeDistributionSchema,
+  agingSubmissionsSchema,
 } from '@colophony/types';
 import {
   orgProcedure,
@@ -36,6 +45,7 @@ import {
 import { submissionService } from '../../services/submission.service.js';
 import { submissionReviewerService } from '../../services/submission-reviewer.service.js';
 import { submissionDiscussionService } from '../../services/submission-discussion.service.js';
+import { submissionAnalyticsService } from '../../services/submission-analytics.service.js';
 import { simsubService } from '../../services/simsub.service.js';
 import { transferService } from '../../services/transfer.service.js';
 import { migrationService } from '../../services/migration.service.js';
@@ -441,6 +451,104 @@ export const submissionsRouter = createRouter({
       try {
         return await submissionDiscussionService.createWithAudit(
           toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  // ─── Analytics procedures ───
+
+  /** Overview stats: totals, acceptance rate, avg response time. */
+  analyticsOverview: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(analyticsFilterSchema)
+    .output(submissionOverviewStatsSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        assertEditorOrAdmin(ctx.authContext.role);
+        return await submissionAnalyticsService.getOverviewStats(
+          ctx.dbTx,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Status breakdown: count per status. */
+  analyticsStatusBreakdown: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(analyticsFilterSchema)
+    .output(submissionStatusBreakdownSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        assertEditorOrAdmin(ctx.authContext.role);
+        return await submissionAnalyticsService.getStatusBreakdown(
+          ctx.dbTx,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Funnel: submission workflow progression. */
+  analyticsFunnel: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(analyticsFilterSchema)
+    .output(submissionFunnelSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        assertEditorOrAdmin(ctx.authContext.role);
+        return await submissionAnalyticsService.getFunnel(ctx.dbTx, input);
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Time series: submissions over time by granularity. */
+  analyticsTimeSeries: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(timeSeriesFilterSchema)
+    .output(submissionTimeSeriesSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        assertEditorOrAdmin(ctx.authContext.role);
+        return await submissionAnalyticsService.getTimeSeries(ctx.dbTx, input);
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Response time distribution: histogram buckets + median. */
+  analyticsResponseTime: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(analyticsFilterSchema)
+    .output(responseTimeDistributionSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        assertEditorOrAdmin(ctx.authContext.role);
+        return await submissionAnalyticsService.getResponseTimeDistribution(
+          ctx.dbTx,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Aging submissions: non-terminal submissions older than threshold. */
+  analyticsAging: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(agingFilterSchema)
+    .output(agingSubmissionsSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        assertEditorOrAdmin(ctx.authContext.role);
+        return await submissionAnalyticsService.getAgingSubmissions(
+          ctx.dbTx,
           input,
         );
       } catch (e) {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -64,6 +64,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.71.2",
+    "recharts": "^3.7.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tus-js-client": "^4.3.1",

--- a/apps/web/src/app/(dashboard)/editor/analytics/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/analytics/page.tsx
@@ -1,0 +1,9 @@
+import { SubmissionAnalyticsPage } from "@/components/analytics/submission-analytics-page";
+
+export default function AnalyticsPage() {
+  return (
+    <div className="p-6">
+      <SubmissionAnalyticsPage />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/editor/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/page.tsx
@@ -7,8 +7,9 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { ClipboardList, Inbox } from "lucide-react";
+import { BarChart3, ClipboardList, Inbox } from "lucide-react";
 import { DashboardPluginSlot } from "./dashboard-plugin-slot";
+import { OverviewStatsCards } from "@/components/analytics/overview-stats-cards";
 
 export default function EditorPage() {
   return (
@@ -19,6 +20,8 @@ export default function EditorPage() {
           Manage your publication&apos;s submission process.
         </p>
       </div>
+
+      <OverviewStatsCards />
 
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         <Link href="/editor/submissions">
@@ -62,6 +65,29 @@ export default function EditorPage() {
             <CardContent>
               <Button variant="outline" size="sm" className="w-full">
                 Manage Forms
+              </Button>
+            </CardContent>
+          </Card>
+        </Link>
+
+        <Link href="/editor/analytics">
+          <Card className="hover:border-primary/50 transition-colors cursor-pointer">
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <div className="rounded-lg bg-primary/10 p-2">
+                  <BarChart3 className="h-5 w-5 text-primary" />
+                </div>
+                <div>
+                  <CardTitle className="text-base">Analytics</CardTitle>
+                  <CardDescription>
+                    Submission trends and performance metrics
+                  </CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Button variant="outline" size="sm" className="w-full">
+                View Analytics
               </Button>
             </CardContent>
           </Card>

--- a/apps/web/src/components/analytics/aging-table.tsx
+++ b/apps/web/src/components/analytics/aging-table.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import { STATUS_COLORS } from "./chart-colors";
+import type { AnalyticsFilter } from "@colophony/types";
+
+interface AgingTableProps {
+  filter: AnalyticsFilter;
+}
+
+export function AgingTable({ filter }: AgingTableProps) {
+  const { data, isPending: isLoading } =
+    trpc.submissions.analyticsAging.useQuery({
+      ...filter,
+      thresholdDays: 14,
+    });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">
+          Aging Submissions
+          {data && (
+            <span className="text-sm font-normal text-muted-foreground ml-2">
+              {data.totalAging} total
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-48 w-full" />
+        ) : data?.totalAging === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No aging submissions found.
+          </p>
+        ) : (
+          <div className="space-y-4">
+            {data?.brackets
+              .filter((b) => b.count > 0)
+              .map((bracket) => (
+                <div key={bracket.label}>
+                  <h4 className="text-sm font-medium mb-2">
+                    {bracket.label}{" "}
+                    <span className="text-muted-foreground">
+                      ({bracket.count})
+                    </span>
+                  </h4>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Title</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead className="text-right">
+                          Days Pending
+                        </TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {bracket.submissions.map((sub) => (
+                        <TableRow key={sub.id}>
+                          <TableCell className="font-medium">
+                            {sub.title ?? "Untitled"}
+                          </TableCell>
+                          <TableCell>
+                            <Badge
+                              variant="secondary"
+                              style={{
+                                backgroundColor: `${STATUS_COLORS[sub.status] ?? "#6B7280"}20`,
+                                color: STATUS_COLORS[sub.status] ?? "#6B7280",
+                              }}
+                            >
+                              {sub.status}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-right">
+                            {sub.daysPending}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/analytics/analytics-filters.tsx
+++ b/apps/web/src/components/analytics/analytics-filters.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { trpc } from "@/lib/trpc";
+
+interface AnalyticsFiltersProps {
+  startDate: string;
+  endDate: string;
+  submissionPeriodId: string;
+  onStartDateChange: (val: string) => void;
+  onEndDateChange: (val: string) => void;
+  onPeriodChange: (val: string) => void;
+}
+
+export function AnalyticsFilters({
+  startDate,
+  endDate,
+  submissionPeriodId,
+  onStartDateChange,
+  onEndDateChange,
+  onPeriodChange,
+}: AnalyticsFiltersProps) {
+  const { data: periods } = trpc.periods.list.useQuery({
+    limit: 100,
+  });
+
+  return (
+    <div className="flex flex-wrap items-end gap-4">
+      <div className="space-y-1">
+        <Label htmlFor="startDate">Start Date</Label>
+        <Input
+          id="startDate"
+          type="date"
+          value={startDate}
+          onChange={(e) => onStartDateChange(e.target.value)}
+          className="w-40"
+        />
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="endDate">End Date</Label>
+        <Input
+          id="endDate"
+          type="date"
+          value={endDate}
+          onChange={(e) => onEndDateChange(e.target.value)}
+          className="w-40"
+        />
+      </div>
+      <div className="space-y-1">
+        <Label>Submission Period</Label>
+        <Select value={submissionPeriodId} onValueChange={onPeriodChange}>
+          <SelectTrigger className="w-48">
+            <SelectValue placeholder="All periods" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All periods</SelectItem>
+            {periods?.items.map((p) => (
+              <SelectItem key={p.id} value={p.id}>
+                {p.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/analytics/chart-colors.ts
+++ b/apps/web/src/components/analytics/chart-colors.ts
@@ -1,0 +1,21 @@
+/** Hex color map for submission statuses — matches Tailwind classes in status-badge.tsx */
+export const STATUS_COLORS: Record<string, string> = {
+  DRAFT: "#6B7280", // gray-500
+  SUBMITTED: "#3B82F6", // blue-500
+  UNDER_REVIEW: "#EAB308", // yellow-500
+  ACCEPTED: "#22C55E", // green-500
+  REJECTED: "#EF4444", // red-500
+  HOLD: "#F97316", // orange-500
+  REVISE_AND_RESUBMIT: "#F59E0B", // amber-500
+  WITHDRAWN: "#A855F7", // purple-500
+};
+
+export const CHART_COLORS = [
+  "#3B82F6",
+  "#22C55E",
+  "#EF4444",
+  "#EAB308",
+  "#F97316",
+  "#A855F7",
+  "#6B7280",
+] as const;

--- a/apps/web/src/components/analytics/funnel-chart.tsx
+++ b/apps/web/src/components/analytics/funnel-chart.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import { STATUS_COLORS } from "./chart-colors";
+import type { AnalyticsFilter } from "@colophony/types";
+
+interface FunnelChartProps {
+  filter: AnalyticsFilter;
+}
+
+export function FunnelChart({ filter }: FunnelChartProps) {
+  const { data, isPending: isLoading } =
+    trpc.submissions.analyticsFunnel.useQuery(filter);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Submission Funnel</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <BarChart
+              data={data?.stages ?? []}
+              layout="vertical"
+              margin={{ left: 80 }}
+            >
+              <XAxis type="number" />
+              <YAxis type="category" dataKey="stage" width={120} />
+              <Tooltip />
+              <Bar dataKey="count" radius={[0, 4, 4, 0]}>
+                {data?.stages.map((entry) => (
+                  <Cell
+                    key={entry.stage}
+                    fill={STATUS_COLORS[entry.stage] ?? "#3B82F6"}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/analytics/overview-stats-cards.tsx
+++ b/apps/web/src/components/analytics/overview-stats-cards.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import type { AnalyticsFilter } from "@colophony/types";
+
+interface OverviewStatsCardsProps {
+  filter?: AnalyticsFilter;
+}
+
+export function OverviewStatsCards({ filter = {} }: OverviewStatsCardsProps) {
+  const { data, isPending: isLoading } =
+    trpc.submissions.analyticsOverview.useQuery(filter);
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="pb-2">
+              <Skeleton className="h-4 w-24" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const trend =
+    data.submissionsLastMonth > 0
+      ? Math.round(
+          ((data.submissionsThisMonth - data.submissionsLastMonth) /
+            data.submissionsLastMonth) *
+            100,
+        )
+      : null;
+
+  const cards = [
+    {
+      title: "Total Submissions",
+      value: data.totalSubmissions.toLocaleString(),
+    },
+    {
+      title: "Acceptance Rate",
+      value: `${data.acceptanceRate.toFixed(1)}%`,
+    },
+    {
+      title: "Avg Response Time",
+      value: data.avgResponseTimeDays
+        ? `${data.avgResponseTimeDays.toFixed(1)}d`
+        : "N/A",
+    },
+    {
+      title: "Pending",
+      value: data.pendingCount.toLocaleString(),
+    },
+    {
+      title: "This Month",
+      value: data.submissionsThisMonth.toLocaleString(),
+      subtitle:
+        trend !== null
+          ? `${trend >= 0 ? "+" : ""}${trend}% vs last month`
+          : undefined,
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+      {cards.map((card) => (
+        <Card key={card.title}>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              {card.title}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{card.value}</div>
+            {card.subtitle && (
+              <p className="text-xs text-muted-foreground mt-1">
+                {card.subtitle}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/analytics/response-time-chart.tsx
+++ b/apps/web/src/components/analytics/response-time-chart.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import type { AnalyticsFilter } from "@colophony/types";
+
+interface ResponseTimeChartProps {
+  filter: AnalyticsFilter;
+}
+
+export function ResponseTimeChart({ filter }: ResponseTimeChartProps) {
+  const { data, isPending: isLoading } =
+    trpc.submissions.analyticsResponseTime.useQuery(filter);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">
+          Response Time Distribution
+          {data?.medianDays != null && (
+            <span className="text-sm font-normal text-muted-foreground ml-2">
+              Median: {data.medianDays.toFixed(1)}d
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <BarChart data={data?.buckets ?? []}>
+              <XAxis dataKey="label" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="count" fill="#3B82F6" radius={[4, 4, 0, 0]} />
+              {data?.medianDays != null && (
+                <ReferenceLine
+                  x={
+                    data.buckets.find(
+                      (b) =>
+                        data.medianDays! >= b.minDays &&
+                        data.medianDays! < b.maxDays,
+                    )?.label
+                  }
+                  stroke="#EF4444"
+                  strokeDasharray="4 4"
+                  label={{ value: "Median", fill: "#EF4444", fontSize: 12 }}
+                />
+              )}
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/analytics/status-breakdown-chart.tsx
+++ b/apps/web/src/components/analytics/status-breakdown-chart.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import { STATUS_COLORS } from "./chart-colors";
+import type { AnalyticsFilter } from "@colophony/types";
+
+interface StatusBreakdownChartProps {
+  filter: AnalyticsFilter;
+}
+
+export function StatusBreakdownChart({ filter }: StatusBreakdownChartProps) {
+  const { data, isPending: isLoading } =
+    trpc.submissions.analyticsStatusBreakdown.useQuery(filter);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Status Breakdown</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <PieChart>
+              <Pie
+                data={data?.breakdown ?? []}
+                dataKey="count"
+                nameKey="status"
+                cx="50%"
+                cy="50%"
+                outerRadius={100}
+                label={({ name, value }) => `${name ?? ""}: ${value}`}
+              >
+                {data?.breakdown.map((entry) => (
+                  <Cell
+                    key={entry.status}
+                    fill={STATUS_COLORS[entry.status] ?? "#6B7280"}
+                  />
+                ))}
+              </Pie>
+              <Tooltip />
+              <Legend />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/analytics/submission-analytics-page.tsx
+++ b/apps/web/src/components/analytics/submission-analytics-page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import type { AnalyticsFilter } from "@colophony/types";
+import { AnalyticsFilters } from "./analytics-filters";
+import { OverviewStatsCards } from "./overview-stats-cards";
+import { StatusBreakdownChart } from "./status-breakdown-chart";
+import { FunnelChart } from "./funnel-chart";
+import { TimeSeriesChart } from "./time-series-chart";
+import { ResponseTimeChart } from "./response-time-chart";
+import { AgingTable } from "./aging-table";
+
+export function SubmissionAnalyticsPage() {
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [submissionPeriodId, setSubmissionPeriodId] = useState("all");
+
+  const filter: AnalyticsFilter = useMemo(() => {
+    const f: AnalyticsFilter = {};
+    if (startDate) f.startDate = new Date(startDate);
+    if (endDate) f.endDate = new Date(endDate);
+    if (submissionPeriodId && submissionPeriodId !== "all")
+      f.submissionPeriodId = submissionPeriodId;
+    return f;
+  }, [startDate, endDate, submissionPeriodId]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Submission Analytics</h1>
+        <p className="text-muted-foreground mt-1">
+          Track submission trends, response times, and workflow performance.
+        </p>
+      </div>
+
+      <AnalyticsFilters
+        startDate={startDate}
+        endDate={endDate}
+        submissionPeriodId={submissionPeriodId}
+        onStartDateChange={setStartDate}
+        onEndDateChange={setEndDate}
+        onPeriodChange={setSubmissionPeriodId}
+      />
+
+      <OverviewStatsCards filter={filter} />
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <StatusBreakdownChart filter={filter} />
+        <FunnelChart filter={filter} />
+      </div>
+
+      <TimeSeriesChart filter={filter} />
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <ResponseTimeChart filter={filter} />
+        <AgingTable filter={filter} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/analytics/time-series-chart.tsx
+++ b/apps/web/src/components/analytics/time-series-chart.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { trpc } from "@/lib/trpc";
+import type { AnalyticsFilter } from "@colophony/types";
+
+interface TimeSeriesChartProps {
+  filter: AnalyticsFilter;
+}
+
+export function TimeSeriesChart({ filter }: TimeSeriesChartProps) {
+  const [granularity, setGranularity] = useState<
+    "daily" | "weekly" | "monthly"
+  >("monthly");
+
+  const { data, isPending: isLoading } =
+    trpc.submissions.analyticsTimeSeries.useQuery({
+      ...filter,
+      granularity,
+    });
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-base">Submissions Over Time</CardTitle>
+        <Select
+          value={granularity}
+          onValueChange={(v) =>
+            setGranularity(v as "daily" | "weekly" | "monthly")
+          }
+        >
+          <SelectTrigger className="w-28">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="daily">Daily</SelectItem>
+            <SelectItem value="weekly">Weekly</SelectItem>
+            <SelectItem value="monthly">Monthly</SelectItem>
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <AreaChart data={data?.points ?? []}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Area
+                type="monotone"
+                dataKey="count"
+                stroke="#3B82F6"
+                fill="#3B82F6"
+                fillOpacity={0.2}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -324,7 +324,7 @@
 
 ### Analytics & Reporting
 
-- [ ] [P1] Submission analytics dashboard — acceptance rate, response time distribution, submissions per period, funnel (submitted → reviewed → accepted/rejected), aging submissions — (persona gap analysis 2026-02-27)
+- [x] [P1] Submission analytics dashboard — acceptance rate, response time distribution, submissions per period, funnel (submitted → reviewed → accepted/rejected), aging submissions — (persona gap analysis 2026-02-27, implemented 2026-02-28)
 - [ ] [P2] Publication data export — CSV/JSON export of all org submissions, with filters (date range, status, period); admin-only — (persona gap analysis 2026-02-27)
 - [ ] [P3] Response time tracking and reminders — flag submissions pending over N days (configurable); optional email reminder to editors — (persona gap analysis 2026-02-27)
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,30 @@ Newest entries first.
 
 ---
 
+## 2026-02-28 — Track 7: Submission Analytics Dashboard
+
+### Done
+
+- **Shared types:** `packages/types/src/analytics.ts` — 3 filter schemas (`analyticsFilterSchema`, `timeSeriesFilterSchema`, `agingFilterSchema`) + 6 response schemas (overview stats, status breakdown, funnel, time series, response time distribution, aging submissions)
+- **Analytics service:** `submission-analytics.service.ts` — 6 methods using raw SQL with `sql.raw()` for aggregation queries (overview stats with `COUNT FILTER`, status breakdown, funnel via `submission_history`, time series with `date_trunc`, response time histogram with `PERCENTILE_CONT`, aging submissions grouped into threshold-relative brackets). RLS handles org scoping automatically.
+- **tRPC:** 6 analytics query procedures on `submissionsRouter` (`analyticsOverview`, `analyticsStatusBreakdown`, `analyticsFunnel`, `analyticsTimeSeries`, `analyticsResponseTime`, `analyticsAging`) — all `orgProcedure` + `requireScopes('submissions:read')` + `assertEditorOrAdmin`
+- **REST:** 6 GET routes under `/submissions/analytics/*` with `z.coerce` for query string params, tagged `Submission Analytics`
+- **GraphQL:** Pothos types (`analytics.ts`) + resolver (`submission-analytics.ts`) with `requireOrgContext` + `requireScopes` guards, 6 query fields
+- **Frontend:** Installed Recharts; 9 new components in `apps/web/src/components/analytics/` — `OverviewStatsCards` (5 stat cards), `StatusBreakdownChart` (PieChart), `FunnelChart` (horizontal BarChart), `TimeSeriesChart` (AreaChart + granularity toggle), `ResponseTimeChart` (histogram + median ReferenceLine), `AgingTable` (grouped shadcn Table), `AnalyticsFilters` (date range + period select), `SubmissionAnalyticsPage` (full dashboard layout), `chart-colors.ts` (hex color map matching status-badge.tsx)
+- **Editor dashboard:** Added `OverviewStatsCards` above nav cards + Analytics navigation card with `BarChart3` icon
+- **New route:** `/editor/analytics` page
+- **Tests:** 10 service unit tests + 11 schema validation tests (21 total, all passing); type-check clean; lint clean
+
+### Decisions
+
+- Raw SQL via `sql.raw()` for analytics aggregations — read-only queries where Drizzle query builder would be overly verbose
+- No audit logging for analytics endpoints — confirmed: read-only aggregations don't need audit trail
+- Funnel counts distinct submissions from `submission_history` per `to_status`, ordered by workflow position in code
+- Age brackets defined relative to threshold (1x-2x, 2x-4x, 4x+) rather than fixed day ranges
+- `Infinity` as maxDays for the last response time bucket (60+ days)
+
+---
+
 ## 2026-02-28 — Track 7 PR5: Internal Discussion Threads on Submissions
 
 ### Done

--- a/packages/types/src/__tests__/analytics.spec.ts
+++ b/packages/types/src/__tests__/analytics.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyticsFilterSchema,
+  submissionOverviewStatsSchema,
+  timeSeriesFilterSchema,
+  agingFilterSchema,
+  responseTimeDistributionSchema,
+} from "../analytics";
+
+describe("analyticsFilterSchema", () => {
+  it("accepts empty object", () => {
+    const result = analyticsFilterSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("coerces date strings to Date", () => {
+    const result = analyticsFilterSchema.parse({
+      startDate: "2026-01-01T00:00:00Z",
+      endDate: "2026-01-31T23:59:59Z",
+    });
+    expect(result.startDate).toBeInstanceOf(Date);
+    expect(result.endDate).toBeInstanceOf(Date);
+  });
+
+  it("rejects invalid UUID", () => {
+    const result = analyticsFilterSchema.safeParse({
+      submissionPeriodId: "not-a-uuid",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("submissionOverviewStatsSchema", () => {
+  it("validates complete object", () => {
+    const data = {
+      totalSubmissions: 50,
+      acceptanceRate: 40.5,
+      avgResponseTimeDays: 12.3,
+      pendingCount: 10,
+      submissionsThisMonth: 8,
+      submissionsLastMonth: 15,
+    };
+    const result = submissionOverviewStatsSchema.parse(data);
+    expect(result).toEqual(data);
+  });
+
+  it("allows null avgResponseTimeDays", () => {
+    const data = {
+      totalSubmissions: 0,
+      acceptanceRate: 0,
+      avgResponseTimeDays: null,
+      pendingCount: 0,
+      submissionsThisMonth: 0,
+      submissionsLastMonth: 0,
+    };
+    const result = submissionOverviewStatsSchema.parse(data);
+    expect(result.avgResponseTimeDays).toBeNull();
+  });
+});
+
+describe("timeSeriesFilterSchema", () => {
+  it("rejects invalid granularity", () => {
+    const result = timeSeriesFilterSchema.safeParse({
+      granularity: "hourly",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("defaults granularity to monthly", () => {
+    const result = timeSeriesFilterSchema.parse({});
+    expect(result.granularity).toBe("monthly");
+  });
+});
+
+describe("agingFilterSchema", () => {
+  it("defaults thresholdDays to 14", () => {
+    const result = agingFilterSchema.parse({});
+    expect(result.thresholdDays).toBe(14);
+  });
+
+  it("rejects zero thresholdDays", () => {
+    const result = agingFilterSchema.safeParse({ thresholdDays: 0 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("responseTimeDistributionSchema", () => {
+  it("validates bucket structure", () => {
+    const data = {
+      buckets: [
+        { label: "< 7 days", count: 10, minDays: 0, maxDays: 7 },
+        { label: "7-14 days", count: 5, minDays: 7, maxDays: 14 },
+      ],
+      medianDays: 9.5,
+    };
+    const result = responseTimeDistributionSchema.parse(data);
+    expect(result.buckets).toHaveLength(2);
+    expect(result.medianDays).toBe(9.5);
+  });
+
+  it("allows null medianDays", () => {
+    const data = {
+      buckets: [],
+      medianDays: null,
+    };
+    const result = responseTimeDistributionSchema.parse(data);
+    expect(result.medianDays).toBeNull();
+  });
+});

--- a/packages/types/src/analytics.ts
+++ b/packages/types/src/analytics.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Filter schemas
+// ---------------------------------------------------------------------------
+
+export const analyticsFilterSchema = z.object({
+  startDate: z.coerce.date().optional(),
+  endDate: z.coerce.date().optional(),
+  submissionPeriodId: z.string().uuid().optional(),
+});
+export type AnalyticsFilter = z.infer<typeof analyticsFilterSchema>;
+
+export const timeSeriesFilterSchema = analyticsFilterSchema.extend({
+  granularity: z.enum(["daily", "weekly", "monthly"]).default("monthly"),
+});
+export type TimeSeriesFilter = z.infer<typeof timeSeriesFilterSchema>;
+
+export const agingFilterSchema = analyticsFilterSchema.extend({
+  thresholdDays: z.number().int().min(1).default(14),
+});
+export type AgingFilter = z.infer<typeof agingFilterSchema>;
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+export const submissionOverviewStatsSchema = z.object({
+  totalSubmissions: z.number().int(),
+  acceptanceRate: z.number().min(0).max(100),
+  avgResponseTimeDays: z.number().nullable(),
+  pendingCount: z.number().int(),
+  submissionsThisMonth: z.number().int(),
+  submissionsLastMonth: z.number().int(),
+});
+export type SubmissionOverviewStats = z.infer<
+  typeof submissionOverviewStatsSchema
+>;
+
+export const submissionStatusBreakdownSchema = z.object({
+  breakdown: z.array(
+    z.object({
+      status: z.string(),
+      count: z.number().int(),
+    }),
+  ),
+});
+export type SubmissionStatusBreakdown = z.infer<
+  typeof submissionStatusBreakdownSchema
+>;
+
+export const submissionFunnelSchema = z.object({
+  stages: z.array(
+    z.object({
+      stage: z.string(),
+      count: z.number().int(),
+    }),
+  ),
+});
+export type SubmissionFunnel = z.infer<typeof submissionFunnelSchema>;
+
+export const submissionTimeSeriesSchema = z.object({
+  granularity: z.enum(["daily", "weekly", "monthly"]),
+  points: z.array(
+    z.object({
+      date: z.string(),
+      count: z.number().int(),
+    }),
+  ),
+});
+export type SubmissionTimeSeries = z.infer<typeof submissionTimeSeriesSchema>;
+
+export const responseTimeDistributionSchema = z.object({
+  buckets: z.array(
+    z.object({
+      label: z.string(),
+      count: z.number().int(),
+      minDays: z.number(),
+      maxDays: z.number(),
+    }),
+  ),
+  medianDays: z.number().nullable(),
+});
+export type ResponseTimeDistribution = z.infer<
+  typeof responseTimeDistributionSchema
+>;
+
+export const agingSubmissionsSchema = z.object({
+  brackets: z.array(
+    z.object({
+      label: z.string(),
+      count: z.number().int(),
+      submissions: z.array(
+        z.object({
+          id: z.string().uuid(),
+          title: z.string().nullable(),
+          status: z.string(),
+          submittedAt: z.coerce.date().nullable(),
+          daysPending: z.number().int(),
+        }),
+      ),
+    }),
+  ),
+  totalAging: z.number().int(),
+});
+export type AgingSubmissions = z.infer<typeof agingSubmissionsSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,3 +29,4 @@ export * from "./csr";
 export * from "./status-mapping";
 export * from "./email-templates";
 export * from "./discussion";
+export * from "./analytics";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,6 +346,9 @@ importers:
       react-hook-form:
         specifier: ^7.71.2
         version: 7.71.2(react@19.2.4)
+      recharts:
+        specifier: ^3.7.0
+        version: 3.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3231,6 +3234,17 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
@@ -4010,6 +4024,33 @@ packages:
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -4866,6 +4907,50 @@ packages:
   custom-error-instance@2.1.1:
     resolution: {integrity: sha512-p6JFxJc3M4OTD2li2qaHkDCw9SfMw82Ldr6OC9Je1aXiGfhx2W8p3GaoeaGrPJTUN9NirTM/KTxHWMUdR1rsUg==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -4914,6 +4999,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -5209,6 +5297,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.44.0:
+    resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
 
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
@@ -5812,6 +5903,12 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -5885,6 +5982,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ioredis-mock@8.13.1:
     resolution: {integrity: sha512-Wsi50AU+cMiI32nAgfwpUaJVBtb4iQdVsOHl9M6R3tePCO/8vGsToCVIG82XWAxN4Se55TZoOzVseu+QngFLyw==}
@@ -7244,6 +7345,18 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -7304,6 +7417,14 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  recharts@3.7.0:
+    resolution: {integrity: sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -7315,6 +7436,14 @@ packages:
   redis-parser@3.0.0:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -7346,6 +7475,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -7788,6 +7920,9 @@ packages:
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -8076,6 +8211,9 @@ packages:
   valid-data-url@3.0.1:
     resolution: {integrity: sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA==}
     engines: {node: '>=10'}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -11603,6 +11741,18 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.4
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+
   '@remirror/core-constants@3.0.0': {}
 
   '@repeaterjs/repeater@3.0.6': {}
@@ -12508,6 +12658,30 @@ snapshots:
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 25.3.0
+
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
 
   '@types/debug@4.1.12':
     dependencies:
@@ -13453,6 +13627,44 @@ snapshots:
 
   custom-error-instance@2.1.1: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-uri-to-buffer@4.0.1: {}
@@ -13493,6 +13705,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -13764,6 +13978,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.44.0: {}
 
   esbuild-register@3.6.0(esbuild@0.25.12):
     dependencies:
@@ -14548,6 +14764,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -14627,6 +14847,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   ioredis-mock@8.13.1(@types/ioredis-mock@8.2.6(ioredis@5.9.3))(ioredis@5.9.3):
     dependencies:
@@ -16443,6 +16665,15 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -16508,6 +16739,26 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  recharts@3.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.44.0
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 18.3.1
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -16518,6 +16769,12 @@ snapshots:
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -16561,6 +16818,8 @@ snapshots:
       - supports-color
 
   requires-port@1.0.0: {}
+
+  reselect@5.1.1: {}
 
   resolve-cwd@3.0.0:
     dependencies:
@@ -17070,6 +17329,8 @@ snapshots:
       readable-stream: 2.3.8
       xtend: 4.0.2
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.0.2: {}
@@ -17363,6 +17624,23 @@ snapshots:
       convert-source-map: 2.0.0
 
   valid-data-url@3.0.1: {}
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
## Summary

- Add submission analytics service with 6 aggregation methods (overview stats, status breakdown, funnel, time series, response time distribution, aging submissions)
- Expose analytics via tRPC, REST, and GraphQL endpoints with `submissions:read` scope + editor/admin role guard
- Add Recharts-powered analytics dashboard at `/editor/analytics` with interactive charts and filters
- Add overview stats cards to the editor home page with month-over-month trend

## Details

**Backend:**
- `packages/types/src/analytics.ts` — 3 filter + 6 response Zod schemas
- `apps/api/src/services/submission-analytics.service.ts` — parameterized SQL aggregations via Drizzle `sql` tagged template literals
- 6 tRPC procedures, 6 REST GET routes, 6 GraphQL query fields

**Frontend (9 components in `apps/web/src/components/analytics/`):**
- `OverviewStatsCards` — 5 KPI cards (total, acceptance rate, avg response time, pending, trend)
- `StatusBreakdownChart` — PieChart
- `FunnelChart` — horizontal BarChart
- `TimeSeriesChart` — AreaChart with granularity toggle
- `ResponseTimeChart` — histogram with median reference line
- `AgingTable` — submissions grouped by age bracket
- `AnalyticsFilters` — date range + period filter

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `submission-analytics.service.ts` | `sql.raw()` for all SQL | Parameterized `sql` tagged templates | Code review found SQL injection risk — user values now safely parameterized |

## Test plan

- [x] 10 service unit tests passing (stats mapping, zero submissions, date/period filters, status grouping, funnel ordering, time series, response time bucketing, aging brackets)
- [x] 11 schema validation tests passing (coercion, defaults, rejection)
- [x] Type-check clean across all workspace packages
- [x] Lint clean
- [ ] Manual QA: start dev servers, navigate to `/editor` (verify stat cards), click Analytics (verify charts render with seed data)
- [ ] Apply date filter and period filter, verify data updates
- [ ] CI passing