### PR TITLE
feat(hopper): track 8 closeout — manual correspondence, duplicate detection, CSR docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **Writer workspace**     | `packages/db/src/schema/writer-workspace.ts`                                     |
 | **CSR types**            | `packages/types/src/csr.ts`                                                      |
 | **CSR service**          | `apps/api/src/services/csr.service.ts` (export/import for data portability)      |
+| **CSR format spec**      | `docs/csr-format.md`                                                             |
 | **Backlog**              | `docs/backlog.md` (track-organized, drives session focus)                        |
 
 Full project structure: [docs/architecture-v2-planning.md](docs/architecture-v2-planning.md)

--- a/apps/api/src/services/correspondence.service.spec.ts
+++ b/apps/api/src/services/correspondence.service.spec.ts
@@ -16,6 +16,7 @@ const mockOrderBy = vi.fn();
 
 vi.mock('@colophony/db', () => ({
   correspondence: { submissionId: 'submission_id', sentAt: 'sent_at' },
+  externalSubmissions: { id: 'id' },
   submissions: { id: 'id' },
   users: { id: 'id', email: 'email', displayName: 'display_name' },
   organizations: { id: 'id', name: 'name' },
@@ -265,6 +266,97 @@ describe('correspondenceService', () => {
           body: 'Test',
         }),
       ).rejects.toThrow(ForbiddenError);
+    });
+  });
+
+  describe('createManualWithAudit', () => {
+    function makeUserCtx() {
+      const tx = makeTx();
+      // Override select chain for external submission lookup
+      const localLimit = vi.fn().mockReturnValue([{ id: 'ext-sub-1' }]);
+      const localWhere = vi.fn().mockReturnValue({ limit: localLimit });
+      const localFrom = vi.fn().mockReturnValue({ where: localWhere });
+      const localSelect = vi.fn().mockReturnValue({ from: localFrom });
+      (tx as unknown as Record<string, unknown>).select = localSelect;
+
+      return {
+        tx,
+        userId: 'user-1',
+        audit: vi.fn(),
+        _localLimit: localLimit,
+      };
+    }
+
+    it('inserts with externalSubmissionId and audits CORRESPONDENCE_MANUAL_LOGGED', async () => {
+      const ctx = makeUserCtx();
+
+      const result = await correspondenceService.createManualWithAudit(ctx, {
+        externalSubmissionId: 'ext-sub-1',
+        direction: 'inbound',
+        channel: 'email',
+        sentAt: '2026-02-01T12:00:00.000Z',
+        body: 'Thank you for your submission.',
+        isPersonalized: false,
+      });
+
+      expect(result).toMatchObject({ id: 'corr-1' });
+      expect(mockValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'manual',
+          externalSubmissionId: 'ext-sub-1',
+          submissionId: null,
+        }),
+      );
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditActions.CORRESPONDENCE_MANUAL_LOGGED,
+          resource: AuditResources.CORRESPONDENCE,
+          resourceId: 'corr-1',
+        }),
+      );
+    });
+
+    it('throws NotFoundError for missing external submission', async () => {
+      const ctx = makeUserCtx();
+      // Return empty from external submission lookup
+      ctx._localLimit.mockReturnValue([]);
+
+      await expect(
+        correspondenceService.createManualWithAudit(ctx, {
+          externalSubmissionId: 'missing-id',
+          direction: 'inbound',
+          channel: 'email',
+          sentAt: '2026-02-01T12:00:00.000Z',
+          body: 'Test',
+          isPersonalized: false,
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe('create', () => {
+    it('supports externalSubmissionId without submissionId', async () => {
+      const tx = makeTx();
+      await correspondenceService.create(tx, {
+        userId: 'user-1',
+        externalSubmissionId: 'ext-sub-1',
+        direction: 'inbound',
+        channel: 'email',
+        sentAt: new Date(),
+        subject: null,
+        body: 'Hello',
+        senderName: null,
+        senderEmail: null,
+        isPersonalized: false,
+        source: 'manual',
+      });
+
+      expect(mockValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          submissionId: null,
+          externalSubmissionId: 'ext-sub-1',
+        }),
+      );
     });
   });
 });

--- a/apps/api/src/services/correspondence.service.ts
+++ b/apps/api/src/services/correspondence.service.ts
@@ -13,8 +13,9 @@ import { AuditActions, AuditResources } from '@colophony/types';
 import type {
   SendEditorMessageInput,
   ListCorrespondenceByUserInput,
+  CreateManualCorrespondenceInput,
 } from '@colophony/types';
-import type { ServiceContext } from './types.js';
+import type { ServiceContext, UserServiceContext } from './types.js';
 import { assertEditorOrAdmin, NotFoundError } from './errors.js';
 import { submissionService } from './submission.service.js';
 import { emailService } from './email.service.js';
@@ -27,7 +28,8 @@ import { validateEnv } from '../config/env.js';
 
 export interface CreateCorrespondenceParams {
   userId: string;
-  submissionId: string;
+  submissionId?: string;
+  externalSubmissionId?: string;
   direction: 'inbound' | 'outbound';
   channel: 'email' | 'portal' | 'in_app' | 'other';
   sentAt: Date;
@@ -49,7 +51,8 @@ export const correspondenceService = {
       .insert(correspondence)
       .values({
         userId: params.userId,
-        submissionId: params.submissionId,
+        submissionId: params.submissionId ?? null,
+        externalSubmissionId: params.externalSubmissionId ?? null,
         direction: params.direction,
         channel: params.channel,
         sentAt: params.sentAt,
@@ -244,5 +247,45 @@ export const correspondenceService = {
     }
 
     return { correspondenceId: record.id };
+  },
+
+  async createManualWithAudit(
+    ctx: UserServiceContext,
+    input: CreateManualCorrespondenceInput,
+  ): Promise<{ id: string }> {
+    // Verify external submission exists (RLS-scoped)
+    const [extSub] = await ctx.tx
+      .select({ id: externalSubmissions.id })
+      .from(externalSubmissions)
+      .where(eq(externalSubmissions.id, input.externalSubmissionId))
+      .limit(1);
+
+    if (!extSub) throw new NotFoundError('External submission not found');
+
+    const record = await correspondenceService.create(ctx.tx, {
+      userId: ctx.userId,
+      externalSubmissionId: input.externalSubmissionId,
+      direction: input.direction,
+      channel: input.channel,
+      sentAt: new Date(input.sentAt),
+      subject: input.subject ?? null,
+      body: input.body,
+      senderName: input.senderName ?? null,
+      senderEmail: input.senderEmail ?? null,
+      isPersonalized: input.isPersonalized,
+      source: 'manual',
+    });
+
+    await ctx.audit({
+      action: AuditActions.CORRESPONDENCE_MANUAL_LOGGED,
+      resource: AuditResources.CORRESPONDENCE,
+      resourceId: record.id,
+      newValue: {
+        externalSubmissionId: input.externalSubmissionId,
+        direction: input.direction,
+      },
+    });
+
+    return { id: record.id };
   },
 };

--- a/apps/api/src/services/external-submission.service.spec.ts
+++ b/apps/api/src/services/external-submission.service.spec.ts
@@ -23,6 +23,7 @@ vi.mock('@colophony/db', () => ({
     id: 'id',
     userId: 'user_id',
     journalName: 'journal_name',
+    sentAt: 'sent_at',
     status: 'status',
     updatedAt: 'updated_at',
   },
@@ -30,6 +31,17 @@ vi.mock('@colophony/db', () => ({
   and: vi.fn((...args: unknown[]) => ['and', ...args]),
   sql: vi.fn(),
 }));
+
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const sqlTagFn = (_strings: TemplateStringsArray, ..._values: unknown[]) =>
+    'sql_expr';
+  return {
+    ...actual,
+    inArray: vi.fn((_col: unknown, vals: unknown) => ['inArray', vals]),
+    sql: sqlTagFn,
+  };
+});
 
 import {
   externalSubmissionService,
@@ -317,6 +329,127 @@ describe('externalSubmissionService', () => {
       await expect(
         externalSubmissionService.deleteWithAudit(ctx, 'missing'),
       ).rejects.toThrow(ExternalSubmissionNotFoundError);
+    });
+  });
+
+  describe('checkDuplicates', () => {
+    function makeDupTx(
+      existingRows: Array<{
+        id: string;
+        journalName: string;
+        sentAt: Date | null;
+      }>,
+    ) {
+      const tx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue(existingRows),
+          }),
+        }),
+      } as unknown as Parameters<
+        typeof externalSubmissionService.checkDuplicates
+      >[0];
+      return tx;
+    }
+
+    it('returns matches within +/- 1 day', async () => {
+      const tx = makeDupTx([
+        {
+          id: 'ext-1',
+          journalName: 'The Paris Review',
+          sentAt: new Date('2026-01-15T00:00:00Z'),
+        },
+      ]);
+
+      const result = await externalSubmissionService.checkDuplicates(
+        tx,
+        'user-1',
+        [
+          {
+            journalName: 'The Paris Review',
+            sentAt: '2026-01-15T12:00:00Z',
+          },
+        ],
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        candidateIndex: 0,
+        existingId: 'ext-1',
+        existingJournalName: 'The Paris Review',
+      });
+    });
+
+    it('returns no matches when sentAt differs by >1 day', async () => {
+      const tx = makeDupTx([
+        {
+          id: 'ext-1',
+          journalName: 'The Paris Review',
+          sentAt: new Date('2026-01-10T00:00:00Z'),
+        },
+      ]);
+
+      const result = await externalSubmissionService.checkDuplicates(
+        tx,
+        'user-1',
+        [
+          {
+            journalName: 'The Paris Review',
+            sentAt: '2026-01-15T00:00:00Z',
+          },
+        ],
+      );
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('matches by name only when neither has sentAt', async () => {
+      const tx = makeDupTx([
+        { id: 'ext-1', journalName: 'Ploughshares', sentAt: null },
+      ]);
+
+      const result = await externalSubmissionService.checkDuplicates(
+        tx,
+        'user-1',
+        [{ journalName: 'Ploughshares' }],
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        candidateIndex: 0,
+        existingId: 'ext-1',
+        existingSentAt: null,
+      });
+    });
+
+    it('returns empty for empty candidates', async () => {
+      const tx = makeDupTx([]);
+
+      const result = await externalSubmissionService.checkDuplicates(
+        tx,
+        'user-1',
+        [],
+      );
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('is case-insensitive on journal name', async () => {
+      const tx = makeDupTx([
+        { id: 'ext-1', journalName: 'the paris review', sentAt: null },
+      ]);
+
+      const result = await externalSubmissionService.checkDuplicates(
+        tx,
+        'user-1',
+        [{ journalName: 'The Paris Review' }],
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        candidateIndex: 0,
+        existingId: 'ext-1',
+      });
     });
   });
 });

