### PR TITLE
feat(register): federation admin UI — remaining 5 sub-pages

### DIFF
--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -304,6 +304,10 @@ git checkout -b <prefix>/<branch-name>
 
 If the user is already on a feature branch, skip this step entirely.
 
+### Step 9: Auto-enter plan mode
+
+After creating the branch (or if already on a feature branch), **immediately enter plan mode** using EnterPlanMode — do not ask the user for confirmation. The session focus was just selected; planning is the obvious next step. Waiting for the user to confirm wastes time when they may have stepped away from the terminal.
+
 ## Important notes
 
 - This is a READ-ONLY operation — do not modify any files or start any services (exception: if the user opts for catch-up housekeeping in Step 1, perform end-session steps before continuing)

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -101,6 +101,11 @@ import {
   TrustPeerInvalidStateError,
   RemoteMetadataFetchError,
 } from '../services/trust.service.js';
+import {
+  HubNotEnabledError,
+  HubInstanceNotFoundError,
+  HubInstanceSuspendedError,
+} from '../services/hub.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -193,6 +198,10 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [TrustPeerAlreadyExistsError, 'CONFLICT'],
   [TrustPeerInvalidStateError, 'CONFLICT'],
   [RemoteMetadataFetchError, 'BAD_REQUEST'],
+  // Hub errors
+  [HubNotEnabledError, 'NOT_FOUND'],
+  [HubInstanceNotFoundError, 'NOT_FOUND'],
+  [HubInstanceSuspendedError, 'FORBIDDEN'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
 ];

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -30,6 +30,10 @@ import { writerProfilesRouter } from './routers/writer-profiles.js';
 import { journalDirectoryRouter } from './routers/journal-directory.js';
 import { workspaceRouter } from './routers/workspace.js';
 import { federationRouter } from './routers/federation.js';
+import { simsubRouter } from './routers/simsub.js';
+import { transferRouter } from './routers/transfer.js';
+import { migrationRouter } from './routers/migration.js';
+import { hubRouter } from './routers/hub.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -81,6 +85,10 @@ export const appRouter = t.router({
   journalDirectory: journalDirectoryRouter,
   workspace: workspaceRouter,
   federation: federationRouter,
+  simsub: simsubRouter,
+  transfers: transferRouter,
+  migrations: migrationRouter,
+  hub: hubRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/hub.spec.ts
+++ b/apps/api/src/trpc/routers/hub.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../services/hub.service.js', () => ({
+  hubService: {
+    assertHubMode: vi.fn(),
+    listInstances: vi.fn(),
+    getInstanceById: vi.fn(),
+    suspendInstance: vi.fn(),
+    revokeInstance: vi.fn(),
+  },
+  HubNotEnabledError: class extends Error {
+    override name = 'HubNotEnabledError';
+  },
+  HubInstanceNotFoundError: class extends Error {
+    override name = 'HubInstanceNotFoundError';
+  },
+  HubInstanceSuspendedError: class extends Error {
+    override name = 'HubInstanceSuspendedError';
+  },
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: () => ({
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: '',
+  }),
+}));
+
+vi.mock('../init.js', () => {
+  const passthrough = {
+    input: vi.fn().mockReturnThis(),
+    output: vi.fn().mockReturnThis(),
+    query: vi.fn().mockReturnThis(),
+    mutation: vi.fn().mockReturnThis(),
+    use: vi.fn().mockReturnThis(),
+  };
+  return {
+    adminProcedure: passthrough,
+    createRouter: vi.fn((routes) => routes),
+  };
+});
+
+vi.mock('../error-mapper.js', () => ({
+  mapServiceError: vi.fn(),
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    object: vi.fn().mockReturnValue({
+      merge: vi.fn().mockReturnValue({}),
+      optional: vi.fn().mockReturnValue({}),
+    }),
+    string: vi.fn().mockReturnValue({
+      uuid: vi.fn().mockReturnValue({}),
+    }),
+  },
+}));
+
+vi.mock('@colophony/types', () => ({
+  hubInstanceListQuerySchema: { optional: vi.fn().mockReturnValue({}) },
+}));
+
+import { hubRouter } from './hub.js';
+
+describe('hubRouter', () => {
+  it('exports all expected procedures', () => {
+    expect(hubRouter).toHaveProperty('listInstances');
+    expect(hubRouter).toHaveProperty('getInstanceById');
+    expect(hubRouter).toHaveProperty('suspendInstance');
+    expect(hubRouter).toHaveProperty('revokeInstance');
+  });
+
+  it('has exactly 4 procedures', () => {
+    expect(Object.keys(hubRouter)).toHaveLength(4);
+  });
+});

--- a/apps/api/src/trpc/routers/hub.ts
+++ b/apps/api/src/trpc/routers/hub.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import { hubInstanceListQuerySchema } from '@colophony/types';
+import { adminProcedure, createRouter } from '../init.js';
+import { mapServiceError } from '../error-mapper.js';
+import { hubService } from '../../services/hub.service.js';
+import { validateEnv } from '../../config/env.js';
+
+export const hubRouter = createRouter({
+  listInstances: adminProcedure
+    .input(hubInstanceListQuerySchema.optional())
+    .query(async ({ input }) => {
+      try {
+        const env = validateEnv();
+        await hubService.assertHubMode(env);
+        return await hubService.listInstances(input ?? undefined);
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  getInstanceById: adminProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .query(async ({ input }) => {
+      try {
+        const env = validateEnv();
+        await hubService.assertHubMode(env);
+        return await hubService.getInstanceById(input.id);
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  suspendInstance: adminProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const env = validateEnv();
+        await hubService.assertHubMode(env);
+        const actorId = ctx.authContext.userId;
+        await hubService.suspendInstance(input.id, actorId);
+        return { success: true };
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  revokeInstance: adminProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const env = validateEnv();
+        await hubService.assertHubMode(env);
+        const actorId = ctx.authContext.userId;
+        await hubService.revokeInstance(input.id, actorId);
+        return { success: true };
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+});

--- a/apps/api/src/trpc/routers/migration.spec.ts
+++ b/apps/api/src/trpc/routers/migration.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../services/migration.service.js', () => ({
+  migrationService: {
+    listMigrationsForUser: vi.fn(),
+    getMigrationById: vi.fn(),
+    getPendingApprovalForUser: vi.fn(),
+    requestMigration: vi.fn(),
+    approveMigration: vi.fn(),
+    rejectMigration: vi.fn(),
+    cancelMigration: vi.fn(),
+  },
+  MigrationNotFoundError: class extends Error {
+    override name = 'MigrationNotFoundError';
+  },
+  MigrationInvalidStateError: class extends Error {
+    override name = 'MigrationInvalidStateError';
+  },
+  MigrationCapabilityError: class extends Error {
+    override name = 'MigrationCapabilityError';
+  },
+  MigrationAlreadyActiveError: class extends Error {
+    override name = 'MigrationAlreadyActiveError';
+  },
+  MigrationUserNotFoundError: class extends Error {
+    override name = 'MigrationUserNotFoundError';
+  },
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: () => ({
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: '',
+  }),
+}));
+
+vi.mock('../init.js', () => {
+  const passthrough = {
+    input: vi.fn().mockReturnThis(),
+    output: vi.fn().mockReturnThis(),
+    query: vi.fn().mockReturnThis(),
+    mutation: vi.fn().mockReturnThis(),
+    use: vi.fn().mockReturnThis(),
+  };
+  return {
+    authedProcedure: passthrough,
+    createRouter: vi.fn((routes) => routes),
+  };
+});
+
+vi.mock('../error-mapper.js', () => ({
+  mapServiceError: vi.fn(),
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    object: vi.fn().mockReturnValue({
+      merge: vi.fn().mockReturnValue({}),
+    }),
+    string: vi.fn().mockReturnValue({
+      uuid: vi.fn().mockReturnValue({}),
+    }),
+  },
+}));
+
+vi.mock('@colophony/types', () => ({
+  migrationListQuerySchema: {},
+  requestMigrationInputSchema: {},
+}));
+
+import { migrationRouter } from './migration.js';
+
+describe('migrationRouter', () => {
+  it('exports all expected procedures', () => {
+    expect(migrationRouter).toHaveProperty('list');
+    expect(migrationRouter).toHaveProperty('getById');
+    expect(migrationRouter).toHaveProperty('listPending');
+    expect(migrationRouter).toHaveProperty('request');
+    expect(migrationRouter).toHaveProperty('approve');
+    expect(migrationRouter).toHaveProperty('reject');
+    expect(migrationRouter).toHaveProperty('cancel');
+  });
+
+  it('has exactly 7 procedures', () => {
+    expect(Object.keys(migrationRouter)).toHaveLength(7);
+  });
+
+  it('query procedures include list, getById, listPending', () => {
+    const queryProcedures = ['list', 'getById', 'listPending'];
+    for (const name of queryProcedures) {
+      expect(migrationRouter).toHaveProperty(name);
+    }
+  });
+
+  it('mutation procedures include request, approve, reject, cancel', () => {
+    const mutationProcedures = ['request', 'approve', 'reject', 'cancel'];
+    for (const name of mutationProcedures) {
+      expect(migrationRouter).toHaveProperty(name);
+    }
+  });
+});

--- a/apps/api/src/trpc/routers/migration.ts
+++ b/apps/api/src/trpc/routers/migration.ts
@@ -1,0 +1,103 @@
+import { z } from 'zod';
+import {
+  migrationListQuerySchema,
+  requestMigrationInputSchema,
+} from '@colophony/types';
+import { authedProcedure, createRouter } from '../init.js';
+import { mapServiceError } from '../error-mapper.js';
+import { migrationService } from '../../services/migration.service.js';
+import { validateEnv } from '../../config/env.js';
+
+export const migrationRouter = createRouter({
+  list: authedProcedure
+    .input(migrationListQuerySchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        const userId = ctx.authContext.userId;
+        return await migrationService.listMigrationsForUser(userId, input);
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  getById: authedProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const userId = ctx.authContext.userId;
+        return await migrationService.getMigrationById(userId, input.id);
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  listPending: authedProcedure.query(async ({ ctx }) => {
+    try {
+      const userId = ctx.authContext.userId;
+      return await migrationService.getPendingApprovalForUser(userId);
+    } catch (error) {
+      mapServiceError(error);
+    }
+  }),
+
+  request: authedProcedure
+    .input(requestMigrationInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const env = validateEnv();
+        const userId = ctx.authContext.userId;
+        return await migrationService.requestMigration(env, {
+          userId,
+          organizationId: input.organizationId,
+          originDomain: input.originDomain,
+          originEmail: input.originEmail,
+        });
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  approve: authedProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const env = validateEnv();
+        const userId = ctx.authContext.userId;
+        await migrationService.approveMigration(env, {
+          userId,
+          migrationId: input.id,
+        });
+        return { success: true };
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  reject: authedProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const env = validateEnv();
+        const userId = ctx.authContext.userId;
+        await migrationService.rejectMigration(env, {
+          userId,
+          migrationId: input.id,
+        });
+        return { success: true };
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  cancel: authedProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const userId = ctx.authContext.userId;
+        await migrationService.cancelMigration(userId, input.id);
+        return { success: true };
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+});

--- a/apps/api/src/trpc/routers/simsub.spec.ts
+++ b/apps/api/src/trpc/routers/simsub.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@colophony/db', () => ({
+  withRls: vi.fn(),
+  simSubChecks: {},
+  eq: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  desc: vi.fn(),
+}));
+
+vi.mock('../../services/simsub.service.js', () => ({
+  simsubService: {
+    grantOverride: vi.fn(),
+  },
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: () => ({
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: '',
+  }),
+}));
+
+vi.mock('../init.js', () => {
+  const passthrough = {
+    input: vi.fn().mockReturnThis(),
+    output: vi.fn().mockReturnThis(),
+    query: vi.fn().mockReturnThis(),
+    mutation: vi.fn().mockReturnThis(),
+    use: vi.fn().mockReturnThis(),
+  };
+  return {
+    adminProcedure: passthrough,
+    createRouter: vi.fn((routes) => routes),
+  };
+});
+
+vi.mock('../error-mapper.js', () => ({
+  mapServiceError: vi.fn(),
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    object: vi.fn().mockReturnValue({
+      merge: vi.fn().mockReturnValue({}),
+    }),
+    string: vi.fn().mockReturnValue({
+      uuid: vi.fn().mockReturnValue({}),
+    }),
+  },
+}));
+
+import { simsubRouter } from './simsub.js';
+
+describe('simsubRouter', () => {
+  it('exports all expected procedures', () => {
+    expect(simsubRouter).toHaveProperty('listChecks');
+    expect(simsubRouter).toHaveProperty('grantOverride');
+  });
+
+  it('has exactly 2 procedures', () => {
+    expect(Object.keys(simsubRouter)).toHaveLength(2);
+  });
+});

