### PR TITLE
fix: post-audit remediation — P0/P1 fixes + tooling hardening

### DIFF
--- a/.claude/hooks/pre-edit-validate.js
+++ b/.claude/hooks/pre-edit-validate.js
@@ -39,4 +39,25 @@ if (hasDbPrefix && hasDrizzleQuery) {
   }
 }
 
+// Warn about outbound fetch without SSRF validation
+const filePath = process.env.CLAUDE_TOOL_ARGS_file_path || '';
+const userUrlVars = ['endpointUrl', 'webhookUrl', 'callbackUrl', 'targetUrl'];
+const hasFetch = newContent.includes('fetch(');
+const hasUserUrl = userUrlVars.some(v => newContent.includes(v));
+const hasSsrfGuard =
+  newContent.includes('validateOutboundUrl') ||
+  newContent.includes('resolveAndCheckPrivateIp');
+
+if (hasFetch && hasUserUrl && !hasSsrfGuard) {
+  console.warn('⚠️  WARNING: fetch() with user-controlled URL detected without SSRF validation.');
+  console.warn('   Use validateOutboundUrl() from apps/api/src/lib/url-validation.ts');
+}
+
+// Warn about unused orgId in service/worker files
+const isServiceOrWorker = filePath.includes('/services/') || filePath.includes('/workers/');
+if (isServiceOrWorker && newContent.includes('_orgId')) {
+  console.warn('⚠️  WARNING: Unused _orgId parameter detected in service/worker file.');
+  console.warn('   Organization ID should be used for explicit filtering (defense-in-depth with RLS).');
+}
+
 process.exit(0);

--- a/.claude/skills/codex-review/SKILL.md
+++ b/.claude/skills/codex-review/SKILL.md
@@ -64,6 +64,9 @@ Key project rules to enforce:
 - PCI compliance: NEVER log card numbers or CVV. NEVER store card data. Stripe Checkout only.
 - Audit logging: sensitive operations MUST be audit logged.
 - Input validation: use Zod schemas from @colophony/types on all API surfaces.
+- Defense-in-depth for multi-tenancy: service methods querying tenant data MUST include explicit organizationId filter even when RLS is active. Unused parameters prefixed with _ in service methods are a red flag for missing filters.
+- SSRF protection: outbound HTTP calls to user-controlled URLs (webhooks, callbacks, federation) MUST validate via validateOutboundUrl(). Direct fetch() to user URLs without SSRF checks is Critical.
+- Unbounded queries: list/query methods returning variable-size data MUST have a LIMIT or pagination. Missing LIMIT in service methods is Important.
 
 Format your review as markdown:
 - Start with a one-line verdict: LGTM, Minor issues, or Issues found

--- a/.claude/skills/opencode-review/SKILL.md
+++ b/.claude/skills/opencode-review/SKILL.md
@@ -62,6 +62,9 @@ Key project rules to enforce:
 - PCI compliance: NEVER log card numbers or CVV. NEVER store card data. Stripe Checkout only.
 - Audit logging: sensitive operations MUST be audit logged.
 - Input validation: use Zod schemas from @colophony/types on all API surfaces.
+- Defense-in-depth for multi-tenancy: service methods querying tenant data MUST include explicit organizationId filter even when RLS is active. Unused parameters prefixed with _ in service methods are a red flag for missing filters.
+- SSRF protection: outbound HTTP calls to user-controlled URLs (webhooks, callbacks, federation) MUST validate via validateOutboundUrl(). Direct fetch() to user URLs without SSRF checks is Critical.
+- Unbounded queries: list/query methods returning variable-size data MUST have a LIMIT or pagination. Missing LIMIT in service methods is Important.
 
 Format your review as markdown:
 - Start with a one-line verdict: LGTM, Minor issues, or Issues found

--- a/.codex/instructions.md
+++ b/.codex/instructions.md
@@ -9,6 +9,9 @@ When reviewing code in this project, enforce these rules:
 - **PCI compliance:** NEVER log card numbers or CVV. NEVER store card data. Stripe Checkout only.
 - **Audit logging:** Sensitive operations MUST be audit logged.
 - **Input validation:** Use Zod schemas from `@colophony/types` on all API surfaces.
+- **Defense-in-depth multi-tenancy:** Service methods querying tenant data MUST include explicit `organizationId` filter even when RLS is active. Unused `_orgId` parameters are a red flag.
+- **SSRF protection:** Outbound HTTP calls to user-controlled URLs MUST validate via `validateOutboundUrl()`. Direct `fetch()` to user URLs without SSRF checks is Critical.
+- **Unbounded queries:** List/query methods returning variable-size data MUST have a `LIMIT` or accept pagination parameters. Missing `LIMIT` is Important.
 
 ## Review Format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **TypeScript SDK**       | `sdks/typescript/` (`@colophony/sdk` — openapi-fetch + generated types)          |
 | **Python SDK**           | `sdks/python/` (`colophony` — openapi-python-client generated)                   |
 | **SDK generation**       | `scripts/generate-sdks.ts` (regenerate both SDKs from committed spec)            |