--- a/apps/api/src/services/external-submission.service.ts
+++ b/apps/api/src/services/external-submission.service.ts
@@ -1,6 +1,10 @@
 import { externalSubmissions, eq, and, type DrizzleDb } from '@colophony/db';
-import { desc, ilike, count } from 'drizzle-orm';
-import type { ListExternalSubmissionsInput, CSRStatus } from '@colophony/types';
+import { desc, ilike, count, inArray, sql } from 'drizzle-orm';
+import type {
+  ListExternalSubmissionsInput,
+  CSRStatus,
+  DuplicateCheckResult,
+} from '@colophony/types';
 import { AuditActions, AuditResources } from '@colophony/types';
 import type { UserServiceContext } from './types.js';
 
@@ -139,6 +143,81 @@ export const externalSubmissionService = {
       .where(eq(externalSubmissions.id, id))
       .returning();
     return deleted ?? null;
+  },
+
+  async checkDuplicates(
+    tx: DrizzleDb,
+    userId: string,
+    candidates: Array<{ journalName: string; sentAt?: string }>,
+  ): Promise<DuplicateCheckResult> {
+    if (candidates.length === 0) return [];
+
+    // Collect unique lowercase journal names
+    const uniqueNames = [
+      ...new Set(candidates.map((c) => c.journalName.toLowerCase())),
+    ];
+
+    // Query existing submissions with matching journal names
+    const existing = await tx
+      .select({
+        id: externalSubmissions.id,
+        journalName: externalSubmissions.journalName,
+        sentAt: externalSubmissions.sentAt,
+      })
+      .from(externalSubmissions)
+      .where(
+        and(
+          eq(externalSubmissions.userId, userId),
+          inArray(sql`lower(${externalSubmissions.journalName})`, uniqueNames),
+        ),
+      );
+
+    const DAY_MS = 86_400_000;
+    const results: DuplicateCheckResult = [];
+
+    for (let i = 0; i < candidates.length; i++) {
+      const candidate = candidates[i];
+      const candidateNameLower = candidate.journalName.toLowerCase();
+
+      for (const row of existing) {
+        if (row.journalName.toLowerCase() !== candidateNameLower) continue;
+
+        const candidateSentAt = candidate.sentAt
+          ? new Date(candidate.sentAt).getTime()
+          : null;
+        const existingSentAt = row.sentAt ? row.sentAt.getTime() : null;
+
+        // If neither has sentAt, match by name only
+        if (candidateSentAt === null && existingSentAt === null) {
+          results.push({
+            candidateIndex: i,
+            existingId: row.id,
+            existingJournalName: row.journalName,
+            existingSentAt: null,
+          });
+          break;
+        }
+
+        // If both have sentAt, check within ±1 day
+        if (
+          candidateSentAt !== null &&
+          existingSentAt !== null &&
+          Math.abs(candidateSentAt - existingSentAt) <= DAY_MS
+        ) {
+          results.push({
+            candidateIndex: i,
+            existingId: row.id,
+            existingJournalName: row.journalName,
+            existingSentAt: row.sentAt!.toISOString(),
+          });
+          break;
+        }
+
+        // One has sentAt and other doesn't — no match
+      }
+    }
+
+    return results;
   },
 
   // -------------------------------------------------------------------------

