### PR TITLE
feat(web): mobile navigation polish

### DIFF
--- a/apps/web/src/components/layout/__tests__/header.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/header.spec.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Header } from "../header";
+
+// --- Mutable mock state ---
+let mockPathname = "/";
+let mockIsAuthenticated = true;
+const mockLogin = jest.fn();
+
+// Track pathname subscribers for simulating navigation
+let pathnameCallback: (() => string) | null = null;
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+    refresh: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+  usePathname: () => mockPathname,
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => React.createElement("a", { href, className }, children),
+}));
+
+jest.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    isAuthenticated: mockIsAuthenticated,
+    login: mockLogin,
+  }),
+}));
+
+jest.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({
+    currentOrg: {
+      id: "org-1",
+      name: "Test Org",
+      slug: "test-org",
+      role: "ADMIN",
+    },
+    organizations: [
+      { id: "org-1", name: "Test Org", slug: "test-org", role: "ADMIN" },
+    ],
+    switchOrganization: jest.fn(),
+    isAdmin: true,
+  }),
+}));
+
+jest.mock("@/components/notifications/notification-bell", () => ({
+  NotificationBell: () => <div data-testid="notification-bell">Bell</div>,
+}));
+
+jest.mock("@/components/plugins/plugin-slot", () => ({
+  PluginSlot: () => null,
+}));
+
+describe("Header", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPathname = "/";
+    mockIsAuthenticated = true;
+  });
+
+  it("renders hamburger menu button on mobile", () => {
+    render(<Header />);
+    const toggleButton = screen.getByRole("button", { name: /toggle menu/i });
+    expect(toggleButton).toBeInTheDocument();
+  });
+
+  it("hides hamburger on desktop via md:hidden class", () => {
+    render(<Header />);
+    const toggleButton = screen.getByRole("button", { name: /toggle menu/i });
+    expect(toggleButton.className).toContain("md:hidden");
+  });
+
+  it("renders navigation sheet when opened", async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+
+    const toggleButton = screen.getByRole("button", { name: /toggle menu/i });
+    await user.click(toggleButton);
+
+    // Sheet should be open — Sidebar renders navigation links
+    expect(screen.getByText("My Submissions")).toBeInTheDocument();
+  });
+
+  it("includes accessible sheet title", async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+
+    const toggleButton = screen.getByRole("button", { name: /toggle menu/i });
+    await user.click(toggleButton);
+
+    const sheetTitle = screen.getByText("Navigation");
+    expect(sheetTitle).toBeInTheDocument();
+    expect(sheetTitle.className).toContain("sr-only");
+  });
+
+  it("closes sheet on pathname change", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<Header />);
+
+    // Open the sheet
+    const toggleButton = screen.getByRole("button", { name: /toggle menu/i });
+    await user.click(toggleButton);
+
+    // Verify sheet is open
+    expect(screen.getByText("My Submissions")).toBeInTheDocument();
+
+    // Simulate navigation by changing pathname and re-rendering
+    mockPathname = "/submissions";
+    rerender(<Header />);
+
+    // The sheet content should no longer be visible
+    // (controlled state set to false by useEffect on pathname change)
+    expect(screen.queryByText("Navigation")).not.toBeInTheDocument();
+  });
+
+  it("renders sign in button when not authenticated", () => {
+    mockIsAuthenticated = false;
+    render(<Header />);
+
+    expect(
+      screen.getByRole("button", { name: /sign in/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders org switcher and user menu when authenticated", () => {
+    render(<Header />);
+
+    expect(screen.getByText("Test Org")).toBeInTheDocument();
+    expect(screen.getByTestId("notification-bell")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/__tests__/header.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/header.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Header } from "../header";
 
@@ -7,9 +7,6 @@ import { Header } from "../header";
 let mockPathname = "/";
 let mockIsAuthenticated = true;
 const mockLogin = jest.fn();
-
-// Track pathname subscribers for simulating navigation
-let pathnameCallback: (() => string) | null = null;
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -125,7 +122,7 @@ describe("Header", () => {
     rerender(<Header />);
 
     // The sheet content should no longer be visible
-    // (controlled state set to false by useEffect on pathname change)
+    // (controlled state reset during render when pathname changes)
     expect(screen.queryByText("Navigation")).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuth } from "@/hooks/use-auth";
@@ -22,9 +22,14 @@ export function Header() {
   const pathname = usePathname();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
-  useEffect(() => {
-    setMobileMenuOpen(false);
-  }, [pathname]);
+  // Close mobile menu on navigation (render-phase state reset, per React docs)
+  const prevPathnameRef = useRef(pathname);
+  if (prevPathnameRef.current !== pathname) {
+    prevPathnameRef.current = pathname;
+    if (mobileMenuOpen) {
+      setMobileMenuOpen(false);
+    }
+  }
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuth } from "@/hooks/use-auth";
@@ -17,36 +17,35 @@ import { Menu } from "lucide-react";
 import { Sidebar } from "./sidebar";
 import { NotificationBell } from "@/components/notifications/notification-bell";
 
+/** Keyed by pathname — remounts on navigation to auto-close the sheet. */
+function MobileMenu() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button variant="ghost" size="icon" className="md:hidden mr-2">
+          <Menu className="h-5 w-5" />
+          <span className="sr-only">Toggle menu</span>
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="left" className="w-64 p-0">
+        <SheetTitle className="sr-only">Navigation</SheetTitle>
+        <Sidebar />
+      </SheetContent>
+    </Sheet>
+  );
+}
+
 export function Header() {
   const { isAuthenticated, login } = useAuth();
   const pathname = usePathname();
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-
-  // Close mobile menu on navigation (render-phase state reset, per React docs)
-  const prevPathnameRef = useRef(pathname);
-  if (prevPathnameRef.current !== pathname) {
-    prevPathnameRef.current = pathname;
-    if (mobileMenuOpen) {
-      setMobileMenuOpen(false);
-    }
-  }
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-14 items-center">
-        {/* Mobile menu */}
-        <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
-          <SheetTrigger asChild>
-            <Button variant="ghost" size="icon" className="md:hidden mr-2">
-              <Menu className="h-5 w-5" />
-              <span className="sr-only">Toggle menu</span>
-            </Button>
-          </SheetTrigger>
-          <SheetContent side="left" className="w-64 p-0">
-            <SheetTitle className="sr-only">Navigation</SheetTitle>
-            <Sidebar />
-          </SheetContent>
-        </Sheet>
+        {/* Mobile menu — key resets state on navigation */}
+        <MobileMenu key={pathname} />
 
         {/* Logo */}
         <Link href="/" className="flex items-center space-x-2 mr-6">

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -1,23 +1,36 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useAuth } from "@/hooks/use-auth";
 import { OrgSwitcher } from "./org-switcher";
 import { UserMenu } from "./user-menu";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 import { Menu } from "lucide-react";
 import { Sidebar } from "./sidebar";
 import { NotificationBell } from "@/components/notifications/notification-bell";
 
 export function Header() {
   const { isAuthenticated, login } = useAuth();
+  const pathname = usePathname();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    setMobileMenuOpen(false);
+  }, [pathname]);
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-14 items-center">
         {/* Mobile menu */}
-        <Sheet>
+        <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
           <SheetTrigger asChild>
             <Button variant="ghost" size="icon" className="md:hidden mr-2">
               <Menu className="h-5 w-5" />
@@ -25,6 +38,7 @@ export function Header() {
             </Button>
           </SheetTrigger>
           <SheetContent side="left" className="w-64 p-0">
+            <SheetTitle className="sr-only">Navigation</SheetTitle>
             <Sidebar />
           </SheetContent>
         </Sheet>

--- a/apps/web/src/components/layout/org-switcher.tsx
+++ b/apps/web/src/components/layout/org-switcher.tsx
@@ -32,14 +32,17 @@ export function OrgSwitcher() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" className="w-[200px] justify-between">
+        <Button
+          variant="outline"
+          className="w-auto sm:w-[200px] justify-between"
+        >
           <div className="flex items-center gap-2 truncate">
             <Building2 className="h-4 w-4 flex-shrink-0" />
-            <span className="truncate">
+            <span className="hidden sm:inline truncate">
               {currentOrg?.name ?? "Select organization"}
             </span>
           </div>
-          <ChevronsUpDown className="h-4 w-4 opacity-50 flex-shrink-0" />
+          <ChevronsUpDown className="hidden sm:block h-4 w-4 opacity-50 flex-shrink-0" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-[200px]" align="end">

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -330,7 +330,7 @@
 
 ### UI Polish
 
-- [ ] [P1] Mobile navigation — hamburger menu or bottom nav for `< md` breakpoints; sidebar is currently `hidden md:flex` with no mobile alternative — (persona gap analysis 2026-02-27)
+- [x] [P1] Mobile navigation — hamburger menu or bottom nav for `< md` breakpoints; sidebar is currently `hidden md:flex` with no mobile alternative — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [ ] [P2] Column sorting in submission queue — sortable by title, submitter, date, status; currently hardcoded `DESC createdAt` — (persona gap analysis 2026-02-27)
 - [ ] [P2] Submission period filter in editor queue — the API supports `submissionPeriodId` filter but the UI doesn't expose a period dropdown — (persona gap analysis 2026-02-27)
 - [ ] [P3] Saved filter presets / views — editors can save named filter+sort combos for their queue — (persona gap analysis 2026-02-27)

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,21 @@ Newest entries first.
 
 ---
 
+## 2026-02-28 — Mobile Navigation Polish
+
+### Done
+
+- **Auto-close Sheet on navigation:** Converted `<Sheet>` in `header.tsx` to controlled state with `usePathname()` effect — tapping a sidebar link now closes the drawer automatically
+- **Accessibility:** Added `<SheetTitle className="sr-only">Navigation</SheetTitle>` to satisfy Radix Dialog a11y requirement (screen reader label)
+- **Responsive OrgSwitcher:** Trigger button collapses to icon-only (`Building2`) below `sm` breakpoint; org name and chevron hidden on mobile via `hidden sm:inline` / `hidden sm:block`
+- **Tests:** New `header.spec.tsx` with 7 tests (hamburger render, md:hidden class, sheet open, a11y title, auto-close on pathname change, auth states)
+
+### Decisions
+
+- Kept existing hamburger + Sheet pattern (was already in place); focused on polish rather than bottom nav alternative
+
+---
+
 ## 2026-02-28 — Track 3: Batch Operations for Editor Submission Queue
 
 ### Done


### PR DESCRIPTION
## Summary

- Auto-close mobile navigation Sheet on client-side route changes (extracted `MobileMenu` component with `key={pathname}` pattern)
- Added `<SheetTitle className="sr-only">` for Radix Dialog accessibility (screen reader label)
- Made `OrgSwitcher` responsive: icon-only (`Building2`) below `sm` breakpoint, full width at `sm+`
- New `header.spec.tsx` test suite (7 tests)

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `header.tsx` | `useState` + `useEffect` for auto-close | Extracted `MobileMenu` component with `key={pathname}` | React Compiler lint rules (`react-hooks/set-state-in-effect`, `react-hooks/refs`) blocked both `useEffect` and ref-during-render patterns; `key` remount is the idiomatic React approach |

## Test plan

- [x] `npx jest header.spec` — 7 tests pass
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean (0 errors in changed files)
- [ ] Manual: mobile viewport, tap hamburger, tap a link — sheet closes and page navigates