+| **SSRF validation**      | `apps/api/src/lib/url-validation.ts` (validateOutboundUrl, isPrivateIPv4/v6)     |
 | **Sentry config**        | `apps/api/src/config/sentry.ts` (init, captureException, isSentryEnabled)        |
 | **Metrics registry**     | `apps/api/src/config/metrics.ts` (Prometheus counters, histograms, gauges)       |
 | **Metrics plugin**       | `apps/api/src/hooks/metrics.ts` (Fastify plugin — HTTP request instrumentation)  |

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -187,6 +187,24 @@ Stripe Checkout only (zero PCI scope). Webhook handler built at `src/webhooks/st
 
 ---
 
+## SSRF Protection
+
+Outbound HTTP calls to user-controlled URLs must validate against private IP ranges.
+
+**Utility:** `src/lib/url-validation.ts` — `validateOutboundUrl(url, { devMode })`.
+
+**Enforced at:** webhook endpoint creation/update, webhook delivery, federation metadata fetch.
+
+**Dev mode:** `NODE_ENV === 'development' || 'test'` allows HTTP and private IPs.
+
+**NEVER:**
+
+- Call `fetch()` on a user-provided URL without SSRF validation
+- Skip HTTPS enforcement in production
+- Allow redirects to bypass SSRF checks
+
+---
+
 ## BullMQ Workers
 
 ### Queue/Worker Pattern

--- a/apps/api/src/lib/url-validation.spec.ts
+++ b/apps/api/src/lib/url-validation.spec.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import dns from 'node:dns';
+import {
+  isPrivateIPv4,
+  isPrivateIPv6,
+  resolveAndCheckPrivateIp,
+  validateOutboundUrl,
+  SsrfValidationError,
+} from './url-validation.js';
+
+vi.mock('node:dns', () => ({
+  default: {
+    promises: {
+      resolve4: vi.fn(),
+      resolve6: vi.fn(),
+    },
+  },
+}));
+
+const mockResolve4 = dns.promises.resolve4 as ReturnType<typeof vi.fn>;
+const mockResolve6 = dns.promises.resolve6 as ReturnType<typeof vi.fn>;
+
+describe('url-validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolve4.mockResolvedValue([]);
+    mockResolve6.mockResolvedValue([]);
+  });
+
+  describe('isPrivateIPv4', () => {
+    it('detects 10.x.x.x', () => {
+      expect(isPrivateIPv4('10.0.0.1')).toBe(true);
+      expect(isPrivateIPv4('10.255.255.255')).toBe(true);
+    });
+
+    it('detects 172.16-31.x.x', () => {
+      expect(isPrivateIPv4('172.16.0.1')).toBe(true);
+      expect(isPrivateIPv4('172.31.255.255')).toBe(true);
+      expect(isPrivateIPv4('172.15.0.1')).toBe(false);
+      expect(isPrivateIPv4('172.32.0.1')).toBe(false);
+    });
+
+    it('detects 192.168.x.x', () => {
+      expect(isPrivateIPv4('192.168.1.1')).toBe(true);
+    });
+
+    it('detects 127.x.x.x loopback', () => {
+      expect(isPrivateIPv4('127.0.0.1')).toBe(true);
+    });
+
+    it('detects 169.254.x.x link-local/metadata', () => {
+      expect(isPrivateIPv4('169.254.169.254')).toBe(true);
+    });
+
+    it('allows public IPs', () => {
+      expect(isPrivateIPv4('93.184.216.34')).toBe(false);
+      expect(isPrivateIPv4('8.8.8.8')).toBe(false);
+    });
+  });
+
+  describe('isPrivateIPv6', () => {
+    it('detects ::1 loopback', () => {
+      expect(isPrivateIPv6('::1')).toBe(true);
+    });
+
+    it('detects fc/fd (ULA)', () => {
+      expect(isPrivateIPv6('fd12::1')).toBe(true);
+      expect(isPrivateIPv6('fc00::1')).toBe(true);
+    });
+
+    it('detects fe80 (link-local)', () => {
+      expect(isPrivateIPv6('fe80::1')).toBe(true);
+    });
+
+    it('allows public IPv6', () => {
+      expect(isPrivateIPv6('2001:db8::1')).toBe(false);
+    });
+  });
+
+  describe('resolveAndCheckPrivateIp', () => {
+    it('rejects when resolve4 returns private IP', async () => {
+      mockResolve4.mockResolvedValue(['10.0.0.1']);
+      await expect(resolveAndCheckPrivateIp('example.com')).rejects.toThrow(
+        SsrfValidationError,
+      );
+    });
+
+    it('rejects when resolve6 returns private IP', async () => {
+      mockResolve6.mockResolvedValue(['::1']);
+      await expect(resolveAndCheckPrivateIp('example.com')).rejects.toThrow(
+        SsrfValidationError,
+      );
+    });
+
+    it('allows public IPs', async () => {
+      mockResolve4.mockResolvedValue(['93.184.216.34']);
+      mockResolve6.mockResolvedValue([]);
+      await expect(
+        resolveAndCheckPrivateIp('example.com'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects IP literals directly (no DNS needed)', async () => {
+      await expect(resolveAndCheckPrivateIp('10.0.0.1')).rejects.toThrow(
+        SsrfValidationError,
+      );
+      expect(mockResolve4).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validateOutboundUrl', () => {
+    it('rejects HTTP URLs in production mode', async () => {
+      await expect(
+        validateOutboundUrl('http://example.com/hook'),
+      ).rejects.toThrow(SsrfValidationError);
+      await expect(
+        validateOutboundUrl('http://example.com/hook'),
+      ).rejects.toThrow(/HTTPS required/);
+    });
+
+    it('allows HTTP in dev mode', async () => {
+      mockResolve4.mockResolvedValue(['93.184.216.34']);
+      await expect(
+        validateOutboundUrl('http://example.com/hook', { devMode: true }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects 10.x.x.x', async () => {
+      mockResolve4.mockResolvedValue(['10.0.0.1']);
+      await expect(
+        validateOutboundUrl('https://example.com/hook'),
+      ).rejects.toThrow(SsrfValidationError);
+    });
+
+    it('rejects 172.16.x.x', async () => {
+      mockResolve4.mockResolvedValue(['172.16.0.1']);
+      await expect(
+        validateOutboundUrl('https://example.com/hook'),
+      ).rejects.toThrow(SsrfValidationError);
+    });
+
+    it('rejects 192.168.x.x', async () => {
+      mockResolve4.mockResolvedValue(['192.168.1.1']);
+      await expect(
+        validateOutboundUrl('https://example.com/hook'),
+      ).rejects.toThrow(SsrfValidationError);
+    });
+
+    it('rejects 127.x.x.x (loopback)', async () => {
+      mockResolve4.mockResolvedValue(['127.0.0.1']);
+      await expect(
+        validateOutboundUrl('https://example.com/hook'),
+      ).rejects.toThrow(SsrfValidationError);
+    });
+
+    it('rejects 169.254.x.x (metadata)', async () => {
+      mockResolve4.mockResolvedValue(['169.254.169.254']);
+      await expect(
+        validateOutboundUrl('https://example.com/hook'),
+      ).rejects.toThrow(SsrfValidationError);
+    });
+
+    it('rejects ::1 (IPv6 loopback)', async () => {
+      mockResolve6.mockResolvedValue(['::1']);
+      await expect(
+        validateOutboundUrl('https://example.com/hook'),
+      ).rejects.toThrow(SsrfValidationError);
+    });
+
+    it('rejects fc/fd (ULA)', async () => {
+      mockResolve6.mockResolvedValue(['fd12::1']);
+      await expect(
+        validateOutboundUrl('https://example.com/hook'),
+      ).rejects.toThrow(SsrfValidationError);
+    });
+
+    it('rejects fe80 (link-local)', async () => {
+      mockResolve6.mockResolvedValue(['fe80::1']);
+      await expect(
+        validateOutboundUrl('https://example.com/hook'),
+      ).rejects.toThrow(SsrfValidationError);
+    });
+
+    it('allows public IPs', async () => {
+      mockResolve4.mockResolvedValue(['93.184.216.34']);
+      await expect(
+        validateOutboundUrl('https://example.com/hook'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects IP literals directly (no DNS needed)', async () => {
+      await expect(
+        validateOutboundUrl('https://10.0.0.1/hook'),
+      ).rejects.toThrow(SsrfValidationError);
+    });
+
+    it('skips all checks in dev mode', async () => {
+      // Private IP + HTTP — should pass in dev mode
+      await expect(
+        validateOutboundUrl('http://10.0.0.1/hook', { devMode: true }),
+      ).resolves.toBeUndefined();
+      expect(mockResolve4).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid URLs', async () => {
+      await expect(validateOutboundUrl('not-a-url')).rejects.toThrow(
+        SsrfValidationError,
+      );
+    });
+  });
+});

--- a/apps/api/src/lib/url-validation.spec.ts
+++ b/apps/api/src/lib/url-validation.spec.ts
@@ -202,6 +202,14 @@ describe('url-validation', () => {
       expect(mockResolve4).not.toHaveBeenCalled();
     });
 
+    it('allows HTTPS + private IP in dev mode', async () => {
+      // HTTPS with private IP — should still pass in dev mode
+      await expect(
+        validateOutboundUrl('https://192.168.1.1/hook', { devMode: true }),
+      ).resolves.toBeUndefined();
+      expect(mockResolve4).not.toHaveBeenCalled();
+    });
+
     it('rejects invalid URLs', async () => {
       await expect(validateOutboundUrl('not-a-url')).rejects.toThrow(
         SsrfValidationError,

--- a/apps/api/src/lib/url-validation.ts
+++ b/apps/api/src/lib/url-validation.ts
@@ -1,0 +1,141 @@
+import dns from 'node:dns';
+
+/**
+ * SSRF validation utilities for outbound HTTP calls to user-controlled URLs.
+ *
+ * Extracted from trust.service.ts for reuse across webhooks, federation, and
+ * any future outbound call site. Validates that resolved IP addresses are not
+ * in private/reserved ranges.
+ */
+
+export class SsrfValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SsrfValidationError';
+  }
+}
+
+export function isPrivateIPv4(addr: string): boolean {
+  const parts = addr.split('.').map(Number);
+  if (parts.length !== 4) return false;
+  const [a, b] = parts;
+
+  return (
+    a === 10 || // 10.0.0.0/8
+    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
+    (a === 192 && b === 168) || // 192.168.0.0/16
+    a === 127 || // 127.0.0.0/8
+    (a === 169 && b === 254) || // 169.254.0.0/16
+    a === 0 // 0.0.0.0/8
+  );
+}
+
+export function isPrivateIPv6(addr: string): boolean {
+  const normalized = addr.toLowerCase();
+  if (normalized === '::1') return true; // loopback
+
+  // ULA fc00::/7 — fc00::–fdff::
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true;
+
+  // Link-local fe80::/10 — fe80::–febf::
+  // First 10 bits are 1111 1110 10, so second hex digit ranges 8–b
+  if (normalized.length >= 4 && normalized.startsWith('fe')) {
+    const thirdChar = normalized[2];
+    if (thirdChar >= '8' && thirdChar <= 'b') return true;
+  }
+
+  return false;
+}
+
+/**
+ * Resolve a hostname and check that none of the resolved addresses are
+ * in private/reserved IP ranges.
+ *
+ * @throws SsrfValidationError if any resolved address is private
+ */
+export async function resolveAndCheckPrivateIp(
+  hostname: string,
+): Promise<void> {
+  // Strip port from hostname before DNS resolution
+  const bareHost = hostname.replace(/:\d+$/, '');
+
+  // Block IP literals directly — DNS resolution may fail for these,
+  // bypassing the private address check entirely
+  if (isPrivateIPv4(bareHost)) {
+    throw new SsrfValidationError(
+      `IP literal resolves to private IPv4 address: ${bareHost}`,
+    );
+  }
+  if (isPrivateIPv6(bareHost) || bareHost === '::1') {
+    throw new SsrfValidationError(
+      `IP literal resolves to private IPv6 address: ${bareHost}`,
+    );
+  }
+
+  // Resolve both IPv4 and IPv6
+  const [ipv4Addrs, ipv6Addrs] = await Promise.all([
+    dns.promises.resolve4(bareHost).catch(() => [] as string[]),
+    dns.promises.resolve6(bareHost).catch(() => [] as string[]),
+  ]);
+
+  for (const addr of ipv4Addrs) {
+    if (isPrivateIPv4(addr)) {
+      throw new SsrfValidationError(
+        `Resolved to private IPv4 address: ${addr}`,
+      );
+    }
+  }
+
+  for (const addr of ipv6Addrs) {
+    if (isPrivateIPv6(addr)) {
+      throw new SsrfValidationError(
+        `Resolved to private IPv6 address: ${addr}`,
+      );
+    }
+  }
+}
+
+/**
+ * Validate a URL for outbound HTTP calls. Ensures:
+ * 1. URL is well-formed
+ * 2. HTTPS is required (unless devMode)
+ * 3. Hostname does not resolve to private/reserved IPs
+ *
+ * @param url - The outbound URL to validate
+ * @param opts.devMode - When true, allows HTTP and skips private IP checks
+ * @throws SsrfValidationError if the URL fails validation
+ */
+export async function validateOutboundUrl(
+  url: string,
+  opts?: { devMode?: boolean },
+): Promise<void> {
+  const devMode = opts?.devMode ?? false;
+
+  // Skip all checks in dev mode
+  if (devMode) return;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new SsrfValidationError(`Invalid URL: ${url}`);
+  }
+
+  // Require HTTPS in production
+  if (parsed.protocol !== 'https:') {
+    throw new SsrfValidationError(
+      `HTTPS required for outbound URLs, got ${parsed.protocol}`,
+    );
+  }
+
+  // Check IP literals directly (hostname without brackets for IPv6)
+  const hostname = parsed.hostname.replace(/^\[/, '').replace(/]$/, '');
+  if (isPrivateIPv4(hostname) || isPrivateIPv6(hostname)) {
+    throw new SsrfValidationError(
+      `URL resolves to private IP address: ${hostname}`,
+    );
+  }
+
+  // DNS resolve + check
+  await resolveAndCheckPrivateIp(hostname);
+}

--- a/apps/api/src/services/__tests__/queue-preset.service.spec.ts
+++ b/apps/api/src/services/__tests__/queue-preset.service.spec.ts
@@ -20,6 +20,7 @@ const mockUpdate = vi.fn().mockReturnValue({
   set: mockSet,
 });
 const mockDeleteFn = vi.fn().mockReturnValue({ where: mockWhere });
+const mockExecute = vi.fn().mockResolvedValue({ rows: [] });
 
 vi.mock('@colophony/db', () => ({
   savedQueuePresets: {
@@ -34,6 +35,7 @@ vi.mock('@colophony/db', () => ({
   },
   eq: vi.fn(),
   and: vi.fn(),
+  sql: vi.fn(),
 }));
 
 vi.mock('drizzle-orm', async (importOriginal) => {
@@ -58,12 +60,14 @@ function makeTx() {
     insert: mockInsert,
     update: mockUpdate,
     delete: mockDeleteFn,
+    execute: mockExecute,
   } as unknown as Parameters<typeof queuePresetService.list>[0];
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockRows = [];
+  mockExecute.mockResolvedValue({ rows: [] });
 });
 
 describe('queuePresetService', () => {
@@ -87,10 +91,8 @@ describe('queuePresetService', () => {
 
   describe('create', () => {
     it('throws at 20 presets', async () => {
-      // Mock count returning 20
-      mockFrom.mockReturnValue({
-        where: vi.fn().mockResolvedValue([{ value: 20 }]),
-      });
+      // Atomic insert returns empty rows when at limit
+      mockExecute.mockResolvedValue({ rows: [] });
 
       await expect(
         queuePresetService.create(makeTx(), 'user-1', 'org-1', {
@@ -102,17 +104,13 @@ describe('queuePresetService', () => {
     });
 
     it('unsets other defaults when isDefault=true', async () => {
-      // Mock count returning 0
-      mockFrom.mockReturnValue({
-        where: vi.fn().mockResolvedValue([{ value: 0 }]),
-      });
-
       const newPreset = {
         id: 'p-new',
         name: 'Default',
         isDefault: true,
       };
-      mockReturning.mockResolvedValue([newPreset]);
+      // Atomic insert succeeds
+      mockExecute.mockResolvedValue({ rows: [newPreset] });
 
       const result = await queuePresetService.create(
         makeTx(),

--- a/apps/api/src/services/queue-preset.service.spec.ts
+++ b/apps/api/src/services/queue-preset.service.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@colophony/db', () => {
+  return {
+    savedQueuePresets: {
+      id: 'id',
+      organizationId: 'organization_id',
+      userId: 'user_id',
+      name: 'name',
+      filters: 'filters',
+      isDefault: 'is_default',
+      createdAt: 'created_at',
+      updatedAt: 'updated_at',
+    },
+    eq: vi.fn(),
+    and: vi.fn(),
+    sql: vi.fn(),
+  };
+});
+
+import {
+  queuePresetService,
+  PresetLimitExceededError,
+  PresetDefaultConflictError,
+} from './queue-preset.service.js';
+
+function createChainMock(terminalValue: unknown) {
+  const returning = vi.fn().mockResolvedValue(terminalValue);
+  const where = vi.fn().mockReturnValue({ returning });
+  const set = vi.fn().mockReturnValue({ where });
+  return { set, where, returning };
+}
+
+describe('queuePresetService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('create()', () => {
+    it('rejects when at preset limit', async () => {
+      const execute = vi.fn().mockResolvedValue({ rows: [] });
+      const tx = {
+        execute,
+        update: vi.fn().mockReturnValue(createChainMock([])),
+      } as never;
+
+      await expect(
+        queuePresetService.create(tx, 'user-1', 'org-1', {
+          name: 'Test',
+          filters: {},
+          isDefault: false,
+        }),
+      ).rejects.toThrow(PresetLimitExceededError);
+    });
+
+    it('succeeds under limit', async () => {
+      const fakeRow = {
+        id: 'preset-1',
+        organization_id: 'org-1',
+        user_id: 'user-1',
+        name: 'Test',
+        filters: {},
+        is_default: false,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+      const execute = vi.fn().mockResolvedValue({ rows: [fakeRow] });
+      const tx = {
+        execute,
+        update: vi.fn().mockReturnValue(createChainMock([])),
+      } as never;
+
+      const result = await queuePresetService.create(tx, 'user-1', 'org-1', {
+        name: 'Test',
+        filters: {},
+        isDefault: false,
+      });
+
+      expect(result).toEqual(fakeRow);
+    });
+
+    it('unsets existing defaults before insert when isDefault', async () => {
+      const fakeRow = {
+        id: 'preset-1',
+        organization_id: 'org-1',
+        user_id: 'user-1',
+        name: 'Default',
+        filters: {},
+        is_default: true,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+      const execute = vi.fn().mockResolvedValue({ rows: [fakeRow] });
+      const chain = createChainMock([]);
+      const updateFn = vi.fn().mockReturnValue(chain);
+      const tx = {
+        execute,
+        update: updateFn,
+      } as never;
+
+      await queuePresetService.create(tx, 'user-1', 'org-1', {
+        name: 'Default',
+        filters: {},
+        isDefault: true,
+      });
+
+      // update() should have been called to unset existing defaults
+      expect(updateFn).toHaveBeenCalled();
+    });
+  });
+
+  describe('update()', () => {
+    it('handles unique violation on concurrent default set', async () => {
+      // Select chain for ownership check
+      const selectWhere = vi.fn().mockResolvedValue([{ id: 'preset-1' }]);
+      const selectFrom = vi.fn().mockReturnValue({ where: selectWhere });
+      const selectFn = vi.fn().mockReturnValue({ from: selectFrom });
+
+      // Update chain for unset-defaults — succeeds
+      const unsetReturning = vi.fn().mockResolvedValue([]);
+      const unsetWhere = vi.fn().mockReturnValue({ returning: unsetReturning });
+      const unsetSet = vi.fn().mockReturnValue({ where: unsetWhere });
+
+      // Update chain for the actual update — throws unique violation
+      const uniqueViolation = new Error('duplicate key value');
+      (uniqueViolation as Error & { code: string }).code = '23505';
+      const updateReturning = vi.fn().mockRejectedValue(uniqueViolation);
+      const updateWhere = vi
+        .fn()
+        .mockReturnValue({ returning: updateReturning });
+      const updateSet = vi.fn().mockReturnValue({ where: updateWhere });
+
+      // update() called twice: first for unset-defaults, second for actual update
+      const updateFn = vi
+        .fn()
+        .mockReturnValueOnce({ set: unsetSet })
+        .mockReturnValueOnce({ set: updateSet });
+
+      const tx = {
+        select: selectFn,
+        update: updateFn,
+      } as never;
+
+      await expect(
+        queuePresetService.update(tx, 'user-1', {
+          id: 'preset-1',
+          isDefault: true,
+        }),
+      ).rejects.toThrow(PresetDefaultConflictError);
+    });
+  });
+});

--- a/apps/api/src/services/queue-preset.service.ts
+++ b/apps/api/src/services/queue-preset.service.ts
@@ -1,5 +1,5 @@
-import { savedQueuePresets, eq, and, type DrizzleDb } from '@colophony/db';
-import { asc, count, ne } from 'drizzle-orm';
+import { savedQueuePresets, eq, and, sql, type DrizzleDb } from '@colophony/db';
+import { asc, ne } from 'drizzle-orm';
 import type {
   CreateQueuePresetInput,
   UpdateQueuePresetInput,
@@ -23,6 +23,22 @@ export class PresetNotFoundError extends Error {
   }
 }
 
+export class PresetDefaultConflictError extends Error {
+  constructor() {
+    super('Another preset was set as default concurrently. Please retry.');
+    this.name = 'PresetDefaultConflictError';
+  }
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === '23505'
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
@@ -44,17 +60,7 @@ export const queuePresetService = {
     organizationId: string,
     input: CreateQueuePresetInput,
   ) {
-    // Check limit
-    const [{ value: existing }] = await tx
-      .select({ value: count() })
-      .from(savedQueuePresets)
-      .where(eq(savedQueuePresets.userId, userId));
-
-    if (existing >= MAX_PRESETS) {
-      throw new PresetLimitExceededError();
-    }
-
-    // If isDefault, unset other defaults
+    // If isDefault, unset other defaults first
     if (input.isDefault) {
       await tx
         .update(savedQueuePresets)
@@ -67,16 +73,30 @@ export const queuePresetService = {
         );
     }
 
-    const [row] = await tx
-      .insert(savedQueuePresets)
-      .values({
-        organizationId,
-        userId,
-        name: input.name,
-        filters: input.filters,
-        isDefault: input.isDefault ?? false,
-      })
-      .returning();
+    // Atomic insert-with-count-guard: INSERT ... SELECT ... WHERE count < MAX
+    const isDefault = input.isDefault ?? false;
+    const result = await tx.execute<{
+      id: string;
+      organization_id: string;
+      user_id: string;
+      name: string;
+      filters: unknown;
+      is_default: boolean;
+      created_at: Date;
+      updated_at: Date;
+    }>(sql`
+      INSERT INTO saved_queue_presets (organization_id, user_id, name, filters, is_default)
+      SELECT ${organizationId}, ${userId}, ${input.name}, ${JSON.stringify(input.filters)}::jsonb, ${isDefault}
+      WHERE (
+        SELECT count(*) FROM saved_queue_presets WHERE user_id = ${userId}
+      ) < ${MAX_PRESETS}
+      RETURNING *
+    `);
+
+    const row = result.rows[0];
+    if (!row) {
+      throw new PresetLimitExceededError();
+    }
 
     return row;
   },
@@ -116,13 +136,20 @@ export const queuePresetService = {
     if (input.filters !== undefined) updates.filters = input.filters;
     if (input.isDefault !== undefined) updates.isDefault = input.isDefault;
 
-    const [row] = await tx
-      .update(savedQueuePresets)
-      .set(updates)
-      .where(eq(savedQueuePresets.id, input.id))
-      .returning();
+    try {
+      const [row] = await tx
+        .update(savedQueuePresets)
+        .set(updates)
+        .where(eq(savedQueuePresets.id, input.id))
+        .returning();
 
-    return row;
+      return row;
+    } catch (err) {
+      if (isUniqueViolation(err)) {
+        throw new PresetDefaultConflictError();
+      }
+      throw err;
+    }
   },
 
   async delete(tx: DrizzleDb, userId: string, id: string) {

--- a/apps/api/src/services/trust.service.ts
+++ b/apps/api/src/services/trust.service.ts
@@ -73,10 +73,6 @@ export class TrustSignatureVerificationError extends Error {
   }
 }
 
-// ---------------------------------------------------------------------------
-// SSRF Protection — uses shared utility from ../lib/url-validation.ts
-// ---------------------------------------------------------------------------
-
 /** Maximum response body size for remote metadata fetches (1 MB). */
 const MAX_METADATA_RESPONSE_BYTES = 1_048_576;
 
@@ -98,7 +94,11 @@ async function fetchAndValidateMetadata(
       await resolveAndCheckPrivateIp(domain);
     } catch (err) {
       if (err instanceof SsrfValidationError) {
-        throw new RemoteMetadataFetchError(domain, err);
+        // Sanitize: don't leak internal IPs in the outward-facing error
+        throw new RemoteMetadataFetchError(
+          domain,
+          new Error('Domain resolves to a private or reserved IP address'),
+        );
       }
       throw err;
     }

--- a/apps/api/src/services/trust.service.ts
+++ b/apps/api/src/services/trust.service.ts
@@ -8,7 +8,6 @@ import {
 } from '@colophony/db';
 import * as jose from 'jose';
 import crypto from 'node:crypto';
-import dns from 'node:dns';
 import {
   AuditActions,
   AuditResources,
@@ -29,6 +28,10 @@ import {
   signFederationRequest,
   verifyFederationSignature,
 } from '../federation/http-signatures.js';
+import {
+  resolveAndCheckPrivateIp,
+  SsrfValidationError,
+} from '../lib/url-validation.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -71,92 +74,11 @@ export class TrustSignatureVerificationError extends Error {
 }
 
 // ---------------------------------------------------------------------------
-// SSRF Protection
+// SSRF Protection — uses shared utility from ../lib/url-validation.ts
 // ---------------------------------------------------------------------------
 
 /** Maximum response body size for remote metadata fetches (1 MB). */
 const MAX_METADATA_RESPONSE_BYTES = 1_048_576;
-
-/**
- * Check whether a hostname resolves to a private/reserved IP address.
- * Throws RemoteMetadataFetchError if any resolved address is private.
- * Skipped in development/test environments to allow localhost.
- */
-async function resolveAndCheckPrivateIp(hostname: string): Promise<void> {
-  // Strip port from hostname before DNS resolution
-  const bareHost = hostname.replace(/:\d+$/, '');
-
-  // Block IP literals directly — DNS resolution may fail for these,
-  // bypassing the private address check entirely
-  if (isPrivateIPv4(bareHost)) {
-    throw new RemoteMetadataFetchError(
-      hostname,
-      new Error(`IP literal resolves to private IPv4 address: ${bareHost}`),
-    );
-  }
-  if (isPrivateIPv6(bareHost) || bareHost === '::1') {
-    throw new RemoteMetadataFetchError(
-      hostname,
-      new Error(`IP literal resolves to private IPv6 address: ${bareHost}`),
-    );
-  }
-
-  // Resolve both IPv4 and IPv6
-  const [ipv4Addrs, ipv6Addrs] = await Promise.all([
-    dns.promises.resolve4(bareHost).catch(() => [] as string[]),
-    dns.promises.resolve6(bareHost).catch(() => [] as string[]),
-  ]);
-
-  for (const addr of ipv4Addrs) {
-    if (isPrivateIPv4(addr)) {
-      throw new RemoteMetadataFetchError(
-        hostname,
-        new Error(`Resolved to private IPv4 address: ${addr}`),
-      );
-    }
-  }
-
-  for (const addr of ipv6Addrs) {
-    if (isPrivateIPv6(addr)) {
-      throw new RemoteMetadataFetchError(
-        hostname,
-        new Error(`Resolved to private IPv6 address: ${addr}`),
-      );
-    }
-  }
-}
-
-function isPrivateIPv4(addr: string): boolean {
-  const parts = addr.split('.').map(Number);
-  if (parts.length !== 4) return false;
-  const [a, b] = parts;
-
-  return (
-    a === 10 || // 10.0.0.0/8
-    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
-    (a === 192 && b === 168) || // 192.168.0.0/16
-    a === 127 || // 127.0.0.0/8
-    (a === 169 && b === 254) || // 169.254.0.0/16
-    a === 0 // 0.0.0.0/8
-  );
-}
-
-function isPrivateIPv6(addr: string): boolean {
-  const normalized = addr.toLowerCase();
-  if (normalized === '::1') return true; // loopback
-
-  // ULA fc00::/7 — fc00::–fdff::
-  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true;
-
-  // Link-local fe80::/10 — fe80::–febf::
-  // First 10 bits are 1111 1110 10, so second hex digit ranges 8–b
-  if (normalized.length >= 4 && normalized.startsWith('fe')) {
-    const thirdChar = normalized[2];
-    if (thirdChar >= '8' && thirdChar <= 'b') return true;
-  }
-
-  return false;
-}
 
 /**
  * Fetch and validate remote instance metadata with full hardening:
@@ -172,7 +94,14 @@ async function fetchAndValidateMetadata(
   // SSRF check — skip in development/test for localhost
   const nodeEnv = process.env.NODE_ENV;
   if (nodeEnv !== 'development' && nodeEnv !== 'test') {
-    await resolveAndCheckPrivateIp(domain);
+    try {
+      await resolveAndCheckPrivateIp(domain);
+    } catch (err) {
+      if (err instanceof SsrfValidationError) {
+        throw new RemoteMetadataFetchError(domain, err);
+      }
+      throw err;
+    }
   }
 
   let response: Response;

--- a/apps/api/src/services/webhook.service.spec.ts
+++ b/apps/api/src/services/webhook.service.spec.ts
@@ -1,8 +1,19 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../lib/url-validation.js', () => ({
+  validateOutboundUrl: vi.fn().mockResolvedValue(undefined),
+  SsrfValidationError: class SsrfValidationError extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = 'SsrfValidationError';
+    }
+  },
+}));
 
 vi.mock('@colophony/db', () => {
-  const eq = vi.fn();
-  const and = vi.fn();
+  const eqMock = vi.fn((...args: unknown[]) => ({ type: 'eq', args }));
+  const andMock = vi.fn((...args: unknown[]) => ({ type: 'and', args }));
+  const sqlMock = vi.fn((...args: unknown[]) => ({ type: 'sql', args }));
   return {
     webhookEndpoints: {
       id: 'id',
@@ -20,15 +31,23 @@ vi.mock('@colophony/db', () => {
       status: 'status',
       createdAt: 'created_at',
     },
-    eq,
-    and,
-    sql: vi.fn(),
+    eq: eqMock,
+    and: andMock,
+    sql: sqlMock,
   };
 });
 
+import { eq, and } from '@colophony/db';
 import { webhookService } from './webhook.service.js';
 
+const eqFn = eq as ReturnType<typeof vi.fn>;
+const andFn = and as ReturnType<typeof vi.fn>;
+
 describe('webhookService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('exports expected endpoint methods', () => {
     /* eslint-disable @typescript-eslint/unbound-method */
     expect(webhookService.createEndpoint).toBeTypeOf('function');
@@ -49,5 +68,28 @@ describe('webhookService', () => {
     expect(webhookService.retryDelivery).toBeTypeOf('function');
     expect(webhookService.countRecentFailures).toBeTypeOf('function');
     /* eslint-enable @typescript-eslint/unbound-method */
+  });
+
+  it('filters by organizationId in getActiveEndpointsForEvent', async () => {
+    const mockWhere = vi.fn().mockResolvedValue([]);
+    const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+    const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+    const mockTx = { select: mockSelect } as never;
+
+    const orgId = 'org-123';
+    const eventType = 'submission.created';
+
+    await webhookService.getActiveEndpointsForEvent(mockTx, orgId, eventType);
+
+    // eq should be called with organizationId column + orgId as the first filter
+    expect(eqFn).toHaveBeenCalledWith('organization_id', orgId);
+    // and() should include the org filter
+    expect(andFn).toHaveBeenCalled();
+    const andArgs = andFn.mock.calls[0];
+    // First arg to and() should be the org filter
+    expect(andArgs[0]).toEqual({
+      type: 'eq',
+      args: ['organization_id', orgId],
+    });
   });
 });

--- a/apps/api/src/services/webhook.service.ts
+++ b/apps/api/src/services/webhook.service.ts
@@ -67,7 +67,10 @@ export const webhookService = {
       await validateOutboundUrl(params.url, { devMode });
     } catch (err) {
       if (err instanceof SsrfValidationError) {
-        throw new WebhookUrlValidationError(err.message);
+        // Sanitize: don't expose internal network details to API consumers
+        throw new WebhookUrlValidationError(
+          'URL is not allowed: must be a public HTTPS endpoint',
+        );
       }
       throw err;
     }
@@ -100,7 +103,9 @@ export const webhookService = {
         await validateOutboundUrl(params.url, { devMode });
       } catch (err) {
         if (err instanceof SsrfValidationError) {
-          throw new WebhookUrlValidationError(err.message);
+          throw new WebhookUrlValidationError(
+            'URL is not allowed: must be a public HTTPS endpoint',
+          );
         }
         throw err;
       }

--- a/apps/api/src/services/webhook.service.ts
+++ b/apps/api/src/services/webhook.service.ts
@@ -8,6 +8,17 @@ import {
   type DrizzleDb,
 } from '@colophony/db';
 import { desc, count } from 'drizzle-orm';
+import {
+  validateOutboundUrl,
+  SsrfValidationError,
+} from '../lib/url-validation.js';
+
+export class WebhookUrlValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WebhookUrlValidationError';
+  }
+}
 
 interface CreateEndpointParams {
   organizationId: string;
@@ -50,6 +61,17 @@ function redactSecret<T extends Record<string, unknown>>(
 
 export const webhookService = {
   async createEndpoint(tx: DrizzleDb, params: CreateEndpointParams) {
+    const devMode =
+      process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
+    try {
+      await validateOutboundUrl(params.url, { devMode });
+    } catch (err) {
+      if (err instanceof SsrfValidationError) {
+        throw new WebhookUrlValidationError(err.message);
+      }
+      throw err;
+    }
+
     const secret = crypto.randomBytes(32).toString('hex');
     const [row] = await tx
       .insert(webhookEndpoints)
@@ -70,6 +92,20 @@ export const webhookService = {
     id: string,
     params: UpdateEndpointParams,
   ) {
+    if (params.url !== undefined) {
+      const devMode =
+        process.env.NODE_ENV === 'development' ||
+        process.env.NODE_ENV === 'test';
+      try {
+        await validateOutboundUrl(params.url, { devMode });
+      } catch (err) {
+        if (err instanceof SsrfValidationError) {
+          throw new WebhookUrlValidationError(err.message);
+        }
+        throw err;
+      }
+    }
+
     const update: Record<string, unknown> = { updatedAt: new Date() };
     if (params.url !== undefined) update.url = params.url;
     if (params.description !== undefined)
@@ -134,7 +170,7 @@ export const webhookService = {
 
   async getActiveEndpointsForEvent(
     tx: DrizzleDb,
-    _orgId: string,
+    orgId: string,
     eventType: string,
   ) {
     return tx
@@ -142,6 +178,7 @@ export const webhookService = {
       .from(webhookEndpoints)
       .where(
         and(
+          eq(webhookEndpoints.organizationId, orgId),
           eq(webhookEndpoints.status, 'ACTIVE'),
           sql`${webhookEndpoints.eventTypes}::jsonb @> ${JSON.stringify([eventType])}::jsonb`,
         ),

--- a/apps/api/src/workers/webhook.worker.ts
+++ b/apps/api/src/workers/webhook.worker.ts
@@ -9,10 +9,7 @@ import { getWebhookBackoffDelay } from '../queues/webhook.queue.js';
 import { webhookService } from '../services/webhook.service.js';
 import { auditService } from '../services/audit.service.js';
 import { createInstrumentedWorker } from '../config/instrumented-worker.js';
-import {
-  validateOutboundUrl,
-  SsrfValidationError,
-} from '../lib/url-validation.js';
+import { validateOutboundUrl } from '../lib/url-validation.js';
 
 const AUTO_DISABLE_THRESHOLD = 5;
 const DELIVERY_TIMEOUT_MS = 30_000;
@@ -37,25 +34,20 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
         );
       });
 
-      // Phase 2: SSRF validation — reject private IPs (permanent failure, no retry)
+      // Phase 2: SSRF validation — all failures are permanent (no retry)
+      // Retrying URL validation could enable DNS rebinding amplification
       const devMode = env.NODE_ENV === 'development' || env.NODE_ENV === 'test';
       try {
         await validateOutboundUrl(endpointUrl, { devMode });
       } catch (err) {
-        if (err instanceof SsrfValidationError) {
-          await withRls({ orgId }, async (tx: DrizzleDb) => {
-            await webhookService.updateDeliveryStatus(
-              tx,
-              deliveryId,
-              'FAILED',
-              {
-                errorMessage: `SSRF blocked: ${err.message}`,
-              },
-            );
+        const errorMsg =
+          err instanceof Error ? err.message : 'URL validation failed';
+        await withRls({ orgId }, async (tx: DrizzleDb) => {
+          await webhookService.updateDeliveryStatus(tx, deliveryId, 'FAILED', {
+            errorMessage: `URL validation failed: ${errorMsg}`,
           });
-          return; // Permanent failure — do not retry
-        }
-        throw err;
+        });
+        return; // Permanent failure — do not retry
       }
 
       // Phase 3: Compute HMAC-SHA256 signature

--- a/apps/api/src/workers/webhook.worker.ts
+++ b/apps/api/src/workers/webhook.worker.ts
@@ -9,6 +9,10 @@ import { getWebhookBackoffDelay } from '../queues/webhook.queue.js';
 import { webhookService } from '../services/webhook.service.js';
 import { auditService } from '../services/audit.service.js';
 import { createInstrumentedWorker } from '../config/instrumented-worker.js';
+import {
+  validateOutboundUrl,
+  SsrfValidationError,
+} from '../lib/url-validation.js';
 
 const AUTO_DISABLE_THRESHOLD = 5;
 const DELIVERY_TIMEOUT_MS = 30_000;
@@ -33,13 +37,34 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
         );
       });
 
-      // Phase 2: Compute HMAC-SHA256 signature
+      // Phase 2: SSRF validation — reject private IPs (permanent failure, no retry)
+      const devMode = env.NODE_ENV === 'development' || env.NODE_ENV === 'test';
+      try {
+        await validateOutboundUrl(endpointUrl, { devMode });
+      } catch (err) {
+        if (err instanceof SsrfValidationError) {
+          await withRls({ orgId }, async (tx: DrizzleDb) => {
+            await webhookService.updateDeliveryStatus(
+              tx,
+              deliveryId,
+              'FAILED',
+              {
+                errorMessage: `SSRF blocked: ${err.message}`,
+              },
+            );
+          });
+          return; // Permanent failure — do not retry
+        }
+        throw err;
+      }
+
+      // Phase 3: Compute HMAC-SHA256 signature
       const body = JSON.stringify(payload);
       const signature =
         'sha256=' +
         crypto.createHmac('sha256', secret).update(body).digest('hex');
 
-      // Phase 3: HTTP POST with timeout
+      // Phase 4: HTTP POST with timeout
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
 
@@ -75,7 +100,7 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
         clearTimeout(timeout);
       }
 
-      // Phase 4: Process response
+      // Phase 5: Process response
       const responseBody = await response.text().catch(() => '');
       const truncatedBody = responseBody.slice(0, 4096);
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -119,6 +119,8 @@
 - [x] [P2] Manual QA of embed form widget — test iframe embedding on third-party page, identity step, form filling (flat + wizard), file uploads with scan status, error states, theme inheritance — (backlog 2026-02-23; done 2026-02-23 — found + fixed CORS + dark mode bugs)
 - [x] [P3] Embed form genre validation: show human-readable labels instead of raw enum values — (manual QA 2026-02-23; done 2026-02-23)
 - [x] [P2] Migration 0015 production reliability — `db:verify` / `db:verify:repair` scripts check `information_schema` for FK constraint drift and auto-repair; integrated into `db:reset` — (GDPR manual QA 2026-02-23; done 2026-02-23)
+- [ ] [P2] Status token expiry: add `status_token_expires_at` column, enforce TTL in `verify_status_token()`, rotate on resubmission — (audit finding #2, 2026-03-01)
+- [ ] [P2] Unbounded aging/reminder queries: cap `getAgingSubmissions()` and `listAgingByOrg()` with LIMIT, paginate analytics, summarize reminder emails — (audit finding #3, 2026-03-01)
 
 ---
 
@@ -173,6 +175,8 @@
 - [x] [P3] Per-capability rate limiting — rate limit per federation capability (simsub, transfer, etc.) rather than global per-peer — (OpenCode review 2026-02-25, deferred to production hardening; done 2026-02-26)
 - [x] [P3] Migration rollback testing — enum casts can fail on dirty data; add rollback scenario tests before production deployment — (OpenCode review 2026-02-25, deferred pre-launch; done 2026-02-26)
 - [x] [P4] Consider splitting schema migrations (enum changes vs new tables) for safer production rollback — documented as pattern + pre-flight validator instead of splitting 0031 (already applied) — (OpenCode review 2026-02-25, deferred pre-launch; done 2026-02-26)
+- [ ] [P3] Federation rate limit fail mode: configurable fail-open/fail-closed + in-process fallback when Redis unavailable — (audit finding #4, 2026-03-01)
+- [ ] [P3] Federation test gaps: integration tests for trust handshake flow and hub-first discovery path — (audit finding #5, 2026-03-01)
 
 ### Design Decisions
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -1,0 +1,22 @@
+# Development Log — March 2026
+
+Newest entries first.
+
+---
+
+## 2026-03-01 — Post-Audit Remediation (P0/P1 Fixes + Tooling Hardening)
+
+### Done
+
+- **P0 — Webhook orgId filter**: Fixed `getActiveEndpointsForEvent()` ignoring its `_orgId` parameter — renamed to `orgId` and added explicit `organizationId` filter as defense-in-depth alongside RLS
+- **P1 — SSRF protection**: Extracted `isPrivateIPv4`, `isPrivateIPv6`, `resolveAndCheckPrivateIp` from `trust.service.ts` into shared `lib/url-validation.ts` with new `validateOutboundUrl()` wrapper. Added SSRF validation to webhook endpoint creation/update and webhook delivery worker. 28 new tests
+- **P1 — Queue preset race condition**: Replaced count-then-insert with atomic `INSERT...SELECT...WHERE count < 20`. Added partial unique index on `(org_id, user_id) WHERE is_default = true` (migration 0046). Added `PresetDefaultConflictError` with unique violation handling
+- **Backlog**: Added 4 deferred audit findings — P2: status token expiry, unbounded aging queries; P3: federation rate limit fail mode, federation test gaps
+- **Tooling hardening**: Added 3 new review rules (defense-in-depth multi-tenancy, SSRF protection, unbounded queries) to OpenCode review prompt, Codex review prompt, Codex instructions, and pre-edit hook. Updated API CLAUDE.md with SSRF section. Updated DB CLAUDE.md with defense-in-depth guidance
+- All 1,427 API tests + 465 web tests passing; type-check and lint clean
+
+### Decisions
+
+- Extracted SSRF utility to shared `lib/url-validation.ts` rather than duplicating — reused by trust.service, webhook.service, and webhook.worker
+- Used atomic INSERT...SELECT for preset limit instead of advisory locks — simpler, race-proof at the SQL level
+- Replaced DB CLAUDE.md "manually filter by organizationId (RLS does this)" with "always include explicit org filter as defense-in-depth" — the audit finding proved RLS-only reliance is insufficient

--- a/docs/post-opencode-review-audit.md
+++ b/docs/post-opencode-review-audit.md
@@ -1,0 +1,62 @@
+# Post-OpenCode Review Audit (From 2026-02-25 Switch)
+
+Scope: Implementations logged after the session `2026-02-25 — Federation Data Model Cleanup + OpenCode Review Skill` in `docs/devlog/2026-02.md`.
+
+Method: Read devlog sessions after the switch point, inspect corresponding code paths, and flag issues affecting security, reliability, performance, or long-term maintainability.
+
+## Findings (Incremental)
+
+### 1) [Security] Outbound webhook URLs are not constrained (SSRF pivot risk in multi-tenant hosting)
+
+- Evidence:
+  - `createWebhookEndpointSchema` and `updateWebhookEndpointSchema` accept any URL: `packages/types/src/webhook.ts:29-49`.
+  - Worker posts directly to `endpointUrl` without host/IP allow/deny checks: `apps/api/src/workers/webhook.worker.ts:48-59`.
+- Why it matters: any org admin can configure callbacks to internal/private network targets reachable from the API runtime, which is a classic SSRF pivot and can be used for lateral movement/exfiltration in hosted deployments.
+- Recommendation: enforce `https` and block private/loopback/link-local/metadata IP ranges after DNS resolution (IPv4+IPv6), with optional explicit allowlist for self-hosted mode.
+
+### 2) [Security/Privacy] Embed status tokens have no expiry or rotation policy
+
+- Evidence:
+  - Verification function matches hash only, with no TTL/expiry condition: `packages/db/migrations/0044_status_token.sql:5-16`.
+  - Runtime verification also does hash lookup only: `apps/api/src/services/status-token.service.ts:58-80`.
+- Why it matters: leaked links remain valid indefinitely, allowing long-lived external visibility into submission metadata.
+- Recommendation: add `status_token_expires_at`, enforce expiry in `verify_status_token()`, and rotate token on resubmission/status-sensitive transitions.
+
+### 3) [Reliability/Performance] Aging analytics/reminder paths are unbounded and can degrade under large orgs
+
+- Evidence:
+  - Analytics query materializes all aging submissions and buckets in memory with no `LIMIT`/pagination: `apps/api/src/services/submission-analytics.service.ts:264-339`.
+  - Reminder source query returns all aging submissions for an org: `apps/api/src/services/submission.service.ts:1252-1303`.
+  - Cron includes full `agingSubmissions` list in each editor email payload: `apps/api/src/inngest/functions/submission-response-reminder.ts:61-111`.
+- Why it matters: large datasets can spike memory, execution time, and email payload size; repeated payload duplication per editor multiplies cost.
+- Recommendation: cap results, paginate analytics details, and send summarized reminder emails (count + top N oldest + dashboard link).
+
+### 4) [Security/Reliability] Federation rate limiting fails open on Redis errors
+
+- Evidence:
+  - Catch block explicitly allows request when Redis eval fails: `apps/api/src/federation/federation-rate-limit.ts:75-81`.
+- Why it matters: during Redis outages/degradation, federation endpoints lose abuse protection exactly when systems are already stressed.
+- Recommendation: configurable fail mode (`fail_open` vs `fail_closed`), with at least a minimal in-process fallback limiter when Redis is unavailable.
+
+### 5) [Reliability/Test Coverage] Critical federation paths were explicitly left untested after the review-tool switch
+
+- Evidence:
+  - Devlog records unresolved gaps: trust handshake not tested, hub-first path not tested: `docs/devlog/2026-02.md:744-747`.
+- Why it matters: these are cross-instance trust and duplicate-detection paths where regressions can silently break federation correctness/security assumptions.
+- Recommendation: add automated integration tests for real handshake flow and hub-first query/decision path before additional federation changes.
+
+### 6) [Future Development/Safety] Webhook endpoint lookup relies on implicit RLS and ignores its `orgId` argument
+
+- Evidence:
+  - `getActiveEndpointsForEvent(tx, _orgId, eventType)` never applies org filter: `apps/api/src/services/webhook.service.ts:135-148`.
+- Why it matters: today this is safe only because callers wrap it in `withRls({ orgId })`. A future call site using superuser context could unintentionally fan out events across tenants.
+- Recommendation: enforce explicit `organizationId` predicate in query even when RLS is expected (`eq(webhookEndpoints.organizationId, orgId)`).
+
+### 7) [Reliability/Data Consistency] Saved preset limits/default semantics are race-prone
+
+- Evidence:
+  - `count` check then insert is non-atomic (can exceed 20 under concurrent requests): `apps/api/src/services/queue-preset.service.ts:47-55,70-78`.
+  - Default-handling updates then inserts with no DB constraint ensuring a single default preset per user: `apps/api/src/services/queue-preset.service.ts:57-68`.
+  - Schema has no partial unique index like `(organization_id, user_id) WHERE is_default`: `packages/db/src/schema/saved-queue-presets.ts:31-45`.
+- Why it matters: inconsistent UI behavior (multiple defaults) and policy drift under concurrent writes.
+- Recommendation: add DB constraints (partial unique index for default, trigger or bounded insert guard) and make create/update transactional with conflict-safe logic.

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -67,8 +67,8 @@ Manuscripts use `owner_id = current_user_id()` instead of org-scoped isolation. 
 
 - Query tenant data without setting org context via `SET LOCAL`
 - Use session-level `SET` (always `SET LOCAL` inside transaction — critical with connection pooling)
-- Manually filter by `organizationId` (RLS does this)
 - Use `app.current_user` (reserved keyword — use `app.user_id`)
+- Rely solely on RLS for tenant isolation in service methods — always include explicit `WHERE organization_id = orgId` as defense-in-depth
 - Skip `FORCE ROW LEVEL SECURITY` on tenant tables
 - Make `app_user` a superuser (superusers bypass RLS)
 - Use `INSERT...RETURNING` when SELECT policy is stricter than INSERT (e.g., `audit_events`) — the RETURNING clause reads the row back via SELECT, so both policies must pass. Drop `.returning()` or widen the SELECT policy.

--- a/packages/db/migrations/0046_queue_preset_default_unique.sql
+++ b/packages/db/migrations/0046_queue_preset_default_unique.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX "saved_queue_presets_one_default_per_user_idx"
+  ON "saved_queue_presets" ("organization_id", "user_id")
+  WHERE "is_default" = true;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1778200000000,
       "tag": "0045_saved_queue_presets",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1778400000000,
+      "tag": "0046_queue_preset_default_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/saved-queue-presets.ts
+++ b/packages/db/src/schema/saved-queue-presets.ts
@@ -43,6 +43,9 @@ export const savedQueuePresets = pgTable(
       table.organizationId,
       table.userId,
     ),
+    uniqueIndex("saved_queue_presets_one_default_per_user_idx")
+      .on(table.organizationId, table.userId)
+      .where(sql`is_default = true`),
     pgPolicy("org_isolation", {
       for: "all",
       using: sql`organization_id = current_org_id()`,


### PR DESCRIPTION
## Summary

- **P0 — Webhook orgId filtering**: Fixed `getActiveEndpointsForEvent()` ignoring its `_orgId` parameter — defense-in-depth filter alongside RLS
- **P1 — SSRF protection**: Extracted shared `lib/url-validation.ts` from `trust.service.ts`, added SSRF validation to webhook endpoint CRUD and delivery worker, sanitized error messages for API consumers
- **P1 — Queue preset race conditions**: Atomic `INSERT...SELECT...WHERE count < 20` replaces count-then-insert; partial unique index enforces one default per user at DB level (migration 0046)
- **Tooling hardening**: Added 3 new review rules (defense-in-depth, SSRF, unbounded queries) to OpenCode/code review prompts, pre-edit hooks, and API/DB CLAUDE.md
- **Backlog**: 4 deferred audit findings (P2/P3) added to appropriate tracks

## Test plan

- [x] 29 new SSRF validation tests (`url-validation.spec.ts`)
- [x] 3 webhook service tests (`webhook.service.spec.ts`)
- [x] 4 queue preset tests (`queue-preset.service.spec.ts`)
- [x] Updated 2 existing preset tests (`__tests__/queue-preset.service.spec.ts`)
- [x] All 1,427 API + 465 web tests passing
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean
- [ ] `pnpm db:migrate` — migration 0046 applies cleanly