--- a/apps/api/src/trpc/routers/correspondence.ts
+++ b/apps/api/src/trpc/routers/correspondence.ts
@@ -4,6 +4,7 @@ import {
   sendEditorMessageSchema,
   correspondenceListItemSchema,
   listCorrespondenceByUserSchema,
+  createManualCorrespondenceSchema,
 } from '@colophony/types';
 import {
   orgProcedure,
@@ -11,7 +12,10 @@ import {
   createRouter,
   requireScopes,
 } from '../init.js';
-import { toServiceContext } from '../../services/context.js';
+import {
+  toServiceContext,
+  toUserServiceContext,
+} from '../../services/context.js';
 import { correspondenceService } from '../../services/correspondence.service.js';
 import { mapServiceError } from '../error-mapper.js';
 
@@ -62,6 +66,21 @@ export const correspondenceRouter = createRouter({
           isPersonalized: r.isPersonalized,
           source: r.source as 'colophony' | 'manual',
         }));
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  logManual: userProcedure
+    .use(requireScopes('correspondence:write'))
+    .input(createManualCorrespondenceSchema)
+    .output(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await correspondenceService.createManualWithAudit(
+          toUserServiceContext(ctx),
+          input,
+        );
       } catch (e) {
         mapServiceError(e);
       }

--- a/apps/api/src/trpc/routers/external-submissions.ts
+++ b/apps/api/src/trpc/routers/external-submissions.ts
@@ -3,6 +3,8 @@ import {
   createExternalSubmissionSchema,
   updateExternalSubmissionSchema,
   listExternalSubmissionsSchema,
+  duplicateCheckInputSchema,
+  duplicateCheckResultSchema,
 } from '@colophony/types';
 import { createRouter, userProcedure, requireScopes } from '../init.js';
 import { toUserServiceContext } from '../../services/context.js';
