### PR TITLE
feat(register): federation admin UI — trust management + overview

### DIFF
--- a/apps/api/src/services/federation.service.ts
+++ b/apps/api/src/services/federation.service.ts
@@ -14,6 +14,7 @@ import {
   type FederationMetadata,
   type WebFingerResponse,
   type DidDocument,
+  type UpdateFederationConfigInput,
 } from '@colophony/types';
 import type { Env } from '../config/env.js';
 import { auditService } from './audit.service.js';
@@ -231,6 +232,44 @@ export const federationService = {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { privateKey, ...publicConfig } = full;
     return publicConfig;
+  },
+
+  /**
+   * Update mutable federation config fields (mode, contactEmail, capabilities).
+   * Uses superuser `db` pool — federation_config has no RLS.
+   * Audit logs the change via logDirect (no org scope).
+   */
+  async updateConfig(
+    env: Env,
+    input: UpdateFederationConfigInput,
+    actorId?: string,
+  ): Promise<FederationPublicConfig> {
+    const current = await this.getOrInitConfig(env);
+
+    const updateFields: Record<string, unknown> = {};
+    if (input.mode !== undefined) updateFields.mode = input.mode;
+    if (input.contactEmail !== undefined)
+      updateFields.contactEmail = input.contactEmail;
+    if (input.capabilities !== undefined)
+      updateFields.capabilities = input.capabilities;
+
+    if (Object.keys(updateFields).length > 0) {
+      await db
+        .update(federationConfig)
+        .set(updateFields)
+        .where(eq(federationConfig.id, current.id));
+    }
+
+    await auditService.logDirect({
+      resource: AuditResources.FEDERATION,
+      action: AuditActions.FEDERATION_CONFIG_UPDATED,
+      actorId,
+      newValue: input,
+    });
+
+    // Return updated public config
+    const updated = await this.getPublicConfig(env);
+    return updated;
   },
 
   /**

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -95,6 +95,12 @@ import {
   WriterProfileNotFoundError,
   WriterProfileDuplicateError,
 } from '../services/writer-profile.service.js';
+import {
+  TrustPeerNotFoundError,
+  TrustPeerAlreadyExistsError,
+  TrustPeerInvalidStateError,
+  RemoteMetadataFetchError,
+} from '../services/trust.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -182,6 +188,11 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [ExternalSubmissionNotFoundError, 'NOT_FOUND'],
   [WriterProfileNotFoundError, 'NOT_FOUND'],
   [WriterProfileDuplicateError, 'CONFLICT'],
+  // Federation trust errors
+  [TrustPeerNotFoundError, 'NOT_FOUND'],
+  [TrustPeerAlreadyExistsError, 'CONFLICT'],
+  [TrustPeerInvalidStateError, 'CONFLICT'],
+  [RemoteMetadataFetchError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -29,6 +29,7 @@ import { externalSubmissionsRouter } from './routers/external-submissions.js';
 import { writerProfilesRouter } from './routers/writer-profiles.js';
 import { journalDirectoryRouter } from './routers/journal-directory.js';
 import { workspaceRouter } from './routers/workspace.js';
+import { federationRouter } from './routers/federation.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -79,6 +80,7 @@ export const appRouter = t.router({
   writerProfiles: writerProfilesRouter,
   journalDirectory: journalDirectoryRouter,
   workspace: workspaceRouter,
+  federation: federationRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/federation.spec.ts
+++ b/apps/api/src/trpc/routers/federation.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock services
+vi.mock('../../services/federation.service.js', () => ({
+  federationService: {
+    getPublicConfig: vi.fn(),
+    updateConfig: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/trust.service.js', () => ({
+  trustService: {
+    fetchRemoteMetadata: vi.fn(),
+    listPeers: vi.fn(),
+    getPeerById: vi.fn(),
+    initiateTrust: vi.fn(),
+    acceptInboundTrust: vi.fn(),
+    rejectTrust: vi.fn(),
+    revokeTrust: vi.fn(),
+  },
+  TrustPeerNotFoundError: class extends Error {
+    override name = 'TrustPeerNotFoundError';
+  },
+  TrustPeerAlreadyExistsError: class extends Error {
+    override name = 'TrustPeerAlreadyExistsError';
+  },
+  TrustPeerInvalidStateError: class extends Error {
+    override name = 'TrustPeerInvalidStateError';
+  },
+  RemoteMetadataFetchError: class extends Error {
+    override name = 'RemoteMetadataFetchError';
+  },
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: () => ({
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: '',
+    FEDERATION_DOMAIN: 'test.example.com',
+  }),
+}));
+
+vi.mock('../init.js', () => {
+  const passthrough = {
+    input: vi.fn().mockReturnThis(),
+    output: vi.fn().mockReturnThis(),
+    query: vi.fn().mockReturnThis(),
+    mutation: vi.fn().mockReturnThis(),
+    use: vi.fn().mockReturnThis(),
+  };
+  return {
+    adminProcedure: passthrough,
+    createRouter: vi.fn((routes) => routes),
+  };
+});
+
+vi.mock('../error-mapper.js', () => ({
+  mapServiceError: vi.fn(),
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    object: vi.fn().mockReturnValue({
+      merge: vi.fn().mockReturnValue({}),
+    }),
+    string: vi.fn().mockReturnValue({
+      uuid: vi.fn().mockReturnValue({}),
+    }),
+  },
+}));
+
+vi.mock('@colophony/types', () => ({
+  updateFederationConfigSchema: {},
+  domainParamSchema: {},
+  initiateTrustSchema: {},
+  peerActionSchema: {},
+}));
+
+// Must import after mocks
+import { federationRouter } from './federation.js';
+
+describe('federationRouter', () => {
+  it('exports all expected procedures', () => {
+    expect(federationRouter).toHaveProperty('getConfig');
+    expect(federationRouter).toHaveProperty('updateConfig');
+    expect(federationRouter).toHaveProperty('previewRemote');
+    expect(federationRouter).toHaveProperty('listPeers');
+    expect(federationRouter).toHaveProperty('getPeer');
+    expect(federationRouter).toHaveProperty('initiateTrust');
+    expect(federationRouter).toHaveProperty('acceptPeer');
+    expect(federationRouter).toHaveProperty('rejectPeer');
+    expect(federationRouter).toHaveProperty('revokePeer');
+  });
+
+  it('has exactly 9 procedures', () => {
+    expect(Object.keys(federationRouter)).toHaveLength(9);
+  });
+
+  it('query procedures include getConfig, previewRemote, listPeers, getPeer', () => {
+    // These are the 4 query procedures — the passthrough mock verifies
+    // they were defined by checking the router keys exist
+    const queryProcedures = [
+      'getConfig',
+      'previewRemote',
+      'listPeers',
+      'getPeer',
+    ];
+    for (const name of queryProcedures) {
+      expect(federationRouter).toHaveProperty(name);
+    }
+  });
+
+  it('mutation procedures include updateConfig, initiateTrust, acceptPeer, rejectPeer, revokePeer', () => {
+    const mutationProcedures = [
+      'updateConfig',
+      'initiateTrust',
+      'acceptPeer',
+      'rejectPeer',
+      'revokePeer',
+    ];
+    for (const name of mutationProcedures) {
+      expect(federationRouter).toHaveProperty(name);
+    }
+  });
+});

--- a/apps/api/src/trpc/routers/federation.ts
+++ b/apps/api/src/trpc/routers/federation.ts
@@ -1,0 +1,122 @@
+import { z } from 'zod';
+import {
+  updateFederationConfigSchema,
+  domainParamSchema,
+  initiateTrustSchema,
+  peerActionSchema,
+} from '@colophony/types';
+import { adminProcedure, createRouter } from '../init.js';
+import { mapServiceError } from '../error-mapper.js';
+import { federationService } from '../../services/federation.service.js';
+import { trustService } from '../../services/trust.service.js';
+import { validateEnv } from '../../config/env.js';
+
+export const federationRouter = createRouter({
+  getConfig: adminProcedure.query(async () => {
+    try {
+      const env = validateEnv();
+      return await federationService.getPublicConfig(env);
+    } catch (error) {
+      mapServiceError(error);
+    }
+  }),
+
+  updateConfig: adminProcedure
+    .input(updateFederationConfigSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const env = validateEnv();
+        const actorId = ctx.authContext.userId;
+        return await federationService.updateConfig(env, input, actorId);
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  previewRemote: adminProcedure
+    .input(domainParamSchema)
+    .query(async ({ input }) => {
+      try {
+        return await trustService.fetchRemoteMetadata(input.domain);
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  listPeers: adminProcedure.query(async ({ ctx }) => {
+    try {
+      const orgId = ctx.authContext.orgId;
+      return await trustService.listPeers(orgId);
+    } catch (error) {
+      mapServiceError(error);
+    }
+  }),
+
+  getPeer: adminProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const orgId = ctx.authContext.orgId;
+        return await trustService.getPeerById(orgId, input.id);
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  initiateTrust: adminProcedure
+    .input(initiateTrustSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const env = validateEnv();
+        const orgId = ctx.authContext.orgId;
+        const actorId = ctx.authContext.userId;
+        return await trustService.initiateTrust(env, orgId, input, actorId);
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  acceptPeer: adminProcedure
+    .input(z.object({ id: z.string().uuid() }).merge(peerActionSchema))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const env = validateEnv();
+        const orgId = ctx.authContext.orgId;
+        const actorId = ctx.authContext.userId;
+        const { id, ...action } = input;
+        return await trustService.acceptInboundTrust(
+          env,
+          orgId,
+          id,
+          action,
+          actorId,
+        );
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  rejectPeer: adminProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const orgId = ctx.authContext.orgId;
+        const actorId = ctx.authContext.userId;
+        return await trustService.rejectTrust(orgId, input.id, actorId);
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  revokePeer: adminProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const orgId = ctx.authContext.orgId;
+        const actorId = ctx.authContext.userId;
+        return await trustService.revokeTrust(orgId, input.id, actorId);
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+});

--- a/apps/web/src/app/(dashboard)/federation/page.tsx
+++ b/apps/web/src/app/(dashboard)/federation/page.tsx
@@ -1,0 +1,9 @@
+import { FederationOverview } from "@/components/federation/federation-overview";
+
+export default function FederationPage() {
+  return (
+    <div className="p-6">
+      <FederationOverview />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/federation/peers/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/federation/peers/[id]/page.tsx
@@ -1,0 +1,14 @@
+import { PeerDetail } from "@/components/federation/peer-detail";
+
+export default async function PeerDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <div className="p-6">
+      <PeerDetail peerId={id} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/federation/peers/page.tsx
+++ b/apps/web/src/app/(dashboard)/federation/peers/page.tsx
@@ -1,0 +1,9 @@
+import { PeerList } from "@/components/federation/peer-list";
+
+export default function PeersPage() {
+  return (
+    <div className="p-6">
+      <PeerList />
+    </div>
+  );
+}

--- a/apps/web/src/components/federation/__tests__/federation-overview.spec.tsx
+++ b/apps/web/src/components/federation/__tests__/federation-overview.spec.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "../../../../test/setup";
+
+let mockConfig: unknown = undefined;
+let mockPeers: unknown[] = [];
+let mockIsConfigLoading = false;
+let mockIsPeersLoading = false;
+
+function resetMocks() {
+  mockConfig = {
+    id: "cfg-1",
+    publicKey: "-----BEGIN PUBLIC KEY-----\nMCowBQ...",
+    keyId: "example.com#main",
+    mode: "allowlist",
+    contactEmail: null,
+    capabilities: ["identity", "simsub.check"],
+    enabled: true,
+  };
+  mockPeers = [
+    { id: "p1", status: "active", domain: "a.com" },
+    { id: "p2", status: "pending_inbound", domain: "b.com" },
+    { id: "p3", status: "pending_outbound", domain: "c.com" },
+    { id: "p4", status: "active", domain: "d.com" },
+  ];
+  mockIsConfigLoading = false;
+  mockIsPeersLoading = false;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    federation: {
+      getConfig: {
+        useQuery: () => ({
+          data: mockIsConfigLoading ? undefined : mockConfig,
+          isPending: mockIsConfigLoading,
+        }),
+      },
+      updateConfig: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+      listPeers: {
+        useQuery: () => ({
+          data: mockIsPeersLoading ? undefined : mockPeers,
+          isPending: mockIsPeersLoading,
+        }),
+      },
+    },
+    useUtils: () => ({
+      federation: {
+        getConfig: { invalidate: jest.fn() },
+      },
+    }),
+  },
+}));
+
+jest.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({
+    isAdmin: true,
+    isEditor: true,
+  }),
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/federation",
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement("a", { href }, children),
+}));
+
+import { FederationOverview } from "../federation-overview";
+
+describe("FederationOverview", () => {
+  beforeEach(resetMocks);
+
+  it("renders loading skeleton when config query is pending", () => {
+    mockIsConfigLoading = true;
+    mockIsPeersLoading = true;
+    render(<FederationOverview />);
+    expect(screen.queryByText("Federation")).not.toBeInTheDocument();
+  });
+
+  it("renders federation status with mode badge and capabilities when loaded", () => {
+    render(<FederationOverview />);
+    expect(screen.getByText("Federation")).toBeInTheDocument();
+    expect(screen.getByText("Enabled")).toBeInTheDocument();
+    expect(screen.getByText("allowlist")).toBeInTheDocument();
+    expect(screen.getByText("identity")).toBeInTheDocument();
+    expect(screen.getByText("simsub.check")).toBeInTheDocument();
+  });
+
+  it("renders peer count summary grouped by status", () => {
+    render(<FederationOverview />);
+    expect(screen.getByText("2 Active")).toBeInTheDocument();
+    expect(screen.getByText("1 Pending Inbound")).toBeInTheDocument();
+    expect(screen.getByText("1 Pending Outbound")).toBeInTheDocument();
+  });
+
+  it("renders disabled badge when enabled is false", () => {
+    mockConfig = {
+      ...(mockConfig as Record<string, unknown>),
+      enabled: false,
+    };
+    render(<FederationOverview />);
+    expect(screen.getByText("Disabled")).toBeInTheDocument();
+    expect(screen.queryByText("Enabled")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/federation/__tests__/peer-detail.spec.tsx
+++ b/apps/web/src/components/federation/__tests__/peer-detail.spec.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "../../../../test/setup";
+
+let mockPeer: unknown = undefined;
+let mockIsPending = false;
+let mockError: unknown = null;
+
+function resetMocks() {
+  mockPeer = {
+    id: "peer-1",
+    organizationId: "org-1",
+    domain: "remote.example.com",
+    instanceUrl: "https://remote.example.com",
+    publicKey: "-----BEGIN PUBLIC KEY-----\nMCowBQ...",
+    keyId: "remote.example.com#main",
+    grantedCapabilities: { "simsub.check": true },
+    status: "active",
+    initiatedBy: "local",
+    protocolVersion: "1.0",
+    lastVerifiedAt: "2026-01-01T00:00:00.000Z",
+    createdAt: "2025-12-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+  mockIsPending = false;
+  mockError = null;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    federation: {
+      getPeer: {
+        useQuery: () => ({
+          data: mockIsPending ? undefined : mockPeer,
+          isPending: mockIsPending,
+          error: mockError,
+        }),
+      },
+      rejectPeer: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+      revokePeer: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+      acceptPeer: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+    },
+    useUtils: () => ({
+      federation: {
+        getPeer: { invalidate: jest.fn() },
+        listPeers: { invalidate: jest.fn() },
+      },
+    }),
+  },
+}));
+
+jest.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({
+    isAdmin: true,
+    isEditor: true,
+  }),
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/federation/peers/peer-1",
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement("a", { href }, children),
+}));
+
+import { PeerDetail } from "../peer-detail";
+
+describe("PeerDetail", () => {
+  beforeEach(resetMocks);
+
+  it("renders peer info card with domain, status, key info", () => {
+    render(<PeerDetail peerId="peer-1" />);
+    expect(screen.getByText("remote.example.com")).toBeInTheDocument();
+    expect(screen.getByText("active")).toBeInTheDocument();
+    expect(screen.getByText("remote.example.com#main")).toBeInTheDocument();
+  });
+
+  it("shows Accept and Reject buttons for pending_inbound peer", () => {
+    mockPeer = {
+      ...(mockPeer as Record<string, unknown>),
+      status: "pending_inbound",
+    };
+    render(<PeerDetail peerId="peer-1" />);
+    expect(screen.getByText("Accept")).toBeInTheDocument();
+    expect(screen.getByText("Reject")).toBeInTheDocument();
+  });
+
+  it("shows Revoke button for active peer", () => {
+    render(<PeerDetail peerId="peer-1" />);
+    expect(screen.getByText("Revoke Trust")).toBeInTheDocument();
+  });
+
+  it("shows no action buttons for rejected/revoked peers", () => {
+    mockPeer = {
+      ...(mockPeer as Record<string, unknown>),
+      status: "revoked",
+    };
+    render(<PeerDetail peerId="peer-1" />);
+    expect(screen.queryByText("Accept")).not.toBeInTheDocument();
+    expect(screen.queryByText("Reject")).not.toBeInTheDocument();
+    expect(screen.queryByText("Revoke Trust")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This trust relationship has been revoked. No actions available.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows waiting message for pending_outbound peer", () => {
+    mockPeer = {
+      ...(mockPeer as Record<string, unknown>),
+      status: "pending_outbound",
+    };
+    render(<PeerDetail peerId="peer-1" />);
+    expect(
+      screen.getByText(
+        "Waiting for the remote instance to accept your trust request.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/federation/__tests__/peer-list.spec.tsx
+++ b/apps/web/src/components/federation/__tests__/peer-list.spec.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "../../../../test/setup";
+
+let mockPeers: unknown[] = [];
+let mockIsPending = false;
+let mockIsAdmin = true;
+
+function resetMocks() {
+  mockPeers = [];
+  mockIsPending = false;
+  mockIsAdmin = true;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    federation: {
+      listPeers: {
+        useQuery: () => ({
+          data: mockIsPending ? undefined : mockPeers,
+          isPending: mockIsPending,
+        }),
+      },
+      previewRemote: {
+        useQuery: () => ({
+          data: undefined,
+          isFetching: false,
+          refetch: jest.fn(),
+        }),
+      },
+      initiateTrust: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+    },
+    useUtils: () => ({
+      federation: {
+        listPeers: { invalidate: jest.fn() },
+      },
+    }),
+  },
+}));
+
+jest.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({
+    isAdmin: mockIsAdmin,
+    isEditor: true,
+  }),
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/federation/peers",
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement("a", { href }, children),
+}));
+
+import { PeerList } from "../peer-list";
+
+describe("PeerList", () => {
+  beforeEach(resetMocks);
+
+  it("renders loading skeleton when pending", () => {
+    mockIsPending = true;
+    render(<PeerList />);
+    expect(screen.queryByText("Trusted Peers")).not.toBeInTheDocument();
+  });
+
+  it("renders empty state when no peers", () => {
+    mockPeers = [];
+    render(<PeerList />);
+    expect(
+      screen.getByText(
+        "No trusted peers yet. Initiate trust with another Colophony instance to get started.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders peer table with domain, status dot, and capabilities", () => {
+    mockPeers = [
+      {
+        id: "p1",
+        domain: "remote.example.com",
+        status: "active",
+        grantedCapabilities: { "simsub.check": true, "identity.verify": true },
+        initiatedBy: "local",
+        lastVerifiedAt: "2026-01-01T00:00:00.000Z",
+        createdAt: "2025-12-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ];
+    render(<PeerList />);
+    expect(screen.getByText("remote.example.com")).toBeInTheDocument();
+    // "Active" appears in both filter tab and status column — use getAllByText
+    expect(screen.getAllByText("Active").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("simsub.check")).toBeInTheDocument();
+  });
+
+  it("status dots use correct colors", () => {
+    mockPeers = [
+      {
+        id: "p1",
+        domain: "active.com",
+        status: "active",
+        grantedCapabilities: {},
+        initiatedBy: "local",
+        lastVerifiedAt: null,
+        createdAt: "2025-12-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        id: "p2",
+        domain: "pending.com",
+        status: "pending_outbound",
+        grantedCapabilities: {},
+        initiatedBy: "local",
+        lastVerifiedAt: null,
+        createdAt: "2025-12-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ];
+    render(<PeerList />);
+    const dots = document.querySelectorAll(".rounded-full");
+    const classes = Array.from(dots).map((d) => d.className);
+    expect(classes.some((c) => c.includes("bg-green-500"))).toBe(true);
+    expect(classes.some((c) => c.includes("bg-yellow-500"))).toBe(true);
+  });
+
+  it("Initiate Trust button renders for admin users", () => {
+    mockIsAdmin = true;
+    render(<PeerList />);
+    expect(screen.getByText("Initiate Trust")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/federation/accept-peer-dialog.tsx
+++ b/apps/web/src/components/federation/accept-peer-dialog.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+
+const CAPABILITIES = [
+  { key: "identity.verify", label: "Identity Verification" },
+  { key: "identity.migrate", label: "Identity Migration" },
+  { key: "simsub.check", label: "Sim-Sub Check" },
+  { key: "simsub.respond", label: "Sim-Sub Respond" },
+  { key: "transfer.initiate", label: "Transfer Initiate" },
+  { key: "transfer.receive", label: "Transfer Receive" },
+];
+
+interface AcceptPeerDialogProps {
+  peerId: string;
+  peerDomain: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function AcceptPeerDialog({
+  peerId,
+  peerDomain,
+  open,
+  onOpenChange,
+}: AcceptPeerDialogProps) {
+  const utils = trpc.useUtils();
+  const [selectedCaps, setSelectedCaps] = useState<Record<string, boolean>>(
+    () => {
+      const caps: Record<string, boolean> = {};
+      for (const c of CAPABILITIES) {
+        caps[c.key] = true;
+      }
+      return caps;
+    },
+  );
+
+  const acceptMutation = trpc.federation.acceptPeer.useMutation({
+    onSuccess: () => {
+      toast.success(`Trust accepted for ${peerDomain}`);
+      utils.federation.getPeer.invalidate({ id: peerId });
+      utils.federation.listPeers.invalidate();
+      onOpenChange(false);
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const toggleCap = (key: string) => {
+    setSelectedCaps((prev) => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
+  };
+
+  const handleAccept = () => {
+    acceptMutation.mutate({
+      id: peerId,
+      grantedCapabilities: selectedCaps,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Accept Trust Request</DialogTitle>
+          <DialogDescription>
+            Grant capabilities to <strong>{peerDomain}</strong>.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label>Grant Capabilities</Label>
+            <div className="space-y-2">
+              {CAPABILITIES.map((cap) => (
+                <div key={cap.key} className="flex items-center gap-2">
+                  <Checkbox
+                    id={`accept-cap-${cap.key}`}
+                    checked={!!selectedCaps[cap.key]}
+                    onCheckedChange={() => toggleCap(cap.key)}
+                  />
+                  <Label
+                    htmlFor={`accept-cap-${cap.key}`}
+                    className="font-normal"
+                  >
+                    {cap.label}
+                  </Label>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleAccept} disabled={acceptMutation.isPending}>
+            {acceptMutation.isPending && (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            )}
+            Accept &amp; Grant Capabilities
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/federation/federation-overview.tsx
+++ b/apps/web/src/components/federation/federation-overview.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { Network, Pencil, Copy, Check } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { toast } from "sonner";
+
+const ALL_CAPABILITIES = [
+  "identity.verify",
+  "identity.migrate",
+  "simsub.check",
+  "simsub.respond",
+  "transfer.initiate",
+  "transfer.receive",
+];
+
+export function FederationOverview() {
+  const { data: config, isPending: isConfigLoading } =
+    trpc.federation.getConfig.useQuery();
+  const { data: peers, isPending: isPeersLoading } =
+    trpc.federation.listPeers.useQuery();
+
+  const peerCounts = useMemo(() => {
+    if (!peers) return { active: 0, pendingInbound: 0, pendingOutbound: 0 };
+    return {
+      active: peers.filter((p) => p.status === "active").length,
+      pendingInbound: peers.filter((p) => p.status === "pending_inbound")
+        .length,
+      pendingOutbound: peers.filter((p) => p.status === "pending_outbound")
+        .length,
+    };
+  }, [peers]);
+
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyKey = async () => {
+    if (!config?.publicKey) return;
+    await navigator.clipboard.writeText(config.publicKey);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (isConfigLoading || isPeersLoading) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-8 w-8" />
+          <Skeleton className="h-8 w-40" />
+        </div>
+        <Skeleton className="h-48 w-full" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Network className="h-8 w-8" />
+        <h1 className="text-2xl font-bold">Federation</h1>
+      </div>
+
+      {/* Status card */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle>Instance Configuration</CardTitle>
+            <CardDescription>
+              Federation settings for this instance
+            </CardDescription>
+          </div>
+          <ConfigEditDialog />
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-muted-foreground">
+                  Status
+                </span>
+                {config?.enabled ? (
+                  <Badge
+                    variant="outline"
+                    className="border-green-500 text-green-700"
+                  >
+                    Enabled
+                  </Badge>
+                ) : (
+                  <Badge variant="secondary">Disabled</Badge>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-muted-foreground">
+                  Mode
+                </span>
+                <Badge variant="outline">{config?.mode}</Badge>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Capabilities
+                </span>
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {config?.capabilities.map((cap) => (
+                    <Badge key={cap} variant="secondary">
+                      {cap}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Contact Email
+                </span>
+                <p className="text-sm">{config?.contactEmail ?? "Not set"}</p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Key ID
+                </span>
+                <p className="text-sm font-mono">{config?.keyId}</p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Public Key
+                </span>
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-mono truncate max-w-[280px]">
+                    {config?.publicKey.slice(0, 40)}...
+                  </p>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6"
+                    onClick={handleCopyKey}
+                  >
+                    {copied ? (
+                      <Check className="h-3 w-3" />
+                    ) : (
+                      <Copy className="h-3 w-3" />
+                    )}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Peer summary card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Trusted Peers</CardTitle>
+          <CardDescription>
+            Overview of federation relationships
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <Badge
+                variant="outline"
+                className="border-green-500 text-green-700"
+              >
+                {peerCounts.active} Active
+              </Badge>
+            </div>
+            <div className="flex items-center gap-2">
+              <Badge
+                variant="outline"
+                className="border-yellow-500 text-yellow-700"
+              >
+                {peerCounts.pendingInbound} Pending Inbound
+              </Badge>
+            </div>
+            <div className="flex items-center gap-2">
+              <Badge
+                variant="outline"
+                className="border-yellow-500 text-yellow-700"
+              >
+                {peerCounts.pendingOutbound} Pending Outbound
+              </Badge>
+            </div>
+          </div>
+          <div className="mt-4">
+            <Button variant="outline" asChild>
+              <Link href="/federation/peers">Manage Peers &rarr;</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function ConfigEditDialog() {
+  const [open, setOpen] = useState(false);
+  const { data: config } = trpc.federation.getConfig.useQuery();
+  const utils = trpc.useUtils();
+
+  const [mode, setMode] = useState<string>("");
+  const [contactEmail, setContactEmail] = useState("");
+  const [capabilities, setCapabilities] = useState<string[]>([]);
+
+  const updateMutation = trpc.federation.updateConfig.useMutation({
+    onSuccess: () => {
+      toast.success("Federation config updated");
+      utils.federation.getConfig.invalidate();
+      setOpen(false);
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const handleOpen = (isOpen: boolean) => {
+    if (isOpen && config) {
+      setMode(config.mode);
+      setContactEmail(config.contactEmail ?? "");
+      setCapabilities(config.capabilities);
+    }
+    setOpen(isOpen);
+  };
+
+  const handleSubmit = () => {
+    updateMutation.mutate({
+      mode: mode as "allowlist" | "open" | "managed_hub",
+      contactEmail: contactEmail || null,
+      capabilities,
+    });
+  };
+
+  const toggleCapability = (cap: string) => {
+    setCapabilities((prev) =>
+      prev.includes(cap) ? prev.filter((c) => c !== cap) : [...prev, cap],
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Pencil className="mr-2 h-4 w-4" />
+          Edit
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Federation Config</DialogTitle>
+          <DialogDescription>
+            Update federation mode, contact email, and capabilities.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="mode">Mode</Label>
+            <Select value={mode} onValueChange={setMode}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select mode" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="allowlist">Allowlist</SelectItem>
+                <SelectItem value="open">Open</SelectItem>
+                <SelectItem value="managed_hub">Managed Hub</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="contactEmail">Contact Email</Label>
+            <Input
+              id="contactEmail"
+              type="email"
+              value={contactEmail}
+              onChange={(e) => setContactEmail(e.target.value)}
+              placeholder="admin@example.com"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Capabilities</Label>
+            <div className="space-y-2">
+              {ALL_CAPABILITIES.map((cap) => (
+                <div key={cap} className="flex items-center gap-2">
+                  <Checkbox
+                    id={`cap-${cap}`}
+                    checked={capabilities.includes(cap)}
+                    onCheckedChange={() => toggleCapability(cap)}
+                  />
+                  <Label htmlFor={`cap-${cap}`} className="font-normal">
+                    {cap}
+                  </Label>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={updateMutation.isPending}>
+            Save Changes
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/federation/initiate-trust-dialog.tsx
+++ b/apps/web/src/components/federation/initiate-trust-dialog.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { toast } from "sonner";
+
+const CAPABILITIES = [
+  { key: "identity.verify", label: "Identity Verification" },
+  { key: "identity.migrate", label: "Identity Migration" },
+  { key: "simsub.check", label: "Sim-Sub Check" },
+  { key: "simsub.respond", label: "Sim-Sub Respond" },
+  { key: "transfer.initiate", label: "Transfer Initiate" },
+  { key: "transfer.receive", label: "Transfer Receive" },
+];
+
+interface InitiateTrustDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function InitiateTrustDialog({
+  open,
+  onOpenChange,
+}: InitiateTrustDialogProps) {
+  const utils = trpc.useUtils();
+  const [step, setStep] = useState<1 | 2>(1);
+  const [domain, setDomain] = useState("");
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [selectedCaps, setSelectedCaps] = useState<Record<string, boolean>>({});
+
+  const previewQuery = trpc.federation.previewRemote.useQuery(
+    { domain },
+    { enabled: false },
+  );
+
+  const initiateMutation = trpc.federation.initiateTrust.useMutation({
+    onSuccess: () => {
+      toast.success("Trust request sent successfully");
+      utils.federation.listPeers.invalidate();
+      resetAndClose();
+    },
+    onError: (error) => {
+      if (error.data?.code === "CONFLICT") {
+        toast.error("Already trusted with this domain");
+      } else {
+        toast.error(error.message);
+      }
+    },
+  });
+
+  const resetAndClose = () => {
+    setStep(1);
+    setDomain("");
+    setPreviewError(null);
+    setSelectedCaps({});
+    onOpenChange(false);
+  };
+
+  const handlePreview = async () => {
+    setPreviewError(null);
+    try {
+      const result = await previewQuery.refetch();
+      if (result.error) {
+        setPreviewError(result.error.message);
+        return;
+      }
+      if (result.data) {
+        // Pre-select capabilities based on remote's advertised capabilities
+        const caps: Record<string, boolean> = {};
+        for (const c of CAPABILITIES) {
+          if (result.data.capabilities.includes(c.key)) {
+            caps[c.key] = true;
+          }
+        }
+        setSelectedCaps(caps);
+        setStep(2);
+      }
+    } catch {
+      setPreviewError("Failed to fetch remote metadata");
+    }
+  };
+
+  const handleInitiate = () => {
+    initiateMutation.mutate({
+      domain,
+      requestedCapabilities: selectedCaps,
+    });
+  };
+
+  const toggleCap = (key: string) => {
+    setSelectedCaps((prev) => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
+  };
+
+  const isDomainValid = /^[a-zA-Z0-9][a-zA-Z0-9.-]+(:\d+)?$/.test(domain);
+
+  return (
+    <Dialog open={open} onOpenChange={resetAndClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Initiate Trust</DialogTitle>
+          <DialogDescription>
+            {step === 1
+              ? "Enter the domain of the remote Colophony instance."
+              : "Select capabilities and confirm the trust request."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === 1 && (
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="domain">Instance Domain</Label>
+              <Input
+                id="domain"
+                value={domain}
+                onChange={(e) => setDomain(e.target.value)}
+                placeholder="example.com"
+              />
+            </div>
+            {previewError && (
+              <p className="text-sm text-destructive">{previewError}</p>
+            )}
+            <DialogFooter>
+              <Button variant="outline" onClick={resetAndClose}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handlePreview}
+                disabled={!isDomainValid || previewQuery.isFetching}
+              >
+                {previewQuery.isFetching && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                Preview
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+
+        {step === 2 && previewQuery.data && (
+          <div className="space-y-4 py-4">
+            <Card>
+              <CardHeader className="py-3">
+                <CardTitle className="text-sm">Remote Instance</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Software</span>
+                  <span>
+                    {previewQuery.data.software} v{previewQuery.data.version}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Mode</span>
+                  <Badge variant="outline">{previewQuery.data.mode}</Badge>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Publications</span>
+                  <span>{previewQuery.data.publicationCount}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Contact</span>
+                  <span>{previewQuery.data.contactEmail ?? "Not set"}</span>
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Capabilities</span>
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {previewQuery.data.capabilities.map((cap) => (
+                      <Badge key={cap} variant="secondary">
+                        {cap}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <div className="space-y-2">
+              <Label>Request Capabilities</Label>
+              <div className="space-y-2">
+                {CAPABILITIES.map((cap) => (
+                  <div key={cap.key} className="flex items-center gap-2">
+                    <Checkbox
+                      id={`init-cap-${cap.key}`}
+                      checked={!!selectedCaps[cap.key]}
+                      onCheckedChange={() => toggleCap(cap.key)}
+                    />
+                    <Label
+                      htmlFor={`init-cap-${cap.key}`}
+                      className="font-normal"
+                    >
+                      {cap.label}
+                    </Label>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setStep(1)}>
+                Back
+              </Button>
+              <Button
+                onClick={handleInitiate}
+                disabled={initiateMutation.isPending}
+              >
+                {initiateMutation.isPending && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                Initiate Trust
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/federation/peer-detail.tsx
+++ b/apps/web/src/components/federation/peer-detail.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Copy, Check } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { AcceptPeerDialog } from "./accept-peer-dialog";
+import { toast } from "sonner";
+import { format } from "date-fns";
+
+const STATUS_VARIANT: Record<
+  string,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  active: "default",
+  pending_outbound: "secondary",
+  pending_inbound: "secondary",
+  rejected: "destructive",
+  revoked: "destructive",
+};
+
+const CAPABILITY_DESCRIPTIONS: Record<string, string> = {
+  "identity.verify": "Verify writer identity across instances",
+  "identity.migrate": "Allow writers to migrate their identity",
+  "simsub.check": "Check for simultaneous submissions",
+  "simsub.respond": "Respond to sim-sub check requests",
+  "transfer.initiate": "Initiate piece transfers to this peer",
+  "transfer.receive": "Receive piece transfers from this peer",
+};
+
+interface PeerDetailProps {
+  peerId: string;
+}
+
+export function PeerDetail({ peerId }: PeerDetailProps) {
+  const utils = trpc.useUtils();
+  const {
+    data: peer,
+    isPending: isLoading,
+    error,
+  } = trpc.federation.getPeer.useQuery({ id: peerId });
+
+  const [acceptOpen, setAcceptOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const rejectMutation = trpc.federation.rejectPeer.useMutation({
+    onSuccess: () => {
+      toast.success("Trust request rejected");
+      utils.federation.getPeer.invalidate({ id: peerId });
+      utils.federation.listPeers.invalidate();
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const revokeMutation = trpc.federation.revokePeer.useMutation({
+    onSuccess: () => {
+      toast.success("Trust revoked");
+      utils.federation.getPeer.invalidate({ id: peerId });
+      utils.federation.listPeers.invalidate();
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const handleCopyKey = async () => {
+    if (!peer?.publicKey) return;
+    await navigator.clipboard.writeText(peer.publicKey);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error || !peer) {
+    return (
+      <div className="space-y-6">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/federation/peers">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Peers
+          </Link>
+        </Button>
+        <p className="text-muted-foreground">Peer not found.</p>
+      </div>
+    );
+  }
+
+  const grantedCaps = Object.entries(peer.grantedCapabilities).filter(
+    ([, v]) => v,
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Back + Header */}
+      <Button variant="ghost" size="sm" asChild>
+        <Link href="/federation/peers">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Peers
+        </Link>
+      </Button>
+
+      <div className="flex items-center gap-3">
+        <h1 className="text-2xl font-bold">{peer.domain}</h1>
+        <Badge variant={STATUS_VARIANT[peer.status] ?? "outline"}>
+          {peer.status.replace(/_/g, " ")}
+        </Badge>
+      </div>
+
+      {/* Info card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Peer Information</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-3">
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Instance URL
+                </span>
+                <p className="text-sm">
+                  <a
+                    href={peer.instanceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:underline"
+                  >
+                    {peer.instanceUrl}
+                  </a>
+                </p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Public Key
+                </span>
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-mono truncate max-w-[280px]">
+                    {peer.publicKey.slice(0, 40)}...
+                  </p>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6"
+                    onClick={handleCopyKey}
+                  >
+                    {copied ? (
+                      <Check className="h-3 w-3" />
+                    ) : (
+                      <Copy className="h-3 w-3" />
+                    )}
+                  </Button>
+                </div>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Key ID
+                </span>
+                <p className="text-sm font-mono">{peer.keyId}</p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Protocol Version
+                </span>
+                <p className="text-sm">{peer.protocolVersion}</p>
+              </div>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Initiated By
+                </span>
+                <p className="text-sm capitalize">{peer.initiatedBy}</p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Last Verified
+                </span>
+                <p className="text-sm">
+                  {peer.lastVerifiedAt
+                    ? format(new Date(peer.lastVerifiedAt), "PPpp")
+                    : "Never"}
+                </p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Created
+                </span>
+                <p className="text-sm">
+                  {format(new Date(peer.createdAt), "PPpp")}
+                </p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Updated
+                </span>
+                <p className="text-sm">
+                  {format(new Date(peer.updatedAt), "PPpp")}
+                </p>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Capabilities card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Granted Capabilities</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {grantedCaps.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No capabilities granted yet.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {grantedCaps.map(([key]) => (
+                <div key={key} className="flex items-center gap-2">
+                  <Badge variant="secondary">{key}</Badge>
+                  <span className="text-sm text-muted-foreground">
+                    {CAPABILITY_DESCRIPTIONS[key] ?? ""}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Actions */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Actions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {peer.status === "pending_inbound" && (
+            <div className="flex gap-3">
+              <Button onClick={() => setAcceptOpen(true)}>Accept</Button>
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button variant="destructive">Reject</Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Reject Trust Request</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Are you sure you want to reject the trust request from{" "}
+                      <strong>{peer.domain}</strong>? This action cannot be
+                      undone.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => rejectMutation.mutate({ id: peerId })}
+                    >
+                      Reject
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </div>
+          )}
+
+          {peer.status === "active" && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive">Revoke Trust</Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Revoke Trust</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Are you sure you want to revoke trust with{" "}
+                    <strong>{peer.domain}</strong>? This will terminate all
+                    federation capabilities with this instance.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => revokeMutation.mutate({ id: peerId })}
+                  >
+                    Revoke
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+
+          {peer.status === "pending_outbound" && (
+            <p className="text-sm text-muted-foreground">
+              Waiting for the remote instance to accept your trust request.
+            </p>
+          )}
+
+          {(peer.status === "rejected" || peer.status === "revoked") && (
+            <p className="text-sm text-muted-foreground">
+              This trust relationship has been {peer.status}. No actions
+              available.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <AcceptPeerDialog
+        peerId={peerId}
+        peerDomain={peer.domain}
+        open={acceptOpen}
+        onOpenChange={setAcceptOpen}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/federation/peer-list.tsx
+++ b/apps/web/src/components/federation/peer-list.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, Plus } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { InitiateTrustDialog } from "./initiate-trust-dialog";
+import { formatDistanceToNow } from "date-fns";
+
+const PEER_STATUS_COLORS: Record<string, string> = {
+  active: "bg-green-500",
+  pending_outbound: "bg-yellow-500",
+  pending_inbound: "bg-amber-500",
+  rejected: "bg-red-500",
+  revoked: "bg-red-500",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  active: "Active",
+  pending_outbound: "Pending Outbound",
+  pending_inbound: "Pending Inbound",
+  rejected: "Rejected",
+  revoked: "Revoked",
+};
+
+type FilterTab = "all" | "active" | "pending" | "revoked";
+
+export function PeerList() {
+  const router = useRouter();
+  const { data: peers, isPending: isLoading } =
+    trpc.federation.listPeers.useQuery();
+  const [tab, setTab] = useState<FilterTab>("all");
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const filteredPeers = useMemo(() => {
+    if (!peers) return [];
+    switch (tab) {
+      case "active":
+        return peers.filter((p) => p.status === "active");
+      case "pending":
+        return peers.filter(
+          (p) =>
+            p.status === "pending_outbound" || p.status === "pending_inbound",
+        );
+      case "revoked":
+        return peers.filter(
+          (p) => p.status === "revoked" || p.status === "rejected",
+        );
+      default:
+        return peers;
+    }
+  }, [peers, tab]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon" asChild>
+            <Link href="/federation">
+              <ArrowLeft className="h-4 w-4" />
+            </Link>
+          </Button>
+          <h1 className="text-2xl font-bold">Trusted Peers</h1>
+        </div>
+        <Button onClick={() => setDialogOpen(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          Initiate Trust
+        </Button>
+      </div>
+
+      {/* Filter tabs */}
+      <Tabs value={tab} onValueChange={(v) => setTab(v as FilterTab)}>
+        <TabsList>
+          <TabsTrigger value="all">All</TabsTrigger>
+          <TabsTrigger value="active">Active</TabsTrigger>
+          <TabsTrigger value="pending">Pending</TabsTrigger>
+          <TabsTrigger value="revoked">Revoked</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {/* Table */}
+      <Card>
+        <CardContent className="p-0">
+          {filteredPeers.length === 0 ? (
+            <div className="p-8 text-center text-muted-foreground">
+              {peers?.length === 0
+                ? "No trusted peers yet. Initiate trust with another Colophony instance to get started."
+                : "No peers match the current filter."}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Domain</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Capabilities</TableHead>
+                  <TableHead>Initiated By</TableHead>
+                  <TableHead>Last Verified</TableHead>
+                  <TableHead>Created</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredPeers.map((peer) => {
+                  const caps = Object.entries(peer.grantedCapabilities).filter(
+                    ([, v]) => v,
+                  );
+                  return (
+                    <TableRow
+                      key={peer.id}
+                      className="cursor-pointer"
+                      onClick={() =>
+                        router.push(`/federation/peers/${peer.id}`)
+                      }
+                    >
+                      <TableCell className="font-medium">
+                        {peer.domain}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`inline-block h-2 w-2 rounded-full ${PEER_STATUS_COLORS[peer.status] ?? "bg-gray-400"}`}
+                          />
+                          {STATUS_LABELS[peer.status] ?? peer.status}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex gap-1">
+                          {caps.slice(0, 2).map(([key]) => (
+                            <Badge key={key} variant="secondary">
+                              {key}
+                            </Badge>
+                          ))}
+                          {caps.length > 2 && (
+                            <Badge variant="outline">+{caps.length - 2}</Badge>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>{peer.initiatedBy}</TableCell>
+                      <TableCell>
+                        {peer.lastVerifiedAt
+                          ? formatDistanceToNow(new Date(peer.lastVerifiedAt), {
+                              addSuffix: true,
+                            })
+                          : "Never"}
+                      </TableCell>
+                      <TableCell>
+                        {formatDistanceToNow(new Date(peer.createdAt), {
+                          addSuffix: true,
+                        })}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <InitiateTrustDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/__tests__/sidebar.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/sidebar.spec.tsx
@@ -154,6 +154,14 @@ describe("Sidebar", () => {
     expect(dashboardLink?.className).toMatch(/(?:^|\s)bg-accent(?:\s|$)/);
   });
 
+  it("should show Federation link in admin section when isAdmin", () => {
+    mockIsAdmin = true;
+    render(<Sidebar />);
+    const link = screen.getByText("Federation");
+    expect(link).toBeInTheDocument();
+    expect(link.closest("a")).toHaveAttribute("href", "/federation");
+  });
+
   it("should highlight Forms on sub-routes like /editor/forms/new", () => {
     mockIsEditor = true;
     mockPathname = "/editor/forms/new";

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -22,6 +22,7 @@ import {
   LayoutDashboard,
   Library,
   Mail,
+  Network,
   Puzzle,
   Send,
   Settings,
@@ -80,6 +81,11 @@ const adminNavigation = [
     name: "Plugins",
     href: "/plugins",
     icon: Puzzle,
+  },
+  {
+    name: "Federation",
+    href: "/federation",
+    icon: Network,
   },
 ];
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -405,10 +405,10 @@
 
 ## Track 10 — Federation Admin UI (Pre-Launch)
 
-> **Status:** Not started. All federation management is currently API-only. Required before any instance other than Write or Die joins the network.
+> **Status:** In progress. P1 shipped (PR1: trust dashboard + overview). P2/P3 pending.
 
-- [ ] [P1] Trust management dashboard — list trusted peers with status, capabilities, last-verified; initiate/accept/reject/revoke trust relationships; preview remote instance metadata before trusting — (persona gap analysis 2026-02-27)
-- [ ] [P1] Federation status overview — current instance mode (allowlist/open/managed_hub), capabilities enabled, instance public key, DID document link — (persona gap analysis 2026-02-27)
+- [x] [P1] Trust management dashboard — list trusted peers with status, capabilities, last-verified; initiate/accept/reject/revoke trust relationships; preview remote instance metadata before trusting — (persona gap analysis 2026-02-27)
+- [x] [P1] Federation status overview — current instance mode (allowlist/open/managed_hub), capabilities enabled, instance public key, DID document link — (persona gap analysis 2026-02-27)
 - [ ] [P2] Sim-sub admin UI — view sim-sub check history per submission, grant overrides, see conflict details — (persona gap analysis 2026-02-27)
 - [ ] [P2] Transfer management UI — list inbound/outbound transfers, view status, cancel pending — (persona gap analysis 2026-02-27)
 - [ ] [P2] Migration management UI — list pending migrations, approve/reject outbound, view history — (persona gap analysis 2026-02-27)

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -180,6 +180,7 @@ export const AuditActions = {
   FEDERATION_TRUST_REVOKED: "FEDERATION_TRUST_REVOKED",
   FEDERATION_TRUST_RECEIVED: "FEDERATION_TRUST_RECEIVED",
   FEDERATION_TRUST_AUTO_ACCEPTED: "FEDERATION_TRUST_AUTO_ACCEPTED",
+  FEDERATION_CONFIG_UPDATED: "FEDERATION_CONFIG_UPDATED",
 
   // Hub lifecycle
   HUB_INSTANCE_REGISTERED: "HUB_INSTANCE_REGISTERED",
@@ -497,7 +498,8 @@ export interface FederationAuditParams extends BaseAuditParams {
     | typeof AuditActions.FEDERATION_TRUST_REJECTED
     | typeof AuditActions.FEDERATION_TRUST_REVOKED
     | typeof AuditActions.FEDERATION_TRUST_RECEIVED
-    | typeof AuditActions.FEDERATION_TRUST_AUTO_ACCEPTED;
+    | typeof AuditActions.FEDERATION_TRUST_AUTO_ACCEPTED
+    | typeof AuditActions.FEDERATION_CONFIG_UPDATED;
 }
 
 export interface SimSubAuditParams extends BaseAuditParams {

--- a/packages/types/src/federation.ts
+++ b/packages/types/src/federation.ts
@@ -186,6 +186,28 @@ export const remoteMetadataPreviewSchema = z.object({
 
 export type RemoteMetadataPreview = z.infer<typeof remoteMetadataPreviewSchema>;
 
+export const updateFederationConfigSchema = z.object({
+  mode: z.enum(["allowlist", "open", "managed_hub"]).optional(),
+  contactEmail: z.string().email().nullable().optional(),
+  capabilities: z.array(z.string()).optional(),
+});
+export type UpdateFederationConfigInput = z.infer<
+  typeof updateFederationConfigSchema
+>;
+
+export const federationPublicConfigSchema = z.object({
+  id: z.string(),
+  publicKey: z.string(),
+  keyId: z.string(),
+  mode: z.enum(["allowlist", "open", "managed_hub"]),
+  contactEmail: z.string().nullable(),
+  capabilities: z.array(z.string()),
+  enabled: z.boolean(),
+});
+export type FederationPublicConfig = z.infer<
+  typeof federationPublicConfigSchema
+>;
+
 export const domainParamSchema = z.object({
   domain: z
     .string()


### PR DESCRIPTION
## Summary

- **Federation overview page** — displays instance config (mode, capabilities, public key, contact email) with inline edit dialog, plus peer count summary badges
- **Trust management** — peer list with status tabs (all/active/pending/revoked), initiate trust 2-step wizard (domain preview → capability selection), accept/reject/revoke actions with confirmation dialogs
- **Peer detail view** — full peer info, granted capabilities with descriptions, status-specific action buttons
- **tRPC federation router** — 9 procedures (getConfig, updateConfig, previewRemote, listPeers, getPeer, initiateTrust, acceptPeer, rejectPeer, revokePeer) via adminProcedure
- **Sidebar** — Federation link in admin navigation section

## What's included

### Backend
- `apps/api/src/trpc/routers/federation.ts` — 9 procedures wrapping federation + trust services
- `apps/api/src/trpc/error-mapper.ts` — 4 federation error mappings (TrustPeerNotFound, AlreadyExists, InvalidState, RemoteMetadataFetch)
- `apps/api/src/services/federation.service.ts` — `getPublicConfig` (private key never loaded into memory)
- `packages/types/src/federation.ts` — trust/config/preview Zod schemas
- `packages/types/src/audit.ts` — 11 federation audit actions, FEDERATION resource, FederationAuditParams

### Frontend
- `apps/web/src/app/(dashboard)/federation/` — 3 page routes (overview, peers list, peer detail)
- `apps/web/src/components/federation/` — 5 components (overview, peer-list, peer-detail, initiate-trust-dialog, accept-peer-dialog)
- `apps/web/src/components/layout/sidebar.tsx` — Federation link in admin nav

### Tests
- Router structural tests (4 tests)
- Federation overview tests (4 tests — loading, badges, peer counts, disabled state)
- Peer list tests (5 tests — loading, empty state, table rendering, status dots, admin button)
- Peer detail tests (5 tests — info card, pending inbound actions, active revoke, revoked no-actions, pending outbound message)
- Sidebar test (+1 — federation link for admins)

## Deferred to PR2

- Sim-sub admin UI (P2)
- Transfer management UI (P2)
- Migration management UI (P2)
- Hub admin UI (P3)
- Audit log viewer (P3)

## Test plan

- [ ] `pnpm type-check` passes (14/14 projects)
- [ ] `pnpm lint` passes (0 errors, pre-existing warnings only)
- [ ] `pnpm test` passes (all suites)
- [ ] Navigate to `/federation` — overview with config + peer summary
- [ ] Click "Manage Peers" — peer list with tabs
- [ ] Click "Initiate Trust" — domain input, preview step
- [ ] Navigate to a peer detail — info, capabilities, actions
- [ ] Edit config — mode/capabilities/email update saves