### PR TITLE
feat(hopper): submission voting and scoring system (#213)

### DIFF
--- a/apps/api/src/graphql/error-mapper.ts
+++ b/apps/api/src/graphql/error-mapper.ts
@@ -63,6 +63,12 @@ import {
   DiscussionCommentNotFoundError,
   DiscussionParentNotFoundError,
 } from '../services/submission-discussion.service.js';
+import {
+  VoteNotFoundError,
+  VotingDisabledError,
+  VoteOnTerminalSubmissionError,
+  ScoreOutOfRangeError,
+} from '../services/submission-vote.service.js';
 
 type GraphQLErrorCode = string;
 
@@ -123,6 +129,11 @@ const errorCodeMap: [new (...args: never[]) => Error, GraphQLErrorCode][] = [
   // Discussion errors
   [DiscussionCommentNotFoundError, 'NOT_FOUND'],
   [DiscussionParentNotFoundError, 'NOT_FOUND'],
+  // Vote errors
+  [VoteNotFoundError, 'NOT_FOUND'],
+  [VotingDisabledError, 'BAD_REQUEST'],
+  [VoteOnTerminalSubmissionError, 'BAD_REQUEST'],
+  [ScoreOutOfRangeError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/graphql/resolvers/index.ts
+++ b/apps/api/src/graphql/resolvers/index.ts
@@ -14,3 +14,4 @@ import './contracts.js';
 import './issues.js';
 import './cms-connections.js';
 import './submission-analytics.js';
+import './submission-votes.js';

--- a/apps/api/src/graphql/resolvers/submission-votes.ts
+++ b/apps/api/src/graphql/resolvers/submission-votes.ts
@@ -1,0 +1,111 @@
+import { builder } from '../builder.js';
+import { requireOrgContext, requireScopes } from '../guards.js';
+import { submissionVoteService } from '../../services/submission-vote.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+import {
+  SubmissionVoteType,
+  VoteSummaryType,
+  VoteDecisionEnum,
+} from '../types/index.js';
+
+// ---------------------------------------------------------------------------
+// Query fields
+// ---------------------------------------------------------------------------
+
+builder.queryFields((t) => ({
+  submissionVotes: t.field({
+    type: [SubmissionVoteType],
+    description:
+      'List all votes on a submission. Accessible to editors, admins, and assigned reviewers.',
+    args: {
+      submissionId: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      try {
+        const orgCtx = requireOrgContext(ctx);
+        await requireScopes(ctx, 'submissions:read');
+        return await submissionVoteService.listVotesWithAccess(
+          toServiceContext(orgCtx),
+          args.submissionId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  submissionVoteSummary: t.field({
+    type: VoteSummaryType,
+    description:
+      'Get aggregated vote tallies and average score. Editor/admin only.',
+    args: {
+      submissionId: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      try {
+        const orgCtx = requireOrgContext(ctx);
+        await requireScopes(ctx, 'submissions:read');
+        return await submissionVoteService.getVoteSummaryWithAccess(
+          toServiceContext(orgCtx),
+          args.submissionId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mutation fields
+// ---------------------------------------------------------------------------
+
+builder.mutationFields((t) => ({
+  castVote: t.field({
+    type: SubmissionVoteType,
+    description: 'Cast or update a vote on a submission.',
+    args: {
+      submissionId: t.arg.string({ required: true }),
+      decision: t.arg({ type: VoteDecisionEnum, required: true }),
+      score: t.arg.float({ required: false }),
+    },
+    resolve: async (_root, args, ctx) => {
+      try {
+        const orgCtx = requireOrgContext(ctx);
+        await requireScopes(ctx, 'submissions:write');
+        return await submissionVoteService.castVoteWithAudit(
+          toServiceContext(orgCtx),
+          {
+            submissionId: args.submissionId,
+            decision: args.decision,
+            score: args.score ?? undefined,
+          },
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  deleteVote: t.field({
+    type: 'Boolean',
+    description: "Remove the current user's vote on a submission.",
+    args: {
+      submissionId: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      try {
+        const orgCtx = requireOrgContext(ctx);
+        await requireScopes(ctx, 'submissions:write');
+        await submissionVoteService.deleteVoteWithAudit(
+          toServiceContext(orgCtx),
+          args.submissionId,
+        );
+        return true;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+}));

--- a/apps/api/src/graphql/types/enums.ts
+++ b/apps/api/src/graphql/types/enums.ts
@@ -35,6 +35,15 @@ export const ScanStatusEnum = builder.enumType('ScanStatus', {
   } as const,
 });
 
+export const VoteDecisionEnum = builder.enumType('VoteDecision', {
+  description: 'Decision cast on a submission vote.',
+  values: {
+    ACCEPT: { description: 'Accept the submission for publication.' },
+    REJECT: { description: 'Reject the submission.' },
+    MAYBE: { description: 'Uncertain — needs further discussion.' },
+  } as const,
+});
+
 export const RoleEnum = builder.enumType('Role', {
   description: 'Member role within an organization.',
   values: {

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -1,5 +1,10 @@
 // Barrel export — ensures all types are registered with the builder
-export { SubmissionStatusEnum, ScanStatusEnum, RoleEnum } from './enums.js';
+export {
+  SubmissionStatusEnum,
+  ScanStatusEnum,
+  RoleEnum,
+  VoteDecisionEnum,
+} from './enums.js';
 export { UserType } from './user.js';
 export { OrganizationType, OrganizationMemberType } from './organization.js';
 export { SubmissionType, SubmissionHistoryType } from './submission.js';
@@ -36,6 +41,7 @@ export {
 } from './issue.js';
 export { CmsConnectionType, CmsAdapterTypeEnum } from './cms-connection.js';
 export { SubmissionDiscussionType } from './discussion.js';
+export { SubmissionVoteType, VoteSummaryType } from './submission-vote.js';
 export {
   SubmissionOverviewStatsType,
   SubmissionStatusBreakdownType,

--- a/apps/api/src/graphql/types/submission-vote.ts
+++ b/apps/api/src/graphql/types/submission-vote.ts
@@ -1,0 +1,61 @@
+import type { SubmissionVote, VoteSummary } from '@colophony/types';
+import { builder } from '../builder.js';
+
+export const SubmissionVoteType = builder
+  .objectRef<SubmissionVote>('SubmissionVote')
+  .implement({
+    description:
+      'A vote cast by a reviewer on a submission (accept/reject/maybe + optional score).',
+    fields: (t) => ({
+      id: t.exposeString('id', { description: 'Vote ID.' }),
+      submissionId: t.exposeString('submissionId', {
+        description: 'ID of the submission.',
+      }),
+      voterUserId: t.exposeString('voterUserId', {
+        description: 'ID of the voter.',
+      }),
+      voterEmail: t.exposeString('voterEmail', {
+        nullable: true,
+        description: "Voter's email address.",
+      }),
+      decision: t.exposeString('decision', {
+        description: 'Vote decision: ACCEPT, REJECT, or MAYBE.',
+      }),
+      score: t.exposeFloat('score', {
+        nullable: true,
+        description: 'Optional numeric score.',
+      }),
+      createdAt: t.expose('createdAt', {
+        type: 'DateTime',
+        description: 'When the vote was cast.',
+      }),
+      updatedAt: t.expose('updatedAt', {
+        type: 'DateTime',
+        description: 'When the vote was last updated.',
+      }),
+    }),
+  });
+
+export const VoteSummaryType = builder
+  .objectRef<VoteSummary>('VoteSummary')
+  .implement({
+    description: 'Aggregated vote tallies and average score for a submission.',
+    fields: (t) => ({
+      acceptCount: t.exposeInt('acceptCount', {
+        description: 'Number of ACCEPT votes.',
+      }),
+      rejectCount: t.exposeInt('rejectCount', {
+        description: 'Number of REJECT votes.',
+      }),
+      maybeCount: t.exposeInt('maybeCount', {
+        description: 'Number of MAYBE votes.',
+      }),
+      totalVotes: t.exposeInt('totalVotes', {
+        description: 'Total number of votes.',
+      }),
+      averageScore: t.exposeFloat('averageScore', {
+        nullable: true,
+        description: 'Average score across all votes (null if no scores).',
+      }),
+    }),
+  });

--- a/apps/api/src/rest/error-mapper.ts
+++ b/apps/api/src/rest/error-mapper.ts
@@ -75,6 +75,12 @@ import {
   DiscussionCommentNotFoundError,
   DiscussionParentNotFoundError,
 } from '../services/submission-discussion.service.js';
+import {
+  VoteNotFoundError,
+  VotingDisabledError,
+  VoteOnTerminalSubmissionError,
+  ScoreOutOfRangeError,
+} from '../services/submission-vote.service.js';
 
 type ORPCErrorCode = ConstructorParameters<typeof ORPCError>[0];
 
@@ -145,6 +151,11 @@ const errorCodeMap: [new (...args: never[]) => Error, ORPCErrorCode][] = [
   // Discussion errors
   [DiscussionCommentNotFoundError, 'NOT_FOUND'],
   [DiscussionParentNotFoundError, 'NOT_FOUND'],
+  // Vote errors
+  [VoteNotFoundError, 'NOT_FOUND'],
+  [VotingDisabledError, 'BAD_REQUEST'],
+  [VoteOnTerminalSubmissionError, 'BAD_REQUEST'],
+  [ScoreOutOfRangeError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/rest/routers/submissions.ts
+++ b/apps/api/src/rest/routers/submissions.ts
@@ -20,11 +20,15 @@ import {
   submissionTimeSeriesSchema,
   responseTimeDistributionSchema,
   agingSubmissionsSchema,
+  castVoteInputSchema,
+  submissionVoteSchema,
+  voteSummarySchema,
 } from '@colophony/types';
 import { restPaginationQuery } from '@colophony/api-contracts';
 import { submissionService } from '../../services/submission.service.js';
 import { submissionReviewerService } from '../../services/submission-reviewer.service.js';
 import { submissionDiscussionService } from '../../services/submission-discussion.service.js';
+import { submissionVoteService } from '../../services/submission-vote.service.js';
 import { submissionAnalyticsService } from '../../services/submission-analytics.service.js';
 import { simsubService } from '../../services/simsub.service.js';
 import { toServiceContext } from '../../services/context.js';
@@ -499,6 +503,114 @@ const addDiscussion = orgProcedure
   });
 
 // ---------------------------------------------------------------------------
+// Vote routes
+// ---------------------------------------------------------------------------
+
+const castVote = orgProcedure
+  .use(requireScopes('submissions:write'))
+  .route({
+    method: 'POST',
+    path: '/submissions/{id}/votes',
+    successStatus: 201,
+    summary: 'Cast or update a vote',
+    description:
+      'Cast or update a vote on a submission. One vote per user per submission (upsert).',
+    operationId: 'castSubmissionVote',
+    tags: ['Submission Votes'],
+  })
+  .input(
+    idParamSchema.merge(
+      castVoteInputSchema.pick({ decision: true, score: true }),
+    ),
+  )
+  .output(submissionVoteSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionVoteService.castVoteWithAudit(
+        toServiceContext(context),
+        {
+          submissionId: input.id,
+          decision: input.decision,
+          score: input.score,
+        },
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const listVotes = orgProcedure
+  .use(requireScopes('submissions:read'))
+  .route({
+    method: 'GET',
+    path: '/submissions/{id}/votes',
+    summary: 'List submission votes',
+    description:
+      'List all votes on a submission. Accessible to editors, admins, and assigned reviewers.',
+    operationId: 'listSubmissionVotes',
+    tags: ['Submission Votes'],
+  })
+  .input(idParamSchema)
+  .output(z.array(submissionVoteSchema))
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionVoteService.listVotesWithAccess(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const voteSummary = orgProcedure
+  .use(requireScopes('submissions:read'))
+  .route({
+    method: 'GET',
+    path: '/submissions/{id}/votes/summary',
+    summary: 'Get vote summary',
+    description:
+      'Get aggregated vote tallies and average score for a submission. Editor/admin only.',
+    operationId: 'getSubmissionVoteSummary',
+    tags: ['Submission Votes'],
+  })
+  .input(idParamSchema)
+  .output(voteSummarySchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionVoteService.getVoteSummaryWithAccess(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const deleteVote = orgProcedure
+  .use(requireScopes('submissions:write'))
+  .route({
+    method: 'DELETE',
+    path: '/submissions/{id}/votes',
+    summary: 'Delete your vote',
+    description: "Remove the current user's vote on a submission.",
+    operationId: 'deleteSubmissionVote',
+    tags: ['Submission Votes'],
+  })
+  .input(idParamSchema)
+  .output(successResponseSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionVoteService.deleteVoteWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+// ---------------------------------------------------------------------------
 // Analytics routes
 // ---------------------------------------------------------------------------
 
@@ -684,6 +796,10 @@ export const submissionsRouter = {
   markReviewerRead,
   listDiscussions,
   addDiscussion,
+  castVote,
+  listVotes,
+  voteSummary,
+  deleteVote,
   analyticsOverview,
   analyticsStatusBreakdown,
   analyticsFunnel,

--- a/apps/api/src/services/submission-vote.service.spec.ts
+++ b/apps/api/src/services/submission-vote.service.spec.ts
@@ -11,6 +11,7 @@ const mockUpdate = vi.fn();
 const mockDeleteFn = vi.fn();
 const mockValues = vi.fn();
 const mockReturning = vi.fn();
+const mockOnConflictDoUpdate = vi.fn();
 const mockSet = vi.fn();
 const mockFrom = vi.fn();
 const mockWhere = vi.fn();
@@ -88,7 +89,11 @@ function makeTx(selectResults: unknown[][]) {
 
   const resetChain = () => {
     mockReturning.mockReturnValue([{ id: 'vote-1' }]);
-    mockValues.mockReturnValue({ returning: mockReturning });
+    mockOnConflictDoUpdate.mockReturnValue({ returning: mockReturning });
+    mockValues.mockReturnValue({
+      returning: mockReturning,
+      onConflictDoUpdate: mockOnConflictDoUpdate,
+    });
     mockInsert.mockReturnValue({ values: mockValues });
 
     mockSet.mockReturnValue({ where: mockWhere });
@@ -400,6 +405,33 @@ describe('submissionVoteService', () => {
       });
 
       expect(result).toBeDefined();
+    });
+
+    it('score 0 accepted when scoreMin is 0', async () => {
+      const ORG_SCORE_MIN_ZERO = {
+        settings: {
+          votingEnabled: true,
+          scoringEnabled: true,
+          scoreMin: 0,
+          scoreMax: 10,
+        },
+      };
+      const VOTE_WITH_ZERO_SCORE = { ...VOTE_ROW, score: '0' };
+      const svc = makeSvc('EDITOR', 'user-editor', [
+        [SUB_ROW], // getSubmissionOrThrow
+        [ORG_SCORE_MIN_ZERO], // resolveVotingConfig
+        [], // upsert: no existing vote
+        [VOTE_WITH_ZERO_SCORE], // return full vote
+      ]);
+
+      const result = await submissionVoteService.castVoteWithAudit(svc, {
+        submissionId: 'sub-1',
+        decision: 'ACCEPT',
+        score: 0,
+      });
+
+      expect(result).toBeDefined();
+      expect(result.score).toBe(0);
     });
   });
 

--- a/apps/api/src/services/submission-vote.service.spec.ts
+++ b/apps/api/src/services/submission-vote.service.spec.ts
@@ -1,0 +1,460 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuditActions, AuditResources } from '@colophony/types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockInsert = vi.fn();
+const mockSelect = vi.fn();
+const mockUpdate = vi.fn();
+const mockDeleteFn = vi.fn();
+const mockValues = vi.fn();
+const mockReturning = vi.fn();
+const mockSet = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockLimit = vi.fn();
+const mockOrderBy = vi.fn();
+const mockLeftJoin = vi.fn();
+
+vi.mock('@colophony/db', () => ({
+  submissionVotes: {
+    id: 'id',
+    organizationId: 'organization_id',
+    submissionId: 'submission_id',
+    voterUserId: 'voter_user_id',
+    decision: 'decision',
+    score: 'score',
+    createdAt: 'created_at',
+    updatedAt: 'updated_at',
+  },
+  submissionReviewers: {
+    id: 'id',
+    submissionId: 'submission_id',
+    reviewerUserId: 'reviewer_user_id',
+  },
+  submissions: {
+    id: 'id',
+    submitterId: 'submitter_id',
+    organizationId: 'organization_id',
+    status: 'status',
+  },
+  organizations: { id: 'id', settings: 'settings' },
+  users: { id: 'id', email: 'email' },
+  eq: vi.fn((_col: unknown, val: unknown) => val),
+  and: vi.fn((...args: unknown[]) => args),
+}));
+
+vi.mock('drizzle-orm', () => {
+  const mockSql = vi.fn();
+  return { sql: mockSql };
+});
+
+vi.mock('./outbox.js', () => ({
+  enqueueOutboxEvent: vi.fn(),
+}));
+
+vi.mock('./submission.service.js', () => ({
+  SubmissionNotFoundError: class SubmissionNotFoundError extends Error {
+    constructor(id: string) {
+      super(`Submission "${id}" not found`);
+      this.name = 'SubmissionNotFoundError';
+    }
+  },
+}));
+
+import { submissionVoteService } from './submission-vote.service.js';
+import {
+  VoteNotFoundError,
+  VotingDisabledError,
+  VoteOnTerminalSubmissionError,
+  ScoreOutOfRangeError,
+} from './submission-vote.service.js';
+import { ForbiddenError } from './errors.js';
+import { enqueueOutboxEvent } from './outbox.js';
+import type { ServiceContext } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a mock DrizzleDb tx that returns sequential results on each
+ * `select().from().where().limit()` chain call.
+ */
+function makeTx(selectResults: unknown[][]) {
+  let callIndex = 0;
+
+  const resetChain = () => {
+    mockReturning.mockReturnValue([{ id: 'vote-1' }]);
+    mockValues.mockReturnValue({ returning: mockReturning });
+    mockInsert.mockReturnValue({ values: mockValues });
+
+    mockSet.mockReturnValue({ where: mockWhere });
+    mockUpdate.mockReturnValue({ set: mockSet });
+
+    mockDeleteFn.mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockImplementation(() => {
+          // Use last selectResults entry for delete result
+          const results = selectResults;
+          // If there's a result that looks like a vote, return it
+          return results.length > 0 ? results[results.length - 1] : [];
+        }),
+      }),
+    });
+  };
+
+  mockLimit.mockImplementation(() => {
+    const result = selectResults[callIndex] ?? [];
+    callIndex++;
+    return result;
+  });
+
+  mockWhere.mockReturnValue({
+    limit: mockLimit,
+    orderBy: mockOrderBy,
+  });
+  mockOrderBy.mockReturnValue([]);
+  mockLeftJoin.mockReturnValue({ where: mockWhere });
+  mockFrom.mockReturnValue({
+    leftJoin: mockLeftJoin,
+    where: mockWhere,
+  });
+  mockSelect.mockReturnValue({ from: mockFrom });
+
+  resetChain();
+
+  return {
+    insert: mockInsert,
+    select: mockSelect,
+    update: mockUpdate,
+    delete: mockDeleteFn,
+  } as unknown as import('@colophony/db').DrizzleDb;
+}
+
+const VOTE_ROW = {
+  id: 'vote-1',
+  submissionId: 'sub-1',
+  voterUserId: 'user-editor',
+  voterEmail: 'editor@test.com',
+  decision: 'ACCEPT',
+  score: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const SUB_ROW = {
+  id: 'sub-1',
+  submitterId: 'user-submitter',
+  organizationId: 'org-1',
+  status: 'UNDER_REVIEW',
+};
+
+const ORG_ROW_VOTING_ON = {
+  settings: {
+    votingEnabled: true,
+    scoringEnabled: false,
+    scoreMin: 1,
+    scoreMax: 10,
+  },
+};
+
+const ORG_ROW_SCORING_ON = {
+  settings: {
+    votingEnabled: true,
+    scoringEnabled: true,
+    scoreMin: 1,
+    scoreMax: 10,
+  },
+};
+
+const ORG_ROW_VOTING_OFF = {
+  settings: {
+    votingEnabled: false,
+    scoringEnabled: false,
+    scoreMin: 1,
+    scoreMax: 10,
+  },
+};
+
+function makeSvc(
+  role: string,
+  userId: string,
+  selectResults: unknown[][],
+): ServiceContext {
+  return {
+    tx: makeTx(selectResults),
+    actor: {
+      userId,
+      orgId: 'org-1',
+      role: role as 'ADMIN' | 'EDITOR' | 'READER',
+    },
+    audit: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('submissionVoteService', () => {
+  describe('castVoteWithAudit', () => {
+    it('cast vote succeeds for EDITOR', async () => {
+      // Call sequence: getSubmission, resolveVotingConfig, existingVote(select), returnVote
+      const svc = makeSvc('EDITOR', 'user-editor', [
+        [SUB_ROW], // getSubmissionOrThrow
+        [ORG_ROW_VOTING_ON], // resolveVotingConfig
+        [], // upsert: check existing vote
+        [VOTE_ROW], // return full vote
+      ]);
+
+      const result = await submissionVoteService.castVoteWithAudit(svc, {
+        submissionId: 'sub-1',
+        decision: 'ACCEPT',
+      });
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe('vote-1');
+      expect(svc.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: AuditResources.SUBMISSION,
+          action: AuditActions.SUBMISSION_VOTE_CAST,
+          resourceId: 'sub-1',
+        }),
+      );
+      expect(enqueueOutboxEvent).toHaveBeenCalledWith(
+        expect.anything(),
+        'hopper/vote.cast',
+        expect.objectContaining({ submissionId: 'sub-1' }),
+      );
+    });
+
+    it('cast vote succeeds for assigned READER', async () => {
+      const svc = makeSvc('READER', 'user-reader', [
+        [SUB_ROW], // getSubmissionOrThrow
+        [{ id: 'reviewer-1' }], // assertEditorAdminOrReviewer: reviewer lookup
+        [ORG_ROW_VOTING_ON], // resolveVotingConfig
+        [], // upsert: check existing vote
+        [VOTE_ROW], // return full vote
+      ]);
+
+      const result = await submissionVoteService.castVoteWithAudit(svc, {
+        submissionId: 'sub-1',
+        decision: 'MAYBE',
+      });
+
+      expect(result).toBeDefined();
+    });
+
+    it('cast vote rejected for non-assigned READER', async () => {
+      const svc = makeSvc('READER', 'user-reader', [
+        [SUB_ROW], // getSubmissionOrThrow
+        [], // assertEditorAdminOrReviewer: reviewer lookup (empty)
+      ]);
+
+      await expect(
+        submissionVoteService.castVoteWithAudit(svc, {
+          submissionId: 'sub-1',
+          decision: 'ACCEPT',
+        }),
+      ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('cast vote rejected for submitter', async () => {
+      const svc = makeSvc('EDITOR', 'user-submitter', [
+        [SUB_ROW], // getSubmissionOrThrow
+      ]);
+
+      await expect(
+        submissionVoteService.castVoteWithAudit(svc, {
+          submissionId: 'sub-1',
+          decision: 'ACCEPT',
+        }),
+      ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('cast vote rejected when voting disabled', async () => {
+      const svc = makeSvc('EDITOR', 'user-editor', [
+        [SUB_ROW], // getSubmissionOrThrow
+        [ORG_ROW_VOTING_OFF], // resolveVotingConfig
+      ]);
+
+      await expect(
+        submissionVoteService.castVoteWithAudit(svc, {
+          submissionId: 'sub-1',
+          decision: 'ACCEPT',
+        }),
+      ).rejects.toThrow(VotingDisabledError);
+    });
+
+    it('cast vote rejected on ACCEPTED submission', async () => {
+      const svc = makeSvc('EDITOR', 'user-editor', [
+        [{ ...SUB_ROW, status: 'ACCEPTED' }],
+      ]);
+
+      await expect(
+        submissionVoteService.castVoteWithAudit(svc, {
+          submissionId: 'sub-1',
+          decision: 'ACCEPT',
+        }),
+      ).rejects.toThrow(VoteOnTerminalSubmissionError);
+    });
+
+    it('cast vote rejected on REJECTED submission', async () => {
+      const svc = makeSvc('EDITOR', 'user-editor', [
+        [{ ...SUB_ROW, status: 'REJECTED' }],
+      ]);
+
+      await expect(
+        submissionVoteService.castVoteWithAudit(svc, {
+          submissionId: 'sub-1',
+          decision: 'REJECT',
+        }),
+      ).rejects.toThrow(VoteOnTerminalSubmissionError);
+    });
+
+    it('cast vote rejected on WITHDRAWN submission', async () => {
+      const svc = makeSvc('EDITOR', 'user-editor', [
+        [{ ...SUB_ROW, status: 'WITHDRAWN' }],
+      ]);
+
+      await expect(
+        submissionVoteService.castVoteWithAudit(svc, {
+          submissionId: 'sub-1',
+          decision: 'ACCEPT',
+        }),
+      ).rejects.toThrow(VoteOnTerminalSubmissionError);
+    });
+
+    it('upsert updates existing vote, audits UPDATED', async () => {
+      const svc = makeSvc('EDITOR', 'user-editor', [
+        [SUB_ROW], // getSubmissionOrThrow
+        [ORG_ROW_VOTING_ON], // resolveVotingConfig
+        [{ id: 'existing-vote-1' }], // upsert: check existing vote (found)
+        [VOTE_ROW], // return full vote
+      ]);
+
+      const result = await submissionVoteService.castVoteWithAudit(svc, {
+        submissionId: 'sub-1',
+        decision: 'REJECT',
+      });
+
+      expect(result).toBeDefined();
+      expect(svc.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditActions.SUBMISSION_VOTE_UPDATED,
+        }),
+      );
+    });
+
+    it('score rejected when out of range', async () => {
+      const svc = makeSvc('EDITOR', 'user-editor', [
+        [SUB_ROW], // getSubmissionOrThrow
+        [ORG_ROW_SCORING_ON], // resolveVotingConfig
+      ]);
+
+      await expect(
+        submissionVoteService.castVoteWithAudit(svc, {
+          submissionId: 'sub-1',
+          decision: 'ACCEPT',
+          score: 11,
+        }),
+      ).rejects.toThrow(ScoreOutOfRangeError);
+    });
+
+    it('score ignored when scoring disabled', async () => {
+      const svc = makeSvc('EDITOR', 'user-editor', [
+        [SUB_ROW], // getSubmissionOrThrow
+        [ORG_ROW_VOTING_ON], // resolveVotingConfig (scoringEnabled: false)
+        [], // upsert: no existing vote
+        [VOTE_ROW], // return full vote
+      ]);
+
+      const result = await submissionVoteService.castVoteWithAudit(svc, {
+        submissionId: 'sub-1',
+        decision: 'ACCEPT',
+        score: 5,
+      });
+
+      expect(result).toBeDefined();
+    });
+
+    it('score accepted within range', async () => {
+      const svc = makeSvc('EDITOR', 'user-editor', [
+        [SUB_ROW], // getSubmissionOrThrow
+        [ORG_ROW_SCORING_ON], // resolveVotingConfig
+        [], // upsert: no existing vote
+        [VOTE_ROW], // return full vote
+      ]);
+
+      const result = await submissionVoteService.castVoteWithAudit(svc, {
+        submissionId: 'sub-1',
+        decision: 'ACCEPT',
+        score: 7,
+      });
+
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('deleteVoteWithAudit', () => {
+    it('delete vote succeeds for own vote', async () => {
+      const svc = makeSvc('EDITOR', 'user-editor', [
+        [SUB_ROW], // getSubmissionOrThrow
+      ]);
+
+      // Mock delete to return a result (vote was found and deleted)
+      mockDeleteFn.mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockReturnValue([{ id: 'vote-1' }]),
+        }),
+      });
+
+      const result = await submissionVoteService.deleteVoteWithAudit(
+        svc,
+        'sub-1',
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(svc.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditActions.SUBMISSION_VOTE_DELETED,
+          resourceId: 'sub-1',
+        }),
+      );
+    });
+
+    it('delete vote fails when no vote exists', async () => {
+      const svc = makeSvc('EDITOR', 'user-editor', [
+        [SUB_ROW], // getSubmissionOrThrow
+      ]);
+
+      // Mock delete to return empty (no vote found)
+      mockDeleteFn.mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockReturnValue([]),
+        }),
+      });
+
+      await expect(
+        submissionVoteService.deleteVoteWithAudit(svc, 'sub-1'),
+      ).rejects.toThrow(VoteNotFoundError);
+    });
+  });
+
+  describe('getVoteSummaryWithAccess', () => {
+    it('vote summary rejected for READER', async () => {
+      const svc = makeSvc('READER', 'user-reader', []);
+
+      await expect(
+        submissionVoteService.getVoteSummaryWithAccess(svc, 'sub-1'),
+      ).rejects.toThrow(ForbiddenError);
+    });
+  });
+});

--- a/apps/api/src/services/submission-vote.service.ts
+++ b/apps/api/src/services/submission-vote.service.ts
@@ -142,7 +142,7 @@ async function upsert(
     score: string | null;
   },
 ): Promise<{ id: string; isNew: boolean }> {
-  // Try insert first; on conflict update
+  // Check for existing vote to determine audit action (CAST vs UPDATED)
   const [existing] = await tx
     .select({ id: submissionVotes.id })
     .from(submissionVotes)
@@ -154,18 +154,7 @@ async function upsert(
     )
     .limit(1);
 
-  if (existing) {
-    await tx
-      .update(submissionVotes)
-      .set({
-        decision: params.decision as 'ACCEPT' | 'REJECT' | 'MAYBE',
-        score: params.score,
-        updatedAt: new Date(),
-      })
-      .where(eq(submissionVotes.id, existing.id));
-    return { id: existing.id, isNew: false };
-  }
-
+  // Atomic upsert via ON CONFLICT
   const [row] = await tx
     .insert(submissionVotes)
     .values({
@@ -175,9 +164,17 @@ async function upsert(
       decision: params.decision as 'ACCEPT' | 'REJECT' | 'MAYBE',
       score: params.score,
     })
+    .onConflictDoUpdate({
+      target: [submissionVotes.submissionId, submissionVotes.voterUserId],
+      set: {
+        decision: params.decision as 'ACCEPT' | 'REJECT' | 'MAYBE',
+        score: params.score,
+        updatedAt: new Date(),
+      },
+    })
     .returning({ id: submissionVotes.id });
 
-  return { id: row.id, isNew: true };
+  return { id: row.id, isNew: !existing };
 }
 
 async function listBySubmission(
@@ -202,7 +199,7 @@ async function listBySubmission(
 
   return rows.map((r) => ({
     ...r,
-    score: r.score ? Number(r.score) : null,
+    score: r.score != null ? Number(r.score) : null,
   }));
 }
 
@@ -235,7 +232,8 @@ async function getSummary(
     rejectCount: result.rejectCount,
     maybeCount: result.maybeCount,
     totalVotes: result.totalVotes,
-    averageScore: result.averageScore ? Number(result.averageScore) : null,
+    averageScore:
+      result.averageScore != null ? Number(result.averageScore) : null,
   };
 }
 

--- a/apps/api/src/services/submission-vote.service.ts
+++ b/apps/api/src/services/submission-vote.service.ts
@@ -1,0 +1,409 @@
+import {
+  submissionVotes,
+  submissionReviewers,
+  submissions,
+  organizations,
+  users,
+  eq,
+  and,
+  type DrizzleDb,
+} from '@colophony/db';
+import { sql } from 'drizzle-orm';
+import {
+  AuditActions,
+  AuditResources,
+  votingConfigSchema,
+  type SubmissionVote,
+  type VoteSummary,
+  type VotingConfig,
+} from '@colophony/types';
+import { enqueueOutboxEvent } from './outbox.js';
+import type { ServiceContext } from './types.js';
+import { ForbiddenError } from './errors.js';
+import { assertEditorOrAdmin } from './errors.js';
+import { SubmissionNotFoundError } from './submission.service.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class VoteNotFoundError extends Error {
+  constructor(submissionId: string) {
+    super(`No vote found for this voter on submission "${submissionId}"`);
+    this.name = 'VoteNotFoundError';
+  }
+}
+
+export class VotingDisabledError extends Error {
+  constructor() {
+    super('Voting is not enabled for this organization');
+    this.name = 'VotingDisabledError';
+  }
+}
+
+export class VoteOnTerminalSubmissionError extends Error {
+  constructor(status: string) {
+    super(`Cannot vote on a submission with terminal status "${status}"`);
+    this.name = 'VoteOnTerminalSubmissionError';
+  }
+}
+
+export class ScoreOutOfRangeError extends Error {
+  constructor(min: number, max: number) {
+    super(`Score must be between ${min} and ${max}`);
+    this.name = 'ScoreOutOfRangeError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Terminal statuses (no votes allowed)
+// ---------------------------------------------------------------------------
+
+const TERMINAL_STATUSES = new Set(['ACCEPTED', 'REJECTED', 'WITHDRAWN']);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getSubmissionOrThrow(tx: DrizzleDb, submissionId: string) {
+  const [submission] = await tx
+    .select({
+      id: submissions.id,
+      submitterId: submissions.submitterId,
+      organizationId: submissions.organizationId,
+      status: submissions.status,
+    })
+    .from(submissions)
+    .where(eq(submissions.id, submissionId))
+    .limit(1);
+
+  if (!submission) throw new SubmissionNotFoundError(submissionId);
+  return submission;
+}
+
+async function assertEditorAdminOrReviewer(
+  tx: DrizzleDb,
+  actorRole: string,
+  actorUserId: string,
+  submissionId: string,
+  submitterId: string | null,
+): Promise<void> {
+  if (submitterId && actorUserId === submitterId) {
+    throw new ForbiddenError('Submitters cannot vote on their own submissions');
+  }
+
+  if (actorRole === 'ADMIN' || actorRole === 'EDITOR') return;
+
+  if (actorRole === 'READER') {
+    const [reviewer] = await tx
+      .select({ id: submissionReviewers.id })
+      .from(submissionReviewers)
+      .where(
+        and(
+          eq(submissionReviewers.submissionId, submissionId),
+          eq(submissionReviewers.reviewerUserId, actorUserId),
+        ),
+      )
+      .limit(1);
+
+    if (reviewer) return;
+  }
+
+  throw new ForbiddenError(
+    'Only editors, admins, and assigned reviewers can vote',
+  );
+}
+
+async function resolveVotingConfig(
+  tx: DrizzleDb,
+  orgId: string,
+): Promise<VotingConfig> {
+  const [org] = await tx
+    .select({ settings: organizations.settings })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
+  const settings = (org?.settings ?? {}) as Record<string, unknown>;
+  return votingConfigSchema.parse(settings);
+}
+
+// ---------------------------------------------------------------------------
+// Pure data methods (accept DrizzleDb tx)
+// ---------------------------------------------------------------------------
+
+async function upsert(
+  tx: DrizzleDb,
+  params: {
+    organizationId: string;
+    submissionId: string;
+    voterUserId: string;
+    decision: string;
+    score: string | null;
+  },
+): Promise<{ id: string; isNew: boolean }> {
+  // Try insert first; on conflict update
+  const [existing] = await tx
+    .select({ id: submissionVotes.id })
+    .from(submissionVotes)
+    .where(
+      and(
+        eq(submissionVotes.submissionId, params.submissionId),
+        eq(submissionVotes.voterUserId, params.voterUserId),
+      ),
+    )
+    .limit(1);
+
+  if (existing) {
+    await tx
+      .update(submissionVotes)
+      .set({
+        decision: params.decision as 'ACCEPT' | 'REJECT' | 'MAYBE',
+        score: params.score,
+        updatedAt: new Date(),
+      })
+      .where(eq(submissionVotes.id, existing.id));
+    return { id: existing.id, isNew: false };
+  }
+
+  const [row] = await tx
+    .insert(submissionVotes)
+    .values({
+      organizationId: params.organizationId,
+      submissionId: params.submissionId,
+      voterUserId: params.voterUserId,
+      decision: params.decision as 'ACCEPT' | 'REJECT' | 'MAYBE',
+      score: params.score,
+    })
+    .returning({ id: submissionVotes.id });
+
+  return { id: row.id, isNew: true };
+}
+
+async function listBySubmission(
+  tx: DrizzleDb,
+  submissionId: string,
+): Promise<SubmissionVote[]> {
+  const rows = await tx
+    .select({
+      id: submissionVotes.id,
+      submissionId: submissionVotes.submissionId,
+      voterUserId: submissionVotes.voterUserId,
+      voterEmail: users.email,
+      decision: submissionVotes.decision,
+      score: submissionVotes.score,
+      createdAt: submissionVotes.createdAt,
+      updatedAt: submissionVotes.updatedAt,
+    })
+    .from(submissionVotes)
+    .leftJoin(users, eq(users.id, submissionVotes.voterUserId))
+    .where(eq(submissionVotes.submissionId, submissionId))
+    .orderBy(submissionVotes.createdAt);
+
+  return rows.map((r) => ({
+    ...r,
+    score: r.score ? Number(r.score) : null,
+  }));
+}
+
+async function getSummary(
+  tx: DrizzleDb,
+  submissionId: string,
+): Promise<VoteSummary> {
+  const [result] = await tx
+    .select({
+      acceptCount:
+        sql<number>`COUNT(*) FILTER (WHERE ${submissionVotes.decision} = 'ACCEPT')`.mapWith(
+          Number,
+        ),
+      rejectCount:
+        sql<number>`COUNT(*) FILTER (WHERE ${submissionVotes.decision} = 'REJECT')`.mapWith(
+          Number,
+        ),
+      maybeCount:
+        sql<number>`COUNT(*) FILTER (WHERE ${submissionVotes.decision} = 'MAYBE')`.mapWith(
+          Number,
+        ),
+      totalVotes: sql<number>`COUNT(*)`.mapWith(Number),
+      averageScore: sql<number | null>`AVG(${submissionVotes.score})`,
+    })
+    .from(submissionVotes)
+    .where(eq(submissionVotes.submissionId, submissionId));
+
+  return {
+    acceptCount: result.acceptCount,
+    rejectCount: result.rejectCount,
+    maybeCount: result.maybeCount,
+    totalVotes: result.totalVotes,
+    averageScore: result.averageScore ? Number(result.averageScore) : null,
+  };
+}
+
+async function deleteByVoter(
+  tx: DrizzleDb,
+  submissionId: string,
+  voterUserId: string,
+): Promise<void> {
+  const deleted = await tx
+    .delete(submissionVotes)
+    .where(
+      and(
+        eq(submissionVotes.submissionId, submissionId),
+        eq(submissionVotes.voterUserId, voterUserId),
+      ),
+    )
+    .returning({ id: submissionVotes.id });
+
+  if (deleted.length === 0) {
+    throw new VoteNotFoundError(submissionId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Access-aware methods (accept ServiceContext)
+// ---------------------------------------------------------------------------
+
+async function castVoteWithAudit(
+  svc: ServiceContext,
+  params: { submissionId: string; decision: string; score?: number },
+): Promise<SubmissionVote> {
+  const submission = await getSubmissionOrThrow(svc.tx, params.submissionId);
+
+  // Access check
+  await assertEditorAdminOrReviewer(
+    svc.tx,
+    svc.actor.role,
+    svc.actor.userId,
+    params.submissionId,
+    submission.submitterId,
+  );
+
+  // Terminal status check
+  if (TERMINAL_STATUSES.has(submission.status)) {
+    throw new VoteOnTerminalSubmissionError(submission.status);
+  }
+
+  // Config check
+  const config = await resolveVotingConfig(svc.tx, svc.actor.orgId);
+  if (!config.votingEnabled) {
+    throw new VotingDisabledError();
+  }
+
+  // Score handling
+  let scoreValue: string | null = null;
+  if (config.scoringEnabled && params.score != null) {
+    if (params.score < config.scoreMin || params.score > config.scoreMax) {
+      throw new ScoreOutOfRangeError(config.scoreMin, config.scoreMax);
+    }
+    scoreValue = params.score.toString();
+  }
+
+  const { id, isNew } = await upsert(svc.tx, {
+    organizationId: svc.actor.orgId,
+    submissionId: params.submissionId,
+    voterUserId: svc.actor.userId,
+    decision: params.decision,
+    score: scoreValue,
+  });
+
+  await svc.audit({
+    resource: AuditResources.SUBMISSION,
+    action: isNew
+      ? AuditActions.SUBMISSION_VOTE_CAST
+      : AuditActions.SUBMISSION_VOTE_UPDATED,
+    resourceId: params.submissionId,
+    newValue: { voteId: id, decision: params.decision, score: params.score },
+  });
+
+  await enqueueOutboxEvent(svc.tx, 'hopper/vote.cast', {
+    orgId: svc.actor.orgId,
+    submissionId: params.submissionId,
+    voteId: id,
+    voterUserId: svc.actor.userId,
+    decision: params.decision,
+    isUpdate: !isNew,
+  });
+
+  // Return the full vote with voter email
+  const [vote] = await svc.tx
+    .select({
+      id: submissionVotes.id,
+      submissionId: submissionVotes.submissionId,
+      voterUserId: submissionVotes.voterUserId,
+      voterEmail: users.email,
+      decision: submissionVotes.decision,
+      score: submissionVotes.score,
+      createdAt: submissionVotes.createdAt,
+      updatedAt: submissionVotes.updatedAt,
+    })
+    .from(submissionVotes)
+    .leftJoin(users, eq(users.id, submissionVotes.voterUserId))
+    .where(eq(submissionVotes.id, id))
+    .limit(1);
+
+  return {
+    ...vote,
+    score: vote.score ? Number(vote.score) : null,
+  };
+}
+
+async function listVotesWithAccess(
+  svc: ServiceContext,
+  submissionId: string,
+): Promise<SubmissionVote[]> {
+  const submission = await getSubmissionOrThrow(svc.tx, submissionId);
+  await assertEditorAdminOrReviewer(
+    svc.tx,
+    svc.actor.role,
+    svc.actor.userId,
+    submissionId,
+    submission.submitterId,
+  );
+  return listBySubmission(svc.tx, submissionId);
+}
+
+async function getVoteSummaryWithAccess(
+  svc: ServiceContext,
+  submissionId: string,
+): Promise<VoteSummary> {
+  assertEditorOrAdmin(svc.actor.role);
+  await getSubmissionOrThrow(svc.tx, submissionId);
+  return getSummary(svc.tx, submissionId);
+}
+
+async function deleteVoteWithAudit(
+  svc: ServiceContext,
+  submissionId: string,
+): Promise<{ success: true }> {
+  const submission = await getSubmissionOrThrow(svc.tx, submissionId);
+
+  // Terminal status check — can't modify votes on terminal submissions
+  if (TERMINAL_STATUSES.has(submission.status)) {
+    throw new VoteOnTerminalSubmissionError(submission.status);
+  }
+
+  await deleteByVoter(svc.tx, submissionId, svc.actor.userId);
+
+  await svc.audit({
+    resource: AuditResources.SUBMISSION,
+    action: AuditActions.SUBMISSION_VOTE_DELETED,
+    resourceId: submissionId,
+  });
+
+  return { success: true };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export const submissionVoteService = {
+  upsert,
+  listBySubmission,
+  getSummary,
+  deleteByVoter,
+  castVoteWithAudit,
+  listVotesWithAccess,
+  getVoteSummaryWithAccess,
+  deleteVoteWithAudit,
+};

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -79,6 +79,12 @@ import {
   DiscussionCommentNotFoundError,
   DiscussionParentNotFoundError,
 } from '../services/submission-discussion.service.js';
+import {
+  VoteNotFoundError,
+  VotingDisabledError,
+  VoteOnTerminalSubmissionError,
+  ScoreOutOfRangeError,
+} from '../services/submission-vote.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -152,6 +158,11 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   // Discussion errors
   [DiscussionCommentNotFoundError, 'NOT_FOUND'],
   [DiscussionParentNotFoundError, 'NOT_FOUND'],
+  // Vote errors
+  [VoteNotFoundError, 'NOT_FOUND'],
+  [VotingDisabledError, 'BAD_REQUEST'],
+  [VoteOnTerminalSubmissionError, 'BAD_REQUEST'],
+  [ScoreOutOfRangeError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];

--- a/apps/api/src/trpc/routers/submissions.ts
+++ b/apps/api/src/trpc/routers/submissions.ts
@@ -35,6 +35,11 @@ import {
   submissionTimeSeriesSchema,
   responseTimeDistributionSchema,
   agingSubmissionsSchema,
+  castVoteInputSchema,
+  listVotesInputSchema,
+  deleteVoteInputSchema,
+  submissionVoteSchema,
+  voteSummarySchema,
 } from '@colophony/types';
 import {
   orgProcedure,
@@ -45,6 +50,7 @@ import {
 import { submissionService } from '../../services/submission.service.js';
 import { submissionReviewerService } from '../../services/submission-reviewer.service.js';
 import { submissionDiscussionService } from '../../services/submission-discussion.service.js';
+import { submissionVoteService } from '../../services/submission-vote.service.js';
 import { submissionAnalyticsService } from '../../services/submission-analytics.service.js';
 import { simsubService } from '../../services/simsub.service.js';
 import { transferService } from '../../services/transfer.service.js';
@@ -452,6 +458,72 @@ export const submissionsRouter = createRouter({
         return await submissionDiscussionService.createWithAudit(
           toServiceContext(ctx),
           input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  // ─── Voting procedures ───
+
+  /** Cast or update a vote on a submission. */
+  castVote: orgProcedure
+    .use(requireScopes('submissions:write'))
+    .input(castVoteInputSchema)
+    .output(submissionVoteSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await submissionVoteService.castVoteWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** List all votes on a submission. */
+  listVotes: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(listVotesInputSchema)
+    .output(z.array(submissionVoteSchema))
+    .query(async ({ ctx, input }) => {
+      try {
+        return await submissionVoteService.listVotesWithAccess(
+          toServiceContext(ctx),
+          input.submissionId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Get vote summary (tallies + average score) — editor/admin only. */
+  getVoteSummary: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(z.object({ submissionId: z.string().uuid() }))
+    .output(voteSummarySchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await submissionVoteService.getVoteSummaryWithAccess(
+          toServiceContext(ctx),
+          input.submissionId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Delete the current user's vote on a submission. */
+  deleteVote: orgProcedure
+    .use(requireScopes('submissions:write'))
+    .input(deleteVoteInputSchema)
+    .output(successResponseSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await submissionVoteService.deleteVoteWithAudit(
+          toServiceContext(ctx),
+          input.submissionId,
         );
       } catch (e) {
         mapServiceError(e);

--- a/apps/web/src/components/organizations/org-settings.tsx
+++ b/apps/web/src/components/organizations/org-settings.tsx
@@ -10,6 +10,7 @@ import { trpc } from "@/lib/trpc";
 import { useOrganization } from "@/hooks/use-organization";
 import { MemberList } from "./member-list";
 import { EmailTemplateSettings } from "./email-template-settings";
+import { VotingSettings } from "./voting-settings";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -138,6 +139,7 @@ export function OrgSettings() {
           <TabsTrigger value="general">General</TabsTrigger>
           <TabsTrigger value="members">Members</TabsTrigger>
           <TabsTrigger value="email-templates">Email Templates</TabsTrigger>
+          <TabsTrigger value="voting">Voting</TabsTrigger>
         </TabsList>
 
         <TabsContent value="general" className="mt-6">
@@ -232,6 +234,22 @@ export function OrgSettings() {
             </CardHeader>
             <CardContent>
               <EmailTemplateSettings />
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="voting" className="mt-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Voting</CardTitle>
+              <CardDescription>
+                {isAdmin
+                  ? "Configure how reviewers and editors vote on submissions."
+                  : "Voting configuration for this organization."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <VotingSettings />
             </CardContent>
           </Card>
         </TabsContent>

--- a/apps/web/src/components/organizations/voting-settings.tsx
+++ b/apps/web/src/components/organizations/voting-settings.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { votingConfigSchema } from "@colophony/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@/components/ui/form";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+
+const formSchema = z.object({
+  votingEnabled: z.boolean(),
+  scoringEnabled: z.boolean(),
+  scoreMin: z.coerce.number().int().min(0),
+  scoreMax: z.coerce.number().int().min(1),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+export function VotingSettings() {
+  const { isAdmin } = useOrganization();
+  const utils = trpc.useUtils();
+
+  const { data: org } = trpc.organizations.get.useQuery();
+
+  const votingConfig = votingConfigSchema.parse(
+    (org?.settings as Record<string, unknown>) ?? {},
+  );
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema) as unknown as Resolver<FormData>,
+    defaultValues: {
+      votingEnabled: false,
+      scoringEnabled: false,
+      scoreMin: 1,
+      scoreMax: 10,
+    },
+  });
+
+  useEffect(() => {
+    if (org) {
+      form.reset({
+        votingEnabled: votingConfig.votingEnabled,
+        scoringEnabled: votingConfig.scoringEnabled,
+        scoreMin: votingConfig.scoreMin,
+        scoreMax: votingConfig.scoreMax,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [org]);
+
+  const updateMutation = trpc.organizations.update.useMutation({
+    onSuccess: () => {
+      utils.organizations.get.invalidate();
+      toast.success("Voting settings updated");
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const onSubmit = (data: FormData) => {
+    const currentSettings = (org?.settings as Record<string, unknown>) ?? {};
+    updateMutation.mutate({
+      settings: {
+        ...currentSettings,
+        votingEnabled: data.votingEnabled,
+        scoringEnabled: data.scoringEnabled,
+        scoreMin: data.scoreMin,
+        scoreMax: data.scoreMax,
+      },
+    });
+  };
+
+  const watchVotingEnabled = form.watch("votingEnabled");
+
+  if (!isAdmin) {
+    return (
+      <div className="space-y-3 text-sm">
+        <p>
+          <span className="font-medium">Voting:</span>{" "}
+          {votingConfig.votingEnabled ? "Enabled" : "Disabled"}
+        </p>
+        {votingConfig.votingEnabled && (
+          <>
+            <p>
+              <span className="font-medium">Scoring:</span>{" "}
+              {votingConfig.scoringEnabled ? "Enabled" : "Disabled"}
+            </p>
+            {votingConfig.scoringEnabled && (
+              <p>
+                <span className="font-medium">Score range:</span>{" "}
+                {votingConfig.scoreMin}–{votingConfig.scoreMax}
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="votingEnabled"
+          render={({ field }) => (
+            <FormItem className="flex items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <FormLabel>Enable Voting</FormLabel>
+                <FormDescription>
+                  Allow reviewers and editors to vote on submissions.
+                </FormDescription>
+              </div>
+              <FormControl>
+                <Switch
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="scoringEnabled"
+          render={({ field }) => (
+            <FormItem className="flex items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <FormLabel>Enable Scoring</FormLabel>
+                <FormDescription>
+                  Allow voters to attach a numeric score to their vote.
+                </FormDescription>
+              </div>
+              <FormControl>
+                <Switch
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                  disabled={!watchVotingEnabled}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <div className="flex gap-4">
+          <FormField
+            control={form.control}
+            name="scoreMin"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Min Score</FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    {...field}
+                    className="w-24"
+                    disabled={!watchVotingEnabled}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="scoreMax"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Max Score</FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    {...field}
+                    className="w-24"
+                    disabled={!watchVotingEnabled}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <Button type="submit" disabled={updateMutation.isPending}>
+          {updateMutation.isPending && (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          )}
+          Save Voting Settings
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/apps/web/src/components/organizations/voting-settings.tsx
+++ b/apps/web/src/components/organizations/voting-settings.tsx
@@ -17,16 +17,22 @@ import {
   FormField,
   FormItem,
   FormLabel,
+  FormMessage,
 } from "@/components/ui/form";
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 
-const formSchema = z.object({
-  votingEnabled: z.boolean(),
-  scoringEnabled: z.boolean(),
-  scoreMin: z.coerce.number().int().min(0),
-  scoreMax: z.coerce.number().int().min(1),
-});
+const formSchema = z
+  .object({
+    votingEnabled: z.boolean(),
+    scoringEnabled: z.boolean(),
+    scoreMin: z.coerce.number().int().min(0),
+    scoreMax: z.coerce.number().int().min(1),
+  })
+  .refine((data) => data.scoreMin < data.scoreMax, {
+    message: "Min score must be less than max score",
+    path: ["scoreMax"],
+  });
 
 type FormData = z.infer<typeof formSchema>;
 
@@ -190,6 +196,7 @@ export function VotingSettings() {
                     disabled={!watchVotingEnabled}
                   />
                 </FormControl>
+                <FormMessage />
               </FormItem>
             )}
           />

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -15,6 +15,7 @@ import { CorrespondenceHistory } from "./correspondence-history";
 import { ReviewerList } from "./reviewer-list";
 import { ReviewerPicker } from "./reviewer-picker";
 import { DiscussionThread } from "./discussion-thread";
+import { VotingPanel } from "./voting-panel";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -50,6 +51,7 @@ import {
 } from "lucide-react";
 import {
   EDITOR_ALLOWED_TRANSITIONS,
+  votingConfigSchema,
   type ScanStatus,
   type SubmissionStatus,
 } from "@colophony/types";
@@ -106,6 +108,11 @@ export function SubmissionDetail({
   const { data: reviewers } = trpc.submissions.listReviewers.useQuery({
     submissionId,
   });
+
+  const { data: org } = trpc.organizations.get.useQuery();
+  const votingConfig = votingConfigSchema.parse(
+    (org?.settings as Record<string, unknown>) ?? {},
+  );
 
   const markReadMutation = trpc.submissions.markReviewerRead.useMutation();
 
@@ -321,6 +328,21 @@ export function SubmissionDetail({
               <DiscussionThread submissionId={submissionId} />
             </CardContent>
           </Card>
+        )}
+
+      {/* Voting — editors, admins, and assigned reviewers (not submitter) */}
+      {(isEditor ||
+        isAdmin ||
+        (reviewers ?? []).some((r) => r.reviewerUserId === user?.id)) &&
+        !isOwner &&
+        submission.status !== "DRAFT" && (
+          <VotingPanel
+            submissionId={submissionId}
+            votingEnabled={votingConfig.votingEnabled}
+            scoringEnabled={votingConfig.scoringEnabled}
+            scoreMin={votingConfig.scoreMin}
+            scoreMax={votingConfig.scoreMax}
+          />
         )}
 
       {/* Content */}

--- a/apps/web/src/components/submissions/voting-panel.tsx
+++ b/apps/web/src/components/submissions/voting-panel.tsx
@@ -88,7 +88,12 @@ export function VotingPanel({
 
   const handleSubmit = () => {
     if (!decision) return;
-    const scoreNum = scoringEnabled && score ? Number(score) : undefined;
+    let scoreNum: number | undefined;
+    if (scoringEnabled && score) {
+      const parsed = Number(score);
+      if (Number.isNaN(parsed)) return;
+      scoreNum = parsed;
+    }
     castVoteMutation.mutate({
       submissionId,
       decision,

--- a/apps/web/src/components/submissions/voting-panel.tsx
+++ b/apps/web/src/components/submissions/voting-panel.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useState } from "react";
+import { trpc } from "@/lib/trpc";
+import { useOrganization } from "@/hooks/use-organization";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { toast } from "sonner";
+import { Loader2, Vote, Trash2 } from "lucide-react";
+import type { VoteDecision } from "@colophony/types";
+
+interface VotingPanelProps {
+  submissionId: string;
+  votingEnabled: boolean;
+  scoringEnabled: boolean;
+  scoreMin: number;
+  scoreMax: number;
+}
+
+const DECISION_LABELS: Record<
+  VoteDecision,
+  { label: string; variant: "default" | "destructive" | "secondary" }
+> = {
+  ACCEPT: { label: "Accept", variant: "default" },
+  REJECT: { label: "Reject", variant: "destructive" },
+  MAYBE: { label: "Maybe", variant: "secondary" },
+};
+
+export function VotingPanel({
+  submissionId,
+  votingEnabled,
+  scoringEnabled,
+  scoreMin,
+  scoreMax,
+}: VotingPanelProps) {
+  const { user, isEditor, isAdmin } = useOrganization();
+  const utils = trpc.useUtils();
+
+  const [decision, setDecision] = useState<VoteDecision | "">("");
+  const [score, setScore] = useState<string>("");
+
+  const { data: votes, isPending: votesLoading } =
+    trpc.submissions.listVotes.useQuery({ submissionId });
+
+  const { data: summary } = trpc.submissions.getVoteSummary.useQuery(
+    { submissionId },
+    { enabled: isEditor || isAdmin },
+  );
+
+  const castVoteMutation = trpc.submissions.castVote.useMutation({
+    onSuccess: () => {
+      toast.success("Vote recorded");
+      utils.submissions.listVotes.invalidate({ submissionId });
+      utils.submissions.getVoteSummary.invalidate({ submissionId });
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const deleteVoteMutation = trpc.submissions.deleteVote.useMutation({
+    onSuccess: () => {
+      toast.success("Vote removed");
+      setDecision("");
+      setScore("");
+      utils.submissions.listVotes.invalidate({ submissionId });
+      utils.submissions.getVoteSummary.invalidate({ submissionId });
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  if (!votingEnabled) return null;
+
+  const myVote = votes?.find((v) => v.voterUserId === user?.id);
+
+  const handleSubmit = () => {
+    if (!decision) return;
+    const scoreNum = scoringEnabled && score ? Number(score) : undefined;
+    castVoteMutation.mutate({
+      submissionId,
+      decision,
+      score: scoreNum,
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Vote className="h-5 w-5" />
+          Voting
+        </CardTitle>
+        <CardDescription>Cast your vote on this submission.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* My Vote */}
+        <div className="space-y-3">
+          <Label className="text-sm font-medium">Your Vote</Label>
+          <RadioGroup
+            value={decision || myVote?.decision || ""}
+            onValueChange={(val) => setDecision(val as VoteDecision)}
+          >
+            {(["ACCEPT", "REJECT", "MAYBE"] as VoteDecision[]).map((d) => (
+              <div key={d} className="flex items-center space-x-2">
+                <RadioGroupItem value={d} id={`vote-${d}`} />
+                <Label htmlFor={`vote-${d}`}>{DECISION_LABELS[d].label}</Label>
+              </div>
+            ))}
+          </RadioGroup>
+
+          {scoringEnabled && (
+            <div className="space-y-1">
+              <Label htmlFor="vote-score" className="text-sm">
+                Score ({scoreMin}–{scoreMax})
+              </Label>
+              <Input
+                id="vote-score"
+                type="number"
+                min={scoreMin}
+                max={scoreMax}
+                step="0.5"
+                placeholder={`${scoreMin}–${scoreMax}`}
+                value={score || (myVote?.score?.toString() ?? "")}
+                onChange={(e) => setScore(e.target.value)}
+                className="w-32"
+              />
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              onClick={handleSubmit}
+              disabled={!decision || castVoteMutation.isPending}
+            >
+              {castVoteMutation.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              {myVote ? "Update Vote" : "Submit Vote"}
+            </Button>
+            {myVote && (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => deleteVoteMutation.mutate({ submissionId })}
+                disabled={deleteVoteMutation.isPending}
+              >
+                <Trash2 className="mr-1 h-4 w-4" />
+                Remove
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* Vote Summary — editors/admins only */}
+        {(isEditor || isAdmin) && summary && summary.totalVotes > 0 && (
+          <>
+            <Separator />
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">Summary</Label>
+              <div className="flex gap-3 text-sm">
+                <span className="text-green-600">
+                  Accept: {summary.acceptCount}
+                </span>
+                <span className="text-red-600">
+                  Reject: {summary.rejectCount}
+                </span>
+                <span className="text-yellow-600">
+                  Maybe: {summary.maybeCount}
+                </span>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {summary.totalVotes} total vote
+                {summary.totalVotes !== 1 ? "s" : ""}
+                {summary.averageScore != null && (
+                  <> &middot; Avg score: {summary.averageScore.toFixed(1)}</>
+                )}
+              </p>
+            </div>
+          </>
+        )}
+
+        {/* All Votes */}
+        {votes && votes.length > 0 && (
+          <>
+            <Separator />
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">All Votes</Label>
+              <div className="space-y-1">
+                {votes.map((vote) => (
+                  <div
+                    key={vote.id}
+                    className="flex items-center justify-between text-sm"
+                  >
+                    <span className="text-muted-foreground truncate">
+                      {vote.voterEmail ?? "Unknown"}
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <Badge variant={DECISION_LABELS[vote.decision].variant}>
+                        {DECISION_LABELS[vote.decision].label}
+                      </Badge>
+                      {vote.score != null && (
+                        <span className="text-muted-foreground">
+                          {vote.score}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
+
+        {votesLoading && (
+          <div className="flex justify-center py-4">
+            <Loader2 className="h-4 w-4 animate-spin" />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -317,7 +317,7 @@
 
 - [x] [P1] Reviewer assignment per submission — assign one or more org members as readers on a submission; track who has read it; show assignment in submission detail — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [x] [P1] Internal discussion threads on submissions — comment system on Hopper submissions (pre-acceptance), separate from the Slate pipeline comments (post-acceptance) — (persona gap analysis 2026-02-27; done 2026-02-28)
-- [ ] [P2] Voting / scoring on submissions — readers cast votes (accept/reject/maybe + optional score); configurable per org; summary visible to editors making final decisions — (persona gap analysis 2026-02-27)
+- [x] [P2] Voting / scoring on submissions — readers cast votes (accept/reject/maybe + optional score); configurable per org; summary visible to editors making final decisions — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [ ] [P2] Blind / anonymous review mode — hide submitter identity from reviewers; admin toggle per submission period — (persona gap analysis 2026-02-27)
 - [ ] [P2] Batch operations — checkbox selection in submission queue; bulk status transitions (reject, move to review); bulk assignment — (persona gap analysis 2026-02-27)
 - [ ] [P3] Submission reading mode — distraction-free view for reading the submitted work; "next unread" navigation within the queue — (persona gap analysis 2026-02-27)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -17,7 +17,8 @@ Newest entries first.
 - **REST:** 4 routes (POST/GET/GET summary/DELETE) under `/submissions/{id}/votes`
 - **GraphQL:** VoteDecisionEnum, SubmissionVoteType, VoteSummaryType, 2 queries + 2 mutations
 - **Frontend:** `VotingPanel` component (my vote radio + score input, vote summary, all votes list), integrated into submission detail with access gating. `VotingSettings` org config component with admin toggle, integrated into org settings as new "Voting" tab.
-- **Tests:** 21 total (15 service + 6 schema), all passing. Type-check clean, lint clean.
+- **Tests:** 22 total (16 service + 6 schema), all passing. Type-check clean, lint clean.
+- **Code review fixes (OpenCode branch review):** Fixed score `0` falsy bug, added scoreMin < scoreMax form validation, made upsert atomic via ON CONFLICT, added NaN pre-validation in voting panel, added basic score range bounds to Zod schema, added test for score `0`
 
 ### Decisions
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-28 — Track 7: Submission Voting & Scoring
+
+### Done
+
+- **DB schema:** `submissionVotes` table with `VoteDecision` enum (ACCEPT/REJECT/MAYBE), optional numeric score, unique (submissionId, voterUserId) constraint, org isolation RLS. Manual migration `0042_submission_votes.sql`.
+- **Shared types:** `packages/types/src/voting.ts` — 7 schemas (voteDecision, votingConfig with defaults, submissionVote, voteSummary, castVoteInput, listVotesInput, deleteVoteInput)
+- **Audit actions:** 3 new actions (SUBMISSION_VOTE_CAST, SUBMISSION_VOTE_UPDATED, SUBMISSION_VOTE_DELETED)
+- **Service:** `submission-vote.service.ts` — 4 error classes, access control (editor/admin always, assigned readers only, submitters never), terminal-status guard, org voting config from JSONB settings, upsert with CAST vs UPDATED audit differentiation, vote summary with COUNT FILTER + AVG, outbox event `hopper/vote.cast`
+- **Error mappers:** Registered 4 vote errors in tRPC, REST, and GraphQL mappers
+- **tRPC:** 4 procedures (castVote, listVotes, getVoteSummary, deleteVote) on submissionsRouter
+- **REST:** 4 routes (POST/GET/GET summary/DELETE) under `/submissions/{id}/votes`
+- **GraphQL:** VoteDecisionEnum, SubmissionVoteType, VoteSummaryType, 2 queries + 2 mutations
+- **Frontend:** `VotingPanel` component (my vote radio + score input, vote summary, all votes list), integrated into submission detail with access gating. `VotingSettings` org config component with admin toggle, integrated into org settings as new "Voting" tab.
+- **Tests:** 21 total (15 service + 6 schema), all passing. Type-check clean, lint clean.
+
+### Decisions
+
+- Manual migration (0042) due to drizzle-kit TUI blocking in non-interactive shells
+- Upsert uses select-then-insert/update for audit action differentiation (CAST vs UPDATED)
+- Used `zodResolver() as unknown as Resolver<FormData>` cast for React Hook Form + z.coerce type mismatch (known RHF issue)
+
+---
+
 ## 2026-02-28 — Track 7: Submission Analytics Dashboard
 
 ### Done

--- a/packages/db/migrations/0042_submission_votes.sql
+++ b/packages/db/migrations/0042_submission_votes.sql
@@ -1,0 +1,32 @@
+CREATE TYPE "public"."VoteDecision" AS ENUM('ACCEPT', 'REJECT', 'MAYBE');
+--> statement-breakpoint
+CREATE TABLE "submission_votes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"submission_id" uuid NOT NULL,
+	"voter_user_id" uuid NOT NULL,
+	"decision" "VoteDecision" NOT NULL,
+	"score" numeric(5, 2),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "submission_votes" ADD CONSTRAINT "submission_votes_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "submission_votes" ADD CONSTRAINT "submission_votes_submission_id_submissions_id_fk" FOREIGN KEY ("submission_id") REFERENCES "public"."submissions"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "submission_votes" ADD CONSTRAINT "submission_votes_voter_user_id_users_id_fk" FOREIGN KEY ("voter_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "submission_votes_sub_voter_idx" ON "submission_votes" USING btree ("submission_id","voter_user_id");
+--> statement-breakpoint
+CREATE INDEX "submission_votes_org_id_idx" ON "submission_votes" USING btree ("organization_id");
+--> statement-breakpoint
+CREATE INDEX "submission_votes_submission_id_idx" ON "submission_votes" USING btree ("submission_id");
+--> statement-breakpoint
+CREATE INDEX "submission_votes_voter_user_id_idx" ON "submission_votes" USING btree ("voter_user_id");
+--> statement-breakpoint
+ALTER TABLE "submission_votes" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "submission_votes" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE POLICY "org_isolation" ON "submission_votes" AS PERMISSIVE FOR ALL TO public USING (organization_id = current_org_id());

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1777400000000,
       "tag": "0041_submission_discussions",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1777600000000,
+      "tag": "0042_submission_votes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -67,6 +67,12 @@ export const formFieldTypeEnum = pgEnum("FormFieldType", [
   "info_text",
 ]);
 
+export const voteDecisionEnum = pgEnum("VoteDecision", [
+  "ACCEPT",
+  "REJECT",
+  "MAYBE",
+]);
+
 // ---------------------------------------------------------------------------
 // Slate — Publication Pipeline
 // ---------------------------------------------------------------------------

--- a/packages/db/src/schema/submissions.ts
+++ b/packages/db/src/schema/submissions.ts
@@ -14,7 +14,11 @@ import {
   customType,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
-import { submissionStatusEnum, simSubCheckResultEnum } from "./enums";
+import {
+  submissionStatusEnum,
+  simSubCheckResultEnum,
+  voteDecisionEnum,
+} from "./enums";
 import { organizations } from "./organizations";
 import { users } from "./users";
 import { formDefinitions } from "./forms";
@@ -305,6 +309,43 @@ export const submissionDiscussions = pgTable(
     index("submission_discussions_submission_id_idx").on(table.submissionId),
     index("submission_discussions_parent_id_idx").on(table.parentId),
     index("submission_discussions_author_id_idx").on(table.authorId),
+    orgIsolationPolicy,
+  ],
+).enableRLS();
+
+// --- submission_votes ---
+
+export const submissionVotes = pgTable(
+  "submission_votes",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    submissionId: uuid("submission_id")
+      .notNull()
+      .references(() => submissions.id, { onDelete: "cascade" }),
+    voterUserId: uuid("voter_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    decision: voteDecisionEnum("decision").notNull(),
+    score: numeric("score", { precision: 5, scale: 2 }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    uniqueIndex("submission_votes_sub_voter_idx").on(
+      table.submissionId,
+      table.voterUserId,
+    ),
+    index("submission_votes_org_id_idx").on(table.organizationId),
+    index("submission_votes_submission_id_idx").on(table.submissionId),
+    index("submission_votes_voter_user_id_idx").on(table.voterUserId),
     orgIsolationPolicy,
   ],
 ).enableRLS();

--- a/packages/types/src/__tests__/voting.spec.ts
+++ b/packages/types/src/__tests__/voting.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  submissionVoteSchema,
+  castVoteInputSchema,
+  votingConfigSchema,
+  voteSummarySchema,
+} from "../voting";
+
+describe("submissionVoteSchema", () => {
+  it("parses valid vote", () => {
+    const data = {
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      submissionId: "550e8400-e29b-41d4-a716-446655440001",
+      voterUserId: "550e8400-e29b-41d4-a716-446655440002",
+      voterEmail: "voter@example.com",
+      decision: "ACCEPT",
+      score: 8.5,
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    };
+
+    const result = submissionVoteSchema.parse(data);
+    expect(result.id).toBe(data.id);
+    expect(result.decision).toBe("ACCEPT");
+    expect(result.score).toBe(8.5);
+  });
+
+  it("coerces date strings", () => {
+    const data = {
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      submissionId: "550e8400-e29b-41d4-a716-446655440001",
+      voterUserId: "550e8400-e29b-41d4-a716-446655440002",
+      voterEmail: null,
+      decision: "REJECT",
+      score: null,
+      createdAt: "2024-06-15T12:00:00Z",
+      updatedAt: "2024-06-15T13:00:00Z",
+    };
+
+    const result = submissionVoteSchema.parse(data);
+    expect(result.createdAt).toBeInstanceOf(Date);
+    expect(result.updatedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe("castVoteInputSchema", () => {
+  it("accepts valid decisions", () => {
+    for (const decision of ["ACCEPT", "REJECT", "MAYBE"]) {
+      const result = castVoteInputSchema.safeParse({
+        submissionId: "550e8400-e29b-41d4-a716-446655440000",
+        decision,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects invalid decision", () => {
+    const result = castVoteInputSchema.safeParse({
+      submissionId: "550e8400-e29b-41d4-a716-446655440000",
+      decision: "ABSTAIN",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("votingConfigSchema", () => {
+  it("defaults missing fields", () => {
+    const result = votingConfigSchema.parse({});
+    expect(result).toEqual({
+      votingEnabled: false,
+      scoringEnabled: false,
+      scoreMin: 1,
+      scoreMax: 10,
+    });
+  });
+});
+
+describe("voteSummarySchema", () => {
+  it("parses with null averageScore", () => {
+    const data = {
+      acceptCount: 3,
+      rejectCount: 1,
+      maybeCount: 2,
+      totalVotes: 6,
+      averageScore: null,
+    };
+
+    const result = voteSummarySchema.parse(data);
+    expect(result.totalVotes).toBe(6);
+    expect(result.averageScore).toBeNull();
+  });
+});

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -214,6 +214,11 @@ export const AuditActions = {
   CORRESPONDENCE_SENT: "CORRESPONDENCE_SENT",
   CORRESPONDENCE_AUTO_CAPTURED: "CORRESPONDENCE_AUTO_CAPTURED",
 
+  // Voting lifecycle
+  SUBMISSION_VOTE_CAST: "SUBMISSION_VOTE_CAST",
+  SUBMISSION_VOTE_UPDATED: "SUBMISSION_VOTE_UPDATED",
+  SUBMISSION_VOTE_DELETED: "SUBMISSION_VOTE_DELETED",
+
   // Discussion lifecycle
   DISCUSSION_COMMENT_ADDED: "DISCUSSION_COMMENT_ADDED",
 
@@ -318,7 +323,10 @@ export interface SubmissionAuditParams extends BaseAuditParams {
     | typeof AuditActions.REVIEWER_ASSIGNED
     | typeof AuditActions.REVIEWER_UNASSIGNED
     | typeof AuditActions.REVIEWER_READ
-    | typeof AuditActions.DISCUSSION_COMMENT_ADDED;
+    | typeof AuditActions.DISCUSSION_COMMENT_ADDED
+    | typeof AuditActions.SUBMISSION_VOTE_CAST
+    | typeof AuditActions.SUBMISSION_VOTE_UPDATED
+    | typeof AuditActions.SUBMISSION_VOTE_DELETED;
 }
 
 export interface FileAuditParams extends BaseAuditParams {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -30,3 +30,4 @@ export * from "./status-mapping";
 export * from "./email-templates";
 export * from "./discussion";
 export * from "./analytics";
+export * from "./voting";

--- a/packages/types/src/voting.ts
+++ b/packages/types/src/voting.ts
@@ -58,7 +58,7 @@ export type VoteSummary = z.infer<typeof voteSummarySchema>;
 export const castVoteInputSchema = z.object({
   submissionId: z.string().uuid(),
   decision: voteDecisionSchema,
-  score: z.number().optional(),
+  score: z.number().min(0).max(1000).optional(),
 });
 
 export type CastVoteInput = z.infer<typeof castVoteInputSchema>;

--- a/packages/types/src/voting.ts
+++ b/packages/types/src/voting.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Vote decision enum
+// ---------------------------------------------------------------------------
+
+export const voteDecisionSchema = z.enum(["ACCEPT", "REJECT", "MAYBE"]);
+export type VoteDecision = z.infer<typeof voteDecisionSchema>;
+
+// ---------------------------------------------------------------------------
+// Voting config (stored in organizations.settings JSONB)
+// ---------------------------------------------------------------------------
+
+export const votingConfigSchema = z.object({
+  votingEnabled: z.boolean().default(false),
+  scoringEnabled: z.boolean().default(false),
+  scoreMin: z.number().default(1),
+  scoreMax: z.number().default(10),
+});
+
+export type VotingConfig = z.infer<typeof votingConfigSchema>;
+
+// ---------------------------------------------------------------------------
+// Submission vote response
+// ---------------------------------------------------------------------------
+
+export const submissionVoteSchema = z.object({
+  id: z.string().uuid(),
+  submissionId: z.string().uuid(),
+  voterUserId: z.string().uuid(),
+  voterEmail: z.string().nullable(),
+  decision: voteDecisionSchema,
+  score: z.number().nullable(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+
+export type SubmissionVote = z.infer<typeof submissionVoteSchema>;
+
+// ---------------------------------------------------------------------------
+// Vote summary (aggregated tallies)
+// ---------------------------------------------------------------------------
+
+export const voteSummarySchema = z.object({
+  acceptCount: z.number(),
+  rejectCount: z.number(),
+  maybeCount: z.number(),
+  totalVotes: z.number(),
+  averageScore: z.number().nullable(),
+});
+
+export type VoteSummary = z.infer<typeof voteSummarySchema>;
+
+// ---------------------------------------------------------------------------
+// Input schemas
+// ---------------------------------------------------------------------------
+
+export const castVoteInputSchema = z.object({
+  submissionId: z.string().uuid(),
+  decision: voteDecisionSchema,
+  score: z.number().optional(),
+});
+
+export type CastVoteInput = z.infer<typeof castVoteInputSchema>;
+
+export const listVotesInputSchema = z.object({
+  submissionId: z.string().uuid(),
+});
+
+export const deleteVoteInputSchema = z.object({
+  submissionId: z.string().uuid(),
+});


### PR DESCRIPTION
## Summary

- Add voting/scoring capability for submissions: reviewers and editors can cast votes (ACCEPT/REJECT/MAYBE) with optional numeric scores, configurable per organization
- Full API surface: tRPC (4 procedures), REST (4 endpoints), GraphQL (2 queries + 2 mutations)
- Frontend: VotingPanel on submission detail + VotingSettings in org settings
- 22 unit tests (16 service + 6 schema), type-check clean, lint clean

## Plan Overrides

| File | Planned | Actual | Rationale |
|---|---|---|---|
| `submission-vote.service.ts` | Separate insert/update in upsert | `ON CONFLICT DO UPDATE` atomic upsert | Code review fix: eliminates race window |
| `voting-settings.tsx` | Simple form schema | Added `.refine()` for scoreMin < scoreMax | Code review fix: prevents invalid config |
| `voting.ts` | `score: z.number().optional()` | `score: z.number().min(0).max(1000).optional()` | Code review fix: basic sanity bounds |
| Test count | 21 tests (15 service + 6 schema) | 22 tests (16 service + 6 schema) | Added score `0` edge case test per review |

## Test plan

- [ ] Run `pnpm db:migrate` to apply migration 0042
- [ ] Enable voting in org settings (Voting tab)
- [ ] Cast vote on submission as editor — verify appears in vote list
- [ ] Update existing vote — verify audit shows VOTE_UPDATED
- [ ] Cast vote as assigned reader — verify allowed
- [ ] Attempt vote as non-assigned reader — verify 403
- [ ] Attempt vote on own submission — verify 403
- [ ] Attempt vote on ACCEPTED/REJECTED/WITHDRAWN submission — verify error
- [ ] Enable scoring, cast vote with score — verify score saved
- [ ] Cast score of 0 — verify not treated as null
- [ ] Set scoreMin > scoreMax in settings — verify validation error
- [ ] Delete own vote — verify removed from list
- [ ] Check vote summary shows correct tallies (editor/admin only)