### PR TITLE
feat(hopper): CSR export/import endpoints for data portability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **Instrumented worker**  | `apps/api/src/config/instrumented-worker.ts` (BullMQ wrapper with metrics)       |
 | **Writer workspace**     | `packages/db/src/schema/writer-workspace.ts`                                     |
 | **CSR types**            | `packages/types/src/csr.ts`                                                      |
+| **CSR service**          | `apps/api/src/services/csr.service.ts` (export/import for data portability)      |
 | **Backlog**              | `docs/backlog.md` (track-organized, drives session focus)                        |
 
 Full project structure: [docs/architecture-v2-planning.md](docs/architecture-v2-planning.md)

--- a/apps/api/src/rest/error-mapper.ts
+++ b/apps/api/src/rest/error-mapper.ts
@@ -81,6 +81,7 @@ import {
   VoteOnTerminalSubmissionError,
   ScoreOutOfRangeError,
 } from '../services/submission-vote.service.js';
+import { CSRImportError } from '../services/csr.service.js';
 
 type ORPCErrorCode = ConstructorParameters<typeof ORPCError>[0];
 
@@ -156,6 +157,8 @@ const errorCodeMap: [new (...args: never[]) => Error, ORPCErrorCode][] = [
   [VotingDisabledError, 'BAD_REQUEST'],
   [VoteOnTerminalSubmissionError, 'BAD_REQUEST'],
   [ScoreOutOfRangeError, 'BAD_REQUEST'],
+  // CSR errors
+  [CSRImportError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
 ];

--- a/apps/api/src/rest/router.ts
+++ b/apps/api/src/rest/router.ts
@@ -17,6 +17,7 @@ import { contractTemplatesRouter } from './routers/contract-templates.js';
 import { contractsRouter } from './routers/contracts.js';
 import { issuesRouter } from './routers/issues.js';
 import { cmsConnectionsRouter } from './routers/cms-connections.js';
+import { csrRouter } from './routers/csr.js';
 import type { RestContext } from './context.js';
 
 const restRouter = {
@@ -35,6 +36,7 @@ const restRouter = {
   contracts: contractsRouter,
   issues: issuesRouter,
   cmsConnections: cmsConnectionsRouter,
+  csr: csrRouter,
 };
 
 const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
@@ -134,6 +136,11 @@ const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
             name: 'CMS Connections',
             description:
               'Manage CMS connections for publishing issues to WordPress or Ghost (Slate).',
+          },
+          {
+            name: 'CSR',
+            description:
+              'Export and import Colophony Submission Records — personal data portability for writers.',
           },
           {
             name: 'Audit',

--- a/apps/api/src/rest/routers/csr.ts
+++ b/apps/api/src/rest/routers/csr.ts
@@ -1,0 +1,84 @@
+import {
+  AuditActions,
+  AuditResources,
+  csrExportEnvelopeSchema,
+  csrImportInputSchema,
+  csrImportResultSchema,
+} from '@colophony/types';
+import { csrService } from '../../services/csr.service.js';
+import { mapServiceError } from '../error-mapper.js';
+import { userProcedure, requireScopes } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// CSR routes (user-scoped, no org required)
+// ---------------------------------------------------------------------------
+
+const exportCsr = userProcedure
+  .use(requireScopes('csr:read'))
+  .route({
+    method: 'GET',
+    path: '/csr/export',
+    summary: 'Export CSR',
+    description:
+      'Exports the full Colophony Submission Record for the authenticated user as JSON.',
+    operationId: 'exportCsr',
+    tags: ['CSR'],
+  })
+  .output(csrExportEnvelopeSchema)
+  .handler(async ({ context }) => {
+    const result = await csrService.assembleExport({
+      userId: context.authContext.userId,
+    });
+    await context.audit({
+      action: AuditActions.CSR_EXPORTED,
+      resource: AuditResources.CSR,
+      newValue: {
+        nativeCount: result.nativeSubmissions.length,
+        externalCount: result.externalSubmissions.length,
+      },
+    });
+    return result;
+  });
+
+const importCsr = userProcedure
+  .use(requireScopes('csr:write'))
+  .route({
+    method: 'POST',
+    path: '/csr/import',
+    summary: 'Import CSR',
+    description:
+      'Imports external submission records and correspondence from a JSON payload.',
+    operationId: 'importCsr',
+    tags: ['CSR'],
+  })
+  .input(csrImportInputSchema)
+  .output(csrImportResultSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const result = await csrService.importRecords(context.dbTx, {
+        userId: context.authContext.userId,
+        input,
+      });
+      await context.audit({
+        action: AuditActions.CSR_IMPORTED,
+        resource: AuditResources.CSR,
+        newValue: {
+          submissionsCreated: result.submissionsCreated,
+          correspondenceCreated: result.correspondenceCreated,
+          importedFrom: input.importedFrom,
+        },
+      });
+      return result;
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const csrRouter = {
+  exportCsr,
+  importCsr,
+};

--- a/apps/api/src/services/csr.service.spec.ts
+++ b/apps/api/src/services/csr.service.spec.ts
@@ -1,0 +1,516 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { mockDb } = vi.hoisted(() => {
+  const mockDb = {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockReturnThis(),
+    innerJoin: vi.fn().mockReturnThis(),
+  };
+  return { mockDb };
+});
+
+vi.mock('@colophony/db', () => ({
+  db: mockDb,
+  submissions: {
+    id: 'submissions.id',
+    submitterId: 'submissions.submitterId',
+    title: 'submissions.title',
+    coverLetter: 'submissions.coverLetter',
+    status: 'submissions.status',
+    formData: 'submissions.formData',
+    submittedAt: 'submissions.submittedAt',
+    organizationId: 'submissions.organizationId',
+    manuscriptVersionId: 'submissions.manuscriptVersionId',
+    submissionPeriodId: 'submissions.submissionPeriodId',
+  },
+  manuscriptVersions: {
+    id: 'manuscriptVersions.id',
+    manuscriptId: 'manuscriptVersions.manuscriptId',
+  },
+  manuscripts: {
+    id: 'manuscripts.id',
+    title: 'manuscripts.title',
+    genre: 'manuscripts.genre',
+    ownerId: 'manuscripts.ownerId',
+    createdAt: 'manuscripts.createdAt',
+  },
+  organizations: { id: 'organizations.id', name: 'organizations.name' },
+  submissionPeriods: {
+    id: 'submissionPeriods.id',
+    name: 'submissionPeriods.name',
+  },
+  submissionHistory: {
+    submissionId: 'submissionHistory.submissionId',
+    fromStatus: 'submissionHistory.fromStatus',
+    toStatus: 'submissionHistory.toStatus',
+    changedAt: 'submissionHistory.changedAt',
+    comment: 'submissionHistory.comment',
+  },
+  externalSubmissions: {
+    id: 'externalSubmissions.id',
+    userId: 'externalSubmissions.userId',
+  },
+  correspondence: {
+    userId: 'correspondence.userId',
+  },
+  writerProfiles: {
+    userId: 'writerProfiles.userId',
+  },
+  users: { id: 'users.id', email: 'users.email' },
+  eq: vi.fn(),
+  inArray: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import type { DrizzleDb } from '@colophony/db';
+import { csrService, CSRImportError } from './csr.service.js';
+
+const validUuid = '00000000-0000-4000-a000-000000000001';
+const validUuid2 = '00000000-0000-4000-a000-000000000002';
+
+describe('csrService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('assembleExport', () => {
+    it('returns empty envelope when user has no data', async () => {
+      let selectCallCount = 0;
+      mockDb.select.mockImplementation(() => {
+        selectCallCount++;
+        return mockDb;
+      });
+
+      mockDb.where.mockImplementation(() => {
+        if (selectCallCount === 1) {
+          // User lookup
+          return [{ id: validUuid, email: 'writer@test.com' }];
+        }
+        // All other queries return empty
+        return [];
+      });
+
+      const envelope = await csrService.assembleExport({
+        userId: validUuid,
+      });
+
+      expect(envelope.version).toBe('1.0');
+      expect(envelope.exportedAt).toBeDefined();
+      expect(envelope.identity.userId).toBe(validUuid);
+      expect(envelope.identity.email).toBe('writer@test.com');
+      expect(envelope.identity.displayName).toBeNull();
+      expect(envelope.nativeSubmissions).toEqual([]);
+      expect(envelope.externalSubmissions).toEqual([]);
+      expect(envelope.correspondence).toEqual([]);
+      expect(envelope.writerProfiles).toEqual([]);
+      expect(envelope.manuscripts).toEqual([]);
+    });
+
+    it('includes native submissions with org/period/genre enrichment', async () => {
+      let selectCallCount = 0;
+      mockDb.select.mockImplementation(() => {
+        selectCallCount++;
+        return mockDb;
+      });
+
+      const mvId = '00000000-0000-4000-a000-000000000010';
+      const periodId = '00000000-0000-4000-a000-000000000030';
+
+      mockDb.where.mockImplementation(() => {
+        if (selectCallCount === 1) {
+          // User
+          return [{ id: validUuid, email: 'writer@test.com' }];
+        }
+        if (selectCallCount === 2) {
+          // Submissions
+          return [
+            {
+              id: validUuid,
+              title: 'Rejected Poem',
+              coverLetter: 'Dear editor',
+              status: 'REJECTED',
+              formData: null,
+              submittedAt: new Date('2025-01-01'),
+              organizationId: validUuid2,
+              manuscriptVersionId: mvId,
+              submissionPeriodId: periodId,
+            },
+            {
+              id: validUuid2,
+              title: 'Submitted Story',
+              coverLetter: null,
+              status: 'SUBMITTED',
+              formData: null,
+              submittedAt: new Date('2025-02-01'),
+              organizationId: validUuid2,
+              manuscriptVersionId: null,
+              submissionPeriodId: null,
+            },
+          ];
+        }
+        if (selectCallCount === 3) {
+          // Orgs
+          return [{ id: validUuid2, name: 'Test Magazine' }];
+        }
+        if (selectCallCount === 4) {
+          // Periods
+          return [{ id: periodId, name: 'Spring 2025' }];
+        }
+        if (selectCallCount === 5) {
+          // Genre JOIN
+          return [
+            {
+              versionId: mvId,
+              genre: { primary: 'poetry', sub: 'lyric', hybrid: [] },
+            },
+          ];
+        }
+        if (selectCallCount === 6) {
+          // History
+          return [
+            {
+              submissionId: validUuid,
+              fromStatus: 'SUBMITTED',
+              toStatus: 'REJECTED',
+              changedAt: new Date('2025-03-01T10:00:00Z'),
+              comment: 'Not a fit',
+            },
+          ];
+        }
+        // External, correspondence, profiles, manuscripts — empty
+        return [];
+      });
+
+      const envelope = await csrService.assembleExport({
+        userId: validUuid,
+      });
+
+      expect(envelope.nativeSubmissions).toHaveLength(2);
+
+      const rejected = envelope.nativeSubmissions[0];
+      expect(rejected.publicationName).toBe('Test Magazine');
+      expect(rejected.periodName).toBe('Spring 2025');
+      expect(rejected.genre).toEqual({
+        primary: 'poetry',
+        sub: 'lyric',
+        hybrid: [],
+      });
+      expect(rejected.decidedAt).toBe('2025-03-01T10:00:00.000Z');
+      expect(rejected.status).toBe('rejected');
+
+      const submitted = envelope.nativeSubmissions[1];
+      expect(submitted.publicationName).toBe('Test Magazine');
+      expect(submitted.status).toBe('sent');
+    });
+
+    it('includes external submissions, correspondence, profiles, manuscripts', async () => {
+      let selectCallCount = 0;
+      mockDb.select.mockImplementation(() => {
+        selectCallCount++;
+        return mockDb;
+      });
+
+      mockDb.where.mockImplementation(() => {
+        if (selectCallCount === 1) {
+          return [{ id: validUuid, email: 'writer@test.com' }];
+        }
+        if (selectCallCount === 2) {
+          // Native submissions — empty
+          return [];
+        }
+        if (selectCallCount === 3) {
+          // External submissions
+          return [
+            {
+              id: validUuid,
+              manuscriptId: null,
+              journalDirectoryId: null,
+              journalName: 'Poetry Daily',
+              status: 'sent',
+              sentAt: new Date('2025-04-01'),
+              respondedAt: null,
+              method: 'email',
+              notes: null,
+              importedFrom: 'csv',
+              createdAt: new Date('2025-04-01'),
+              updatedAt: new Date('2025-04-01'),
+            },
+          ];
+        }
+        if (selectCallCount === 4) {
+          // Correspondence
+          return [
+            {
+              id: validUuid2,
+              submissionId: null,
+              externalSubmissionId: validUuid,
+              direction: 'outbound',
+              channel: 'email',
+              sentAt: new Date('2025-04-02'),
+              subject: 'Submission',
+              body: 'Dear editors...',
+              senderName: 'Writer',
+              senderEmail: 'writer@test.com',
+              isPersonalized: false,
+              source: 'manual',
+              capturedAt: new Date('2025-04-02'),
+            },
+          ];
+        }
+        if (selectCallCount === 5) {
+          // Writer profiles
+          return [
+            {
+              id: validUuid,
+              platform: 'submittable',
+              externalId: 'user123',
+              profileUrl: null,
+            },
+          ];
+        }
+        if (selectCallCount === 6) {
+          // Manuscripts
+          return [
+            {
+              id: validUuid,
+              title: 'My Poems',
+              genre: { primary: 'poetry', sub: null, hybrid: [] },
+              createdAt: new Date('2025-01-01'),
+            },
+          ];
+        }
+        return [];
+      });
+
+      const envelope = await csrService.assembleExport({
+        userId: validUuid,
+      });
+
+      expect(envelope.externalSubmissions).toHaveLength(1);
+      expect(envelope.externalSubmissions[0].journalName).toBe('Poetry Daily');
+      expect(envelope.correspondence).toHaveLength(1);
+      expect(envelope.correspondence[0].body).toBe('Dear editors...');
+      expect(envelope.writerProfiles).toHaveLength(1);
+      expect(envelope.writerProfiles[0].platform).toBe('submittable');
+      expect(envelope.manuscripts).toHaveLength(1);
+      expect(envelope.manuscripts[0].title).toBe('My Poems');
+    });
+
+    it('respects MAX_NATIVE_SUBMISSIONS cap', async () => {
+      let selectCallCount = 0;
+      mockDb.select.mockImplementation(() => {
+        selectCallCount++;
+        return mockDb;
+      });
+
+      mockDb.where.mockImplementation(() => {
+        if (selectCallCount === 1) {
+          return [{ id: validUuid, email: 'writer@test.com' }];
+        }
+        return [];
+      });
+
+      await csrService.assembleExport({ userId: validUuid });
+
+      // Should call .limit(10000) on native submissions query
+      expect(mockDb.limit).toHaveBeenCalledWith(10_000);
+    });
+
+    it('handles null genre gracefully', async () => {
+      let selectCallCount = 0;
+      mockDb.select.mockImplementation(() => {
+        selectCallCount++;
+        return mockDb;
+      });
+
+      mockDb.where.mockImplementation(() => {
+        if (selectCallCount === 1) {
+          return [{ id: validUuid, email: 'writer@test.com' }];
+        }
+        if (selectCallCount === 2) return []; // Native submissions
+        if (selectCallCount === 3) return []; // External submissions
+        if (selectCallCount === 4) return []; // Correspondence
+        if (selectCallCount === 5) return []; // Writer profiles
+        if (selectCallCount === 6) {
+          // Manuscripts — null genre
+          return [
+            {
+              id: validUuid,
+              title: 'Untitled',
+              genre: null,
+              createdAt: new Date('2025-01-01'),
+            },
+          ];
+        }
+        return [];
+      });
+
+      const envelope = await csrService.assembleExport({
+        userId: validUuid,
+      });
+
+      expect(envelope.manuscripts[0].genre).toBeNull();
+    });
+  });
+
+  describe('importRecords', () => {
+    // Use a separate mock tx for imports
+    const mockTx = {
+      insert: vi.fn().mockReturnThis(),
+      values: vi.fn().mockReturnThis(),
+      returning: vi.fn(),
+    };
+
+    beforeEach(() => {
+      mockTx.insert.mockReturnThis();
+      mockTx.values.mockReturnThis();
+      mockTx.returning.mockResolvedValue([]);
+    });
+
+    it('creates external submissions with importedFrom tag', async () => {
+      mockTx.returning.mockResolvedValue([
+        { id: 'new-1' },
+        { id: 'new-2' },
+        { id: 'new-3' },
+      ]);
+
+      const result = await csrService.importRecords(
+        mockTx as unknown as DrizzleDb,
+        {
+          userId: validUuid,
+          input: {
+            submissions: [
+              { journalName: 'Journal A', status: 'sent' },
+              { journalName: 'Journal B', status: 'rejected' },
+              { journalName: 'Journal C', status: 'accepted' },
+            ],
+            correspondence: [],
+            importedFrom: 'duotrope_export',
+          },
+        },
+      );
+
+      expect(result.submissionsCreated).toBe(3);
+      expect(result.correspondenceCreated).toBe(0);
+      expect(mockTx.insert).toHaveBeenCalledTimes(1);
+      expect(mockTx.values).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            userId: validUuid,
+            journalName: 'Journal A',
+            importedFrom: 'duotrope_export',
+          }),
+        ]),
+      );
+    });
+
+    it('creates correspondence linked to new submissions', async () => {
+      mockTx.returning.mockResolvedValueOnce([
+        { id: 'new-sub-1' },
+        { id: 'new-sub-2' },
+      ]);
+
+      const result = await csrService.importRecords(
+        mockTx as unknown as DrizzleDb,
+        {
+          userId: validUuid,
+          input: {
+            submissions: [
+              { journalName: 'Journal A', status: 'sent' },
+              { journalName: 'Journal B', status: 'sent' },
+            ],
+            correspondence: [
+              {
+                externalSubmissionIndex: 0,
+                direction: 'outbound' as const,
+                channel: 'email' as const,
+                sentAt: '2025-04-01T00:00:00Z',
+                body: 'Dear editors...',
+                isPersonalized: false,
+              },
+            ],
+            importedFrom: 'csr_import',
+          },
+        },
+      );
+
+      expect(result.submissionsCreated).toBe(2);
+      expect(result.correspondenceCreated).toBe(1);
+      // Second insert call is for correspondence
+      expect(mockTx.insert).toHaveBeenCalledTimes(2);
+      expect(mockTx.values).toHaveBeenLastCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            userId: validUuid,
+            externalSubmissionId: 'new-sub-1',
+            body: 'Dear editors...',
+            source: 'manual',
+          }),
+        ]),
+      );
+    });
+
+    it('throws CSRImportError on invalid externalSubmissionIndex', async () => {
+      mockTx.returning.mockResolvedValueOnce([
+        { id: 'new-sub-1' },
+        { id: 'new-sub-2' },
+      ]);
+
+      await expect(
+        csrService.importRecords(mockTx as unknown as DrizzleDb, {
+          userId: validUuid,
+          input: {
+            submissions: [
+              { journalName: 'Journal A', status: 'sent' },
+              { journalName: 'Journal B', status: 'sent' },
+            ],
+            correspondence: [
+              {
+                externalSubmissionIndex: 5,
+                direction: 'outbound' as const,
+                channel: 'email' as const,
+                sentAt: '2025-04-01T00:00:00Z',
+                body: 'Dear editors...',
+                isPersonalized: false,
+              },
+            ],
+            importedFrom: 'csr_import',
+          },
+        }),
+      ).rejects.toThrow(CSRImportError);
+    });
+
+    it('handles empty correspondence array', async () => {
+      mockTx.returning.mockResolvedValueOnce([{ id: 'new-1' }]);
+
+      const result = await csrService.importRecords(
+        mockTx as unknown as DrizzleDb,
+        {
+          userId: validUuid,
+          input: {
+            submissions: [{ journalName: 'Journal A', status: 'sent' }],
+            correspondence: [],
+            importedFrom: 'csr_import',
+          },
+        },
+      );
+
+      expect(result.submissionsCreated).toBe(1);
+      expect(result.correspondenceCreated).toBe(0);
+      // Only one insert call (submissions)
+      expect(mockTx.insert).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/api/src/services/csr.service.ts
+++ b/apps/api/src/services/csr.service.ts
@@ -1,0 +1,396 @@
+import {
+  db,
+  submissions,
+  organizations,
+  submissionPeriods,
+  submissionHistory,
+  manuscriptVersions,
+  manuscripts,
+  externalSubmissions,
+  correspondence,
+  writerProfiles,
+  users,
+  eq,
+  inArray,
+} from '@colophony/db';
+import type { DrizzleDb } from '@colophony/db';
+import type {
+  CSRExportEnvelope,
+  CSRNativeSubmission,
+  CSRImportInput,
+  CSRImportResult,
+  Genre,
+  MigrationStatusHistoryEntry,
+} from '@colophony/types';
+import { genreSchema, hopperToCsrStatus } from '@colophony/types';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class CSRExportError extends Error {
+  override name = 'CSRExportError' as const;
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class CSRImportError extends Error {
+  override name = 'CSRImportError' as const;
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_NATIVE_SUBMISSIONS = 10_000;
+const MAX_EXTERNAL = 10_000;
+const MAX_CORRESPONDENCE = 50_000;
+
+/** Statuses that indicate a terminal/decided submission. */
+const TERMINAL_STATUSES = new Set(['ACCEPTED', 'REJECTED', 'WITHDRAWN']);
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const csrService = {
+  /**
+   * Assemble a full CSR export envelope for a user.
+   *
+   * Uses superuser `db` — justified: CSR export is a user-level operation
+   * that spans all orgs. Same justification as migration bundle and GDPR.
+   */
+  async assembleExport(params: { userId: string }): Promise<CSRExportEnvelope> {
+    // 1. User identity
+    const [user] = await db
+      .select({ id: users.id, email: users.email })
+      .from(users)
+      .where(eq(users.id, params.userId));
+
+    if (!user) {
+      throw new CSRExportError('User not found');
+    }
+
+    // 2. Native submissions (cross-org)
+    const allSubmissions = await db
+      .select({
+        id: submissions.id,
+        title: submissions.title,
+        coverLetter: submissions.coverLetter,
+        status: submissions.status,
+        formData: submissions.formData,
+        submittedAt: submissions.submittedAt,
+        organizationId: submissions.organizationId,
+        manuscriptVersionId: submissions.manuscriptVersionId,
+        submissionPeriodId: submissions.submissionPeriodId,
+      })
+      .from(submissions)
+      .limit(MAX_NATIVE_SUBMISSIONS)
+      .where(eq(submissions.submitterId, params.userId));
+
+    // 3. Batch-fetch orgs
+    const orgIds = [...new Set(allSubmissions.map((s) => s.organizationId))];
+    const orgMap = new Map<string, string>();
+    if (orgIds.length > 0) {
+      const orgs = await db
+        .select({ id: organizations.id, name: organizations.name })
+        .from(organizations)
+        .where(inArray(organizations.id, orgIds));
+      for (const org of orgs) {
+        orgMap.set(org.id, org.name);
+      }
+    }
+
+    // 4. Batch-fetch periods
+    const periodIds = [
+      ...new Set(
+        allSubmissions
+          .map((s) => s.submissionPeriodId)
+          .filter((id): id is string => id != null),
+      ),
+    ];
+    const periodMap = new Map<string, string>();
+    if (periodIds.length > 0) {
+      const periods = await db
+        .select({ id: submissionPeriods.id, name: submissionPeriods.name })
+        .from(submissionPeriods)
+        .where(inArray(submissionPeriods.id, periodIds));
+      for (const p of periods) {
+        periodMap.set(p.id, p.name);
+      }
+    }
+
+    // 5. Batch-fetch genre via manuscript JOIN
+    const allVersionIds = allSubmissions
+      .map((s) => s.manuscriptVersionId)
+      .filter((id): id is string => id != null);
+    const genreMap = new Map<string, Genre | null>();
+    if (allVersionIds.length > 0) {
+      const genreRows = await db
+        .select({
+          versionId: manuscriptVersions.id,
+          genre: manuscripts.genre,
+        })
+        .from(manuscriptVersions)
+        .innerJoin(
+          manuscripts,
+          eq(manuscriptVersions.manuscriptId, manuscripts.id),
+        )
+        .where(inArray(manuscriptVersions.id, allVersionIds));
+      for (const row of genreRows) {
+        if (row.genre == null) {
+          genreMap.set(row.versionId, null);
+        } else {
+          const parsed = genreSchema.safeParse(row.genre);
+          genreMap.set(row.versionId, parsed.success ? parsed.data : null);
+        }
+      }
+    }
+
+    // 6. Batch-fetch submission history
+    const allSubIds = allSubmissions.map((s) => s.id);
+    const historyMap = new Map<
+      string,
+      { decidedAt: string | null; statusHistory: MigrationStatusHistoryEntry[] }
+    >();
+    if (allSubIds.length > 0) {
+      const historyRows = await db
+        .select({
+          submissionId: submissionHistory.submissionId,
+          fromStatus: submissionHistory.fromStatus,
+          toStatus: submissionHistory.toStatus,
+          changedAt: submissionHistory.changedAt,
+          comment: submissionHistory.comment,
+        })
+        .from(submissionHistory)
+        .where(inArray(submissionHistory.submissionId, allSubIds));
+
+      const grouped = new Map<string, typeof historyRows>();
+      for (const row of historyRows) {
+        const existing = grouped.get(row.submissionId);
+        if (existing) {
+          existing.push(row);
+        } else {
+          grouped.set(row.submissionId, [row]);
+        }
+      }
+
+      for (const [subId, rows] of grouped) {
+        rows.sort(
+          (a, b) =>
+            new Date(a.changedAt).getTime() - new Date(b.changedAt).getTime(),
+        );
+
+        const statusHistory: MigrationStatusHistoryEntry[] = rows.map((r) => ({
+          from: r.fromStatus ? hopperToCsrStatus(r.fromStatus) : null,
+          to: hopperToCsrStatus(r.toStatus),
+          changedAt: new Date(r.changedAt).toISOString(),
+          comment: r.comment,
+        }));
+
+        let decidedAt: string | null = null;
+        for (const r of rows) {
+          if (TERMINAL_STATUSES.has(r.toStatus)) {
+            decidedAt = new Date(r.changedAt).toISOString();
+          }
+        }
+
+        historyMap.set(subId, { decidedAt, statusHistory });
+      }
+    }
+
+    // 7. Build native submissions (all in one array, no closed/active split)
+    const nativeSubmissions: CSRNativeSubmission[] = allSubmissions.map(
+      (sub) => {
+        const genre = sub.manuscriptVersionId
+          ? (genreMap.get(sub.manuscriptVersionId) ?? null)
+          : null;
+        const periodName = sub.submissionPeriodId
+          ? (periodMap.get(sub.submissionPeriodId) ?? null)
+          : null;
+        const history = historyMap.get(sub.id);
+
+        return {
+          originSubmissionId: sub.id,
+          title: sub.title,
+          genre,
+          coverLetter: sub.coverLetter,
+          status: hopperToCsrStatus(sub.status),
+          formData: sub.formData ?? null,
+          submittedAt: sub.submittedAt?.toISOString() ?? null,
+          decidedAt: history?.decidedAt ?? null,
+          publicationName: orgMap.get(sub.organizationId) ?? null,
+          periodName,
+          statusHistory: history?.statusHistory ?? [],
+        };
+      },
+    );
+
+    // 8. External submissions
+    const extSubs = await db
+      .select()
+      .from(externalSubmissions)
+      .limit(MAX_EXTERNAL)
+      .where(eq(externalSubmissions.userId, params.userId));
+
+    const externalSubmissionsResult = extSubs.map((s) => ({
+      id: s.id,
+      manuscriptId: s.manuscriptId,
+      journalDirectoryId: s.journalDirectoryId,
+      journalName: s.journalName,
+      status: s.status,
+      sentAt: s.sentAt?.toISOString() ?? null,
+      respondedAt: s.respondedAt?.toISOString() ?? null,
+      method: s.method,
+      notes: s.notes,
+      importedFrom: s.importedFrom,
+      createdAt: s.createdAt.toISOString(),
+      updatedAt: s.updatedAt.toISOString(),
+    }));
+
+    // 9. Correspondence
+    const corr = await db
+      .select()
+      .from(correspondence)
+      .limit(MAX_CORRESPONDENCE)
+      .where(eq(correspondence.userId, params.userId));
+
+    const correspondenceResult = corr.map((c) => ({
+      id: c.id,
+      submissionId: c.submissionId,
+      externalSubmissionId: c.externalSubmissionId,
+      direction: c.direction,
+      channel: c.channel,
+      sentAt: c.sentAt.toISOString(),
+      subject: c.subject,
+      body: c.body,
+      senderName: c.senderName,
+      senderEmail: c.senderEmail,
+      isPersonalized: c.isPersonalized,
+      source: c.source as 'colophony' | 'manual',
+      capturedAt: c.capturedAt.toISOString(),
+    }));
+
+    // 10. Writer profiles
+    const profiles = await db
+      .select()
+      .from(writerProfiles)
+      .where(eq(writerProfiles.userId, params.userId));
+
+    const writerProfilesResult = profiles.map((p) => ({
+      id: p.id,
+      platform: p.platform,
+      externalId: p.externalId,
+      profileUrl: p.profileUrl,
+    }));
+
+    // 11. Manuscripts
+    const mss = await db
+      .select({
+        id: manuscripts.id,
+        title: manuscripts.title,
+        genre: manuscripts.genre,
+        createdAt: manuscripts.createdAt,
+      })
+      .from(manuscripts)
+      .where(eq(manuscripts.ownerId, params.userId));
+
+    const manuscriptsResult = mss.map((m) => {
+      let genre: Genre | null = null;
+      if (m.genre != null) {
+        const parsed = genreSchema.safeParse(m.genre);
+        genre = parsed.success ? parsed.data : null;
+      }
+      return {
+        id: m.id,
+        title: m.title,
+        genre,
+        createdAt: m.createdAt.toISOString(),
+      };
+    });
+
+    return {
+      version: '1.0',
+      exportedAt: new Date().toISOString(),
+      identity: {
+        userId: user.id,
+        email: user.email,
+        displayName: null,
+      },
+      nativeSubmissions,
+      externalSubmissions: externalSubmissionsResult,
+      correspondence: correspondenceResult,
+      writerProfiles: writerProfilesResult,
+      manuscripts: manuscriptsResult,
+    };
+  },
+
+  /**
+   * Import external submissions and correspondence from a CSR JSON payload.
+   *
+   * Uses RLS-scoped `tx` from userProcedure.
+   */
+  async importRecords(
+    tx: DrizzleDb,
+    params: { userId: string; input: CSRImportInput },
+  ): Promise<CSRImportResult> {
+    const { userId, input } = params;
+
+    // 1. Batch-insert external submissions
+    const submissionValues = input.submissions.map((s) => ({
+      userId,
+      journalName: s.journalName,
+      journalDirectoryId: s.journalDirectoryId ?? null,
+      status: s.status,
+      sentAt: s.sentAt ? new Date(s.sentAt) : null,
+      respondedAt: s.respondedAt ? new Date(s.respondedAt) : null,
+      method: s.method ?? null,
+      notes: s.notes ?? null,
+      importedFrom: s.importedFrom ?? input.importedFrom,
+    }));
+
+    const createdSubs = await tx
+      .insert(externalSubmissions)
+      .values(submissionValues)
+      .returning({ id: externalSubmissions.id });
+
+    // 2. Insert correspondence linked to new submissions
+    let correspondenceCreated = 0;
+    if (input.correspondence.length > 0) {
+      const correspondenceValues = input.correspondence.map((c) => {
+        if (c.externalSubmissionIndex >= createdSubs.length) {
+          throw new CSRImportError(
+            `Invalid externalSubmissionIndex ${c.externalSubmissionIndex}: only ${createdSubs.length} submissions were created`,
+          );
+        }
+
+        return {
+          userId,
+          externalSubmissionId: createdSubs[c.externalSubmissionIndex].id,
+          direction: c.direction,
+          channel: c.channel,
+          sentAt: new Date(c.sentAt),
+          subject: c.subject ?? null,
+          body: c.body,
+          senderName: c.senderName ?? null,
+          senderEmail: c.senderEmail ?? null,
+          isPersonalized: c.isPersonalized,
+          source: 'manual' as const,
+          capturedAt: new Date(),
+        };
+      });
+
+      await tx.insert(correspondence).values(correspondenceValues);
+      correspondenceCreated = correspondenceValues.length;
+    }
+
+    return {
+      submissionsCreated: createdSubs.length,
+      correspondenceCreated,
+    };
+  },
+};

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -89,6 +89,7 @@ import {
   PresetLimitExceededError,
   PresetNotFoundError,
 } from '../services/queue-preset.service.js';
+import { CSRImportError } from '../services/csr.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -170,6 +171,8 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   // Preset errors
   [PresetLimitExceededError, 'BAD_REQUEST'],
   [PresetNotFoundError, 'NOT_FOUND'],
+  // CSR errors
+  [CSRImportError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -24,6 +24,7 @@ import { webhooksRouter } from './routers/webhooks.js';
 import { correspondenceRouter } from './routers/correspondence.js';
 import { emailTemplatesRouter } from './routers/email-templates.js';
 import { queuePresetsRouter } from './routers/queue-presets.js';
+import { csrRouter } from './routers/csr.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -69,6 +70,7 @@ export const appRouter = t.router({
   correspondence: correspondenceRouter,
   emailTemplates: emailTemplatesRouter,
   queuePresets: queuePresetsRouter,
+  csr: csrRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/csr.spec.ts
+++ b/apps/api/src/trpc/routers/csr.spec.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+// ---------------------------------------------------------------------------
+// Service mock
+// ---------------------------------------------------------------------------
+
+const { mockAssembleExport, mockImportRecords } = vi.hoisted(() => ({
+  mockAssembleExport: vi.fn(),
+  mockImportRecords: vi.fn(),
+}));
+
+vi.mock('../../services/csr.service.js', () => ({
+  csrService: {
+    assembleExport: mockAssembleExport,
+    importRecords: mockImportRecords,
+  },
+  CSRImportError: class CSRImportError extends Error {
+    override name = 'CSRImportError';
+  },
+  CSRExportError: class CSRExportError extends Error {
+    override name = 'CSRExportError';
+  },
+}));
+
+// Mock all other services that the appRouter imports
+vi.mock('../../services/organization.service.js', () => ({
+  organizationService: {},
+  UserNotFoundError: class extends Error {},
+  SlugTakenError: class extends Error {},
+  LastAdminError: class extends Error {},
+}));
+
+vi.mock('../../services/submission.service.js', () => ({
+  submissionService: {},
+  SubmissionNotFoundError: class extends Error {},
+  NotDraftError: class extends Error {},
+  InvalidStatusTransitionError: class extends Error {},
+  UnscannedFilesError: class extends Error {},
+  InfectedFilesError: class extends Error {},
+  FormDefinitionMismatchError: class extends Error {},
+  MissingRevisionNotesError: class extends Error {},
+  NotReviseAndResubmitError: class extends Error {},
+}));
+
+vi.mock('../../services/file.service.js', () => ({
+  fileService: {},
+  FileNotFoundError: class extends Error {},
+  FileNotCleanError: class extends Error {},
+}));
+
+vi.mock('../../services/manuscript.service.js', () => ({
+  manuscriptService: {},
+  ManuscriptNotFoundError: class extends Error {},
+  ManuscriptVersionNotFoundError: class extends Error {},
+}));
+
+vi.mock('../../services/form.service.js', () => ({
+  formService: {},
+  FormNotFoundError: class extends Error {},
+  FormFieldNotFoundError: class extends Error {},
+  FormPageNotFoundError: class extends Error {},
+  FormNotDraftError: class extends Error {},
+  FormNotPublishedError: class extends Error {},
+  DuplicateFieldKeyError: class extends Error {},
+  FormHasNoFieldsError: class extends Error {},
+  FormInUseError: class extends Error {},
+  InvalidFormDataError: class extends Error {},
+  InvalidBranchReferenceError: class extends Error {},
+}));
+
+vi.mock('../../services/period.service.js', () => ({
+  periodService: {},
+  PeriodNotFoundError: class extends Error {},
+  PeriodHasSubmissionsError: class extends Error {},
+}));
+
+vi.mock('../../services/publication.service.js', () => ({
+  publicationService: {},
+  PublicationNotFoundError: class extends Error {},
+  PublicationSlugConflictError: class extends Error {},
+}));
+
+vi.mock('../../services/pipeline.service.js', () => ({
+  pipelineService: {},
+  PipelineItemNotFoundError: class extends Error {},
+  PipelineItemAlreadyExistsError: class extends Error {},
+  InvalidPipelineTransitionError: class extends Error {},
+  SubmissionNotAcceptedError: class extends Error {},
+}));
+
+vi.mock('../../services/contract-template.service.js', () => ({
+  contractTemplateService: {},
+  ContractTemplateNotFoundError: class extends Error {},
+}));
+
+vi.mock('../../services/contract.service.js', () => ({
+  contractService: {},
+  ContractNotFoundError: class extends Error {},
+}));
+
+vi.mock('../../services/issue.service.js', () => ({
+  issueService: {},
+  IssueNotFoundError: class extends Error {},
+  IssueItemAlreadyExistsError: class extends Error {},
+}));
+
+vi.mock('../../services/cms-connection.service.js', () => ({
+  cmsConnectionService: {},
+  CmsConnectionNotFoundError: class extends Error {},
+}));
+
+vi.mock('../../services/simsub.service.js', () => ({
+  simSubService: {},
+  SimSubConflictError: class extends Error {},
+}));
+
+vi.mock('../../services/transfer.service.js', () => ({
+  transferService: {},
+  TransferNotFoundError: class extends Error {},
+  TransferInvalidStateError: class extends Error {},
+  TransferCapabilityError: class extends Error {},
+}));
+
+vi.mock('../../services/migration.service.js', () => ({
+  migrationService: {},
+  MigrationNotFoundError: class extends Error {},
+  MigrationInvalidStateError: class extends Error {},
+  MigrationCapabilityError: class extends Error {},
+  MigrationAlreadyActiveError: class extends Error {},
+  MigrationUserNotFoundError: class extends Error {},
+}));
+
+vi.mock('../../services/email-template.service.js', () => ({
+  emailTemplateService: {},
+  EmailTemplateNotFoundError: class extends Error {},
+  InvalidMergeFieldError: class extends Error {},
+}));
+
+vi.mock('../../services/submission-reviewer.service.js', () => ({
+  submissionReviewerService: {},
+  ReviewerAlreadyAssignedError: class extends Error {},
+  ReviewerNotAssignedError: class extends Error {},
+  ReviewerNotOrgMemberError: class extends Error {},
+}));
+
+vi.mock('../../services/submission-discussion.service.js', () => ({
+  submissionDiscussionService: {},
+  DiscussionCommentNotFoundError: class extends Error {},
+  DiscussionParentNotFoundError: class extends Error {},
+}));
+
+vi.mock('../../services/submission-vote.service.js', () => ({
+  submissionVoteService: {},
+  VoteNotFoundError: class extends Error {},
+  VotingDisabledError: class extends Error {},
+  VoteOnTerminalSubmissionError: class extends Error {},
+  ScoreOutOfRangeError: class extends Error {},
+}));
+
+vi.mock('../../services/queue-preset.service.js', () => ({
+  queuePresetService: {},
+  PresetLimitExceededError: class extends Error {},
+  PresetNotFoundError: class extends Error {},
+}));
+
+vi.mock('../../services/gdpr.service.js', () => ({
+  gdprService: {},
+  UserNotDeletableError: class extends Error {},
+  OrgNotDeletableError: class extends Error {},
+}));
+
+vi.mock('../../services/context.js', () => ({
+  toUserServiceContext: vi.fn((ctx: unknown) => ctx),
+  toOrgServiceContext: vi.fn((ctx: unknown) => ctx),
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: () => ({
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: '',
+  }),
+}));
+
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  organizations: {},
+  organizationMembers: {},
+  users: {},
+  auditEvents: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { appRouter } from '../router.js';
+import type { TRPCContext } from '../context.js';
+
+const USER_ID = '00000000-0000-4000-a000-000000000001';
+
+function userContext(): TRPCContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: '00000000-0000-4000-a000-000000000099',
+      email: 'test@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+    },
+    dbTx: {} as TRPCContext['dbTx'],
+    audit: vi.fn(),
+  };
+}
+
+function unauthContext(): TRPCContext {
+  return {
+    authContext: null,
+    dbTx: null,
+    audit: vi.fn(),
+  };
+}
+
+const createCaller = (appRouter as any).createCaller as (
+  ctx: TRPCContext,
+) => any;
+
+describe('csr tRPC router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('csr.export', () => {
+    it('returns CSR envelope and audits', async () => {
+      const mockEnvelope = {
+        version: '1.0',
+        exportedAt: '2025-06-01T00:00:00.000Z',
+        identity: {
+          userId: USER_ID,
+          email: 'test@example.com',
+          displayName: null,
+        },
+        nativeSubmissions: [],
+        externalSubmissions: [],
+        correspondence: [],
+        writerProfiles: [],
+        manuscripts: [],
+      };
+      mockAssembleExport.mockResolvedValueOnce(mockEnvelope);
+
+      const ctx = userContext();
+      const caller = createCaller(ctx);
+      const result = await caller.csr.export();
+
+      expect(result.version).toBe('1.0');
+      expect(result.identity.userId).toBe(USER_ID);
+      expect(mockAssembleExport).toHaveBeenCalledWith({ userId: USER_ID });
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'CSR_EXPORTED',
+          resource: 'csr',
+        }),
+      );
+    });
+
+    it('requires authentication', async () => {
+      const caller = createCaller(unauthContext());
+      await expect(caller.csr.export()).rejects.toThrow(TRPCError);
+    });
+  });
+
+  describe('csr.import', () => {
+    it('creates records and audits', async () => {
+      mockImportRecords.mockResolvedValueOnce({
+        submissionsCreated: 3,
+        correspondenceCreated: 1,
+      });
+
+      const ctx = userContext();
+      const caller = createCaller(ctx);
+      const result = await caller.csr.import({
+        submissions: [
+          { journalName: 'Journal A', status: 'sent' },
+          { journalName: 'Journal B', status: 'rejected' },
+          { journalName: 'Journal C', status: 'accepted' },
+        ],
+        correspondence: [],
+        importedFrom: 'test_import',
+      });
+
+      expect(result.submissionsCreated).toBe(3);
+      expect(result.correspondenceCreated).toBe(1);
+      expect(mockImportRecords).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ userId: USER_ID }),
+      );
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'CSR_IMPORTED',
+          resource: 'csr',
+        }),
+      );
+    });
+
+    it('maps CSRImportError to BAD_REQUEST', async () => {
+      // Import the mocked error class
+      const { CSRImportError } = await import('../../services/csr.service.js');
+      mockImportRecords.mockRejectedValueOnce(
+        new CSRImportError('Invalid index'),
+      );
+
+      const caller = createCaller(userContext());
+      await expect(
+        caller.csr.import({
+          submissions: [{ journalName: 'Journal A', status: 'sent' }],
+          correspondence: [],
+          importedFrom: 'test',
+        }),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          code: 'BAD_REQUEST',
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/trpc/routers/csr.ts
+++ b/apps/api/src/trpc/routers/csr.ts
@@ -1,0 +1,55 @@
+import {
+  AuditActions,
+  AuditResources,
+  csrExportEnvelopeSchema,
+  csrImportInputSchema,
+  csrImportResultSchema,
+} from '@colophony/types';
+import { createRouter, userProcedure, requireScopes } from '../init.js';
+import { csrService } from '../../services/csr.service.js';
+import { mapServiceError } from '../error-mapper.js';
+
+export const csrRouter = createRouter({
+  export: userProcedure
+    .use(requireScopes('csr:read'))
+    .output(csrExportEnvelopeSchema)
+    .query(async ({ ctx }) => {
+      const result = await csrService.assembleExport({
+        userId: ctx.authContext.userId,
+      });
+      await ctx.audit({
+        action: AuditActions.CSR_EXPORTED,
+        resource: AuditResources.CSR,
+        newValue: {
+          nativeCount: result.nativeSubmissions.length,
+          externalCount: result.externalSubmissions.length,
+        },
+      });
+      return result;
+    }),
+
+  import: userProcedure
+    .use(requireScopes('csr:write'))
+    .input(csrImportInputSchema)
+    .output(csrImportResultSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const result = await csrService.importRecords(ctx.dbTx, {
+          userId: ctx.authContext.userId,
+          input,
+        });
+        await ctx.audit({
+          action: AuditActions.CSR_IMPORTED,
+          resource: AuditResources.CSR,
+          newValue: {
+            submissionsCreated: result.submissionsCreated,
+            correspondenceCreated: result.correspondenceCreated,
+            importedFrom: input.importedFrom,
+          },
+        });
+        return result;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+});

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -349,8 +349,8 @@
 - [x] [P2] MigrationBundle: use last terminal transition for `decidedAt` — current impl uses first; REJECTED→ACCEPTED would reflect rejection date — (code review 2026-02-27; done 2026-02-28)
 - [x] [P2] MigrationBundle: Zod-validate genre JSONB from DB — currently cast `as Genre | null` without validation — (code review 2026-02-27; done 2026-02-28)
 - [x] [P2] MigrationBundle: add submission count LIMIT/batching for users with thousands of submissions — (code review 2026-02-27; done 2026-02-28)
-- [ ] [P1] CSR export endpoint — tRPC + REST endpoint for writers to download their full CSR as JSON; aggregates Colophony-native submissions (cross-org), external submissions, correspondence, and piece groupings — replaces GDPR export placeholder — (register-data-standard.md Section 2.1; 2026-02-27)
-- [ ] [P1] CSR import endpoint — ingest external submission records from JSON/CSV; flexible column mapping for CSV; piece grouping by normalized title; source tagging (`importedFrom` field) — (register-data-standard.md Section 3; 2026-02-27)
+- [x] [P1] CSR export endpoint — tRPC + REST endpoint for writers to download their full CSR as JSON; aggregates Colophony-native submissions (cross-org), external submissions, correspondence, writer profiles, and manuscripts — (register-data-standard.md Section 2.1; done 2026-03-01)
+- [x] [P1] CSR import endpoint — ingest external submission records from JSON with correspondence linking; CSV import with column mapping deferred to writer workspace UI track — (register-data-standard.md Section 3; done 2026-03-01)
 - [ ] [P2] CSR format documentation — human-readable spec with field descriptions, examples, status mapping table, and extension points; publishable as part of project docs — (register-data-standard.md; 2026-02-27)
 
 ### Correspondence Tracking
@@ -358,7 +358,7 @@
 - [x] [P0] `correspondence` DB table — new table for editor-writer messages linked to submissions; fields: direction (inbound/outbound), channel (email/portal/in_app), body, senderName, senderEmail, isPersonalized flag; RLS scoped to submission owner + org editors; XOR CHECK on submission_id/external_submission_id — (register-data-standard.md Section 2.8, 4.2; done 2026-02-27 PR pending)
 - [x] [P1] Auto-capture Colophony correspondence — auto-insert correspondence records on acceptance/rejection notifications + editor messages; captures status transition comments — (register-data-standard.md Section 2.8; done 2026-02-27 PR pending)
 - [ ] [P2] Manual correspondence logging — writers can paste/enter notable editor messages (personalized rejections, encouragement letters) for external submissions; lightweight form: paste text, mark as personalized, save — (register-data-standard.md Section 2.8; 2026-02-27)
-- [ ] [P2] Correspondence in CSR export — include all correspondence records in the writer's CSR download, linked to submission records — (register-data-standard.md Section 2.8; 2026-02-27)
+- [x] [P2] Correspondence in CSR export — include all correspondence records in the writer's CSR download, linked to submission records — (register-data-standard.md Section 2.8; done 2026-03-01)
 
 ### Writer as Top-Level Entity
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -1,0 +1,22 @@
+# Development Log — March 2026
+
+Newest entries first.
+
+## 2026-03-01 — CSR Export/Import Endpoints
+
+### Done
+
+- Implemented Track 8 P1: CSR export/import endpoints for personal data portability
+- Created 7 new Zod schemas in `packages/types/src/csr.ts` (export envelope, import input/result, native submission, manuscript summary, import external submission, import correspondence)
+- Added audit actions (`CSR_EXPORTED`, `CSR_IMPORTED`), resource (`CSR`), `CSRAuditParams` interface, and API key scopes (`csr:read`, `csr:write`)
+- Built `csr.service.ts` with `assembleExport()` (superuser cross-org query reusing migration bundle patterns) and `importRecords()` (RLS-scoped transaction)
+- Created tRPC router (`csr.export` query + `csr.import` mutation) and REST/oRPC router (`GET /csr/export` + `POST /csr/import`) with OpenAPI tags
+- Wired `CSRImportError → BAD_REQUEST` error mapping on both tRPC and REST surfaces
+- 13 new tests (9 service + 4 router), full suite 1394/1394 passing
+
+### Decisions
+
+- `displayName` always `null` in export envelope — users table has no displayName column
+- Native submissions flattened into one array (no closed/active split) unlike migration bundle — no file manifest needed for personal export
+- Reused `MigrationStatusHistoryEntry` type for status history to avoid schema duplication
+- New CSR envelope (not reusing MigrationBundle) — federation fields irrelevant to personal export, and CSR includes external submissions/correspondence/profiles/manuscripts that MigrationBundle lacks

--- a/packages/types/src/api-key.ts
+++ b/packages/types/src/api-key.ts
@@ -35,6 +35,8 @@ export const apiKeyScopeSchema = z
     "cms:write",
     "email_templates:read",
     "email_templates:write",
+    "csr:read",
+    "csr:write",
     "audit:read",
   ])
   .describe("Permission scope for the API key");

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -228,6 +228,10 @@ export const AuditActions = {
   EMAIL_TEMPLATE_UPDATED: "EMAIL_TEMPLATE_UPDATED",
   EMAIL_TEMPLATE_DELETED: "EMAIL_TEMPLATE_DELETED",
 
+  // CSR export/import
+  CSR_EXPORTED: "CSR_EXPORTED",
+  CSR_IMPORTED: "CSR_IMPORTED",
+
   // Audit access
   AUDIT_ACCESSED: "AUDIT_ACCESSED",
 } as const;
@@ -265,6 +269,7 @@ export const AuditResources = {
   WEBHOOK_DELIVERY: "webhook_delivery",
   CORRESPONDENCE: "correspondence",
   EMAIL_TEMPLATE: "email_template",
+  CSR: "csr",
   AUDIT: "audit",
 } as const;
 
@@ -588,6 +593,11 @@ export interface EmailTemplateAuditParams extends BaseAuditParams {
     | typeof AuditActions.EMAIL_TEMPLATE_DELETED;
 }
 
+export interface CSRAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.CSR;
+  action: typeof AuditActions.CSR_EXPORTED | typeof AuditActions.CSR_IMPORTED;
+}
+
 export interface AuditAccessAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.AUDIT;
   action: typeof AuditActions.AUDIT_ACCESSED;
@@ -631,6 +641,7 @@ export type AuditLogParams =
   | WebhookDeliveryAuditParams
   | CorrespondenceAuditParams
   | EmailTemplateAuditParams
+  | CSRAuditParams
   | AuditAccessAuditParams
   | SystemAuditParams;
 

--- a/packages/types/src/csr.ts
+++ b/packages/types/src/csr.ts
@@ -178,3 +178,114 @@ export const createWriterProfileSchema = z.object({
   externalId: z.string().max(500).optional(),
   profileUrl: z.string().url().max(1000).optional(),
 });
+
+// ---------------------------------------------------------------------------
+// CSR Export/Import — personal data portability
+// ---------------------------------------------------------------------------
+
+// --- Native submission (Colophony-origin, mirrors migration history fields) ---
+
+export const csrNativeSubmissionSchema = z
+  .object({
+    originSubmissionId: z.string().uuid(),
+    title: z.string().nullable(),
+    genre: genreSchema.nullable(),
+    coverLetter: z.string().nullable(),
+    status: csrStatusSchema,
+    formData: z.record(z.string(), z.unknown()).nullable(),
+    submittedAt: z.string().datetime().nullable(),
+    decidedAt: z.string().datetime().nullable(),
+    publicationName: z.string().nullable(),
+    periodName: z.string().nullable(),
+    statusHistory: z.array(
+      z.object({
+        from: csrStatusSchema.nullable(),
+        to: csrStatusSchema,
+        changedAt: z.string().datetime(),
+        comment: z.string().nullable(),
+      }),
+    ),
+  })
+  .describe("Colophony-native submission record for CSR export");
+
+export type CSRNativeSubmission = z.infer<typeof csrNativeSubmissionSchema>;
+
+// --- Manuscript summary (lightweight reference for export) ---
+
+export const csrManuscriptSummarySchema = z.object({
+  id: z.string().uuid(),
+  title: z.string().nullable(),
+  genre: genreSchema.nullable(),
+  createdAt: z.string().datetime(),
+});
+
+export type CSRManuscriptSummary = z.infer<typeof csrManuscriptSummarySchema>;
+
+// --- Export envelope ---
+
+export const csrExportEnvelopeSchema = z
+  .object({
+    version: z.literal("1.0"),
+    exportedAt: z.string().datetime(),
+    identity: z.object({
+      userId: z.string().uuid(),
+      email: z.string().email(),
+      displayName: z.string().nullable(),
+    }),
+    nativeSubmissions: z.array(csrNativeSubmissionSchema),
+    externalSubmissions: z.array(externalSubmissionSchema),
+    correspondence: z.array(correspondenceSchema),
+    writerProfiles: z.array(writerProfileSchema),
+    manuscripts: z.array(csrManuscriptSummarySchema),
+  })
+  .describe("Full CSR export envelope — personal data portability");
+
+export type CSRExportEnvelope = z.infer<typeof csrExportEnvelopeSchema>;
+
+// --- Import schemas ---
+
+export const csrImportExternalSubmissionSchema = z.object({
+  journalName: z.string().min(1).max(500),
+  journalDirectoryId: z.string().uuid().optional(),
+  status: csrStatusSchema.default("sent"),
+  sentAt: z.string().datetime().optional(),
+  respondedAt: z.string().datetime().optional(),
+  method: z.string().max(100).optional(),
+  notes: z.string().optional(),
+  importedFrom: z.string().max(100).optional(),
+});
+
+export type CSRImportExternalSubmission = z.infer<
+  typeof csrImportExternalSubmissionSchema
+>;
+
+export const csrImportCorrespondenceSchema = z.object({
+  externalSubmissionIndex: z.number().int().min(0),
+  direction: correspondenceDirectionSchema,
+  channel: correspondenceChannelSchema.default("email"),
+  sentAt: z.string().datetime(),
+  subject: z.string().max(500).optional(),
+  body: z.string().min(1),
+  senderName: z.string().max(255).optional(),
+  senderEmail: z.string().email().max(255).optional(),
+  isPersonalized: z.boolean().default(false),
+});
+
+export type CSRImportCorrespondence = z.infer<
+  typeof csrImportCorrespondenceSchema
+>;
+
+export const csrImportInputSchema = z.object({
+  submissions: z.array(csrImportExternalSubmissionSchema).min(1).max(5000),
+  correspondence: z.array(csrImportCorrespondenceSchema).default([]),
+  importedFrom: z.string().max(100).default("csr_import"),
+});
+
+export type CSRImportInput = z.infer<typeof csrImportInputSchema>;
+
+export const csrImportResultSchema = z.object({
+  submissionsCreated: z.number().int(),
+  correspondenceCreated: z.number().int(),
+});
+
+export type CSRImportResult = z.infer<typeof csrImportResultSchema>;


### PR DESCRIPTION
## Summary

- Add tRPC and REST endpoints for writers to export their full Colophony Submission Record (CSR) as JSON and import external submission records
- Export assembles: native submissions (cross-org), external submissions, correspondence, writer profiles, and manuscripts into a versioned `1.0` envelope
- Import ingests external submissions with optional correspondence from structured JSON (CSV import deferred to writer workspace UI track)
- 13 new tests (9 service + 4 router), full suite 1394/1394 passing

## Test plan

- [x] `pnpm type-check` — 14/14 packages pass
- [x] `pnpm test` — 1394/1394 tests pass, 0 regressions
- [x] `pnpm lint` — clean (API + types)
- [x] Service unit tests: empty envelope, native enrichment, all sections, limit cap, null genre, import CRUD, index validation, empty correspondence
- [x] Router tests: export returns envelope + audits, auth required, import with audit, error mapping
- [ ] CI pipeline