### PR TITLE
feat(hopper): blind/anonymous review mode per submission period

### DIFF
--- a/apps/api/src/graphql/resolvers/submissions.ts
+++ b/apps/api/src/graphql/resolvers/submissions.ts
@@ -98,7 +98,11 @@ builder.queryFields((t) => ({
       });
       try {
         assertEditorOrAdmin(orgCtx.authContext.role);
-        return await submissionService.listAll(orgCtx.dbTx, input);
+        return await submissionService.listAll(
+          orgCtx.dbTx,
+          input,
+          orgCtx.authContext.role,
+        );
       } catch (e) {
         mapServiceError(e);
       }

--- a/apps/api/src/graphql/types/submission.ts
+++ b/apps/api/src/graphql/types/submission.ts
@@ -3,6 +3,8 @@ import { builder } from '../builder.js';
 import { SubmissionStatusEnum } from './enums.js';
 import { FileType } from './file.js';
 import { UserType } from './user.js';
+import { resolveBlindMode } from '../../services/blind-review.helper.js';
+import { shouldBlindSubmitter } from '@colophony/types';
 
 export const SubmissionType = builder
   .objectRef<Submission>('Submission')
@@ -81,11 +83,26 @@ export const SubmissionType = builder
       submitter: t.field({
         type: UserType,
         nullable: true,
-        description: 'The user who created this submission.',
-        resolve: (submission, _args, ctx) =>
-          submission.submitterId
-            ? ctx.loaders.user.load(submission.submitterId)
-            : null,
+        description:
+          'The user who created this submission. Returns null when blind review is active.',
+        resolve: async (submission, _args, ctx) => {
+          if (!submission.submitterId) return null;
+          if (ctx.authContext?.role && ctx.dbTx) {
+            const blindMode = await resolveBlindMode(
+              ctx.dbTx,
+              submission.submissionPeriodId,
+            );
+            if (
+              shouldBlindSubmitter({
+                blindMode,
+                callerRole: ctx.authContext.role,
+              })
+            ) {
+              return null;
+            }
+          }
+          return ctx.loaders.user.load(submission.submitterId);
+        },
       }),
     }),
   });