@@ -36,6 +38,22 @@ export const externalSubmissionsRouter = createRouter({
         const row = await externalSubmissionService.getById(ctx.dbTx, input.id);
         if (!row) throw new ExternalSubmissionNotFoundError(input.id);
         return row;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  checkDuplicates: userProcedure
+    .use(requireScopes('external-submissions:read'))
+    .input(duplicateCheckInputSchema)
+    .output(duplicateCheckResultSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await externalSubmissionService.checkDuplicates(
+          ctx.dbTx,
+          ctx.authContext.userId,
+          input.candidates,
+        );
       } catch (e) {
         mapServiceError(e);
       }

--- a/apps/web/src/components/workspace/external-submission-detail.tsx
+++ b/apps/web/src/components/workspace/external-submission-detail.tsx
@@ -20,7 +20,8 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { CsrStatusBadge } from "./csr-status-badge";
 import { ExternalSubmissionForm } from "./external-submission-form";
-import { ArrowLeft, Pencil, Trash2 } from "lucide-react";
+import { ArrowLeft, Mail, Pencil, Trash2 } from "lucide-react";
+import { LogCorrespondenceDialog } from "./log-correspondence-dialog";
 import { format } from "date-fns";
 
 interface ExternalSubmissionDetailProps {
@@ -33,6 +34,7 @@ export function ExternalSubmissionDetail({
   const router = useRouter();
   const utils = trpc.useUtils();
   const [isEditing, setIsEditing] = useState(false);
+  const [logDialogOpen, setLogDialogOpen] = useState(false);
 
   const {
     data: submission,
@@ -95,6 +97,10 @@ export function ExternalSubmissionDetail({
           </div>
         </div>
         <div className="flex gap-2">
+          <Button variant="outline" onClick={() => setLogDialogOpen(true)}>
+            <Mail className="mr-2 h-4 w-4" />
+            Log Message
+          </Button>
           <Button variant="outline" onClick={() => setIsEditing(true)}>
             <Pencil className="mr-2 h-4 w-4" />
             Edit
@@ -174,6 +180,13 @@ export function ExternalSubmissionDetail({
           )}
         </CardContent>
       </Card>
+
+      <LogCorrespondenceDialog
+        externalSubmissionId={id}
+        journalName={submission.journalName}
+        open={logDialogOpen}
+        onOpenChange={setLogDialogOpen}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/workspace/import-page.tsx
+++ b/apps/web/src/components/workspace/import-page.tsx
@@ -127,18 +127,19 @@ export function ImportPage() {
   );
 
   useEffect(() => {
-    if (duplicateCheckQuery.data && validation) {
-      setValidation({
-        ...validation,
-        duplicateWarnings: duplicateCheckQuery.data.map((d) => ({
-          rowIndex: d.candidateIndex,
-          existingJournalName: d.existingJournalName,
-          existingSentAt: d.existingSentAt,
-        })),
+    if (duplicateCheckQuery.data) {
+      setValidation((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          duplicateWarnings: duplicateCheckQuery.data.map((d) => ({
+            rowIndex: d.candidateIndex,
+            existingJournalName: d.existingJournalName,
+            existingSentAt: d.existingSentAt,
+          })),
+        };
       });
     }
-    // Only run when duplicate check data arrives
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [duplicateCheckQuery.data]);
 
   // --- Import mutation ---

--- a/apps/web/src/components/workspace/import-page.tsx
+++ b/apps/web/src/components/workspace/import-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback } from "react";
 import Link from "next/link";
 import { ArrowLeft, ArrowRight, Loader2, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -126,21 +126,19 @@ export function ImportPage() {
     },
   );
 
-  useEffect(() => {
-    if (duplicateCheckQuery.data) {
-      setValidation((prev) => {
-        if (!prev) return prev;
-        return {
-          ...prev,
-          duplicateWarnings: duplicateCheckQuery.data.map((d) => ({
-            rowIndex: d.candidateIndex,
-            existingJournalName: d.existingJournalName,
-            existingSentAt: d.existingSentAt,
-          })),
-        };
-      });
-    }
-  }, [duplicateCheckQuery.data]);
+  // Merge duplicate warnings into validation at render time (no effect needed)
+  const validationWithDuplicates = useMemo(() => {
+    if (!validation) return null;
+    if (!duplicateCheckQuery.data) return validation;
+    return {
+      ...validation,
+      duplicateWarnings: duplicateCheckQuery.data.map((d) => ({
+        rowIndex: d.candidateIndex,
+        existingJournalName: d.existingJournalName,
+        existingSentAt: d.existingSentAt,
+      })),
+    };
+  }, [validation, duplicateCheckQuery.data]);
 
   // --- Import mutation ---
   const utils = trpc.useUtils();
@@ -492,7 +490,7 @@ export function ImportPage() {
           {importResult ? (
             <div className="space-y-4">
               <ImportReview
-                validation={validation!}
+                validation={validationWithDuplicates!}
                 onImport={handleImport}
                 onBack={handleBack}
                 isPending={false}
@@ -508,9 +506,9 @@ export function ImportPage() {
               </div>
             </div>
           ) : (
-            validation && (
+            validationWithDuplicates && (
               <ImportReview
-                validation={validation}
+                validation={validationWithDuplicates}
                 onImport={handleImport}
                 onBack={handleBack}
                 isPending={importMutation.isPending}

--- a/apps/web/src/components/workspace/import-page.tsx
+++ b/apps/web/src/components/workspace/import-page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import Link from "next/link";
-import { ArrowLeft, ArrowRight } from "lucide-react";
+import { ArrowLeft, ArrowRight, Loader2, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -58,6 +58,7 @@ export function ImportPage() {
     null,
   );
   const [importError, setImportError] = useState<string | null>(null);
+  const [duplicateCheckEnabled, setDuplicateCheckEnabled] = useState(false);
 
   const presetDef = IMPORT_PRESETS[preset];
 
@@ -101,6 +102,44 @@ export function ImportPage() {
     { names: journalNames },
     { enabled: step === 3 && journalNames.length > 0 },
   );
+
+  // --- Duplicate check ---
+  const duplicateCandidates = useMemo(() => {
+    if (!parsed || !hasJournalNameMapping) return [];
+    const journalCol = columnMappings.find((m) => m.target === "journalName");
+    const sentAtCol = columnMappings.find((m) => m.target === "sentAt");
+    if (!journalCol) return [];
+    return parsed.rows
+      .map((row) => ({
+        journalName: row[journalCol.csvHeader]?.trim() ?? "",
+        sentAt: sentAtCol
+          ? (row[sentAtCol.csvHeader]?.trim() ?? undefined)
+          : undefined,
+      }))
+      .filter((c) => c.journalName.length > 0);
+  }, [parsed, hasJournalNameMapping, columnMappings]);
+
+  const duplicateCheckQuery = trpc.externalSubmissions.checkDuplicates.useQuery(
+    { candidates: duplicateCandidates },
+    {
+      enabled: duplicateCheckEnabled && duplicateCandidates.length > 0,
+    },
+  );
+
+  useEffect(() => {
+    if (duplicateCheckQuery.data && validation) {
+      setValidation({
+        ...validation,
+        duplicateWarnings: duplicateCheckQuery.data.map((d) => ({
+          rowIndex: d.candidateIndex,
+          existingJournalName: d.existingJournalName,
+          existingSentAt: d.existingSentAt,
+        })),
+      });
+    }
+    // Only run when duplicate check data arrives
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [duplicateCheckQuery.data]);
 
   // --- Import mutation ---
   const utils = trpc.useUtils();
@@ -281,6 +320,7 @@ export function ImportPage() {
     setValidation(null);
     setImportResult(null);
     setImportError(null);
+    setDuplicateCheckEnabled(false);
   }, []);
 
   // --- Render ---
@@ -425,6 +465,29 @@ export function ImportPage() {
       {/* Step 3: Review & Import */}
       {step === 3 && (
         <div className="space-y-4">
+          {!importResult && validation && (
+            <div className="flex justify-end">
+              <Button
+                variant="outline"
+                onClick={() => setDuplicateCheckEnabled(true)}
+                disabled={
+                  duplicateCheckQuery.isFetching || duplicateCheckEnabled
+                }
+              >
+                {duplicateCheckQuery.isFetching ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Search className="mr-2 h-4 w-4" />
+                )}
+                {duplicateCheckQuery.data
+                  ? `${duplicateCheckQuery.data.length} Duplicate${duplicateCheckQuery.data.length !== 1 ? "s" : ""} Found`
+                  : duplicateCheckQuery.isFetching
+                    ? "Checking..."
+                    : "Check for Duplicates"}
+              </Button>
+            </div>
+          )}
+
           {importResult ? (
             <div className="space-y-4">
               <ImportReview

--- a/apps/web/src/components/workspace/log-correspondence-dialog.tsx
+++ b/apps/web/src/components/workspace/log-correspondence-dialog.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useForm, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { trpc } from "@/lib/trpc";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Loader2 } from "lucide-react";
+
+const formSchema = z.object({
+  externalSubmissionId: z.string().uuid(),
+  direction: z.enum(["inbound", "outbound"]),
+  channel: z.enum(["email", "portal", "in_app", "other"]).default("email"),
+  sentAt: z.string().min(1, "Date is required"),
+  subject: z.string().max(500).optional(),
+  body: z.string().min(1, "Message body is required").max(10000),
+  senderName: z.string().max(255).optional(),
+  senderEmail: z.string().email().max(255).optional().or(z.literal("")),
+  isPersonalized: z.boolean().default(false),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+interface LogCorrespondenceDialogProps {
+  externalSubmissionId: string;
+  journalName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function LogCorrespondenceDialog({
+  externalSubmissionId,
+  journalName,
+  open,
+  onOpenChange,
+}: LogCorrespondenceDialogProps) {
+  const utils = trpc.useUtils();
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema) as unknown as Resolver<FormData>,
+    defaultValues: {
+      externalSubmissionId,
+      direction: "inbound",
+      channel: "email",
+      sentAt: new Date().toISOString().slice(0, 16),
+      subject: "",
+      body: "",
+      senderName: "",
+      senderEmail: "",
+      isPersonalized: false,
+    },
+  });
+
+  const mutation = trpc.correspondence.logManual.useMutation({
+    onSuccess: () => {
+      toast.success("Correspondence logged");
+      utils.correspondence.listByUser.invalidate();
+      form.reset();
+      onOpenChange(false);
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  function onSubmit(data: FormData) {
+    mutation.mutate({
+      externalSubmissionId: data.externalSubmissionId,
+      direction: data.direction,
+      channel: data.channel,
+      sentAt: new Date(data.sentAt).toISOString(),
+      subject: data.subject || undefined,
+      body: data.body,
+      senderName: data.senderName || undefined,
+      senderEmail: data.senderEmail || undefined,
+      isPersonalized: data.isPersonalized,
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Log Correspondence — {journalName}</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="direction"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Direction</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="inbound">
+                        Received from editor
+                      </SelectItem>
+                      <SelectItem value="outbound">Sent to editor</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="channel"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Channel</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="email">Email</SelectItem>
+                      <SelectItem value="portal">Portal</SelectItem>
+                      <SelectItem value="in_app">In-App</SelectItem>
+                      <SelectItem value="other">Other</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="sentAt"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Date</FormLabel>
+                  <FormControl>
+                    <Input type="datetime-local" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="subject"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Subject (optional)</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Re: Submission" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="body"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Message</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Paste or type the message content..."
+                      rows={5}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="senderName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Sender Name (optional)</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Editor name" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="senderEmail"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Sender Email (optional)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        placeholder="editor@journal.com"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="isPersonalized"
+              render={({ field }) => (
+                <FormItem className="flex items-center gap-2 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormLabel className="font-normal">
+                    Personalized message (not a form response)
+                  </FormLabel>
+                </FormItem>
+              )}
+            />
+
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={mutation.isPending}>
+                {mutation.isPending && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                Log Message
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -357,13 +357,13 @@
 - [x] [P2] MigrationBundle: add submission count LIMIT/batching for users with thousands of submissions — (code review 2026-02-27; done 2026-02-28)
 - [x] [P1] CSR export endpoint — tRPC + REST endpoint for writers to download their full CSR as JSON; aggregates Colophony-native submissions (cross-org), external submissions, correspondence, writer profiles, and manuscripts — (register-data-standard.md Section 2.1; done 2026-03-01)
 - [x] [P1] CSR import endpoint — ingest external submission records from JSON with correspondence linking; CSV import with column mapping deferred to writer workspace UI track — (register-data-standard.md Section 3; done 2026-03-01)
-- [ ] [P2] CSR format documentation — human-readable spec with field descriptions, examples, status mapping table, and extension points; publishable as part of project docs — (register-data-standard.md; 2026-02-27)
+- [x] [P2] CSR format documentation — human-readable spec with field descriptions, examples, status mapping table, and extension points; publishable as part of project docs — (register-data-standard.md; 2026-02-27; done 2026-03-01)
 
 ### Correspondence Tracking
 
 - [x] [P0] `correspondence` DB table — new table for editor-writer messages linked to submissions; fields: direction (inbound/outbound), channel (email/portal/in_app), body, senderName, senderEmail, isPersonalized flag; RLS scoped to submission owner + org editors; XOR CHECK on submission_id/external_submission_id — (register-data-standard.md Section 2.8, 4.2; done 2026-02-27 PR pending)
 - [x] [P1] Auto-capture Colophony correspondence — auto-insert correspondence records on acceptance/rejection notifications + editor messages; captures status transition comments — (register-data-standard.md Section 2.8; done 2026-02-27 PR pending)
-- [ ] [P2] Manual correspondence logging — writers can paste/enter notable editor messages (personalized rejections, encouragement letters) for external submissions; lightweight form: paste text, mark as personalized, save — (register-data-standard.md Section 2.8; 2026-02-27)
+- [x] [P2] Manual correspondence logging — writers can paste/enter notable editor messages (personalized rejections, encouragement letters) for external submissions; lightweight form: paste text, mark as personalized, save — (register-data-standard.md Section 2.8; 2026-02-27; done 2026-03-01)
 - [x] [P2] Correspondence in CSR export — include all correspondence records in the writer's CSR download, linked to submission records — (register-data-standard.md Section 2.8; done 2026-03-01)
 
 ### Writer as Top-Level Entity
@@ -376,7 +376,7 @@
 - [x] [P2] Cross-org submission portfolio — aggregated view: Colophony-native submissions from all orgs + external tracked submissions, unified by piece grouping — (persona gap analysis 2026-02-27; done 2026-03-01)
 - [x] [P2] Writer-facing analytics — personal response time stats, submissions pending, acceptance rate, submissions per month; derived from both native and manually-tracked records — (persona gap analysis 2026-02-27; done 2026-03-01)
 - [x] [P2] Import flows — Submittable CSV import, Chill Subs import (via directoryIds mapping), generic CSV with column mapping UI — (register-data-standard.md Section 3; done 2026-03-01)
-- [ ] [P3] Import duplicate detection — opt-in "Check for duplicates" button compares (journalName + sentAt ± 1 day) against existing subs — (DEVLOG 2026-03-01, deferred from import flows PR)
+- [x] [P3] Import duplicate detection — opt-in "Check for duplicates" button compares (journalName + sentAt ± 1 day) against existing subs — (DEVLOG 2026-03-01, deferred from import flows PR; done 2026-03-01)
 
 ### Design Decisions
 

--- a/docs/csr-format.md
+++ b/docs/csr-format.md
@@ -1,0 +1,368 @@
+# CSR Format Specification (v1.0)
+
+> **Canonical source:** `packages/types/src/csr.ts`
+> **Status:** Stable (v1.0)
+
+The Colophony Submission Record (CSR) is a JSON-based data portability format for writers. It enables export of all submission-related data from a Colophony instance and import of external submission records from CSV or JSON sources.
+
+---
+
+## Export Envelope
+
+The top-level export structure (`csrExportEnvelopeSchema`):
+
+| Field                  | Type              | Description                                           |
+| ---------------------- | ----------------- | ----------------------------------------------------- |
+| `version`              | `"1.0"` (literal) | Format version                                        |
+| `exportedAt`           | ISO 8601 datetime | When the export was generated                         |
+| `identity`             | object            | Exporting user identity                               |
+| `identity.userId`      | UUID              | Colophony user ID                                     |
+| `identity.email`       | string (email)    | User email                                            |
+| `identity.displayName` | string \| null    | Display name                                          |
+| `nativeSubmissions`    | array             | Colophony-origin submissions (see Native Submissions) |
+| `externalSubmissions`  | array             | Manually-tracked external submissions                 |
+| `correspondence`       | array             | Editor-writer correspondence records                  |
+| `writerProfiles`       | array             | External platform profile links                       |
+| `manuscripts`          | array             | Lightweight manuscript references                     |
+
+---
+
+## Status Model
+
+CSR defines 10 harmonized statuses that map across submission systems:
+
+| CSR Status    | Description                                                    |
+| ------------- | -------------------------------------------------------------- |
+| `draft`       | Not yet submitted                                              |
+| `sent`        | Submitted / sent to journal                                    |
+| `in_review`   | Under active editorial review                                  |
+| `hold`        | Held for further consideration (shortlisted)                   |
+| `accepted`    | Accepted for publication                                       |
+| `rejected`    | Declined by the journal                                        |
+| `withdrawn`   | Withdrawn by the writer                                        |
+| `no_response` | No response received (external submissions only)               |
+| `revise`      | Revise and resubmit requested                                  |
+| `unknown`     | Status could not be determined (fallback for unmapped imports) |
+
+### Hopper-to-CSR Status Mapping
+
+Source: `packages/types/src/status-mapping.ts`
+
+| Hopper Status         | CSR Status  |
+| --------------------- | ----------- |
+| `DRAFT`               | `draft`     |
+| `SUBMITTED`           | `sent`      |
+| `UNDER_REVIEW`        | `in_review` |
+| `HOLD`                | `hold`      |
+| `ACCEPTED`            | `accepted`  |
+| `REJECTED`            | `rejected`  |
+| `WITHDRAWN`           | `withdrawn` |
+| `REVISE_AND_RESUBMIT` | `revise`    |
+
+CSR statuses `no_response` and `unknown` have no Hopper equivalent. The reverse mapping (`csrToHopperStatus`) returns `null` for these.
+
+---
+
+## Genre Model
+
+Genres live on manuscripts, not submissions. The genre schema (`genreSchema`):
+
+| Field     | Type                    | Description                                           |
+| --------- | ----------------------- | ----------------------------------------------------- |
+| `primary` | enum (10 values)        | Primary genre classification                          |
+| `sub`     | string \| null          | Freetext subgenre (e.g., "flash", "lyric essay")      |
+| `hybrid`  | array of primary genres | Additional primary genres for hybrid/cross-genre work |
+
+**Primary genres:** `poetry`, `fiction`, `creative_nonfiction`, `nonfiction`, `drama`, `translation`, `visual_art`, `comics`, `audio`, `other`
+
+---
+
+## Journal Reference
+
+The `journalRefSchema` supports graceful degradation from fully-federated to freetext-only references:
+
+| Field             | Type              | Description                                      |
+| ----------------- | ----------------- | ------------------------------------------------ |
+| `id`              | UUID (optional)   | Internal journal ID                              |
+| `name`            | string (required) | Journal display name (always present)            |
+| `colophonyDomain` | string \| null    | Federated Colophony instance domain              |
+| `colophonyOrgId`  | UUID \| null      | Org ID on the federated instance                 |
+| `externalUrl`     | URL \| null       | Journal website URL                              |
+| `directoryIds`    | Record \| null    | Third-party directory IDs (e.g., Duotrope, CLMP) |
+
+**Degradation:** Federated (has `colophonyDomain` + `colophonyOrgId`) > Directory-linked (has `directoryIds`) > Freetext (name only).
+
+---
+
+## Field Reference
+
+### Native Submissions
+
+Colophony-origin submissions exported via `csrNativeSubmissionSchema`:
+
+| Field                | Type             | Description                        |
+| -------------------- | ---------------- | ---------------------------------- |
+| `originSubmissionId` | UUID             | Original Colophony submission ID   |
+| `title`              | string \| null   | Submission title                   |
+| `genre`              | Genre \| null    | Structured genre (see Genre Model) |
+| `coverLetter`        | string \| null   | Cover letter text                  |
+| `status`             | CSRStatus        | Harmonized status                  |
+| `formData`           | Record \| null   | Custom form field data             |
+| `submittedAt`        | datetime \| null | When submitted                     |
+| `decidedAt`          | datetime \| null | When decision was made             |
+| `publicationName`    | string \| null   | Publication/journal name           |
+| `periodName`         | string \| null   | Reading period name                |
+| `statusHistory`      | array            | Status change audit trail          |
+
+### External Submissions
+
+Manually-tracked submissions (`externalSubmissionSchema`):
+
+| Field                | Type             | Description                             |
+| -------------------- | ---------------- | --------------------------------------- |
+| `id`                 | UUID             | Record ID                               |
+| `manuscriptId`       | UUID \| null     | Linked manuscript                       |
+| `journalDirectoryId` | UUID \| null     | Linked journal directory entry          |
+| `journalName`        | string           | Journal name (always present)           |
+| `status`             | CSRStatus        | Harmonized status                       |
+| `sentAt`             | datetime \| null | When sent to journal                    |
+| `respondedAt`        | datetime \| null | When response received                  |
+| `method`             | string \| null   | Submission method (e.g., "Submittable") |
+| `notes`              | string \| null   | Writer notes                            |
+| `importedFrom`       | string \| null   | Import source identifier                |
+| `createdAt`          | datetime         | Record creation time                    |
+| `updatedAt`          | datetime         | Last update time                        |
+
+### Correspondence
+
+Editor-writer correspondence (`correspondenceSchema`):
+
+| Field                  | Type           | Description                                    |
+| ---------------------- | -------------- | ---------------------------------------------- |
+| `id`                   | UUID           | Record ID                                      |
+| `submissionId`         | UUID \| null   | Linked native submission (XOR)                 |
+| `externalSubmissionId` | UUID \| null   | Linked external submission (XOR)               |
+| `direction`            | enum           | `inbound` or `outbound`                        |
+| `channel`              | enum           | `email`, `portal`, `in_app`, `other`           |
+| `sentAt`               | datetime       | When the message was sent                      |
+| `subject`              | string \| null | Message subject line                           |
+| `body`                 | string         | Message body (min 1 char)                      |
+| `senderName`           | string \| null | Sender display name                            |
+| `senderEmail`          | email \| null  | Sender email address                           |
+| `isPersonalized`       | boolean        | Whether this was a personal (non-form) message |
+| `source`               | enum           | `colophony` (auto-captured) or `manual`        |
+| `capturedAt`           | datetime       | When the record was created                    |
+
+### Writer Profiles
+
+External platform profile links (`writerProfileSchema`):
+
+| Field        | Type           | Description                         |
+| ------------ | -------------- | ----------------------------------- |
+| `id`         | UUID           | Record ID                           |
+| `platform`   | string         | Platform name (e.g., "Submittable") |
+| `externalId` | string \| null | External platform user ID           |
+| `profileUrl` | URL \| null    | Profile page URL                    |
+
+### Manuscripts
+
+Lightweight manuscript summaries (`csrManuscriptSummarySchema`):
+
+| Field       | Type           | Description      |
+| ----------- | -------------- | ---------------- |
+| `id`        | UUID           | Manuscript ID    |
+| `title`     | string \| null | Manuscript title |
+| `genre`     | Genre \| null  | Structured genre |
+| `createdAt` | datetime       | Creation time    |
+
+---
+
+## Import Format
+
+### JSON Import
+
+The `csrImportInputSchema` accepts:
+
+| Field            | Type   | Description                                          |
+| ---------------- | ------ | ---------------------------------------------------- |
+| `submissions`    | array  | External submissions to create (1-5000)              |
+| `correspondence` | array  | Correspondence records to attach (default: [])       |
+| `importedFrom`   | string | Source identifier (default: `"csr_import"`, max 100) |
+
+**Correspondence linkage:** Each correspondence record has an `externalSubmissionIndex` (0-based integer) that references the position in the `submissions` array. After submissions are created, correspondence records are linked to the resulting submission IDs.
+
+### Import Result
+
+| Field                   | Type | Description                              |
+| ----------------------- | ---- | ---------------------------------------- |
+| `submissionsCreated`    | int  | Number of submissions created            |
+| `correspondenceCreated` | int  | Number of correspondence records created |
+
+---
+
+## CSV Import Presets
+
+CSV import is handled client-side with preset column/status mappings, then submitted as a JSON import payload.
+
+### Submittable
+
+- **ID:** `submittable`
+- **Column patterns:** Title → journalName, Status, Submitted → sentAt, Response → respondedAt
+- **Status mappings:** "In-Progress" → `in_review`, "Accepted" → `accepted`, "Declined" → `rejected`, "Withdrawn" → `withdrawn`, "Draft" → `draft`
+- **Date formats:** `MM/dd/yyyy`, `yyyy-MM-dd`
+
+### Chill Subs
+
+- **ID:** `chillsubs`
+- **Column patterns:** Market/Publication → journalName, Status, Date Sent → sentAt, Date Response → respondedAt
+- **Status mappings:** "Sent" → `sent`, "Accepted" → `accepted`, "Rejected" → `rejected`, "Withdrawn" → `withdrawn`, "No Response" → `no_response`
+- **Date formats:** `yyyy-MM-dd`, `MM/dd/yyyy`
+
+### Generic
+
+- **ID:** `generic`
+- **Column patterns:** Journal/Publication/Magazine → journalName, Status, Sent/Submitted → sentAt, Response/Replied → respondedAt
+- **Status mappings:** None (user maps manually)
+- **Date formats:** `yyyy-MM-dd`, `MM/dd/yyyy`, `dd/MM/yyyy`
+
+Preset definitions: `apps/web/src/lib/csv-import.ts`
+Type definitions: `packages/types/src/csv-import.ts`
+
+---
+
+## Examples
+
+### Export Envelope
+
+```json
+{
+  "version": "1.0",
+  "exportedAt": "2026-03-01T12:00:00.000Z",
+  "identity": {
+    "userId": "550e8400-e29b-41d4-a716-446655440000",
+    "email": "writer@example.com",
+    "displayName": "Jane Author"
+  },
+  "nativeSubmissions": [
+    {
+      "originSubmissionId": "660e8400-e29b-41d4-a716-446655440001",
+      "title": "Autumn Leaves",
+      "genre": { "primary": "poetry", "sub": "lyric", "hybrid": [] },
+      "coverLetter": "Dear Editors, please consider...",
+      "status": "in_review",
+      "formData": null,
+      "submittedAt": "2026-01-15T10:00:00.000Z",
+      "decidedAt": null,
+      "publicationName": "The Example Review",
+      "periodName": "Spring 2026",
+      "statusHistory": [
+        {
+          "from": null,
+          "to": "sent",
+          "changedAt": "2026-01-15T10:00:00.000Z",
+          "comment": null
+        },
+        {
+          "from": "sent",
+          "to": "in_review",
+          "changedAt": "2026-01-20T08:30:00.000Z",
+          "comment": null
+        }
+      ]
+    }
+  ],
+  "externalSubmissions": [
+    {
+      "id": "770e8400-e29b-41d4-a716-446655440002",
+      "manuscriptId": null,
+      "journalDirectoryId": null,
+      "journalName": "The Paris Review",
+      "status": "rejected",
+      "sentAt": "2025-11-01T00:00:00.000Z",
+      "respondedAt": "2026-02-15T00:00:00.000Z",
+      "method": "Submittable",
+      "notes": "Form rejection",
+      "importedFrom": "submittable",
+      "createdAt": "2026-02-20T09:00:00.000Z",
+      "updatedAt": "2026-02-20T09:00:00.000Z"
+    }
+  ],
+  "correspondence": [
+    {
+      "id": "880e8400-e29b-41d4-a716-446655440003",
+      "submissionId": null,
+      "externalSubmissionId": "770e8400-e29b-41d4-a716-446655440002",
+      "direction": "inbound",
+      "channel": "email",
+      "sentAt": "2026-02-15T14:00:00.000Z",
+      "subject": "Re: Submission",
+      "body": "Thank you for submitting. Unfortunately...",
+      "senderName": "Editor",
+      "senderEmail": "editor@parisreview.com",
+      "isPersonalized": false,
+      "source": "manual",
+      "capturedAt": "2026-02-20T09:05:00.000Z"
+    }
+  ],
+  "writerProfiles": [
+    {
+      "id": "990e8400-e29b-41d4-a716-446655440004",
+      "platform": "Submittable",
+      "externalId": "sub_12345",
+      "profileUrl": "https://submittable.com/profile/12345"
+    }
+  ],
+  "manuscripts": [
+    {
+      "id": "aa0e8400-e29b-41d4-a716-446655440005",
+      "title": "Autumn Leaves",
+      "genre": { "primary": "poetry", "sub": "lyric", "hybrid": [] },
+      "createdAt": "2025-10-01T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+### Import Payload
+
+```json
+{
+  "submissions": [
+    {
+      "journalName": "The Paris Review",
+      "status": "rejected",
+      "sentAt": "2025-11-01T00:00:00.000Z",
+      "respondedAt": "2026-02-15T00:00:00.000Z",
+      "method": "Submittable",
+      "notes": "Form rejection",
+      "importedFrom": "submittable"
+    },
+    {
+      "journalName": "Ploughshares",
+      "status": "sent",
+      "sentAt": "2026-01-10T00:00:00.000Z"
+    }
+  ],
+  "correspondence": [
+    {
+      "externalSubmissionIndex": 0,
+      "direction": "inbound",
+      "channel": "email",
+      "sentAt": "2026-02-15T14:00:00.000Z",
+      "subject": "Re: Submission",
+      "body": "Thank you for submitting. Unfortunately..."
+    }
+  ],
+  "importedFrom": "submittable"
+}
+```
+
+---
+
+## Extension Points
+
+- **Hybrid genre:** The `hybrid` array allows cross-genre works without losing the primary classification
+- **Unknown status:** The `unknown` fallback ensures imports never fail due to unmappable statuses
+- **`importedFrom` provenance:** Tracks the origin system for each imported record, enabling future de-duplication
+- **Directory linking:** `journalDirectoryId` links to the shared journal directory; batch matching during CSV import auto-links known journals
+- **Source field:** Correspondence `source` distinguishes auto-captured (`colophony`) from manually logged (`manual`) records

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,23 @@ Newest entries first.
 
 ---
 
+## 2026-03-01 — Track 8 Closeout (Manual Correspondence, Duplicate Detection, CSR Docs)
+
+### Done
+
+- **Manual correspondence logging**: `createManualCorrespondenceSchema` in `csr.ts`, `CORRESPONDENCE_MANUAL_LOGGED` audit action, `correspondence:write` API key scope, `createManualWithAudit()` service method with RLS-scoped external submission verification, `logManual` tRPC mutation, `LogCorrespondenceDialog` component (react-hook-form + zodResolver), "Log Message" button on external submission detail page
+- **Import duplicate detection**: `duplicateCheckInputSchema`/`duplicateCheckResultSchema` in `csv-import.ts`, `checkDuplicates()` service method (case-insensitive name match + sentAt within ±1 day), `checkDuplicates` tRPC query, opt-in "Check for Duplicates" button wired into import wizard review step with warning population
+- **CSR format documentation**: `docs/csr-format.md` — complete spec covering export envelope, status model (10 statuses + Hopper mapping), genre model, journal reference degradation, field reference tables, import format, CSV presets, examples, and extension points
+- **Tests**: 8 new unit tests (3 correspondence manual, 5 duplicate detection) — all passing; existing tests unbroken (26/26 in both spec files)
+- **Quality gates**: `pnpm type-check`, `pnpm lint` both clean
+
+### Decisions
+
+- Duplicate check is opt-in (button click) rather than automatic — avoids slowing down happy-path imports; query only fires when user explicitly requests it
+- `CreateCorrespondenceParams.submissionId` changed from required to optional (XOR with `externalSubmissionId`) — backward compatible since existing callers always pass `submissionId`
+
+---
+
 ## 2026-03-01 — CSV Import Flows (Track 8 P2)
 
 ### Done

--- a/packages/types/src/api-key.ts
+++ b/packages/types/src/api-key.ts
@@ -43,6 +43,7 @@ export const apiKeyScopeSchema = z
     "writer-profiles:write",
     "journal-directory:read",
     "correspondence:read",
+    "correspondence:write",
     "audit:read",
   ])
   .describe("Permission scope for the API key");

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -214,6 +214,7 @@ export const AuditActions = {
   // Correspondence lifecycle
   CORRESPONDENCE_SENT: "CORRESPONDENCE_SENT",
   CORRESPONDENCE_AUTO_CAPTURED: "CORRESPONDENCE_AUTO_CAPTURED",
+  CORRESPONDENCE_MANUAL_LOGGED: "CORRESPONDENCE_MANUAL_LOGGED",
 
   // Voting lifecycle
   SUBMISSION_VOTE_CAST: "SUBMISSION_VOTE_CAST",
@@ -610,7 +611,8 @@ export interface CorrespondenceAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.CORRESPONDENCE;
   action:
     | typeof AuditActions.CORRESPONDENCE_SENT
-    | typeof AuditActions.CORRESPONDENCE_AUTO_CAPTURED;
+    | typeof AuditActions.CORRESPONDENCE_AUTO_CAPTURED
+    | typeof AuditActions.CORRESPONDENCE_MANUAL_LOGGED;
 }
 
 export interface EmailTemplateAuditParams extends BaseAuditParams {

--- a/packages/types/src/csr.ts
+++ b/packages/types/src/csr.ts
@@ -173,6 +173,22 @@ export const createCorrespondenceSchema = z
     },
   );
 
+export const createManualCorrespondenceSchema = z.object({
+  externalSubmissionId: z.string().uuid(),
+  direction: correspondenceDirectionSchema,
+  channel: correspondenceChannelSchema.default("email"),
+  sentAt: z.string().datetime(),
+  subject: z.string().max(500).optional(),
+  body: z.string().min(1).max(10000),
+  senderName: z.string().max(255).optional(),
+  senderEmail: z.string().email().max(255).optional(),
+  isPersonalized: z.boolean().default(false),
+});
+
+export type CreateManualCorrespondenceInput = z.infer<
+  typeof createManualCorrespondenceSchema
+>;
+
 export const createWriterProfileSchema = z.object({
   platform: z.string().min(1).max(100),
   externalId: z.string().max(500).optional(),

--- a/packages/types/src/csv-import.ts
+++ b/packages/types/src/csv-import.ts
@@ -1,6 +1,33 @@
 import { z } from "zod";
 import type { CSRStatus } from "./csr";
 
+// --- Duplicate check ---
+
+export const duplicateCheckInputSchema = z.object({
+  candidates: z
+    .array(
+      z.object({
+        journalName: z.string().min(1).max(500),
+        sentAt: z.string().datetime().optional(),
+      }),
+    )
+    .min(1)
+    .max(5000),
+});
+
+export type DuplicateCheckInput = z.infer<typeof duplicateCheckInputSchema>;
+
+export const duplicateCheckResultSchema = z.array(
+  z.object({
+    candidateIndex: z.number().int(),
+    existingId: z.string().uuid(),
+    existingJournalName: z.string(),
+    existingSentAt: z.string().datetime().nullable(),
+  }),
+);
+
+export type DuplicateCheckResult = z.infer<typeof duplicateCheckResultSchema>;
+
 // --- Preset enum ---
 
 export const csvImportPresetSchema = z.enum([


### PR DESCRIPTION
## Summary

Closes out Track 8 (Register Data Standard & Writer Tools) with the three remaining items:

- **Manual correspondence logging** — writers can log editor messages (acceptance letters, personalized rejections) against external submissions via a dialog on the detail page. New `CORRESPONDENCE_MANUAL_LOGGED` audit action, `logManual` tRPC mutation, and `correspondence:write` API key scope.
- **Import duplicate detection** — opt-in "Check for Duplicates" button on the CSV import review step. Matches by journal name (case-insensitive) and sentAt within ±1 day. Results displayed as warnings in the existing ImportReview component.
- **CSR format documentation** — `docs/csr-format.md` with complete spec: envelope structure, status model (10 statuses + Hopper mapping), genre model, journal reference degradation, field reference tables, import/export formats, CSV presets, examples, and extension points.

## Test plan

- [ ] Manual correspondence: Create an external submission → click "Log Message" → fill form → verify record appears in correspondence archive (`/workspace/correspondence`)
- [ ] Duplicate detection: Import a CSV → on review step click "Check for Duplicates" → verify warning badges appear for matching entries → proceed with import
- [ ] Unit tests: `pnpm test` passes (8 new tests: 3 correspondence manual, 5 duplicate detection)
- [ ] Type check: `pnpm type-check` passes
- [ ] Lint: `pnpm lint` passes