### PR TITLE
feat(hopper): cross-org portfolio view + writer analytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,9 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **Hub client service**   | `apps/api/src/services/hub-client.service.ts`                                    |
 | **Analytics service**    | `apps/api/src/services/submission-analytics.service.ts`                          |
 | **Analytics components** | `apps/web/src/components/analytics/` (charts, filters, dashboard page)           |
+| **Portfolio service**    | `apps/api/src/services/portfolio.service.ts` (cross-org UNION ALL, status maps)  |
+| **Writer analytics svc** | `apps/api/src/services/writer-analytics.service.ts` (personal stats/charts)      |
+| **Writer analytics UI**  | `apps/web/src/components/workspace/writer-*` (analytics page + chart components) |
 | **Next.js frontend**     | `apps/web/`                                                                      |
 | **tRPC client**          | `apps/web/src/lib/trpc.ts`                                                       |
 | **Plugin components**    | `apps/web/src/components/plugins/` (PluginSlot, extensions, error boundary)      |

--- a/apps/api/src/services/portfolio.service.spec.ts
+++ b/apps/api/src/services/portfolio.service.spec.ts
@@ -84,8 +84,8 @@ describe('portfolioService', () => {
       });
 
       expect(result.items).toHaveLength(2);
-      expect(result.items[0]!.source).toBe('external');
-      expect(result.items[1]!.source).toBe('native');
+      expect(result.items[0]?.source).toBe('external');
+      expect(result.items[1]?.source).toBe('native');
     });
 
     it('maps native SUBMITTED to CSR sent', () => {
@@ -105,8 +105,9 @@ describe('portfolioService', () => {
       });
 
       expect(result.items).toHaveLength(1);
-      expect(result.items[0]!.status).toBe('accepted');
+      expect(result.items[0]?.status).toBe('accepted');
       // Verify the query was called (includes both native + external for 'accepted')
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(tx.execute).toHaveBeenCalled();
     });
 
@@ -119,7 +120,7 @@ describe('portfolioService', () => {
       });
 
       expect(result.items).toHaveLength(1);
-      expect(result.items[0]!.source).toBe('native');
+      expect(result.items[0]?.source).toBe('native');
     });
 
     it('filters by source=external excludes native', async () => {
@@ -131,7 +132,7 @@ describe('portfolioService', () => {
       });
 
       expect(result.items).toHaveLength(1);
-      expect(result.items[0]!.source).toBe('external');
+      expect(result.items[0]?.source).toBe('external');
     });
 
     it('search filters by title and journalName with ILIKE', async () => {
@@ -143,6 +144,7 @@ describe('portfolioService', () => {
       });
 
       // The service escapes ILIKE special chars — verify execute was called
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(tx.execute).toHaveBeenCalled();
     });
 
@@ -154,6 +156,7 @@ describe('portfolioService', () => {
       });
 
       // Verify the query was called (pagination is in SQL)
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(tx.execute).toHaveBeenCalled();
     });
 
@@ -170,10 +173,10 @@ describe('portfolioService', () => {
         limit: 20,
       });
 
-      expect(result.items[0]!.manuscriptId).toBe(
+      expect(result.items[0]?.manuscriptId).toBe(
         '00000000-0000-0000-0000-000000000099',
       );
-      expect(result.items[0]!.manuscriptTitle).toBe('My Book');
+      expect(result.items[0]?.manuscriptTitle).toBe('My Book');
     });
   });
 

--- a/apps/api/src/services/portfolio.service.spec.ts
+++ b/apps/api/src/services/portfolio.service.spec.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@colophony/db', () => ({
+  sql: Object.assign((...args: unknown[]) => ({ __sql: true, args }), {
+    raw: (s: string) => ({ __raw: true, value: s }),
+    join: (...args: unknown[]) => ({ __join: true, args }),
+  }),
+}));
+
+import {
+  portfolioService,
+  NATIVE_TO_CSR,
+  CSR_TO_NATIVE,
+} from './portfolio.service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const USER_ID = '00000000-0000-0000-0000-000000000001';
+
+function makeTx(rows: unknown[]) {
+  return {
+    execute: vi.fn().mockResolvedValue({ rows }),
+  } as unknown as Parameters<typeof portfolioService.list>[0];
+}
+
+function makeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    total: 2,
+    source: 'native',
+    id: '00000000-0000-0000-0000-000000000010',
+    title: 'My Poem',
+    journal_name: 'Lit Review',
+    status: 'sent',
+    sent_at: '2025-06-01T00:00:00.000Z',
+    responded_at: null,
+    manuscript_id: '00000000-0000-0000-0000-000000000020',
+    manuscript_title: 'Collected Works',
+    created_at: '2025-06-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('portfolioService', () => {
+  describe('list', () => {
+    it('returns empty portfolio for user with no submissions', async () => {
+      const tx = makeTx([]);
+      const result = await portfolioService.list(tx, USER_ID, {
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.items).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(result.totalPages).toBe(0);
+    });
+
+    it('merges native and external sorted by createdAt desc', async () => {
+      const rows = [
+        makeRow({
+          source: 'external',
+          created_at: '2025-07-01T00:00:00.000Z',
+          total: 2,
+        }),
+        makeRow({
+          source: 'native',
+          created_at: '2025-06-01T00:00:00.000Z',
+          total: 2,
+        }),
+      ];
+      const tx = makeTx(rows);
+      const result = await portfolioService.list(tx, USER_ID, {
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0]!.source).toBe('external');
+      expect(result.items[1]!.source).toBe('native');
+    });
+
+    it('maps native SUBMITTED to CSR sent', () => {
+      expect(NATIVE_TO_CSR['SUBMITTED']).toBe('sent');
+      expect(NATIVE_TO_CSR['UNDER_REVIEW']).toBe('in_review');
+      expect(NATIVE_TO_CSR['ACCEPTED']).toBe('accepted');
+      expect(NATIVE_TO_CSR['REJECTED']).toBe('rejected');
+      expect(NATIVE_TO_CSR['REVISE_AND_RESUBMIT']).toBe('revise');
+    });
+
+    it('filters by harmonized status across both sources', async () => {
+      const tx = makeTx([makeRow({ status: 'accepted', total: 1 })]);
+      const result = await portfolioService.list(tx, USER_ID, {
+        status: 'accepted',
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]!.status).toBe('accepted');
+      // Verify the query was called (includes both native + external for 'accepted')
+      expect(tx.execute).toHaveBeenCalled();
+    });
+
+    it('filters by source=native excludes external', async () => {
+      const tx = makeTx([makeRow({ source: 'native', total: 1 })]);
+      const result = await portfolioService.list(tx, USER_ID, {
+        source: 'native',
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]!.source).toBe('native');
+    });
+
+    it('filters by source=external excludes native', async () => {
+      const tx = makeTx([makeRow({ source: 'external', total: 1 })]);
+      const result = await portfolioService.list(tx, USER_ID, {
+        source: 'external',
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]!.source).toBe('external');
+    });
+
+    it('search filters by title and journalName with ILIKE', async () => {
+      const tx = makeTx([makeRow({ total: 1 })]);
+      await portfolioService.list(tx, USER_ID, {
+        search: 'test%query',
+        page: 1,
+        limit: 20,
+      });
+
+      // The service escapes ILIKE special chars — verify execute was called
+      expect(tx.execute).toHaveBeenCalled();
+    });
+
+    it('paginates with correct LIMIT/OFFSET', async () => {
+      const tx = makeTx([]);
+      await portfolioService.list(tx, USER_ID, {
+        page: 2,
+        limit: 10,
+      });
+
+      // Verify the query was called (pagination is in SQL)
+      expect(tx.execute).toHaveBeenCalled();
+    });
+
+    it('includes manuscriptId and manuscriptTitle via JOIN', async () => {
+      const tx = makeTx([
+        makeRow({
+          manuscript_id: '00000000-0000-0000-0000-000000000099',
+          manuscript_title: 'My Book',
+          total: 1,
+        }),
+      ]);
+      const result = await portfolioService.list(tx, USER_ID, {
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.items[0]!.manuscriptId).toBe(
+        '00000000-0000-0000-0000-000000000099',
+      );
+      expect(result.items[0]!.manuscriptTitle).toBe('My Book');
+    });
+  });
+
+  describe('CSR_TO_NATIVE mapping', () => {
+    it('has reverse mapping for all native statuses', () => {
+      expect(CSR_TO_NATIVE['sent']).toEqual(['SUBMITTED']);
+      expect(CSR_TO_NATIVE['accepted']).toEqual(['ACCEPTED']);
+      expect(CSR_TO_NATIVE['no_response']).toEqual([]);
+    });
+  });
+});

