### PR TITLE
feat(hopper): embed submitter confirmation email + status check page

### DIFF
--- a/apps/api/src/graphql/resolvers/submissions-mutations.spec.ts
+++ b/apps/api/src/graphql/resolvers/submissions-mutations.spec.ts
@@ -306,6 +306,7 @@ describe('Submission mutations — resolver wiring', () => {
       searchVector: null,
       transferredFromDomain: null,
       transferredFromTransferId: null,
+      statusTokenHash: null,
     };
     // eslint-disable-next-line @typescript-eslint/unbound-method
     vi.mocked(submissionService.createWithAudit).mockResolvedValue(submission);
@@ -409,6 +410,7 @@ describe('Submission mutations — resolver wiring', () => {
         searchVector: null,
         transferredFromDomain: null,
         transferredFromTransferId: null,
+        statusTokenHash: null,
       },
       historyEntry: {
         id: 'hist-1',
@@ -477,6 +479,7 @@ describe('Submission mutations — resolver wiring', () => {
       searchVector: null,
       transferredFromDomain: null,
       transferredFromTransferId: null,
+      statusTokenHash: null,
     };
     // eslint-disable-next-line @typescript-eslint/unbound-method
     vi.mocked(submissionService.createWithAudit).mockResolvedValue(submission);
@@ -554,6 +557,7 @@ describe('Submission mutations — resolver wiring', () => {
       searchVector: null,
       transferredFromDomain: null,
       transferredFromTransferId: null,
+      statusTokenHash: null,
     };
     // eslint-disable-next-line @typescript-eslint/unbound-method
     vi.mocked(submissionService.updateAsOwner).mockResolvedValue(submission);

--- a/apps/api/src/inngest/events.ts
+++ b/apps/api/src/inngest/events.ts
@@ -98,6 +98,9 @@ export interface HopperSubmissionSubmittedEvent {
     orgId: string;
     submissionId: string;
     submitterId: string;
+    isEmbed?: boolean;
+    submitterEmail?: string;
+    statusToken?: string;
   };
 }
 

--- a/apps/api/src/inngest/functions/__tests__/embed-submission-confirmation.spec.ts
+++ b/apps/api/src/inngest/functions/__tests__/embed-submission-confirmation.spec.ts
@@ -126,30 +126,34 @@ describe('embedSubmissionConfirmation', () => {
     } as ReturnType<typeof validateEnv>);
 
     // Mock withRls to resolve data
-    mockWithRls.mockImplementation(async (_ctx: unknown, fn: Function) => {
-      const mockTx = {};
-      return fn(mockTx);
-    });
+    mockWithRls.mockImplementation(
+      async (_ctx: unknown, fn: (tx: unknown) => Promise<unknown>) => {
+        const mockTx = {};
+        return fn(mockTx);
+      },
+    );
 
     // First call: resolve-data (withRls for submission + org lookup)
     let resolveDataCallIndex = 0;
-    mockWithRls.mockImplementation(async (_ctx: unknown, fn: Function) => {
-      resolveDataCallIndex++;
-      const mockTx = {
-        select: vi.fn().mockReturnThis(),
-        from: vi.fn().mockReturnThis(),
-        where: vi.fn().mockReturnThis(),
-        limit: vi.fn().mockImplementation(() => {
-          // First limit call: submission query
-          // Second limit call: org query
-          if (resolveDataCallIndex === 1) {
-            return Promise.resolve([{ title: 'My Great Poem' }]);
-          }
-          return Promise.resolve([{ name: 'Poetry Review' }]);
-        }),
-      };
-      return fn(mockTx);
-    });
+    mockWithRls.mockImplementation(
+      async (_ctx: unknown, fn: (tx: unknown) => Promise<unknown>) => {
+        resolveDataCallIndex++;
+        const mockTx = {
+          select: vi.fn().mockReturnThis(),
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockImplementation(() => {
+            // First limit call: submission query
+            // Second limit call: org query
+            if (resolveDataCallIndex === 1) {
+              return Promise.resolve([{ title: 'My Great Poem' }]);
+            }
+            return Promise.resolve([{ name: 'Poetry Review' }]);
+          }),
+        };
+        return fn(mockTx);
+      },
+    );
 
     const step = makeStep();
     // Override step.run to actually execute functions but also let us check calls

--- a/apps/api/src/inngest/functions/__tests__/embed-submission-confirmation.spec.ts
+++ b/apps/api/src/inngest/functions/__tests__/embed-submission-confirmation.spec.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockWithRls = vi.fn();
+vi.mock('@colophony/db', () => ({
+  withRls: (...args: unknown[]) => mockWithRls(...args),
+  submissions: { id: 'id', title: 'title' },
+  organizations: { id: 'id', name: 'name' },
+  eq: vi.fn(),
+}));
+
+const mockCreateEmail = vi.fn().mockResolvedValue({ id: 'es-1' });
+vi.mock('../../../services/email.service.js', () => ({
+  emailService: {
+    create: (...args: unknown[]) => mockCreateEmail(...args),
+  },
+}));
+
+const mockAuditLog = vi.fn();
+vi.mock('../../../services/audit.service.js', () => ({
+  auditService: {
+    log: (...args: unknown[]) => mockAuditLog(...args),
+  },
+}));
+
+vi.mock('@colophony/types', () => ({
+  AuditActions: { EMAIL_QUEUED: 'EMAIL_QUEUED' },
+  AuditResources: { EMAIL: 'email' },
+}));
+
+const mockEnqueueEmail = vi.fn();
+vi.mock('../../../queues/email.queue.js', () => ({
+  enqueueEmail: (...args: unknown[]) => mockEnqueueEmail(...args),
+}));
+
+vi.mock('../../../config/env.js', () => ({
+  validateEnv: vi.fn(() => ({
+    EMAIL_PROVIDER: 'smtp',
+    SMTP_FROM: 'noreply@test.com',
+    CORS_ORIGIN: 'http://localhost:3000',
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: '',
+  })),
+}));
+
+vi.mock('../../client.js', () => ({
+  inngest: {
+    createFunction: vi.fn(
+      (_config: unknown, _trigger: unknown, handler: unknown) => handler,
+    ),
+  },
+}));
+
+import { embedSubmissionConfirmation } from '../embed-submission-confirmation.js';
+
+// The mock makes createFunction return the handler directly
+const handler = embedSubmissionConfirmation as unknown as (ctx: {
+  event: { data: Record<string, unknown> };
+  step: { run: (name: string, fn: () => Promise<unknown>) => Promise<unknown> };
+}) => Promise<Record<string, unknown>>;
+
+function makeStep() {
+  return {
+    run: vi.fn((_name: string, fn: () => Promise<unknown>) => fn()),
+  };
+}
+
+describe('embedSubmissionConfirmation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips non-embed submissions (isEmbed falsy)', async () => {
+    const result = await handler({
+      event: {
+        data: {
+          orgId: 'org-1',
+          submissionId: 'sub-1',
+          submitterId: 'user-1',
+          // No isEmbed, submitterEmail, statusToken
+        },
+      },
+      step: makeStep(),
+    });
+
+    expect(result).toEqual({
+      skipped: true,
+      reason: 'not-embed-submission',
+    });
+    expect(mockEnqueueEmail).not.toHaveBeenCalled();
+  });
+
+  it('skips when EMAIL_PROVIDER is none', async () => {
+    const { validateEnv } = await import('../../../config/env.js');
+    vi.mocked(validateEnv).mockReturnValue({
+      EMAIL_PROVIDER: 'none',
+    } as ReturnType<typeof validateEnv>);
+
+    const result = await handler({
+      event: {
+        data: {
+          orgId: 'org-1',
+          submissionId: 'sub-1',
+          submitterId: 'user-1',
+          isEmbed: true,
+          submitterEmail: 'test@example.com',
+          statusToken: 'col_sta_abc123',
+        },
+      },
+      step: makeStep(),
+    });
+
+    expect(result).toEqual({ skipped: true, reason: 'email-disabled' });
+    expect(mockEnqueueEmail).not.toHaveBeenCalled();
+  });
+
+  it('queues confirmation email with correct template data for embed submission', async () => {
+    const { validateEnv } = await import('../../../config/env.js');
+    vi.mocked(validateEnv).mockReturnValue({
+      EMAIL_PROVIDER: 'smtp',
+      SMTP_FROM: 'noreply@test.com',
+      CORS_ORIGIN: 'http://localhost:3000',
+      REDIS_HOST: 'localhost',
+      REDIS_PORT: 6379,
+      REDIS_PASSWORD: '',
+    } as ReturnType<typeof validateEnv>);
+
+    // Mock withRls to resolve data
+    mockWithRls.mockImplementation(async (_ctx: unknown, fn: Function) => {
+      const mockTx = {};
+      return fn(mockTx);
+    });
+
+    // First call: resolve-data (withRls for submission + org lookup)
+    let resolveDataCallIndex = 0;
+    mockWithRls.mockImplementation(async (_ctx: unknown, fn: Function) => {
+      resolveDataCallIndex++;
+      const mockTx = {
+        select: vi.fn().mockReturnThis(),
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockImplementation(() => {
+          // First limit call: submission query
+          // Second limit call: org query
+          if (resolveDataCallIndex === 1) {
+            return Promise.resolve([{ title: 'My Great Poem' }]);
+          }
+          return Promise.resolve([{ name: 'Poetry Review' }]);
+        }),
+      };
+      return fn(mockTx);
+    });
+
+    const step = makeStep();
+    // Override step.run to actually execute functions but also let us check calls
+    step.run.mockImplementation(
+      async (name: string, fn: () => Promise<unknown>) => {
+        if (name === 'resolve-data') {
+          return { submissionTitle: 'My Great Poem', orgName: 'Poetry Review' };
+        }
+        return fn();
+      },
+    );
+
+    const result = await handler({
+      event: {
+        data: {
+          orgId: 'org-1',
+          submissionId: 'sub-1',
+          submitterId: 'user-1',
+          isEmbed: true,
+          submitterEmail: 'submitter@example.com',
+          statusToken: 'col_sta_abc123def456',
+        },
+      },
+      step,
+    });
+
+    expect(result).toEqual({ sent: true, to: 'submitter@example.com' });
+    expect(mockEnqueueEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ EMAIL_PROVIDER: 'smtp' }),
+      expect.objectContaining({
+        to: 'submitter@example.com',
+        templateName: 'embed-submission-confirmation',
+        templateData: {
+          submissionTitle: 'My Great Poem',
+          orgName: 'Poetry Review',
+          statusCheckUrl:
+            'http://localhost:3000/embed/status/col_sta_abc123def456',
+        },
+      }),
+    );
+  });
+});