--- a/apps/api/src/graphql/types/submission.ts
+++ b/apps/api/src/graphql/types/submission.ts
@@ -87,19 +87,19 @@ export const SubmissionType = builder
           'The user who created this submission. Returns null when blind review is active.',
         resolve: async (submission, _args, ctx) => {
           if (!submission.submitterId) return null;
-          if (ctx.authContext?.role && ctx.dbTx) {
-            const blindMode = await resolveBlindMode(
-              ctx.dbTx,
-              submission.submissionPeriodId,
-            );
-            if (
-              shouldBlindSubmitter({
-                blindMode,
-                callerRole: ctx.authContext.role,
-              })
-            ) {
-              return null;
-            }
+          // Fail secure: if we can't determine blind mode, hide submitter
+          if (!ctx.authContext?.role || !ctx.dbTx) return null;
+          const blindMode = await resolveBlindMode(
+            ctx.dbTx,
+            submission.submissionPeriodId,
+          );
+          if (
+            shouldBlindSubmitter({
+              blindMode,
+              callerRole: ctx.authContext.role,
+            })
+          ) {
+            return null;
           }
           return ctx.loaders.user.load(submission.submitterId);
         },

--- a/apps/api/src/rest/routers/submissions.ts
+++ b/apps/api/src/rest/routers/submissions.ts
@@ -98,7 +98,11 @@ const list = orgProcedure
   .handler(async ({ input, context }) => {
     try {
       assertEditorOrAdmin(context.authContext.role);
-      return await submissionService.listAll(context.dbTx, input);
+      return await submissionService.listAll(
+        context.dbTx,
+        input,
+        context.authContext.role,
+      );
     } catch (e) {
       mapServiceError(e);
     }

--- a/apps/api/src/services/blind-review.helper.spec.ts
+++ b/apps/api/src/services/blind-review.helper.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resolveBlindMode,
+  applySubmitterBlinding,
+  applyVoterBlinding,
+  applyAuthorBlinding,
+  applyReviewerBlinding,
+} from './blind-review.helper.js';
+
+// Mock @colophony/db
+vi.mock('@colophony/db', () => {
+  const submissionPeriods = {
+    id: 'id',
+    blindReviewMode: 'blind_review_mode',
+  };
+  return {
+    submissionPeriods,
+    eq: vi.fn((_a, _b) => 'eq-condition'),
+  };
+});
+
+function createMockTx(rows: unknown[] = []) {
+  const limitFn = vi.fn().mockResolvedValue(rows);
+  const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
+  const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+  const selectFn = vi.fn().mockReturnValue({ from: fromFn });
+  return { select: selectFn } as unknown as import('@colophony/db').DrizzleDb;
+}
+
+describe('resolveBlindMode', () => {
+  it('returns none when periodId is null', async () => {
+    const tx = createMockTx();
+    expect(await resolveBlindMode(tx, null)).toBe('none');
+    expect(tx.select).not.toHaveBeenCalled();
+  });
+
+  it('returns mode from DB', async () => {
+    const tx = createMockTx([{ blindReviewMode: 'single_blind' }]);
+    expect(await resolveBlindMode(tx, 'period-1')).toBe('single_blind');
+  });
+
+  it('returns none when period not found', async () => {
+    const tx = createMockTx([]);
+    expect(await resolveBlindMode(tx, 'nonexistent')).toBe('none');
+  });
+});
+
+describe('applySubmitterBlinding', () => {
+  it('nulls email for editor in single_blind', () => {
+    const item = { submitterEmail: 'test@example.com', id: '1' };
+    const result = applySubmitterBlinding(item, 'single_blind', 'EDITOR');
+    expect(result.submitterEmail).toBeNull();
+  });
+
+  it('preserves email for admin in single_blind', () => {
+    const item = { submitterEmail: 'test@example.com', id: '1' };
+    const result = applySubmitterBlinding(item, 'single_blind', 'ADMIN');
+    expect(result.submitterEmail).toBe('test@example.com');
+  });
+});
+
+describe('applyVoterBlinding', () => {
+  it('nulls email for editor in double_blind', () => {
+    const item = { voterEmail: 'voter@example.com', id: '1' };
+    const result = applyVoterBlinding(item, 'double_blind', 'EDITOR');
+    expect(result.voterEmail).toBeNull();
+  });
+
+  it('preserves email for editor in single_blind', () => {
+    const item = { voterEmail: 'voter@example.com', id: '1' };
+    const result = applyVoterBlinding(item, 'single_blind', 'EDITOR');
+    expect(result.voterEmail).toBe('voter@example.com');
+  });
+});
+
+describe('applyAuthorBlinding', () => {
+  it('nulls email for reader in double_blind', () => {
+    const item = { authorEmail: 'author@example.com', id: '1' };
+    const result = applyAuthorBlinding(item, 'double_blind', 'READER');
+    expect(result.authorEmail).toBeNull();
+  });
+
+  it('preserves email for admin in double_blind', () => {
+    const item = { authorEmail: 'author@example.com', id: '1' };
+    const result = applyAuthorBlinding(item, 'double_blind', 'ADMIN');
+    expect(result.authorEmail).toBe('author@example.com');
+  });
+});
+
+describe('applyReviewerBlinding', () => {
+  it('nulls email for editor in double_blind', () => {
+    const item = { reviewerEmail: 'reviewer@example.com', id: '1' };
+    const result = applyReviewerBlinding(item, 'double_blind', 'EDITOR');
+    expect(result.reviewerEmail).toBeNull();
+  });
+
+  it('preserves email in none mode', () => {
+    const item = { reviewerEmail: 'reviewer@example.com', id: '1' };
+    const result = applyReviewerBlinding(item, 'none', 'EDITOR');
+    expect(result.reviewerEmail).toBe('reviewer@example.com');
+  });
+});

--- a/apps/api/src/services/blind-review.helper.spec.ts
+++ b/apps/api/src/services/blind-review.helper.spec.ts
@@ -31,6 +31,7 @@ describe('resolveBlindMode', () => {
   it('returns none when periodId is null', async () => {
     const tx = createMockTx();
     expect(await resolveBlindMode(tx, null)).toBe('none');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(tx.select).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/services/blind-review.helper.ts
+++ b/apps/api/src/services/blind-review.helper.ts
@@ -1,0 +1,77 @@
+import { submissionPeriods, eq, type DrizzleDb } from '@colophony/db';
+import type { BlindReviewMode, Role } from '@colophony/types';
+import {
+  shouldBlindSubmitter,
+  shouldBlindPeerIdentity,
+} from '@colophony/types';
+
+/**
+ * Resolve the blind review mode for a submission period.
+ * Returns 'none' when periodId is null or the period is not found.
+ */
+export async function resolveBlindMode(
+  tx: DrizzleDb,
+  submissionPeriodId: string | null,
+): Promise<BlindReviewMode> {
+  if (!submissionPeriodId) return 'none';
+
+  const [period] = await tx
+    .select({ blindReviewMode: submissionPeriods.blindReviewMode })
+    .from(submissionPeriods)
+    .where(eq(submissionPeriods.id, submissionPeriodId))
+    .limit(1);
+
+  return (period?.blindReviewMode as BlindReviewMode) ?? 'none';
+}
+
+/**
+ * Null out submitterEmail when blind review is active and caller is not ADMIN.
+ */
+export function applySubmitterBlinding<
+  T extends { submitterEmail: string | null },
+>(item: T, blindMode: BlindReviewMode, callerRole: Role): T {
+  if (shouldBlindSubmitter({ blindMode, callerRole })) {
+    return { ...item, submitterEmail: null };
+  }
+  return item;
+}
+
+/**
+ * Null out voterEmail when double-blind and caller is not ADMIN.
+ */
+export function applyVoterBlinding<T extends { voterEmail: string | null }>(
+  item: T,
+  blindMode: BlindReviewMode,
+  callerRole: Role,
+): T {
+  if (shouldBlindPeerIdentity({ blindMode, callerRole })) {
+    return { ...item, voterEmail: null };
+  }
+  return item;
+}
+
+/**
+ * Null out authorEmail when double-blind and caller is not ADMIN.
+ */
+export function applyAuthorBlinding<T extends { authorEmail: string | null }>(
+  item: T,
+  blindMode: BlindReviewMode,
+  callerRole: Role,
+): T {
+  if (shouldBlindPeerIdentity({ blindMode, callerRole })) {
+    return { ...item, authorEmail: null };
+  }
+  return item;
+}
+
+/**
+ * Null out reviewerEmail when double-blind and caller is not ADMIN.
+ */
+export function applyReviewerBlinding<
+  T extends { reviewerEmail: string | null },
+>(item: T, blindMode: BlindReviewMode, callerRole: Role): T {
+  if (shouldBlindPeerIdentity({ blindMode, callerRole })) {
+    return { ...item, reviewerEmail: null };
+  }
+  return item;
+}

--- a/apps/api/src/services/blind-review.helper.ts
+++ b/apps/api/src/services/blind-review.helper.ts
@@ -21,7 +21,7 @@ export async function resolveBlindMode(
     .where(eq(submissionPeriods.id, submissionPeriodId))
     .limit(1);
 
-  return (period?.blindReviewMode as BlindReviewMode) ?? 'none';
+  return period?.blindReviewMode ?? 'none';
 }
 
 /**

--- a/apps/api/src/services/period.service.ts
+++ b/apps/api/src/services/period.service.ts
@@ -140,6 +140,7 @@ export const periodService = {
         fee: input.fee != null ? String(input.fee) : null,
         maxSubmissions: input.maxSubmissions ?? null,
         formDefinitionId: input.formDefinitionId ?? null,
+        blindReviewMode: input.blindReviewMode ?? 'none',
       })
       .returning();
 
@@ -178,6 +179,8 @@ export const periodService = {
       values.maxSubmissions = input.maxSubmissions ?? null;
     if (input.formDefinitionId !== undefined)
       values.formDefinitionId = input.formDefinitionId ?? null;
+    if (input.blindReviewMode !== undefined)
+      values.blindReviewMode = input.blindReviewMode;
 
     const [row] = await tx
       .update(submissionPeriods)

--- a/apps/api/src/services/submission-discussion.service.ts
+++ b/apps/api/src/services/submission-discussion.service.ts
@@ -15,6 +15,10 @@ import { enqueueOutboxEvent } from './outbox.js';
 import type { ServiceContext } from './types.js';
 import { ForbiddenError } from './errors.js';
 import { SubmissionNotFoundError } from './submission.service.js';
+import {
+  resolveBlindMode,
+  applyAuthorBlinding,
+} from './blind-review.helper.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -74,6 +78,7 @@ async function getSubmissionOrThrow(tx: DrizzleDb, submissionId: string) {
       id: submissions.id,
       submitterId: submissions.submitterId,
       organizationId: submissions.organizationId,
+      submissionPeriodId: submissions.submissionPeriodId,
     })
     .from(submissions)
     .where(eq(submissions.id, submissionId))
@@ -212,7 +217,13 @@ async function listWithAccess(
     submissionId,
     submission.submitterId,
   );
-  return listBySubmission(svc.tx, submissionId);
+  const comments = await listBySubmission(svc.tx, submissionId);
+
+  const blindMode = await resolveBlindMode(
+    svc.tx,
+    submission.submissionPeriodId,
+  );
+  return comments.map((c) => applyAuthorBlinding(c, blindMode, svc.actor.role));
 }
 
 async function createWithAudit(
@@ -300,7 +311,11 @@ async function createWithAudit(
     .where(eq(submissionDiscussions.id, id))
     .limit(1);
 
-  return comment;
+  const blindMode = await resolveBlindMode(
+    svc.tx,
+    submission.submissionPeriodId,
+  );
+  return applyAuthorBlinding(comment, blindMode, svc.actor.role);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/services/submission-reviewer.service.ts
+++ b/apps/api/src/services/submission-reviewer.service.ts
@@ -15,6 +15,10 @@ import { enqueueOutboxEvent } from './outbox.js';
 import type { ServiceContext } from './types.js';
 import { assertEditorOrAdmin, assertOwnerOrEditor } from './errors.js';
 import { SubmissionNotFoundError } from './submission.service.js';
+import {
+  resolveBlindMode,
+  applyReviewerBlinding,
+} from './blind-review.helper.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -160,6 +164,7 @@ async function getSubmissionOrThrow(tx: DrizzleDb, submissionId: string) {
       id: submissions.id,
       submitterId: submissions.submitterId,
       organizationId: submissions.organizationId,
+      submissionPeriodId: submissions.submissionPeriodId,
     })
     .from(submissions)
     .where(eq(submissions.id, submissionId))
@@ -270,7 +275,15 @@ async function listBySubmissionWithAccess(
 ): Promise<SubmissionReviewer[]> {
   const submission = await getSubmissionOrThrow(svc.tx, submissionId);
   assertOwnerOrEditor(svc.actor.userId, svc.actor.role, submission.submitterId);
-  return listBySubmission(svc.tx, submissionId);
+  const reviewers = await listBySubmission(svc.tx, submissionId);
+
+  const blindMode = await resolveBlindMode(
+    svc.tx,
+    submission.submissionPeriodId,
+  );
+  return reviewers.map((r) =>
+    applyReviewerBlinding(r, blindMode, svc.actor.role),
+  );
 }
 
 async function markReadWithAudit(

--- a/apps/api/src/services/submission-vote.service.ts
+++ b/apps/api/src/services/submission-vote.service.ts
@@ -22,6 +22,7 @@ import type { ServiceContext } from './types.js';
 import { ForbiddenError } from './errors.js';
 import { assertEditorOrAdmin } from './errors.js';
 import { SubmissionNotFoundError } from './submission.service.js';
+import { resolveBlindMode, applyVoterBlinding } from './blind-review.helper.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -72,6 +73,7 @@ async function getSubmissionOrThrow(tx: DrizzleDb, submissionId: string) {
       submitterId: submissions.submitterId,
       organizationId: submissions.organizationId,
       status: submissions.status,
+      submissionPeriodId: submissions.submissionPeriodId,
     })
     .from(submissions)
     .where(eq(submissions.id, submissionId))
@@ -339,10 +341,16 @@ async function castVoteWithAudit(
     .where(eq(submissionVotes.id, id))
     .limit(1);
 
-  return {
+  const castResult: SubmissionVote = {
     ...vote,
     score: vote.score ? Number(vote.score) : null,
   };
+
+  const blindMode = await resolveBlindMode(
+    svc.tx,
+    submission.submissionPeriodId,
+  );
+  return applyVoterBlinding(castResult, blindMode, svc.actor.role);
 }
 
 async function listVotesWithAccess(
@@ -357,7 +365,13 @@ async function listVotesWithAccess(
     submissionId,
     submission.submitterId,
   );
-  return listBySubmission(svc.tx, submissionId);
+  const votes = await listBySubmission(svc.tx, submissionId);
+
+  const blindMode = await resolveBlindMode(
+    svc.tx,
+    submission.submissionPeriodId,
+  );
+  return votes.map((v) => applyVoterBlinding(v, blindMode, svc.actor.role));
 }
 
 async function getVoteSummaryWithAccess(

--- a/apps/api/src/services/submission.service.access.spec.ts
+++ b/apps/api/src/services/submission.service.access.spec.ts
@@ -64,6 +64,8 @@ vi.mock('./outbox.js', () => ({
 vi.mock('@colophony/types', () => ({
   isValidStatusTransition: vi.fn(() => true),
   isEditorAllowedTransition: vi.fn(() => true),
+  shouldBlindSubmitter: vi.fn(() => false),
+  shouldBlindPeerIdentity: vi.fn(() => false),
   AuditActions: {
     SUBMISSION_CREATED: 'SUBMISSION_CREATED',
     SUBMISSION_UPDATED: 'SUBMISSION_UPDATED',

--- a/apps/api/src/services/submission.service.spec.ts
+++ b/apps/api/src/services/submission.service.spec.ts
@@ -90,6 +90,8 @@ vi.mock('drizzle-orm', () => ({
 vi.mock('@colophony/types', () => ({
   isValidStatusTransition: vi.fn(() => true),
   isEditorAllowedTransition: vi.fn(() => true),
+  shouldBlindSubmitter: vi.fn(() => false),
+  shouldBlindPeerIdentity: vi.fn(() => false),
   AuditActions: {
     SUBMISSION_CREATED: 'SUBMISSION_CREATED',
     SUBMISSION_UPDATED: 'SUBMISSION_UPDATED',

--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -35,6 +35,10 @@ import {
   assertEditorOrAdmin,
 } from './errors.js';
 import {
+  resolveBlindMode,
+  applySubmitterBlinding,
+} from './blind-review.helper.js';
+import {
   formService,
   FormNotFoundError,
   FormNotPublishedError,
@@ -182,7 +186,11 @@ export const submissionService = {
    * List all submissions in the org (editor view).
    * RLS handles org filtering.
    */
-  async listAll(tx: DrizzleDb, input: ListSubmissionsInput) {
+  async listAll(
+    tx: DrizzleDb,
+    input: ListSubmissionsInput,
+    callerRole?: import('@colophony/types').Role,
+  ) {
     const { status, submissionPeriodId, search, page, limit } = input;
     const offset = (page - 1) * limit;
 
@@ -236,8 +244,42 @@ export const submissionService = {
       tx.select({ count: count() }).from(submissions).where(where),
     ]);
 
+    // Apply blind review: batch-fetch blind modes for all distinct periods
+    let blindedItems = items;
+    if (callerRole && callerRole !== 'ADMIN') {
+      const periodIds = [
+        ...new Set(
+          items
+            .map((i) => i.submissionPeriodId)
+            .filter((id): id is string => id != null),
+        ),
+      ];
+
+      if (periodIds.length > 0) {
+        const blindModes = new Map<
+          string,
+          import('@colophony/types').BlindReviewMode
+        >();
+        for (const periodId of periodIds) {
+          blindModes.set(periodId, await resolveBlindMode(tx, periodId));
+        }
+        blindedItems = items.map((item) => {
+          const mode = item.submissionPeriodId
+            ? (blindModes.get(item.submissionPeriodId) ?? 'none')
+            : 'none';
+          return applySubmitterBlinding(item, mode, callerRole);
+        });
+      }
+    }
+
     const total = countResult[0]?.count ?? 0;
-    return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
+    return {
+      items: blindedItems,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
   },
 
   /**
@@ -577,6 +619,16 @@ export const submissionService = {
       svc.actor.role,
       submission.submitterId,
     );
+
+    // Apply blind review if caller is not the submitter
+    if (submission.submitterId !== svc.actor.userId) {
+      const blindMode = await resolveBlindMode(
+        svc.tx,
+        submission.submissionPeriodId,
+      );
+      return applySubmitterBlinding(submission, blindMode, svc.actor.role);
+    }
+
     return submission;
   },
 

--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -10,6 +10,7 @@ import {
   users,
   eq,
   and,
+  inArray,
   sql,
   type DrizzleDb,
 } from '@colophony/db';
@@ -256,12 +257,22 @@ export const submissionService = {
       ];
 
       if (periodIds.length > 0) {
+        const rows = await tx
+          .select({
+            id: submissionPeriods.id,
+            blindReviewMode: submissionPeriods.blindReviewMode,
+          })
+          .from(submissionPeriods)
+          .where(inArray(submissionPeriods.id, periodIds));
         const blindModes = new Map<
           string,
           import('@colophony/types').BlindReviewMode
         >();
-        for (const periodId of periodIds) {
-          blindModes.set(periodId, await resolveBlindMode(tx, periodId));
+        for (const row of rows) {
+          blindModes.set(
+            row.id,
+            row.blindReviewMode as import('@colophony/types').BlindReviewMode,
+          );
         }
         blindedItems = items.map((item) => {
           const mode = item.submissionPeriodId

--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -269,10 +269,7 @@ export const submissionService = {
           import('@colophony/types').BlindReviewMode
         >();
         for (const row of rows) {
-          blindModes.set(
-            row.id,
-            row.blindReviewMode as import('@colophony/types').BlindReviewMode,
-          );
+          blindModes.set(row.id, row.blindReviewMode);
         }
         blindedItems = items.map((item) => {
           const mode = item.submissionPeriodId

--- a/apps/api/src/trpc/routers/submissions.ts
+++ b/apps/api/src/trpc/routers/submissions.ts
@@ -82,7 +82,11 @@ export const submissionsRouter = createRouter({
     .query(async ({ ctx, input }) => {
       try {
         assertEditorOrAdmin(ctx.authContext.role);
-        return await submissionService.listAll(ctx.dbTx, input);
+        return await submissionService.listAll(
+          ctx.dbTx,
+          input,
+          ctx.authContext.role,
+        );
       } catch (e) {
         mapServiceError(e);
       }

--- a/apps/web/src/components/periods/period-form-dialog.tsx
+++ b/apps/web/src/components/periods/period-form-dialog.tsx
@@ -45,6 +45,7 @@ interface PeriodData {
   fee: number | null;
   maxSubmissions: number | null;
   formDefinitionId: string | null;
+  blindReviewMode?: string;
 }
 
 /**
@@ -59,6 +60,7 @@ const formSchema = z.object({
   fee: z.string().optional(),
   maxSubmissions: z.string().optional(),
   formDefinitionId: z.string().optional(),
+  blindReviewMode: z.string().optional(),
 });
 
 type FormData = z.infer<typeof formSchema>;
@@ -93,6 +95,7 @@ export function PeriodFormDialog({
       fee: "",
       maxSubmissions: "",
       formDefinitionId: "__none__",
+      blindReviewMode: "none",
     },
   });
 
@@ -107,6 +110,7 @@ export function PeriodFormDialog({
         maxSubmissions:
           period.maxSubmissions != null ? String(period.maxSubmissions) : "",
         formDefinitionId: period.formDefinitionId ?? "__none__",
+        blindReviewMode: period.blindReviewMode ?? "none",
       });
     } else if (open) {
       form.reset({
@@ -117,6 +121,7 @@ export function PeriodFormDialog({
         fee: "",
         maxSubmissions: "",
         formDefinitionId: "__none__",
+        blindReviewMode: "none",
       });
     }
   }, [open, period, form]);
@@ -159,6 +164,10 @@ export function PeriodFormDialog({
       formDefinitionId:
         data.formDefinitionId && data.formDefinitionId !== "__none__"
           ? data.formDefinitionId
+          : undefined,
+      blindReviewMode:
+        data.blindReviewMode && data.blindReviewMode !== "none"
+          ? (data.blindReviewMode as "single_blind" | "double_blind")
           : undefined,
     };
 
@@ -308,6 +317,29 @@ export function PeriodFormDialog({
                           {f.name}
                         </SelectItem>
                       ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="blindReviewMode"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Blind Review</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="None" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="none">None</SelectItem>
+                      <SelectItem value="single_blind">Single Blind</SelectItem>
+                      <SelectItem value="double_blind">Double Blind</SelectItem>
                     </SelectContent>
                   </Select>
                   <FormMessage />

--- a/apps/web/src/components/periods/period-list.tsx
+++ b/apps/web/src/components/periods/period-list.tsx
@@ -25,6 +25,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Calendar,
@@ -34,6 +35,11 @@ import {
   Trash2,
   X,
 } from "lucide-react";
+
+const BLIND_REVIEW_LABELS: Record<string, string> = {
+  single_blind: "Single Blind",
+  double_blind: "Double Blind",
+};
 
 const SKELETON_ITEMS = Array.from({ length: 5 });
 
@@ -172,7 +178,16 @@ export function PeriodList() {
                     <TableCell>
                       <PeriodStatusBadge status={status} />
                     </TableCell>
-                    <TableCell className="font-medium">{item.name}</TableCell>
+                    <TableCell className="font-medium">
+                      {item.name}
+                      {item.blindReviewMode &&
+                        item.blindReviewMode !== "none" && (
+                          <Badge variant="secondary" className="ml-2 text-xs">
+                            {BLIND_REVIEW_LABELS[item.blindReviewMode] ??
+                              item.blindReviewMode}
+                          </Badge>
+                        )}
+                    </TableCell>
                     <TableCell className="text-muted-foreground">
                       {format(new Date(item.opensAt), "MMM d, yyyy h:mm a")}
                     </TableCell>

--- a/apps/web/src/components/submissions/__tests__/editor-submission-queue.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/editor-submission-queue.spec.tsx
@@ -109,7 +109,7 @@ describe("EditorSubmissionQueue", () => {
     expect(screen.getByText("(Untitled)")).toBeInTheDocument();
   });
 
-  it('renders "\u2014" for null submitterEmail', () => {
+  it('renders "[Anonymous]" for null submitterEmail', () => {
     mockData = {
       items: [makeItem({ id: "sub-3", submitterEmail: null })],
       total: 1,
@@ -118,7 +118,7 @@ describe("EditorSubmissionQueue", () => {
       totalPages: 1,
     };
     render(<EditorSubmissionQueue />);
-    expect(screen.getByText("\u2014")).toBeInTheDocument();
+    expect(screen.getByText("[Anonymous]")).toBeInTheDocument();
   });
 
   it("title link points to /editor/[id]", () => {

--- a/apps/web/src/components/submissions/discussion-thread.tsx
+++ b/apps/web/src/components/submissions/discussion-thread.tsx
@@ -176,7 +176,7 @@ function CommentItem({
       <div className="space-y-1">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">
-            {comment.authorEmail ?? "Unknown"}
+            {comment.authorEmail ?? "[Anonymous]"}
           </span>
           <span className="text-xs text-muted-foreground">
             {formatDistanceToNow(new Date(comment.createdAt), {

--- a/apps/web/src/components/submissions/editor-submission-queue.tsx
+++ b/apps/web/src/components/submissions/editor-submission-queue.tsx
@@ -149,7 +149,7 @@ export function EditorSubmissionQueue() {
                     </Link>
                   </TableCell>
                   <TableCell className="text-muted-foreground">
-                    {item.submitterEmail ?? "\u2014"}
+                    {item.submitterEmail ?? "[Anonymous]"}
                   </TableCell>
                   <TableCell className="text-muted-foreground">
                     {item.submittedAt

--- a/apps/web/src/components/submissions/reviewer-list.tsx
+++ b/apps/web/src/components/submissions/reviewer-list.tsx
@@ -54,7 +54,7 @@ export function ReviewerList({ submissionId }: ReviewerListProps) {
         >
           <div className="flex-1 min-w-0">
             <p className="text-sm font-medium truncate">
-              {reviewer.reviewerEmail}
+              {reviewer.reviewerEmail ?? "[Anonymous]"}
             </p>
             <div className="flex items-center gap-1.5 mt-0.5">
               <Badge variant="outline" className="text-xs">

--- a/apps/web/src/components/submissions/voting-panel.tsx
+++ b/apps/web/src/components/submissions/voting-panel.tsx
@@ -211,7 +211,7 @@ export function VotingPanel({
                     className="flex items-center justify-between text-sm"
                   >
                     <span className="text-muted-foreground truncate">
-                      {vote.voterEmail ?? "Unknown"}
+                      {vote.voterEmail ?? "[Anonymous]"}
                     </span>
                     <div className="flex items-center gap-2">
                       <Badge variant={DECISION_LABELS[vote.decision].variant}>

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -318,7 +318,7 @@
 - [x] [P1] Reviewer assignment per submission — assign one or more org members as readers on a submission; track who has read it; show assignment in submission detail — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [x] [P1] Internal discussion threads on submissions — comment system on Hopper submissions (pre-acceptance), separate from the Slate pipeline comments (post-acceptance) — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [x] [P2] Voting / scoring on submissions — readers cast votes (accept/reject/maybe + optional score); configurable per org; summary visible to editors making final decisions — (persona gap analysis 2026-02-27; done 2026-02-28)
-- [ ] [P2] Blind / anonymous review mode — hide submitter identity from reviewers; admin toggle per submission period — (persona gap analysis 2026-02-27)
+- [x] [P2] Blind / anonymous review mode — hide submitter identity from reviewers; admin toggle per submission period — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [ ] [P2] Batch operations — checkbox selection in submission queue; bulk status transitions (reject, move to review); bulk assignment — (persona gap analysis 2026-02-27)
 - [ ] [P3] Submission reading mode — distraction-free view for reading the submitted work; "next unread" navigation within the queue — (persona gap analysis 2026-02-27)
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,33 @@ Newest entries first.
 
 ---
 
+## 2026-02-28 — Track 7: Blind/Anonymous Review Mode
+
+### Done
+
+- **DB schema:** `BlindReviewMode` enum (`none`, `single_blind`, `double_blind`) + `blind_review_mode` column on `submission_periods` table. Manual migration `0043_blind_review_mode.sql`.
+- **Shared types:** `blindReviewModeSchema` in `submission.ts`; new `blind-review.ts` with `shouldBlindSubmitter()`, `shouldBlindPeerIdentity()`, `ANONYMOUS_LABEL`, `BlindContext` type
+- **Service helper:** `blind-review.helper.ts` — `resolveBlindMode()` (queries period), `applySubmitterBlinding()`, `applyVoterBlinding()`, `applyAuthorBlinding()`, `applyReviewerBlinding()`
+- **Service layer updates:** Blinding enforced at service layer so all 3 API surfaces inherit automatically:
+  - `submission.service.ts` — batch blinding in `listAll()` (Map of periodId→blindMode), blinding in `getByIdWithAccess()`
+  - `submission-vote.service.ts` — voter blinding in `listVotesWithAccess()` + `castVoteWithAudit()`
+  - `submission-discussion.service.ts` — author blinding in `listWithAccess()` + `createWithAudit()`
+  - `submission-reviewer.service.ts` — reviewer blinding in `listBySubmissionWithAccess()`
+  - `period.service.ts` — `blindReviewMode` in create/update
+- **API router updates:** All 3 surfaces pass `callerRole` to `listAll()`; GraphQL `submitter` field resolver checks blind mode before loading via dataloader
+- **Frontend:** Period form dialog with blind review mode select; period list badge; `[Anonymous]` label in editor queue, voting panel, discussion thread, reviewer list
+- **Tests:** 9 shared type tests + 11 helper tests; updated mocks in `submission.service.spec.ts`, `submission.service.access.spec.ts`, `editor-submission-queue.spec.tsx`
+- All 1338 API tests, 420 web tests, 69 types tests passing; type-check clean
+
+### Decisions
+
+- Service-layer enforcement (not API surface) — single source of truth, all surfaces inherit blinding
+- GraphQL `submitter` field resolver gets separate blind check since it uses dataloaders (bypasses email-based blinding)
+- Batch resolution in `listAll`: collect unique periodIds, fetch modes into Map, apply per item
+- `reviewerEmail` made nullable in types to match blinding behavior
+
+---
+
 ## 2026-02-28 — Track 7: Submission Voting & Scoring
 
 ### Done

--- a/packages/db/migrations/0043_blind_review_mode.sql
+++ b/packages/db/migrations/0043_blind_review_mode.sql
@@ -1,0 +1,3 @@
+CREATE TYPE "BlindReviewMode" AS ENUM ('none', 'single_blind', 'double_blind');
+--> statement-breakpoint
+ALTER TABLE "submission_periods" ADD COLUMN "blind_review_mode" "BlindReviewMode" DEFAULT 'none' NOT NULL;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1777600000000,
       "tag": "0042_submission_votes",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1777800000000,
+      "tag": "0043_blind_review_mode",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -73,6 +73,12 @@ export const voteDecisionEnum = pgEnum("VoteDecision", [
   "MAYBE",
 ]);
 
+export const blindReviewModeEnum = pgEnum("BlindReviewMode", [
+  "none",
+  "single_blind",
+  "double_blind",
+]);
+
 // ---------------------------------------------------------------------------
 // Slate — Publication Pipeline
 // ---------------------------------------------------------------------------

--- a/packages/db/src/schema/submissions.ts
+++ b/packages/db/src/schema/submissions.ts
@@ -18,6 +18,7 @@ import {
   submissionStatusEnum,
   simSubCheckResultEnum,
   voteDecisionEnum,
+  blindReviewModeEnum,
 } from "./enums";
 import { organizations } from "./organizations";
 import { users } from "./users";
@@ -59,6 +60,9 @@ export const submissionPeriods = pgTable(
       onDelete: "set null",
     }),
     simSubProhibited: boolean("sim_sub_prohibited").notNull().default(false),
+    blindReviewMode: blindReviewModeEnum("blind_review_mode")
+      .notNull()
+      .default("none"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),

--- a/packages/types/src/__tests__/blind-review.spec.ts
+++ b/packages/types/src/__tests__/blind-review.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { shouldBlindSubmitter, shouldBlindPeerIdentity } from "../blind-review";
+
+describe("shouldBlindSubmitter", () => {
+  it("returns false for mode=none", () => {
+    expect(
+      shouldBlindSubmitter({ blindMode: "none", callerRole: "EDITOR" }),
+    ).toBe(false);
+  });
+
+  it("returns true for single_blind + EDITOR", () => {
+    expect(
+      shouldBlindSubmitter({
+        blindMode: "single_blind",
+        callerRole: "EDITOR",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for single_blind + READER", () => {
+    expect(
+      shouldBlindSubmitter({
+        blindMode: "single_blind",
+        callerRole: "READER",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for single_blind + ADMIN", () => {
+    expect(
+      shouldBlindSubmitter({ blindMode: "single_blind", callerRole: "ADMIN" }),
+    ).toBe(false);
+  });
+
+  it("returns true for double_blind + EDITOR", () => {
+    expect(
+      shouldBlindSubmitter({
+        blindMode: "double_blind",
+        callerRole: "EDITOR",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("shouldBlindPeerIdentity", () => {
+  it("returns false for single_blind + EDITOR", () => {
+    expect(
+      shouldBlindPeerIdentity({
+        blindMode: "single_blind",
+        callerRole: "EDITOR",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for double_blind + EDITOR", () => {
+    expect(
+      shouldBlindPeerIdentity({
+        blindMode: "double_blind",
+        callerRole: "EDITOR",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for double_blind + READER", () => {
+    expect(
+      shouldBlindPeerIdentity({
+        blindMode: "double_blind",
+        callerRole: "READER",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for double_blind + ADMIN", () => {
+    expect(
+      shouldBlindPeerIdentity({
+        blindMode: "double_blind",
+        callerRole: "ADMIN",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/types/src/blind-review.ts
+++ b/packages/types/src/blind-review.ts
@@ -1,0 +1,25 @@
+import type { BlindReviewMode } from "./submission";
+
+export const ANONYMOUS_LABEL = "[Anonymous]";
+
+export interface BlindContext {
+  blindMode: BlindReviewMode;
+  callerRole: "ADMIN" | "EDITOR" | "READER";
+}
+
+/**
+ * Returns true when submitter identity should be hidden.
+ * In both single_blind and double_blind, editors and readers cannot see the submitter.
+ * Only admins can see submitter identity when blinding is active.
+ */
+export function shouldBlindSubmitter(ctx: BlindContext): boolean {
+  return ctx.blindMode !== "none" && ctx.callerRole !== "ADMIN";
+}
+
+/**
+ * Returns true when peer identities (voters, commenters, reviewers) should be hidden.
+ * Only in double_blind mode, and only for non-admins.
+ */
+export function shouldBlindPeerIdentity(ctx: BlindContext): boolean {
+  return ctx.blindMode === "double_blind" && ctx.callerRole !== "ADMIN";
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -31,3 +31,4 @@ export * from "./email-templates";
 export * from "./discussion";
 export * from "./analytics";
 export * from "./voting";
+export * from "./blind-review";

--- a/packages/types/src/submission.ts
+++ b/packages/types/src/submission.ts
@@ -240,6 +240,12 @@ export const listSubmissionsSchema = z.object({
 
 export type ListSubmissionsInput = z.infer<typeof listSubmissionsSchema>;
 
+export const blindReviewModeSchema = z
+  .enum(["none", "single_blind", "double_blind"])
+  .describe("Blind review mode for the submission period");
+
+export type BlindReviewMode = z.infer<typeof blindReviewModeSchema>;
+
 export const submissionPeriodSchema = z.object({
   id: z.string().uuid().describe("Unique identifier for the submission period"),
   organizationId: z.string().uuid().describe("ID of the owning organization"),
@@ -263,6 +269,7 @@ export const submissionPeriodSchema = z.object({
   simSubProhibited: z
     .boolean()
     .describe("Whether simultaneous submissions are prohibited"),
+  blindReviewMode: blindReviewModeSchema,
   createdAt: z.date().describe("When the period was created"),
   updatedAt: z.date().describe("When the period was last updated"),
 });
@@ -303,6 +310,11 @@ export const createSubmissionPeriodSchema = z.object({
     .optional()
     .describe(
       "Whether simultaneous submissions are prohibited (default: false)",
+    ),
+  blindReviewMode: blindReviewModeSchema
+    .optional()
+    .describe(
+      "Blind review mode: none, single_blind, or double_blind (default: none)",
     ),
 });
 
@@ -450,7 +462,7 @@ export const submissionReviewerSchema = z.object({
   id: z.string().uuid(),
   submissionId: z.string().uuid(),
   reviewerUserId: z.string().uuid(),
-  reviewerEmail: z.string().email(),
+  reviewerEmail: z.string().nullable(),
   reviewerRole: z.enum(["ADMIN", "EDITOR", "READER"]),
   assignedBy: z.string().uuid().nullable(),
   assignedAt: z.coerce.date(),


### PR DESCRIPTION
## Summary

- Add per-submission-period blind review toggle (`none`, `single_blind`, `double_blind`) with `BlindReviewMode` enum + migration
- Enforce blinding at the service layer so tRPC, REST, and GraphQL all inherit automatically
- Single-blind: hides submitter identity from editors/readers (admins can see)
- Double-blind: additionally hides peer identities (voters, commenters, reviewers) from editors/readers

## Changes

**DB:** `BlindReviewMode` enum, `blind_review_mode` column on `submission_periods` (migration 0043)

**Types:** `blindReviewModeSchema`, `shouldBlindSubmitter()`, `shouldBlindPeerIdentity()`, `ANONYMOUS_LABEL`

**Services:** `blind-review.helper.ts` (resolveBlindMode + 4 apply*Blinding helpers), blinding in submission/vote/discussion/reviewer services, period service create/update

**API:** All 3 surfaces pass `callerRole` to `listAll()`; GraphQL `submitter` field resolver fails secure

**Frontend:** Period form dialog with blind mode select, period list badge, `[Anonymous]` display in editor queue/voting/discussion/reviewer views

**Tests:** 20 new tests (9 shared types + 11 helper), updated mocks in 3 existing spec files

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `submission.service.ts` | Sequential `resolveBlindMode()` per period | Single `inArray` batch query | code review: N+1 query concern |
| `graphql/types/submission.ts` | Check context, fall through if missing | Fail secure: return null if context missing | code review: identity leak on malformed context |

## Test plan

- [x] All 1338 API tests passing
- [x] All 420 web tests passing
- [x] All 69 types tests passing
- [x] Type-check clean across all packages
- [x] Lint clean
- [ ] Manual: create period with single_blind, submit as writer, view as editor — submitter email shows "[Anonymous]"
- [ ] Manual: switch to double_blind, view votes/discussions as editor — voter/author emails show "[Anonymous]"
- [ ] Manual: view as admin — all identities visible
- [ ] Run `pnpm db:reset` to apply migration 0043