### PR TITLE
fix(web): handle 410 Gone for expired embed status tokens

### DIFF
--- a/apps/web/src/components/embed/__tests__/embed-status-check.spec.tsx
+++ b/apps/web/src/components/embed/__tests__/embed-status-check.spec.tsx
@@ -1,0 +1,103 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { EmbedStatusCheck } from "../embed-status-check";
+import "../../../../test/setup";
+
+// Mock embed-api module
+jest.mock("@/lib/embed-api", () => ({
+  fetchSubmissionStatus: jest.fn(),
+}));
+
+import { fetchSubmissionStatus } from "@/lib/embed-api";
+import type { EmbedApiError } from "@/lib/embed-api";
+
+const mockFetch = fetchSubmissionStatus as jest.MockedFunction<
+  typeof fetchSubmissionStatus
+>;
+
+const defaultProps = {
+  statusToken: "col_sta_abc123",
+  apiUrl: "http://localhost:4000",
+};
+
+describe("EmbedStatusCheck", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows loading spinner initially", () => {
+    mockFetch.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<EmbedStatusCheck {...defaultProps} />);
+
+    expect(
+      screen.getByText("", { selector: ".animate-spin" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders submission status on success", async () => {
+    mockFetch.mockResolvedValue({
+      title: "My Poem",
+      status: "Under Review",
+      submittedAt: "2026-02-15T00:00:00.000Z",
+      organizationName: "Test Journal",
+      periodName: "Spring 2026",
+    });
+
+    render(<EmbedStatusCheck {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("My Poem")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Under Review")).toBeInTheDocument();
+    expect(screen.getByText("Test Journal")).toBeInTheDocument();
+    expect(screen.getByText("Spring 2026")).toBeInTheDocument();
+  });
+
+  it("shows not found for 404 response", async () => {
+    const err: EmbedApiError = {
+      status: 404,
+      error: "not_found",
+      message: "Submission not found",
+    };
+    mockFetch.mockRejectedValue(err);
+
+    render(<EmbedStatusCheck {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Submission Not Found")).toBeInTheDocument();
+    });
+  });
+
+  it("shows expired message for 410 response", async () => {
+    const err: EmbedApiError = {
+      status: 410,
+      error: "token_expired",
+      message:
+        "This status link has expired. Please contact the publication for an update.",
+    };
+    mockFetch.mockRejectedValue(err);
+
+    render(<EmbedStatusCheck {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Status Link Expired")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/contact the publication directly/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows generic error for other failures", async () => {
+    const err: EmbedApiError = {
+      status: 500,
+      error: "internal",
+      message: "Server error",
+    };
+    mockFetch.mockRejectedValue(err);
+
+    render(<EmbedStatusCheck {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Something Went Wrong")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/embed/embed-status-check.tsx
+++ b/apps/web/src/components/embed/embed-status-check.tsx
@@ -11,7 +11,7 @@ import {
   AlertCircle,
 } from "lucide-react";
 
-type ViewState = "loading" | "loaded" | "not_found" | "error";
+type ViewState = "loading" | "loaded" | "not_found" | "token_expired" | "error";
 
 const STATUS_ICONS: Record<string, typeof CheckCircle> = {
   Accepted: CheckCircle,
@@ -52,7 +52,9 @@ export function EmbedStatusCheck({
       } catch (err) {
         if (cancelled) return;
         const apiErr = err as EmbedApiError;
-        if (apiErr.status === 404) {
+        if (apiErr.status === 410) {
+          setViewState("token_expired");
+        } else if (apiErr.status === 404) {
           setViewState("not_found");
         } else {
           setViewState("error");
@@ -81,6 +83,19 @@ export function EmbedStatusCheck({
         <h2 className="text-lg font-semibold">Submission Not Found</h2>
         <p className="text-sm text-muted-foreground mt-2">
           This status link is invalid or has expired.
+        </p>
+      </div>
+    );
+  }
+
+  if (viewState === "token_expired") {
+    return (
+      <div className="max-w-md mx-auto text-center py-16 px-4">
+        <Clock className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+        <h2 className="text-lg font-semibold">Status Link Expired</h2>
+        <p className="text-sm text-muted-foreground mt-2">
+          This status link has expired. Please contact the publication directly
+          for an update on your submission.
         </p>
       </div>
     );

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -316,7 +316,7 @@
 - [x] [P1] "Revise and resubmit" status — add R&R to SubmissionStatus enum + transition map; editor sends revision notes, writer resubmits against the same submission record — (persona gap analysis 2026-02-27; done 2026-02-27 PR pending)
 - [x] [P2] Embed submitter confirmation email — send a receipt email to the address provided in the embed identity step; include submission title, journal name, and a status-check token/link — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [x] [P2] Embed submitter status check — public page at `/embed/status/:token` where embed submitters (no account) can check their submission status — (persona gap analysis 2026-02-27; done 2026-02-28)
-- [ ] [P3] Embed status check: handle 410 Gone for expired tokens — show user-friendly "token expired" message in `embed-status-check.tsx` — (audit remediation P2/P3, 2026-03-01)
+- [x] [P3] Embed status check: handle 410 Gone for expired tokens — show user-friendly "token expired" message in `embed-status-check.tsx` — (audit remediation P2/P3, 2026-03-01; done 2026-03-01)
 - [ ] [P3] Status token rotation on R&R resubmission — generate new token when embed submitter resubmits after revise-and-resubmit; no resubmit flow in embed service yet — (audit remediation P2/P3, 2026-03-01)
 
 ### Editorial Workflow

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,15 @@ Newest entries first.
 
 ---
 
+## 2026-03-01 — Embed 410 Gone Handling
+
+### Done
+
+- Handle 410 Gone for expired status tokens in `embed-status-check.tsx` — added `token_expired` view state with Clock icon and user-friendly message directing submitter to contact the publication
+- Added 5 unit tests for `EmbedStatusCheck` component (loading, success, 404, 410, generic error)
+
+---
+
 ## 2026-03-01 — Post-Audit Remediation (P2/P3 Deferred Findings)
 
 ### Done


### PR DESCRIPTION
## Summary
- Handle 410 Gone response for expired status tokens in `embed-status-check.tsx`
- Show user-friendly "Status Link Expired" message with Clock icon instead of generic error
- Added 5 unit tests covering all view states (loading, success, 404, 410, error)

Closes Track 7 P3 backlog item: "Embed status check: handle 410 Gone for expired tokens"

## Test plan
- [x] Unit tests pass (5/5 new tests in `embed-status-check.spec.tsx`)
- [ ] Manual: visit `/embed/status/<expired-token>` and verify "Status Link Expired" message displays