--- a/apps/api/src/inngest/functions/embed-submission-confirmation.ts
+++ b/apps/api/src/inngest/functions/embed-submission-confirmation.ts
@@ -1,0 +1,93 @@
+import { withRls, submissions, organizations, eq } from '@colophony/db';
+import { AuditActions, AuditResources } from '@colophony/types';
+import { inngest } from '../client.js';
+import type { HopperSubmissionSubmittedEvent } from '../events.js';
+import { emailService } from '../../services/email.service.js';
+import { auditService } from '../../services/audit.service.js';
+import { enqueueEmail } from '../../queues/email.queue.js';
+import { validateEnv } from '../../config/env.js';
+
+export const embedSubmissionConfirmation = inngest.createFunction(
+  {
+    id: 'embed-submission-confirmation',
+    name: 'Embed Submission Confirmation Email',
+    retries: 3,
+  },
+  { event: 'hopper/submission.submitted' },
+  async ({ event, step }) => {
+    const { orgId, submissionId, isEmbed, submitterEmail, statusToken } =
+      event.data as HopperSubmissionSubmittedEvent['data'];
+
+    // Only handle embed submissions
+    if (!isEmbed || !submitterEmail || !statusToken) {
+      return { skipped: true, reason: 'not-embed-submission' };
+    }
+
+    const env = validateEnv();
+    if (env.EMAIL_PROVIDER === 'none') {
+      return { skipped: true, reason: 'email-disabled' };
+    }
+
+    const data = await step.run('resolve-data', async () => {
+      return withRls({ orgId }, async (tx) => {
+        const [submission] = await tx
+          .select({ title: submissions.title })
+          .from(submissions)
+          .where(eq(submissions.id, submissionId))
+          .limit(1);
+
+        const [org] = await tx
+          .select({ name: organizations.name })
+          .from(organizations)
+          .where(eq(organizations.id, orgId))
+          .limit(1);
+
+        return {
+          submissionTitle: submission?.title ?? 'Untitled',
+          orgName: org?.name ?? 'Unknown Organization',
+        };
+      });
+    });
+
+    const statusCheckUrl = `${env.CORS_ORIGIN}/embed/status/${statusToken}`;
+
+    await step.run('queue-confirmation-email', async () => {
+      const emailSend = await withRls({ orgId }, async (tx) => {
+        const row = await emailService.create(tx, {
+          organizationId: orgId,
+          recipientEmail: submitterEmail,
+          templateName: 'embed-submission-confirmation',
+          eventType: 'embed.submission.confirmation',
+          subject: `Submission received: ${data.submissionTitle}`,
+        });
+        await auditService.log(tx, {
+          resource: AuditResources.EMAIL,
+          action: AuditActions.EMAIL_QUEUED,
+          resourceId: row.id,
+          organizationId: orgId,
+          newValue: {
+            to: submitterEmail,
+            templateName: 'embed-submission-confirmation',
+            eventType: 'embed.submission.confirmation',
+          },
+        });
+        return row;
+      });
+
+      await enqueueEmail(env, {
+        emailSendId: emailSend.id,
+        orgId,
+        to: submitterEmail,
+        from: env.SMTP_FROM ?? env.SENDGRID_FROM ?? 'noreply@colophony.dev',
+        templateName: 'embed-submission-confirmation',
+        templateData: {
+          submissionTitle: data.submissionTitle,
+          orgName: data.orgName,
+          statusCheckUrl,
+        },
+      });
+    });
+
+    return { sent: true, to: submitterEmail };
+  },
+);