--- a/apps/api/src/trpc/routers/simsub.ts
+++ b/apps/api/src/trpc/routers/simsub.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import { withRls, simSubChecks, eq } from '@colophony/db';
+import { desc } from 'drizzle-orm';
+import { adminProcedure, createRouter } from '../init.js';
+import { mapServiceError } from '../error-mapper.js';
+import { simsubService } from '../../services/simsub.service.js';
+
+export const simsubRouter = createRouter({
+  listChecks: adminProcedure
+    .input(z.object({ submissionId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const orgId = ctx.authContext.orgId;
+        return await withRls({ orgId }, async (tx) => {
+          return tx
+            .select()
+            .from(simSubChecks)
+            .where(eq(simSubChecks.submissionId, input.submissionId))
+            .orderBy(desc(simSubChecks.createdAt));
+        });
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  grantOverride: adminProcedure
+    .input(z.object({ submissionId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const orgId = ctx.authContext.orgId;
+        const userId = ctx.authContext.userId;
+        await simsubService.grantOverride(orgId, input.submissionId, userId);
+        return { success: true };
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+});

--- a/apps/api/src/trpc/routers/transfer.spec.ts
+++ b/apps/api/src/trpc/routers/transfer.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../services/transfer.service.js', () => ({
+  transferService: {
+    listTransfersForOrg: vi.fn(),
+    getTransferById: vi.fn(),
+    cancelTransfer: vi.fn(),
+  },
+  TransferNotFoundError: class extends Error {
+    override name = 'TransferNotFoundError';
+  },
+  TransferInvalidStateError: class extends Error {
+    override name = 'TransferInvalidStateError';
+  },
+  TransferCapabilityError: class extends Error {
+    override name = 'TransferCapabilityError';
+  },
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: () => ({
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: '',
+  }),
+}));
+
+vi.mock('../init.js', () => {
+  const passthrough = {
+    input: vi.fn().mockReturnThis(),
+    output: vi.fn().mockReturnThis(),
+    query: vi.fn().mockReturnThis(),
+    mutation: vi.fn().mockReturnThis(),
+    use: vi.fn().mockReturnThis(),
+  };
+  return {
+    adminProcedure: passthrough,
+    createRouter: vi.fn((routes) => routes),
+  };
+});
+
+vi.mock('../error-mapper.js', () => ({
+  mapServiceError: vi.fn(),
+}));
+
+vi.mock('zod', () => ({
+  z: {
+    object: vi.fn().mockReturnValue({
+      merge: vi.fn().mockReturnValue({}),
+    }),
+    string: vi.fn().mockReturnValue({
+      uuid: vi.fn().mockReturnValue({}),
+    }),
+  },
+}));
+
+vi.mock('@colophony/types', () => ({
+  transferListQuerySchema: {},
+}));
+
+import { transferRouter } from './transfer.js';
+
+describe('transferRouter', () => {
+  it('exports all expected procedures', () => {
+    expect(transferRouter).toHaveProperty('list');
+    expect(transferRouter).toHaveProperty('getById');
+    expect(transferRouter).toHaveProperty('cancel');
+  });
+
+  it('has exactly 3 procedures', () => {
+    expect(Object.keys(transferRouter)).toHaveLength(3);
+  });
+});

--- a/apps/api/src/trpc/routers/transfer.ts
+++ b/apps/api/src/trpc/routers/transfer.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { transferListQuerySchema } from '@colophony/types';
+import { adminProcedure, createRouter } from '../init.js';
+import { mapServiceError } from '../error-mapper.js';
+import { transferService } from '../../services/transfer.service.js';
+
+export const transferRouter = createRouter({
+  list: adminProcedure
+    .input(transferListQuerySchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        const orgId = ctx.authContext.orgId;
+        return await transferService.listTransfersForOrg(orgId, input);
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  getById: adminProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const orgId = ctx.authContext.orgId;
+        return await transferService.getTransferById(orgId, input.id);
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+
+  cancel: adminProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const orgId = ctx.authContext.orgId;
+        const userId = ctx.authContext.userId;
+        await transferService.cancelTransfer(orgId, userId, input.id);
+        return { success: true };
+      } catch (error) {
+        mapServiceError(error);
+      }
+    }),
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",

--- a/apps/web/src/app/(dashboard)/federation/audit/page.tsx
+++ b/apps/web/src/app/(dashboard)/federation/audit/page.tsx
@@ -1,0 +1,9 @@
+import { AuditLogViewer } from "@/components/federation/audit-log-viewer";
+
+export default function AuditPage() {
+  return (
+    <div className="p-6">
+      <AuditLogViewer />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/federation/hub/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/federation/hub/[id]/page.tsx
@@ -1,0 +1,14 @@
+import { HubInstanceDetail } from "@/components/federation/hub-instance-detail";
+
+export default async function HubInstanceDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <div className="p-6">
+      <HubInstanceDetail instanceId={id} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/federation/hub/page.tsx
+++ b/apps/web/src/app/(dashboard)/federation/hub/page.tsx
@@ -1,0 +1,9 @@
+import { HubAdmin } from "@/components/federation/hub-admin";
+
+export default function HubPage() {
+  return (
+    <div className="p-6">
+      <HubAdmin />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/federation/migrations/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/federation/migrations/[id]/page.tsx
@@ -1,0 +1,14 @@
+import { MigrationDetail } from "@/components/federation/migration-detail";
+
+export default async function MigrationDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <div className="p-6">
+      <MigrationDetail migrationId={id} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/federation/migrations/page.tsx
+++ b/apps/web/src/app/(dashboard)/federation/migrations/page.tsx
@@ -1,0 +1,9 @@
+import { MigrationList } from "@/components/federation/migration-list";
+
+export default function MigrationsPage() {
+  return (
+    <div className="p-6">
+      <MigrationList />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/federation/sim-sub/page.tsx
+++ b/apps/web/src/app/(dashboard)/federation/sim-sub/page.tsx
@@ -1,0 +1,9 @@
+import { SimSubAdmin } from "@/components/federation/sim-sub-admin";
+
+export default function SimSubPage() {
+  return (
+    <div className="p-6">
+      <SimSubAdmin />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/federation/transfers/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/federation/transfers/[id]/page.tsx
@@ -1,0 +1,14 @@
+import { TransferDetail } from "@/components/federation/transfer-detail";
+
+export default async function TransferDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <div className="p-6">
+      <TransferDetail transferId={id} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/federation/transfers/page.tsx
+++ b/apps/web/src/app/(dashboard)/federation/transfers/page.tsx
@@ -1,0 +1,9 @@
+import { TransferList } from "@/components/federation/transfer-list";
+
+export default function TransfersPage() {
+  return (
+    <div className="p-6">
+      <TransferList />
+    </div>
+  );
+}

--- a/apps/web/src/components/federation/__tests__/audit-log-viewer.spec.tsx
+++ b/apps/web/src/components/federation/__tests__/audit-log-viewer.spec.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "../../../../test/setup";
+
+let mockEvents: unknown[] = [
+  {
+    id: "e1",
+    action: "FEDERATION_TRUST_INITIATED",
+    resource: "federation",
+    resourceId: "res-123456789",
+    actorId: "act-987654321",
+    ipAddress: "192.168.1.1",
+    userAgent: null,
+    method: "POST",
+    route: "/trpc/federation.initiateTrust",
+    oldValue: null,
+    newValue: null,
+    createdAt: "2024-01-01T00:00:00Z",
+  },
+];
+let mockIsPending = false;
+
+function resetMocks() {
+  mockEvents = [
+    {
+      id: "e1",
+      action: "FEDERATION_TRUST_INITIATED",
+      resource: "federation",
+      resourceId: "res-123456789",
+      actorId: "act-987654321",
+      ipAddress: "192.168.1.1",
+      userAgent: null,
+      method: "POST",
+      route: "/trpc/federation.initiateTrust",
+      oldValue: null,
+      newValue: null,
+      createdAt: "2024-01-01T00:00:00Z",
+    },
+  ];
+  mockIsPending = false;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    audit: {
+      list: {
+        useQuery: () => ({
+          data: {
+            items: mockEvents,
+            total: mockEvents.length,
+            totalPages: 1,
+          },
+          isPending: mockIsPending,
+        }),
+      },
+    },
+  },
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/federation/audit",
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement("a", { href }, children),
+}));
+
+import { AuditLogViewer } from "../audit-log-viewer";
+
+describe("AuditLogViewer", () => {
+  beforeEach(resetMocks);
+
+  it("renders loading skeleton when pending", () => {
+    mockIsPending = true;
+    render(<AuditLogViewer />);
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("renders empty state when no events", () => {
+    mockEvents = [];
+    render(<AuditLogViewer />);
+    expect(screen.getByText("No audit events found.")).toBeInTheDocument();
+  });
+
+  it("renders event table with action badges", () => {
+    render(<AuditLogViewer />);
+    expect(screen.getByText("FEDERATION_TRUST_INITIATED")).toBeInTheDocument();
+  });
+
+  it("renders filter controls section", () => {
+    render(<AuditLogViewer />);
+    expect(
+      screen.getByRole("button", { name: /filters/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/federation/__tests__/hub-admin.spec.tsx
+++ b/apps/web/src/components/federation/__tests__/hub-admin.spec.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "../../../../test/setup";
+
+let mockInstances: unknown[] = [
+  {
+    id: "i1",
+    domain: "spoke.example.com",
+    instanceUrl: "https://spoke.example.com",
+    status: "active",
+    lastSeenAt: "2024-06-01",
+    createdAt: "2024-01-01",
+  },
+];
+let mockIsPending = false;
+let mockError: unknown = null;
+
+function resetMocks() {
+  mockInstances = [
+    {
+      id: "i1",
+      domain: "spoke.example.com",
+      instanceUrl: "https://spoke.example.com",
+      status: "active",
+      lastSeenAt: "2024-06-01",
+      createdAt: "2024-01-01",
+    },
+  ];
+  mockIsPending = false;
+  mockError = null;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    hub: {
+      listInstances: {
+        useQuery: () => ({
+          data: mockInstances,
+          isPending: mockIsPending,
+          error: mockError,
+        }),
+      },
+    },
+  },
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/federation/hub",
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement("a", { href }, children),
+}));
+
+import { HubAdmin } from "../hub-admin";
+
+describe("HubAdmin", () => {
+  beforeEach(resetMocks);
+
+  it("renders loading skeleton when pending", () => {
+    mockIsPending = true;
+    mockInstances = [];
+    render(<HubAdmin />);
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("renders hub not enabled message when error is NOT_FOUND", () => {
+    mockError = { data: { code: "NOT_FOUND" }, message: "not found" };
+    mockInstances = [];
+    render(<HubAdmin />);
+    expect(screen.getByText(/hub mode is not enabled/i)).toBeInTheDocument();
+  });
+
+  it("renders instance table with status badges", () => {
+    render(<HubAdmin />);
+    expect(screen.getByText("spoke.example.com")).toBeInTheDocument();
+    expect(screen.getByText("active")).toBeInTheDocument();
+  });
+
+  it("renders tab controls", () => {
+    render(<HubAdmin />);
+    expect(screen.getByRole("tab", { name: /all/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /active/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /suspended/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /revoked/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/federation/__tests__/hub-instance-detail.spec.tsx
+++ b/apps/web/src/components/federation/__tests__/hub-instance-detail.spec.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "../../../../test/setup";
+
+let mockInstance: unknown = {
+  id: "i-1",
+  domain: "spoke.example.com",
+  instanceUrl: "https://spoke.example.com",
+  status: "active",
+  lastSeenAt: "2024-06-01",
+  createdAt: "2024-01-01",
+  metadata: { version: "1.0" },
+};
+let mockIsPending = false;
+
+function resetMocks() {
+  mockInstance = {
+    id: "i-1",
+    domain: "spoke.example.com",
+    instanceUrl: "https://spoke.example.com",
+    status: "active",
+    lastSeenAt: "2024-06-01",
+    createdAt: "2024-01-01",
+    metadata: { version: "1.0" },
+  };
+  mockIsPending = false;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    hub: {
+      getInstanceById: {
+        useQuery: () => ({
+          data: mockInstance,
+          isPending: mockIsPending,
+          error: null,
+        }),
+      },
+      suspendInstance: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+      revokeInstance: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+    },
+    useUtils: () => ({
+      hub: {
+        getInstanceById: {
+          invalidate: jest.fn(),
+        },
+        listInstances: {
+          invalidate: jest.fn(),
+        },
+      },
+    }),
+  },
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/federation/hub/i-1",
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement("a", { href }, children),
+}));
+
+import { HubInstanceDetail } from "../hub-instance-detail";
+
+describe("HubInstanceDetail", () => {
+  beforeEach(resetMocks);
+
+  it("renders loading skeleton when pending", () => {
+    mockIsPending = true;
+    mockInstance = undefined;
+    render(<HubInstanceDetail instanceId="i-1" />);
+    expect(screen.queryByText("spoke.example.com")).not.toBeInTheDocument();
+  });
+
+  it("renders not found when instance is null", () => {
+    mockInstance = null;
+    render(<HubInstanceDetail instanceId="i-1" />);
+    expect(screen.getByText("Instance not found.")).toBeInTheDocument();
+  });
+
+  it("renders instance info fields", () => {
+    render(<HubInstanceDetail instanceId="i-1" />);
+    expect(screen.getByText("spoke.example.com")).toBeInTheDocument();
+  });
+
+  it("renders suspend and revoke buttons for active status", () => {
+    render(<HubInstanceDetail instanceId="i-1" />);
+    expect(
+      screen.getByRole("button", { name: /suspend/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /revoke/i })).toBeInTheDocument();
+  });
+
+  it("renders only revoke for suspended status", () => {
+    mockInstance = {
+      ...(mockInstance as object),
+      status: "suspended",
+    };
+    render(<HubInstanceDetail instanceId="i-1" />);
+    expect(screen.getByRole("button", { name: /revoke/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /suspend/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/federation/__tests__/migration-detail.spec.tsx
+++ b/apps/web/src/components/federation/__tests__/migration-detail.spec.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "../../../../test/setup";
+
+let mockMigration: unknown = {
+  id: "m-1",
+  direction: "outbound",
+  status: "PENDING_APPROVAL",
+  userDid: "did:example:user",
+  peerUserDid: "did:example:peer",
+  peerDomain: "other.org",
+  peerInstanceUrl: "https://other.org",
+  callbackUrl: "https://other.org/callback",
+  createdAt: "2024-01-01",
+  approvedAt: null,
+  completedAt: null,
+  failureReason: null,
+};
+let mockIsPending = false;
+
+function resetMocks() {
+  mockMigration = {
+    id: "m-1",
+    direction: "outbound",
+    status: "PENDING_APPROVAL",
+    userDid: "did:example:user",
+    peerUserDid: "did:example:peer",
+    peerDomain: "other.org",
+    peerInstanceUrl: "https://other.org",
+    callbackUrl: "https://other.org/callback",
+    createdAt: "2024-01-01",
+    approvedAt: null,
+    completedAt: null,
+    failureReason: null,
+  };
+  mockIsPending = false;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    migrations: {
+      getById: {
+        useQuery: () => ({
+          data: mockMigration,
+          isPending: mockIsPending,
+          error: null,
+        }),
+      },
+      approve: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+      reject: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+      cancel: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+    },
+    useUtils: () => ({
+      migrations: {
+        getById: {
+          invalidate: jest.fn(),
+        },
+        list: {
+          invalidate: jest.fn(),
+        },
+        listPending: {
+          invalidate: jest.fn(),
+        },
+      },
+    }),
+  },
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/federation/migrations/m-1",
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement("a", { href }, children),
+}));
+
+import { MigrationDetail } from "../migration-detail";
+
+describe("MigrationDetail", () => {
+  beforeEach(resetMocks);
+
+  it("renders loading skeleton when pending", () => {
+    mockIsPending = true;
+    mockMigration = undefined;
+    render(<MigrationDetail migrationId="m-1" />);
+    expect(screen.queryByText("other.org")).not.toBeInTheDocument();
+  });
+
+  it("renders not found when migration is null", () => {
+    mockMigration = null;
+    render(<MigrationDetail migrationId="m-1" />);
+    expect(screen.getByText("Migration not found.")).toBeInTheDocument();
+  });
+
+  it("renders approve and reject buttons for PENDING_APPROVAL outbound", () => {
+    render(<MigrationDetail migrationId="m-1" />);
+    expect(
+      screen.getByRole("button", { name: /approve/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reject/i })).toBeInTheDocument();
+  });
+
+  it("renders cancel button for non-terminal status", () => {
+    mockMigration = {
+      ...(mockMigration as object),
+      status: "APPROVED",
+      direction: "inbound",
+    };
+    render(<MigrationDetail migrationId="m-1" />);
+    expect(
+      screen.getByRole("button", { name: /cancel migration/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders terminal message for completed", () => {
+    mockMigration = {
+      ...(mockMigration as object),
+      status: "COMPLETED",
+      completedAt: "2024-06-01",
+    };
+    render(<MigrationDetail migrationId="m-1" />);
+    expect(screen.getByText(/terminal state/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/federation/__tests__/migration-list.spec.tsx
+++ b/apps/web/src/components/federation/__tests__/migration-list.spec.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "../../../../test/setup";
+
+let mockMigrations: unknown[] = [
+  {
+    id: "m1",
+    direction: "outbound",
+    peerDomain: "other.org",
+    status: "PENDING_APPROVAL",
+    userDid: "did:example:user1234567890",
+    createdAt: "2024-01-01",
+  },
+];
+let mockPending: unknown[] = [{ id: "m1" }];
+let mockIsPending = false;
+
+function resetMocks() {
+  mockMigrations = [
+    {
+      id: "m1",
+      direction: "outbound",
+      peerDomain: "other.org",
+      status: "PENDING_APPROVAL",
+      userDid: "did:example:user1234567890",
+      createdAt: "2024-01-01",
+    },
+  ];
+  mockPending = [{ id: "m1" }];
+  mockIsPending = false;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    migrations: {
+      list: {
+        useQuery: () => ({
+          data: { migrations: mockMigrations, total: mockMigrations.length },
+          isPending: mockIsPending,
+        }),
+      },
+      listPending: {
+        useQuery: () => ({
+          data: mockPending,
+        }),
+      },
+    },
+  },
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/federation/migrations",
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement("a", { href }, children),
+}));
+
+import { MigrationList } from "../migration-list";
+
+describe("MigrationList", () => {
+  beforeEach(resetMocks);
+
+  it("renders loading skeleton when pending", () => {
+    mockIsPending = true;
+    render(<MigrationList />);
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("renders empty state when no migrations", () => {
+    mockMigrations = [];
+    mockPending = [];
+    render(<MigrationList />);
+    expect(screen.getByText("No migrations found.")).toBeInTheDocument();
+  });
+
+  it("renders migration table with direction and status badges", () => {
+    render(<MigrationList />);
+    expect(screen.getByText("outbound")).toBeInTheDocument();
+    expect(screen.getByText("other.org")).toBeInTheDocument();
+    expect(screen.getByText("PENDING APPROVAL")).toBeInTheDocument();
+  });
+
+  it("renders pending approval banner", () => {
+    render(<MigrationList />);
+    expect(screen.getByText(/pending your approval/i)).toBeInTheDocument();
+  });
+
+  it("renders tab controls", () => {
+    render(<MigrationList />);
+    expect(screen.getByRole("tab", { name: /all/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: /pending approval/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: /in progress/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /completed/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /cancelled/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/federation/__tests__/sim-sub-admin.spec.tsx
+++ b/apps/web/src/components/federation/__tests__/sim-sub-admin.spec.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "../../../../test/setup";
+
+let mockIsPending = false;
+
+function resetMocks() {
+  mockIsPending = false;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    simsub: {
+      listChecks: {
+        useQuery: () => ({
+          data: undefined,
+          isPending: mockIsPending,
+          error: null,
+        }),
+      },
+      grantOverride: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+    },
+    useUtils: () => ({
+      simsub: {
+        listChecks: {
+          invalidate: jest.fn(),
+        },
+      },
+    }),
+  },
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/federation/sim-sub",
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement("a", { href }, children),
+}));
+
+import { SimSubAdmin } from "../sim-sub-admin";
+
+describe("SimSubAdmin", () => {
+  beforeEach(resetMocks);
+
+  it("renders heading and back link", () => {
+    render(<SimSubAdmin />);
+    expect(screen.getByText("Sim-Sub Checks")).toBeInTheDocument();
+    expect(screen.getByRole("link")).toBeInTheDocument();
+  });
+
+  it("renders lookup form with input and button", () => {
+    render(<SimSubAdmin />);
+    expect(screen.getByPlaceholderText("Submission UUID")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /look up/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show results card on initial render", () => {
+    render(<SimSubAdmin />);
+    expect(screen.queryByText("Check History")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/federation/__tests__/transfer-detail.spec.tsx
+++ b/apps/web/src/components/federation/__tests__/transfer-detail.spec.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "../../../../test/setup";
+
+let mockTransfer: unknown = {
+  id: "t-1",
+  submissionId: "sub-123",
+  targetDomain: "peer.com",
+  status: "PENDING",
+  submitterDid: "did:example:123",
+  contentFingerprint: "abc123",
+  tokenExpiresAt: "2024-12-01",
+  createdAt: "2024-01-01",
+  completedAt: null,
+  updatedAt: "2024-01-01",
+  failureReason: null,
+  fileManifest: [
+    {
+      filename: "story.docx",
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      size: 12345,
+    },
+  ],
+};
+let mockIsPending = false;
+let mockError: unknown = null;
+
+function resetMocks() {
+  mockTransfer = {
+    id: "t-1",
+    submissionId: "sub-123",
+    targetDomain: "peer.com",
+    status: "PENDING",
+    submitterDid: "did:example:123",
+    contentFingerprint: "abc123",
+    tokenExpiresAt: "2024-12-01",
+    createdAt: "2024-01-01",
+    completedAt: null,
+    updatedAt: "2024-01-01",
+    failureReason: null,
+    fileManifest: [
+      {
+        filename: "story.docx",
+        mimeType:
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        size: 12345,
+      },
+    ],
+  };
+  mockIsPending = false;
+  mockError = null;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    transfers: {
+      getById: {
+        useQuery: () => ({
+          data: mockTransfer,
+          isPending: mockIsPending,
+          error: mockError,
+        }),
+      },
+      cancel: {
+        useMutation: () => ({
+          mutate: jest.fn(),
+          isPending: false,
+        }),
+      },
+    },
+    useUtils: () => ({
+      transfers: {
+        getById: {
+          invalidate: jest.fn(),
+        },
+        list: {
+          invalidate: jest.fn(),
+        },
+      },
+    }),
+  },
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/federation/transfers/t-1",
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement("a", { href }, children),
+}));
+
+import { TransferDetail } from "../transfer-detail";
+
+describe("TransferDetail", () => {
+  beforeEach(resetMocks);
+
+  it("renders loading skeleton when pending", () => {
+    mockIsPending = true;
+    mockTransfer = undefined;
+    render(<TransferDetail transferId="t-1" />);
+    expect(screen.queryByText("peer.com")).not.toBeInTheDocument();
+  });
+
+  it("renders not found when transfer is null", () => {
+    mockTransfer = null;
+    render(<TransferDetail transferId="t-1" />);
+    expect(screen.getByText("Transfer not found.")).toBeInTheDocument();
+  });
+
+  it("renders transfer info fields", () => {
+    render(<TransferDetail transferId="t-1" />);
+    expect(screen.getByText("peer.com")).toBeInTheDocument();
+    expect(screen.getByText("sub-123")).toBeInTheDocument();
+  });
+
+  it("renders cancel button for PENDING status", () => {
+    render(<TransferDetail transferId="t-1" />);
+    expect(
+      screen.getByRole("button", { name: /cancel transfer/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders file manifest table", () => {
+    render(<TransferDetail transferId="t-1" />);
+    expect(screen.getByText("story.docx")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/federation/__tests__/transfer-list.spec.tsx
+++ b/apps/web/src/components/federation/__tests__/transfer-list.spec.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "../../../../test/setup";
+
+let mockTransfers: unknown[] = [
+  {
+    id: "t1",
+    targetDomain: "peer.com",
+    status: "PENDING",
+    submissionId: "sub-1234-5678",
+    createdAt: "2024-01-01",
+    completedAt: null,
+  },
+];
+let mockIsPending = false;
+
+function resetMocks() {
+  mockTransfers = [
+    {
+      id: "t1",
+      targetDomain: "peer.com",
+      status: "PENDING",
+      submissionId: "sub-1234-5678",
+      createdAt: "2024-01-01",
+      completedAt: null,
+    },
+  ];
+  mockIsPending = false;
+}
+
+jest.mock("@/lib/trpc", () => ({
+  trpc: {
+    transfers: {
+      list: {
+        useQuery: () => ({
+          data: { transfers: mockTransfers, total: mockTransfers.length },
+          isPending: mockIsPending,
+        }),
+      },
+    },
+  },
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/federation/transfers",
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement("a", { href }, children),
+}));
+
+import { TransferList } from "../transfer-list";
+
+describe("TransferList", () => {
+  beforeEach(resetMocks);
+
+  it("renders loading skeleton when pending", () => {
+    mockIsPending = true;
+    render(<TransferList />);
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("renders empty state when no transfers", () => {
+    mockTransfers = [];
+    render(<TransferList />);
+    expect(screen.getByText("No transfers found.")).toBeInTheDocument();
+  });
+
+  it("renders transfer table with status badges", () => {
+    render(<TransferList />);
+    expect(screen.getByText("peer.com")).toBeInTheDocument();
+    expect(screen.getByText("PENDING")).toBeInTheDocument();
+  });
+
+  it("renders tab controls", () => {
+    render(<TransferList />);
+    expect(screen.getByRole("tab", { name: /all/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /pending/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /completed/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /failed/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/federation/audit-log-viewer.tsx
+++ b/apps/web/src/components/federation/audit-log-viewer.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Filter, ChevronDown, ChevronUp } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { format } from "date-fns";
+
+const ACTION_GROUPS = [
+  "USER_CREATED",
+  "ORG_CREATED",
+  "SUBMISSION_CREATED",
+  "FEDERATION_TRUST_INITIATED",
+  "SIMSUB_CHECK_PERFORMED",
+  "TRANSFER_INITIATED",
+  "MIGRATION_REQUESTED",
+  "HUB_INSTANCE_REGISTERED",
+  "AUDIT_ACCESSED",
+] as const;
+
+const RESOURCE_OPTIONS = [
+  "user",
+  "organization",
+  "submission",
+  "federation",
+  "simsub",
+  "transfer",
+  "migration",
+  "hub",
+  "audit",
+] as const;
+
+interface AuditEvent {
+  id: string;
+  action: string;
+  resource: string;
+  resourceId: string | null;
+  actorId: string | null;
+  ipAddress: string | null;
+  userAgent: string | null;
+  method: string | null;
+  route: string | null;
+  oldValue: unknown;
+  newValue: unknown;
+  createdAt: string;
+}
+
+export function AuditLogViewer() {
+  const [page, setPage] = useState(1);
+  const [action, setAction] = useState<string>("all");
+  const [resource, setResource] = useState<string>("all");
+  const [actorId, setActorId] = useState("");
+  const [resourceId, setResourceId] = useState("");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [selectedEvent, setSelectedEvent] = useState<AuditEvent | null>(null);
+
+  const queryInput = {
+    page,
+    limit: 25,
+    ...(action !== "all" ? { action } : {}),
+    ...(resource !== "all" ? { resource } : {}),
+    ...(actorId ? { actorId } : {}),
+    ...(resourceId ? { resourceId } : {}),
+    ...(dateFrom ? { dateFrom: new Date(dateFrom) } : {}),
+    ...(dateTo ? { dateTo: new Date(dateTo) } : {}),
+  } as Parameters<typeof trpc.audit.list.useQuery>[0];
+
+  const { data, isPending: isLoading } = trpc.audit.list.useQuery(queryInput);
+
+  const events = (data?.items ?? []) as AuditEvent[];
+  const total = data?.total ?? 0;
+  const totalPages = data?.totalPages ?? 1;
+
+  return (
+    <div className="space-y-6">
+      <Button variant="ghost" size="sm" asChild>
+        <Link href="/federation">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Federation
+        </Link>
+      </Button>
+
+      <h1 className="text-2xl font-bold">Audit Log</h1>
+
+      {/* Filter bar */}
+      <Collapsible open={filtersOpen} onOpenChange={setFiltersOpen}>
+        <Card>
+          <CardHeader className="pb-3">
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" className="flex w-full justify-between">
+                <div className="flex items-center gap-2">
+                  <Filter className="h-4 w-4" />
+                  <span>Filters</span>
+                </div>
+                {filtersOpen ? (
+                  <ChevronUp className="h-4 w-4" />
+                ) : (
+                  <ChevronDown className="h-4 w-4" />
+                )}
+              </Button>
+            </CollapsibleTrigger>
+          </CardHeader>
+          <CollapsibleContent>
+            <CardContent>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                <div className="space-y-2">
+                  <Label>Action</Label>
+                  <Select value={action} onValueChange={setAction}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="All actions" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All Actions</SelectItem>
+                      {ACTION_GROUPS.map((a) => (
+                        <SelectItem key={a} value={a}>
+                          {a}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Resource</Label>
+                  <Select value={resource} onValueChange={setResource}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="All resources" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All Resources</SelectItem>
+                      {RESOURCE_OPTIONS.map((r) => (
+                        <SelectItem key={r} value={r}>
+                          {r}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Actor ID</Label>
+                  <Input
+                    placeholder="UUID"
+                    value={actorId}
+                    onChange={(e) => setActorId(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Resource ID</Label>
+                  <Input
+                    placeholder="UUID"
+                    value={resourceId}
+                    onChange={(e) => setResourceId(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>From</Label>
+                  <Input
+                    type="date"
+                    value={dateFrom}
+                    onChange={(e) => setDateFrom(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>To</Label>
+                  <Input
+                    type="date"
+                    value={dateTo}
+                    onChange={(e) => setDateTo(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="mt-4">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setAction("all");
+                    setResource("all");
+                    setActorId("");
+                    setResourceId("");
+                    setDateFrom("");
+                    setDateTo("");
+                    setPage(1);
+                  }}
+                >
+                  Clear Filters
+                </Button>
+              </div>
+            </CardContent>
+          </CollapsibleContent>
+        </Card>
+      </Collapsible>
+
+      {/* Events table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Events</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : events.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No audit events found.
+            </p>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Timestamp</TableHead>
+                    <TableHead>Action</TableHead>
+                    <TableHead>Resource</TableHead>
+                    <TableHead>Resource ID</TableHead>
+                    <TableHead>Actor ID</TableHead>
+                    <TableHead>IP</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {events.map((event) => (
+                    <TableRow
+                      key={event.id}
+                      className="cursor-pointer"
+                      onClick={() => setSelectedEvent(event)}
+                    >
+                      <TableCell className="text-xs">
+                        {format(new Date(event.createdAt), "PPpp")}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="secondary" className="text-xs">
+                          {event.action}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>{event.resource}</TableCell>
+                      <TableCell className="font-mono text-xs">
+                        {event.resourceId
+                          ? `${event.resourceId.slice(0, 8)}...`
+                          : "—"}
+                      </TableCell>
+                      <TableCell className="font-mono text-xs">
+                        {event.actorId
+                          ? `${event.actorId.slice(0, 8)}...`
+                          : "—"}
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        {event.ipAddress ?? "—"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {totalPages > 1 && (
+                <div className="mt-4 flex items-center justify-between">
+                  <p className="text-sm text-muted-foreground">
+                    Page {page} of {totalPages} ({total} total)
+                  </p>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={page <= 1}
+                      onClick={() => setPage((p) => p - 1)}
+                    >
+                      Previous
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={page >= totalPages}
+                      onClick={() => setPage((p) => p + 1)}
+                    >
+                      Next
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Event detail dialog */}
+      <Dialog
+        open={!!selectedEvent}
+        onOpenChange={(open) => !open && setSelectedEvent(null)}
+      >
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Audit Event Detail</DialogTitle>
+          </DialogHeader>
+          {selectedEvent && (
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div>
+                  <span className="font-medium text-muted-foreground">
+                    Action
+                  </span>
+                  <p>{selectedEvent.action}</p>
+                </div>
+                <div>
+                  <span className="font-medium text-muted-foreground">
+                    Resource
+                  </span>
+                  <p>{selectedEvent.resource}</p>
+                </div>
+                <div>
+                  <span className="font-medium text-muted-foreground">
+                    Resource ID
+                  </span>
+                  <p className="font-mono text-xs">
+                    {selectedEvent.resourceId ?? "—"}
+                  </p>
+                </div>
+                <div>
+                  <span className="font-medium text-muted-foreground">
+                    Actor ID
+                  </span>
+                  <p className="font-mono text-xs">
+                    {selectedEvent.actorId ?? "—"}
+                  </p>
+                </div>
+                <div>
+                  <span className="font-medium text-muted-foreground">
+                    IP Address
+                  </span>
+                  <p>{selectedEvent.ipAddress ?? "—"}</p>
+                </div>
+                <div>
+                  <span className="font-medium text-muted-foreground">
+                    Method / Route
+                  </span>
+                  <p>
+                    {selectedEvent.method} {selectedEvent.route ?? "—"}
+                  </p>
+                </div>
+                <div className="col-span-2">
+                  <span className="font-medium text-muted-foreground">
+                    User Agent
+                  </span>
+                  <p className="text-xs break-all">
+                    {selectedEvent.userAgent ?? "—"}
+                  </p>
+                </div>
+              </div>
+              {selectedEvent.oldValue != null && (
+                <div>
+                  <span className="text-sm font-medium text-muted-foreground">
+                    Old Value
+                  </span>
+                  <pre className="mt-1 max-h-48 overflow-auto rounded bg-muted p-2 text-xs">
+                    {JSON.stringify(selectedEvent.oldValue, null, 2)}
+                  </pre>
+                </div>
+              )}
+              {selectedEvent.newValue != null && (
+                <div>
+                  <span className="text-sm font-medium text-muted-foreground">
+                    New Value
+                  </span>
+                  <pre className="mt-1 max-h-48 overflow-auto rounded bg-muted p-2 text-xs">
+                    {JSON.stringify(selectedEvent.newValue, null, 2)}
+                  </pre>
+                </div>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/components/federation/federation-overview.tsx
+++ b/apps/web/src/components/federation/federation-overview.tsx
@@ -2,7 +2,17 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { Network, Pencil, Copy, Check } from "lucide-react";
+import {
+  Network,
+  Pencil,
+  Copy,
+  Check,
+  Search,
+  ArrowRightLeft,
+  UserRoundCog,
+  Server,
+  ScrollText,
+} from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -178,6 +188,90 @@ export function FederationOverview() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Navigation cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <Card className="transition-colors hover:bg-accent">
+          <Link href="/federation/sim-sub" className="block">
+            <CardHeader className="pb-2">
+              <div className="flex items-center gap-2">
+                <Search className="h-5 w-5 text-muted-foreground" />
+                <CardTitle className="text-base">Sim-Sub Checks</CardTitle>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Look up simultaneous submission check history and manage
+                overrides.
+              </p>
+            </CardContent>
+          </Link>
+        </Card>
+
+        <Card className="transition-colors hover:bg-accent">
+          <Link href="/federation/transfers" className="block">
+            <CardHeader className="pb-2">
+              <div className="flex items-center gap-2">
+                <ArrowRightLeft className="h-5 w-5 text-muted-foreground" />
+                <CardTitle className="text-base">Piece Transfers</CardTitle>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                View and manage submission transfers between instances.
+              </p>
+            </CardContent>
+          </Link>
+        </Card>
+
+        <Card className="transition-colors hover:bg-accent">
+          <Link href="/federation/migrations" className="block">
+            <CardHeader className="pb-2">
+              <div className="flex items-center gap-2">
+                <UserRoundCog className="h-5 w-5 text-muted-foreground" />
+                <CardTitle className="text-base">Identity Migrations</CardTitle>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Manage writer identity migration requests and approvals.
+              </p>
+            </CardContent>
+          </Link>
+        </Card>
+
+        <Card className="transition-colors hover:bg-accent">
+          <Link href="/federation/hub" className="block">
+            <CardHeader className="pb-2">
+              <div className="flex items-center gap-2">
+                <Server className="h-5 w-5 text-muted-foreground" />
+                <CardTitle className="text-base">Hub Administration</CardTitle>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Manage hub-registered instances (requires managed hub mode).
+              </p>
+            </CardContent>
+          </Link>
+        </Card>
+
+        <Card className="transition-colors hover:bg-accent">
+          <Link href="/federation/audit" className="block">
+            <CardHeader className="pb-2">
+              <div className="flex items-center gap-2">
+                <ScrollText className="h-5 w-5 text-muted-foreground" />
+                <CardTitle className="text-base">Audit Log</CardTitle>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                View the audit trail for all federation and system events.
+              </p>
+            </CardContent>
+          </Link>
+        </Card>
+      </div>
 
       {/* Peer summary card */}
       <Card>

--- a/apps/web/src/components/federation/hub-admin.tsx
+++ b/apps/web/src/components/federation/hub-admin.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, Info } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { format } from "date-fns";
+
+const STATUS_COLORS: Record<string, string> = {
+  active: "border-green-500 text-green-700",
+  suspended: "border-yellow-500 text-yellow-700",
+  revoked: "border-red-500 text-red-700",
+};
+
+type Tab = "all" | "active" | "suspended" | "revoked";
+
+export function HubAdmin() {
+  const router = useRouter();
+  const [tab, setTab] = useState<Tab>("all");
+
+  const {
+    data: instances,
+    isPending: isLoading,
+    error,
+  } = trpc.hub.listInstances.useQuery();
+
+  // Hub not enabled — show info card
+  if (error?.data?.code === "NOT_FOUND") {
+    return (
+      <div className="space-y-6">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/federation">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Federation
+          </Link>
+        </Button>
+
+        <h1 className="text-2xl font-bold">Hub Administration</h1>
+
+        <Card>
+          <CardContent className="flex items-center gap-3 py-6">
+            <Info className="h-5 w-5 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              Hub mode is not enabled on this instance. Set federation mode to
+              &ldquo;managed_hub&rdquo; to enable hub administration.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const allInstances = instances ?? [];
+  const filtered =
+    tab === "all" ? allInstances : allInstances.filter((i) => i.status === tab);
+
+  return (
+    <div className="space-y-6">
+      <Button variant="ghost" size="sm" asChild>
+        <Link href="/federation">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Federation
+        </Link>
+      </Button>
+
+      <h1 className="text-2xl font-bold">Hub Administration</h1>
+
+      <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)}>
+        <TabsList>
+          <TabsTrigger value="all">All</TabsTrigger>
+          <TabsTrigger value="active">Active</TabsTrigger>
+          <TabsTrigger value="suspended">Suspended</TabsTrigger>
+          <TabsTrigger value="revoked">Revoked</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Registered Instances</CardTitle>
+          <CardDescription>Instances registered with this hub</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : filtered.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No instances found.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Domain</TableHead>
+                  <TableHead>Instance URL</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last Seen</TableHead>
+                  <TableHead>Registered</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map((instance) => (
+                  <TableRow
+                    key={instance.id}
+                    className="cursor-pointer"
+                    onClick={() =>
+                      router.push(`/federation/hub/${instance.id}`)
+                    }
+                  >
+                    <TableCell>{instance.domain}</TableCell>
+                    <TableCell className="text-sm">
+                      {instance.instanceUrl}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="outline"
+                        className={STATUS_COLORS[instance.status] ?? ""}
+                      >
+                        {instance.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {instance.lastSeenAt
+                        ? format(new Date(instance.lastSeenAt), "PP")
+                        : "—"}
+                    </TableCell>
+                    <TableCell>
+                      {format(new Date(instance.createdAt), "PP")}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/federation/hub-instance-detail.tsx
+++ b/apps/web/src/components/federation/hub-instance-detail.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import { format } from "date-fns";
+
+const STATUS_COLORS: Record<string, string> = {
+  active: "border-green-500 text-green-700",
+  suspended: "border-yellow-500 text-yellow-700",
+  revoked: "border-red-500 text-red-700",
+};
+
+interface HubInstanceDetailProps {
+  instanceId: string;
+}
+
+export function HubInstanceDetail({ instanceId }: HubInstanceDetailProps) {
+  const utils = trpc.useUtils();
+
+  const {
+    data: instance,
+    isPending: isLoading,
+    error,
+  } = trpc.hub.getInstanceById.useQuery({ id: instanceId });
+
+  const suspendMutation = trpc.hub.suspendInstance.useMutation({
+    onSuccess: () => {
+      toast.success("Instance suspended");
+      utils.hub.getInstanceById.invalidate({ id: instanceId });
+      utils.hub.listInstances.invalidate();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const revokeMutation = trpc.hub.revokeInstance.useMutation({
+    onSuccess: () => {
+      toast.success("Instance revoked");
+      utils.hub.getInstanceById.invalidate({ id: instanceId });
+      utils.hub.listInstances.invalidate();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error || !instance) {
+    return (
+      <div className="space-y-6">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/federation/hub">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Hub
+          </Link>
+        </Button>
+        <p className="text-muted-foreground">Instance not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Button variant="ghost" size="sm" asChild>
+        <Link href="/federation/hub">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Hub
+        </Link>
+      </Button>
+
+      <div className="flex items-center gap-3">
+        <h1 className="text-2xl font-bold">{instance.domain}</h1>
+        <Badge
+          variant="outline"
+          className={STATUS_COLORS[instance.status] ?? ""}
+        >
+          {instance.status}
+        </Badge>
+      </div>
+
+      {/* Info card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Instance Information</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-3">
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Instance URL
+                </span>
+                <p className="text-sm">
+                  <a
+                    href={instance.instanceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:underline"
+                  >
+                    {instance.instanceUrl}
+                  </a>
+                </p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Last Seen
+                </span>
+                <p className="text-sm">
+                  {instance.lastSeenAt
+                    ? format(new Date(instance.lastSeenAt), "PPpp")
+                    : "Never"}
+                </p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Registered
+                </span>
+                <p className="text-sm">
+                  {format(new Date(instance.createdAt), "PPpp")}
+                </p>
+              </div>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Metadata
+                </span>
+                {instance.metadata ? (
+                  <pre className="mt-1 max-h-48 overflow-auto rounded bg-muted p-2 text-xs">
+                    {JSON.stringify(instance.metadata, null, 2)}
+                  </pre>
+                ) : (
+                  <p className="text-sm text-muted-foreground">None</p>
+                )}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Actions */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Actions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {instance.status === "active" && (
+            <div className="flex gap-3">
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button variant="outline">Suspend</Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Suspend Instance</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Suspending <strong>{instance.domain}</strong> will
+                      temporarily disable its hub access. You can revoke it
+                      permanently later.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => suspendMutation.mutate({ id: instanceId })}
+                    >
+                      Suspend
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button variant="destructive">Revoke</Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Revoke Instance</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Revoking <strong>{instance.domain}</strong> will
+                      permanently remove its hub registration. This cannot be
+                      undone.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => revokeMutation.mutate({ id: instanceId })}
+                    >
+                      Revoke
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </div>
+          )}
+
+          {instance.status === "suspended" && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive">Revoke</Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Revoke Instance</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Revoking <strong>{instance.domain}</strong> will permanently
+                    remove its hub registration. This cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => revokeMutation.mutate({ id: instanceId })}
+                  >
+                    Revoke
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+
+          {instance.status === "revoked" && (
+            <p className="text-sm text-muted-foreground">
+              This instance has been revoked. No actions available.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/federation/migration-detail.tsx
+++ b/apps/web/src/components/federation/migration-detail.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import { format } from "date-fns";
+
+const STATUS_COLORS: Record<string, string> = {
+  PENDING: "border-yellow-500 text-yellow-700",
+  PENDING_APPROVAL: "border-orange-500 text-orange-700",
+  APPROVED: "border-blue-500 text-blue-700",
+  BUNDLE_SENT: "border-blue-500 text-blue-700",
+  PROCESSING: "border-blue-500 text-blue-700",
+  COMPLETED: "border-green-500 text-green-700",
+  REJECTED: "border-red-500 text-red-700",
+  FAILED: "border-red-500 text-red-700",
+  EXPIRED: "border-gray-400 text-gray-600",
+  CANCELLED: "border-gray-400 text-gray-600",
+};
+
+const TERMINAL_STATUSES = new Set([
+  "COMPLETED",
+  "REJECTED",
+  "FAILED",
+  "EXPIRED",
+  "CANCELLED",
+]);
+
+interface MigrationDetailProps {
+  migrationId: string;
+}
+
+export function MigrationDetail({ migrationId }: MigrationDetailProps) {
+  const utils = trpc.useUtils();
+
+  const {
+    data: migration,
+    isPending: isLoading,
+    error,
+  } = trpc.migrations.getById.useQuery({ id: migrationId });
+
+  const approveMutation = trpc.migrations.approve.useMutation({
+    onSuccess: () => {
+      toast.success("Migration approved");
+      utils.migrations.getById.invalidate({ id: migrationId });
+      utils.migrations.list.invalidate();
+      utils.migrations.listPending.invalidate();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const rejectMutation = trpc.migrations.reject.useMutation({
+    onSuccess: () => {
+      toast.success("Migration rejected");
+      utils.migrations.getById.invalidate({ id: migrationId });
+      utils.migrations.list.invalidate();
+      utils.migrations.listPending.invalidate();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const cancelMutation = trpc.migrations.cancel.useMutation({
+    onSuccess: () => {
+      toast.success("Migration cancelled");
+      utils.migrations.getById.invalidate({ id: migrationId });
+      utils.migrations.list.invalidate();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error || !migration) {
+    return (
+      <div className="space-y-6">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/federation/migrations">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Migrations
+          </Link>
+        </Button>
+        <p className="text-muted-foreground">Migration not found.</p>
+      </div>
+    );
+  }
+
+  const canApproveReject =
+    migration.status === "PENDING_APPROVAL" &&
+    migration.direction === "outbound";
+  const canCancel = !TERMINAL_STATUSES.has(migration.status);
+
+  return (
+    <div className="space-y-6">
+      <Button variant="ghost" size="sm" asChild>
+        <Link href="/federation/migrations">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Migrations
+        </Link>
+      </Button>
+
+      <div className="flex items-center gap-3">
+        <h1 className="text-2xl font-bold">Migration Detail</h1>
+        <Badge
+          variant="outline"
+          className={STATUS_COLORS[migration.status] ?? ""}
+        >
+          {migration.status.replace(/_/g, " ")}
+        </Badge>
+      </div>
+
+      {/* Info card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Migration Information</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-3">
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Direction
+                </span>
+                <p className="text-sm capitalize">{migration.direction}</p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  User DID
+                </span>
+                <p className="text-sm font-mono">{migration.userDid ?? "—"}</p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Peer User DID
+                </span>
+                <p className="text-sm font-mono">
+                  {migration.peerUserDid ?? "—"}
+                </p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Peer Domain
+                </span>
+                <p className="text-sm">{migration.peerDomain}</p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Peer Instance URL
+                </span>
+                <p className="text-sm">{migration.peerInstanceUrl ?? "—"}</p>
+              </div>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Callback URL
+                </span>
+                <p className="text-sm font-mono text-xs break-all">
+                  {migration.callbackUrl ?? "—"}
+                </p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Created
+                </span>
+                <p className="text-sm">
+                  {format(new Date(migration.createdAt), "PPpp")}
+                </p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Approved
+                </span>
+                <p className="text-sm">
+                  {migration.approvedAt
+                    ? format(new Date(migration.approvedAt), "PPpp")
+                    : "—"}
+                </p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Completed
+                </span>
+                <p className="text-sm">
+                  {migration.completedAt
+                    ? format(new Date(migration.completedAt), "PPpp")
+                    : "—"}
+                </p>
+              </div>
+              {migration.failureReason && (
+                <div>
+                  <span className="text-sm font-medium text-muted-foreground">
+                    Failure Reason
+                  </span>
+                  <p className="text-sm text-destructive">
+                    {migration.failureReason}
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Actions */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Actions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {canApproveReject && (
+            <div className="flex gap-3">
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button>Approve</Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Approve Migration</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      This will approve the identity migration from{" "}
+                      <strong>{migration.peerDomain}</strong>. The migration
+                      process will proceed.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() =>
+                        approveMutation.mutate({ id: migrationId })
+                      }
+                    >
+                      Approve
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button variant="destructive">Reject</Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Reject Migration</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Are you sure you want to reject this migration? This
+                      action cannot be undone.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => rejectMutation.mutate({ id: migrationId })}
+                    >
+                      Reject
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </div>
+          )}
+
+          {!canApproveReject && canCancel && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive">Cancel Migration</Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Cancel Migration</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Are you sure you want to cancel this migration? This action
+                    cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Keep Migration</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => cancelMutation.mutate({ id: migrationId })}
+                  >
+                    Cancel Migration
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+
+          {TERMINAL_STATUSES.has(migration.status) && (
+            <p className="text-sm text-muted-foreground">
+              This migration has reached a terminal state (
+              {migration.status.toLowerCase().replace(/_/g, " ")}). No actions
+              available.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/federation/migration-list.tsx
+++ b/apps/web/src/components/federation/migration-list.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, AlertTriangle } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { format } from "date-fns";
+
+const STATUS_COLORS: Record<string, string> = {
+  PENDING: "border-yellow-500 text-yellow-700",
+  PENDING_APPROVAL: "border-orange-500 text-orange-700",
+  APPROVED: "border-blue-500 text-blue-700",
+  BUNDLE_SENT: "border-blue-500 text-blue-700",
+  PROCESSING: "border-blue-500 text-blue-700",
+  COMPLETED: "border-green-500 text-green-700",
+  REJECTED: "border-red-500 text-red-700",
+  FAILED: "border-red-500 text-red-700",
+  EXPIRED: "border-gray-400 text-gray-600",
+  CANCELLED: "border-gray-400 text-gray-600",
+};
+
+const DIRECTION_COLORS: Record<string, string> = {
+  inbound: "border-blue-500 text-blue-700",
+  outbound: "border-purple-500 text-purple-700",
+};
+
+type Tab =
+  | "all"
+  | "pending_approval"
+  | "in_progress"
+  | "completed"
+  | "cancelled";
+
+export function MigrationList() {
+  const router = useRouter();
+  const [tab, setTab] = useState<Tab>("all");
+  const [direction, setDirection] = useState<string>("all");
+  const [page, setPage] = useState(1);
+
+  const { data, isPending: isLoading } = trpc.migrations.list.useQuery({
+    page,
+    limit: 20,
+    direction:
+      direction === "all" ? undefined : (direction as "inbound" | "outbound"),
+  });
+
+  const { data: pendingApproval } = trpc.migrations.listPending.useQuery();
+
+  const migrations = data?.migrations ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.ceil(total / 20);
+
+  const IN_PROGRESS_STATUSES = new Set([
+    "PENDING",
+    "APPROVED",
+    "BUNDLE_SENT",
+    "PROCESSING",
+  ]);
+
+  const filtered =
+    tab === "all"
+      ? migrations
+      : tab === "pending_approval"
+        ? migrations.filter((m) => m.status === "PENDING_APPROVAL")
+        : tab === "in_progress"
+          ? migrations.filter((m) => IN_PROGRESS_STATUSES.has(m.status))
+          : tab === "completed"
+            ? migrations.filter((m) => m.status === "COMPLETED")
+            : migrations.filter(
+                (m) => m.status === "CANCELLED" || m.status === "EXPIRED",
+              );
+
+  return (
+    <div className="space-y-6">
+      <Button variant="ghost" size="sm" asChild>
+        <Link href="/federation">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Federation
+        </Link>
+      </Button>
+
+      <h1 className="text-2xl font-bold">Identity Migrations</h1>
+
+      {/* Pending approval banner */}
+      {pendingApproval && pendingApproval.length > 0 && (
+        <Card className="border-orange-200 bg-orange-50">
+          <CardContent className="flex items-center gap-3 py-3">
+            <AlertTriangle className="h-5 w-5 text-orange-600" />
+            <p className="text-sm text-orange-800">
+              <strong>{pendingApproval.length}</strong> migration
+              {pendingApproval.length === 1 ? "" : "s"} pending your approval
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="flex items-center gap-4">
+        <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)}>
+          <TabsList>
+            <TabsTrigger value="all">All</TabsTrigger>
+            <TabsTrigger value="pending_approval">Pending Approval</TabsTrigger>
+            <TabsTrigger value="in_progress">In Progress</TabsTrigger>
+            <TabsTrigger value="completed">Completed</TabsTrigger>
+            <TabsTrigger value="cancelled">Cancelled</TabsTrigger>
+          </TabsList>
+        </Tabs>
+
+        <Select value={direction} onValueChange={setDirection}>
+          <SelectTrigger className="w-[150px]">
+            <SelectValue placeholder="Direction" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Directions</SelectItem>
+            <SelectItem value="inbound">Inbound</SelectItem>
+            <SelectItem value="outbound">Outbound</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Migrations</CardTitle>
+          <CardDescription>
+            Identity migration requests across federated instances
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : filtered.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No migrations found.
+            </p>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Direction</TableHead>
+                    <TableHead>Peer Domain</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>User DID</TableHead>
+                    <TableHead>Created</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filtered.map((migration) => (
+                    <TableRow
+                      key={migration.id}
+                      className="cursor-pointer"
+                      onClick={() =>
+                        router.push(`/federation/migrations/${migration.id}`)
+                      }
+                    >
+                      <TableCell>
+                        <Badge
+                          variant="outline"
+                          className={
+                            DIRECTION_COLORS[migration.direction] ?? ""
+                          }
+                        >
+                          {migration.direction}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>{migration.peerDomain}</TableCell>
+                      <TableCell>
+                        <Badge
+                          variant="outline"
+                          className={STATUS_COLORS[migration.status] ?? ""}
+                        >
+                          {migration.status.replace(/_/g, " ")}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="font-mono text-xs">
+                        {migration.userDid
+                          ? `${migration.userDid.slice(0, 16)}...`
+                          : "—"}
+                      </TableCell>
+                      <TableCell>
+                        {format(new Date(migration.createdAt), "PP")}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {totalPages > 1 && (
+                <div className="mt-4 flex items-center justify-between">
+                  <p className="text-sm text-muted-foreground">
+                    Page {page} of {totalPages} ({total} total)
+                  </p>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={page <= 1}
+                      onClick={() => setPage((p) => p - 1)}
+                    >
+                      Previous
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={page >= totalPages}
+                      onClick={() => setPage((p) => p + 1)}
+                    >
+                      Next
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/federation/sim-sub-admin.tsx
+++ b/apps/web/src/components/federation/sim-sub-admin.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Search } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import { format } from "date-fns";
+
+const RESULT_COLORS: Record<string, string> = {
+  CLEAR: "border-green-500 text-green-700",
+  CONFLICT: "border-red-500 text-red-700",
+  PARTIAL: "border-yellow-500 text-yellow-700",
+  SKIPPED: "border-gray-400 text-gray-600",
+};
+
+export function SimSubAdmin() {
+  const [submissionId, setSubmissionId] = useState("");
+  const [queryId, setQueryId] = useState<string | null>(null);
+  const utils = trpc.useUtils();
+
+  const {
+    data: checks,
+    isPending: isLoading,
+    error,
+  } = trpc.simsub.listChecks.useQuery(
+    { submissionId: queryId! },
+    { enabled: !!queryId },
+  );
+
+  const overrideMutation = trpc.simsub.grantOverride.useMutation({
+    onSuccess: () => {
+      toast.success("Override granted");
+      if (queryId)
+        utils.simsub.listChecks.invalidate({ submissionId: queryId });
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const handleLookup = () => {
+    const trimmed = submissionId.trim();
+    if (trimmed) setQueryId(trimmed);
+  };
+
+  const latestConflict = checks?.find((c) => c.result === "CONFLICT") ?? null;
+
+  return (
+    <div className="space-y-6">
+      <Button variant="ghost" size="sm" asChild>
+        <Link href="/federation">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Federation
+        </Link>
+      </Button>
+
+      <h1 className="text-2xl font-bold">Sim-Sub Checks</h1>
+
+      {/* Lookup form */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Look Up Submission</CardTitle>
+          <CardDescription>
+            Enter a submission ID to view its simultaneous submission check
+            history.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-3">
+            <Input
+              placeholder="Submission UUID"
+              value={submissionId}
+              onChange={(e) => setSubmissionId(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleLookup()}
+            />
+            <Button onClick={handleLookup} disabled={!submissionId.trim()}>
+              <Search className="mr-2 h-4 w-4" />
+              Look Up
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Results */}
+      {queryId && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Check History</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="space-y-2">
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ) : error ? (
+              <p className="text-sm text-destructive">{error.message}</p>
+            ) : !checks || checks.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No sim-sub checks found for this submission.
+              </p>
+            ) : (
+              <>
+                {latestConflict && (
+                  <div className="mb-4">
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button variant="destructive" size="sm">
+                          Grant Override
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>
+                            Grant Sim-Sub Override
+                          </AlertDialogTitle>
+                          <AlertDialogDescription>
+                            This will allow the submission to proceed despite
+                            the simultaneous submission conflict. Are you sure?
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={() =>
+                              overrideMutation.mutate({
+                                submissionId: queryId,
+                              })
+                            }
+                          >
+                            Grant Override
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  </div>
+                )}
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Date</TableHead>
+                      <TableHead>Result</TableHead>
+                      <TableHead>Fingerprint</TableHead>
+                      <TableHead>Override</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {checks.map((check) => (
+                      <React.Fragment key={check.id}>
+                        <TableRow>
+                          <TableCell>
+                            {format(new Date(check.createdAt), "PPpp")}
+                          </TableCell>
+                          <TableCell>
+                            <Badge
+                              variant="outline"
+                              className={RESULT_COLORS[check.result] ?? ""}
+                            >
+                              {check.result}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="font-mono text-xs">
+                            {check.fingerprint?.slice(0, 16) ?? "—"}
+                          </TableCell>
+                          <TableCell>
+                            {check.overriddenBy ? (
+                              <Badge variant="secondary">Overridden</Badge>
+                            ) : (
+                              "—"
+                            )}
+                          </TableCell>
+                        </TableRow>
+                        {check.result === "CONFLICT" && (
+                          <TableRow>
+                            <TableCell colSpan={4}>
+                              <div className="space-y-2 py-2 text-sm">
+                                {check.localConflicts.length > 0 && (
+                                  <div>
+                                    <span className="font-medium">
+                                      Local conflicts:
+                                    </span>{" "}
+                                    {check.localConflicts
+                                      .map((c) => c.publicationName)
+                                      .join(", ")}
+                                  </div>
+                                )}
+                                {check.remoteResults.length > 0 && (
+                                  <div>
+                                    <span className="font-medium">
+                                      Remote results:
+                                    </span>{" "}
+                                    {check.remoteResults
+                                      .map((r) => `${r.domain}: ${r.status}`)
+                                      .join(", ")}
+                                  </div>
+                                )}
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        )}
+                      </React.Fragment>
+                    ))}
+                  </TableBody>
+                </Table>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/federation/transfer-detail.tsx
+++ b/apps/web/src/components/federation/transfer-detail.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import { format } from "date-fns";
+
+const STATUS_COLORS: Record<string, string> = {
+  PENDING: "border-yellow-500 text-yellow-700",
+  FILES_REQUESTED: "border-blue-500 text-blue-700",
+  COMPLETED: "border-green-500 text-green-700",
+  REJECTED: "border-red-500 text-red-700",
+  FAILED: "border-red-500 text-red-700",
+  CANCELLED: "border-gray-400 text-gray-600",
+  EXPIRED: "border-gray-400 text-gray-600",
+};
+
+const CANCELLABLE_STATUSES = new Set(["PENDING", "FILES_REQUESTED"]);
+
+interface TransferDetailProps {
+  transferId: string;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function TransferDetail({ transferId }: TransferDetailProps) {
+  const utils = trpc.useUtils();
+
+  const {
+    data: transfer,
+    isPending: isLoading,
+    error,
+  } = trpc.transfers.getById.useQuery({ id: transferId });
+
+  const cancelMutation = trpc.transfers.cancel.useMutation({
+    onSuccess: () => {
+      toast.success("Transfer cancelled");
+      utils.transfers.getById.invalidate({ id: transferId });
+      utils.transfers.list.invalidate();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error || !transfer) {
+    return (
+      <div className="space-y-6">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/federation/transfers">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Transfers
+          </Link>
+        </Button>
+        <p className="text-muted-foreground">Transfer not found.</p>
+      </div>
+    );
+  }
+
+  const fileManifest = (transfer.fileManifest ?? []) as Array<{
+    filename: string;
+    mimeType: string;
+    size: number;
+  }>;
+
+  return (
+    <div className="space-y-6">
+      <Button variant="ghost" size="sm" asChild>
+        <Link href="/federation/transfers">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Transfers
+        </Link>
+      </Button>
+
+      <div className="flex items-center gap-3">
+        <h1 className="text-2xl font-bold">Transfer Detail</h1>
+        <Badge
+          variant="outline"
+          className={STATUS_COLORS[transfer.status] ?? ""}
+        >
+          {transfer.status.replace(/_/g, " ")}
+        </Badge>
+      </div>
+
+      {/* Info card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Transfer Information</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-3">
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Submission ID
+                </span>
+                <p className="text-sm font-mono">{transfer.submissionId}</p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Target Domain
+                </span>
+                <p className="text-sm">{transfer.targetDomain}</p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Submitter DID
+                </span>
+                <p className="text-sm font-mono">
+                  {transfer.submitterDid ?? "—"}
+                </p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Content Fingerprint
+                </span>
+                <p className="text-sm font-mono">
+                  {transfer.contentFingerprint ?? "—"}
+                </p>
+              </div>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Token Expires
+                </span>
+                <p className="text-sm">
+                  {transfer.tokenExpiresAt
+                    ? format(new Date(transfer.tokenExpiresAt), "PPpp")
+                    : "—"}
+                </p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Created
+                </span>
+                <p className="text-sm">
+                  {format(new Date(transfer.createdAt), "PPpp")}
+                </p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Completed
+                </span>
+                <p className="text-sm">
+                  {transfer.completedAt
+                    ? format(new Date(transfer.completedAt), "PPpp")
+                    : "—"}
+                </p>
+              </div>
+              {transfer.failureReason && (
+                <div>
+                  <span className="text-sm font-medium text-muted-foreground">
+                    Failure Reason
+                  </span>
+                  <p className="text-sm text-destructive">
+                    {transfer.failureReason}
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* File manifest */}
+      {fileManifest.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>File Manifest</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Filename</TableHead>
+                  <TableHead>MIME Type</TableHead>
+                  <TableHead>Size</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {fileManifest.map((file, i) => (
+                  <TableRow key={i}>
+                    <TableCell>{file.filename}</TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {file.mimeType}
+                    </TableCell>
+                    <TableCell>{formatBytes(file.size)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Cancel action */}
+      {CANCELLABLE_STATUSES.has(transfer.status) && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Actions</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive">Cancel Transfer</Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Cancel Transfer</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Are you sure you want to cancel this transfer to{" "}
+                    <strong>{transfer.targetDomain}</strong>? This action cannot
+                    be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Keep Transfer</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => cancelMutation.mutate({ id: transferId })}
+                  >
+                    Cancel Transfer
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/federation/transfer-list.tsx
+++ b/apps/web/src/components/federation/transfer-list.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { format } from "date-fns";
+
+const STATUS_COLORS: Record<string, string> = {
+  PENDING: "border-yellow-500 text-yellow-700",
+  FILES_REQUESTED: "border-blue-500 text-blue-700",
+  COMPLETED: "border-green-500 text-green-700",
+  REJECTED: "border-red-500 text-red-700",
+  FAILED: "border-red-500 text-red-700",
+  CANCELLED: "border-gray-400 text-gray-600",
+  EXPIRED: "border-gray-400 text-gray-600",
+};
+
+type Tab = "all" | "pending" | "completed" | "failed";
+
+export function TransferList() {
+  const router = useRouter();
+  const [tab, setTab] = useState<Tab>("all");
+  const [page, setPage] = useState(1);
+
+  const { data, isPending: isLoading } = trpc.transfers.list.useQuery({
+    page,
+    limit: 20,
+  });
+
+  const transfers = data?.transfers ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.ceil(total / 20);
+
+  const filtered =
+    tab === "all"
+      ? transfers
+      : tab === "pending"
+        ? transfers.filter(
+            (t) => t.status === "PENDING" || t.status === "FILES_REQUESTED",
+          )
+        : tab === "completed"
+          ? transfers.filter((t) => t.status === "COMPLETED")
+          : transfers.filter(
+              (t) => t.status === "FAILED" || t.status === "REJECTED",
+            );
+
+  return (
+    <div className="space-y-6">
+      <Button variant="ghost" size="sm" asChild>
+        <Link href="/federation">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Federation
+        </Link>
+      </Button>
+
+      <h1 className="text-2xl font-bold">Piece Transfers</h1>
+
+      <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)}>
+        <TabsList>
+          <TabsTrigger value="all">All</TabsTrigger>
+          <TabsTrigger value="pending">Pending</TabsTrigger>
+          <TabsTrigger value="completed">Completed</TabsTrigger>
+          <TabsTrigger value="failed">Failed</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Transfers</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : filtered.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No transfers found.</p>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Target Domain</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Submission</TableHead>
+                    <TableHead>Created</TableHead>
+                    <TableHead>Completed</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filtered.map((transfer) => (
+                    <TableRow
+                      key={transfer.id}
+                      className="cursor-pointer"
+                      onClick={() =>
+                        router.push(`/federation/transfers/${transfer.id}`)
+                      }
+                    >
+                      <TableCell>{transfer.targetDomain}</TableCell>
+                      <TableCell>
+                        <Badge
+                          variant="outline"
+                          className={STATUS_COLORS[transfer.status] ?? ""}
+                        >
+                          {transfer.status.replace(/_/g, " ")}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="font-mono text-xs">
+                        {transfer.submissionId.slice(0, 8)}...
+                      </TableCell>
+                      <TableCell>
+                        {format(new Date(transfer.createdAt), "PP")}
+                      </TableCell>
+                      <TableCell>
+                        {transfer.completedAt
+                          ? format(new Date(transfer.completedAt), "PP")
+                          : "—"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {totalPages > 1 && (
+                <div className="mt-4 flex items-center justify-between">
+                  <p className="text-sm text-muted-foreground">
+                    Page {page} of {totalPages} ({total} total)
+                  </p>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={page <= 1}
+                      onClick={() => setPage((p) => p - 1)}
+                    >
+                      Previous
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={page >= totalPages}
+                      onClick={() => setPage((p) => p + 1)}
+                    >
+                      Next
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/collapsible.tsx
+++ b/apps/web/src/components/ui/collapsible.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+
+const Collapsible = CollapsiblePrimitive.Root;
+
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
+
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -405,15 +405,15 @@
 
 ## Track 10 — Federation Admin UI (Pre-Launch)
 
-> **Status:** In progress. P1 shipped (PR1: trust dashboard + overview). P2/P3 pending.
+> **Status:** Complete. P1 shipped (PR1: trust dashboard + overview). P2/P3 shipped (PR2: remaining 5 sub-pages).
 
 - [x] [P1] Trust management dashboard — list trusted peers with status, capabilities, last-verified; initiate/accept/reject/revoke trust relationships; preview remote instance metadata before trusting — (persona gap analysis 2026-02-27)
 - [x] [P1] Federation status overview — current instance mode (allowlist/open/managed_hub), capabilities enabled, instance public key, DID document link — (persona gap analysis 2026-02-27)
-- [ ] [P2] Sim-sub admin UI — view sim-sub check history per submission, grant overrides, see conflict details — (persona gap analysis 2026-02-27)
-- [ ] [P2] Transfer management UI — list inbound/outbound transfers, view status, cancel pending — (persona gap analysis 2026-02-27)
-- [ ] [P2] Migration management UI — list pending migrations, approve/reject outbound, view history — (persona gap analysis 2026-02-27)
-- [ ] [P3] Hub admin UI (managed hosting only) — list registered instances, suspend/revoke, view attestation status — (persona gap analysis 2026-02-27)
-- [ ] [P3] Audit log viewer — browse audit events with filters (actor, action, resource, date range) — (persona gap analysis 2026-02-27)
+- [x] [P2] Sim-sub admin UI — view sim-sub check history per submission, grant overrides, see conflict details — (persona gap analysis 2026-02-27)
+- [x] [P2] Transfer management UI — list inbound/outbound transfers, view status, cancel pending — (persona gap analysis 2026-02-27)
+- [x] [P2] Migration management UI — list pending migrations, approve/reject outbound, view history — (persona gap analysis 2026-02-27)
+- [x] [P3] Hub admin UI (managed hosting only) — list registered instances, suspend/revoke, view attestation status — (persona gap analysis 2026-02-27)
+- [x] [P3] Audit log viewer — browse audit events with filters (actor, action, resource, date range) — (persona gap analysis 2026-02-27)
 
 ---
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,26 @@ Newest entries first.
 
 ---
 
+## 2026-03-02 — Track 10 PR2: Federation Admin UI (Remaining Pages)
+
+### Done
+
+- **Backend tRPC routers**: 4 new routers — `simsub` (listChecks, grantOverride), `transfers` (list, getById, cancel), `migrations` (list, getById, listPending, request, approve, reject, cancel), `hub` (listInstances, getInstanceById, suspendInstance, revokeInstance). Registered all in `router.ts`. Added hub error mappings (HubNotEnabledError, HubInstanceNotFoundError, HubInstanceSuspendedError) to `error-mapper.ts`
+- **Frontend pages**: 8 new page files under `/federation/` — sim-sub, transfers, transfers/[id], migrations, migrations/[id], hub, hub/[id], audit
+- **Frontend components**: 8 new components — `sim-sub-admin` (lookup form + results table + override), `transfer-list` (tabs + paginated table), `transfer-detail` (info card + file manifest + cancel), `migration-list` (tabs + direction filter + pending banner), `migration-detail` (info card + approve/reject/cancel), `hub-admin` (hub-not-enabled guard + instance table), `hub-instance-detail` (info card + suspend/revoke), `audit-log-viewer` (collapsible filters + event table + detail dialog)
+- **Federation overview**: Added 5 navigation cards (Sim-Sub Checks, Piece Transfers, Identity Migrations, Hub Administration, Audit Log) with icons linking to sub-pages
+- **UI component**: Added `collapsible.tsx` Radix primitive wrapper (used by audit-log-viewer filter bar)
+- **Tests**: 4 Vitest API specs (10 tests) + 8 Jest frontend specs (39 tests); full suite 149 suites / 1522 tests passing
+- **Quality gates**: `pnpm type-check` 14/14, `pnpm lint` 0 errors, `pnpm test` all passing
+
+### Decisions
+
+- Migration router uses `authedProcedure` (user-scoped, not admin) — matches REST route pattern, userId-scoped via RLS
+- Sim-sub conflict details displayed inline with `React.Fragment` rows instead of Collapsible — avoids Radix+table DOM nesting complexity
+- Audit log filter types cast via `as Parameters<typeof ...>` to handle AuditActions enum type mismatch without duplicating the enum on the frontend
+
+---
+
 ## 2026-03-01 — Track 8 Closeout (Manual Correspondence, Duplicate Detection, CSR Docs)
 
 ### Done

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collapsible':
+        specifier: ^1.1.12
+        version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2774,6 +2777,19 @@ packages:
 
   '@radix-ui/react-checkbox@1.3.3':
     resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.12':
+    resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -11286,6 +11302,22 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:


### PR DESCRIPTION
## Summary

- **Sim-Sub Checks** — submission ID lookup, result badges (CLEAR/CONFLICT/PARTIAL/SKIPPED), inline conflict details, grant override action
- **Piece Transfers** — tabbed list (all/pending/completed/failed), detail view with file manifest, cancel action for pending transfers
- **Identity Migrations** — tabbed list with direction filter, pending approval banner, detail view with approve/reject/cancel actions
- **Hub Administration** — hub-not-enabled guard, instance table with status tabs, instance detail with suspend/revoke actions
- **Audit Log** — collapsible filter bar (action, resource, actor, date range), event table with detail dialog showing old/new values
- **Federation overview** — 5 navigation cards linking to sub-pages
- **Backend**: 4 new tRPC routers (simsub, transfer, migration, hub) with 16 total procedures + hub error mappings
- **Tests**: 4 Vitest API specs (10 tests) + 8 Jest frontend specs (39 tests); full suite 149 suites / 1522 tests passing

## What's included

### Backend
- `apps/api/src/trpc/routers/simsub.ts` — 2 procedures (listChecks, grantOverride)
- `apps/api/src/trpc/routers/transfer.ts` — 3 procedures (list, getById, cancel)
- `apps/api/src/trpc/routers/migration.ts` — 7 procedures (list, getById, listPending, request, approve, reject, cancel)
- `apps/api/src/trpc/routers/hub.ts` — 4 procedures (listInstances, getInstanceById, suspendInstance, revokeInstance)
- `apps/api/src/trpc/error-mapper.ts` — 3 hub error mappings
- `apps/api/src/trpc/router.ts` — registered 4 new routers

### Frontend
- 8 page files under `/federation/` (sim-sub, transfers, transfers/[id], migrations, migrations/[id], hub, hub/[id], audit)
- 8 components (sim-sub-admin, transfer-list, transfer-detail, migration-list, migration-detail, hub-admin, hub-instance-detail, audit-log-viewer)
- `collapsible.tsx` — Radix primitive wrapper (used by audit log filter bar)
- `federation-overview.tsx` — 5 navigation cards with icons

### Tests
- 4 Vitest API specs: simsub, transfer, migration, hub routers
- 8 Jest frontend specs: all new components

## Design decisions

- Migration router uses `authedProcedure` (user-scoped, not admin) — matches REST route pattern, userId-scoped via RLS
- Sim-sub conflict details inline via React.Fragment (not Collapsible) — avoids Radix+table DOM nesting issues
- Audit log filter types cast via `as Parameters<typeof ...>` — avoids duplicating AuditActions enum on frontend

## Test plan

- [x] `pnpm type-check` passes (14/14 projects)
- [x] `pnpm lint` passes (0 errors, 5 pre-existing warnings)
- [x] `pnpm test` passes (149 suites / 1522 tests)
- [ ] Navigate to `/federation` — overview shows 5 navigation cards
- [ ] Click each card — page loads with correct layout
- [ ] Sim-sub: enter submission ID, lookup shows results table
- [ ] Transfers: tabs filter list, row click navigates to detail
- [ ] Migrations: direction filter + tabs, pending banner shows when applicable
- [ ] Hub: hub-not-enabled message or instance table depending on config
- [ ] Audit: filter bar collapses/expands, events table with row detail dialog