--- a/apps/api/src/services/portfolio.service.ts
+++ b/apps/api/src/services/portfolio.service.ts
@@ -53,7 +53,7 @@ function buildNativeSubquery(
   conditions.push(sql.raw(`s.status != 'DRAFT'`));
 
   if (status) {
-    const nativeStatuses = CSR_TO_NATIVE[status]!;
+    const nativeStatuses = CSR_TO_NATIVE[status] ?? [];
     const statusList = nativeStatuses.map((s) => sql`${s}`);
     conditions.push(
       sql`s.status::text IN (${sql.join(statusList, sql.raw(', '))})`,
@@ -170,8 +170,11 @@ export const portfolioService = {
       return { items: [], total: 0, page, limit, totalPages: 0 };
     }
 
+    const first = parts[0];
     const unionQuery =
-      parts.length === 1 ? parts[0]! : sql.join(parts, sql.raw(' UNION ALL '));
+      parts.length === 1 && first
+        ? first
+        : sql.join(parts, sql.raw(' UNION ALL '));
 
     const result = await tx.execute(sql`
       WITH portfolio AS (${unionQuery})

--- a/apps/api/src/services/portfolio.service.ts
+++ b/apps/api/src/services/portfolio.service.ts
@@ -1,0 +1,227 @@
+import { sql, type DrizzleDb } from '@colophony/db';
+import type { SQL } from 'drizzle-orm';
+import type {
+  CSRStatus,
+  ListPortfolioInput,
+  PortfolioItem,
+  PortfolioListResponse,
+} from '@colophony/types';
+
+// ---------------------------------------------------------------------------
+// Status mapping — native (uppercase) ↔ CSR (lowercase)
+// ---------------------------------------------------------------------------
+
+export const NATIVE_TO_CSR: Record<string, CSRStatus> = {
+  DRAFT: 'draft',
+  SUBMITTED: 'sent',
+  UNDER_REVIEW: 'in_review',
+  HOLD: 'hold',
+  ACCEPTED: 'accepted',
+  REJECTED: 'rejected',
+  WITHDRAWN: 'withdrawn',
+  REVISE_AND_RESUBMIT: 'revise',
+};
+
+export const CSR_TO_NATIVE: Record<string, string[]> = {
+  draft: ['DRAFT'],
+  sent: ['SUBMITTED'],
+  in_review: ['UNDER_REVIEW'],
+  hold: ['HOLD'],
+  accepted: ['ACCEPTED'],
+  rejected: ['REJECTED'],
+  withdrawn: ['WITHDRAWN'],
+  revise: ['REVISE_AND_RESUBMIT'],
+  no_response: [],
+  unknown: [],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildNativeSubquery(
+  userId: string,
+  status: CSRStatus | undefined,
+  searchEscaped: string | null,
+): SQL | null {
+  if (status) {
+    const nativeStatuses = CSR_TO_NATIVE[status] ?? [];
+    if (nativeStatuses.length === 0) return null;
+  }
+
+  const conditions: SQL[] = [sql`s.submitter_id = ${userId}`];
+  conditions.push(sql.raw(`s.status != 'DRAFT'`));
+
+  if (status) {
+    const nativeStatuses = CSR_TO_NATIVE[status]!;
+    const statusList = nativeStatuses.map((s) => sql`${s}`);
+    conditions.push(
+      sql`s.status::text IN (${sql.join(statusList, sql.raw(', '))})`,
+    );
+  }
+
+  if (searchEscaped) {
+    conditions.push(
+      sql`(s.title ILIKE '%' || ${searchEscaped} || '%' OR o.name ILIKE '%' || ${searchEscaped} || '%')`,
+    );
+  }
+
+  const where = sql.join(conditions, sql.raw(' AND '));
+
+  return sql`
+    SELECT
+      'native'::text AS source,
+      s.id,
+      s.title,
+      o.name AS journal_name,
+      CASE s.status::text
+        WHEN 'DRAFT' THEN 'draft'
+        WHEN 'SUBMITTED' THEN 'sent'
+        WHEN 'UNDER_REVIEW' THEN 'in_review'
+        WHEN 'HOLD' THEN 'hold'
+        WHEN 'ACCEPTED' THEN 'accepted'
+        WHEN 'REJECTED' THEN 'rejected'
+        WHEN 'WITHDRAWN' THEN 'withdrawn'
+        WHEN 'REVISE_AND_RESUBMIT' THEN 'revise'
+        ELSE 'unknown'
+      END AS status,
+      s.submitted_at AS sent_at,
+      sh_decision.decided_at AS responded_at,
+      m.id AS manuscript_id,
+      m.title AS manuscript_title,
+      s.created_at
+    FROM submissions s
+    LEFT JOIN organizations o ON o.id = s.organization_id
+    LEFT JOIN manuscript_versions mv ON mv.id = s.manuscript_version_id
+    LEFT JOIN manuscripts m ON m.id = mv.manuscript_id
+    LEFT JOIN LATERAL (
+      SELECT MIN(sh.changed_at) AS decided_at
+      FROM submission_history sh
+      WHERE sh.submission_id = s.id
+        AND sh.to_status IN ('ACCEPTED', 'REJECTED', 'WITHDRAWN')
+    ) sh_decision ON true
+    WHERE ${where}
+  `;
+}
+
+function buildExternalSubquery(
+  userId: string,
+  status: CSRStatus | undefined,
+  searchEscaped: string | null,
+): SQL {
+  const conditions: SQL[] = [sql`es.user_id = ${userId}`];
+
+  if (status) {
+    conditions.push(sql`es.status::text = ${status}`);
+  }
+  if (searchEscaped) {
+    conditions.push(sql`es.journal_name ILIKE '%' || ${searchEscaped} || '%'`);
+  }
+
+  const where = sql.join(conditions, sql.raw(' AND '));
+
+  return sql`
+    SELECT
+      'external'::text AS source,
+      es.id,
+      es.journal_name AS title,
+      es.journal_name,
+      es.status::text,
+      es.sent_at,
+      es.responded_at,
+      es.manuscript_id,
+      m2.title AS manuscript_title,
+      es.created_at
+    FROM external_submissions es
+    LEFT JOIN manuscripts m2 ON m2.id = es.manuscript_id
+    WHERE ${where}
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const portfolioService = {
+  async list(
+    tx: DrizzleDb,
+    userId: string,
+    input: ListPortfolioInput,
+  ): Promise<PortfolioListResponse> {
+    const { search, status, source, page, limit } = input;
+    const offset = (page - 1) * limit;
+
+    const searchEscaped = search ? search.replace(/[\\%_]/g, '\\$&') : null;
+
+    const includeNative = !source || source === 'native';
+    const includeExternal = !source || source === 'external';
+
+    const parts: SQL[] = [];
+
+    if (includeNative) {
+      const nativeSql = buildNativeSubquery(userId, status, searchEscaped);
+      if (nativeSql) parts.push(nativeSql);
+    }
+    if (includeExternal) {
+      parts.push(buildExternalSubquery(userId, status, searchEscaped));
+    }
+
+    if (parts.length === 0) {
+      return { items: [], total: 0, page, limit, totalPages: 0 };
+    }
+
+    const unionQuery =
+      parts.length === 1 ? parts[0]! : sql.join(parts, sql.raw(' UNION ALL '));
+
+    const result = await tx.execute(sql`
+      WITH portfolio AS (${unionQuery})
+      SELECT
+        (SELECT COUNT(*)::int FROM portfolio) AS total,
+        p.*
+      FROM portfolio p
+      ORDER BY p.created_at DESC
+      LIMIT ${limit} OFFSET ${offset}
+    `);
+
+    const rows = result.rows as Array<{
+      total: number;
+      source: string;
+      id: string;
+      title: string | null;
+      journal_name: string | null;
+      status: string;
+      sent_at: string | Date | null;
+      responded_at: string | Date | null;
+      manuscript_id: string | null;
+      manuscript_title: string | null;
+      created_at: string | Date;
+    }>;
+
+    const total = rows[0]?.total ?? 0;
+
+    const items: PortfolioItem[] = rows.map((row) => ({
+      id: row.id,
+      source: row.source as 'native' | 'external',
+      title: row.title,
+      journalName: row.journal_name,
+      status: row.status as CSRStatus,
+      sentAt: row.sent_at
+        ? new Date(row.sent_at as string).toISOString()
+        : null,
+      respondedAt: row.responded_at
+        ? new Date(row.responded_at as string).toISOString()
+        : null,
+      manuscriptId: row.manuscript_id,
+      manuscriptTitle: row.manuscript_title,
+      createdAt: new Date(row.created_at as string).toISOString(),
+    }));
+
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+};

--- a/apps/api/src/services/writer-analytics.service.spec.ts
+++ b/apps/api/src/services/writer-analytics.service.spec.ts
@@ -209,6 +209,7 @@ describe('writerAnalyticsService', () => {
       });
 
       expect(result.totalSubmissions).toBe(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(tx.execute).toHaveBeenCalledTimes(4);
     });
   });
@@ -301,16 +302,9 @@ describe('writerAnalyticsService', () => {
       );
 
       expect(result.buckets).toHaveLength(5);
-      // < 7 days: 5
-      expect(result.buckets[0]!.count).toBe(1);
-      // 7-14 days: 10
-      expect(result.buckets[1]!.count).toBe(1);
-      // 14-28 days: 20
-      expect(result.buckets[2]!.count).toBe(1);
-      // 28-60 days: 45
-      expect(result.buckets[3]!.count).toBe(1);
-      // 60+ days: 90
-      expect(result.buckets[4]!.count).toBe(1);
+      const counts = result.buckets.map((b) => b.count);
+      // [<7d, 7-14d, 14-28d, 28-60d, 60+d] — one entry in each
+      expect(counts).toEqual([1, 1, 1, 1, 1]);
 
       // median of [5, 10, 20, 45, 90] = 20
       expect(result.medianDays).toBe(20);

--- a/apps/api/src/services/writer-analytics.service.spec.ts
+++ b/apps/api/src/services/writer-analytics.service.spec.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@colophony/db', () => ({
+  sql: Object.assign((...args: unknown[]) => ({ __sql: true, args }), {
+    raw: (s: string) => ({ __raw: true, value: s }),
+    join: (...args: unknown[]) => ({ __join: true, args }),
+  }),
+}));
+
+vi.mock('./portfolio.service.js', () => ({
+  NATIVE_TO_CSR: {
+    DRAFT: 'draft',
+    SUBMITTED: 'sent',
+    UNDER_REVIEW: 'in_review',
+    HOLD: 'hold',
+    ACCEPTED: 'accepted',
+    REJECTED: 'rejected',
+    WITHDRAWN: 'withdrawn',
+    REVISE_AND_RESUBMIT: 'revise',
+  },
+}));
+
+import { writerAnalyticsService } from './writer-analytics.service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const USER_ID = '00000000-0000-0000-0000-000000000001';
+
+function makeTx(execResults: Array<{ rows: unknown[] }>) {
+  let callIdx = 0;
+  return {
+    execute: vi.fn().mockImplementation(() => {
+      const result = execResults[callIdx] ?? { rows: [] };
+      callIdx++;
+      return Promise.resolve(result);
+    }),
+  } as unknown as Parameters<typeof writerAnalyticsService.getOverview>[0];
+}
+
+// ---------------------------------------------------------------------------
+// Tests — getOverview
+// ---------------------------------------------------------------------------
+
+describe('writerAnalyticsService', () => {
+  describe('getOverview', () => {
+    it('returns zeros for user with no submissions', async () => {
+      const tx = makeTx([
+        // native counts
+        {
+          rows: [
+            {
+              total: 0,
+              accepted: 0,
+              rejected: 0,
+              pending: 0,
+              this_month: 0,
+              last_month: 0,
+            },
+          ],
+        },
+        // external counts
+        {
+          rows: [
+            {
+              total: 0,
+              accepted: 0,
+              rejected: 0,
+              pending: 0,
+              this_month: 0,
+              last_month: 0,
+            },
+          ],
+        },
+        // native avg response
+        { rows: [{ avg_days: null, cnt: 0 }] },
+        // external avg response
+        { rows: [{ avg_days: null, cnt: 0 }] },
+      ]);
+
+      const result = await writerAnalyticsService.getOverview(tx, USER_ID, {});
+
+      expect(result.totalSubmissions).toBe(0);
+      expect(result.nativeCount).toBe(0);
+      expect(result.externalCount).toBe(0);
+      expect(result.acceptanceRate).toBe(0);
+      expect(result.avgResponseTimeDays).toBeNull();
+      expect(result.pendingCount).toBe(0);
+    });
+
+    it('merges native and external counts', async () => {
+      const tx = makeTx([
+        {
+          rows: [
+            {
+              total: 5,
+              accepted: 2,
+              rejected: 1,
+              pending: 2,
+              this_month: 1,
+              last_month: 2,
+            },
+          ],
+        },
+        {
+          rows: [
+            {
+              total: 3,
+              accepted: 1,
+              rejected: 1,
+              pending: 1,
+              this_month: 0,
+              last_month: 1,
+            },
+          ],
+        },
+        { rows: [{ avg_days: 20, cnt: 3 }] },
+        { rows: [{ avg_days: 10, cnt: 2 }] },
+      ]);
+
+      const result = await writerAnalyticsService.getOverview(tx, USER_ID, {});
+
+      expect(result.totalSubmissions).toBe(8);
+      expect(result.nativeCount).toBe(5);
+      expect(result.externalCount).toBe(3);
+      expect(result.pendingCount).toBe(3);
+      // 3 accepted / 5 decided = 60%
+      expect(result.acceptanceRate).toBe(60);
+      expect(result.submissionsThisMonth).toBe(1);
+      expect(result.submissionsLastMonth).toBe(3);
+    });
+
+    it('computes weighted avg response time', async () => {
+      const tx = makeTx([
+        {
+          rows: [
+            {
+              total: 2,
+              accepted: 1,
+              rejected: 1,
+              pending: 0,
+              this_month: 0,
+              last_month: 0,
+            },
+          ],
+        },
+        {
+          rows: [
+            {
+              total: 1,
+              accepted: 1,
+              rejected: 0,
+              pending: 0,
+              this_month: 0,
+              last_month: 0,
+            },
+          ],
+        },
+        // native: 30 days avg, 2 entries
+        { rows: [{ avg_days: 30, cnt: 2 }] },
+        // external: 10 days avg, 1 entry
+        { rows: [{ avg_days: 10, cnt: 1 }] },
+      ]);
+
+      const result = await writerAnalyticsService.getOverview(tx, USER_ID, {});
+
+      // weighted: (30*2 + 10*1) / 3 = 70/3 ≈ 23.3
+      expect(result.avgResponseTimeDays).toBe(23.3);
+    });
+
+    it('respects date filter', async () => {
+      const tx = makeTx([
+        {
+          rows: [
+            {
+              total: 1,
+              accepted: 1,
+              rejected: 0,
+              pending: 0,
+              this_month: 0,
+              last_month: 0,
+            },
+          ],
+        },
+        {
+          rows: [
+            {
+              total: 0,
+              accepted: 0,
+              rejected: 0,
+              pending: 0,
+              this_month: 0,
+              last_month: 0,
+            },
+          ],
+        },
+        { rows: [{ avg_days: null, cnt: 0 }] },
+        { rows: [{ avg_days: null, cnt: 0 }] },
+      ]);
+
+      const result = await writerAnalyticsService.getOverview(tx, USER_ID, {
+        startDate: new Date('2025-01-01'),
+        endDate: new Date('2025-12-31'),
+      });
+
+      expect(result.totalSubmissions).toBe(1);
+      expect(tx.execute).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getStatusBreakdown
+  // ---------------------------------------------------------------------------
+
+  describe('getStatusBreakdown', () => {
+    it('harmonizes native SUBMITTED + external sent into one entry', async () => {
+      const tx = makeTx([
+        // native
+        { rows: [{ status: 'SUBMITTED', count: 3 }] },
+        // external
+        { rows: [{ status: 'sent', count: 2 }] },
+      ]);
+
+      const result = await writerAnalyticsService.getStatusBreakdown(
+        tx,
+        USER_ID,
+        {},
+      );
+
+      const sentEntry = result.breakdown.find((b) => b.status === 'sent');
+      expect(sentEntry).toBeDefined();
+      expect(sentEntry!.count).toBe(5);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getTimeSeries
+  // ---------------------------------------------------------------------------
+
+  describe('getTimeSeries', () => {
+    it('groups by month with source breakdown', async () => {
+      const tx = makeTx([
+        // native
+        {
+          rows: [
+            { date: '2025-06-01', count: 3 },
+            { date: '2025-07-01', count: 1 },
+          ],
+        },
+        // external
+        {
+          rows: [
+            { date: '2025-06-01', count: 2 },
+            { date: '2025-08-01', count: 4 },
+          ],
+        },
+      ]);
+
+      const result = await writerAnalyticsService.getTimeSeries(tx, USER_ID, {
+        granularity: 'monthly',
+      });
+
+      expect(result.granularity).toBe('monthly');
+      expect(result.points).toHaveLength(3);
+
+      const jun = result.points.find((p) => p.date === '2025-06-01');
+      expect(jun).toBeDefined();
+      expect(jun!.nativeCount).toBe(3);
+      expect(jun!.externalCount).toBe(2);
+      expect(jun!.count).toBe(5);
+
+      const aug = result.points.find((p) => p.date === '2025-08-01');
+      expect(aug).toBeDefined();
+      expect(aug!.nativeCount).toBe(0);
+      expect(aug!.externalCount).toBe(4);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getResponseTime
+  // ---------------------------------------------------------------------------
+
+  describe('getResponseTime', () => {
+    it('buckets native and external together', async () => {
+      const tx = makeTx([
+        // native days
+        { rows: [{ days: 5 }, { days: 20 }, { days: 45 }] },
+        // external days
+        { rows: [{ days: 10 }, { days: 90 }] },
+      ]);
+
+      const result = await writerAnalyticsService.getResponseTime(
+        tx,
+        USER_ID,
+        {},
+      );
+
+      expect(result.buckets).toHaveLength(5);
+      // < 7 days: 5
+      expect(result.buckets[0]!.count).toBe(1);
+      // 7-14 days: 10
+      expect(result.buckets[1]!.count).toBe(1);
+      // 14-28 days: 20
+      expect(result.buckets[2]!.count).toBe(1);
+      // 28-60 days: 45
+      expect(result.buckets[3]!.count).toBe(1);
+      // 60+ days: 90
+      expect(result.buckets[4]!.count).toBe(1);
+
+      // median of [5, 10, 20, 45, 90] = 20
+      expect(result.medianDays).toBe(20);
+    });
+
+    it('excludes submissions without response dates', async () => {
+      const tx = makeTx([
+        // native — empty (no decisions)
+        { rows: [] },
+        // external — empty (no responded_at)
+        { rows: [] },
+      ]);
+
+      const result = await writerAnalyticsService.getResponseTime(
+        tx,
+        USER_ID,
+        {},
+      );
+
+      expect(result.medianDays).toBeNull();
+      expect(result.buckets.every((b) => b.count === 0)).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/services/writer-analytics.service.ts
+++ b/apps/api/src/services/writer-analytics.service.ts
@@ -373,10 +373,12 @@ export const writerAnalyticsService = {
     let medianDays: number | null = null;
     if (allDays.length > 0) {
       const mid = Math.floor(allDays.length / 2);
+      const a = allDays[mid - 1] ?? 0;
+      const b = allDays[mid] ?? 0;
       medianDays =
         allDays.length % 2 === 0
-          ? Math.round(((allDays[mid - 1]! + allDays[mid]!) / 2) * 10) / 10
-          : Math.round(allDays[mid]! * 10) / 10;
+          ? Math.round(((a + b) / 2) * 10) / 10
+          : Math.round(b * 10) / 10;
     }
 
     return {

--- a/apps/api/src/services/writer-analytics.service.ts
+++ b/apps/api/src/services/writer-analytics.service.ts
@@ -1,0 +1,392 @@
+import { sql, type DrizzleDb } from '@colophony/db';
+import type { SQL } from 'drizzle-orm';
+import type {
+  WriterAnalyticsFilter,
+  WriterTimeSeriesFilter,
+  WriterOverviewStats,
+  WriterStatusBreakdown,
+  WriterTimeSeries,
+  WriterResponseTime,
+} from '@colophony/types';
+import { NATIVE_TO_CSR } from './portfolio.service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function nativeDateFilter(filter: WriterAnalyticsFilter, alias = 's'): SQL {
+  const parts: SQL[] = [];
+  if (filter.startDate) {
+    parts.push(sql`${sql.raw(`${alias}.submitted_at`)} >= ${filter.startDate}`);
+  }
+  if (filter.endDate) {
+    parts.push(sql`${sql.raw(`${alias}.submitted_at`)} <= ${filter.endDate}`);
+  }
+  return parts.length > 0 ? sql.join(parts, sql.raw(' AND ')) : sql.raw('TRUE');
+}
+
+function externalDateFilter(filter: WriterAnalyticsFilter, alias = 'es'): SQL {
+  const parts: SQL[] = [];
+  if (filter.startDate) {
+    parts.push(sql`${sql.raw(`${alias}.sent_at`)} >= ${filter.startDate}`);
+  }
+  if (filter.endDate) {
+    parts.push(sql`${sql.raw(`${alias}.sent_at`)} <= ${filter.endDate}`);
+  }
+  return parts.length > 0 ? sql.join(parts, sql.raw(' AND ')) : sql.raw('TRUE');
+}
+
+// ---------------------------------------------------------------------------
+// Response time buckets
+// ---------------------------------------------------------------------------
+
+const RESPONSE_BUCKETS = [
+  { label: '< 7 days', minDays: 0, maxDays: 7 },
+  { label: '7-14 days', minDays: 7, maxDays: 14 },
+  { label: '14-28 days', minDays: 14, maxDays: 28 },
+  { label: '28-60 days', minDays: 28, maxDays: 60 },
+  { label: '60+ days', minDays: 60, maxDays: Infinity },
+];
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const writerAnalyticsService = {
+  async getOverview(
+    tx: DrizzleDb,
+    userId: string,
+    filter: WriterAnalyticsFilter,
+  ): Promise<WriterOverviewStats> {
+    const nDateFilter = nativeDateFilter(filter);
+    const eDateFilter = externalDateFilter(filter);
+
+    const now = new Date();
+    const thisMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+
+    // Native counts
+    const [nativeRow] = (
+      await tx.execute(sql`
+      SELECT
+        COUNT(*)::int AS total,
+        COUNT(*) FILTER (WHERE s.status IN ('ACCEPTED'))::int AS accepted,
+        COUNT(*) FILTER (WHERE s.status IN ('REJECTED'))::int AS rejected,
+        COUNT(*) FILTER (WHERE s.status IN ('SUBMITTED', 'UNDER_REVIEW', 'HOLD', 'REVISE_AND_RESUBMIT'))::int AS pending,
+        COUNT(*) FILTER (WHERE s.submitted_at >= ${thisMonthStart})::int AS this_month,
+        COUNT(*) FILTER (WHERE s.submitted_at >= ${lastMonthStart} AND s.submitted_at < ${thisMonthStart})::int AS last_month
+      FROM submissions s
+      WHERE s.submitter_id = ${userId}
+        AND s.status != 'DRAFT'
+        AND ${nDateFilter}
+    `)
+    ).rows as Array<{
+      total: number;
+      accepted: number;
+      rejected: number;
+      pending: number;
+      this_month: number;
+      last_month: number;
+    }>;
+
+    // External counts
+    const [externalRow] = (
+      await tx.execute(sql`
+      SELECT
+        COUNT(*)::int AS total,
+        COUNT(*) FILTER (WHERE es.status = 'accepted')::int AS accepted,
+        COUNT(*) FILTER (WHERE es.status = 'rejected')::int AS rejected,
+        COUNT(*) FILTER (WHERE es.status IN ('sent', 'in_review', 'hold', 'revise'))::int AS pending,
+        COUNT(*) FILTER (WHERE es.sent_at >= ${thisMonthStart})::int AS this_month,
+        COUNT(*) FILTER (WHERE es.sent_at >= ${lastMonthStart} AND es.sent_at < ${thisMonthStart})::int AS last_month
+      FROM external_submissions es
+      WHERE es.user_id = ${userId}
+        AND ${eDateFilter}
+    `)
+    ).rows as Array<{
+      total: number;
+      accepted: number;
+      rejected: number;
+      pending: number;
+      this_month: number;
+      last_month: number;
+    }>;
+
+    const n = nativeRow ?? {
+      total: 0,
+      accepted: 0,
+      rejected: 0,
+      pending: 0,
+      this_month: 0,
+      last_month: 0,
+    };
+    const e = externalRow ?? {
+      total: 0,
+      accepted: 0,
+      rejected: 0,
+      pending: 0,
+      this_month: 0,
+      last_month: 0,
+    };
+
+    const totalAccepted = n.accepted + e.accepted;
+    const totalDecided = totalAccepted + n.rejected + e.rejected;
+    const acceptanceRate =
+      totalDecided > 0
+        ? Math.round((totalAccepted / totalDecided) * 10000) / 100
+        : 0;
+
+    // Average response time — native: first terminal transition
+    const [nativeAvg] = (
+      await tx.execute(sql`
+      SELECT AVG(EXTRACT(EPOCH FROM sh.decided_at - s.submitted_at) / 86400) AS avg_days,
+             COUNT(*)::int AS cnt
+      FROM submissions s
+      INNER JOIN LATERAL (
+        SELECT MIN(sh2.changed_at) AS decided_at
+        FROM submission_history sh2
+        WHERE sh2.submission_id = s.id
+          AND sh2.to_status IN ('ACCEPTED', 'REJECTED')
+      ) sh ON sh.decided_at IS NOT NULL
+      WHERE s.submitter_id = ${userId}
+        AND s.status != 'DRAFT'
+        AND ${nDateFilter}
+    `)
+    ).rows as Array<{ avg_days: number | null; cnt: number }>;
+
+    // External avg response
+    const [externalAvg] = (
+      await tx.execute(sql`
+      SELECT AVG(EXTRACT(EPOCH FROM (es.responded_at - es.sent_at)) / 86400) AS avg_days,
+             COUNT(*)::int AS cnt
+      FROM external_submissions es
+      WHERE es.user_id = ${userId}
+        AND es.responded_at IS NOT NULL
+        AND es.sent_at IS NOT NULL
+        AND ${eDateFilter}
+    `)
+    ).rows as Array<{ avg_days: number | null; cnt: number }>;
+
+    // Weighted average
+    const nAvg = nativeAvg?.avg_days ?? null;
+    const nCnt = nativeAvg?.cnt ?? 0;
+    const eAvg = externalAvg?.avg_days ?? null;
+    const eCnt = externalAvg?.cnt ?? 0;
+
+    let avgResponseTimeDays: number | null = null;
+    if (nCnt + eCnt > 0) {
+      const nTotal = nAvg != null ? nAvg * nCnt : 0;
+      const eTotal = eAvg != null ? eAvg * eCnt : 0;
+      avgResponseTimeDays =
+        Math.round(((nTotal + eTotal) / (nCnt + eCnt)) * 10) / 10;
+    }
+
+    return {
+      totalSubmissions: n.total + e.total,
+      nativeCount: n.total,
+      externalCount: e.total,
+      acceptanceRate,
+      avgResponseTimeDays,
+      pendingCount: n.pending + e.pending,
+      submissionsThisMonth: n.this_month + e.this_month,
+      submissionsLastMonth: n.last_month + e.last_month,
+    };
+  },
+
+  async getStatusBreakdown(
+    tx: DrizzleDb,
+    userId: string,
+    filter: WriterAnalyticsFilter,
+  ): Promise<WriterStatusBreakdown> {
+    const nDateFilter = nativeDateFilter(filter);
+    const eDateFilter = externalDateFilter(filter);
+
+    // Native grouped by status
+    const nativeRows = (
+      await tx.execute(sql`
+      SELECT s.status::text, COUNT(*)::int AS count
+      FROM submissions s
+      WHERE s.submitter_id = ${userId}
+        AND s.status != 'DRAFT'
+        AND ${nDateFilter}
+      GROUP BY s.status
+    `)
+    ).rows as Array<{ status: string; count: number }>;
+
+    // External grouped by status
+    const externalRows = (
+      await tx.execute(sql`
+      SELECT es.status::text, COUNT(*)::int AS count
+      FROM external_submissions es
+      WHERE es.user_id = ${userId}
+        AND ${eDateFilter}
+      GROUP BY es.status
+    `)
+    ).rows as Array<{ status: string; count: number }>;
+
+    // Merge into harmonized map
+    const countMap = new Map<string, number>();
+    for (const row of nativeRows) {
+      const csrStatus = NATIVE_TO_CSR[row.status] ?? 'unknown';
+      countMap.set(csrStatus, (countMap.get(csrStatus) ?? 0) + row.count);
+    }
+    for (const row of externalRows) {
+      countMap.set(row.status, (countMap.get(row.status) ?? 0) + row.count);
+    }
+
+    const breakdown = Array.from(countMap.entries())
+      .map(([status, count]) => ({ status, count }))
+      .sort((a, b) => b.count - a.count);
+
+    return { breakdown };
+  },
+
+  async getTimeSeries(
+    tx: DrizzleDb,
+    userId: string,
+    filter: WriterTimeSeriesFilter,
+  ): Promise<WriterTimeSeries> {
+    const { granularity = 'monthly' } = filter;
+    const nDateFilter = nativeDateFilter(filter);
+    const eDateFilter = externalDateFilter(filter);
+
+    const truncUnit =
+      granularity === 'daily'
+        ? 'day'
+        : granularity === 'weekly'
+          ? 'week'
+          : 'month';
+
+    // Native time series
+    const nativePoints = (
+      await tx.execute(sql`
+      SELECT
+        date_trunc(${truncUnit}, s.submitted_at)::date::text AS date,
+        COUNT(*)::int AS count
+      FROM submissions s
+      WHERE s.submitter_id = ${userId}
+        AND s.status != 'DRAFT'
+        AND s.submitted_at IS NOT NULL
+        AND ${nDateFilter}
+      GROUP BY 1
+      ORDER BY 1
+    `)
+    ).rows as Array<{ date: string; count: number }>;
+
+    // External time series
+    const externalPoints = (
+      await tx.execute(sql`
+      SELECT
+        date_trunc(${truncUnit}, es.sent_at)::date::text AS date,
+        COUNT(*)::int AS count
+      FROM external_submissions es
+      WHERE es.user_id = ${userId}
+        AND es.sent_at IS NOT NULL
+        AND ${eDateFilter}
+      GROUP BY 1
+      ORDER BY 1
+    `)
+    ).rows as Array<{ date: string; count: number }>;
+
+    // Merge into date-keyed map
+    const dateMap = new Map<
+      string,
+      { nativeCount: number; externalCount: number }
+    >();
+
+    for (const p of nativePoints) {
+      const entry = dateMap.get(p.date) ?? { nativeCount: 0, externalCount: 0 };
+      entry.nativeCount += p.count;
+      dateMap.set(p.date, entry);
+    }
+    for (const p of externalPoints) {
+      const entry = dateMap.get(p.date) ?? { nativeCount: 0, externalCount: 0 };
+      entry.externalCount += p.count;
+      dateMap.set(p.date, entry);
+    }
+
+    const points = Array.from(dateMap.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, { nativeCount, externalCount }]) => ({
+        date,
+        count: nativeCount + externalCount,
+        nativeCount,
+        externalCount,
+      }));
+
+    return { granularity, points };
+  },
+
+  async getResponseTime(
+    tx: DrizzleDb,
+    userId: string,
+    filter: WriterAnalyticsFilter,
+  ): Promise<WriterResponseTime> {
+    const nDateFilter = nativeDateFilter(filter);
+    const eDateFilter = externalDateFilter(filter);
+
+    // Native response times (days)
+    const nativeDays = (
+      await tx.execute(sql`
+      SELECT EXTRACT(EPOCH FROM (sh.decided_at - s.submitted_at)) / 86400 AS days
+      FROM submissions s
+      INNER JOIN LATERAL (
+        SELECT MIN(sh2.changed_at) AS decided_at
+        FROM submission_history sh2
+        WHERE sh2.submission_id = s.id
+          AND sh2.to_status IN ('ACCEPTED', 'REJECTED')
+      ) sh ON sh.decided_at IS NOT NULL
+      WHERE s.submitter_id = ${userId}
+        AND s.status != 'DRAFT'
+        AND s.submitted_at IS NOT NULL
+        AND ${nDateFilter}
+    `)
+    ).rows as Array<{ days: number }>;
+
+    // External response times (days)
+    const externalDays = (
+      await tx.execute(sql`
+      SELECT EXTRACT(EPOCH FROM (es.responded_at - es.sent_at)) / 86400 AS days
+      FROM external_submissions es
+      WHERE es.user_id = ${userId}
+        AND es.responded_at IS NOT NULL
+        AND es.sent_at IS NOT NULL
+        AND ${eDateFilter}
+    `)
+    ).rows as Array<{ days: number }>;
+
+    // Combine and bucket
+    const allDays = [...nativeDays, ...externalDays]
+      .map((r) => Number(r.days))
+      .filter((d) => d >= 0)
+      .sort((a, b) => a - b);
+
+    const buckets = RESPONSE_BUCKETS.map((b) => ({
+      ...b,
+      count: allDays.filter(
+        (d) =>
+          d >= b.minDays && (b.maxDays === Infinity ? true : d < b.maxDays),
+      ).length,
+    }));
+
+    // Median
+    let medianDays: number | null = null;
+    if (allDays.length > 0) {
+      const mid = Math.floor(allDays.length / 2);
+      medianDays =
+        allDays.length % 2 === 0
+          ? Math.round(((allDays[mid - 1]! + allDays[mid]!) / 2) * 10) / 10
+          : Math.round(allDays[mid]! * 10) / 10;
+    }
+
+    return {
+      buckets: buckets.map((b) => ({
+        label: b.label,
+        count: b.count,
+        minDays: b.minDays,
+        maxDays: b.maxDays === Infinity ? 999 : b.maxDays,
+      })),
+      medianDays,
+    };
+  },
+};

--- a/apps/api/src/trpc/routers/workspace.ts
+++ b/apps/api/src/trpc/routers/workspace.ts
@@ -1,6 +1,13 @@
 import { createRouter, userProcedure, requireScopes } from '../init.js';
 import { workspaceStatsService } from '../../services/workspace-stats.service.js';
+import { portfolioService } from '../../services/portfolio.service.js';
+import { writerAnalyticsService } from '../../services/writer-analytics.service.js';
 import { mapServiceError } from '../error-mapper.js';
+import {
+  listPortfolioSchema,
+  writerAnalyticsFilterSchema,
+  writerTimeSeriesFilterSchema,
+} from '@colophony/types';
 
 export const workspaceRouter = createRouter({
   stats: userProcedure
@@ -10,6 +17,81 @@ export const workspaceRouter = createRouter({
         return await workspaceStatsService.getStats(
           ctx.dbTx,
           ctx.authContext.userId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  portfolio: userProcedure
+    .use(requireScopes('external-submissions:read'))
+    .input(listPortfolioSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await portfolioService.list(
+          ctx.dbTx,
+          ctx.authContext.userId,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  analyticsOverview: userProcedure
+    .use(requireScopes('external-submissions:read'))
+    .input(writerAnalyticsFilterSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await writerAnalyticsService.getOverview(
+          ctx.dbTx,
+          ctx.authContext.userId,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  analyticsStatusBreakdown: userProcedure
+    .use(requireScopes('external-submissions:read'))
+    .input(writerAnalyticsFilterSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await writerAnalyticsService.getStatusBreakdown(
+          ctx.dbTx,
+          ctx.authContext.userId,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  analyticsTimeSeries: userProcedure
+    .use(requireScopes('external-submissions:read'))
+    .input(writerTimeSeriesFilterSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await writerAnalyticsService.getTimeSeries(
+          ctx.dbTx,
+          ctx.authContext.userId,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  analyticsResponseTime: userProcedure
+    .use(requireScopes('external-submissions:read'))
+    .input(writerAnalyticsFilterSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await writerAnalyticsService.getResponseTime(
+          ctx.dbTx,
+          ctx.authContext.userId,
+          input,
         );
       } catch (e) {
         mapServiceError(e);

--- a/apps/web/src/app/(dashboard)/workspace/analytics/page.tsx
+++ b/apps/web/src/app/(dashboard)/workspace/analytics/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { WriterAnalyticsPage } from "@/components/workspace/writer-analytics-page";
+
+export default function WorkspaceAnalyticsPage() {
+  return (
+    <div className="p-6">
+      <WriterAnalyticsPage />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/workspace/portfolio/page.tsx
+++ b/apps/web/src/app/(dashboard)/workspace/portfolio/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { PortfolioList } from "@/components/workspace/portfolio-list";
+
+export default function PortfolioPage() {
+  return (
+    <div className="p-6">
+      <PortfolioList />
+    </div>
+  );
+}

--- a/apps/web/src/components/analytics/chart-colors.ts
+++ b/apps/web/src/components/analytics/chart-colors.ts
@@ -10,6 +10,20 @@ export const STATUS_COLORS: Record<string, string> = {
   WITHDRAWN: "#A855F7", // purple-500
 };
 
+/** Hex color map for CSR (harmonized) statuses — lowercase keys */
+export const CSR_STATUS_COLORS: Record<string, string> = {
+  draft: "#6B7280", // gray-500
+  sent: "#3B82F6", // blue-500
+  in_review: "#EAB308", // yellow-500
+  hold: "#F97316", // orange-500
+  accepted: "#22C55E", // green-500
+  rejected: "#EF4444", // red-500
+  withdrawn: "#A855F7", // purple-500
+  no_response: "#9CA3AF", // gray-400
+  revise: "#F59E0B", // amber-500
+  unknown: "#D1D5DB", // gray-300
+};
+
 export const CHART_COLORS = [
   "#3B82F6",
   "#22C55E",

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { useOrganization } from "@/hooks/use-organization";
 import { PluginSlot } from "@/components/plugins/plugin-slot";
 import {
+  BarChart3,
   BookCopy,
   BookMarked,
   BookOpen,
@@ -17,6 +18,7 @@ import {
   GitBranch,
   Globe,
   Inbox,
+  Layers,
   LayoutDashboard,
   Library,
   Mail,
@@ -35,6 +37,8 @@ const writerNavigation = [
     href: "/workspace/correspondence",
     icon: Mail,
   },
+  { name: "Portfolio", href: "/workspace/portfolio", icon: Layers },
+  { name: "Analytics", href: "/workspace/analytics", icon: BarChart3 },
 ];
 
 const submitterNavigation = [

--- a/apps/web/src/components/workspace/portfolio-item-card.tsx
+++ b/apps/web/src/components/workspace/portfolio-item-card.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { CsrStatusBadge } from "./csr-status-badge";
+import { formatDistanceToNow } from "date-fns";
+import type { PortfolioItem } from "@colophony/types";
+
+interface PortfolioItemCardProps {
+  item: PortfolioItem;
+}
+
+export function PortfolioItemCard({ item }: PortfolioItemCardProps) {
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-2">
+        <div className="flex items-center gap-2">
+          <Badge variant={item.source === "native" ? "default" : "secondary"}>
+            {item.source === "native" ? "Colophony" : "External"}
+          </Badge>
+          <CsrStatusBadge status={item.status} />
+        </div>
+
+        <h3 className="font-medium text-sm truncate">
+          {item.title ?? "Untitled"}
+        </h3>
+
+        {item.journalName && (
+          <p className="text-xs text-muted-foreground truncate">
+            {item.journalName}
+          </p>
+        )}
+
+        <div className="flex items-center gap-4 text-xs text-muted-foreground">
+          {item.sentAt && (
+            <span>
+              Sent{" "}
+              {formatDistanceToNow(new Date(item.sentAt), { addSuffix: true })}
+            </span>
+          )}
+          {item.respondedAt && (
+            <span>
+              Responded{" "}
+              {formatDistanceToNow(new Date(item.respondedAt), {
+                addSuffix: true,
+              })}
+            </span>
+          )}
+        </div>
+
+        {item.manuscriptTitle && (
+          <p className="text-xs text-muted-foreground truncate">
+            Manuscript: {item.manuscriptTitle}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/workspace/portfolio-list.tsx
+++ b/apps/web/src/components/workspace/portfolio-list.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { trpc } from "@/lib/trpc";
+import { useDebounce } from "@/hooks/use-debounce";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { PortfolioItemCard } from "./portfolio-item-card";
+import { Layers, Search } from "lucide-react";
+import type {
+  CSRStatus,
+  PortfolioSource,
+  PortfolioItem,
+} from "@colophony/types";
+
+const STATUS_OPTIONS: Array<{ value: CSRStatus | "all"; label: string }> = [
+  { value: "all", label: "All Statuses" },
+  { value: "sent", label: "Sent" },
+  { value: "in_review", label: "In Review" },
+  { value: "hold", label: "On Hold" },
+  { value: "accepted", label: "Accepted" },
+  { value: "rejected", label: "Rejected" },
+  { value: "withdrawn", label: "Withdrawn" },
+  { value: "no_response", label: "No Response" },
+  { value: "revise", label: "Revise" },
+  { value: "unknown", label: "Unknown" },
+];
+
+const SOURCE_OPTIONS: Array<{
+  value: PortfolioSource | "all";
+  label: string;
+}> = [
+  { value: "all", label: "All Sources" },
+  { value: "native", label: "Colophony" },
+  { value: "external", label: "External" },
+];
+
+const SKELETON_ITEMS = Array.from({ length: 6 });
+
+export function PortfolioList() {
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebounce(search, 300);
+  const [status, setStatus] = useState<CSRStatus | "all">("all");
+  const [source, setSource] = useState<PortfolioSource | "all">("all");
+  const [groupByPiece, setGroupByPiece] = useState(false);
+  const [page, setPage] = useState(1);
+  const limit = 20;
+
+  const [prevSearch, setPrevSearch] = useState(debouncedSearch);
+  if (prevSearch !== debouncedSearch) {
+    setPrevSearch(debouncedSearch);
+    setPage(1);
+  }
+
+  const {
+    data,
+    isPending: isLoading,
+    error,
+  } = trpc.workspace.portfolio.useQuery({
+    search: debouncedSearch || undefined,
+    status: status === "all" ? undefined : status,
+    source: source === "all" ? undefined : source,
+    page,
+    limit,
+  });
+
+  const items = data?.items;
+  const groupedItems = useMemo(() => {
+    if (!groupByPiece || !items) return null;
+    const groups = new Map<string, { title: string; items: PortfolioItem[] }>();
+    for (const item of items) {
+      const key = item.manuscriptId ?? "__ungrouped__";
+      const group = groups.get(key) ?? {
+        title: item.manuscriptTitle ?? "Ungrouped",
+        items: [],
+      };
+      group.items.push(item);
+      groups.set(key, group);
+    }
+    return Array.from(groups.values());
+  }, [groupByPiece, items]);
+
+  if (error) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-destructive">
+          Failed to load portfolio: {error.message}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <div className="flex items-center gap-2">
+          <Layers className="h-6 w-6" />
+          <h1 className="text-2xl font-bold">Portfolio</h1>
+        </div>
+        <p className="text-muted-foreground">
+          Unified view of all submissions across Colophony and external journals
+        </p>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[200px] max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search titles, journals..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+
+        <Select
+          value={status}
+          onValueChange={(v) => {
+            setStatus(v as CSRStatus | "all");
+            setPage(1);
+          }}
+        >
+          <SelectTrigger className="w-36">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {STATUS_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={source}
+          onValueChange={(v) => {
+            setSource(v as PortfolioSource | "all");
+            setPage(1);
+          }}
+        >
+          <SelectTrigger className="w-32">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {SOURCE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <div className="flex items-center gap-2">
+          <Switch
+            id="group-by-piece"
+            checked={groupByPiece}
+            onCheckedChange={setGroupByPiece}
+          />
+          <Label htmlFor="group-by-piece" className="text-sm">
+            Group by piece
+          </Label>
+        </div>
+      </div>
+
+      {/* Loading */}
+      {isLoading && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {SKELETON_ITEMS.map((_, i) => (
+            <Skeleton key={i} className="h-36 rounded-lg" />
+          ))}
+        </div>
+      )}
+
+      {/* Content */}
+      {!isLoading && data && (
+        <>
+          {data.items.length === 0 ? (
+            <div className="text-center py-12 text-muted-foreground">
+              No submissions found
+            </div>
+          ) : groupedItems ? (
+            <div className="space-y-6">
+              {groupedItems.map((group) => (
+                <div key={group.title} className="space-y-3">
+                  <h2 className="text-lg font-semibold">{group.title}</h2>
+                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {group.items.map((item) => (
+                      <PortfolioItemCard key={item.id} item={item} />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {data.items.map((item) => (
+                <PortfolioItemCard key={item.id} item={item} />
+              ))}
+            </div>
+          )}
+
+          {/* Pagination */}
+          {data.totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {data.page} of {data.totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= data.totalPages}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/workspace/workspace-dashboard.tsx
+++ b/apps/web/src/components/workspace/workspace-dashboard.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { WorkspaceStatsCards } from "./workspace-stats-cards";
-import { Plus, Send, Mail } from "lucide-react";
+import { Plus, Send, Mail, Layers, BarChart3 } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 
 export function WorkspaceDashboard() {
@@ -93,6 +93,18 @@ export function WorkspaceDashboard() {
           <Button variant="outline">
             <Mail className="mr-2 h-4 w-4" />
             View Correspondence
+          </Button>
+        </Link>
+        <Link href="/workspace/portfolio">
+          <Button variant="outline">
+            <Layers className="mr-2 h-4 w-4" />
+            View Portfolio
+          </Button>
+        </Link>
+        <Link href="/workspace/analytics">
+          <Button variant="outline">
+            <BarChart3 className="mr-2 h-4 w-4" />
+            Analytics
           </Button>
         </Link>
       </div>

--- a/apps/web/src/components/workspace/writer-analytics-filters.tsx
+++ b/apps/web/src/components/workspace/writer-analytics-filters.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface WriterAnalyticsFiltersProps {
+  startDate: string;
+  endDate: string;
+  onStartDateChange: (value: string) => void;
+  onEndDateChange: (value: string) => void;
+}
+
+export function WriterAnalyticsFilters({
+  startDate,
+  endDate,
+  onStartDateChange,
+  onEndDateChange,
+}: WriterAnalyticsFiltersProps) {
+  return (
+    <div className="flex flex-wrap items-end gap-4">
+      <div className="space-y-1">
+        <Label htmlFor="start-date" className="text-sm">
+          From
+        </Label>
+        <Input
+          id="start-date"
+          type="date"
+          value={startDate}
+          onChange={(e) => onStartDateChange(e.target.value)}
+          className="w-40"
+        />
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="end-date" className="text-sm">
+          To
+        </Label>
+        <Input
+          id="end-date"
+          type="date"
+          value={endDate}
+          onChange={(e) => onEndDateChange(e.target.value)}
+          className="w-40"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/workspace/writer-analytics-page.tsx
+++ b/apps/web/src/components/workspace/writer-analytics-page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+import { BarChart3 } from "lucide-react";
+import { WriterAnalyticsFilters } from "./writer-analytics-filters";
+import { WriterOverviewCards } from "./writer-overview-cards";
+import { WriterStatusChart } from "./writer-status-chart";
+import { WriterTimeSeriesChart } from "./writer-time-series-chart";
+import { WriterResponseTimeChart } from "./writer-response-time-chart";
+import type { WriterAnalyticsFilter } from "@colophony/types";
+
+export function WriterAnalyticsPage() {
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  const filter: WriterAnalyticsFilter = {
+    ...(startDate ? { startDate: new Date(startDate) } : {}),
+    ...(endDate ? { endDate: new Date(endDate) } : {}),
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <div className="flex items-center gap-2">
+          <BarChart3 className="h-6 w-6" />
+          <h1 className="text-2xl font-bold">Writer Analytics</h1>
+        </div>
+        <p className="text-muted-foreground">
+          Personal submission statistics across all journals
+        </p>
+      </div>
+
+      {/* Filters */}
+      <WriterAnalyticsFilters
+        startDate={startDate}
+        endDate={endDate}
+        onStartDateChange={setStartDate}
+        onEndDateChange={setEndDate}
+      />
+
+      {/* Overview cards */}
+      <WriterOverviewCards filter={filter} />
+
+      {/* Charts — 2-col grid */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <WriterStatusChart filter={filter} />
+        <WriterTimeSeriesChart filter={filter} />
+      </div>
+
+      {/* Response time chart — full width */}
+      <WriterResponseTimeChart filter={filter} />
+    </div>
+  );
+}

--- a/apps/web/src/components/workspace/writer-overview-cards.tsx
+++ b/apps/web/src/components/workspace/writer-overview-cards.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import type { WriterAnalyticsFilter } from "@colophony/types";
+
+interface WriterOverviewCardsProps {
+  filter: WriterAnalyticsFilter;
+}
+
+export function WriterOverviewCards({ filter }: WriterOverviewCardsProps) {
+  const { data, isPending: isLoading } =
+    trpc.workspace.analyticsOverview.useQuery(filter);
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="pb-2">
+              <Skeleton className="h-4 w-24" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const trend =
+    data.submissionsLastMonth > 0
+      ? Math.round(
+          ((data.submissionsThisMonth - data.submissionsLastMonth) /
+            data.submissionsLastMonth) *
+            100,
+        )
+      : null;
+
+  const cards = [
+    {
+      title: "Total Submissions",
+      value: data.totalSubmissions.toLocaleString(),
+      subtitle: `${data.nativeCount} native, ${data.externalCount} external`,
+    },
+    {
+      title: "Acceptance Rate",
+      value: `${data.acceptanceRate.toFixed(1)}%`,
+    },
+    {
+      title: "Avg Response Time",
+      value: data.avgResponseTimeDays
+        ? `${data.avgResponseTimeDays.toFixed(1)}d`
+        : "N/A",
+    },
+    {
+      title: "Pending",
+      value: data.pendingCount.toLocaleString(),
+    },
+    {
+      title: "This Month",
+      value: data.submissionsThisMonth.toLocaleString(),
+      subtitle:
+        trend !== null
+          ? `${trend >= 0 ? "+" : ""}${trend}% vs last month`
+          : undefined,
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+      {cards.map((card) => (
+        <Card key={card.title}>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              {card.title}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{card.value}</div>
+            {card.subtitle && (
+              <p className="text-xs text-muted-foreground mt-1">
+                {card.subtitle}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/workspace/writer-response-time-chart.tsx
+++ b/apps/web/src/components/workspace/writer-response-time-chart.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import type { WriterAnalyticsFilter } from "@colophony/types";
+
+interface WriterResponseTimeChartProps {
+  filter: WriterAnalyticsFilter;
+}
+
+export function WriterResponseTimeChart({
+  filter,
+}: WriterResponseTimeChartProps) {
+  const { data, isPending: isLoading } =
+    trpc.workspace.analyticsResponseTime.useQuery(filter);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">
+          Response Time Distribution
+          {data?.medianDays != null && (
+            <span className="text-sm font-normal text-muted-foreground ml-2">
+              Median: {data.medianDays.toFixed(1)}d
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <BarChart data={data?.buckets ?? []}>
+              <XAxis dataKey="label" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="count" fill="#3B82F6" radius={[4, 4, 0, 0]} />
+              {data?.medianDays != null && (
+                <ReferenceLine
+                  x={
+                    data.buckets.find(
+                      (b) =>
+                        data.medianDays! >= b.minDays &&
+                        data.medianDays! < b.maxDays,
+                    )?.label
+                  }
+                  stroke="#EF4444"
+                  strokeDasharray="4 4"
+                  label={{ value: "Median", fill: "#EF4444", fontSize: 12 }}
+                />
+              )}
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/workspace/writer-status-chart.tsx
+++ b/apps/web/src/components/workspace/writer-status-chart.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import { CSR_STATUS_COLORS } from "@/components/analytics/chart-colors";
+import type { WriterAnalyticsFilter } from "@colophony/types";
+
+interface WriterStatusChartProps {
+  filter: WriterAnalyticsFilter;
+}
+
+export function WriterStatusChart({ filter }: WriterStatusChartProps) {
+  const { data, isPending: isLoading } =
+    trpc.workspace.analyticsStatusBreakdown.useQuery(filter);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Status Breakdown</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <PieChart>
+              <Pie
+                data={data?.breakdown ?? []}
+                dataKey="count"
+                nameKey="status"
+                cx="50%"
+                cy="50%"
+                outerRadius={100}
+                label={({ name, value }) => `${name ?? ""}: ${value}`}
+              >
+                {data?.breakdown.map((entry) => (
+                  <Cell
+                    key={entry.status}
+                    fill={CSR_STATUS_COLORS[entry.status] ?? "#6B7280"}
+                  />
+                ))}
+              </Pie>
+              <Tooltip />
+              <Legend />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/workspace/writer-time-series-chart.tsx
+++ b/apps/web/src/components/workspace/writer-time-series-chart.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Legend,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { trpc } from "@/lib/trpc";
+import type { WriterAnalyticsFilter } from "@colophony/types";
+
+interface WriterTimeSeriesChartProps {
+  filter: WriterAnalyticsFilter;
+}
+
+export function WriterTimeSeriesChart({ filter }: WriterTimeSeriesChartProps) {
+  const [granularity, setGranularity] = useState<
+    "daily" | "weekly" | "monthly"
+  >("monthly");
+
+  const { data, isPending: isLoading } =
+    trpc.workspace.analyticsTimeSeries.useQuery({
+      ...filter,
+      granularity,
+    });
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-base">Submissions Over Time</CardTitle>
+        <Select
+          value={granularity}
+          onValueChange={(v) =>
+            setGranularity(v as "daily" | "weekly" | "monthly")
+          }
+        >
+          <SelectTrigger className="w-28">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="daily">Daily</SelectItem>
+            <SelectItem value="weekly">Weekly</SelectItem>
+            <SelectItem value="monthly">Monthly</SelectItem>
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <AreaChart data={data?.points ?? []}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Legend />
+              <Area
+                type="monotone"
+                dataKey="nativeCount"
+                name="Colophony"
+                stackId="1"
+                stroke="#3B82F6"
+                fill="#3B82F6"
+                fillOpacity={0.4}
+              />
+              <Area
+                type="monotone"
+                dataKey="externalCount"
+                name="External"
+                stackId="1"
+                stroke="#A855F7"
+                fill="#A855F7"
+                fillOpacity={0.4}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -373,8 +373,8 @@
 - [x] [P1] `writer_profiles` DB table — external platform links (Chill Subs ID, Submittable ID, etc.) per user; unique on (user_id, platform) — (register-data-standard.md Section 2.2, 4.2; done 2026-02-27 PR pending)
 - [x] [P1] Writer workspace UI — new top-level nav section ("My Writing"); dashboard with stats, correspondence archive, sidebar restructure — (register-data-standard.md Section 4.3; done 2026-03-01 PR pending)
 - [x] [P1] External submission tracking UI — CRUD with journal autocomplete, status filter, pagination, card grid — (register-data-standard.md Section 3; done 2026-03-01 PR pending)
-- [ ] [P2] Cross-org submission portfolio — aggregated view: Colophony-native submissions from all orgs + external tracked submissions, unified by piece grouping — (persona gap analysis 2026-02-27)
-- [ ] [P2] Writer-facing analytics — personal response time stats, submissions pending, acceptance rate, submissions per month; derived from both native and manually-tracked records — (persona gap analysis 2026-02-27)
+- [x] [P2] Cross-org submission portfolio — aggregated view: Colophony-native submissions from all orgs + external tracked submissions, unified by piece grouping — (persona gap analysis 2026-02-27; done 2026-03-01)
+- [x] [P2] Writer-facing analytics — personal response time stats, submissions pending, acceptance rate, submissions per month; derived from both native and manually-tracked records — (persona gap analysis 2026-02-27; done 2026-03-01)
 - [ ] [P2] Import flows — Submittable CSV import, Chill Subs import (via directoryIds mapping), generic CSV with column mapping UI — (register-data-standard.md Section 3; 2026-02-27)
 
 ### Design Decisions

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,27 @@ Newest entries first.
 
 ---
 
+## 2026-03-01 — Cross-Org Portfolio + Writer Analytics (Track 8 P2)
+
+### Done
+
+- **Types**: `writer-analytics.ts` with 4 filter/response schemas (overview, breakdown, timeSeries, responseTime); extended `csr.ts` with portfolio schemas (portfolioSource, portfolioItem, listPortfolio, portfolioListResponse)
+- **Portfolio service**: SQL `UNION ALL` query merging native submissions (via `submissions_submitter_read` RLS) and external submissions; `NATIVE_TO_CSR`/`CSR_TO_NATIVE` status mappings; ILIKE search with wildcard escaping; status/source filtering; LATERAL JOIN for native decision dates from `submission_history`; CTE for count + pagination
+- **Writer analytics service**: 4 endpoints — `getOverview` (two COUNT queries, weighted avg response time), `getStatusBreakdown` (harmonized GROUP BY merge), `getTimeSeries` (date_trunc grouped with native/external breakdown), `getResponseTime` (bucket distribution with median calculation)
+- **tRPC router**: 5 new procedures on `workspaceRouter` — `portfolio`, `analyticsOverview`, `analyticsStatusBreakdown`, `analyticsTimeSeries`, `analyticsResponseTime`; all `userProcedure` + `requireScopes('external-submissions:read')`
+- **Frontend**: Portfolio page with search, status/source filters, group-by-piece toggle (useMemo grouping), card grid, pagination; Analytics page with date range filters, 5-card overview (total with native/external breakdown, acceptance rate, avg response, pending, this month with trend), status PieChart with CSR_STATUS_COLORS, stacked AreaChart (native blue + external purple), response time BarChart with median ReferenceLine
+- **Sidebar + dashboard**: Added Portfolio (Layers icon) and Analytics (BarChart3 icon) to writer navigation; added quick-action buttons on workspace dashboard
+- **Tests**: 18 new unit tests (10 portfolio, 8 analytics); all 1496 API tests passing; type-check 14/14, lint 0 errors
+
+### Decisions
+
+- Status harmonization via CASE expression in SQL + JS maps — no new enum needed, CSR statuses are the canonical harmonized set
+- SQL UNION ALL with CTE for portfolio (correct pagination across both sources) vs app-level merge for analytics (simpler for aggregates where data shapes differ)
+- Group-by-piece: flat API response with manuscriptId/manuscriptTitle, frontend groups via useMemo — avoids separate API shape
+- React Compiler compatibility: extracted `data?.items` to `items` variable for useMemo deps matching
+
+---
+
 ## 2026-03-01 — Writer Workspace UI (Track 8 P1)
 
 ### Done

--- a/packages/types/src/csr.ts
+++ b/packages/types/src/csr.ts
@@ -240,6 +240,45 @@ export type CorrespondenceUserListItem = z.infer<
   typeof correspondenceUserListItemSchema
 >;
 
+// --- Portfolio (cross-org unified view) ---
+
+export const portfolioSourceSchema = z.enum(["native", "external"]);
+export type PortfolioSource = z.infer<typeof portfolioSourceSchema>;
+
+export const portfolioItemSchema = z.object({
+  id: z.string().uuid(),
+  source: portfolioSourceSchema,
+  title: z.string().nullable(),
+  journalName: z.string().nullable(),
+  status: csrStatusSchema,
+  sentAt: z.string().datetime().nullable(),
+  respondedAt: z.string().datetime().nullable(),
+  manuscriptId: z.string().uuid().nullable(),
+  manuscriptTitle: z.string().nullable(),
+  createdAt: z.string().datetime(),
+});
+export type PortfolioItem = z.infer<typeof portfolioItemSchema>;
+
+export const listPortfolioSchema = z.object({
+  search: z.string().optional(),
+  status: csrStatusSchema.optional(),
+  source: portfolioSourceSchema.optional(),
+  page: z.number().int().min(1).default(1),
+  limit: z.number().int().min(1).max(100).default(20),
+});
+export type ListPortfolioInput = z.infer<typeof listPortfolioSchema>;
+
+export const portfolioListResponseSchema = z.object({
+  items: z.array(portfolioItemSchema),
+  total: z.number().int(),
+  page: z.number().int(),
+  limit: z.number().int(),
+  totalPages: z.number().int(),
+});
+export type PortfolioListResponse = z.infer<typeof portfolioListResponseSchema>;
+
+// --- Workspace Stats ---
+
 export const workspaceStatsSchema = z.object({
   manuscriptCount: z.number().int(),
   pendingSubmissions: z.number().int(),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -26,6 +26,7 @@ export * from "./notification";
 export * from "./webhook";
 export * from "./correspondence";
 export * from "./csr";
+export * from "./writer-analytics";
 export * from "./status-mapping";
 export * from "./email-templates";
 export * from "./discussion";

--- a/packages/types/src/writer-analytics.ts
+++ b/packages/types/src/writer-analytics.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Filter schemas
+// ---------------------------------------------------------------------------
+
+export const writerAnalyticsFilterSchema = z.object({
+  startDate: z.coerce.date().optional(),
+  endDate: z.coerce.date().optional(),
+});
+export type WriterAnalyticsFilter = z.infer<typeof writerAnalyticsFilterSchema>;
+
+export const writerTimeSeriesFilterSchema = writerAnalyticsFilterSchema.extend({
+  granularity: z.enum(["daily", "weekly", "monthly"]).default("monthly"),
+});
+export type WriterTimeSeriesFilter = z.infer<
+  typeof writerTimeSeriesFilterSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+export const writerOverviewStatsSchema = z.object({
+  totalSubmissions: z.number().int(),
+  nativeCount: z.number().int(),
+  externalCount: z.number().int(),
+  acceptanceRate: z.number().min(0).max(100),
+  avgResponseTimeDays: z.number().nullable(),
+  pendingCount: z.number().int(),
+  submissionsThisMonth: z.number().int(),
+  submissionsLastMonth: z.number().int(),
+});
+export type WriterOverviewStats = z.infer<typeof writerOverviewStatsSchema>;
+
+export const writerStatusBreakdownSchema = z.object({
+  breakdown: z.array(
+    z.object({
+      status: z.string(),
+      count: z.number().int(),
+    }),
+  ),
+});
+export type WriterStatusBreakdown = z.infer<typeof writerStatusBreakdownSchema>;
+
+export const writerTimeSeriesSchema = z.object({
+  granularity: z.enum(["daily", "weekly", "monthly"]),
+  points: z.array(
+    z.object({
+      date: z.string(),
+      count: z.number().int(),
+      nativeCount: z.number().int(),
+      externalCount: z.number().int(),
+    }),
+  ),
+});
+export type WriterTimeSeries = z.infer<typeof writerTimeSeriesSchema>;
+
+export const writerResponseTimeSchema = z.object({
+  buckets: z.array(
+    z.object({
+      label: z.string(),
+      count: z.number().int(),
+      minDays: z.number(),
+      maxDays: z.number(),
+    }),
+  ),
+  medianDays: z.number().nullable(),
+});
+export type WriterResponseTime = z.infer<typeof writerResponseTimeSchema>;


### PR DESCRIPTION
## Summary

- **Portfolio view**: Unified cross-org submission list combining native Colophony submissions (via `submissions_submitter_read` RLS policy) and external tracked submissions using SQL `UNION ALL` with CTE for correct pagination/count
- **Writer analytics**: Personal analytics dashboard with 4 endpoints — overview stats (native/external breakdown, acceptance rate, weighted avg response time), status breakdown (harmonized native→CSR mapping), time series (stacked native/external by granularity), response time distribution (bucketed with median)
- **Frontend**: Portfolio page with search/status/source filters, group-by-piece toggle, card grid with pagination; Analytics page with date range filters, 5-card overview, PieChart, stacked AreaChart, BarChart with median reference line

## Test plan

- [x] `pnpm type-check` — all 14 packages pass
- [x] `pnpm lint` — 0 new errors
- [x] `pnpm test` — all 1496 tests pass (18 new: 10 portfolio, 8 analytics)
- [ ] Manual: `/workspace/portfolio` — verify unified list with native + external, filters, group-by-piece
- [ ] Manual: `/workspace/analytics` — verify 4 charts render with data, date filter applies
- [ ] Verify sidebar shows Portfolio and Analytics links under "My Writing"