--- a/apps/api/src/inngest/functions/index.ts
+++ b/apps/api/src/inngest/functions/index.ts
@@ -15,3 +15,4 @@ export {
 export { reviewerAssignedNotification } from './reviewer-notifications.js';
 export { discussionCommentNotification } from './discussion-notifications.js';
 export { webhookDelivery } from './webhook-delivery.js';
+export { embedSubmissionConfirmation } from './embed-submission-confirmation.js';

--- a/apps/api/src/inngest/serve.ts
+++ b/apps/api/src/inngest/serve.ts
@@ -15,6 +15,7 @@ import {
   reviewerAssignedNotification,
   discussionCommentNotification,
   webhookDelivery,
+  embedSubmissionConfirmation,
 } from './functions/index.js';
 
 /**
@@ -43,6 +44,7 @@ export async function registerInngestRoutes(
       reviewerAssignedNotification,
       discussionCommentNotification,
       webhookDelivery,
+      embedSubmissionConfirmation,
     ],
   });
 

--- a/apps/api/src/routes/embed.routes.spec.ts
+++ b/apps/api/src/routes/embed.routes.spec.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockEmbedTokenService, mockEmbedSubmissionService } = vi.hoisted(() => {
+const {
+  mockEmbedTokenService,
+  mockEmbedSubmissionService,
+  mockStatusTokenService,
+} = vi.hoisted(() => {
   const mockEmbedTokenService = {
     verifyToken: vi.fn(),
   };
@@ -10,11 +14,22 @@ const { mockEmbedTokenService, mockEmbedSubmissionService } = vi.hoisted(() => {
     prepareUpload: vi.fn(),
     getUploadStatus: vi.fn(),
   };
-  return { mockEmbedTokenService, mockEmbedSubmissionService };
+  const mockStatusTokenService = {
+    verifyToken: vi.fn(),
+  };
+  return {
+    mockEmbedTokenService,
+    mockEmbedSubmissionService,
+    mockStatusTokenService,
+  };
 });
 
 vi.mock('../services/embed-token.service.js', () => ({
   embedTokenService: mockEmbedTokenService,
+}));
+
+vi.mock('../services/status-token.service.js', () => ({
+  statusTokenService: mockStatusTokenService,
 }));
 
 vi.mock('../services/embed-submission.service.js', () => ({
@@ -164,12 +179,13 @@ describe('embed routes', () => {
   });
 
   describe('POST /embed/:token/submit', () => {
-    it('creates guest user and submission', async () => {
+    it('creates guest user and submission with status token', async () => {
       const token = makeVerifiedToken();
       mockEmbedTokenService.verifyToken.mockResolvedValueOnce(token);
       mockEmbedSubmissionService.submitFromEmbed.mockResolvedValueOnce({
         submissionId: 'sub-1',
         userId: 'user-1',
+        statusToken: 'col_sta_abc123',
       });
 
       const app = await buildTestApp();
@@ -187,6 +203,7 @@ describe('embed routes', () => {
       const body = JSON.parse(res.body);
       expect(body.success).toBe(true);
       expect(body.submissionId).toBe('sub-1');
+      expect(body.statusToken).toBe('col_sta_abc123');
     });
 
     it('returns 400 for invalid email', async () => {
@@ -364,6 +381,83 @@ describe('embed routes', () => {
       expect(res.statusCode).toBe(400);
       const body = JSON.parse(res.body);
       expect(body.error).toBe('validation_error');
+    });
+  });
+
+  describe('GET /embed/status/:statusToken', () => {
+    it('returns 404 for malformed token (wrong prefix)', async () => {
+      const app = await buildTestApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/embed/status/badprefix_abc123',
+      });
+
+      expect(res.statusCode).toBe(404);
+      expect(JSON.parse(res.body)).toMatchObject({ error: 'not_found' });
+      expect(mockStatusTokenService.verifyToken).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 for unknown valid-format token', async () => {
+      mockStatusTokenService.verifyToken.mockResolvedValueOnce(null);
+
+      const app = await buildTestApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/embed/status/col_sta_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1',
+      });
+
+      expect(res.statusCode).toBe(404);
+      expect(JSON.parse(res.body)).toMatchObject({ error: 'not_found' });
+    });
+
+    it('returns submission data for valid token', async () => {
+      mockStatusTokenService.verifyToken.mockResolvedValueOnce({
+        submissionId: 'sub-1',
+        title: 'My Poem',
+        status: 'Under Review',
+        submittedAt: new Date('2026-02-15T12:00:00Z'),
+        organizationName: 'Poetry Review',
+        periodName: 'Spring 2026',
+      });
+
+      const app = await buildTestApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/embed/status/col_sta_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body).toEqual({
+        title: 'My Poem',
+        status: 'Under Review',
+        submittedAt: '2026-02-15T12:00:00.000Z',
+        organizationName: 'Poetry Review',
+        periodName: 'Spring 2026',
+      });
+    });
+
+    it('returns null fields gracefully', async () => {
+      mockStatusTokenService.verifyToken.mockResolvedValueOnce({
+        submissionId: 'sub-1',
+        title: null,
+        status: 'Under Review',
+        submittedAt: null,
+        organizationName: 'Lit Mag',
+        periodName: null,
+      });
+
+      const app = await buildTestApp();
+      const res = await app.inject({
+        method: 'GET',
+        url: '/embed/status/col_sta_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.title).toBeNull();
+      expect(body.submittedAt).toBeNull();
+      expect(body.periodName).toBeNull();
     });
   });
 });

--- a/apps/api/src/routes/embed.routes.ts
+++ b/apps/api/src/routes/embed.routes.ts
@@ -4,6 +4,7 @@ import {
   embedSubmitSchema,
   embedPrepareUploadSchema,
   embedUploadStatusQuerySchema,
+  STATUS_TOKEN_PREFIX,
 } from '@colophony/types';
 import type { Env } from '../config/env.js';
 import {
@@ -14,6 +15,7 @@ import {
   embedSubmissionService,
   PeriodClosedError,
 } from '../services/embed-submission.service.js';
+import { statusTokenService } from '../services/status-token.service.js';
 
 /**
  * Atomic Lua script: INCR key, set PEXPIRE on first hit, return [count, pttl].
@@ -241,17 +243,19 @@ export async function registerEmbedRoutes(
       }
 
       try {
-        const { submissionId } = await embedSubmissionService.submitFromEmbed(
-          token,
-          parsed.data,
-          request.ip,
-          request.headers['user-agent'],
-        );
+        const { submissionId, statusToken } =
+          await embedSubmissionService.submitFromEmbed(
+            token,
+            parsed.data,
+            request.ip,
+            request.headers['user-agent'],
+          );
 
         return {
           success: true,
           submissionId,
           message: 'Submission received successfully',
+          statusToken,
         };
       } catch (err) {
         if (err instanceof PeriodClosedError) {
@@ -475,6 +479,88 @@ export async function registerEmbedRoutes(
         }
         throw err;
       }
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // GET /embed/status/:statusToken — public submission status check
+  // ---------------------------------------------------------------------------
+  app.get<{ Params: { statusToken: string } }>(
+    '/embed/status/:statusToken',
+    {
+      /* eslint-disable @typescript-eslint/no-misused-promises */
+      preHandler: async function embedStatusCheckRateLimit(
+        request: FastifyRequest,
+        reply: FastifyReply,
+      ) {
+        const redisClient = getRedis();
+        if (!redisClient) return;
+
+        const windowMs = env.RATE_LIMIT_WINDOW_SECONDS * 1000;
+        const windowId = Math.floor(Date.now() / windowMs);
+        const key = `${env.RATE_LIMIT_KEY_PREFIX}:embed:status:${request.ip}:${windowId}`;
+
+        try {
+          const result = (await redisClient.eval(
+            RATE_LIMIT_LUA,
+            1,
+            key,
+            windowMs,
+          )) as [number, number];
+          const count = result[0];
+
+          const statusLimit = 30;
+          if (count > statusLimit) {
+            const remainingMs = windowMs - (Date.now() % windowMs);
+            const retryAfterSeconds = Math.ceil(remainingMs / 1000);
+            reply.header('Retry-After', retryAfterSeconds);
+            request.log.warn(
+              { ip: request.ip, count, limit: statusLimit },
+              'Embed status check rate limit exceeded',
+            );
+            return reply.status(429).send({
+              error: 'rate_limit_exceeded',
+              message: 'Too many requests. Please try again later.',
+            });
+          }
+        } catch {
+          request.log.warn(
+            'Embed status check rate limit Redis error — allowing request',
+          );
+        }
+      },
+      /* eslint-enable @typescript-eslint/no-misused-promises */
+    },
+    async (request, reply) => {
+      const { statusToken } = request.params;
+
+      // Format check
+      if (
+        !statusToken.startsWith(STATUS_TOKEN_PREFIX) ||
+        statusToken.length < 20
+      ) {
+        return reply.status(404).send({
+          error: 'not_found',
+          message: 'Submission not found',
+        });
+      }
+
+      const result = await statusTokenService.verifyToken(statusToken);
+
+      if (!result) {
+        return reply.status(404).send({
+          error: 'not_found',
+          message: 'Submission not found',
+        });
+      }
+
+      return {
+        title: result.title,
+        status: result.status,
+        submittedAt: result.submittedAt?.toISOString() ?? null,
+        organizationName: result.organizationName,
+        periodName: result.periodName,
+      };
     },
   );
 }

