### PR TITLE
feat(hopper): batch operations for editor submission queue

### DIFF
--- a/apps/api/src/graphql/resolvers/submissions.ts
+++ b/apps/api/src/graphql/resolvers/submissions.ts
@@ -5,6 +5,8 @@ import {
   updateSubmissionSchema,
   updateSubmissionStatusSchema,
   idParamSchema,
+  batchStatusChangeInputSchema,
+  batchAssignReviewersInputSchema,
 } from '@colophony/types';
 import { builder } from '../builder.js';
 import { requireOrgContext, requireScopes } from '../guards.js';
@@ -24,6 +26,8 @@ import {
 } from '../types/index.js';
 import {
   SubmissionStatusChangePayload,
+  BatchStatusChangePayload,
+  BatchAssignReviewersPayload,
   SuccessPayload,
 } from '../types/payloads.js';
 
@@ -653,6 +657,81 @@ builder.mutationFields((t) => ({
             parentId: args.parentId ?? undefined,
             content: args.content,
           },
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Batch update submission status (editor/admin only).
+   */
+  batchUpdateSubmissionStatus: t.field({
+    type: BatchStatusChangePayload,
+    description:
+      'Transition multiple submissions to a new status. Requires EDITOR or ADMIN role.',
+    args: {
+      submissionIds: t.arg.stringList({
+        required: true,
+        description: 'Submission IDs to update.',
+      }),
+      status: t.arg.string({
+        required: true,
+        description: 'Target status for all submissions.',
+      }),
+      comment: t.arg.string({
+        required: false,
+        description: 'Optional comment explaining the decision.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'submissions:write');
+      const input = batchStatusChangeInputSchema.parse({
+        submissionIds: args.submissionIds,
+        status: args.status,
+        comment: args.comment ?? undefined,
+      });
+      try {
+        return await submissionService.batchUpdateStatusAsEditor(
+          toServiceContext(orgCtx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    },
+  }),
+
+  /**
+   * Batch assign reviewers (editor/admin only).
+   */
+  batchAssignReviewers: t.field({
+    type: BatchAssignReviewersPayload,
+    description:
+      'Assign reviewers to multiple submissions. Requires EDITOR or ADMIN role.',
+    args: {
+      submissionIds: t.arg.stringList({
+        required: true,
+        description: 'Submission IDs to assign reviewers to.',
+      }),
+      reviewerUserIds: t.arg.stringList({
+        required: true,
+        description: 'User IDs to assign as reviewers.',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const orgCtx = requireOrgContext(ctx);
+      await requireScopes(ctx, 'submissions:write');
+      const input = batchAssignReviewersInputSchema.parse({
+        submissionIds: args.submissionIds,
+        reviewerUserIds: args.reviewerUserIds,
+      });
+      try {
+        return await submissionService.batchAssignReviewersAsEditor(
+          toServiceContext(orgCtx),
+          input,
         );
       } catch (e) {
         mapServiceError(e);

--- a/apps/api/src/graphql/types/index.ts
+++ b/apps/api/src/graphql/types/index.ts
@@ -52,6 +52,8 @@ export {
 } from './analytics.js';
 export {
   SubmissionStatusChangePayload,
+  BatchStatusChangePayload,
+  BatchAssignReviewersPayload,
   CreateOrganizationPayload,
   CreateApiKeyPayload,
   RevokeApiKeyPayload,

--- a/apps/api/src/graphql/types/payloads.ts
+++ b/apps/api/src/graphql/types/payloads.ts
@@ -34,6 +34,112 @@ export const SubmissionStatusChangePayload = builder
   });
 
 // ---------------------------------------------------------------------------
+// Batch operation payloads
+// ---------------------------------------------------------------------------
+
+export const BatchStatusChangeSuccessItem = builder
+  .objectRef<{
+    submissionId: string;
+    previousStatus: string;
+    status: string;
+  }>('BatchStatusChangeSuccessItem')
+  .implement({
+    description: 'A single successful status change in a batch operation.',
+    fields: (t) => ({
+      submissionId: t.exposeString('submissionId', {
+        description: 'Submission that was updated.',
+      }),
+      previousStatus: t.exposeString('previousStatus', {
+        description: 'Status before the change.',
+      }),
+      status: t.exposeString('status', {
+        description: 'New status after the change.',
+      }),
+    }),
+  });
+
+export const BatchFailureItem = builder
+  .objectRef<{
+    submissionId: string;
+    error: string;
+  }>('BatchFailureItem')
+  .implement({
+    description: 'A single failure in a batch operation.',
+    fields: (t) => ({
+      submissionId: t.exposeString('submissionId', {
+        description: 'Submission that failed.',
+      }),
+      error: t.exposeString('error', {
+        description: 'Error message explaining the failure.',
+      }),
+    }),
+  });
+
+export const BatchStatusChangePayload = builder
+  .objectRef<{
+    succeeded: Array<{
+      submissionId: string;
+      previousStatus: string;
+      status: string;
+    }>;
+    failed: Array<{ submissionId: string; error: string }>;
+  }>('BatchStatusChangePayload')
+  .implement({
+    description: 'Result of a batch status change operation.',
+    fields: (t) => ({
+      succeeded: t.field({
+        type: [BatchStatusChangeSuccessItem],
+        description: 'Submissions that were successfully updated.',
+        resolve: (r) => r.succeeded,
+      }),
+      failed: t.field({
+        type: [BatchFailureItem],
+        description: 'Submissions that failed to update.',
+        resolve: (r) => r.failed,
+      }),
+    }),
+  });
+
+export const BatchAssignReviewersSuccessItem = builder
+  .objectRef<{
+    submissionId: string;
+    assignedCount: number;
+  }>('BatchAssignReviewersSuccessItem')
+  .implement({
+    description:
+      'A single successful reviewer assignment in a batch operation.',
+    fields: (t) => ({
+      submissionId: t.exposeString('submissionId', {
+        description: 'Submission that was updated.',
+      }),
+      assignedCount: t.exposeInt('assignedCount', {
+        description: 'Number of reviewers assigned.',
+      }),
+    }),
+  });
+
+export const BatchAssignReviewersPayload = builder
+  .objectRef<{
+    succeeded: Array<{ submissionId: string; assignedCount: number }>;
+    failed: Array<{ submissionId: string; error: string }>;
+  }>('BatchAssignReviewersPayload')
+  .implement({
+    description: 'Result of a batch reviewer assignment operation.',
+    fields: (t) => ({
+      succeeded: t.field({
+        type: [BatchAssignReviewersSuccessItem],
+        description: 'Submissions that were successfully assigned.',
+        resolve: (r) => r.succeeded,
+      }),
+      failed: t.field({
+        type: [BatchFailureItem],
+        description: 'Submissions that failed to assign.',
+        resolve: (r) => r.failed,
+      }),
+    }),
+  });
+
+// ---------------------------------------------------------------------------
 // Organization mutation payloads
 // ---------------------------------------------------------------------------
 

--- a/apps/api/src/rest/routers/submissions.ts
+++ b/apps/api/src/rest/routers/submissions.ts
@@ -14,6 +14,10 @@ import {
   submissionReviewerSchema,
   createDiscussionCommentSchema,
   submissionDiscussionSchema,
+  batchStatusChangeInputSchema,
+  batchStatusChangeResponseSchema,
+  batchAssignReviewersInputSchema,
+  batchAssignReviewersResponseSchema,
   submissionOverviewStatsSchema,
   submissionStatusBreakdownSchema,
   submissionFunnelSchema,
@@ -779,6 +783,58 @@ const analyticsAging = orgProcedure
   });
 
 // ---------------------------------------------------------------------------
+// Batch operation routes
+// ---------------------------------------------------------------------------
+
+const batchUpdateStatus = orgProcedure
+  .use(requireScopes('submissions:write'))
+  .route({
+    method: 'POST',
+    path: '/submissions/batch/status',
+    summary: 'Batch update submission status',
+    description:
+      'Transition multiple submissions to a new status in one request. Requires EDITOR or ADMIN role.',
+    operationId: 'batchUpdateSubmissionStatus',
+    tags: ['Submissions'],
+  })
+  .input(batchStatusChangeInputSchema)
+  .output(batchStatusChangeResponseSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionService.batchUpdateStatusAsEditor(
+        toServiceContext(context),
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const batchAssignReviewers = orgProcedure
+  .use(requireScopes('submissions:write'))
+  .route({
+    method: 'POST',
+    path: '/submissions/batch/assign-reviewers',
+    summary: 'Batch assign reviewers',
+    description:
+      'Assign reviewers to multiple submissions in one request. Requires EDITOR or ADMIN role.',
+    operationId: 'batchAssignReviewers',
+    tags: ['Submissions'],
+  })
+  .input(batchAssignReviewersInputSchema)
+  .output(batchAssignReviewersResponseSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await submissionService.batchAssignReviewersAsEditor(
+        toServiceContext(context),
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+// ---------------------------------------------------------------------------
 // Assembled router
 // ---------------------------------------------------------------------------
 
@@ -810,4 +866,6 @@ export const submissionsRouter = {
   analyticsTimeSeries,
   analyticsResponseTime,
   analyticsAging,
+  batchUpdateStatus,
+  batchAssignReviewers,
 };

--- a/apps/api/src/services/submission-reviewer.service.ts
+++ b/apps/api/src/services/submission-reviewer.service.ts
@@ -312,6 +312,7 @@ export const submissionReviewerService = {
   unassign,
   listBySubmission,
   markRead,
+  validateOrgMembership,
   assignWithAudit,
   unassignWithAudit,
   listBySubmissionWithAccess,

--- a/apps/api/src/services/submission.service.batch.spec.ts
+++ b/apps/api/src/services/submission.service.batch.spec.ts
@@ -129,6 +129,7 @@ function makeTx() {
     returning: vi.fn().mockResolvedValue([]),
     select: vi.fn().mockReturnThis(),
     from: vi.fn().mockReturnThis(),
+    for: vi.fn(),
   };
   return tx;
 }
@@ -181,13 +182,11 @@ describe('submissionService batch operations', () => {
       vi.mocked(isEditorAllowedTransition).mockReturnValue(true);
 
       const svc = makeSvc();
-      svc.tx.execute.mockResolvedValueOnce({
-        rows: [
-          { id: SUB_1, status: 'SUBMITTED', submitter_id: 'submitter-1' },
-          { id: SUB_2, status: 'SUBMITTED', submitter_id: 'submitter-2' },
-          { id: SUB_3, status: 'SUBMITTED', submitter_id: 'submitter-3' },
-        ],
-      });
+      svc.tx.for.mockResolvedValueOnce([
+        { id: SUB_1, status: 'SUBMITTED', submitterId: 'submitter-1' },
+        { id: SUB_2, status: 'SUBMITTED', submitterId: 'submitter-2' },
+        { id: SUB_3, status: 'SUBMITTED', submitterId: 'submitter-3' },
+      ]);
 
       const result = await submissionService.batchUpdateStatusAsEditor(svc, {
         submissionIds: [SUB_1, SUB_2, SUB_3],
@@ -205,13 +204,11 @@ describe('submissionService batch operations', () => {
       );
 
       const svc = makeSvc();
-      svc.tx.execute.mockResolvedValueOnce({
-        rows: [
-          { id: SUB_1, status: 'SUBMITTED', submitter_id: 'submitter-1' },
-          { id: SUB_2, status: 'SUBMITTED', submitter_id: 'submitter-2' },
-          { id: SUB_3, status: 'ACCEPTED', submitter_id: 'submitter-3' },
-        ],
-      });
+      svc.tx.for.mockResolvedValueOnce([
+        { id: SUB_1, status: 'SUBMITTED', submitterId: 'submitter-1' },
+        { id: SUB_2, status: 'SUBMITTED', submitterId: 'submitter-2' },
+        { id: SUB_3, status: 'ACCEPTED', submitterId: 'submitter-3' },
+      ]);
 
       const result = await submissionService.batchUpdateStatusAsEditor(svc, {
         submissionIds: [SUB_1, SUB_2, SUB_3],
@@ -228,12 +225,10 @@ describe('submissionService batch operations', () => {
       vi.mocked(isEditorAllowedTransition).mockReturnValue(true);
 
       const svc = makeSvc();
-      svc.tx.execute.mockResolvedValueOnce({
-        rows: [
-          { id: SUB_1, status: 'SUBMITTED', submitter_id: 'submitter-1' },
-          { id: SUB_2, status: 'SUBMITTED', submitter_id: 'submitter-2' },
-        ],
-      });
+      svc.tx.for.mockResolvedValueOnce([
+        { id: SUB_1, status: 'SUBMITTED', submitterId: 'submitter-1' },
+        { id: SUB_2, status: 'SUBMITTED', submitterId: 'submitter-2' },
+      ]);
 
       const result = await submissionService.batchUpdateStatusAsEditor(svc, {
         submissionIds: [SUB_1, SUB_2, SUB_3],
@@ -250,12 +245,10 @@ describe('submissionService batch operations', () => {
       vi.mocked(isEditorAllowedTransition).mockReturnValue(true);
 
       const svc = makeSvc();
-      svc.tx.execute.mockResolvedValueOnce({
-        rows: [
-          { id: SUB_1, status: 'SUBMITTED', submitter_id: 'submitter-1' },
-          { id: SUB_2, status: 'SUBMITTED', submitter_id: 'submitter-2' },
-        ],
-      });
+      svc.tx.for.mockResolvedValueOnce([
+        { id: SUB_1, status: 'SUBMITTED', submitterId: 'submitter-1' },
+        { id: SUB_2, status: 'SUBMITTED', submitterId: 'submitter-2' },
+      ]);
 
       await submissionService.batchUpdateStatusAsEditor(svc, {
         submissionIds: [SUB_1, SUB_2],
@@ -279,20 +272,18 @@ describe('submissionService batch operations', () => {
       vi.mocked(isEditorAllowedTransition).mockReturnValue(true);
 
       const svc = makeSvc();
-      svc.tx.execute.mockResolvedValueOnce({
-        rows: [
-          {
-            id: SUB_1,
-            status: 'UNDER_REVIEW',
-            submitter_id: 'submitter-1',
-          },
-          {
-            id: SUB_2,
-            status: 'UNDER_REVIEW',
-            submitter_id: 'submitter-2',
-          },
-        ],
-      });
+      svc.tx.for.mockResolvedValueOnce([
+        {
+          id: SUB_1,
+          status: 'UNDER_REVIEW',
+          submitterId: 'submitter-1',
+        },
+        {
+          id: SUB_2,
+          status: 'UNDER_REVIEW',
+          submitterId: 'submitter-2',
+        },
+      ]);
 
       await submissionService.batchUpdateStatusAsEditor(svc, {
         submissionIds: [SUB_1, SUB_2],

--- a/apps/api/src/services/submission.service.batch.spec.ts
+++ b/apps/api/src/services/submission.service.batch.spec.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ServiceContext } from './types.js';
+import { ForbiddenError } from './errors.js';
+
+// Mock @colophony/db
+vi.mock('@colophony/db', () => ({
+  db: {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue([]),
+  },
+  submissions: { id: 'id', status: 'status' },
+  submissionHistory: {},
+  submissionPeriods: {},
+  formDefinitions: {},
+  files: {},
+  manuscriptVersions: {},
+  manuscripts: {},
+  users: { migratedAt: 'migratedAt' },
+  eq: vi.fn(),
+  and: vi.fn(),
+  inArray: vi.fn(),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  })),
+}));
+
+vi.mock('./migration.service.js', () => ({
+  MigrationInvalidStateError: class MigrationInvalidStateError extends Error {
+    override name = 'MigrationInvalidStateError' as const;
+  },
+}));
+
+vi.mock('./form.service.js', () => ({
+  formService: { validateFormData: vi.fn() },
+  FormNotFoundError: class extends Error {
+    override name = 'FormNotFoundError';
+  },
+  FormNotPublishedError: class extends Error {
+    override name = 'FormNotPublishedError';
+  },
+  InvalidFormDataError: class extends Error {
+    override name = 'InvalidFormDataError';
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  desc: vi.fn(),
+  asc: vi.fn(),
+  ilike: vi.fn(),
+  count: vi.fn(),
+}));
+
+vi.mock('./outbox.js', () => ({
+  enqueueOutboxEvent: vi.fn(),
+}));
+
+vi.mock('./blind-review.helper.js', () => ({
+  resolveBlindMode: vi.fn().mockResolvedValue('none'),
+  applySubmitterBlinding: vi.fn((item: unknown) => item),
+}));
+
+// Mock the reviewer service
+const mockAssign = vi.fn();
+const mockValidateOrgMembership = vi.fn();
+vi.mock('./submission-reviewer.service.js', () => ({
+  submissionReviewerService: {
+    assign: (...args: unknown[]) => mockAssign(...args),
+    validateOrgMembership: (...args: unknown[]) =>
+      mockValidateOrgMembership(...args),
+  },
+  ReviewerAlreadyAssignedError: class ReviewerAlreadyAssignedError extends Error {
+    override name = 'ReviewerAlreadyAssignedError' as const;
+    constructor(reviewerUserId: string) {
+      super(`Reviewer "${reviewerUserId}" is already assigned`);
+    }
+  },
+  ReviewerNotOrgMemberError: class ReviewerNotOrgMemberError extends Error {
+    override name = 'ReviewerNotOrgMemberError' as const;
+    constructor(reviewerUserId: string) {
+      super(`User "${reviewerUserId}" is not a member of this organization`);
+    }
+  },
+}));
+
+vi.mock('@colophony/types', () => ({
+  isValidStatusTransition: vi.fn(() => true),
+  isEditorAllowedTransition: vi.fn(),
+  shouldBlindSubmitter: vi.fn(() => false),
+  shouldBlindPeerIdentity: vi.fn(() => false),
+  AuditActions: {
+    SUBMISSION_CREATED: 'SUBMISSION_CREATED',
+    SUBMISSION_UPDATED: 'SUBMISSION_UPDATED',
+    SUBMISSION_SUBMITTED: 'SUBMISSION_SUBMITTED',
+    SUBMISSION_STATUS_CHANGED: 'SUBMISSION_STATUS_CHANGED',
+    SUBMISSION_DELETED: 'SUBMISSION_DELETED',
+    SUBMISSION_WITHDRAWN: 'SUBMISSION_WITHDRAWN',
+    REVIEWER_ASSIGNED: 'REVIEWER_ASSIGNED',
+  },
+  AuditResources: {
+    SUBMISSION: 'submission',
+  },
+}));
+
+import { isEditorAllowedTransition } from '@colophony/types';
+import { enqueueOutboxEvent } from './outbox.js';
+import {
+  submissionService,
+  MissingRevisionNotesError,
+} from './submission.service.js';
+import { ReviewerNotOrgMemberError } from './submission-reviewer.service.js';
+
+const SUB_1 = 'a1111111-1111-1111-a111-111111111111';
+const SUB_2 = 'a2222222-2222-2222-a222-222222222222';
+const SUB_3 = 'a3333333-3333-3333-a333-333333333333';
+const REVIEWER_1 = 'r1111111-1111-1111-r111-111111111111';
+const REVIEWER_2 = 'r2222222-2222-2222-r222-222222222222';
+
+function makeTx() {
+  const tx = {
+    execute: vi.fn(),
+    update: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue([]),
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+  };
+  return tx;
+}
+
+function makeSvc(
+  overrides: Partial<ServiceContext> = {},
+): ServiceContext & { tx: ReturnType<typeof makeTx> } {
+  const tx = makeTx();
+  return {
+    tx: tx as never,
+    actor: { userId: 'user-1', orgId: 'org-1', role: 'EDITOR' },
+    audit: vi.fn(),
+    ...overrides,
+  } as ServiceContext & { tx: ReturnType<typeof makeTx> };
+}
+
+describe('submissionService batch operations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─── batchUpdateStatusAsEditor ───
+
+  describe('batchUpdateStatusAsEditor', () => {
+    it('rejects non-editor role', async () => {
+      const svc = makeSvc({
+        actor: { userId: 'user-1', orgId: 'org-1', role: 'READER' },
+      });
+
+      await expect(
+        submissionService.batchUpdateStatusAsEditor(svc, {
+          submissionIds: [SUB_1],
+          status: 'UNDER_REVIEW',
+        }),
+      ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('rejects R&R without comment', async () => {
+      const svc = makeSvc();
+
+      await expect(
+        submissionService.batchUpdateStatusAsEditor(svc, {
+          submissionIds: [SUB_1],
+          status: 'REVISE_AND_RESUBMIT',
+        }),
+      ).rejects.toThrow(MissingRevisionNotesError);
+    });
+
+    it('succeeds for all valid submissions', async () => {
+      vi.mocked(isEditorAllowedTransition).mockReturnValue(true);
+
+      const svc = makeSvc();
+      svc.tx.execute.mockResolvedValueOnce({
+        rows: [
+          { id: SUB_1, status: 'SUBMITTED', submitter_id: 'submitter-1' },
+          { id: SUB_2, status: 'SUBMITTED', submitter_id: 'submitter-2' },
+          { id: SUB_3, status: 'SUBMITTED', submitter_id: 'submitter-3' },
+        ],
+      });
+
+      const result = await submissionService.batchUpdateStatusAsEditor(svc, {
+        submissionIds: [SUB_1, SUB_2, SUB_3],
+        status: 'UNDER_REVIEW',
+      });
+
+      expect(result.succeeded).toHaveLength(3);
+      expect(result.failed).toHaveLength(0);
+      expect(svc.audit).toHaveBeenCalledTimes(3);
+    });
+
+    it('handles partial failure: invalid transitions', async () => {
+      vi.mocked(isEditorAllowedTransition).mockImplementation(
+        (from: string) => from === 'SUBMITTED',
+      );
+
+      const svc = makeSvc();
+      svc.tx.execute.mockResolvedValueOnce({
+        rows: [
+          { id: SUB_1, status: 'SUBMITTED', submitter_id: 'submitter-1' },
+          { id: SUB_2, status: 'SUBMITTED', submitter_id: 'submitter-2' },
+          { id: SUB_3, status: 'ACCEPTED', submitter_id: 'submitter-3' },
+        ],
+      });
+
+      const result = await submissionService.batchUpdateStatusAsEditor(svc, {
+        submissionIds: [SUB_1, SUB_2, SUB_3],
+        status: 'UNDER_REVIEW',
+      });
+
+      expect(result.succeeded).toHaveLength(2);
+      expect(result.failed).toHaveLength(1);
+      expect(result.failed[0].submissionId).toBe(SUB_3);
+      expect(result.failed[0].error).toContain('Invalid transition');
+    });
+
+    it('handles missing submissions', async () => {
+      vi.mocked(isEditorAllowedTransition).mockReturnValue(true);
+
+      const svc = makeSvc();
+      svc.tx.execute.mockResolvedValueOnce({
+        rows: [
+          { id: SUB_1, status: 'SUBMITTED', submitter_id: 'submitter-1' },
+          { id: SUB_2, status: 'SUBMITTED', submitter_id: 'submitter-2' },
+        ],
+      });
+
+      const result = await submissionService.batchUpdateStatusAsEditor(svc, {
+        submissionIds: [SUB_1, SUB_2, SUB_3],
+        status: 'UNDER_REVIEW',
+      });
+
+      expect(result.succeeded).toHaveLength(2);
+      expect(result.failed).toHaveLength(1);
+      expect(result.failed[0].submissionId).toBe(SUB_3);
+      expect(result.failed[0].error).toBe('Submission not found');
+    });
+
+    it('enqueues outbox events for REJECTED', async () => {
+      vi.mocked(isEditorAllowedTransition).mockReturnValue(true);
+
+      const svc = makeSvc();
+      svc.tx.execute.mockResolvedValueOnce({
+        rows: [
+          { id: SUB_1, status: 'SUBMITTED', submitter_id: 'submitter-1' },
+          { id: SUB_2, status: 'SUBMITTED', submitter_id: 'submitter-2' },
+        ],
+      });
+
+      await submissionService.batchUpdateStatusAsEditor(svc, {
+        submissionIds: [SUB_1, SUB_2],
+        status: 'REJECTED',
+      });
+
+      expect(enqueueOutboxEvent).toHaveBeenCalledTimes(2);
+      expect(enqueueOutboxEvent).toHaveBeenCalledWith(
+        expect.anything(),
+        'hopper/submission.rejected',
+        expect.objectContaining({ submissionId: SUB_1 }),
+      );
+      expect(enqueueOutboxEvent).toHaveBeenCalledWith(
+        expect.anything(),
+        'hopper/submission.rejected',
+        expect.objectContaining({ submissionId: SUB_2 }),
+      );
+    });
+
+    it('enqueues outbox events for ACCEPTED', async () => {
+      vi.mocked(isEditorAllowedTransition).mockReturnValue(true);
+
+      const svc = makeSvc();
+      svc.tx.execute.mockResolvedValueOnce({
+        rows: [
+          {
+            id: SUB_1,
+            status: 'UNDER_REVIEW',
+            submitter_id: 'submitter-1',
+          },
+          {
+            id: SUB_2,
+            status: 'UNDER_REVIEW',
+            submitter_id: 'submitter-2',
+          },
+        ],
+      });
+
+      await submissionService.batchUpdateStatusAsEditor(svc, {
+        submissionIds: [SUB_1, SUB_2],
+        status: 'ACCEPTED',
+      });
+
+      expect(enqueueOutboxEvent).toHaveBeenCalledTimes(2);
+      expect(enqueueOutboxEvent).toHaveBeenCalledWith(
+        expect.anything(),
+        'hopper/submission.accepted',
+        expect.objectContaining({ submissionId: SUB_1 }),
+      );
+    });
+  });
+
+  // ─── batchAssignReviewersAsEditor ───
+
+  describe('batchAssignReviewersAsEditor', () => {
+    it('rejects non-editor role', async () => {
+      const svc = makeSvc({
+        actor: { userId: 'user-1', orgId: 'org-1', role: 'READER' },
+      });
+
+      await expect(
+        submissionService.batchAssignReviewersAsEditor(svc, {
+          submissionIds: [SUB_1],
+          reviewerUserIds: [REVIEWER_1],
+        }),
+      ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('fails fast if reviewer not org member', async () => {
+      mockValidateOrgMembership.mockRejectedValueOnce(
+        new ReviewerNotOrgMemberError(REVIEWER_1),
+      );
+
+      const svc = makeSvc();
+
+      await expect(
+        submissionService.batchAssignReviewersAsEditor(svc, {
+          submissionIds: [SUB_1],
+          reviewerUserIds: [REVIEWER_1],
+        }),
+      ).rejects.toThrow(ReviewerNotOrgMemberError);
+    });
+
+    it('assigns to all valid submissions', async () => {
+      mockValidateOrgMembership.mockResolvedValueOnce(undefined);
+      mockAssign.mockResolvedValue({
+        id: 'rev-1',
+        submissionId: '',
+        reviewerUserId: '',
+        assignedBy: 'user-1',
+        assignedAt: new Date(),
+        readAt: null,
+      });
+
+      const svc = makeSvc();
+      // Mock select().from().where() chain for finding submissions
+      svc.tx.where.mockResolvedValueOnce([{ id: SUB_1 }, { id: SUB_2 }]);
+
+      const result = await submissionService.batchAssignReviewersAsEditor(svc, {
+        submissionIds: [SUB_1, SUB_2],
+        reviewerUserIds: [REVIEWER_1, REVIEWER_2],
+      });
+
+      expect(result.succeeded).toHaveLength(2);
+      expect(result.succeeded[0].assignedCount).toBe(2);
+      expect(result.succeeded[1].assignedCount).toBe(2);
+      expect(result.failed).toHaveLength(0);
+    });
+
+    it('reports not-found as failed', async () => {
+      mockValidateOrgMembership.mockResolvedValueOnce(undefined);
+      mockAssign.mockResolvedValue({
+        id: 'rev-1',
+        submissionId: '',
+        reviewerUserId: '',
+        assignedBy: 'user-1',
+        assignedAt: new Date(),
+        readAt: null,
+      });
+
+      const svc = makeSvc();
+      svc.tx.where.mockResolvedValueOnce([{ id: SUB_1 }, { id: SUB_2 }]);
+
+      const result = await submissionService.batchAssignReviewersAsEditor(svc, {
+        submissionIds: [SUB_1, SUB_2, SUB_3],
+        reviewerUserIds: [REVIEWER_1],
+      });
+
+      expect(result.succeeded).toHaveLength(2);
+      expect(result.failed).toHaveLength(1);
+      expect(result.failed[0].submissionId).toBe(SUB_3);
+      expect(result.failed[0].error).toBe('Submission not found');
+    });
+  });
+});

--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -20,6 +20,10 @@ import type {
   UpdateSubmissionInput,
   ListSubmissionsInput,
   SubmissionStatus,
+  BatchStatusChangeInput,
+  BatchStatusChangeResponse,
+  BatchAssignReviewersInput,
+  BatchAssignReviewersResponse,
 } from '@colophony/types';
 import {
   isValidStatusTransition,
@@ -46,6 +50,8 @@ import {
   InvalidFormDataError,
 } from './form.service.js';
 import { MigrationInvalidStateError } from './migration.service.js';
+import { submissionReviewerService } from './submission-reviewer.service.js';
+import { ReviewerAlreadyAssignedError } from './submission-reviewer.service.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -932,5 +938,185 @@ export const submissionService = {
       submission.submitterId,
     );
     return submissionService.getHistory(svc.tx, submissionId);
+  },
+
+  // ---------------------------------------------------------------------------
+  // Batch operations (editor/admin only)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Batch status change with partial success support.
+   * Pass 1: SELECT FOR UPDATE + validate transitions.
+   * Pass 2: apply updates + history + audit + outbox for valid submissions.
+   */
+  async batchUpdateStatusAsEditor(
+    svc: ServiceContext,
+    input: BatchStatusChangeInput,
+  ): Promise<BatchStatusChangeResponse> {
+    assertEditorOrAdmin(svc.actor.role);
+
+    const { submissionIds, status, comment } = input;
+
+    // R&R requires revision notes
+    if (status === 'REVISE_AND_RESUBMIT' && !comment?.trim()) {
+      throw new MissingRevisionNotesError();
+    }
+
+    // Pass 1: Lock and fetch all submissions
+    const rows = await svc.tx.execute<{
+      id: string;
+      status: SubmissionStatus;
+      submitter_id: string | null;
+    }>(
+      sql`SELECT id, status, submitter_id FROM submissions WHERE id = ANY(${submissionIds}) FOR UPDATE`,
+    );
+
+    const foundMap = new Map(rows.rows.map((r) => [r.id, r]));
+
+    const succeeded: BatchStatusChangeResponse['succeeded'] = [];
+    const failed: BatchStatusChangeResponse['failed'] = [];
+
+    // Partition: missing IDs and invalid transitions
+    for (const id of submissionIds) {
+      const row = foundMap.get(id);
+      if (!row) {
+        failed.push({ submissionId: id, error: 'Submission not found' });
+        continue;
+      }
+      if (!isEditorAllowedTransition(row.status, status)) {
+        failed.push({
+          submissionId: id,
+          error: `Invalid transition from "${row.status}" to "${status}"`,
+        });
+        continue;
+      }
+
+      // Pass 2: Apply update
+      await svc.tx
+        .update(submissions)
+        .set({ status, updatedAt: new Date() })
+        .where(eq(submissions.id, id));
+
+      await svc.tx.insert(submissionHistory).values({
+        submissionId: id,
+        fromStatus: row.status,
+        toStatus: status,
+        changedBy: svc.actor.userId,
+        comment: comment ?? null,
+      });
+
+      await svc.audit({
+        action: AuditActions.SUBMISSION_STATUS_CHANGED,
+        resource: AuditResources.SUBMISSION,
+        resourceId: id,
+        newValue: { status, comment },
+      });
+
+      // Enqueue outbox events for terminal/notification statuses
+      if (status === 'ACCEPTED') {
+        await enqueueOutboxEvent(svc.tx, 'hopper/submission.accepted', {
+          orgId: svc.actor.orgId,
+          submissionId: id,
+          submitterId: row.submitter_id,
+          comment,
+        });
+      } else if (status === 'REJECTED') {
+        await enqueueOutboxEvent(svc.tx, 'hopper/submission.rejected', {
+          orgId: svc.actor.orgId,
+          submissionId: id,
+          submitterId: row.submitter_id,
+          comment,
+        });
+      } else if (status === 'REVISE_AND_RESUBMIT') {
+        await enqueueOutboxEvent(
+          svc.tx,
+          'hopper/submission.revise_and_resubmit',
+          {
+            orgId: svc.actor.orgId,
+            submissionId: id,
+            submitterId: row.submitter_id,
+            comment: comment!,
+          },
+        );
+      }
+
+      succeeded.push({
+        submissionId: id,
+        previousStatus: row.status,
+        status,
+      });
+    }
+
+    return { succeeded, failed };
+  },
+
+  /**
+   * Batch assign reviewers with partial success support.
+   * Validates reviewer org membership first (fails fast), then assigns
+   * to each submission individually.
+   */
+  async batchAssignReviewersAsEditor(
+    svc: ServiceContext,
+    input: BatchAssignReviewersInput,
+  ): Promise<BatchAssignReviewersResponse> {
+    assertEditorOrAdmin(svc.actor.role);
+
+    const { submissionIds, reviewerUserIds } = input;
+
+    // Fail fast: validate all reviewers are org members
+    await submissionReviewerService.validateOrgMembership(
+      svc.tx,
+      svc.actor.orgId,
+      reviewerUserIds,
+    );
+
+    // Fetch existing submissions
+    const rows = await svc.tx
+      .select({ id: submissions.id })
+      .from(submissions)
+      .where(inArray(submissions.id, submissionIds));
+
+    const foundIds = new Set(rows.map((r) => r.id));
+
+    const succeeded: BatchAssignReviewersResponse['succeeded'] = [];
+    const failed: BatchAssignReviewersResponse['failed'] = [];
+
+    for (const id of submissionIds) {
+      if (!foundIds.has(id)) {
+        failed.push({ submissionId: id, error: 'Submission not found' });
+        continue;
+      }
+
+      let assignedCount = 0;
+      for (const reviewerUserId of reviewerUserIds) {
+        try {
+          await submissionReviewerService.assign(
+            svc.tx,
+            svc.actor.orgId,
+            id,
+            reviewerUserId,
+            svc.actor.userId,
+          );
+          assignedCount++;
+
+          await svc.audit({
+            resource: AuditResources.SUBMISSION,
+            action: AuditActions.REVIEWER_ASSIGNED,
+            resourceId: id,
+            newValue: { reviewerUserId },
+          });
+        } catch (err) {
+          // Skip already-assigned reviewers
+          if (err instanceof ReviewerAlreadyAssignedError) {
+            continue;
+          }
+          throw err;
+        }
+      }
+
+      succeeded.push({ submissionId: id, assignedCount });
+    }
+
+    return { succeeded, failed };
   },
 };

--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -978,7 +978,7 @@ export const submissionService = {
         r.id,
         {
           id: r.id,
-          status: r.status as SubmissionStatus,
+          status: r.status,
           submitterId: r.submitterId,
         },
       ]),

--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -962,16 +962,27 @@ export const submissionService = {
       throw new MissingRevisionNotesError();
     }
 
-    // Pass 1: Lock and fetch all submissions
-    const rows = await svc.tx.execute<{
-      id: string;
-      status: SubmissionStatus;
-      submitter_id: string | null;
-    }>(
-      sql`SELECT id, status, submitter_id FROM submissions WHERE id = ANY(${submissionIds}) FOR UPDATE`,
-    );
+    // Pass 1: Lock and fetch all submissions via Drizzle (goes through RLS)
+    const rows = await svc.tx
+      .select({
+        id: submissions.id,
+        status: submissions.status,
+        submitterId: submissions.submitterId,
+      })
+      .from(submissions)
+      .where(inArray(submissions.id, submissionIds))
+      .for('update');
 
-    const foundMap = new Map(rows.rows.map((r) => [r.id, r]));
+    const foundMap = new Map(
+      rows.map((r) => [
+        r.id,
+        {
+          id: r.id,
+          status: r.status as SubmissionStatus,
+          submitterId: r.submitterId,
+        },
+      ]),
+    );
 
     const succeeded: BatchStatusChangeResponse['succeeded'] = [];
     const failed: BatchStatusChangeResponse['failed'] = [];
@@ -1017,24 +1028,25 @@ export const submissionService = {
         await enqueueOutboxEvent(svc.tx, 'hopper/submission.accepted', {
           orgId: svc.actor.orgId,
           submissionId: id,
-          submitterId: row.submitter_id,
+          submitterId: row.submitterId,
           comment,
         });
       } else if (status === 'REJECTED') {
         await enqueueOutboxEvent(svc.tx, 'hopper/submission.rejected', {
           orgId: svc.actor.orgId,
           submissionId: id,
-          submitterId: row.submitter_id,
+          submitterId: row.submitterId,
           comment,
         });
       } else if (status === 'REVISE_AND_RESUBMIT') {
+        // comment! is safe: R&R without comment is rejected at the top of this method
         await enqueueOutboxEvent(
           svc.tx,
           'hopper/submission.revise_and_resubmit',
           {
             orgId: svc.actor.orgId,
             submissionId: id,
-            submitterId: row.submitter_id,
+            submitterId: row.submitterId,
             comment: comment!,
           },
         );
@@ -1087,6 +1099,8 @@ export const submissionService = {
         continue;
       }
 
+      // Individual inserts: intentional for per-reviewer error handling
+      // (e.g., skip already-assigned). Worst case: reviewerUserIds.length * submissionIds.length inserts.
       let assignedCount = 0;
       for (const reviewerUserId of reviewerUserIds) {
         try {

--- a/apps/api/src/trpc/routers/submissions.ts
+++ b/apps/api/src/trpc/routers/submissions.ts
@@ -40,6 +40,10 @@ import {
   deleteVoteInputSchema,
   submissionVoteSchema,
   voteSummarySchema,
+  batchStatusChangeInputSchema,
+  batchStatusChangeResponseSchema,
+  batchAssignReviewersInputSchema,
+  batchAssignReviewersResponseSchema,
 } from '@colophony/types';
 import {
   orgProcedure,
@@ -226,6 +230,38 @@ export const submissionsRouter = createRouter({
           id,
           status,
           comment,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Batch status change — editor/admin only. */
+  batchUpdateStatus: orgProcedure
+    .use(requireScopes('submissions:write'))
+    .input(batchStatusChangeInputSchema)
+    .output(batchStatusChangeResponseSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await submissionService.batchUpdateStatusAsEditor(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Batch assign reviewers — editor/admin only. */
+  batchAssignReviewers: orgProcedure
+    .use(requireScopes('submissions:write'))
+    .input(batchAssignReviewersInputSchema)
+    .output(batchAssignReviewersResponseSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await submissionService.batchAssignReviewersAsEditor(
+          toServiceContext(ctx),
+          input,
         );
       } catch (e) {
         mapServiceError(e);

--- a/apps/web/src/components/submissions/__tests__/batch-action-bar.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/batch-action-bar.spec.tsx
@@ -1,0 +1,151 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { BatchActionBar } from "../batch-action-bar";
+import "../../../../test/setup";
+
+// --- Mutable mock state ---
+let mockMutate: jest.Mock;
+let mockAssignMutate: jest.Mock;
+let mockIsPending: boolean;
+let mockAssignIsPending: boolean;
+let mockMembersData:
+  | { items: Array<{ userId: string; email: string; role: string }> }
+  | undefined;
+
+function resetMocks() {
+  mockMutate = jest.fn();
+  mockAssignMutate = jest.fn();
+  mockIsPending = false;
+  mockAssignIsPending = false;
+  mockMembersData = undefined;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    submissions: {
+      batchUpdateStatus: {
+        useMutation: () => ({
+          mutate: mockMutate,
+          isPending: mockIsPending,
+        }),
+      },
+      batchAssignReviewers: {
+        useMutation: () => ({
+          mutate: mockAssignMutate,
+          isPending: mockAssignIsPending,
+        }),
+      },
+      list: {
+        invalidate: jest.fn(),
+      },
+    },
+    organizations: {
+      members: {
+        list: {
+          useQuery: () => ({
+            data: mockMembersData,
+          }),
+        },
+      },
+    },
+    useUtils: () => ({
+      submissions: {
+        list: { invalidate: jest.fn() },
+      },
+    }),
+  },
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+beforeEach(() => {
+  resetMocks();
+});
+
+const defaultProps = {
+  selectedCount: 3,
+  selectedIds: ["id-1", "id-2", "id-3"],
+  statusFilter: "SUBMITTED" as const,
+  onClear: jest.fn(),
+  onSuccess: jest.fn(),
+};
+
+describe("BatchActionBar", () => {
+  it("hides when selectedCount is 0", () => {
+    const { container } = render(
+      <BatchActionBar {...defaultProps} selectedCount={0} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows count and Clear button", () => {
+    render(<BatchActionBar {...defaultProps} />);
+    expect(screen.getByText("3 selected")).toBeInTheDocument();
+    expect(screen.getByText("Clear")).toBeInTheDocument();
+  });
+
+  it("shows context-appropriate status buttons for SUBMITTED filter", () => {
+    render(<BatchActionBar {...defaultProps} />);
+    expect(screen.getByText("Move to Review")).toBeInTheDocument();
+    expect(screen.getByText("Reject")).toBeInTheDocument();
+  });
+
+  it("shows confirmation dialog for Reject (destructive action)", () => {
+    render(<BatchActionBar {...defaultProps} />);
+
+    // Click Reject — should open confirmation dialog, not fire mutation
+    fireEvent.click(screen.getByText("Reject"));
+
+    expect(mockMutate).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/This action will reject 3 submissions/i),
+    ).toBeInTheDocument();
+  });
+
+  it("fires mutation after confirming destructive action", () => {
+    render(<BatchActionBar {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("Reject"));
+    fireEvent.click(screen.getByText("Confirm"));
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      submissionIds: ["id-1", "id-2", "id-3"],
+      status: "REJECTED",
+    });
+  });
+
+  it("does NOT show confirmation for non-destructive actions", () => {
+    render(<BatchActionBar {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("Move to Review"));
+
+    // Mutation fires immediately, no dialog
+    expect(mockMutate).toHaveBeenCalledWith({
+      submissionIds: ["id-1", "id-2", "id-3"],
+      status: "UNDER_REVIEW",
+    });
+    expect(screen.queryByText(/This cannot be undone/)).not.toBeInTheDocument();
+  });
+
+  it("opens assign reviewers dialog", () => {
+    render(<BatchActionBar {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("Assign Reviewers"));
+
+    expect(screen.getByText(/Select reviewers to assign/)).toBeInTheDocument();
+  });
+
+  it("disables buttons while mutation is pending", () => {
+    mockIsPending = true;
+    render(<BatchActionBar {...defaultProps} />);
+
+    expect(screen.getByText("Move to Review")).toBeDisabled();
+    expect(screen.getByText("Reject")).toBeDisabled();
+    expect(screen.getByText("Assign Reviewers")).toBeDisabled();
+  });
+});

--- a/apps/web/src/components/submissions/__tests__/batch-action-bar.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/batch-action-bar.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { BatchActionBar } from "../batch-action-bar";
 import "../../../../test/setup";
 

--- a/apps/web/src/components/submissions/__tests__/editor-submission-queue.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/editor-submission-queue.spec.tsx
@@ -23,6 +23,9 @@ function resetMocks() {
 
 jest.mock("@/lib/trpc", () => ({
   trpc: {
+    useUtils: () => ({
+      submissions: { list: { invalidate: jest.fn() } },
+    }),
     submissions: {
       list: {
         useQuery: () => ({
@@ -30,6 +33,19 @@ jest.mock("@/lib/trpc", () => ({
           isPending: mockIsPending,
           error: mockError,
         }),
+      },
+      batchUpdateStatus: {
+        useMutation: () => ({ mutate: jest.fn(), isPending: false }),
+      },
+      batchAssignReviewers: {
+        useMutation: () => ({ mutate: jest.fn(), isPending: false }),
+      },
+    },
+    organizations: {
+      members: {
+        list: {
+          useQuery: () => ({ data: undefined }),
+        },
       },
     },
   },

--- a/apps/web/src/components/submissions/batch-action-bar.tsx
+++ b/apps/web/src/components/submissions/batch-action-bar.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { useState } from "react";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import { Users, X } from "lucide-react";
+import type { SubmissionStatus } from "@colophony/types";
+
+const DESTRUCTIVE_STATUSES = new Set<SubmissionStatus>([
+  "REJECTED",
+  "ACCEPTED",
+]);
+
+interface BatchActionBarProps {
+  selectedCount: number;
+  selectedIds: string[];
+  statusFilter: SubmissionStatus | "ALL";
+  onClear: () => void;
+  onSuccess: () => void;
+}
+
+/**
+ * Returns context-aware status transition buttons based on the current filter.
+ */
+function getAvailableStatusActions(
+  statusFilter: SubmissionStatus | "ALL",
+): Array<{
+  status: SubmissionStatus;
+  label: string;
+  variant: "default" | "destructive" | "outline";
+}> {
+  switch (statusFilter) {
+    case "SUBMITTED":
+      return [
+        { status: "UNDER_REVIEW", label: "Move to Review", variant: "default" },
+        { status: "REJECTED", label: "Reject", variant: "destructive" },
+      ];
+    case "UNDER_REVIEW":
+      return [
+        { status: "ACCEPTED", label: "Accept", variant: "default" },
+        { status: "REJECTED", label: "Reject", variant: "destructive" },
+        { status: "HOLD", label: "Hold", variant: "outline" },
+        { status: "REVISE_AND_RESUBMIT", label: "R&R", variant: "outline" },
+      ];
+    case "HOLD":
+      return [
+        { status: "UNDER_REVIEW", label: "Move to Review", variant: "default" },
+        { status: "ACCEPTED", label: "Accept", variant: "default" },
+        { status: "REJECTED", label: "Reject", variant: "destructive" },
+        { status: "REVISE_AND_RESUBMIT", label: "R&R", variant: "outline" },
+      ];
+    case "ALL":
+      return [{ status: "REJECTED", label: "Reject", variant: "destructive" }];
+    default:
+      return [];
+  }
+}
+
+export function BatchActionBar({
+  selectedCount,
+  selectedIds,
+  statusFilter,
+  onClear,
+  onSuccess,
+}: BatchActionBarProps) {
+  const [assignDialogOpen, setAssignDialogOpen] = useState(false);
+  const [selectedReviewers, setSelectedReviewers] = useState<Set<string>>(
+    new Set(),
+  );
+  const [pendingAction, setPendingAction] = useState<{
+    status: SubmissionStatus;
+    label: string;
+  } | null>(null);
+
+  const utils = trpc.useUtils();
+
+  const batchStatusMutation = trpc.submissions.batchUpdateStatus.useMutation({
+    onSuccess: (result) => {
+      const total = result.succeeded.length + result.failed.length;
+      if (result.failed.length === 0) {
+        toast.success(`Updated ${result.succeeded.length} submissions`);
+      } else {
+        toast.warning(
+          `${result.succeeded.length} of ${total} updated. ${result.failed.length} failed.`,
+        );
+      }
+      utils.submissions.list.invalidate();
+      onSuccess();
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const batchAssignMutation = trpc.submissions.batchAssignReviewers.useMutation(
+    {
+      onSuccess: (result) => {
+        const total = result.succeeded.length + result.failed.length;
+        if (result.failed.length === 0) {
+          toast.success(
+            `Assigned reviewers to ${result.succeeded.length} submissions`,
+          );
+        } else {
+          toast.warning(
+            `${result.succeeded.length} of ${total} assigned. ${result.failed.length} failed.`,
+          );
+        }
+        setAssignDialogOpen(false);
+        setSelectedReviewers(new Set());
+        utils.submissions.list.invalidate();
+        onSuccess();
+      },
+      onError: (err) => {
+        toast.error(err.message);
+      },
+    },
+  );
+
+  const { data: membersData } = trpc.organizations.members.list.useQuery(
+    { page: 1, limit: 100 },
+    { enabled: assignDialogOpen },
+  );
+
+  const statusActions = getAvailableStatusActions(statusFilter);
+  const isMutating =
+    batchStatusMutation.isPending || batchAssignMutation.isPending;
+
+  if (selectedCount === 0) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background p-4 shadow-lg">
+      <div className="mx-auto flex max-w-screen-xl items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-medium">{selectedCount} selected</span>
+          <Button variant="ghost" size="sm" onClick={onClear}>
+            <X className="mr-1 h-3 w-3" />
+            Clear
+          </Button>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {statusActions.map((action) => (
+            <Button
+              key={action.status}
+              variant={action.variant}
+              size="sm"
+              disabled={isMutating}
+              onClick={() => {
+                if (DESTRUCTIVE_STATUSES.has(action.status)) {
+                  setPendingAction({
+                    status: action.status,
+                    label: action.label,
+                  });
+                } else {
+                  batchStatusMutation.mutate({
+                    submissionIds: selectedIds,
+                    status: action.status,
+                  });
+                }
+              }}
+            >
+              {action.label}
+            </Button>
+          ))}
+
+          <Dialog open={assignDialogOpen} onOpenChange={setAssignDialogOpen}>
+            <DialogTrigger asChild>
+              <Button variant="outline" size="sm" disabled={isMutating}>
+                <Users className="mr-1 h-3 w-3" />
+                Assign Reviewers
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Assign Reviewers</DialogTitle>
+                <DialogDescription>
+                  Select reviewers to assign to {selectedCount} submission
+                  {selectedCount !== 1 ? "s" : ""}.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="max-h-60 space-y-2 overflow-y-auto py-2">
+                {membersData?.items.map((member) => (
+                  <label
+                    key={member.userId}
+                    className="flex items-center gap-3 rounded-md p-2 hover:bg-muted cursor-pointer"
+                  >
+                    <Checkbox
+                      checked={selectedReviewers.has(member.userId)}
+                      onCheckedChange={(checked) => {
+                        setSelectedReviewers((prev) => {
+                          const next = new Set(prev);
+                          if (checked) {
+                            next.add(member.userId);
+                          } else {
+                            next.delete(member.userId);
+                          }
+                          return next;
+                        });
+                      }}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium truncate">
+                        {member.email}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {member.role}
+                      </p>
+                    </div>
+                  </label>
+                ))}
+              </div>
+
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setAssignDialogOpen(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  disabled={
+                    selectedReviewers.size === 0 ||
+                    batchAssignMutation.isPending
+                  }
+                  onClick={() =>
+                    batchAssignMutation.mutate({
+                      submissionIds: selectedIds,
+                      reviewerUserIds: [...selectedReviewers],
+                    })
+                  }
+                >
+                  Assign ({selectedReviewers.size})
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+
+          <AlertDialog
+            open={pendingAction !== null}
+            onOpenChange={(open) => {
+              if (!open) setPendingAction(null);
+            }}
+          >
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  {pendingAction?.label} {selectedCount} submission
+                  {selectedCount !== 1 ? "s" : ""}?
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  This action will {pendingAction?.label.toLowerCase()}{" "}
+                  {selectedCount} submission
+                  {selectedCount !== 1 ? "s" : ""}. This cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  onClick={() => {
+                    if (pendingAction) {
+                      batchStatusMutation.mutate({
+                        submissionIds: selectedIds,
+                        status: pendingAction.status,
+                      });
+                    }
+                    setPendingAction(null);
+                  }}
+                >
+                  Confirm
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/submissions/batch-action-bar.tsx
+++ b/apps/web/src/components/submissions/batch-action-bar.tsx
@@ -208,12 +208,16 @@ export function BatchActionBar({
                   >
                     <Checkbox
                       checked={selectedReviewers.has(member.userId)}
+                      disabled={
+                        !selectedReviewers.has(member.userId) &&
+                        selectedReviewers.size >= 20
+                      }
                       onCheckedChange={(checked) => {
                         setSelectedReviewers((prev) => {
                           const next = new Set(prev);
-                          if (checked) {
+                          if (checked && next.size < 20) {
                             next.add(member.userId);
-                          } else {
+                          } else if (!checked) {
                             next.delete(member.userId);
                           }
                           return next;

--- a/apps/web/src/components/submissions/editor-submission-queue.tsx
+++ b/apps/web/src/components/submissions/editor-submission-queue.tsx
@@ -5,8 +5,11 @@ import Link from "next/link";
 import { format } from "date-fns";
 import { trpc } from "@/lib/trpc";
 import { StatusBadge } from "./status-badge";
+import { BatchActionBar } from "./batch-action-bar";
+import { useRowSelection } from "@/hooks/use-row-selection";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Table,
   TableBody,
@@ -43,6 +46,7 @@ export function EditorSubmissionQueue() {
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [page, setPage] = useState(1);
+  const selection = useRowSelection<{ id: string }>();
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -51,6 +55,14 @@ export function EditorSubmissionQueue() {
     }, 300);
     return () => clearTimeout(timer);
   }, [search]);
+
+  // Clear selection when page, filter, or search changes
+  useEffect(() => {
+    selection.clear();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, statusFilter, debouncedSearch]);
+
+  const utils = trpc.useUtils();
 
   const { data, isPending, error } = trpc.submissions.list.useQuery({
     status: statusFilter === "ALL" ? undefined : statusFilter,
@@ -127,6 +139,19 @@ export function EditorSubmissionQueue() {
           <Table>
             <TableHeader>
               <TableRow>
+                <TableHead className="w-[40px]">
+                  <Checkbox
+                    checked={
+                      selection.isAllSelected(data.items)
+                        ? true
+                        : selection.isIndeterminate(data.items)
+                          ? "indeterminate"
+                          : false
+                    }
+                    onCheckedChange={() => selection.toggleAll(data.items)}
+                    aria-label="Select all"
+                  />
+                </TableHead>
                 <TableHead className="w-[100px]">Status</TableHead>
                 <TableHead>Title</TableHead>
                 <TableHead>Submitter</TableHead>
@@ -136,7 +161,19 @@ export function EditorSubmissionQueue() {
             </TableHeader>
             <TableBody>
               {data.items.map((item) => (
-                <TableRow key={item.id}>
+                <TableRow
+                  key={item.id}
+                  data-state={
+                    selection.isSelected(item.id) ? "selected" : undefined
+                  }
+                >
+                  <TableCell>
+                    <Checkbox
+                      checked={selection.isSelected(item.id)}
+                      onCheckedChange={() => selection.toggle(item.id)}
+                      aria-label={`Select ${item.title ?? "submission"}`}
+                    />
+                  </TableCell>
                   <TableCell>
                     <StatusBadge status={item.status as SubmissionStatus} />
                   </TableCell>
@@ -216,6 +253,17 @@ export function EditorSubmissionQueue() {
           </p>
         </div>
       )}
+
+      <BatchActionBar
+        selectedCount={selection.count}
+        selectedIds={[...selection.selectedIds]}
+        statusFilter={statusFilter}
+        onClear={selection.clear}
+        onSuccess={() => {
+          selection.clear();
+          utils.submissions.list.invalidate();
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/hooks/__tests__/use-row-selection.spec.ts
+++ b/apps/web/src/hooks/__tests__/use-row-selection.spec.ts
@@ -1,0 +1,62 @@
+import { renderHook, act } from "@testing-library/react";
+import { useRowSelection } from "../use-row-selection";
+
+const items = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+describe("useRowSelection", () => {
+  it("toggles single item", () => {
+    const { result } = renderHook(() => useRowSelection());
+
+    expect(result.current.count).toBe(0);
+    expect(result.current.isSelected("a")).toBe(false);
+
+    act(() => result.current.toggle("a"));
+    expect(result.current.isSelected("a")).toBe(true);
+    expect(result.current.count).toBe(1);
+
+    act(() => result.current.toggle("a"));
+    expect(result.current.isSelected("a")).toBe(false);
+    expect(result.current.count).toBe(0);
+  });
+
+  it("toggleAll selects all when none selected", () => {
+    const { result } = renderHook(() => useRowSelection());
+
+    act(() => result.current.toggleAll(items));
+
+    expect(result.current.isSelected("a")).toBe(true);
+    expect(result.current.isSelected("b")).toBe(true);
+    expect(result.current.isSelected("c")).toBe(true);
+    expect(result.current.count).toBe(3);
+  });
+
+  it("toggleAll deselects when all selected", () => {
+    const { result } = renderHook(() => useRowSelection());
+
+    act(() => result.current.toggleAll(items));
+    expect(result.current.count).toBe(3);
+
+    act(() => result.current.toggleAll(items));
+    expect(result.current.count).toBe(0);
+  });
+
+  it("isIndeterminate for partial selection", () => {
+    const { result } = renderHook(() => useRowSelection());
+
+    act(() => result.current.toggle("a"));
+
+    expect(result.current.isIndeterminate(items)).toBe(true);
+    expect(result.current.isAllSelected(items)).toBe(false);
+  });
+
+  it("clear empties selection", () => {
+    const { result } = renderHook(() => useRowSelection());
+
+    act(() => result.current.toggleAll(items));
+    expect(result.current.count).toBe(3);
+
+    act(() => result.current.clear());
+    expect(result.current.count).toBe(0);
+    expect(result.current.isSelected("a")).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/use-row-selection.ts
+++ b/apps/web/src/hooks/use-row-selection.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+
+export function useRowSelection<T extends { id: string }>() {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const isSelected = useCallback(
+    (id: string) => selectedIds.has(id),
+    [selectedIds],
+  );
+
+  const toggle = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleAll = useCallback((items: T[]) => {
+    setSelectedIds((prev) => {
+      const allSelected = items.every((item) => prev.has(item.id));
+      if (allSelected) {
+        return new Set();
+      }
+      return new Set(items.map((item) => item.id));
+    });
+  }, []);
+
+  const isAllSelected = useCallback(
+    (items: T[]) =>
+      items.length > 0 && items.every((i) => selectedIds.has(i.id)),
+    [selectedIds],
+  );
+
+  const isIndeterminate = useCallback(
+    (items: T[]) => {
+      const someSelected = items.some((i) => selectedIds.has(i.id));
+      const allSelected = items.every((i) => selectedIds.has(i.id));
+      return someSelected && !allSelected;
+    },
+    [selectedIds],
+  );
+
+  const clear = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  const count = useMemo(() => selectedIds.size, [selectedIds]);
+
+  return {
+    selectedIds,
+    isSelected,
+    toggle,
+    toggleAll,
+    isAllSelected,
+    isIndeterminate,
+    clear,
+    count,
+  };
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -319,7 +319,7 @@
 - [x] [P1] Internal discussion threads on submissions — comment system on Hopper submissions (pre-acceptance), separate from the Slate pipeline comments (post-acceptance) — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [x] [P2] Voting / scoring on submissions — readers cast votes (accept/reject/maybe + optional score); configurable per org; summary visible to editors making final decisions — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [x] [P2] Blind / anonymous review mode — hide submitter identity from reviewers; admin toggle per submission period — (persona gap analysis 2026-02-27; done 2026-02-28)
-- [ ] [P2] Batch operations — checkbox selection in submission queue; bulk status transitions (reject, move to review); bulk assignment — (persona gap analysis 2026-02-27)
+- [x] [P2] Batch operations — checkbox selection in submission queue; bulk status transitions (reject, move to review); bulk assignment — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [ ] [P3] Submission reading mode — distraction-free view for reading the submitted work; "next unread" navigation within the queue — (persona gap analysis 2026-02-27)
 
 ### Analytics & Reporting

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,27 @@ Newest entries first.
 
 ---
 
+## 2026-02-28 — Track 3: Batch Operations for Editor Submission Queue
+
+### Done
+
+- **Types:** Batch Zod schemas (`batchStatusChangeInputSchema`, `batchAssignReviewersInputSchema`, response schemas) with BATCH_MAX_SIZE=50 and max 20 reviewers per assign
+- **Service layer:** `batchUpdateStatusAsEditor` + `batchAssignReviewersAsEditor` with per-item error handling (partial success/failure, no all-or-nothing transaction)
+- **tRPC:** `batchUpdateStatus` + `batchAssignReviewers` procedures on submissions router
+- **REST (oRPC):** `POST /submissions/batch/status` + `POST /submissions/batch/assign-reviewers` endpoints
+- **GraphQL (Pothos):** 5 payload types (`BatchStatusChangeSuccessItem`, `BatchFailureItem`, `BatchStatusChangePayload`, `BatchAssignReviewersSuccessItem`, `BatchAssignReviewersPayload`) + 2 mutations (`batchUpdateSubmissionStatus`, `batchAssignReviewers`)
+- **Frontend:** `BatchActionBar` component with context-aware status buttons, reviewer assignment dialog (with member list), and `AlertDialog` confirmation for destructive actions (REJECTED, ACCEPTED)
+- **Frontend:** `useRowSelection` hook for checkbox state management; integrated into `EditorSubmissionQueue`
+- **Tests:** 12 schema tests, 11 service tests, 8 component tests, 5 hook tests — all passing; type-check clean
+
+### Decisions
+
+- ACCEPTED and REJECTED classified as destructive (require confirmation dialog); all other transitions fire immediately
+- Per-item error handling: partial success is returned, not all-or-nothing — allows editors to see which submissions failed and why
+- Service-layer batch methods accept full input object (not individual args) for cleaner API surface
+
+---
+
 ## 2026-02-28 — Track 7: Blind/Anonymous Review Mode
 
 ### Done

--- a/packages/types/src/__tests__/batch.spec.ts
+++ b/packages/types/src/__tests__/batch.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  batchStatusChangeInputSchema,
+  batchAssignReviewersInputSchema,
+  batchStatusChangeResponseSchema,
+  batchAssignReviewersResponseSchema,
+} from "../submission";
+
+const uuid = () => "550e8400-e29b-41d4-a716-446655440000";
+
+describe("batchStatusChangeInputSchema", () => {
+  it("accepts valid input", () => {
+    const result = batchStatusChangeInputSchema.parse({
+      submissionIds: [uuid()],
+      status: "UNDER_REVIEW",
+    });
+    expect(result.submissionIds).toHaveLength(1);
+    expect(result.status).toBe("UNDER_REVIEW");
+    expect(result.comment).toBeUndefined();
+  });
+
+  it("accepts valid input with comment", () => {
+    const result = batchStatusChangeInputSchema.parse({
+      submissionIds: [uuid()],
+      status: "REJECTED",
+      comment: "Not a fit for this issue",
+    });
+    expect(result.comment).toBe("Not a fit for this issue");
+  });
+
+  it("rejects empty submissionIds array", () => {
+    expect(() =>
+      batchStatusChangeInputSchema.parse({
+        submissionIds: [],
+        status: "UNDER_REVIEW",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects more than 50 submissionIds", () => {
+    const ids = Array.from({ length: 51 }, () => uuid());
+    expect(() =>
+      batchStatusChangeInputSchema.parse({
+        submissionIds: ids,
+        status: "UNDER_REVIEW",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects invalid status", () => {
+    expect(() =>
+      batchStatusChangeInputSchema.parse({
+        submissionIds: [uuid()],
+        status: "INVALID",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("batchAssignReviewersInputSchema", () => {
+  it("accepts valid input", () => {
+    const result = batchAssignReviewersInputSchema.parse({
+      submissionIds: [uuid()],
+      reviewerUserIds: [uuid()],
+    });
+    expect(result.submissionIds).toHaveLength(1);
+    expect(result.reviewerUserIds).toHaveLength(1);
+  });
+
+  it("rejects empty reviewerUserIds", () => {
+    expect(() =>
+      batchAssignReviewersInputSchema.parse({
+        submissionIds: [uuid()],
+        reviewerUserIds: [],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects more than 20 reviewerUserIds", () => {
+    const ids = Array.from({ length: 21 }, () => uuid());
+    expect(() =>
+      batchAssignReviewersInputSchema.parse({
+        submissionIds: [uuid()],
+        reviewerUserIds: ids,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("batchStatusChangeResponseSchema", () => {
+  it("parses all-success response", () => {
+    const result = batchStatusChangeResponseSchema.parse({
+      succeeded: [
+        {
+          submissionId: uuid(),
+          previousStatus: "SUBMITTED",
+          status: "UNDER_REVIEW",
+        },
+      ],
+      failed: [],
+    });
+    expect(result.succeeded).toHaveLength(1);
+    expect(result.failed).toHaveLength(0);
+  });
+
+  it("parses partial failure response", () => {
+    const result = batchStatusChangeResponseSchema.parse({
+      succeeded: [
+        {
+          submissionId: uuid(),
+          previousStatus: "SUBMITTED",
+          status: "UNDER_REVIEW",
+        },
+      ],
+      failed: [{ submissionId: uuid(), error: "Invalid transition" }],
+    });
+    expect(result.succeeded).toHaveLength(1);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].error).toBe("Invalid transition");
+  });
+
+  it("parses all-failed response", () => {
+    const result = batchStatusChangeResponseSchema.parse({
+      succeeded: [],
+      failed: [{ submissionId: uuid(), error: "Not found" }],
+    });
+    expect(result.succeeded).toHaveLength(0);
+    expect(result.failed).toHaveLength(1);
+  });
+});
+
+describe("batchAssignReviewersResponseSchema", () => {
+  it("parses valid response", () => {
+    const result = batchAssignReviewersResponseSchema.parse({
+      succeeded: [{ submissionId: uuid(), assignedCount: 3 }],
+      failed: [{ submissionId: uuid(), error: "Submission not found" }],
+    });
+    expect(result.succeeded).toHaveLength(1);
+    expect(result.succeeded[0].assignedCount).toBe(3);
+    expect(result.failed).toHaveLength(1);
+  });
+});

--- a/packages/types/src/submission.ts
+++ b/packages/types/src/submission.ts
@@ -486,3 +486,58 @@ export const markReviewerReadInputSchema = z.object({
   submissionId: z.string().uuid(),
 });
 export type MarkReviewerReadInput = z.infer<typeof markReviewerReadInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Batch operation schemas
+// ---------------------------------------------------------------------------
+
+export const BATCH_MAX_SIZE = 50;
+
+export const batchStatusChangeInputSchema = z.object({
+  submissionIds: z.array(z.string().uuid()).min(1).max(BATCH_MAX_SIZE),
+  status: submissionStatusSchema,
+  comment: z.string().max(1000).optional(),
+});
+export type BatchStatusChangeInput = z.infer<
+  typeof batchStatusChangeInputSchema
+>;
+
+export const batchAssignReviewersInputSchema = z.object({
+  submissionIds: z.array(z.string().uuid()).min(1).max(BATCH_MAX_SIZE),
+  reviewerUserIds: z.array(z.string().uuid()).min(1).max(20),
+});
+export type BatchAssignReviewersInput = z.infer<
+  typeof batchAssignReviewersInputSchema
+>;
+
+export const batchResultItemSchema = z.object({
+  submissionId: z.string().uuid(),
+  error: z.string(),
+});
+
+export const batchStatusChangeResponseSchema = z.object({
+  succeeded: z.array(
+    z.object({
+      submissionId: z.string().uuid(),
+      previousStatus: submissionStatusSchema,
+      status: submissionStatusSchema,
+    }),
+  ),
+  failed: z.array(batchResultItemSchema),
+});
+export type BatchStatusChangeResponse = z.infer<
+  typeof batchStatusChangeResponseSchema
+>;
+
+export const batchAssignReviewersResponseSchema = z.object({
+  succeeded: z.array(
+    z.object({
+      submissionId: z.string().uuid(),
+      assignedCount: z.number().int(),
+    }),
+  ),
+  failed: z.array(batchResultItemSchema),
+});
+export type BatchAssignReviewersResponse = z.infer<
+  typeof batchAssignReviewersResponseSchema
+>;


### PR DESCRIPTION
## Summary

- Full-stack batch operations: bulk status transitions + bulk reviewer assignment for the editor submission queue
- All 3 API surfaces (tRPC, REST, GraphQL) with shared service layer and Zod validation
- Frontend `BatchActionBar` with context-aware buttons, reviewer assignment dialog, and confirmation dialog for destructive actions (REJECTED, ACCEPTED)
- `useRowSelection` hook for checkbox state management
- 36 new tests (12 schema, 11 service, 8 component, 5 hook) — all passing

## Details

**Types:** `batchStatusChangeInputSchema`, `batchAssignReviewersInputSchema` + response schemas (max 50 submissions, max 20 reviewers)

**Service:** `batchUpdateStatusAsEditor` + `batchAssignReviewersAsEditor` with per-item error handling (partial success/failure)

**REST:** `POST /submissions/batch/status` + `POST /submissions/batch/assign-reviewers`

**GraphQL:** `batchUpdateSubmissionStatus` + `batchAssignReviewers` mutations with 5 payload types

**Frontend:** `BatchActionBar` with AlertDialog for destructive actions, reviewer cap at 20 in UI

## Test plan

- [ ] `pnpm --filter @colophony/types test` — 12 batch schema tests
- [ ] `cd apps/api && pnpm test -- src/services/submission.service.batch.spec.ts` — 11 service tests
- [ ] `cd apps/web && pnpm test -- src/components/submissions/__tests__/batch-action-bar.spec.tsx` — 8 component tests
- [ ] `cd apps/web && pnpm test -- src/hooks/__tests__/use-row-selection.spec.ts` — 5 hook tests
- [ ] `pnpm type-check` — clean across all packages