### PR TITLE
feat(hopper): Track 7 P3 closeout — reading mode, reminders, saved presets

### DIFF
--- a/apps/api/src/inngest/functions/__tests__/submission-response-reminder.spec.ts
+++ b/apps/api/src/inngest/functions/__tests__/submission-response-reminder.spec.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Mock dependencies ---
+
+// Use a container object so vi.mock factory (hoisted) can reference it
+const mocks = {
+  withRls: vi.fn(),
+  dbFromResult: [] as Array<Record<string, unknown>>,
+  queueEmail: vi.fn(),
+  listAgingByOrg: vi.fn(),
+  emailProvider: 'smtp' as string,
+};
+
+vi.mock('@colophony/db', () => ({
+  withRls: (...args: unknown[]) => mocks.withRls(...args),
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockImplementation(() => mocks.dbFromResult),
+    }),
+  },
+  organizations: { id: 'id', name: 'name', settings: 'settings' },
+  organizationMembers: {
+    userId: 'userId',
+    organizationId: 'organizationId',
+    role: 'role',
+  },
+  users: { id: 'id', email: 'email' },
+  eq: vi.fn(),
+  and: vi.fn(),
+  inArray: vi.fn(),
+}));
+
+vi.mock('@colophony/types', () => ({
+  orgSettingsSchema: {
+    safeParse: vi.fn((settings: Record<string, unknown>) => ({
+      success: true,
+      data: {
+        responseReminderEnabled: settings?.responseReminderEnabled ?? false,
+        responseReminderDays: settings?.responseReminderDays ?? 30,
+      },
+    })),
+  },
+}));
+
+vi.mock('../../helpers/queue-email-for-recipient.js', () => ({
+  queueEmailForRecipient: (...args: unknown[]) => mocks.queueEmail(...args),
+}));
+
+vi.mock('../../../services/submission.service.js', () => ({
+  submissionService: {
+    listAgingByOrg: (...args: unknown[]) => mocks.listAgingByOrg(...args),
+  },
+}));
+
+vi.mock('../../../config/env.js', () => ({
+  validateEnv: vi.fn(() => ({
+    EMAIL_PROVIDER: mocks.emailProvider,
+  })),
+}));
+
+vi.mock('../../client.js', () => ({
+  inngest: {
+    createFunction: vi.fn(
+      (_config: unknown, _trigger: unknown, handler: unknown) => handler,
+    ),
+  },
+}));
+
+// Import after mocks
+import { submissionResponseReminderCron } from '../submission-response-reminder.js';
+
+// The handler is the raw function (due to mock)
+const handler = submissionResponseReminderCron as unknown as (ctx: {
+  step: { run: (name: string, fn: () => Promise<unknown>) => Promise<unknown> };
+}) => Promise<unknown>;
+
+function makeStep() {
+  return {
+    run: vi.fn((_name: string, fn: () => Promise<unknown>) => fn()),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.emailProvider = 'smtp';
+  mocks.dbFromResult = [];
+});
+
+describe('submissionResponseReminderCron', () => {
+  it('skips when email provider is none', async () => {
+    mocks.emailProvider = 'none';
+    const result = await handler({ step: makeStep() });
+    expect(result).toEqual({ skipped: true, reason: 'email provider is none' });
+    expect(mocks.queueEmail).not.toHaveBeenCalled();
+  });
+
+  it('skips org when reminders disabled', async () => {
+    mocks.dbFromResult = [
+      {
+        id: 'org-1',
+        name: 'Test Org',
+        settings: { responseReminderEnabled: false },
+      },
+    ];
+
+    const result = await handler({ step: makeStep() });
+    expect(result).toEqual({
+      skipped: true,
+      reason: 'no orgs with reminders enabled',
+    });
+    expect(mocks.listAgingByOrg).not.toHaveBeenCalled();
+  });
+
+  it('processes org with correct threshold and sends emails', async () => {
+    const agingItems = [
+      {
+        id: 's-1',
+        title: 'Poem A',
+        submittedAt: new Date(),
+        submitterEmail: 'a@test.com',
+        daysPending: 35,
+      },
+      {
+        id: 's-2',
+        title: 'Poem B',
+        submittedAt: new Date(),
+        submitterEmail: 'b@test.com',
+        daysPending: 20,
+      },
+    ];
+
+    const editors = [
+      { userId: 'u-1', email: 'ed1@test.com' },
+      { userId: 'u-2', email: 'ed2@test.com' },
+    ];
+
+    // Step 1: find orgs
+    mocks.dbFromResult = [
+      {
+        id: 'org-1',
+        name: 'Test Org',
+        settings: {
+          responseReminderEnabled: true,
+          responseReminderDays: 14,
+        },
+      },
+    ];
+
+    // withRls calls — order: listAgingByOrg, then editors query
+    let withRlsCallCount = 0;
+    mocks.withRls.mockImplementation(
+      async (_ctx: unknown, fn: (tx: unknown) => Promise<unknown>) => {
+        withRlsCallCount++;
+        if (withRlsCallCount === 1) {
+          // listAgingByOrg
+          mocks.listAgingByOrg.mockResolvedValue(agingItems);
+          return fn({});
+        }
+        // editors query
+        return editors;
+      },
+    );
+
+    const result = await handler({ step: makeStep() });
+    expect(result).toEqual({ processed: 1, totalEmails: 2 });
+    expect(mocks.queueEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips org with no aging submissions', async () => {
+    mocks.dbFromResult = [
+      {
+        id: 'org-1',
+        name: 'Test Org',
+        settings: {
+          responseReminderEnabled: true,
+          responseReminderDays: 30,
+        },
+      },
+    ];
+
+    mocks.withRls.mockImplementation(
+      async (_ctx: unknown, fn: (tx: unknown) => Promise<unknown>) => {
+        mocks.listAgingByOrg.mockResolvedValue([]);
+        return fn({});
+      },
+    );
+
+    const result = await handler({ step: makeStep() });
+    expect(result).toEqual({ processed: 1, totalEmails: 0 });
+    expect(mocks.queueEmail).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/inngest/functions/index.ts
+++ b/apps/api/src/inngest/functions/index.ts
@@ -16,3 +16,4 @@ export { reviewerAssignedNotification } from './reviewer-notifications.js';
 export { discussionCommentNotification } from './discussion-notifications.js';
 export { webhookDelivery } from './webhook-delivery.js';
 export { embedSubmissionConfirmation } from './embed-submission-confirmation.js';
+export { submissionResponseReminderCron } from './submission-response-reminder.js';

--- a/apps/api/src/inngest/functions/submission-notifications.ts
+++ b/apps/api/src/inngest/functions/submission-notifications.ts
@@ -9,7 +9,6 @@ import {
   and,
   inArray,
 } from '@colophony/db';
-import { AuditActions, AuditResources } from '@colophony/types';
 import { inngest } from '../client.js';
 import type {
   HopperSubmissionSubmittedEvent,
@@ -18,13 +17,9 @@ import type {
   HopperSubmissionWithdrawnEvent,
   HopperSubmissionReviseAndResubmitEvent,
 } from '../events.js';
-import { notificationPreferenceService } from '../../services/notification-preference.service.js';
-import { emailService } from '../../services/email.service.js';
-import { auditService } from '../../services/audit.service.js';
 import { correspondenceService } from '../../services/correspondence.service.js';
-import { enqueueEmail } from '../../queues/email.queue.js';
-import { validateEnv } from '../../config/env.js';
 import { queueInAppNotification } from '../helpers/queue-in-app-notification.js';
+import { queueEmailForRecipient } from '../helpers/queue-email-for-recipient.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -73,62 +68,6 @@ async function getOrgEditors(orgId: string) {
         ),
       );
     return members;
-  });
-}
-
-async function queueEmailForRecipient(params: {
-  orgId: string;
-  userId: string;
-  email: string;
-  eventType: string;
-  templateName: string;
-  templateData: Record<string, unknown>;
-  subject: string;
-}) {
-  const env = validateEnv();
-  if (env.EMAIL_PROVIDER === 'none') return;
-
-  const enabled = await withRls({ orgId: params.orgId }, async (tx) => {
-    return notificationPreferenceService.isEmailEnabled(
-      tx,
-      params.orgId,
-      params.userId,
-      params.eventType,
-    );
-  });
-
-  if (!enabled) return;
-
-  const emailSend = await withRls({ orgId: params.orgId }, async (tx) => {
-    const row = await emailService.create(tx, {
-      organizationId: params.orgId,
-      recipientUserId: params.userId,
-      recipientEmail: params.email,
-      templateName: params.templateName,
-      eventType: params.eventType,
-      subject: params.subject,
-    });
-    await auditService.log(tx, {
-      resource: AuditResources.EMAIL,
-      action: AuditActions.EMAIL_QUEUED,
-      resourceId: row.id,
-      organizationId: params.orgId,
-      newValue: {
-        to: params.email,
-        templateName: params.templateName,
-        eventType: params.eventType,
-      },
-    });
-    return row;
-  });
-
-  await enqueueEmail(env, {
-    emailSendId: emailSend.id,
-    orgId: params.orgId,
-    to: params.email,
-    from: env.SMTP_FROM ?? env.SENDGRID_FROM ?? 'noreply@colophony.dev',
-    templateName: params.templateName,
-    templateData: params.templateData,
   });
 }
 

--- a/apps/api/src/inngest/functions/submission-response-reminder.ts
+++ b/apps/api/src/inngest/functions/submission-response-reminder.ts
@@ -1,0 +1,127 @@
+import {
+  withRls,
+  db,
+  organizations,
+  organizationMembers,
+  users,
+  eq,
+  and,
+  inArray,
+} from '@colophony/db';
+import { orgSettingsSchema } from '@colophony/types';
+import { inngest } from '../client.js';
+import { queueEmailForRecipient } from '../helpers/queue-email-for-recipient.js';
+import { submissionService } from '../../services/submission.service.js';
+import { validateEnv } from '../../config/env.js';
+
+export const submissionResponseReminderCron = inngest.createFunction(
+  {
+    id: 'submission-response-reminder-cron',
+    name: 'Submission Response Reminder (Weekly)',
+    retries: 1,
+  },
+  { cron: 'TZ=UTC 0 9 * * 1' },
+  async ({ step }) => {
+    const env = validateEnv();
+    if (env.EMAIL_PROVIDER === 'none') {
+      return { skipped: true, reason: 'email provider is none' };
+    }
+
+    // Step 1: Find orgs with reminders enabled (superuser query — no RLS)
+    const eligibleOrgs = await step.run('find-eligible-orgs', async () => {
+      const allOrgs = await db
+        .select({
+          id: organizations.id,
+          name: organizations.name,
+          settings: organizations.settings,
+        })
+        .from(organizations);
+
+      return allOrgs
+        .map((org) => {
+          const parsed = orgSettingsSchema.safeParse(org.settings ?? {});
+          const settings = parsed.success
+            ? parsed.data
+            : { responseReminderEnabled: false, responseReminderDays: 30 };
+          return { id: org.id, name: org.name, settings };
+        })
+        .filter((org) => org.settings.responseReminderEnabled);
+    });
+
+    if (eligibleOrgs.length === 0) {
+      return { skipped: true, reason: 'no orgs with reminders enabled' };
+    }
+
+    let totalEmails = 0;
+
+    // Step 2: Process each org
+    for (const org of eligibleOrgs) {
+      const result = await step.run(`process-org-${org.id}`, async () => {
+        // Get aging submissions (within RLS context)
+        const agingSubmissions = await withRls(
+          { orgId: org.id },
+          async (tx) => {
+            return submissionService.listAgingByOrg(
+              tx,
+              org.settings.responseReminderDays,
+            );
+          },
+        );
+
+        if (agingSubmissions.length === 0) {
+          return { emailsSent: 0 };
+        }
+
+        // Get editors for this org
+        const editors = await withRls({ orgId: org.id }, async (tx) => {
+          return tx
+            .select({
+              userId: organizationMembers.userId,
+              email: users.email,
+            })
+            .from(organizationMembers)
+            .innerJoin(users, eq(users.id, organizationMembers.userId))
+            .where(
+              and(
+                eq(organizationMembers.organizationId, org.id),
+                inArray(organizationMembers.role, ['ADMIN', 'EDITOR']),
+              ),
+            );
+        });
+
+        let emailsSent = 0;
+        for (const editor of editors) {
+          if (!editor.email) continue;
+
+          await queueEmailForRecipient({
+            orgId: org.id,
+            userId: editor.userId,
+            email: editor.email,
+            eventType: 'submission.response_reminder',
+            templateName: 'submission-response-reminder',
+            templateData: {
+              orgName: org.name,
+              editorName: editor.email,
+              agingSubmissions: agingSubmissions.map((s) => ({
+                title: s.title ?? '(Untitled)',
+                submitterEmail: s.submitterEmail ?? '[Anonymous]',
+                daysPending: s.daysPending,
+              })),
+            },
+            subject: `Response reminder: ${agingSubmissions.length} submission${agingSubmissions.length !== 1 ? 's' : ''} awaiting review`,
+          });
+          emailsSent++;
+        }
+
+        return { emailsSent };
+      });
+
+      totalEmails += result.emailsSent;
+    }
+
+    return {
+      processed: eligibleOrgs.length,
+      totalEmails,
+    };
+  },
+);

--- a/apps/api/src/inngest/helpers/queue-email-for-recipient.ts
+++ b/apps/api/src/inngest/helpers/queue-email-for-recipient.ts
@@ -1,0 +1,63 @@
+import { withRls } from '@colophony/db';
+import { AuditActions, AuditResources } from '@colophony/types';
+import { notificationPreferenceService } from '../../services/notification-preference.service.js';
+import { emailService } from '../../services/email.service.js';
+import { auditService } from '../../services/audit.service.js';
+import { enqueueEmail } from '../../queues/email.queue.js';
+import { validateEnv } from '../../config/env.js';
+
+export async function queueEmailForRecipient(params: {
+  orgId: string;
+  userId: string;
+  email: string;
+  eventType: string;
+  templateName: string;
+  templateData: Record<string, unknown>;
+  subject: string;
+}) {
+  const env = validateEnv();
+  if (env.EMAIL_PROVIDER === 'none') return;
+
+  const enabled = await withRls({ orgId: params.orgId }, async (tx) => {
+    return notificationPreferenceService.isEmailEnabled(
+      tx,
+      params.orgId,
+      params.userId,
+      params.eventType,
+    );
+  });
+
+  if (!enabled) return;
+
+  const emailSend = await withRls({ orgId: params.orgId }, async (tx) => {
+    const row = await emailService.create(tx, {
+      organizationId: params.orgId,
+      recipientUserId: params.userId,
+      recipientEmail: params.email,
+      templateName: params.templateName,
+      eventType: params.eventType,
+      subject: params.subject,
+    });
+    await auditService.log(tx, {
+      resource: AuditResources.EMAIL,
+      action: AuditActions.EMAIL_QUEUED,
+      resourceId: row.id,
+      organizationId: params.orgId,
+      newValue: {
+        to: params.email,
+        templateName: params.templateName,
+        eventType: params.eventType,
+      },
+    });
+    return row;
+  });
+
+  await enqueueEmail(env, {
+    emailSendId: emailSend.id,
+    orgId: params.orgId,
+    to: params.email,
+    from: env.SMTP_FROM ?? env.SENDGRID_FROM ?? 'noreply@colophony.dev',
+    templateName: params.templateName,
+    templateData: params.templateData,
+  });
+}

--- a/apps/api/src/inngest/serve.ts
+++ b/apps/api/src/inngest/serve.ts
@@ -16,6 +16,7 @@ import {
   discussionCommentNotification,
   webhookDelivery,
   embedSubmissionConfirmation,
+  submissionResponseReminderCron,
 } from './functions/index.js';
 
 /**
@@ -45,6 +46,7 @@ export async function registerInngestRoutes(
       discussionCommentNotification,
       webhookDelivery,
       embedSubmissionConfirmation,
+      submissionResponseReminderCron,
     ],
   });
 

--- a/apps/api/src/services/__tests__/queue-preset.service.spec.ts
+++ b/apps/api/src/services/__tests__/queue-preset.service.spec.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Build chainable mocks
+let mockRows: Array<Record<string, unknown>> = [];
+
+const mockReturning = vi.fn().mockImplementation(() => mockRows);
+const mockWhere = vi.fn().mockImplementation(() => mockRows);
+const mockOrderBy = vi.fn().mockImplementation(() => mockRows);
+const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+
+const mockFrom = vi.fn().mockReturnValue({
+  where: vi.fn().mockImplementation(() => mockRows),
+  orderBy: mockOrderBy,
+});
+
+const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+const mockInsert = vi.fn().mockReturnValue({ values: mockValues });
+const mockUpdate = vi.fn().mockReturnValue({
+  set: mockSet,
+});
+const mockDeleteFn = vi.fn().mockReturnValue({ where: mockWhere });
+
+vi.mock('@colophony/db', () => ({
+  savedQueuePresets: {
+    id: 'id',
+    organizationId: 'organization_id',
+    userId: 'user_id',
+    name: 'name',
+    filters: 'filters',
+    isDefault: 'is_default',
+    createdAt: 'created_at',
+    updatedAt: 'updated_at',
+  },
+  eq: vi.fn(),
+  and: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('drizzle-orm')>();
+  return {
+    ...mod,
+    asc: vi.fn(),
+    count: vi.fn(),
+    ne: vi.fn(),
+  };
+});
+
+import {
+  queuePresetService,
+  PresetLimitExceededError,
+  PresetNotFoundError,
+} from '../queue-preset.service.js';
+
+function makeTx() {
+  return {
+    select: mockSelect,
+    insert: mockInsert,
+    update: mockUpdate,
+    delete: mockDeleteFn,
+  } as unknown as Parameters<typeof queuePresetService.list>[0];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRows = [];
+});
+
+describe('queuePresetService', () => {
+  describe('list', () => {
+    it('returns user presets ordered by name', async () => {
+      const presets = [
+        { id: 'p-1', name: 'Alpha' },
+        { id: 'p-2', name: 'Beta' },
+      ];
+      mockOrderBy.mockResolvedValue(presets);
+      mockFrom.mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: mockOrderBy,
+        }),
+      });
+
+      const result = await queuePresetService.list(makeTx(), 'user-1');
+      expect(result).toEqual(presets);
+    });
+  });
+
+  describe('create', () => {
+    it('throws at 20 presets', async () => {
+      // Mock count returning 20
+      mockFrom.mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ value: 20 }]),
+      });
+
+      await expect(
+        queuePresetService.create(makeTx(), 'user-1', 'org-1', {
+          name: 'Too many',
+          filters: {},
+          isDefault: false,
+        }),
+      ).rejects.toThrow(PresetLimitExceededError);
+    });
+
+    it('unsets other defaults when isDefault=true', async () => {
+      // Mock count returning 0
+      mockFrom.mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ value: 0 }]),
+      });
+
+      const newPreset = {
+        id: 'p-new',
+        name: 'Default',
+        isDefault: true,
+      };
+      mockReturning.mockResolvedValue([newPreset]);
+
+      const result = await queuePresetService.create(
+        makeTx(),
+        'user-1',
+        'org-1',
+        { name: 'Default', filters: {}, isDefault: true },
+      );
+      expect(result).toEqual(newPreset);
+      // update was called to unset other defaults
+      expect(mockUpdate).toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    it('throws for missing row', async () => {
+      mockFrom.mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      });
+
+      await expect(
+        queuePresetService.delete(makeTx(), 'user-1', 'p-missing'),
+      ).rejects.toThrow(PresetNotFoundError);
+    });
+  });
+
+  describe('update', () => {
+    it('throws for missing row', async () => {
+      mockFrom.mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      });
+
+      await expect(
+        queuePresetService.update(makeTx(), 'user-1', {
+          id: 'p-missing',
+          name: 'New name',
+        }),
+      ).rejects.toThrow(PresetNotFoundError);
+    });
+  });
+});

--- a/apps/api/src/services/__tests__/submission-service-aging.spec.ts
+++ b/apps/api/src/services/__tests__/submission-service-aging.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Build a chainable mock for select().from().leftJoin().where().orderBy()
+let mockRows: Array<Record<string, unknown>> = [];
+
+const mockOrderBy = vi.fn().mockImplementation(() => mockRows);
+const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+const mockLeftJoin = vi.fn().mockReturnValue({ where: mockWhere });
+const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin });
+const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+
+vi.mock('@colophony/db', () => ({
+  db: {},
+  submissions: {
+    id: 'id',
+    title: 'title',
+    submittedAt: 'submitted_at',
+    submitterId: 'submitter_id',
+    status: 'status',
+  },
+  users: { id: 'id', email: 'email' },
+  eq: vi.fn(),
+  and: vi.fn(),
+  inArray: vi.fn(),
+  sql: vi.fn(),
+  type: {},
+}));
+
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('drizzle-orm')>();
+  return {
+    ...mod,
+    lte: vi.fn(),
+    notInArray: vi.fn(),
+    isNotNull: vi.fn(),
+  };
+});
+
+// Mock other service imports that submission.service.ts imports
+vi.mock('../outbox.js', () => ({
+  enqueueOutboxEvent: vi.fn(),
+}));
+vi.mock('../errors.js', () => ({
+  ForbiddenError: class extends Error {},
+  NotFoundError: class extends Error {},
+  assertOwnerOrEditor: vi.fn(),
+  assertEditorOrAdmin: vi.fn(),
+}));
+vi.mock('../blind-review.helper.js', () => ({
+  resolveBlindMode: vi.fn(),
+  applySubmitterBlinding: vi.fn(),
+}));
+vi.mock('../form.service.js', () => ({
+  formService: {},
+  FormNotFoundError: class extends Error {},
+  FormNotPublishedError: class extends Error {},
+  InvalidFormDataError: class extends Error {},
+}));
+vi.mock('../migration.service.js', () => ({
+  MigrationInvalidStateError: class extends Error {},
+}));
+vi.mock('../submission-reviewer.service.js', () => ({
+  submissionReviewerService: {},
+  ReviewerAlreadyAssignedError: class extends Error {},
+}));
+
+import { submissionService } from '../submission.service.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRows = [];
+});
+
+describe('submissionService.listAgingByOrg', () => {
+  const fakeTx = {
+    select: mockSelect,
+  } as unknown as Parameters<typeof submissionService.listAgingByOrg>[0];
+
+  it('returns submissions older than threshold', async () => {
+    const thirtyFiveDaysAgo = new Date();
+    thirtyFiveDaysAgo.setDate(thirtyFiveDaysAgo.getDate() - 35);
+
+    mockRows = [
+      {
+        id: 's-1',
+        title: 'Old Poem',
+        submittedAt: thirtyFiveDaysAgo,
+        submitterEmail: 'poet@test.com',
+      },
+    ];
+
+    const results = await submissionService.listAgingByOrg(fakeTx, 30);
+    expect(results).toHaveLength(1);
+    expect(results[0].daysPending).toBeGreaterThanOrEqual(35);
+    expect(results[0].title).toBe('Old Poem');
+  });
+
+  it('returns empty for no matching rows', async () => {
+    mockRows = [];
+    const results = await submissionService.listAgingByOrg(fakeTx, 30);
+    expect(results).toEqual([]);
+  });
+
+  it('computes daysPending correctly', async () => {
+    const tenDaysAgo = new Date();
+    tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
+
+    mockRows = [
+      {
+        id: 's-2',
+        title: 'Recent',
+        submittedAt: tenDaysAgo,
+        submitterEmail: 'x@test.com',
+      },
+    ];
+
+    const results = await submissionService.listAgingByOrg(fakeTx, 5);
+    expect(results[0].daysPending).toBeGreaterThanOrEqual(10);
+  });
+});

--- a/apps/api/src/services/queue-preset.service.ts
+++ b/apps/api/src/services/queue-preset.service.ts
@@ -1,0 +1,144 @@
+import { savedQueuePresets, eq, and, type DrizzleDb } from '@colophony/db';
+import { asc, count, ne } from 'drizzle-orm';
+import type {
+  CreateQueuePresetInput,
+  UpdateQueuePresetInput,
+} from '@colophony/types';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class PresetLimitExceededError extends Error {
+  constructor() {
+    super('Maximum of 20 saved presets reached');
+    this.name = 'PresetLimitExceededError';
+  }
+}
+
+export class PresetNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Preset "${id}" not found`);
+    this.name = 'PresetNotFoundError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+const MAX_PRESETS = 20;
+
+export const queuePresetService = {
+  async list(tx: DrizzleDb, userId: string) {
+    return tx
+      .select()
+      .from(savedQueuePresets)
+      .where(eq(savedQueuePresets.userId, userId))
+      .orderBy(asc(savedQueuePresets.name));
+  },
+
+  async create(
+    tx: DrizzleDb,
+    userId: string,
+    organizationId: string,
+    input: CreateQueuePresetInput,
+  ) {
+    // Check limit
+    const [{ value: existing }] = await tx
+      .select({ value: count() })
+      .from(savedQueuePresets)
+      .where(eq(savedQueuePresets.userId, userId));
+
+    if (existing >= MAX_PRESETS) {
+      throw new PresetLimitExceededError();
+    }
+
+    // If isDefault, unset other defaults
+    if (input.isDefault) {
+      await tx
+        .update(savedQueuePresets)
+        .set({ isDefault: false, updatedAt: new Date() })
+        .where(
+          and(
+            eq(savedQueuePresets.userId, userId),
+            eq(savedQueuePresets.isDefault, true),
+          ),
+        );
+    }
+
+    const [row] = await tx
+      .insert(savedQueuePresets)
+      .values({
+        organizationId,
+        userId,
+        name: input.name,
+        filters: input.filters,
+        isDefault: input.isDefault ?? false,
+      })
+      .returning();
+
+    return row;
+  },
+
+  async update(tx: DrizzleDb, userId: string, input: UpdateQueuePresetInput) {
+    // Check ownership
+    const [existing] = await tx
+      .select({ id: savedQueuePresets.id })
+      .from(savedQueuePresets)
+      .where(
+        and(
+          eq(savedQueuePresets.id, input.id),
+          eq(savedQueuePresets.userId, userId),
+        ),
+      );
+
+    if (!existing) {
+      throw new PresetNotFoundError(input.id);
+    }
+
+    // If setting as default, unset others
+    if (input.isDefault) {
+      await tx
+        .update(savedQueuePresets)
+        .set({ isDefault: false, updatedAt: new Date() })
+        .where(
+          and(
+            eq(savedQueuePresets.userId, userId),
+            eq(savedQueuePresets.isDefault, true),
+            ne(savedQueuePresets.id, input.id),
+          ),
+        );
+    }
+
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
+    if (input.name !== undefined) updates.name = input.name;
+    if (input.filters !== undefined) updates.filters = input.filters;
+    if (input.isDefault !== undefined) updates.isDefault = input.isDefault;
+
+    const [row] = await tx
+      .update(savedQueuePresets)
+      .set(updates)
+      .where(eq(savedQueuePresets.id, input.id))
+      .returning();
+
+    return row;
+  },
+
+  async delete(tx: DrizzleDb, userId: string, id: string) {
+    const [existing] = await tx
+      .select({ id: savedQueuePresets.id })
+      .from(savedQueuePresets)
+      .where(
+        and(eq(savedQueuePresets.id, id), eq(savedQueuePresets.userId, userId)),
+      );
+
+    if (!existing) {
+      throw new PresetNotFoundError(id);
+    }
+
+    await tx.delete(savedQueuePresets).where(eq(savedQueuePresets.id, id));
+
+    return { deleted: true };
+  },
+};

--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -14,7 +14,15 @@ import {
   sql,
   type DrizzleDb,
 } from '@colophony/db';
-import { desc, asc, ilike, count } from 'drizzle-orm';
+import {
+  desc,
+  asc,
+  ilike,
+  count,
+  lte,
+  notInArray,
+  isNotNull,
+} from 'drizzle-orm';
 import type {
   CreateSubmissionInput,
   UpdateSubmissionInput,
@@ -1239,5 +1247,58 @@ export const submissionService = {
     }
 
     return { succeeded, failed };
+  },
+
+  async listAgingByOrg(
+    tx: DrizzleDb,
+    thresholdDays: number,
+  ): Promise<
+    Array<{
+      id: string;
+      title: string | null;
+      submittedAt: Date | null;
+      submitterEmail: string | null;
+      daysPending: number;
+    }>
+  > {
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - thresholdDays);
+
+    const rows = await tx
+      .select({
+        id: submissions.id,
+        title: submissions.title,
+        submittedAt: submissions.submittedAt,
+        submitterEmail: users.email,
+      })
+      .from(submissions)
+      .leftJoin(users, eq(users.id, submissions.submitterId))
+      .where(
+        and(
+          notInArray(submissions.status, [
+            'ACCEPTED',
+            'REJECTED',
+            'WITHDRAWN',
+            'DRAFT',
+          ]),
+          isNotNull(submissions.submittedAt),
+          lte(submissions.submittedAt, cutoffDate),
+        ),
+      )
+      .orderBy(asc(submissions.submittedAt));
+
+    const now = new Date();
+    return rows.map((row) => ({
+      id: row.id,
+      title: row.title,
+      submittedAt: row.submittedAt,
+      submitterEmail: row.submitterEmail,
+      daysPending: row.submittedAt
+        ? Math.floor(
+            (now.getTime() - new Date(row.submittedAt).getTime()) /
+              (1000 * 60 * 60 * 24),
+          )
+        : 0,
+    }));
   },
 };

--- a/apps/api/src/templates/email/templates.ts
+++ b/apps/api/src/templates/email/templates.ts
@@ -8,6 +8,7 @@ import type {
   ReviewerAssignedTemplateData,
   DiscussionCommentTemplateData,
   EmbedSubmissionConfirmationData,
+  ResponseReminderTemplateData,
 } from './types.js';
 import { wrapInLayout } from './layout.js';
 
@@ -301,6 +302,54 @@ function embedSubmissionConfirmation(
   };
 }
 
+function submissionResponseReminder(
+  data: Record<string, unknown>,
+): TemplateResult {
+  const d = data as unknown as ResponseReminderTemplateData;
+  const rows = d.agingSubmissions
+    .map(
+      (s) =>
+        `<tr>
+          <td style="padding:8px;border-bottom:1px solid #e5e7eb">${escapeHtml(s.title)}</td>
+          <td style="padding:8px;border-bottom:1px solid #e5e7eb">${escapeHtml(s.submitterEmail)}</td>
+          <td style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:right">${s.daysPending}d</td>
+        </tr>`,
+    )
+    .join('');
+  return {
+    subject: `Response reminder: ${d.agingSubmissions.length} submission${d.agingSubmissions.length !== 1 ? 's' : ''} awaiting review`,
+    mjml: wrapInLayout(
+      `<mj-text>
+        <p>Hi ${escapeHtml(d.editorName)},</p>
+        <p>The following submissions at ${escapeHtml(d.orgName)} have been waiting for a response:</p>
+      </mj-text>
+      <mj-table>
+        <tr style="background-color:#f3f4f6;text-align:left">
+          <th style="padding:8px">Title</th>
+          <th style="padding:8px">Submitter</th>
+          <th style="padding:8px;text-align:right">Age</th>
+        </tr>
+        ${rows}
+      </mj-table>
+      ${d.queueUrl ? `<mj-button href="${escapeHtml(d.queueUrl)}" background-color="#2563eb" color="#ffffff" font-size="14px" padding="16px 0">View Queue</mj-button>` : ''}`,
+      d.orgName,
+    ),
+    text: [
+      `Hi ${d.editorName},`,
+      ``,
+      `The following submissions at ${d.orgName} have been waiting for a response:`,
+      ``,
+      ...d.agingSubmissions.map(
+        (s) => `- ${s.title} (${s.submitterEmail}) — ${s.daysPending} days`,
+      ),
+      ``,
+      d.queueUrl ? `View queue: ${d.queueUrl}` : '',
+    ]
+      .filter(Boolean)
+      .join('\n'),
+  };
+}
+
 export const templates: Record<TemplateName, TemplateRenderer> = {
   'submission-received': submissionReceived,
   'submission-accepted': submissionAccepted,
@@ -313,6 +362,7 @@ export const templates: Record<TemplateName, TemplateRenderer> = {
   'reviewer-assigned': reviewerAssigned,
   'discussion-comment': discussionComment,
   'embed-submission-confirmation': embedSubmissionConfirmation,
+  'submission-response-reminder': submissionResponseReminder,
 };
 
 function stripHtml(html: string): string {

--- a/apps/api/src/templates/email/types.ts
+++ b/apps/api/src/templates/email/types.ts
@@ -9,7 +9,8 @@ export type TemplateName =
   | 'editor-message'
   | 'reviewer-assigned'
   | 'discussion-comment'
-  | 'embed-submission-confirmation';
+  | 'embed-submission-confirmation'
+  | 'submission-response-reminder';
 
 export interface SubmissionTemplateData {
   submissionTitle: string;
@@ -62,6 +63,17 @@ export interface EmbedSubmissionConfirmationData {
   statusCheckUrl: string;
 }
 
+export interface ResponseReminderTemplateData {
+  orgName: string;
+  editorName: string;
+  agingSubmissions: Array<{
+    title: string;
+    submitterEmail: string;
+    daysPending: number;
+  }>;
+  queueUrl?: string;
+}
+
 export type TemplateData =
   | SubmissionTemplateData
   | ContractTemplateData
@@ -69,4 +81,5 @@ export type TemplateData =
   | EditorMessageTemplateData
   | ReviewerAssignedTemplateData
   | DiscussionCommentTemplateData
-  | EmbedSubmissionConfirmationData;
+  | EmbedSubmissionConfirmationData
+  | ResponseReminderTemplateData;

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -85,6 +85,10 @@ import {
   VoteOnTerminalSubmissionError,
   ScoreOutOfRangeError,
 } from '../services/submission-vote.service.js';
+import {
+  PresetLimitExceededError,
+  PresetNotFoundError,
+} from '../services/queue-preset.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -163,6 +167,9 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [VotingDisabledError, 'BAD_REQUEST'],
   [VoteOnTerminalSubmissionError, 'BAD_REQUEST'],
   [ScoreOutOfRangeError, 'BAD_REQUEST'],
+  // Preset errors
+  [PresetLimitExceededError, 'BAD_REQUEST'],
+  [PresetNotFoundError, 'NOT_FOUND'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -23,6 +23,7 @@ import { pluginsRouter } from './routers/plugins.js';
 import { webhooksRouter } from './routers/webhooks.js';
 import { correspondenceRouter } from './routers/correspondence.js';
 import { emailTemplatesRouter } from './routers/email-templates.js';
+import { queuePresetsRouter } from './routers/queue-presets.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -67,6 +68,7 @@ export const appRouter = t.router({
   plugins: pluginsRouter,
   correspondence: correspondenceRouter,
   emailTemplates: emailTemplatesRouter,
+  queuePresets: queuePresetsRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/__tests__/queue-presets.spec.ts
+++ b/apps/api/src/trpc/routers/__tests__/queue-presets.spec.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+// --- Service mock ---
+const mockList = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock('../../../services/queue-preset.service.js', () => ({
+  queuePresetService: {
+    list: (...args: unknown[]) => mockList(...args),
+    create: (...args: unknown[]) => mockCreate(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+  PresetLimitExceededError: class PresetLimitExceededError extends Error {
+    constructor() {
+      super('Maximum of 20 saved presets reached');
+      this.name = 'PresetLimitExceededError';
+    }
+  },
+  PresetNotFoundError: class PresetNotFoundError extends Error {
+    constructor(id: string) {
+      super(`Preset "${id}" not found`);
+      this.name = 'PresetNotFoundError';
+    }
+  },
+}));
+
+// Mock procedure builders to pass through to handler
+vi.mock('../../init.js', () => {
+  const noopMiddleware = {
+    use: function (this: unknown) {
+      return this;
+    },
+    input: function (this: unknown) {
+      return this;
+    },
+    output: function (this: unknown) {
+      return this;
+    },
+    query: (fn: unknown) => fn,
+    mutation: (fn: unknown) => fn,
+  };
+  return {
+    orgProcedure: noopMiddleware,
+    createRouter: (routes: Record<string, unknown>) => routes,
+    requireScopes: () => vi.fn(),
+  };
+});
+
+vi.mock('../../error-mapper.js', async () => {
+  const { PresetLimitExceededError, PresetNotFoundError } =
+    await import('../../../services/queue-preset.service.js');
+  return {
+    mapServiceError: (e: unknown) => {
+      if (e instanceof PresetLimitExceededError) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: (e as Error).message,
+        });
+      }
+      if (e instanceof PresetNotFoundError) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: (e as Error).message,
+        });
+      }
+      throw e;
+    },
+  };
+});
+
+import { queuePresetsRouter } from '../queue-presets.js';
+
+const router = queuePresetsRouter as unknown as Record<
+  string,
+  (ctx: { ctx: Record<string, unknown>; input?: unknown }) => Promise<unknown>
+>;
+
+const fakeCtx = {
+  ctx: {
+    dbTx: {},
+    authContext: {
+      userId: 'user-1',
+      orgId: 'org-1',
+    },
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('queuePresetsRouter', () => {
+  it('list returns empty array when no presets', async () => {
+    mockList.mockResolvedValue([]);
+    const result = await router.list(fakeCtx);
+    expect(result).toEqual([]);
+  });
+
+  it('create saves preset and returns it', async () => {
+    const preset = {
+      id: 'p-1',
+      organizationId: 'org-1',
+      userId: 'user-1',
+      name: 'My Filter',
+      filters: { status: 'SUBMITTED' },
+      isDefault: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockCreate.mockResolvedValue(preset);
+    const result = await router.create({
+      ...fakeCtx,
+      input: { name: 'My Filter', filters: { status: 'SUBMITTED' } },
+    });
+    expect(result).toEqual(preset);
+  });
+
+  it('create returns BAD_REQUEST at limit', async () => {
+    const { PresetLimitExceededError } =
+      await import('../../../services/queue-preset.service.js');
+    mockCreate.mockRejectedValue(new PresetLimitExceededError());
+    await expect(
+      router.create({
+        ...fakeCtx,
+        input: { name: 'Too many', filters: {} },
+      }),
+    ).rejects.toThrow(TRPCError);
+
+    try {
+      await router.create({
+        ...fakeCtx,
+        input: { name: 'Too many', filters: {} },
+      });
+    } catch (e) {
+      expect((e as TRPCError).code).toBe('BAD_REQUEST');
+    }
+  });
+
+  it('delete returns NOT_FOUND for missing', async () => {
+    const { PresetNotFoundError } =
+      await import('../../../services/queue-preset.service.js');
+    mockDelete.mockRejectedValue(new PresetNotFoundError('p-999'));
+    await expect(
+      router.delete({ ...fakeCtx, input: { id: 'p-999' } }),
+    ).rejects.toThrow(TRPCError);
+
+    try {
+      await router.delete({ ...fakeCtx, input: { id: 'p-999' } });
+    } catch (e) {
+      expect((e as TRPCError).code).toBe('NOT_FOUND');
+    }
+  });
+
+  it('update returns NOT_FOUND for missing', async () => {
+    const { PresetNotFoundError } =
+      await import('../../../services/queue-preset.service.js');
+    mockUpdate.mockRejectedValue(new PresetNotFoundError('p-999'));
+    await expect(
+      router.update({
+        ...fakeCtx,
+        input: { id: 'p-999', name: 'New name' },
+      }),
+    ).rejects.toThrow(TRPCError);
+
+    try {
+      await router.update({
+        ...fakeCtx,
+        input: { id: 'p-999', name: 'New name' },
+      });
+    } catch (e) {
+      expect((e as TRPCError).code).toBe('NOT_FOUND');
+    }
+  });
+});

--- a/apps/api/src/trpc/routers/queue-presets.ts
+++ b/apps/api/src/trpc/routers/queue-presets.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod';
+import {
+  queuePresetSchema,
+  presetFiltersSchema,
+  createQueuePresetSchema,
+  updateQueuePresetSchema,
+  deleteQueuePresetSchema,
+  type QueuePreset,
+} from '@colophony/types';
+import { orgProcedure, createRouter, requireScopes } from '../init.js';
+import { queuePresetService } from '../../services/queue-preset.service.js';
+import { mapServiceError } from '../error-mapper.js';
+
+/** Parse JSONB `filters` from Drizzle row into typed object. */
+function toPreset(
+  row: { filters: unknown } & Record<string, unknown>,
+): QueuePreset {
+  return {
+    ...row,
+    filters: presetFiltersSchema.parse(row.filters),
+  } as QueuePreset;
+}
+
+export const queuePresetsRouter = createRouter({
+  list: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .output(z.array(queuePresetSchema))
+    .query(async ({ ctx }) => {
+      try {
+        const rows = await queuePresetService.list(
+          ctx.dbTx,
+          ctx.authContext.userId,
+        );
+        return rows.map(toPreset);
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  create: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(createQueuePresetSchema)
+    .output(queuePresetSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const row = await queuePresetService.create(
+          ctx.dbTx,
+          ctx.authContext.userId,
+          ctx.authContext.orgId,
+          input,
+        );
+        return toPreset(row);
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  update: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(updateQueuePresetSchema)
+    .output(queuePresetSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const row = await queuePresetService.update(
+          ctx.dbTx,
+          ctx.authContext.userId,
+          input,
+        );
+        return toPreset(row);
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  delete: orgProcedure
+    .use(requireScopes('submissions:read'))
+    .input(deleteQueuePresetSchema)
+    .output(z.object({ deleted: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await queuePresetService.delete(
+          ctx.dbTx,
+          ctx.authContext.userId,
+          input.id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+});

--- a/apps/web/src/app/(dashboard)/editor/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/[id]/page.tsx
@@ -2,13 +2,26 @@ import { SubmissionDetail } from "@/components/submissions/submission-detail";
 
 export default async function EditorSubmissionDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ queue?: string; idx?: string }>;
 }) {
   const { id } = await params;
+  const sp = await searchParams;
+
+  const queueIds = sp.queue ? sp.queue.split(",").filter(Boolean) : undefined;
+  const queueIdx =
+    sp.idx != null && queueIds ? parseInt(sp.idx, 10) : undefined;
+
   return (
     <div className="p-6">
-      <SubmissionDetail submissionId={id} backHref="/editor/submissions" />
+      <SubmissionDetail
+        submissionId={id}
+        backHref="/editor/submissions"
+        queueIds={queueIds}
+        queueIdx={queueIdx}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/submissions/__tests__/editor-submission-queue-presets.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/editor-submission-queue-presets.spec.tsx
@@ -1,0 +1,179 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { EditorSubmissionQueue } from "../editor-submission-queue";
+import "../../../../test/setup";
+
+// --- Mutable mock state ---
+let mockData:
+  | {
+      items: Array<Record<string, unknown>>;
+      total: number;
+      page: number;
+      limit: number;
+      totalPages: number;
+    }
+  | undefined;
+let mockIsPending: boolean;
+let mockError: { message: string } | null;
+let mockPeriodsData: { items: Array<{ id: string; name: string }> } | undefined;
+let mockIsAdmin: boolean;
+let mockPresets: Array<{
+  id: string;
+  name: string;
+  filters: Record<string, unknown>;
+  isDefault: boolean;
+}>;
+
+const mockCreateMutate = jest.fn();
+const mockDeleteMutate = jest.fn();
+
+function resetMocks() {
+  mockData = {
+    items: [
+      {
+        id: "sub-1",
+        title: "My Poem",
+        status: "SUBMITTED",
+        submittedAt: "2026-01-15T12:00:00.000Z",
+        createdAt: "2026-01-14T12:00:00.000Z",
+        submitterEmail: "poet@example.com",
+      },
+    ],
+    total: 1,
+    page: 1,
+    limit: 20,
+    totalPages: 1,
+  };
+  mockIsPending = false;
+  mockError = null;
+  mockPeriodsData = undefined;
+  mockIsAdmin = false;
+  mockPresets = [];
+  mockCreateMutate.mockClear();
+  mockDeleteMutate.mockClear();
+}
+
+jest.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({
+    isAdmin: mockIsAdmin,
+    isEditor: true,
+    currentOrg: {
+      id: "org-1",
+      name: "Test Org",
+      role: mockIsAdmin ? "ADMIN" : "EDITOR",
+    },
+  }),
+}));
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    useUtils: () => ({
+      submissions: {
+        list: { invalidate: jest.fn() },
+        export: { fetch: jest.fn().mockResolvedValue([]) },
+      },
+      queuePresets: {
+        list: { invalidate: jest.fn() },
+      },
+    }),
+    submissions: {
+      list: {
+        useQuery: () => ({
+          data: mockData,
+          isPending: mockIsPending,
+          error: mockError,
+        }),
+      },
+      batchUpdateStatus: {
+        useMutation: () => ({ mutate: jest.fn(), isPending: false }),
+      },
+      batchAssignReviewers: {
+        useMutation: () => ({ mutate: jest.fn(), isPending: false }),
+      },
+    },
+    periods: {
+      list: {
+        useQuery: () => ({ data: mockPeriodsData }),
+      },
+    },
+    organizations: {
+      members: {
+        list: {
+          useQuery: () => ({ data: undefined }),
+        },
+      },
+    },
+    queuePresets: {
+      list: {
+        useQuery: () => ({ data: mockPresets }),
+      },
+      create: {
+        useMutation: (opts?: { onSuccess?: () => void }) => ({
+          mutate: (...args: unknown[]) => {
+            mockCreateMutate(...args);
+            opts?.onSuccess?.();
+          },
+          isPending: false,
+        }),
+      },
+      delete: {
+        useMutation: (opts?: { onSuccess?: () => void }) => ({
+          mutate: (...args: unknown[]) => {
+            mockDeleteMutate(...args);
+            opts?.onSuccess?.();
+          },
+          isPending: false,
+        }),
+      },
+    },
+  },
+}));
+
+beforeEach(() => {
+  resetMocks();
+});
+
+describe("EditorSubmissionQueue — Presets", () => {
+  it("shows preset dropdown when presets exist", () => {
+    mockPresets = [
+      {
+        id: "p-1",
+        name: "My Preset",
+        filters: { status: "SUBMITTED" },
+        isDefault: false,
+      },
+    ];
+    render(<EditorSubmissionQueue />);
+    expect(screen.getByText("Presets")).toBeInTheDocument();
+  });
+
+  it("hides preset dropdown when no presets", () => {
+    mockPresets = [];
+    render(<EditorSubmissionQueue />);
+    expect(screen.queryByText("Presets")).not.toBeInTheDocument();
+  });
+
+  it("opens save dialog on Save Filter click", () => {
+    render(<EditorSubmissionQueue />);
+    fireEvent.click(screen.getByText("Save Filter"));
+    expect(screen.getByText("Save Filter Preset")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("e.g. Pending reviews"),
+    ).toBeInTheDocument();
+  });
+
+  it("saves preset with current filters", () => {
+    render(<EditorSubmissionQueue />);
+    fireEvent.click(screen.getByText("Save Filter"));
+
+    const input = screen.getByPlaceholderText("e.g. Pending reviews");
+    fireEvent.change(input, { target: { value: "My New Preset" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(mockCreateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "My New Preset",
+        filters: expect.any(Object),
+      }),
+    );
+  });
+});

--- a/apps/web/src/components/submissions/__tests__/editor-submission-queue.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/editor-submission-queue.spec.tsx
@@ -46,6 +46,9 @@ jest.mock("@/lib/trpc", () => ({
         list: { invalidate: jest.fn() },
         export: { fetch: jest.fn().mockResolvedValue([]) },
       },
+      queuePresets: {
+        list: { invalidate: jest.fn() },
+      },
     }),
     submissions: {
       list: {
@@ -75,6 +78,17 @@ jest.mock("@/lib/trpc", () => ({
         list: {
           useQuery: () => ({ data: undefined }),
         },
+      },
+    },
+    queuePresets: {
+      list: {
+        useQuery: () => ({ data: [] }),
+      },
+      create: {
+        useMutation: () => ({ mutate: jest.fn(), isPending: false }),
+      },
+      delete: {
+        useMutation: () => ({ mutate: jest.fn(), isPending: false }),
       },
     },
   },
@@ -176,7 +190,7 @@ describe("EditorSubmissionQueue", () => {
     };
     render(<EditorSubmissionQueue />);
     const link = screen.getByText("My Poem").closest("a");
-    expect(link).toHaveAttribute("href", "/editor/abc123");
+    expect(link?.getAttribute("href")).toContain("/editor/abc123");
   });
 
   it("shows pagination when totalPages > 1", () => {

--- a/apps/web/src/components/submissions/__tests__/submission-detail.spec.tsx
+++ b/apps/web/src/components/submissions/__tests__/submission-detail.spec.tsx
@@ -1,0 +1,220 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SubmissionDetail } from "../submission-detail";
+import "../../../../test/setup";
+
+// --- Mutable mock state ---
+let mockSubmission: Record<string, unknown> | undefined;
+let mockIsLoading: boolean;
+let mockIsEditor: boolean;
+let mockIsAdmin: boolean;
+let mockUserId: string;
+let mockReviewers: Array<{ reviewerUserId: string }>;
+let mockHistory: Array<Record<string, unknown>>;
+
+function resetMocks() {
+  mockIsLoading = false;
+  mockIsEditor = true;
+  mockIsAdmin = false;
+  mockUserId = "user-editor";
+  mockReviewers = [];
+  mockHistory = [];
+  mockSubmission = {
+    id: "sub-1",
+    title: "Test Poem",
+    content: "Line one\nLine two",
+    coverLetter: null,
+    status: "SUBMITTED",
+    submitterId: "user-submitter",
+    manuscriptVersionId: "mv-1",
+    formDefinitionId: null,
+    formData: null,
+    createdAt: "2026-01-14T12:00:00.000Z",
+    manuscript: null,
+  };
+}
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: jest.fn(),
+    refresh: jest.fn(),
+  }),
+}));
+
+jest.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({
+    user: { id: mockUserId },
+    isEditor: mockIsEditor,
+    isAdmin: mockIsAdmin,
+    currentOrg: { id: "org-1", name: "Test Org", role: "EDITOR" },
+  }),
+}));
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    useUtils: () => ({
+      submissions: {
+        getById: { invalidate: jest.fn() },
+        getHistory: { invalidate: jest.fn() },
+      },
+      files: {
+        getDownloadUrl: { fetch: jest.fn() },
+      },
+    }),
+    submissions: {
+      getById: {
+        useQuery: () => ({
+          data: mockSubmission,
+          isPending: mockIsLoading,
+        }),
+      },
+      getHistory: {
+        useQuery: () => ({ data: mockHistory }),
+      },
+      listReviewers: {
+        useQuery: () => ({ data: mockReviewers }),
+      },
+      markReviewerRead: {
+        useMutation: () => ({ mutate: jest.fn() }),
+      },
+      delete: {
+        useMutation: () => ({ mutate: jest.fn(), isPending: false }),
+      },
+      withdraw: {
+        useMutation: () => ({ mutate: jest.fn(), isPending: false }),
+      },
+    },
+    files: {
+      listByManuscriptVersion: {
+        useQuery: () => ({ data: [] }),
+      },
+    },
+    organizations: {
+      get: {
+        useQuery: () => ({ data: { settings: {} } }),
+      },
+    },
+  },
+}));
+
+jest.mock("@/components/plugins/plugin-slot", () => ({
+  PluginSlot: () => null,
+}));
+
+jest.mock("../status-transition", () => ({
+  StatusTransition: () => <div data-testid="status-transition" />,
+}));
+
+jest.mock("../revise-and-resubmit-card", () => ({
+  ReviseAndResubmitCard: () => <div data-testid="rr-card" />,
+}));
+
+jest.mock("../compose-message-dialog", () => ({
+  ComposeMessageDialog: () => null,
+}));
+
+jest.mock("../correspondence-history", () => ({
+  CorrespondenceHistory: () => <div data-testid="correspondence" />,
+}));
+
+jest.mock("../reviewer-list", () => ({
+  ReviewerList: () => <div data-testid="reviewer-list" />,
+}));
+
+jest.mock("../reviewer-picker", () => ({
+  ReviewerPicker: () => <div data-testid="reviewer-picker" />,
+}));
+
+jest.mock("../discussion-thread", () => ({
+  DiscussionThread: () => <div data-testid="discussion-thread" />,
+}));
+
+jest.mock("../voting-panel", () => ({
+  VotingPanel: () => <div data-testid="voting-panel" />,
+}));
+
+jest.mock("../form-renderer/read-only-form-fields", () => ({
+  ReadOnlyFormFields: () => <div data-testid="form-fields" />,
+}));
+
+beforeEach(() => {
+  resetMocks();
+  mockPush.mockClear();
+});
+
+describe("SubmissionDetail — Reading Mode", () => {
+  it("shows reading mode toggle for editor", () => {
+    render(<SubmissionDetail submissionId="sub-1" />);
+    expect(
+      screen.getByRole("button", { name: /toggle reading mode/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides reading mode toggle for non-editor owner", () => {
+    mockIsEditor = false;
+    mockIsAdmin = false;
+    mockUserId = "user-submitter";
+    render(<SubmissionDetail submissionId="sub-1" />);
+    expect(
+      screen.queryByRole("button", { name: /toggle reading mode/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides editor actions in reading mode", () => {
+    render(<SubmissionDetail submissionId="sub-1" />);
+    expect(screen.getByText("Editor Actions")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /toggle reading mode/i }),
+    );
+
+    expect(screen.queryByText("Editor Actions")).not.toBeInTheDocument();
+  });
+
+  it("shows next/prev nav with queue context", () => {
+    render(
+      <SubmissionDetail
+        submissionId="b"
+        queueIds={["a", "b", "c"]}
+        queueIdx={1}
+      />,
+    );
+
+    expect(screen.getByText("Previous")).toBeEnabled();
+    expect(screen.getByText("Next")).toBeEnabled();
+    expect(screen.getByText("2 of 3")).toBeInTheDocument();
+  });
+
+  it("disables Previous on first item", () => {
+    render(
+      <SubmissionDetail
+        submissionId="a"
+        queueIds={["a", "b", "c"]}
+        queueIdx={0}
+      />,
+    );
+
+    expect(screen.getByText("Previous").closest("button")).toBeDisabled();
+    expect(screen.getByText("Next").closest("button")).toBeEnabled();
+  });
+
+  it("disables Next on last item", () => {
+    render(
+      <SubmissionDetail
+        submissionId="c"
+        queueIds={["a", "b", "c"]}
+        queueIdx={2}
+      />,
+    );
+
+    expect(screen.getByText("Previous").closest("button")).toBeEnabled();
+    expect(screen.getByText("Next").closest("button")).toBeDisabled();
+  });
+
+  it("hides nav bar without queue context", () => {
+    render(<SubmissionDetail submissionId="sub-1" />);
+    expect(screen.queryByText(/^\d+ of \d+$/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/submissions/editor-submission-queue.tsx
+++ b/apps/web/src/components/submissions/editor-submission-queue.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
-import { format } from "date-fns";
+import { format, differenceInDays } from "date-fns";
 import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
 import { useOrganization } from "@/hooks/use-organization";
@@ -37,6 +37,15 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import {
   Inbox,
   MoreHorizontal,
   Eye,
@@ -45,11 +54,14 @@ import {
   ArrowDown,
   ArrowUpDown,
   Download,
+  Bookmark,
+  BookmarkPlus,
 } from "lucide-react";
 import type {
   SubmissionStatus,
   SubmissionSortBy,
   SortOrder,
+  PresetFilters,
 } from "@colophony/types";
 
 const STATUS_TABS: Array<{ value: SubmissionStatus | "ALL"; label: string }> = [
@@ -62,15 +74,52 @@ const STATUS_TABS: Array<{ value: SubmissionStatus | "ALL"; label: string }> = [
   { value: "WITHDRAWN", label: "Withdrawn" },
 ];
 
+const TERMINAL_STATUSES = new Set(["ACCEPTED", "REJECTED", "WITHDRAWN"]);
+
+function AgeBadge({
+  submittedAt,
+  status,
+}: {
+  submittedAt: string | null;
+  status: string;
+}) {
+  if (TERMINAL_STATUSES.has(status) || !submittedAt) {
+    return <span className="text-muted-foreground">{"\u2014"}</span>;
+  }
+  const days = differenceInDays(new Date(), new Date(submittedAt));
+  let colorClass =
+    "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300";
+  if (days > 30) {
+    colorClass = "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300";
+  } else if (days >= 14) {
+    colorClass =
+      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300";
+  }
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${colorClass}`}
+    >
+      {days}d
+    </span>
+  );
+}
+
 const SORTABLE_COLUMNS: Array<{
   key: SubmissionSortBy;
   label: string;
   className?: string;
+  id?: string;
 }> = [
   { key: "status", label: "Status", className: "w-[100px]" },
   { key: "title", label: "Title" },
   { key: "submitterEmail", label: "Submitter" },
   { key: "submittedAt", label: "Submitted", className: "w-[140px]" },
+  {
+    key: "submittedAt",
+    label: "Age",
+    className: "w-[80px]",
+    id: "age",
+  },
 ];
 
 const EXPORT_COLUMNS = [
@@ -82,6 +131,14 @@ const EXPORT_COLUMNS = [
   { key: "createdAt", label: "Created At" },
   { key: "periodName", label: "Submission Period" },
 ];
+
+function buildEditorHref(id: string, ids: string[], idx: number): string {
+  const params = new URLSearchParams({
+    queue: ids.join(","),
+    idx: String(idx),
+  });
+  return `/editor/${id}?${params.toString()}`;
+}
 
 function SortIcon({
   column,
@@ -113,6 +170,8 @@ export function EditorSubmissionQueue() {
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
   const [periodFilter, setPeriodFilter] = useState("");
   const [isExporting, setIsExporting] = useState(false);
+  const [showSavePresetDialog, setShowSavePresetDialog] = useState(false);
+  const [presetName, setPresetName] = useState("");
   const selection = useRowSelection<{ id: string }>();
   const { isAdmin } = useOrganization();
 
@@ -133,6 +192,23 @@ export function EditorSubmissionQueue() {
   const utils = trpc.useUtils();
 
   const { data: periods } = trpc.periods.list.useQuery({ limit: 100 });
+  const { data: presets } = trpc.queuePresets.list.useQuery();
+  const createPresetMutation = trpc.queuePresets.create.useMutation({
+    onSuccess: () => {
+      toast.success("Preset saved");
+      setShowSavePresetDialog(false);
+      setPresetName("");
+      utils.queuePresets.list.invalidate();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+  const deletePresetMutation = trpc.queuePresets.delete.useMutation({
+    onSuccess: () => {
+      toast.success("Preset deleted");
+      utils.queuePresets.list.invalidate();
+    },
+    onError: (err) => toast.error(err.message),
+  });
 
   const { data, isPending, error } = trpc.submissions.list.useQuery({
     status: statusFilter === "ALL" ? undefined : statusFilter,
@@ -166,6 +242,34 @@ export function EditorSubmissionQueue() {
     setPeriodFilter(value === "all" ? "" : value);
     setPage(1);
   }, []);
+
+  const getCurrentFilters = useCallback((): PresetFilters => {
+    return {
+      status: statusFilter === "ALL" ? undefined : statusFilter,
+      sortBy,
+      sortOrder,
+      periodFilter: periodFilter || undefined,
+      search: debouncedSearch || undefined,
+    };
+  }, [statusFilter, sortBy, sortOrder, periodFilter, debouncedSearch]);
+
+  const applyPreset = useCallback((filters: PresetFilters) => {
+    setStatusFilter((filters.status as SubmissionStatus | "ALL") ?? "ALL");
+    setSortBy((filters.sortBy as SubmissionSortBy) ?? "createdAt");
+    setSortOrder((filters.sortOrder as SortOrder) ?? "desc");
+    setPeriodFilter(filters.periodFilter ?? "");
+    setSearch(filters.search ?? "");
+    setDebouncedSearch(filters.search ?? "");
+    setPage(1);
+  }, []);
+
+  const handleSavePreset = useCallback(() => {
+    if (!presetName.trim()) return;
+    createPresetMutation.mutate({
+      name: presetName.trim(),
+      filters: getCurrentFilters(),
+    });
+  }, [presetName, getCurrentFilters, createPresetMutation]);
 
   const handleExport = useCallback(
     async (exportFormat: "json" | "csv") => {
@@ -288,6 +392,47 @@ export function EditorSubmissionQueue() {
             ))}
           </SelectContent>
         </Select>
+
+        {/* Preset buttons */}
+        {presets && presets.length > 0 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm">
+                <Bookmark className="mr-2 h-4 w-4" />
+                Presets
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              {presets.map((preset) => (
+                <DropdownMenuItem
+                  key={preset.id}
+                  className="flex items-center justify-between"
+                  onClick={() => applyPreset(preset.filters as PresetFilters)}
+                >
+                  <span className="truncate">{preset.name}</span>
+                  <button
+                    type="button"
+                    className="ml-2 text-muted-foreground hover:text-destructive"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      deletePresetMutation.mutate({ id: preset.id });
+                    }}
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setShowSavePresetDialog(true)}
+        >
+          <BookmarkPlus className="mr-2 h-4 w-4" />
+          Save Filter
+        </Button>
       </div>
 
       {/* Status tabs */}
@@ -321,7 +466,7 @@ export function EditorSubmissionQueue() {
                   />
                 </TableHead>
                 {SORTABLE_COLUMNS.map((col) => (
-                  <TableHead key={col.key} className={col.className}>
+                  <TableHead key={col.id ?? col.key} className={col.className}>
                     <button
                       type="button"
                       className="inline-flex items-center hover:text-foreground"
@@ -340,58 +485,69 @@ export function EditorSubmissionQueue() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {data.items.map((item) => (
-                <TableRow
-                  key={item.id}
-                  data-state={
-                    selection.isSelected(item.id) ? "selected" : undefined
-                  }
-                >
-                  <TableCell>
-                    <Checkbox
-                      checked={selection.isSelected(item.id)}
-                      onCheckedChange={() => selection.toggle(item.id)}
-                      aria-label={`Select ${item.title ?? "submission"}`}
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <StatusBadge status={item.status as SubmissionStatus} />
-                  </TableCell>
-                  <TableCell>
-                    <Link
-                      href={`/editor/${item.id}`}
-                      className="font-medium hover:underline"
-                    >
-                      {item.title ?? "(Untitled)"}
-                    </Link>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {item.submitterEmail ?? "[Anonymous]"}
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {item.submittedAt
-                      ? format(new Date(item.submittedAt), "MMM d, yyyy")
-                      : "\u2014"}
-                  </TableCell>
-                  <TableCell>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" size="icon" className="h-8 w-8">
-                          <MoreHorizontal className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem asChild>
-                          <Link href={`/editor/${item.id}`}>
-                            <Eye className="mr-2 h-4 w-4" />
-                            View
-                          </Link>
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </TableCell>
-                </TableRow>
-              ))}
+              {data.items.map((item, idx) => {
+                const ids = data.items.map((i) => i.id);
+                const href = buildEditorHref(item.id, ids, idx);
+                return (
+                  <TableRow
+                    key={item.id}
+                    data-state={
+                      selection.isSelected(item.id) ? "selected" : undefined
+                    }
+                  >
+                    <TableCell>
+                      <Checkbox
+                        checked={selection.isSelected(item.id)}
+                        onCheckedChange={() => selection.toggle(item.id)}
+                        aria-label={`Select ${item.title ?? "submission"}`}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <StatusBadge status={item.status as SubmissionStatus} />
+                    </TableCell>
+                    <TableCell>
+                      <Link href={href} className="font-medium hover:underline">
+                        {item.title ?? "(Untitled)"}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {item.submitterEmail ?? "[Anonymous]"}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {item.submittedAt
+                        ? format(new Date(item.submittedAt), "MMM d, yyyy")
+                        : "\u2014"}
+                    </TableCell>
+                    <TableCell>
+                      <AgeBadge
+                        submittedAt={item.submittedAt as string | null}
+                        status={item.status as string}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                          >
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem asChild>
+                            <Link href={href}>
+                              <Eye className="mr-2 h-4 w-4" />
+                              View
+                            </Link>
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
 
@@ -444,6 +600,50 @@ export function EditorSubmissionQueue() {
           utils.submissions.list.invalidate();
         }}
       />
+
+      {/* Save preset dialog */}
+      <Dialog
+        open={showSavePresetDialog}
+        onOpenChange={setShowSavePresetDialog}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Save Filter Preset</DialogTitle>
+            <DialogDescription>
+              Save the current filter settings for quick access later.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="preset-name">Preset name</Label>
+              <Input
+                id="preset-name"
+                placeholder="e.g. Pending reviews"
+                value={presetName}
+                onChange={(e) => setPresetName(e.target.value)}
+                maxLength={100}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setShowSavePresetDialog(false);
+                setPresetName("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSavePreset}
+              disabled={!presetName.trim() || createPresetMutation.isPending}
+            >
+              {createPresetMutation.isPending ? "Saving..." : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -39,6 +39,7 @@ import {
   Edit,
   Trash2,
   ArrowLeft,
+  ArrowRight,
   File,
   Download,
   Clock,
@@ -60,6 +61,8 @@ import { ReadOnlyFormFields } from "./form-renderer/read-only-form-fields";
 interface SubmissionDetailProps {
   submissionId: string;
   backHref?: string;
+  queueIds?: string[];
+  queueIdx?: number;
 }
 
 const scanStatusIcons: Record<
@@ -73,6 +76,14 @@ const scanStatusIcons: Record<
   FAILED: AlertCircle,
 };
 
+function buildQueueHref(id: string, ids: string[], idx: number): string {
+  const params = new URLSearchParams({
+    queue: ids.join(","),
+    idx: String(idx),
+  });
+  return `/editor/${id}?${params.toString()}`;
+}
+
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -82,12 +93,15 @@ function formatFileSize(bytes: number): string {
 export function SubmissionDetail({
   submissionId,
   backHref = "/submissions",
+  queueIds,
+  queueIdx,
 }: SubmissionDetailProps) {
   const router = useRouter();
   const { user, isEditor, isAdmin } = useOrganization();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showWithdrawDialog, setShowWithdrawDialog] = useState(false);
   const [showComposeDialog, setShowComposeDialog] = useState(false);
+  const [isReadingMode, setIsReadingMode] = useState(false);
   const utils = trpc.useUtils();
 
   const { data: submission, isPending: isLoading } =
@@ -209,6 +223,17 @@ export function SubmissionDetail({
         </div>
 
         <div className="flex gap-2">
+          {(isEditor || isAdmin) && (
+            <Button
+              variant={isReadingMode ? "default" : "outline"}
+              size="icon"
+              onClick={() => setIsReadingMode((prev) => !prev)}
+              aria-pressed={isReadingMode}
+              aria-label="Toggle reading mode"
+            >
+              <BookOpen className="h-4 w-4" />
+            </Button>
+          )}
           {canEdit && (
             <Link href={`/submissions/${submissionId}/edit`}>
               <Button variant="outline">
@@ -237,8 +262,42 @@ export function SubmissionDetail({
         </div>
       </div>
 
-      {/* Editor status transitions */}
-      {(isEditor || isAdmin) &&
+      {/* Queue navigation */}
+      {queueIds && queueIds.length > 0 && queueIdx != null && (
+        <div className="flex items-center justify-between rounded-lg border p-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={queueIdx <= 0}
+            onClick={() => {
+              const prevIdx = queueIdx - 1;
+              router.push(buildQueueHref(queueIds[prevIdx], queueIds, prevIdx));
+            }}
+          >
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            Previous
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            {queueIdx + 1} of {queueIds.length}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={queueIdx >= queueIds.length - 1}
+            onClick={() => {
+              const nextIdx = queueIdx + 1;
+              router.push(buildQueueHref(queueIds[nextIdx], queueIds, nextIdx));
+            }}
+          >
+            Next
+            <ArrowRight className="ml-1 h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      {/* Editor status transitions — hidden in reading mode */}
+      {!isReadingMode &&
+        (isEditor || isAdmin) &&
         EDITOR_ALLOWED_TRANSITIONS[submission.status as SubmissionStatus]
           ?.length > 0 && (
           <Card>
@@ -267,8 +326,9 @@ export function SubmissionDetail({
           </Card>
         )}
 
-      {/* Revise and Resubmit card — shown to owner when in R&R status */}
-      {isOwner &&
+      {/* Revise and Resubmit card — shown to owner when in R&R status, hidden in reading mode */}
+      {!isReadingMode &&
+        isOwner &&
         submission.status === "REVISE_AND_RESUBMIT" &&
         submission.manuscript && (
           <ReviseAndResubmitCard
@@ -282,8 +342,8 @@ export function SubmissionDetail({
           />
         )}
 
-      {/* Reviewers */}
-      {(isEditor || isAdmin || isOwner) && (
+      {/* Reviewers — hidden in reading mode */}
+      {!isReadingMode && (isEditor || isAdmin || isOwner) && (
         <Card>
           <CardHeader>
             <div className="flex items-center justify-between">
@@ -309,10 +369,11 @@ export function SubmissionDetail({
         </Card>
       )}
 
-      {/* Internal Discussion — editors, admins, and assigned reviewers only */}
-      {(isEditor ||
-        isAdmin ||
-        (reviewers ?? []).some((r) => r.reviewerUserId === user?.id)) &&
+      {/* Internal Discussion — hidden in reading mode */}
+      {!isReadingMode &&
+        (isEditor ||
+          isAdmin ||
+          (reviewers ?? []).some((r) => r.reviewerUserId === user?.id)) &&
         !isOwner && (
           <Card>
             <CardHeader>
@@ -330,10 +391,11 @@ export function SubmissionDetail({
           </Card>
         )}
 
-      {/* Voting — editors, admins, and assigned reviewers (not submitter) */}
-      {(isEditor ||
-        isAdmin ||
-        (reviewers ?? []).some((r) => r.reviewerUserId === user?.id)) &&
+      {/* Voting — hidden in reading mode */}
+      {!isReadingMode &&
+        (isEditor ||
+          isAdmin ||
+          (reviewers ?? []).some((r) => r.reviewerUserId === user?.id)) &&
         !isOwner &&
         submission.status !== "DRAFT" && (
           <VotingPanel
@@ -346,8 +408,16 @@ export function SubmissionDetail({
         )}
 
       {/* Content */}
-      <div className="grid gap-6 md:grid-cols-3">
-        <div className="md:col-span-2 space-y-6">
+      <div
+        className={
+          isReadingMode
+            ? "max-w-3xl mx-auto space-y-6"
+            : "grid gap-6 md:grid-cols-3"
+        }
+      >
+        <div
+          className={isReadingMode ? "space-y-6" : "md:col-span-2 space-y-6"}
+        >
           {/* Main content */}
           <Card>
             <CardHeader>
@@ -355,7 +425,13 @@ export function SubmissionDetail({
             </CardHeader>
             <CardContent>
               {submission.content ? (
-                <div className="whitespace-pre-wrap text-sm">
+                <div
+                  className={
+                    isReadingMode
+                      ? "prose prose-sm max-w-none leading-relaxed text-base"
+                      : "whitespace-pre-wrap text-sm"
+                  }
+                >
                   {submission.content}
                 </div>
               ) : (
@@ -381,15 +457,21 @@ export function SubmissionDetail({
                 <CardTitle>Cover Letter</CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="whitespace-pre-wrap text-sm">
+                <div
+                  className={
+                    isReadingMode
+                      ? "prose prose-sm max-w-none leading-relaxed text-base"
+                      : "whitespace-pre-wrap text-sm"
+                  }
+                >
                   {submission.coverLetter}
                 </div>
               </CardContent>
             </Card>
           )}
 
-          {/* Linked manuscript */}
-          {submission.manuscript && (
+          {/* Linked manuscript — hidden in reading mode */}
+          {!isReadingMode && submission.manuscript && (
             <Card>
               <CardHeader>
                 <CardTitle>Linked Manuscript</CardTitle>
@@ -476,75 +558,81 @@ export function SubmissionDetail({
             </Card>
           )}
 
-          <PluginSlot
-            point="submission.detail.section"
-            context={{ submissionId: submission.id }}
-            className="space-y-4"
-          />
-        </div>
-
-        {/* Sidebar */}
-        <div className="space-y-6">
-          {/* History */}
-          <Card>
-            <CardHeader>
-              <CardTitle>History</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {history && history.length > 0 ? (
-                <div className="space-y-4">
-                  {history.map((event, index) => (
-                    <div key={event.id} className="relative">
-                      {index < history.length - 1 && (
-                        <div className="absolute left-2 top-8 bottom-0 w-px bg-border" />
-                      )}
-                      <div className="flex gap-3">
-                        <div className="w-4 h-4 mt-1 rounded-full bg-primary flex-shrink-0" />
-                        <div className="space-y-1">
-                          <span className="text-sm">
-                            {event.fromStatus ? (
-                              <>
-                                Changed from{" "}
-                                <Badge variant="outline" className="text-xs">
-                                  {event.fromStatus}
-                                </Badge>{" "}
-                                to{" "}
-                                <Badge variant="outline" className="text-xs">
-                                  {event.toStatus}
-                                </Badge>
-                              </>
-                            ) : (
-                              <>
-                                Status set to{" "}
-                                <Badge variant="outline" className="text-xs">
-                                  {event.toStatus}
-                                </Badge>
-                              </>
-                            )}
-                          </span>
-                          {event.comment && (
-                            <p className="text-sm text-muted-foreground">
-                              &ldquo;{event.comment}&rdquo;
-                            </p>
-                          )}
-                          <p className="text-xs text-muted-foreground">
-                            {format(new Date(event.changedAt), "PPp")}
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">No history yet</p>
-              )}
-            </CardContent>
-          </Card>
-
-          {(isEditor || isAdmin) && (
-            <CorrespondenceHistory submissionId={submissionId} />
+          {!isReadingMode && (
+            <PluginSlot
+              point="submission.detail.section"
+              context={{ submissionId: submission.id }}
+              className="space-y-4"
+            />
           )}
         </div>
+
+        {/* Sidebar — hidden in reading mode */}
+        {!isReadingMode && (
+          <div className="space-y-6">
+            {/* History */}
+            <Card>
+              <CardHeader>
+                <CardTitle>History</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {history && history.length > 0 ? (
+                  <div className="space-y-4">
+                    {history.map((event, index) => (
+                      <div key={event.id} className="relative">
+                        {index < history.length - 1 && (
+                          <div className="absolute left-2 top-8 bottom-0 w-px bg-border" />
+                        )}
+                        <div className="flex gap-3">
+                          <div className="w-4 h-4 mt-1 rounded-full bg-primary flex-shrink-0" />
+                          <div className="space-y-1">
+                            <span className="text-sm">
+                              {event.fromStatus ? (
+                                <>
+                                  Changed from{" "}
+                                  <Badge variant="outline" className="text-xs">
+                                    {event.fromStatus}
+                                  </Badge>{" "}
+                                  to{" "}
+                                  <Badge variant="outline" className="text-xs">
+                                    {event.toStatus}
+                                  </Badge>
+                                </>
+                              ) : (
+                                <>
+                                  Status set to{" "}
+                                  <Badge variant="outline" className="text-xs">
+                                    {event.toStatus}
+                                  </Badge>
+                                </>
+                              )}
+                            </span>
+                            {event.comment && (
+                              <p className="text-sm text-muted-foreground">
+                                &ldquo;{event.comment}&rdquo;
+                              </p>
+                            )}
+                            <p className="text-xs text-muted-foreground">
+                              {format(new Date(event.changedAt), "PPp")}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    No history yet
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+
+            {(isEditor || isAdmin) && (
+              <CorrespondenceHistory submissionId={submissionId} />
+            )}
+          </div>
+        )}
       </div>
 
       {/* Compose message dialog */}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -303,7 +303,7 @@
 
 ## Track 7 — Editorial Experience (Pre-Launch)
 
-> **Status:** In progress. PR1 (correspondence) shipped. PR2 (email templates) pending.
+> **Status:** Complete. All P0-P3 items shipped.
 
 ### Correspondence & Communication
 
@@ -320,20 +320,20 @@
 - [x] [P2] Voting / scoring on submissions — readers cast votes (accept/reject/maybe + optional score); configurable per org; summary visible to editors making final decisions — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [x] [P2] Blind / anonymous review mode — hide submitter identity from reviewers; admin toggle per submission period — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [x] [P2] Batch operations — checkbox selection in submission queue; bulk status transitions (reject, move to review); bulk assignment — (persona gap analysis 2026-02-27; done 2026-02-28)
-- [ ] [P3] Submission reading mode — distraction-free view for reading the submitted work; "next unread" navigation within the queue — (persona gap analysis 2026-02-27)
+- [x] [P3] Submission reading mode — distraction-free view for reading the submitted work; "next unread" navigation within the queue — (persona gap analysis 2026-02-27; done 2026-02-28)
 
 ### Analytics & Reporting
 
 - [x] [P1] Submission analytics dashboard — acceptance rate, response time distribution, submissions per period, funnel (submitted → reviewed → accepted/rejected), aging submissions — (persona gap analysis 2026-02-27, implemented 2026-02-28)
 - [x] [P2] Publication data export — CSV/JSON export of all org submissions, with filters (date range, status, period); admin-only — (persona gap analysis 2026-02-27; done 2026-02-28)
-- [ ] [P3] Response time tracking and reminders — flag submissions pending over N days (configurable); optional email reminder to editors — (persona gap analysis 2026-02-27)
+- [x] [P3] Response time tracking and reminders — flag submissions pending over N days (configurable); optional email reminder to editors — (persona gap analysis 2026-02-27; done 2026-02-28)
 
 ### UI Polish
 
 - [x] [P1] Mobile navigation — hamburger menu or bottom nav for `< md` breakpoints; sidebar is currently `hidden md:flex` with no mobile alternative — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [x] [P2] Column sorting in submission queue — sortable by title, submitter, date, status; currently hardcoded `DESC createdAt` — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [x] [P2] Submission period filter in editor queue — the API supports `submissionPeriodId` filter but the UI doesn't expose a period dropdown — (persona gap analysis 2026-02-27; done 2026-02-28)
-- [ ] [P3] Saved filter presets / views — editors can save named filter+sort combos for their queue — (persona gap analysis 2026-02-27)
+- [x] [P3] Saved filter presets / views — editors can save named filter+sort combos for their queue — (persona gap analysis 2026-02-27; done 2026-02-28)
 
 ---
 

--- a/docs/devlog/2026-02.md
+++ b/docs/devlog/2026-02.md
@@ -4,6 +4,25 @@ Newest entries first.
 
 ---
 
+## 2026-02-28 — Track 7 P3 Closeout: Reading Mode, Reminders, Saved Presets
+
+### Done
+
+- **Reading mode**: Toggle in submission detail strips view to content-only with prose styling; prev/next queue navigation via URL search params passed from editor queue links
+- **Age badge column**: Color-coded days-pending indicator in editor queue (green <14d, yellow 14-30d, red >30d); `OrgSettings` Zod schema for reminder configuration
+- **Response time reminders**: Inngest weekly cron (`submission-response-reminder`) emails editors about aging submissions exceeding org threshold; extracted `queueEmailForRecipient` to shared helper; `listAgingByOrg` service method; MJML email template
+- **Saved filter presets**: New `saved_queue_presets` table with RLS (migration 0045), Zod types, service layer with 20-preset limit, tRPC CRUD router; frontend preset dropdown, save dialog, and delete UI
+- **Tests**: 26 new tests — 6 reading mode, 4 preset UI, 4 response reminder cron, 3 aging submissions, 5 preset service, 5 preset tRPC router; all 1843 tests passing
+- Track 7 fully complete (all P0-P3 items shipped)
+
+### Decisions
+
+- Age column sorts by `submittedAt` (inverse of age) — no new sort field needed
+- Preset UI stays in `editor-submission-queue.tsx` — not large enough to warrant extraction
+- `toPreset()` helper in tRPC router parses JSONB `filters` via `presetFiltersSchema`
+
+---
+
 ## 2026-02-28 — Editorial Polish: Column Sorting, Period Filter, Data Export
 
 ### Done

--- a/packages/db/migrations/0045_saved_queue_presets.sql
+++ b/packages/db/migrations/0045_saved_queue_presets.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "saved_queue_presets" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"filters" jsonb NOT NULL,
+	"is_default" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "saved_queue_presets" ADD CONSTRAINT "saved_queue_presets_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "saved_queue_presets" ADD CONSTRAINT "saved_queue_presets_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "saved_queue_presets_org_user_name_idx" ON "saved_queue_presets" USING btree ("organization_id","user_id","name");
+--> statement-breakpoint
+CREATE INDEX "saved_queue_presets_org_user_idx" ON "saved_queue_presets" USING btree ("organization_id","user_id");
+--> statement-breakpoint
+ALTER TABLE "saved_queue_presets" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "saved_queue_presets" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE POLICY "org_isolation" ON "saved_queue_presets" AS PERMISSIVE FOR ALL TO public USING (organization_id = current_org_id());

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1778000000000,
       "tag": "0044_status_token",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1778200000000,
+      "tag": "0045_saved_queue_presets",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -29,4 +29,5 @@ export * from "./notifications-inbox";
 export * from "./webhook-endpoints";
 export * from "./writer-workspace";
 export * from "./email-templates";
+export * from "./saved-queue-presets";
 export * from "./relations";

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -25,6 +25,7 @@ import {
   correspondence,
   writerProfiles,
 } from "./writer-workspace";
+import { savedQueuePresets } from "./saved-queue-presets";
 
 // --- organizations ---
 
@@ -45,6 +46,7 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   issues: many(issues),
   cmsConnections: many(cmsConnections),
   trustedPeers: many(trustedPeers),
+  savedQueuePresets: many(savedQueuePresets),
 }));
 
 // --- users ---
@@ -61,6 +63,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   externalSubmissions: many(externalSubmissions),
   correspondence: many(correspondence),
   writerProfiles: many(writerProfiles),
+  savedQueuePresets: many(savedQueuePresets),
 }));
 
 // --- organization_members ---

--- a/packages/db/src/schema/saved-queue-presets.ts
+++ b/packages/db/src/schema/saved-queue-presets.ts
@@ -1,0 +1,51 @@
+import {
+  boolean,
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  timestamp,
+  jsonb,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { organizations } from "./organizations";
+import { users } from "./users";
+
+export const savedQueuePresets = pgTable(
+  "saved_queue_presets",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    name: varchar("name", { length: 100 }).notNull(),
+    filters: jsonb("filters").notNull(),
+    isDefault: boolean("is_default").default(false).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("saved_queue_presets_org_user_name_idx").on(
+      table.organizationId,
+      table.userId,
+      table.name,
+    ),
+    index("saved_queue_presets_org_user_idx").on(
+      table.organizationId,
+      table.userId,
+    ),
+    pgPolicy("org_isolation", {
+      for: "all",
+      using: sql`organization_id = current_org_id()`,
+    }),
+  ],
+).enableRLS();

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -32,3 +32,4 @@ export * from "./discussion";
 export * from "./analytics";
 export * from "./voting";
 export * from "./blind-review";
+export * from "./queue-preset";

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -142,3 +142,9 @@ export const updateMemberRoleSchema = z.object({
 });
 
 export type UpdateMemberRoleInput = z.infer<typeof updateMemberRoleSchema>;
+
+export const orgSettingsSchema = z.object({
+  responseReminderEnabled: z.boolean().default(false),
+  responseReminderDays: z.number().int().min(1).max(365).default(30),
+});
+export type OrgSettings = z.infer<typeof orgSettingsSchema>;

--- a/packages/types/src/queue-preset.ts
+++ b/packages/types/src/queue-preset.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+export const presetFiltersSchema = z.object({
+  status: z.string().optional(),
+  sortBy: z.string().optional(),
+  sortOrder: z.enum(["asc", "desc"]).optional(),
+  periodFilter: z.string().optional(),
+  search: z.string().optional(),
+});
+export type PresetFilters = z.infer<typeof presetFiltersSchema>;
+
+export const queuePresetSchema = z.object({
+  id: z.string().uuid(),
+  organizationId: z.string().uuid(),
+  userId: z.string().uuid(),
+  name: z.string(),
+  filters: presetFiltersSchema,
+  isDefault: z.boolean(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+export type QueuePreset = z.infer<typeof queuePresetSchema>;
+
+export const createQueuePresetSchema = z.object({
+  name: z.string().min(1).max(100),
+  filters: presetFiltersSchema,
+  isDefault: z.boolean().optional().default(false),
+});
+export type CreateQueuePresetInput = z.infer<typeof createQueuePresetSchema>;
+
+export const updateQueuePresetSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1).max(100).optional(),
+  filters: presetFiltersSchema.optional(),
+  isDefault: z.boolean().optional(),
+});
+export type UpdateQueuePresetInput = z.infer<typeof updateQueuePresetSchema>;
+
+export const deleteQueuePresetSchema = z.object({
+  id: z.string().uuid(),
+});
+export type DeleteQueuePresetInput = z.infer<typeof deleteQueuePresetSchema>;


### PR DESCRIPTION
## Summary

- **Reading mode**: Distraction-free content view toggle for editors/admins with prose styling; prev/next queue navigation via URL search params
- **Age badge column**: Color-coded days-pending indicator in editor queue (green <14d, yellow 14-30d, red >30d)
- **Response time reminders**: Weekly Inngest cron emails editors about submissions exceeding org-configured threshold; extracted `queueEmailForRecipient` to shared helper
- **Saved filter presets**: Database-backed preset CRUD (schema + migration + types + service + tRPC router + frontend UI) with 20-preset limit per user

Closes out all Track 7 P3 items. Track 7 (Editorial Experience) is now complete.

## Test plan

- [x] Type check clean (14/14 packages)
- [x] All 1843 unit tests passing (1378 API + 465 web)
- [x] 26 new tests across 6 spec files
- [ ] Manual: toggle reading mode, verify content-only layout
- [ ] Manual: navigate prev/next from queue
- [ ] Manual: verify age badges in queue
- [ ] Manual: save/load/delete filter presets
- [ ] CI: all jobs green

## OpenCode Review

- **Verdict:** LGTM
- **Plan drift:** 21/21 items matched, zero drift
- **Findings:** 3 minor suggestions — all either already handled or not actionable