--- a/apps/api/src/services/__tests__/status-token.service.spec.ts
+++ b/apps/api/src/services/__tests__/status-token.service.spec.ts
@@ -20,6 +20,9 @@ vi.mock('@colophony/types', () => ({
 import { statusTokenService } from '../status-token.service.js';
 import { pool } from '@colophony/db';
 
+// Extract to avoid @typescript-eslint/unbound-method on pool.query
+const mockPoolQuery = vi.mocked(pool.query);
+
 describe('statusTokenService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -57,21 +60,21 @@ describe('statusTokenService', () => {
 
   describe('verifyToken', () => {
     it('returns null for unknown token', async () => {
-      vi.mocked(pool.query).mockResolvedValue({ rows: [] } as never);
+      mockPoolQuery.mockResolvedValue({ rows: [] } as never);
 
       const result = await statusTokenService.verifyToken(
         'col_sta_0000000000000000000000000000dead',
       );
 
       expect(result).toBeNull();
-      expect(pool.query).toHaveBeenCalledWith(
+      expect(mockPoolQuery).toHaveBeenCalledWith(
         'SELECT * FROM verify_status_token($1)',
         [expect.stringMatching(/^[a-f0-9]{64}$/)],
       );
     });
 
     it('returns mapped result for valid token with user-friendly status', async () => {
-      vi.mocked(pool.query).mockResolvedValue({
+      mockPoolQuery.mockResolvedValue({
         rows: [
           {
             submission_id: 'sub-1',
@@ -99,7 +102,7 @@ describe('statusTokenService', () => {
     });
 
     it('maps ACCEPTED status correctly', async () => {
-      vi.mocked(pool.query).mockResolvedValue({
+      mockPoolQuery.mockResolvedValue({
         rows: [
           {
             submission_id: 'sub-2',
@@ -118,7 +121,7 @@ describe('statusTokenService', () => {
     });
 
     it('maps REJECTED to Not Accepted', async () => {
-      vi.mocked(pool.query).mockResolvedValue({
+      mockPoolQuery.mockResolvedValue({
         rows: [
           {
             submission_id: 'sub-3',

--- a/apps/api/src/services/__tests__/status-token.service.spec.ts
+++ b/apps/api/src/services/__tests__/status-token.service.spec.ts
@@ -20,7 +20,7 @@ vi.mock('@colophony/types', () => ({
 import { statusTokenService } from '../status-token.service.js';
 import { pool } from '@colophony/db';
 
-// Extract to avoid @typescript-eslint/unbound-method on pool.query
+// eslint-disable-next-line @typescript-eslint/unbound-method -- pool.query is a mock
 const mockPoolQuery = vi.mocked(pool.query);
 
 describe('statusTokenService', () => {

--- a/apps/api/src/services/__tests__/status-token.service.spec.ts
+++ b/apps/api/src/services/__tests__/status-token.service.spec.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import crypto from 'node:crypto';
+
+const mockUpdate = vi.fn().mockReturnThis();
+const mockSet = vi.fn().mockReturnThis();
+const mockWhere = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@colophony/db', () => ({
+  pool: {
+    query: vi.fn(),
+  },
+  submissions: { id: 'id', statusTokenHash: 'status_token_hash' },
+  eq: vi.fn(),
+}));
+
+vi.mock('@colophony/types', () => ({
+  STATUS_TOKEN_PREFIX: 'col_sta_',
+}));
+
+import { statusTokenService } from '../status-token.service.js';
+import { pool } from '@colophony/db';
+
+describe('statusTokenService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('generateAndStore', () => {
+    it('stores SHA-256 hash and returns col_sta_ prefixed token', async () => {
+      const mockTx = {
+        update: mockUpdate,
+      } as unknown as Parameters<typeof statusTokenService.generateAndStore>[0];
+      mockUpdate.mockReturnValue({ set: mockSet });
+      mockSet.mockReturnValue({ where: mockWhere });
+
+      const token = await statusTokenService.generateAndStore(
+        mockTx,
+        'sub-123',
+      );
+
+      expect(token).toMatch(/^col_sta_[a-f0-9]{32}$/);
+      expect(mockUpdate).toHaveBeenCalled();
+      expect(mockSet).toHaveBeenCalledWith({
+        statusTokenHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      });
+
+      // Verify the stored hash is the SHA-256 of the returned token
+      const expectedHash = crypto
+        .createHash('sha256')
+        .update(token)
+        .digest('hex');
+      expect(mockSet).toHaveBeenCalledWith({
+        statusTokenHash: expectedHash,
+      });
+    });
+  });
+
+  describe('verifyToken', () => {
+    it('returns null for unknown token', async () => {
+      vi.mocked(pool.query).mockResolvedValue({ rows: [] } as never);
+
+      const result = await statusTokenService.verifyToken(
+        'col_sta_0000000000000000000000000000dead',
+      );
+
+      expect(result).toBeNull();
+      expect(pool.query).toHaveBeenCalledWith(
+        'SELECT * FROM verify_status_token($1)',
+        [expect.stringMatching(/^[a-f0-9]{64}$/)],
+      );
+    });
+
+    it('returns mapped result for valid token with user-friendly status', async () => {
+      vi.mocked(pool.query).mockResolvedValue({
+        rows: [
+          {
+            submission_id: 'sub-1',
+            submission_title: 'My Poem',
+            submission_status: 'HOLD',
+            submitted_at: new Date('2026-01-15T00:00:00Z'),
+            organization_name: 'Poetry Review',
+            period_name: 'Spring 2026',
+          },
+        ],
+      } as never);
+
+      const result = await statusTokenService.verifyToken(
+        'col_sta_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1',
+      );
+
+      expect(result).toEqual({
+        submissionId: 'sub-1',
+        title: 'My Poem',
+        status: 'Under Review', // HOLD maps to Under Review
+        submittedAt: new Date('2026-01-15T00:00:00Z'),
+        organizationName: 'Poetry Review',
+        periodName: 'Spring 2026',
+      });
+    });
+
+    it('maps ACCEPTED status correctly', async () => {
+      vi.mocked(pool.query).mockResolvedValue({
+        rows: [
+          {
+            submission_id: 'sub-2',
+            submission_title: 'Story',
+            submission_status: 'ACCEPTED',
+            submitted_at: null,
+            organization_name: 'Lit Mag',
+            period_name: null,
+          },
+        ],
+      } as never);
+
+      const result = await statusTokenService.verifyToken('col_sta_test');
+
+      expect(result?.status).toBe('Accepted');
+    });
+
+    it('maps REJECTED to Not Accepted', async () => {
+      vi.mocked(pool.query).mockResolvedValue({
+        rows: [
+          {
+            submission_id: 'sub-3',
+            submission_title: 'Essay',
+            submission_status: 'REJECTED',
+            submitted_at: null,
+            organization_name: 'Review',
+            period_name: null,
+          },
+        ],
+      } as never);
+
+      const result = await statusTokenService.verifyToken('col_sta_test');
+
+      expect(result?.status).toBe('Not Accepted');
+    });
+  });
+});

--- a/apps/api/src/services/embed-submission.service.spec.ts
+++ b/apps/api/src/services/embed-submission.service.spec.ts
@@ -6,6 +6,8 @@ const {
   mockAuditService,
   mockSubmissionService,
   mockFileService,
+  mockStatusTokenService,
+  mockEnqueueOutboxEvent,
 } = vi.hoisted(() => {
   const mockDb = {
     select: vi.fn(),
@@ -23,12 +25,18 @@ const {
   const mockFileService = {
     listByManuscriptVersion: vi.fn(),
   };
+  const mockStatusTokenService = {
+    generateAndStore: vi.fn().mockResolvedValue('col_sta_testtoken123'),
+  };
+  const mockEnqueueOutboxEvent = vi.fn();
   return {
     mockDb,
     mockWithRls,
     mockAuditService,
     mockSubmissionService,
     mockFileService,
+    mockStatusTokenService,
+    mockEnqueueOutboxEvent,
   };
 });
 
@@ -56,6 +64,8 @@ vi.mock('@colophony/db', () => ({
     formDefinitionId: 'form_definition_id',
     sortOrder: 'sort_order',
   },
+  submissions: { id: 'id', statusTokenHash: 'status_token_hash' },
+  pool: { query: vi.fn() },
   eq: vi.fn((_col: unknown, val: unknown) => val),
   sql: vi.fn(),
 }));
@@ -74,6 +84,14 @@ vi.mock('./submission.service.js', () => ({
 
 vi.mock('./file.service.js', () => ({
   fileService: mockFileService,
+}));
+
+vi.mock('./status-token.service.js', () => ({
+  statusTokenService: mockStatusTokenService,
+}));
+
+vi.mock('./outbox.js', () => ({
+  enqueueOutboxEvent: mockEnqueueOutboxEvent,
 }));
 
 import {

--- a/apps/api/src/services/embed-submission.service.ts
+++ b/apps/api/src/services/embed-submission.service.ts
@@ -27,6 +27,8 @@ import type { VerifiedEmbedToken } from './embed-token.service.js';
 import { auditService } from './audit.service.js';
 import { submissionService } from './submission.service.js';
 import { fileService } from './file.service.js';
+import { statusTokenService } from './status-token.service.js';
+import { enqueueOutboxEvent } from './outbox.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -257,7 +259,7 @@ export const embedSubmissionService = {
     input: EmbedSubmitInput,
     ipAddress: string,
     userAgent: string | undefined,
-  ): Promise<{ submissionId: string; userId: string }> {
+  ): Promise<{ submissionId: string; userId: string; statusToken: string }> {
     // Step 1: Find/create guest user (no RLS)
     const { id: userId, isNew } =
       await embedSubmissionService.findOrCreateGuestUser(
@@ -328,7 +330,23 @@ export const embedSubmissionService = {
           },
         });
 
-        return { submissionId: submission.id };
+        // Step 6: Generate status token for public status checking
+        const statusToken = await statusTokenService.generateAndStore(
+          tx,
+          submission.id,
+        );
+
+        // Step 7: Enqueue outbox event (triggers editor + embed confirmation notifications)
+        await enqueueOutboxEvent(tx, 'hopper/submission.submitted', {
+          orgId: token.organizationId,
+          submissionId: submission.id,
+          submitterId: userId,
+          isEmbed: true,
+          submitterEmail: input.email,
+          statusToken,
+        });
+
+        return { submissionId: submission.id, statusToken };
       },
     );
 

--- a/apps/api/src/services/status-token.service.ts
+++ b/apps/api/src/services/status-token.service.ts
@@ -1,0 +1,82 @@
+import crypto from 'node:crypto';
+import { pool, submissions, eq, type DrizzleDb } from '@colophony/db';
+import { STATUS_TOKEN_PREFIX } from '@colophony/types';
+
+export interface StatusCheckResult {
+  submissionId: string;
+  title: string | null;
+  status: string;
+  submittedAt: Date | null;
+  organizationName: string;
+  periodName: string | null;
+}
+
+function hashToken(plainText: string): string {
+  return crypto.createHash('sha256').update(plainText).digest('hex');
+}
+
+/**
+ * User-friendly status mapping.
+ * Internal statuses → labels safe for external submitters.
+ */
+const STATUS_DISPLAY_MAP: Record<string, string> = {
+  SUBMITTED: 'Under Review',
+  UNDER_REVIEW: 'Under Review',
+  HOLD: 'Under Review',
+  ACCEPTED: 'Accepted',
+  REJECTED: 'Not Accepted',
+  WITHDRAWN: 'Withdrawn',
+  REVISE_AND_RESUBMIT: 'Revision Requested',
+};
+
+function mapStatusForDisplay(internalStatus: string): string {
+  return STATUS_DISPLAY_MAP[internalStatus] ?? 'Under Review';
+}
+
+export const statusTokenService = {
+  /**
+   * Generate a status token, hash it, and store the hash on the submission.
+   * Returns the plain-text token (shown once to the submitter).
+   */
+  async generateAndStore(tx: DrizzleDb, submissionId: string): Promise<string> {
+    const randomHex = crypto.randomBytes(16).toString('hex'); // 32 hex chars
+    const plainToken = `${STATUS_TOKEN_PREFIX}${randomHex}`;
+    const tokenHash = hashToken(plainToken);
+
+    await tx
+      .update(submissions)
+      .set({ statusTokenHash: tokenHash })
+      .where(eq(submissions.id, submissionId));
+
+    return plainToken;
+  },
+
+  /**
+   * Verify a status token by hashing and looking up via SECURITY DEFINER function.
+   * Bypasses RLS for public status check (no auth context).
+   */
+  async verifyToken(plainTextToken: string): Promise<StatusCheckResult | null> {
+    const tokenHash = hashToken(plainTextToken);
+
+    const result = await pool.query<{
+      submission_id: string;
+      submission_title: string | null;
+      submission_status: string;
+      submitted_at: Date | null;
+      organization_name: string;
+      period_name: string | null;
+    }>('SELECT * FROM verify_status_token($1)', [tokenHash]);
+
+    if (result.rows.length === 0) return null;
+
+    const row = result.rows[0];
+    return {
+      submissionId: row.submission_id,
+      title: row.submission_title,
+      status: mapStatusForDisplay(row.submission_status),
+      submittedAt: row.submitted_at,
+      organizationName: row.organization_name,
+      periodName: row.period_name,
+    };
+  },
+};

--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -238,6 +238,7 @@ export const submissionService = {
           createdAt: submissions.createdAt,
           updatedAt: submissions.updatedAt,
           searchVector: submissions.searchVector,
+          statusTokenHash: submissions.statusTokenHash,
           transferredFromDomain: submissions.transferredFromDomain,
           transferredFromTransferId: submissions.transferredFromTransferId,
           submitterEmail: users.email,

--- a/apps/api/src/templates/email/templates.ts
+++ b/apps/api/src/templates/email/templates.ts
@@ -7,6 +7,7 @@ import type {
   EditorMessageTemplateData,
   ReviewerAssignedTemplateData,
   DiscussionCommentTemplateData,
+  EmbedSubmissionConfirmationData,
 } from './types.js';
 import { wrapInLayout } from './layout.js';
 
@@ -270,6 +271,36 @@ function discussionComment(data: Record<string, unknown>): TemplateResult {
   };
 }
 
+function embedSubmissionConfirmation(
+  data: Record<string, unknown>,
+): TemplateResult {
+  const d = data as unknown as EmbedSubmissionConfirmationData;
+  return {
+    subject: `Submission received: ${d.submissionTitle}`,
+    mjml: wrapInLayout(
+      `<mj-text>
+        <p>Thank you for your submission!</p>
+        <p><strong>Title:</strong> ${escapeHtml(d.submissionTitle)}</p>
+        <p>Your submission to ${escapeHtml(d.orgName)} has been received and is under review.</p>
+      </mj-text>
+      <mj-button href="${escapeHtml(d.statusCheckUrl)}" background-color="#2563eb" color="#ffffff" font-size="14px" padding="16px 0">
+        Check Submission Status
+      </mj-button>
+      <mj-text font-size="12px" color="#6b7280">
+        <p>Or copy this link: ${escapeHtml(d.statusCheckUrl)}</p>
+      </mj-text>`,
+      d.orgName,
+    ),
+    text: [
+      `Thank you for your submission!`,
+      `Title: ${d.submissionTitle}`,
+      `Your submission to ${d.orgName} has been received and is under review.`,
+      ``,
+      `Check your submission status: ${d.statusCheckUrl}`,
+    ].join('\n'),
+  };
+}
+
 export const templates: Record<TemplateName, TemplateRenderer> = {
   'submission-received': submissionReceived,
   'submission-accepted': submissionAccepted,
@@ -281,6 +312,7 @@ export const templates: Record<TemplateName, TemplateRenderer> = {
   'editor-message': editorMessage,
   'reviewer-assigned': reviewerAssigned,
   'discussion-comment': discussionComment,
+  'embed-submission-confirmation': embedSubmissionConfirmation,
 };
 
 function stripHtml(html: string): string {

--- a/apps/api/src/templates/email/types.ts
+++ b/apps/api/src/templates/email/types.ts
@@ -8,7 +8,8 @@ export type TemplateName =
   | 'copyeditor-assigned'
   | 'editor-message'
   | 'reviewer-assigned'
-  | 'discussion-comment';
+  | 'discussion-comment'
+  | 'embed-submission-confirmation';
 
 export interface SubmissionTemplateData {
   submissionTitle: string;
@@ -55,10 +56,17 @@ export interface DiscussionCommentTemplateData {
   submissionUrl?: string;
 }
 
+export interface EmbedSubmissionConfirmationData {
+  submissionTitle: string;
+  orgName: string;
+  statusCheckUrl: string;
+}
+
 export type TemplateData =
   | SubmissionTemplateData
   | ContractTemplateData
   | CopyeditorAssignedData
   | EditorMessageTemplateData
   | ReviewerAssignedTemplateData
-  | DiscussionCommentTemplateData;
+  | DiscussionCommentTemplateData
+  | EmbedSubmissionConfirmationData;

--- a/apps/web/e2e/embed/embed-status-check.spec.ts
+++ b/apps/web/e2e/embed/embed-status-check.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect, EMBED_TEST_EMAIL } from "../helpers/embed-fixtures";
+
+test.describe("Embed Status Check (/embed/status/:token)", () => {
+  test("embed submission success page shows status link and confirmation message", async ({
+    page,
+    embedData,
+  }) => {
+    await page.goto(`/embed/${embedData.plainToken}`);
+
+    // Complete identity
+    await page.getByLabel(/email/i).fill(EMBED_TEST_EMAIL);
+    await page.getByRole("button", { name: "Continue" }).click();
+    await expect(page.getByLabel("Title *")).toBeVisible({ timeout: 10_000 });
+
+    // Fill form
+    await page.getByLabel("Title *").fill("E2E Status Check Submission");
+    await page.getByRole("combobox").click();
+    await page.getByRole("option", { name: "Fiction", exact: true }).click();
+
+    // Submit
+    await page.getByRole("button", { name: "Submit" }).click();
+
+    // Success page
+    await expect(
+      page.getByRole("heading", { name: "Submission Received" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Verify confirmation message
+    await expect(
+      page.getByText("A confirmation email has been sent"),
+    ).toBeVisible();
+
+    // Verify status check link
+    const statusLink = page.getByTestId("status-check-link");
+    await expect(statusLink).toBeVisible();
+    await expect(statusLink).toHaveText("Check your submission status");
+
+    // Extract and verify the link points to the status page
+    const href = await statusLink.getAttribute("href");
+    expect(href).toMatch(/^\/embed\/status\/col_sta_/);
+  });
+
+  test("status check page displays submission info for valid token", async ({
+    page,
+    embedData,
+  }) => {
+    await page.goto(`/embed/${embedData.plainToken}`);
+
+    // Complete identity
+    await page.getByLabel(/email/i).fill(EMBED_TEST_EMAIL);
+    await page.getByRole("button", { name: "Continue" }).click();
+    await expect(page.getByLabel("Title *")).toBeVisible({ timeout: 10_000 });
+
+    // Fill form
+    await page.getByLabel("Title *").fill("Status Page E2E Test");
+    await page.getByRole("combobox").click();
+    await page.getByRole("option", { name: "Poetry" }).click();
+
+    // Submit
+    await page.getByRole("button", { name: "Submit" }).click();
+
+    // Wait for success
+    await expect(
+      page.getByRole("heading", { name: "Submission Received" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Navigate to status page via the link
+    const statusLink = page.getByTestId("status-check-link");
+    await expect(statusLink).toBeVisible();
+    const href = await statusLink.getAttribute("href");
+    expect(href).toBeTruthy();
+
+    await page.goto(href!);
+
+    // Verify status page content
+    await expect(page.getByText("Submission Status")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText("Status Page E2E Test")).toBeVisible();
+    await expect(page.getByText("Under Review")).toBeVisible();
+    await expect(page.getByText(embedData.periodName)).toBeVisible();
+  });
+
+  test("status check page shows not found for invalid token", async ({
+    page,
+  }) => {
+    await page.goto("/embed/status/col_sta_0000000000000000000000000000dead");
+
+    await expect(page.getByText("Submission Not Found")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/apps/web/src/app/embed/status/[statusToken]/page.tsx
+++ b/apps/web/src/app/embed/status/[statusToken]/page.tsx
@@ -1,0 +1,12 @@
+import { EmbedStatusCheck } from "@/components/embed/embed-status-check";
+
+export default async function EmbedStatusPage({
+  params,
+}: {
+  params: Promise<{ statusToken: string }>;
+}) {
+  const { statusToken } = await params;
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+
+  return <EmbedStatusCheck statusToken={statusToken} apiUrl={apiUrl} />;
+}

--- a/apps/web/src/components/embed/embed-form.tsx
+++ b/apps/web/src/components/embed/embed-form.tsx
@@ -37,6 +37,7 @@ interface EmbedState {
     retryAfter?: number;
   } | null;
   submissionId: string | null;
+  statusToken: string | null;
 }
 
 function mapErrorType(
@@ -62,6 +63,7 @@ export function EmbedForm({ token, apiUrl }: EmbedFormProps) {
     uploadContext: null,
     error: null,
     submissionId: null,
+    statusToken: null,
   });
 
   const [identityLoading, setIdentityLoading] = useState(false);
@@ -173,6 +175,7 @@ export function EmbedForm({ token, apiUrl }: EmbedFormProps) {
           ...prev,
           step: "success",
           submissionId: result.submissionId,
+          statusToken: result.statusToken ?? null,
         }));
       } catch (err) {
         const apiErr = err as EmbedApiError;
@@ -236,6 +239,7 @@ export function EmbedForm({ token, apiUrl }: EmbedFormProps) {
           <EmbedSuccess
             submissionId={state.submissionId}
             periodName={state.formData.period.name}
+            statusToken={state.statusToken ?? undefined}
           />
         )}
 

--- a/apps/web/src/components/embed/embed-status-check.tsx
+++ b/apps/web/src/components/embed/embed-status-check.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { fetchSubmissionStatus, type EmbedApiError } from "@/lib/embed-api";
+import type { EmbedStatusCheckResponse } from "@colophony/types";
+import {
+  Loader2,
+  CheckCircle,
+  XCircle,
+  Clock,
+  AlertCircle,
+} from "lucide-react";
+
+type ViewState = "loading" | "loaded" | "not_found" | "error";
+
+const STATUS_ICONS: Record<string, typeof CheckCircle> = {
+  Accepted: CheckCircle,
+  "Not Accepted": XCircle,
+  Withdrawn: AlertCircle,
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  "Under Review": "bg-yellow-100 text-yellow-800",
+  Accepted: "bg-green-100 text-green-800",
+  "Not Accepted": "bg-red-100 text-red-800",
+  Withdrawn: "bg-gray-100 text-gray-800",
+  "Revision Requested": "bg-blue-100 text-blue-800",
+};
+
+interface EmbedStatusCheckProps {
+  statusToken: string;
+  apiUrl: string;
+}
+
+export function EmbedStatusCheck({
+  statusToken,
+  apiUrl,
+}: EmbedStatusCheckProps) {
+  const [viewState, setViewState] = useState<ViewState>("loading");
+  const [data, setData] = useState<EmbedStatusCheckResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const result = await fetchSubmissionStatus(apiUrl, statusToken);
+        if (!cancelled) {
+          setData(result);
+          setViewState("loaded");
+        }
+      } catch (err) {
+        if (cancelled) return;
+        const apiErr = err as EmbedApiError;
+        if (apiErr.status === 404) {
+          setViewState("not_found");
+        } else {
+          setViewState("error");
+        }
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [apiUrl, statusToken]);
+
+  if (viewState === "loading") {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (viewState === "not_found") {
+    return (
+      <div className="max-w-md mx-auto text-center py-16 px-4">
+        <AlertCircle className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+        <h2 className="text-lg font-semibold">Submission Not Found</h2>
+        <p className="text-sm text-muted-foreground mt-2">
+          This status link is invalid or has expired.
+        </p>
+      </div>
+    );
+  }
+
+  if (viewState === "error") {
+    return (
+      <div className="max-w-md mx-auto text-center py-16 px-4">
+        <AlertCircle className="h-12 w-12 text-destructive mx-auto mb-4" />
+        <h2 className="text-lg font-semibold">Something Went Wrong</h2>
+        <p className="text-sm text-muted-foreground mt-2">
+          Unable to load submission status. Please try again later.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const StatusIcon = STATUS_ICONS[data.status] ?? Clock;
+  const statusColor =
+    STATUS_COLORS[data.status] ?? "bg-yellow-100 text-yellow-800";
+
+  return (
+    <div className="max-w-md mx-auto py-12 px-4">
+      <div className="border rounded-lg p-6 space-y-4">
+        <div className="text-center">
+          <p className="text-sm text-muted-foreground">
+            {data.organizationName}
+          </p>
+          <h2 className="text-lg font-semibold mt-1">Submission Status</h2>
+        </div>
+
+        <div className="space-y-3">
+          {data.title && (
+            <div>
+              <p className="text-xs text-muted-foreground uppercase tracking-wide">
+                Title
+              </p>
+              <p className="font-medium">{data.title}</p>
+            </div>
+          )}
+
+          <div>
+            <p className="text-xs text-muted-foreground uppercase tracking-wide">
+              Status
+            </p>
+            <div className="flex items-center gap-2 mt-1">
+              <StatusIcon className="h-4 w-4" />
+              <span
+                className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${statusColor}`}
+              >
+                {data.status}
+              </span>
+            </div>
+          </div>
+
+          {data.periodName && (
+            <div>
+              <p className="text-xs text-muted-foreground uppercase tracking-wide">
+                Submission Period
+              </p>
+              <p className="text-sm">{data.periodName}</p>
+            </div>
+          )}
+
+          {data.submittedAt && (
+            <div>
+              <p className="text-xs text-muted-foreground uppercase tracking-wide">
+                Submitted
+              </p>
+              <p className="text-sm">
+                {new Date(data.submittedAt).toLocaleDateString(undefined, {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/embed/embed-success.tsx
+++ b/apps/web/src/components/embed/embed-success.tsx
@@ -1,13 +1,20 @@
 "use client";
 
-import { CheckCircle } from "lucide-react";
+import { CheckCircle, Mail } from "lucide-react";
 
 interface EmbedSuccessProps {
   submissionId: string;
   periodName: string;
+  statusToken?: string;
 }
 
-export function EmbedSuccess({ submissionId, periodName }: EmbedSuccessProps) {
+export function EmbedSuccess({
+  submissionId,
+  periodName,
+  statusToken,
+}: EmbedSuccessProps) {
+  const statusUrl = statusToken ? `/embed/status/${statusToken}` : null;
+
   return (
     <div className="flex flex-col items-center text-center py-8 space-y-4">
       <CheckCircle className="h-16 w-16 text-green-600" />
@@ -17,6 +24,21 @@ export function EmbedSuccess({ submissionId, periodName }: EmbedSuccessProps) {
           Your submission to <strong>{periodName}</strong> has been received.
         </p>
       </div>
+      {statusToken && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Mail className="h-4 w-4" />
+          <span>A confirmation email has been sent to your inbox.</span>
+        </div>
+      )}
+      {statusUrl && (
+        <a
+          href={statusUrl}
+          className="text-sm text-primary underline hover:no-underline"
+          data-testid="status-check-link"
+        >
+          Check your submission status
+        </a>
+      )}
       <p className="text-xs text-muted-foreground">
         Confirmation ID: {submissionId}
       </p>

--- a/apps/web/src/lib/embed-api.ts
+++ b/apps/web/src/lib/embed-api.ts
@@ -1,8 +1,10 @@
 import type {
   EmbedFormResponse,
   EmbedSubmitInput,
+  EmbedSubmitResponse,
   EmbedPrepareUploadResponse,
   EmbedUploadStatusResponse,
+  EmbedStatusCheckResponse,
 } from "@colophony/types";
 
 export interface EmbedApiError {
@@ -50,7 +52,7 @@ export async function submitEmbedForm(
   apiUrl: string,
   token: string,
   body: EmbedSubmitInput,
-): Promise<{ success: boolean; submissionId: string; message: string }> {
+): Promise<EmbedSubmitResponse> {
   const res = await fetch(`${apiUrl}/embed/${token}/submit`, {
     method: "POST",
     headers: {
@@ -92,4 +94,14 @@ export async function fetchUploadStatus(
     },
   );
   return handleResponse<EmbedUploadStatusResponse>(res);
+}
+
+export async function fetchSubmissionStatus(
+  apiUrl: string,
+  statusToken: string,
+): Promise<EmbedStatusCheckResponse> {
+  const res = await fetch(`${apiUrl}/embed/status/${statusToken}`, {
+    headers: { Accept: "application/json" },
+  });
+  return handleResponse<EmbedStatusCheckResponse>(res);
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -310,8 +310,8 @@
 - [x] [P0] Editor-to-writer personalized correspondence — compose and send messages to individual submitters from the submission detail view; editor comments on status transitions included in notification emails — (persona gap analysis 2026-02-27; done 2026-02-27 PR pending)
 - [x] [P0] Customizable email templates — admin UI for editing MJML templates per org (acceptance, rejection, under review, custom); replace hardcoded boilerplate with org-branded voice — (persona gap analysis 2026-02-27; done 2026-02-27 PR pending)
 - [x] [P1] "Revise and resubmit" status — add R&R to SubmissionStatus enum + transition map; editor sends revision notes, writer resubmits against the same submission record — (persona gap analysis 2026-02-27; done 2026-02-27 PR pending)
-- [ ] [P2] Embed submitter confirmation email — send a receipt email to the address provided in the embed identity step; include submission title, journal name, and a status-check token/link — (persona gap analysis 2026-02-27)
-- [ ] [P2] Embed submitter status check — public page at `/embed/status/:token` where embed submitters (no account) can check their submission status — (persona gap analysis 2026-02-27)
+- [x] [P2] Embed submitter confirmation email — send a receipt email to the address provided in the embed identity step; include submission title, journal name, and a status-check token/link — (persona gap analysis 2026-02-27; done 2026-02-28)
+- [x] [P2] Embed submitter status check — public page at `/embed/status/:token` where embed submitters (no account) can check their submission status — (persona gap analysis 2026-02-27; done 2026-02-28)
 
 ### Editorial Workflow
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-02-28 — Embed Submitter Confirmation Email + Status Check Page
+
+### Done
+
+- **Migration 0044**: Added `status_token_hash` column to `submissions`, index, and `verify_status_token()` SECURITY DEFINER function for RLS-bypassing public lookups
+- **Status token service**: `generateAndStore()` (col*sta* prefix + 32 hex, SHA-256 hashed) and `verifyToken()` with user-friendly status mapping (HOLD→"Under Review", REJECTED→"Not Accepted")
+- **Embed submission service**: Wired status token generation and outbox event (`hopper/submission.submitted` with `isEmbed` flag) into the existing RLS transaction
+- **Embed routes**: Updated POST submit to return `statusToken`; added GET `/embed/status/:statusToken` with rate limiting (30/window) and format validation
+- **Inngest function**: `embedSubmissionConfirmation` — listens to submission event, sends transactional confirmation email (skips notification preferences) with status check URL
+- **Email template**: `embed-submission-confirmation` MJML template with CTA button linking to status page
+- **Frontend**: `EmbedStatusCheck` client component (loading/loaded/not_found/error states, status badge with color coding), server page at `/embed/status/[statusToken]`, updated `EmbedSuccess` with confirmation message and status link
+- **Unit tests**: 5 status-token service tests, 3 Inngest confirmation tests, 4 embed route status tests, updated existing service/resolver mocks for new `statusTokenHash` column
+- **E2E tests**: 3 tests — success page shows status link, status page displays submission info, invalid token shows not found
+- All 1361 unit tests passing, type-check clean (6/6)
+
+### Decisions
+
+- Status token stored as SHA-256 hash directly on submissions (1:1, no join table needed)
+- Confirmation email is transactional — always sent, no preference check (submitter explicitly provided email)
+- Reused existing `hopper/submission.submitted` outbox event with `isEmbed` flag rather than creating a new event type
+
+---
+
 ## 2026-02-28 — Fix Playwright Submissions E2E CI Failure
 
 ### Done

--- a/packages/db/migrations/0044_status_token.sql
+++ b/packages/db/migrations/0044_status_token.sql
@@ -1,0 +1,20 @@
+ALTER TABLE "submissions" ADD COLUMN "status_token_hash" varchar(128);
+--> statement-breakpoint
+CREATE INDEX "submissions_status_token_hash_idx" ON "submissions" ("status_token_hash");
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION verify_status_token(p_token_hash varchar)
+RETURNS TABLE(
+  submission_id uuid, submission_title varchar,
+  submission_status text, submitted_at timestamptz,
+  organization_name varchar, period_name varchar
+) LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT s.id, s.title, s.status::text, s.submitted_at, o.name, sp.name
+  FROM public.submissions s
+  JOIN public.organizations o ON o.id = s.organization_id
+  LEFT JOIN public.submission_periods sp ON sp.id = s.submission_period_id
+  WHERE s.status_token_hash = p_token_hash
+$$;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION verify_status_token(varchar) FROM PUBLIC;
+--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION verify_status_token(varchar) TO app_user;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1777800000000,
       "tag": "0043_blind_review_mode",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1778000000000,
+      "tag": "0044_status_token",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/submissions.ts
+++ b/packages/db/src/schema/submissions.ts
@@ -130,6 +130,7 @@ export const submissions = pgTable(
     transferredFromTransferId: varchar("transferred_from_transfer_id", {
       length: 255,
     }),
+    statusTokenHash: varchar("status_token_hash", { length: 128 }),
     searchVector: tsvector("search_vector"),
   },
   (table) => [
@@ -149,6 +150,7 @@ export const submissions = pgTable(
       table.status,
       table.submittedAt,
     ),
+    index("submissions_status_token_hash_idx").on(table.statusTokenHash),
     index("submissions_search_vector_idx").using("gin", table.searchVector),
     orgIsolationPolicy,
     // Submitter-scoped read: submitters can see their own submissions cross-org

--- a/packages/types/src/embed.ts
+++ b/packages/types/src/embed.ts
@@ -6,6 +6,7 @@ import { scanStatusSchema } from "./file";
 // ---------------------------------------------------------------------------
 
 export const EMBED_TOKEN_PREFIX = "col_emb_";
+export const STATUS_TOKEN_PREFIX = "col_sta_";
 
 // ---------------------------------------------------------------------------
 // Theme config
@@ -159,9 +160,28 @@ export const embedSubmitResponseSchema = z.object({
   success: z.literal(true),
   submissionId: z.string().uuid().describe("Created submission ID"),
   message: z.string().describe("Confirmation message"),
+  statusToken: z
+    .string()
+    .optional()
+    .describe("Status check token (col_sta_ prefixed)"),
 });
 
 export type EmbedSubmitResponse = z.infer<typeof embedSubmitResponseSchema>;
+
+export const embedStatusCheckResponseSchema = z.object({
+  title: z.string().nullable().describe("Submission title"),
+  status: z.string().describe("User-friendly submission status"),
+  submittedAt: z
+    .string()
+    .nullable()
+    .describe("Submission date (ISO-8601 string)"),
+  organizationName: z.string().describe("Organization name"),
+  periodName: z.string().nullable().describe("Submission period name"),
+});
+
+export type EmbedStatusCheckResponse = z.infer<
+  typeof embedStatusCheckResponseSchema
+>;
 
 // ---------------------------------------------------------------------------
 // Revoke schema


### PR DESCRIPTION
## Summary

- Add transactional confirmation email sent to embed submitters after form submission, with a link to check their submission status
- Add public status check page at `/embed/status/:token` where embed submitters (no account) can view their submission status without authentication
- Status token stored as SHA-256 hash on `submissions` table, looked up via `verify_status_token()` SECURITY DEFINER function (bypasses RLS for public access)
- Internal statuses mapped to user-friendly labels: HOLD → "Under Review", REJECTED → "Not Accepted"

## Test plan

- [x] 5 unit tests for status token service (generate, verify, status mapping)
- [x] 3 unit tests for Inngest confirmation function (skip non-embed, skip email disabled, queue email)
- [x] 4 unit tests for embed status route (malformed token, unknown token, valid token, null fields)
- [x] 3 E2E tests (success page shows status link, status page displays info, invalid token shows not found)
- [x] All 1361 unit tests passing
- [x] Type-check clean (6/6)
- [x] Lint clean (0 errors)
- [ ] Run E2E tests against live environment to verify full flow