### PR TITLE
feat(register): sim-sub policy versioning + fingerprint split

### DIFF
--- a/.claude/skills/end-session/SKILL.md
+++ b/.claude/skills/end-session/SKILL.md
@@ -52,12 +52,12 @@ Scan the conversation to identify:
 
 ### Step 3: Note code review status
 
-<!-- Active review tool: /opencode-review. To switch back: replace /opencode-review with /codex-review -->
+<!-- Active review tool: /codex-review. To switch back: replace /codex-review with /opencode-review -->
 
-Check the conversation history for any `/opencode-review` or `/codex-review` invocations during this session. **Distinguish between review types** — they are not interchangeable:
+Check the conversation history for any `/codex-review` or `/opencode-review` invocations during this session. **Distinguish between review types** — they are not interchangeable:
 
-- **Plan review** (`/opencode-review plan`): Reviews the _plan file_ for soundness before implementation. Does NOT review actual code written.
-- **Branch review** (`/opencode-review branch`): Reviews the _actual code diff_ against `origin/main`. This is the implementation review.
+- **Plan review** (`/codex-review plan`): Reviews the _plan file_ for soundness before implementation. Does NOT review actual code written.
+- **Branch review** (`/codex-review branch`): Reviews the _actual code diff_ against `origin/main`. This is the implementation review.
 
 Record which types were run:
 
@@ -189,13 +189,13 @@ git commit -m "docs: update devlog and docs for [session date] session"
 
 ### Step 6.5: Run branch review
 
-<!-- Active review tool: /opencode-review. To switch back: replace /opencode-review with /codex-review -->
+<!-- Active review tool: /codex-review. To switch back: replace /codex-review with /opencode-review -->
 
 After all commits (code + docs) are complete but before pushing, run a branch review:
 
 1. **Check prerequisites:** Verify all code changes are committed (no uncommitted changes except `session-handoff.md` which is gitignored).
 
-2. **Run the review:** Execute `/opencode-review branch` (which includes plan drift detection if a plan file exists).
+2. **Run the review:** Execute `/codex-review branch` (which includes plan drift detection if a plan file exists).
 
 3. **Present findings to the user:** Show the review results and ask which findings (if any) to address before the PR.
 
@@ -207,9 +207,9 @@ After all commits (code + docs) are complete but before pushing, run a branch re
 
 - The session had no code changes (doc-only update)
 - The user explicitly says to skip review (e.g., "just push it")
-- An `/opencode-review branch` (or `/codex-review branch`) was already run during this session and no code changes were made after it
+- A `/codex-review branch` (or `/opencode-review branch`) was already run during this session and no code changes were made after it
 
-**IMPORTANT: A plan review (`/opencode-review plan`) does NOT substitute for a branch review.** Plan reviews check the plan's assumptions against the codebase; branch reviews check the actual implementation. Even if a plan review ran earlier in the session, a branch review is still required here unless explicitly skipped by the user.
+**IMPORTANT: A plan review (`/codex-review plan`) does NOT substitute for a branch review.** Plan reviews check the plan's assumptions against the codebase; branch reviews check the actual implementation. Even if a plan review ran earlier in the session, a branch review is still required here unless explicitly skipped by the user.
 
 Update the session summary (Step 9) to include the review outcome under "Code Review", distinguishing between plan and branch reviews.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,14 +303,14 @@ Wait for user confirmation or redirection on each decision before proceeding to 
 - All decisions were already made in the requirements (backlog item specifies the approach)
 - The user explicitly says "just do it" or "use your judgment"
 
-### Plan Review: OpenCode Integration
+### Plan Review: Codex Integration
 
-<!-- To switch back to Codex: replace /opencode-review with /codex-review below -->
+<!-- To switch to OpenCode: replace /codex-review with /opencode-review below -->
 
 Every non-trivial plan **must be reviewed before presenting to the user for approval**. The workflow is:
 
 1. **Write the plan** (after decision surfacing, per above)
-2. **Run `/opencode-review plan`** automatically — do not ask the user, just run it
+2. **Run `/codex-review plan`** automatically — do not ask the user, just run it
 3. **Evaluate review findings** — adjust the plan for any critical or important issues; for dismissed suggestions, add a brief note (e.g., "Review suggested X; dismissed because Y")
 4. **Present the reviewed plan** to the user for approval
 

--- a/apps/api/src/graphql/resolvers/submissions-mutations.spec.ts
+++ b/apps/api/src/graphql/resolvers/submissions-mutations.spec.ts
@@ -308,6 +308,7 @@ describe('Submission mutations — resolver wiring', () => {
       transferredFromTransferId: null,
       statusTokenHash: null,
       statusTokenExpiresAt: null,
+      simSubPolicyRequirement: null,
     };
     // eslint-disable-next-line @typescript-eslint/unbound-method
     vi.mocked(submissionService.createWithAudit).mockResolvedValue(submission);
@@ -413,6 +414,7 @@ describe('Submission mutations — resolver wiring', () => {
         transferredFromTransferId: null,
         statusTokenHash: null,
         statusTokenExpiresAt: null,
+        simSubPolicyRequirement: null,
       },
       historyEntry: {
         id: 'hist-1',
@@ -483,6 +485,7 @@ describe('Submission mutations — resolver wiring', () => {
       transferredFromTransferId: null,
       statusTokenHash: null,
       statusTokenExpiresAt: null,
+      simSubPolicyRequirement: null,
     };
     // eslint-disable-next-line @typescript-eslint/unbound-method
     vi.mocked(submissionService.createWithAudit).mockResolvedValue(submission);
@@ -562,6 +565,7 @@ describe('Submission mutations — resolver wiring', () => {
       transferredFromTransferId: null,
       statusTokenHash: null,
       statusTokenExpiresAt: null,
+      simSubPolicyRequirement: null,
     };
     // eslint-disable-next-line @typescript-eslint/unbound-method
     vi.mocked(submissionService.updateAsOwner).mockResolvedValue(submission);

--- a/apps/api/src/services/file.service.ts
+++ b/apps/api/src/services/file.service.ts
@@ -143,6 +143,14 @@ export const fileService = {
     return updated ?? null;
   },
 
+  async updateContentHash(
+    tx: DrizzleDb,
+    fileId: string,
+    contentHash: string,
+  ): Promise<void> {
+    await tx.update(files).set({ contentHash }).where(eq(files.id, fileId));
+  },
+
   async delete(tx: DrizzleDb, fileId: string) {
     const [deleted] = await tx
       .delete(files)

--- a/apps/api/src/services/fingerprint.service.spec.ts
+++ b/apps/api/src/services/fingerprint.service.spec.ts
@@ -9,11 +9,13 @@ vi.mock('@colophony/db', () => ({
     id: 'id',
     manuscriptId: 'manuscript_id',
     contentFingerprint: 'content_fingerprint',
+    federationFingerprint: 'federation_fingerprint',
   },
   manuscripts: { id: 'id', title: 'title' },
   files: {
     filename: 'filename',
     size: 'size',
+    contentHash: 'content_hash',
     manuscriptVersionId: 'manuscript_version_id',
     scanStatus: 'scan_status',
   },
@@ -31,6 +33,8 @@ vi.mock('@colophony/db', () => ({
 
 import {
   normalizeText,
+  computeContentFingerprint,
+  computeFederationFingerprint,
   computeFingerprint,
   fingerprintService,
   FingerprintComputationError,
@@ -63,41 +67,88 @@ describe('normalizeText', () => {
 });
 
 // ---------------------------------------------------------------------------
-// computeFingerprint
+// computeContentFingerprint
 // ---------------------------------------------------------------------------
 
-describe('computeFingerprint', () => {
-  it('produces consistent SHA-256 hex (64 chars)', () => {
-    const fp = computeFingerprint('My Poem', 'some text', ['file1', 'file2']);
+describe('computeContentFingerprint', () => {
+  it('produces deterministic SHA-256 hex (64 chars)', () => {
+    const fp = computeContentFingerprint('My Poem', 'some text', [
+      'abc123',
+      'def456',
+    ]);
     expect(fp).toHaveLength(64);
     expect(fp).toMatch(/^[a-f0-9]{64}$/);
     // Deterministic
-    expect(computeFingerprint('My Poem', 'some text', ['file1', 'file2'])).toBe(
-      fp,
-    );
+    expect(
+      computeContentFingerprint('My Poem', 'some text', ['abc123', 'def456']),
+    ).toBe(fp);
   });
 
   it('same content with different whitespace produces same hash', () => {
-    const fp1 = computeFingerprint('My  Poem', '  some   text  ', []);
-    const fp2 = computeFingerprint('my poem', 'some text', []);
-    expect(fp1).toBe(fp2);
-  });
-
-  it('different titles produce different hashes', () => {
-    const fp1 = computeFingerprint('Poem A', null, []);
-    const fp2 = computeFingerprint('Poem B', null, []);
-    expect(fp1).not.toBe(fp2);
-  });
-
-  it('file hash order does not affect fingerprint (sorted)', () => {
-    const fp1 = computeFingerprint('title', null, ['b', 'a', 'c']);
-    const fp2 = computeFingerprint('title', null, ['c', 'a', 'b']);
+    const fp1 = computeContentFingerprint('My  Poem', '  some   text  ', []);
+    const fp2 = computeContentFingerprint('my poem', 'some text', []);
     expect(fp1).toBe(fp2);
   });
 
   it('null contentText handled correctly', () => {
-    const fp = computeFingerprint('title', null, []);
+    const fp = computeContentFingerprint('title', null, []);
     expect(fp).toHaveLength(64);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeFederationFingerprint
+// ---------------------------------------------------------------------------
+
+describe('computeFederationFingerprint', () => {
+  it('produces deterministic SHA-256 hex (64 chars)', () => {
+    const fp = computeFederationFingerprint('My Poem', 'some text', [
+      'poem.docx:1234',
+      'cover.pdf:5678',
+    ]);
+    expect(fp).toHaveLength(64);
+    expect(fp).toMatch(/^[a-f0-9]{64}$/);
+    // Deterministic
+    expect(
+      computeFederationFingerprint('My Poem', 'some text', [
+        'poem.docx:1234',
+        'cover.pdf:5678',
+      ]),
+    ).toBe(fp);
+  });
+
+  it('file identifier order does not affect fingerprint (sorted)', () => {
+    const fp1 = computeFederationFingerprint('title', null, ['b:1', 'a:2']);
+    const fp2 = computeFederationFingerprint('title', null, ['a:2', 'b:1']);
+    expect(fp1).toBe(fp2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// content and federation fingerprints differ
+// ---------------------------------------------------------------------------
+
+describe('content vs federation fingerprints', () => {
+  it('differ given different file inputs', () => {
+    const content = computeContentFingerprint('Title', 'body', [
+      'abc123def456abc123def456abc123def456abc123def456abc123def456abcd',
+    ]);
+    const federation = computeFederationFingerprint('Title', 'body', [
+      'poem.docx:1234',
+    ]);
+    expect(content).not.toBe(federation);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeFingerprint (deprecated alias)
+// ---------------------------------------------------------------------------
+
+describe('computeFingerprint (deprecated alias)', () => {
+  it('is identical to computeFederationFingerprint', () => {
+    const fp1 = computeFingerprint('title', 'text', ['file1:100']);
+    const fp2 = computeFederationFingerprint('title', 'text', ['file1:100']);
+    expect(fp1).toBe(fp2);
   });
 });
 
@@ -106,36 +157,61 @@ describe('computeFingerprint', () => {
 // ---------------------------------------------------------------------------
 
 describe('fingerprintService.computeAndStore', () => {
-  it('computes and persists fingerprint on manuscript version', async () => {
-    const mockTx = {
+  function makeMockTx() {
+    return {
       select: vi.fn(),
       update: vi.fn(),
     } as any;
+  }
+
+  function setupComputeAndStoreMocks(
+    mockTx: any,
+    opts: {
+      version?: { id: string; manuscriptId: string } | null;
+      manuscript?: { title: string } | null;
+      files?: Array<{
+        filename: string;
+        size: number;
+        contentHash: string | null;
+      }>;
+      submission?: { content: string | null } | null;
+    } = {},
+  ) {
+    const {
+      version = { id: 'v1', manuscriptId: 'm1' },
+      manuscript = { title: 'My Poem' },
+      files: fileList = [
+        { filename: 'poem.pdf', size: 1024, contentHash: 'abc123' },
+      ],
+      submission = { content: 'poem content' },
+    } = opts;
 
     // version query
     mockTx.select.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: 'v1', manuscriptId: 'm1' }]),
+          limit: vi.fn().mockResolvedValue(version ? [version] : []),
         }),
       }),
     });
+
+    if (!version) return;
 
     // manuscript query
     mockTx.select.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ title: 'My Poem' }]),
+          limit: vi.fn().mockResolvedValue(manuscript ? [manuscript] : []),
         }),
       }),
     });
 
+    if (!manuscript) return;
+
     // files query
     mockTx.select.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi
-          .fn()
-          .mockResolvedValue([{ filename: 'poem.pdf', size: 1024 }]),
+        where: vi.fn().mockResolvedValue(fileList),
       }),
     });
 
@@ -143,7 +219,7 @@ describe('fingerprintService.computeAndStore', () => {
     mockTx.select.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ content: 'poem content' }]),
+          limit: vi.fn().mockResolvedValue(submission ? [submission] : []),
         }),
       }),
     });
@@ -154,76 +230,66 @@ describe('fingerprintService.computeAndStore', () => {
         where: vi.fn().mockResolvedValue(undefined),
       }),
     });
+  }
 
-    const fp = await fingerprintService.computeAndStore(mockTx, 'v1');
-    expect(fp).toHaveLength(64);
+  it('returns both fingerprints and stores both', async () => {
+    const mockTx = makeMockTx();
+    setupComputeAndStoreMocks(mockTx, {
+      files: [{ filename: 'poem.pdf', size: 1024, contentHash: 'abc123' }],
+    });
+
+    const result = await fingerprintService.computeAndStore(mockTx, 'v1');
+    expect(result.contentFingerprint).toHaveLength(64);
+    expect(result.federationFingerprint).toHaveLength(64);
     expect(mockTx.update).toHaveBeenCalled();
   });
 
+  it('content and federation fingerprints differ when contentHash present', async () => {
+    const mockTx = makeMockTx();
+    setupComputeAndStoreMocks(mockTx, {
+      files: [{ filename: 'poem.pdf', size: 1024, contentHash: 'abc123' }],
+    });
+
+    const result = await fingerprintService.computeAndStore(mockTx, 'v1');
+    // contentHash 'abc123' vs identifier 'poem.pdf:1024' → different fingerprints
+    expect(result.contentFingerprint).not.toBe(result.federationFingerprint);
+  });
+
+  it('falls back to filename:size when contentHash is null', async () => {
+    const mockTx = makeMockTx();
+    setupComputeAndStoreMocks(mockTx, {
+      files: [{ filename: 'poem.pdf', size: 1024, contentHash: null }],
+    });
+
+    const result = await fingerprintService.computeAndStore(mockTx, 'v1');
+    // Both use filename:size when contentHash is null, so they should be equal
+    expect(result.contentFingerprint).toBe(result.federationFingerprint);
+  });
+
   it('only includes CLEAN files', async () => {
-    const mockTx = {
-      select: vi.fn(),
-      update: vi.fn(),
-    } as any;
+    const mockTx = makeMockTx();
+    setupComputeAndStoreMocks(mockTx, { files: [] });
 
-    // version
-    mockTx.select.mockReturnValueOnce({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: 'v1', manuscriptId: 'm1' }]),
-        }),
-      }),
-    });
-
-    // manuscript
-    mockTx.select.mockReturnValueOnce({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ title: 'Test' }]),
-        }),
-      }),
-    });
-
-    // files — the WHERE clause in the service already filters by CLEAN
-    mockTx.select.mockReturnValueOnce({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue([]),
-      }),
-    });
-
-    // linked submission
-    mockTx.select.mockReturnValueOnce({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([]),
-        }),
-      }),
-    });
-
-    // update
-    mockTx.update.mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(undefined),
-      }),
-    });
-
-    const fp = await fingerprintService.computeAndStore(mockTx, 'v1');
-    expect(fp).toHaveLength(64);
+    const result = await fingerprintService.computeAndStore(mockTx, 'v1');
+    expect(result.contentFingerprint).toHaveLength(64);
+    expect(result.federationFingerprint).toHaveLength(64);
   });
 
   it('throws FingerprintComputationError for missing version', async () => {
-    const mockTx = {
-      select: vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([]),
-          }),
-        }),
-      }),
-    } as any;
+    const mockTx = makeMockTx();
+    setupComputeAndStoreMocks(mockTx, { version: null });
 
     await expect(
       fingerprintService.computeAndStore(mockTx, 'nonexistent'),
+    ).rejects.toThrow(FingerprintComputationError);
+  });
+
+  it('throws FingerprintComputationError for missing manuscript', async () => {
+    const mockTx = makeMockTx();
+    setupComputeAndStoreMocks(mockTx, { manuscript: null });
+
+    await expect(
+      fingerprintService.computeAndStore(mockTx, 'v1'),
     ).rejects.toThrow(FingerprintComputationError);
   });
 });
@@ -233,37 +299,47 @@ describe('fingerprintService.computeAndStore', () => {
 // ---------------------------------------------------------------------------
 
 describe('fingerprintService.getOrCompute', () => {
-  it('returns stored fingerprint without recomputing', async () => {
-    const existingFp = 'a'.repeat(64);
+  it('returns stored fingerprints without recomputing', async () => {
+    const existingContent = 'a'.repeat(64);
+    const existingFederation = 'b'.repeat(64);
     const mockTx = {
       select: vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
-            limit: vi
-              .fn()
-              .mockResolvedValue([{ contentFingerprint: existingFp }]),
+            limit: vi.fn().mockResolvedValue([
+              {
+                contentFingerprint: existingContent,
+                federationFingerprint: existingFederation,
+              },
+            ]),
           }),
         }),
       }),
     } as any;
 
     const result = await fingerprintService.getOrCompute(mockTx, 'v1');
-    expect(result).toBe(existingFp);
+    expect(result.contentFingerprint).toBe(existingContent);
+    expect(result.federationFingerprint).toBe(existingFederation);
     // Only one select call (no computeAndStore)
     expect(mockTx.select).toHaveBeenCalledTimes(1);
   });
 
-  it('computes and stores if not present', async () => {
+  it('recomputes when federationFingerprint is missing', async () => {
     const mockTx = {
       select: vi.fn(),
       update: vi.fn(),
     } as any;
 
-    // getOrCompute initial check — no fingerprint
+    // getOrCompute initial check — contentFingerprint present, federation missing
     mockTx.select.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ contentFingerprint: null }]),
+          limit: vi.fn().mockResolvedValue([
+            {
+              contentFingerprint: 'a'.repeat(64),
+              federationFingerprint: null,
+            },
+          ]),
         }),
       }),
     });
@@ -302,7 +378,65 @@ describe('fingerprintService.getOrCompute', () => {
     });
 
     const result = await fingerprintService.getOrCompute(mockTx, 'v1');
-    expect(result).toHaveLength(64);
+    expect(result.contentFingerprint).toHaveLength(64);
+    expect(result.federationFingerprint).toHaveLength(64);
     expect(mockTx.update).toHaveBeenCalled();
+  });
+
+  it('recomputes when both fingerprints are missing', async () => {
+    const mockTx = {
+      select: vi.fn(),
+      update: vi.fn(),
+    } as any;
+
+    // getOrCompute initial check — no fingerprints
+    mockTx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi
+            .fn()
+            .mockResolvedValue([
+              { contentFingerprint: null, federationFingerprint: null },
+            ]),
+        }),
+      }),
+    });
+
+    // computeAndStore calls
+    mockTx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: 'v1', manuscriptId: 'm1' }]),
+        }),
+      }),
+    });
+    mockTx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ title: 'Title' }]),
+        }),
+      }),
+    });
+    mockTx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+    mockTx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+    mockTx.update.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    });
+
+    const result = await fingerprintService.getOrCompute(mockTx, 'v1');
+    expect(result.contentFingerprint).toHaveLength(64);
+    expect(result.federationFingerprint).toHaveLength(64);
   });
 });

--- a/apps/api/src/services/fingerprint.service.ts
+++ b/apps/api/src/services/fingerprint.service.ts
@@ -32,15 +32,15 @@ export function normalizeText(text: string): string {
 }
 
 /**
- * Compute a SHA-256 hex fingerprint from title, optional content text,
- * and file hashes (sorted for determinism).
+ * Compute a content fingerprint using SHA-256 content hashes of actual file bytes.
+ * Used for local sim-sub detection (higher accuracy than filename:size).
  */
-export function computeFingerprint(
+export function computeContentFingerprint(
   title: string,
   contentText: string | null,
-  fileHashes: string[],
+  fileContentHashes: string[],
 ): string {
-  const sorted = [...fileHashes].sort();
+  const sorted = [...fileContentHashes].sort();
   const input =
     normalizeText(title) +
     '\0' +
@@ -50,21 +50,57 @@ export function computeFingerprint(
   return crypto.createHash('sha256').update(input).digest('hex');
 }
 
+/**
+ * Compute a federation fingerprint using filename:size identifiers.
+ * Used for cross-instance sim-sub detection (no file content shared).
+ */
+export function computeFederationFingerprint(
+  title: string,
+  contentText: string | null,
+  fileIdentifiers: string[],
+): string {
+  const sorted = [...fileIdentifiers].sort();
+  const input =
+    normalizeText(title) +
+    '\0' +
+    normalizeText(contentText ?? '') +
+    '\0' +
+    sorted.join(',');
+  return crypto.createHash('sha256').update(input).digest('hex');
+}
+
+/**
+ * @deprecated Use computeFederationFingerprint instead.
+ * Kept temporarily for backwards compatibility during migration.
+ */
+export const computeFingerprint = computeFederationFingerprint;
+
+// ---------------------------------------------------------------------------
+// Return type for dual fingerprints
+// ---------------------------------------------------------------------------
+
+export interface DualFingerprint {
+  contentFingerprint: string;
+  federationFingerprint: string;
+}
+
 // ---------------------------------------------------------------------------
 // Service (DB-dependent)
 // ---------------------------------------------------------------------------
 
 export const fingerprintService = {
   /**
-   * Compute fingerprint from manuscript version data and store it.
+   * Compute both fingerprints from manuscript version data and store them.
    *
-   * Uses the manuscript title, submission content (if linked), and
-   * storage keys of CLEAN files as the fingerprint inputs.
+   * Content fingerprint uses SHA-256 file content hashes (from ClamAV scan).
+   * Federation fingerprint uses filename:size identifiers (cross-instance stable).
+   * When contentHash is null (files scanned before this change), falls back
+   * to filename:size for the content fingerprint too.
    */
   async computeAndStore(
     tx: DrizzleDb,
     manuscriptVersionId: string,
-  ): Promise<string> {
+  ): Promise<DualFingerprint> {
     // Load version + manuscript title
     const [version] = await tx
       .select({
@@ -93,14 +129,12 @@ export const fingerprintService = {
       );
     }
 
-    // Get CLEAN file identifiers for fingerprinting.
-    // Uses filename + size (not storageKey) for cross-instance stability:
-    // the same file uploaded to different instances has the same name/size
-    // but different storage keys.
+    // Get CLEAN files with content hash + file identifiers
     const cleanFiles = await tx
       .select({
         filename: files.filename,
         size: files.size,
+        contentHash: files.contentHash,
       })
       .from(files)
       .where(
@@ -110,7 +144,12 @@ export const fingerprintService = {
         ),
       );
 
-    const fileHashes = cleanFiles.map((f) => `${f.filename}:${f.size}`);
+    // Content fingerprint: prefer contentHash, fall back to filename:size
+    const contentHashes = cleanFiles.map(
+      (f) => f.contentHash ?? `${f.filename}:${f.size}`,
+    );
+    // Federation fingerprint: always filename:size (cross-instance stable)
+    const fileIdentifiers = cleanFiles.map((f) => `${f.filename}:${f.size}`);
 
     // Check if there's a linked submission with content text
     const [linkedSubmission] = await tx
@@ -121,30 +160,39 @@ export const fingerprintService = {
 
     const contentText = linkedSubmission?.content ?? null;
 
-    const fingerprint = computeFingerprint(
+    const contentFingerprint = computeContentFingerprint(
       manuscript.title,
       contentText,
-      fileHashes,
+      contentHashes,
+    );
+    const federationFingerprint = computeFederationFingerprint(
+      manuscript.title,
+      contentText,
+      fileIdentifiers,
     );
 
-    // Store on the version
+    // Store both on the version
     await tx
       .update(manuscriptVersions)
-      .set({ contentFingerprint: fingerprint })
+      .set({ contentFingerprint, federationFingerprint })
       .where(eq(manuscriptVersions.id, manuscriptVersionId));
 
-    return fingerprint;
+    return { contentFingerprint, federationFingerprint };
   },
 
   /**
-   * Return the stored fingerprint, or compute and store it if absent.
+   * Return stored fingerprints, or compute and store if absent.
+   * Recomputes if either fingerprint is missing.
    */
   async getOrCompute(
     tx: DrizzleDb,
     manuscriptVersionId: string,
-  ): Promise<string> {
+  ): Promise<DualFingerprint> {
     const [version] = await tx
-      .select({ contentFingerprint: manuscriptVersions.contentFingerprint })
+      .select({
+        contentFingerprint: manuscriptVersions.contentFingerprint,
+        federationFingerprint: manuscriptVersions.federationFingerprint,
+      })
       .from(manuscriptVersions)
       .where(eq(manuscriptVersions.id, manuscriptVersionId))
       .limit(1);
@@ -155,8 +203,11 @@ export const fingerprintService = {
       );
     }
 
-    if (version.contentFingerprint) {
-      return version.contentFingerprint;
+    if (version.contentFingerprint && version.federationFingerprint) {
+      return {
+        contentFingerprint: version.contentFingerprint,
+        federationFingerprint: version.federationFingerprint,
+      };
     }
 
     return this.computeAndStore(tx, manuscriptVersionId);

--- a/apps/api/src/services/simsub.service.spec.ts
+++ b/apps/api/src/services/simsub.service.spec.ts
@@ -45,6 +45,7 @@ vi.mock('@colophony/db', () => ({
     contentFingerprint: 'content_fingerprint',
     federationFingerprint: 'federation_fingerprint',
     manuscriptId: 'manuscript_id',
+    versionNumber: 'version_number',
   },
   submissions: {
     id: 'id',
@@ -54,13 +55,25 @@ vi.mock('@colophony/db', () => ({
     simSubCheckResult: 'sim_sub_check_result',
     simSubCheckedAt: 'sim_sub_checked_at',
     simSubOverride: 'sim_sub_override',
+    simSubPolicyRequirement: 'sim_sub_policy_requirement',
     submittedAt: 'submitted_at',
   },
   submissionPeriods: {
     id: 'id',
-    simSubProhibited: 'sim_sub_prohibited',
+    simSubPolicy: 'sim_sub_policy',
     publicationId: 'publication_id',
     name: 'name',
+  },
+  manuscripts: {
+    id: 'id',
+    genre: 'genre',
+  },
+  externalSubmissions: {
+    id: 'id',
+    manuscriptId: 'manuscript_id',
+    journalName: 'journal_name',
+    status: 'status',
+    sentAt: 'sent_at',
   },
   publications: { id: 'id', name: 'name' },
   users: {
@@ -153,7 +166,11 @@ function makeEnv(overrides: Record<string, unknown> = {}) {
 // Import after mocks
 // ---------------------------------------------------------------------------
 
-import { simsubService } from './simsub.service.js';
+import {
+  simsubService,
+  resolveEffectivePolicy,
+  SimSubConflictError,
+} from './simsub.service.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -970,5 +987,664 @@ describe('simsubService.handleInboundCheck — uses federation fingerprint', () 
       'federation',
     );
     checkLocalSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR3: resolveEffectivePolicy
+// ---------------------------------------------------------------------------
+
+describe('resolveEffectivePolicy', () => {
+  it('returns base type when no overrides', () => {
+    const result = resolveEffectivePolicy({ type: 'prohibited' }, 'poetry');
+    expect(result).toBe('prohibited');
+  });
+
+  it('returns base type when genre does not match overrides', () => {
+    const result = resolveEffectivePolicy(
+      {
+        type: 'allowed',
+        genreOverrides: [{ genre: 'fiction', type: 'prohibited' }],
+      },
+      'poetry',
+    );
+    expect(result).toBe('allowed');
+  });
+
+  it('applies genre override when genre matches', () => {
+    const result = resolveEffectivePolicy(
+      {
+        type: 'allowed',
+        genreOverrides: [{ genre: 'poetry', type: 'prohibited' }],
+      },
+      'poetry',
+    );
+    expect(result).toBe('prohibited');
+  });
+
+  it('returns base type when genre is null', () => {
+    const result = resolveEffectivePolicy(
+      {
+        type: 'prohibited',
+        genreOverrides: [{ genre: 'poetry', type: 'allowed' }],
+      },
+      null,
+    );
+    expect(result).toBe('prohibited');
+  });
+
+  it('returns base type when genre is undefined', () => {
+    const result = resolveEffectivePolicy(
+      {
+        type: 'allowed_notify',
+        genreOverrides: [{ genre: 'fiction', type: 'prohibited' }],
+      },
+      undefined,
+    );
+    expect(result).toBe('allowed_notify');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR3: checkSiblingVersions
+// ---------------------------------------------------------------------------
+
+describe('simsubService.checkSiblingVersions', () => {
+  it('returns empty when version not found', async () => {
+    mockWithRls.mockImplementationOnce(async (_ctx: any, fn: any) => {
+      return fn({
+        select: () => ({
+          from: () => ({
+            where: () => ({
+              limit: () => Promise.resolve([]),
+            }),
+          }),
+        }),
+      });
+    });
+
+    const result = await simsubService.checkSiblingVersions('user1', 'v1');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty when no sibling versions exist', async () => {
+    mockWithRls.mockImplementationOnce(async (_ctx: any, fn: any) => {
+      return fn({
+        select: () => ({
+          from: () => ({
+            where: (..._args: any[]) => {
+              // First call: find version → return manuscriptId
+              // Second call: find siblings → return empty
+              return {
+                limit: () => Promise.resolve([{ manuscriptId: 'm1' }]),
+              };
+            },
+          }),
+        }),
+      });
+    });
+
+    // The mock above returns manuscriptId but no siblings
+    // We need the second select to return empty
+    let callCount = 0;
+    mockWithRls.mockReset();
+    mockWithRls.mockImplementationOnce(async (_ctx: any, fn: any) => {
+      return fn({
+        select: () => ({
+          from: () => ({
+            where: () => {
+              callCount++;
+              if (callCount === 1) {
+                return {
+                  limit: () => Promise.resolve([{ manuscriptId: 'm1' }]),
+                };
+              }
+              return { limit: () => Promise.resolve([]) };
+            },
+          }),
+        }),
+      });
+    });
+
+    const result = await simsubService.checkSiblingVersions('user1', 'v1');
+    expect(result).toEqual([]);
+  });
+
+  it('returns conflicts for active sibling submissions', async () => {
+    // Phase 1: user-scoped — find manuscriptId and sibling versions
+    let phase1Call = 0;
+    mockWithRls.mockImplementationOnce(async (_ctx: any, fn: any) => {
+      return fn({
+        select: () => ({
+          from: () => ({
+            where: () => {
+              phase1Call++;
+              if (phase1Call === 1) {
+                return {
+                  limit: () => Promise.resolve([{ manuscriptId: 'm1' }]),
+                };
+              }
+              return {
+                limit: () => Promise.resolve([{ id: 'v2', versionNumber: 2 }]),
+              };
+            },
+          }),
+        }),
+      });
+    });
+
+    // Phase 2: superuser — find active submissions on sibling versions
+    dbSelectResult = [
+      {
+        submissionId: 's2',
+        manuscriptVersionId: 'v2',
+        publicationName: 'Lit Mag X',
+        status: 'SUBMITTED',
+        submittedAt: new Date('2026-02-01'),
+      },
+    ];
+
+    const result = await simsubService.checkSiblingVersions(
+      'user1',
+      'v1',
+      's1',
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].publicationName).toBe('Lit Mag X');
+    expect(result[0].versionNumber).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR3: checkWriterDisclosed
+// ---------------------------------------------------------------------------
+
+describe('simsubService.checkWriterDisclosed', () => {
+  it('returns active external submissions for manuscript', async () => {
+    mockWithRls.mockImplementationOnce(async (_ctx: any, fn: any) => {
+      return fn({
+        select: () => ({
+          from: () => ({
+            where: () => ({
+              limit: () =>
+                Promise.resolve([
+                  {
+                    id: 'ext1',
+                    journalName: 'Poetry Journal',
+                    status: 'sent',
+                    sentAt: new Date('2026-01-15'),
+                  },
+                  {
+                    id: 'ext2',
+                    journalName: 'Fiction Review',
+                    status: 'in_review',
+                    sentAt: new Date('2026-02-01'),
+                  },
+                ]),
+            }),
+          }),
+        }),
+      });
+    });
+
+    const result = await simsubService.checkWriterDisclosed('user1', 'm1');
+    expect(result).toHaveLength(2);
+    expect(result[0].journalName).toBe('Poetry Journal');
+    expect(result[1].journalName).toBe('Fiction Review');
+  });
+
+  it('returns empty when no active external submissions', async () => {
+    mockWithRls.mockImplementationOnce(async (_ctx: any, fn: any) => {
+      return fn({
+        select: () => ({
+          from: () => ({
+            where: () => ({
+              limit: () => Promise.resolve([]),
+            }),
+          }),
+        }),
+      });
+    });
+
+    const result = await simsubService.checkWriterDisclosed('user1', 'm1');
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR3: preSubmitCheck — policy model
+// ---------------------------------------------------------------------------
+
+describe('simsubService.preSubmitCheck', () => {
+  function makeMockTx(overrides: Record<string, unknown> = {}) {
+    const selectResults =
+      (overrides.selectResults as Record<number, unknown[]>) ?? {};
+    let selectCallCount = 0;
+
+    return {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCallCount++;
+            const result = selectResults[selectCallCount] ?? [];
+            return { limit: () => Promise.resolve(result) };
+          },
+        }),
+      }),
+      update: () => ({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      }),
+      insert: () => ({
+        values: vi.fn().mockResolvedValue(undefined),
+      }),
+    };
+  }
+
+  it('skips check when policy is allowed', async () => {
+    const performFullCheckSpy = vi.spyOn(simsubService, 'performFullCheck');
+
+    const tx = makeMockTx({
+      selectResults: {
+        // 1st select: submission
+        1: [
+          {
+            manuscriptVersionId: 'v1',
+            submissionPeriodId: 'p1',
+            simSubOverride: false,
+          },
+        ],
+        // 2nd select: period policy
+        2: [{ simSubPolicy: { type: 'allowed' } }],
+      },
+    });
+
+    await simsubService.preSubmitCheck(
+      makeEnv(),
+      tx as any,
+      'sub1',
+      'user1',
+      'org1',
+    );
+
+    expect(performFullCheckSpy).not.toHaveBeenCalled();
+    performFullCheckSpy.mockRestore();
+  });
+
+  it('skips check when simSubOverride is true', async () => {
+    const performFullCheckSpy = vi.spyOn(simsubService, 'performFullCheck');
+
+    const tx = makeMockTx({
+      selectResults: {
+        1: [
+          {
+            manuscriptVersionId: 'v1',
+            submissionPeriodId: 'p1',
+            simSubOverride: true,
+          },
+        ],
+      },
+    });
+
+    await simsubService.preSubmitCheck(
+      makeEnv(),
+      tx as any,
+      'sub1',
+      'user1',
+      'org1',
+    );
+
+    expect(performFullCheckSpy).not.toHaveBeenCalled();
+    performFullCheckSpy.mockRestore();
+  });
+
+  it('throws SimSubConflictError for prohibited + CONFLICT', async () => {
+    const tx = makeMockTx({
+      selectResults: {
+        1: [
+          {
+            manuscriptVersionId: 'v1',
+            submissionPeriodId: 'p1',
+            simSubOverride: false,
+          },
+        ],
+        2: [{ simSubPolicy: { type: 'prohibited' } }],
+        3: [{ manuscriptId: 'm1' }], // version lookup
+        4: [{ genre: { primary: 'poetry' } }], // manuscript genre
+      },
+    });
+
+    const performFullCheckSpy = vi
+      .spyOn(simsubService, 'performFullCheck')
+      .mockResolvedValue({
+        result: 'CONFLICT',
+        fingerprint: 'fp',
+        federationFingerprint: 'ffp',
+        localConflicts: [
+          { publicationName: 'Test Mag', submittedAt: '2026-01-01' },
+        ],
+        remoteResults: [],
+      });
+
+    await expect(
+      simsubService.preSubmitCheck(
+        makeEnv(),
+        tx as any,
+        'sub1',
+        'user1',
+        'org1',
+      ),
+    ).rejects.toThrow(SimSubConflictError);
+
+    performFullCheckSpy.mockRestore();
+  });
+
+  it('records notify requirement for allowed_notify + CONFLICT', async () => {
+    const mockSet = vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    });
+    let selectCallCount = 0;
+    const tx = {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return {
+                limit: () =>
+                  Promise.resolve([
+                    {
+                      manuscriptVersionId: 'v1',
+                      submissionPeriodId: 'p1',
+                      simSubOverride: false,
+                    },
+                  ]),
+              };
+            }
+            if (selectCallCount === 2) {
+              return {
+                limit: () =>
+                  Promise.resolve([
+                    {
+                      simSubPolicy: {
+                        type: 'allowed_notify',
+                        notifyWindowHours: 48,
+                      },
+                    },
+                  ]),
+              };
+            }
+            if (selectCallCount === 3) {
+              return { limit: () => Promise.resolve([{ manuscriptId: 'm1' }]) };
+            }
+            if (selectCallCount === 4) {
+              return {
+                limit: () =>
+                  Promise.resolve([{ genre: { primary: 'poetry' } }]),
+              };
+            }
+            return { limit: () => Promise.resolve([]) };
+          },
+        }),
+      }),
+      update: () => ({ set: mockSet }),
+      insert: () => ({ values: vi.fn().mockResolvedValue(undefined) }),
+    };
+
+    const performFullCheckSpy = vi
+      .spyOn(simsubService, 'performFullCheck')
+      .mockResolvedValue({
+        result: 'CONFLICT',
+        fingerprint: 'fp',
+        federationFingerprint: 'ffp',
+        localConflicts: [
+          { publicationName: 'Test Mag', submittedAt: '2026-01-01' },
+        ],
+        remoteResults: [],
+      });
+
+    await simsubService.preSubmitCheck(
+      makeEnv(),
+      tx as any,
+      'sub1',
+      'user1',
+      'org1',
+    );
+
+    // Should have called update to set the policy requirement
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        simSubPolicyRequirement: expect.objectContaining({
+          type: 'notify',
+          windowHours: 48,
+        }),
+      }),
+    );
+
+    performFullCheckSpy.mockRestore();
+  });
+
+  it('applies genre override: base allowed, fiction override prohibited', async () => {
+    const tx = makeMockTx({
+      selectResults: {
+        1: [
+          {
+            manuscriptVersionId: 'v1',
+            submissionPeriodId: 'p1',
+            simSubOverride: false,
+          },
+        ],
+        2: [
+          {
+            simSubPolicy: {
+              type: 'allowed',
+              genreOverrides: [{ genre: 'fiction', type: 'prohibited' }],
+            },
+          },
+        ],
+        3: [{ manuscriptId: 'm1' }],
+        4: [{ genre: { primary: 'fiction' } }],
+      },
+    });
+
+    const performFullCheckSpy = vi
+      .spyOn(simsubService, 'performFullCheck')
+      .mockResolvedValue({
+        result: 'CONFLICT',
+        fingerprint: 'fp',
+        federationFingerprint: 'ffp',
+        localConflicts: [
+          { publicationName: 'Test Mag', submittedAt: '2026-01-01' },
+        ],
+        remoteResults: [],
+      });
+
+    await expect(
+      simsubService.preSubmitCheck(
+        makeEnv(),
+        tx as any,
+        'sub1',
+        'user1',
+        'org1',
+      ),
+    ).rejects.toThrow(SimSubConflictError);
+
+    performFullCheckSpy.mockRestore();
+  });
+
+  it('genre override allows: base prohibited, poetry override allowed', async () => {
+    const performFullCheckSpy = vi.spyOn(simsubService, 'performFullCheck');
+
+    const tx = makeMockTx({
+      selectResults: {
+        1: [
+          {
+            manuscriptVersionId: 'v1',
+            submissionPeriodId: 'p1',
+            simSubOverride: false,
+          },
+        ],
+        2: [
+          {
+            simSubPolicy: {
+              type: 'prohibited',
+              genreOverrides: [{ genre: 'poetry', type: 'allowed' }],
+            },
+          },
+        ],
+        3: [{ manuscriptId: 'm1' }],
+        4: [{ genre: { primary: 'poetry' } }],
+      },
+    });
+
+    await simsubService.preSubmitCheck(
+      makeEnv(),
+      tx as any,
+      'sub1',
+      'user1',
+      'org1',
+    );
+
+    // Should NOT call performFullCheck because effective type is 'allowed'
+    expect(performFullCheckSpy).not.toHaveBeenCalled();
+    performFullCheckSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR3: performFullCheck — includes sibling + writer-disclosed
+// ---------------------------------------------------------------------------
+
+describe('simsubService.performFullCheck — version-aware checks', () => {
+  const contentFingerprint = 'c'.repeat(64);
+  const federationFingerprint = 'f'.repeat(64);
+
+  beforeEach(() => {
+    mockGetOrCompute.mockResolvedValue({
+      contentFingerprint,
+      federationFingerprint,
+    });
+    dbSelectResult = [{ email: 'alice@test.example.com' }];
+  });
+
+  it('includes sibling and writer-disclosed conflicts in result', async () => {
+    mockWithRls.mockImplementation(async (_ctx: any, fn: any) => {
+      const mockTx = {
+        select: () => ({
+          from: () => ({
+            where: () => ({
+              limit: () => Promise.resolve([{ manuscriptId: 'm1' }]),
+            }),
+          }),
+        }),
+        insert: () => ({ values: vi.fn().mockResolvedValue(undefined) }),
+        update: () => ({
+          set: () => ({ where: vi.fn().mockResolvedValue(undefined) }),
+        }),
+      };
+      return fn(mockTx);
+    });
+
+    const checkLocalSpy = vi
+      .spyOn(simsubService, 'checkLocal')
+      .mockResolvedValue([]);
+    const checkRemoteSpy = vi
+      .spyOn(simsubService, 'checkRemote')
+      .mockResolvedValue([]);
+    const checkSiblingSpy = vi
+      .spyOn(simsubService, 'checkSiblingVersions')
+      .mockResolvedValue([
+        {
+          versionId: 'v2',
+          versionNumber: 2,
+          submissionId: 's2',
+          publicationName: 'Sibling Mag',
+          status: 'SUBMITTED',
+          submittedAt: '2026-02-01T00:00:00Z',
+        },
+      ]);
+    const checkWriterSpy = vi
+      .spyOn(simsubService, 'checkWriterDisclosed')
+      .mockResolvedValue([
+        {
+          externalSubmissionId: 'ext1',
+          journalName: 'External Journal',
+          status: 'sent',
+          sentAt: '2026-01-15T00:00:00Z',
+        },
+      ]);
+
+    const result = await simsubService.performFullCheck(
+      makeEnv(),
+      'sub1',
+      'v1',
+      'user1',
+      'org1',
+    );
+
+    expect(result.result).toBe('CONFLICT');
+    expect(result.siblingVersionConflicts).toHaveLength(1);
+    expect(result.writerDisclosedConflicts).toHaveLength(1);
+    expect(result.siblingVersionConflicts![0].publicationName).toBe(
+      'Sibling Mag',
+    );
+    expect(result.writerDisclosedConflicts![0].journalName).toBe(
+      'External Journal',
+    );
+
+    checkLocalSpy.mockRestore();
+    checkRemoteSpy.mockRestore();
+    checkSiblingSpy.mockRestore();
+    checkWriterSpy.mockRestore();
+  });
+
+  it('returns CLEAR when no conflicts of any kind', async () => {
+    mockWithRls.mockImplementation(async (_ctx: any, fn: any) => {
+      const mockTx = {
+        select: () => ({
+          from: () => ({
+            where: () => ({
+              limit: () => Promise.resolve([{ manuscriptId: 'm1' }]),
+            }),
+          }),
+        }),
+        insert: () => ({ values: vi.fn().mockResolvedValue(undefined) }),
+        update: () => ({
+          set: () => ({ where: vi.fn().mockResolvedValue(undefined) }),
+        }),
+      };
+      return fn(mockTx);
+    });
+
+    const checkLocalSpy = vi
+      .spyOn(simsubService, 'checkLocal')
+      .mockResolvedValue([]);
+    const checkRemoteSpy = vi
+      .spyOn(simsubService, 'checkRemote')
+      .mockResolvedValue([]);
+    const checkSiblingSpy = vi
+      .spyOn(simsubService, 'checkSiblingVersions')
+      .mockResolvedValue([]);
+    const checkWriterSpy = vi
+      .spyOn(simsubService, 'checkWriterDisclosed')
+      .mockResolvedValue([]);
+
+    const result = await simsubService.performFullCheck(
+      makeEnv(),
+      'sub1',
+      'v1',
+      'user1',
+      'org1',
+    );
+
+    expect(result.result).toBe('CLEAR');
+    expect(result.siblingVersionConflicts).toHaveLength(0);
+    expect(result.writerDisclosedConflicts).toHaveLength(0);
+
+    checkLocalSpy.mockRestore();
+    checkRemoteSpy.mockRestore();
+    checkSiblingSpy.mockRestore();
+    checkWriterSpy.mockRestore();
   });
 });

--- a/apps/api/src/services/simsub.service.spec.ts
+++ b/apps/api/src/services/simsub.service.spec.ts
@@ -25,7 +25,9 @@ vi.mock('@colophony/db', () => ({
           },
           innerJoin: () => ({
             leftJoin: () => ({
-              where: () => Promise.resolve(dbSelectResult),
+              where: () => ({
+                limit: () => Promise.resolve(dbSelectResult),
+              }),
             }),
           }),
           then: (resolve: (v: unknown[]) => void) =>
@@ -41,6 +43,7 @@ vi.mock('@colophony/db', () => ({
   manuscriptVersions: {
     id: 'id',
     contentFingerprint: 'content_fingerprint',
+    federationFingerprint: 'federation_fingerprint',
     manuscriptId: 'manuscript_id',
   },
   submissions: {
@@ -70,6 +73,7 @@ vi.mock('@colophony/db', () => ({
     id: 'id',
     submissionId: 'submission_id',
     fingerprint: 'fingerprint',
+    federationFingerprint: 'federation_fingerprint',
     submitterDid: 'submitter_did',
     result: 'result',
     localConflicts: 'local_conflicts',
@@ -124,6 +128,10 @@ vi.mock('./hub-client.service.js', () => ({
       mockQueryHubFingerprints(...args),
     pushFingerprint: (...args: unknown[]) => mockPushFingerprint(...args),
   },
+}));
+
+vi.mock('../lib/url-validation.js', () => ({
+  validateOutboundUrl: vi.fn().mockResolvedValue(undefined),
 }));
 
 const mockFetch = vi.fn();
@@ -465,10 +473,14 @@ describe('simsubService.checkRemote', () => {
 // ---------------------------------------------------------------------------
 
 describe('simsubService.performFullCheck', () => {
-  const fingerprint = 'f'.repeat(64);
+  const contentFingerprint = 'c'.repeat(64);
+  const federationFingerprint = 'f'.repeat(64);
 
   beforeEach(() => {
-    mockGetOrCompute.mockResolvedValue(fingerprint);
+    mockGetOrCompute.mockResolvedValue({
+      contentFingerprint,
+      federationFingerprint,
+    });
 
     // User email lookup
     dbSelectResult = [{ email: 'alice@test.example.com' }];
@@ -517,7 +529,8 @@ describe('simsubService.performFullCheck', () => {
     );
 
     expect(result.result).toBe('CLEAR');
-    expect(result.fingerprint).toBe(fingerprint);
+    expect(result.fingerprint).toBe(contentFingerprint);
+    expect(result.federationFingerprint).toBe(federationFingerprint);
     checkLocalSpy.mockRestore();
     checkRemoteSpy.mockRestore();
   });
@@ -739,10 +752,14 @@ describe('simsubService.checkRemote — hub integration', () => {
 });
 
 describe('simsubService.performFullCheck — hub push', () => {
-  const fingerprint = 'f'.repeat(64);
+  const contentFingerprint = 'c'.repeat(64);
+  const federationFingerprint = 'f'.repeat(64);
 
   beforeEach(() => {
-    mockGetOrCompute.mockResolvedValue(fingerprint);
+    mockGetOrCompute.mockResolvedValue({
+      contentFingerprint,
+      federationFingerprint,
+    });
     dbSelectResult = [{ email: 'alice@test.example.com' }];
     mockPushFingerprint.mockResolvedValue(undefined);
   });
@@ -785,7 +802,173 @@ describe('simsubService.performFullCheck — hub push', () => {
     );
 
     expect(mockPushFingerprint).toHaveBeenCalled();
+    // Verify hub push uses federation fingerprint (not content)
+    const pushCall = mockPushFingerprint.mock.calls[0];
+    expect(pushCall[1].fingerprint).toBe(federationFingerprint);
     checkLocalSpy.mockRestore();
     checkRemoteSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR1: Fingerprint split — dual fingerprint tests
+// ---------------------------------------------------------------------------
+
+describe('simsubService.performFullCheck — dual fingerprints', () => {
+  const contentFingerprint = 'c'.repeat(64);
+  const federationFingerprint = 'f'.repeat(64);
+
+  beforeEach(() => {
+    mockGetOrCompute.mockResolvedValue({
+      contentFingerprint,
+      federationFingerprint,
+    });
+    dbSelectResult = [{ email: 'alice@test.example.com' }];
+  });
+
+  it('passes content fingerprint to checkLocal', async () => {
+    mockWithRls.mockImplementation(async (_ctx: any, fn: any) => {
+      const mockTx = {
+        select: () => ({
+          from: () => ({
+            where: () => ({ limit: () => Promise.resolve([]) }),
+          }),
+        }),
+        insert: () => ({ values: vi.fn().mockResolvedValue(undefined) }),
+        update: () => ({
+          set: () => ({ where: vi.fn().mockResolvedValue(undefined) }),
+        }),
+      };
+      return fn(mockTx);
+    });
+
+    const checkLocalSpy = vi
+      .spyOn(simsubService, 'checkLocal')
+      .mockResolvedValue([]);
+    const checkRemoteSpy = vi
+      .spyOn(simsubService, 'checkRemote')
+      .mockResolvedValue([]);
+
+    await simsubService.performFullCheck(
+      makeEnv(),
+      'sub1',
+      'v1',
+      'user1',
+      'org1',
+    );
+
+    // checkLocal should receive content fingerprint (2nd arg)
+    expect(checkLocalSpy).toHaveBeenCalledWith(
+      'user1',
+      contentFingerprint,
+      'sub1',
+    );
+    checkLocalSpy.mockRestore();
+    checkRemoteSpy.mockRestore();
+  });
+
+  it('passes federation fingerprint to checkRemote', async () => {
+    mockWithRls.mockImplementation(async (_ctx: any, fn: any) => {
+      const mockTx = {
+        select: () => ({
+          from: () => ({
+            where: () => ({ limit: () => Promise.resolve([]) }),
+          }),
+        }),
+        insert: () => ({ values: vi.fn().mockResolvedValue(undefined) }),
+        update: () => ({
+          set: () => ({ where: vi.fn().mockResolvedValue(undefined) }),
+        }),
+      };
+      return fn(mockTx);
+    });
+
+    const checkLocalSpy = vi
+      .spyOn(simsubService, 'checkLocal')
+      .mockResolvedValue([]);
+    const checkRemoteSpy = vi
+      .spyOn(simsubService, 'checkRemote')
+      .mockResolvedValue([]);
+
+    await simsubService.performFullCheck(
+      makeEnv(),
+      'sub1',
+      'v1',
+      'user1',
+      'org1',
+    );
+
+    // checkRemote should receive federation fingerprint (2nd arg)
+    expect(checkRemoteSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      federationFingerprint,
+      expect.stringContaining('did:web:'),
+      'org1',
+    );
+    checkLocalSpy.mockRestore();
+    checkRemoteSpy.mockRestore();
+  });
+
+  it('stores both fingerprints in sim_sub_checks', async () => {
+    mockWithRls.mockImplementation(async (_ctx: any, fn: any) => {
+      const insertValues = vi.fn().mockResolvedValue(undefined);
+      const mockTx = {
+        select: () => ({
+          from: () => ({
+            where: () => ({ limit: () => Promise.resolve([]) }),
+          }),
+        }),
+        insert: () => ({ values: insertValues }),
+        update: () => ({
+          set: () => ({ where: vi.fn().mockResolvedValue(undefined) }),
+        }),
+      };
+      return fn(mockTx);
+    });
+
+    const checkLocalSpy = vi
+      .spyOn(simsubService, 'checkLocal')
+      .mockResolvedValue([]);
+    const checkRemoteSpy = vi
+      .spyOn(simsubService, 'checkRemote')
+      .mockResolvedValue([]);
+
+    const result = await simsubService.performFullCheck(
+      makeEnv(),
+      'sub1',
+      'v1',
+      'user1',
+      'org1',
+    );
+
+    expect(result.fingerprint).toBe(contentFingerprint);
+    expect(result.federationFingerprint).toBe(federationFingerprint);
+    checkLocalSpy.mockRestore();
+    checkRemoteSpy.mockRestore();
+  });
+});
+
+describe('simsubService.handleInboundCheck — uses federation fingerprint', () => {
+  it('passes federation column to checkLocal', async () => {
+    dbSelectResult = [{ id: 'user1' }];
+
+    const checkLocalSpy = vi
+      .spyOn(simsubService, 'checkLocal')
+      .mockResolvedValueOnce([]);
+
+    await simsubService.handleInboundCheck(
+      makeEnv(),
+      'did:web:test.example.com:users:alice',
+      'fingerprint123',
+    );
+
+    // handleInboundCheck should pass 'federation' as the column parameter
+    expect(checkLocalSpy).toHaveBeenCalledWith(
+      'user1',
+      'fingerprint123',
+      undefined,
+      'federation',
+    );
+    checkLocalSpy.mockRestore();
   });
 });

--- a/apps/api/src/services/simsub.service.ts
+++ b/apps/api/src/services/simsub.service.ts
@@ -28,6 +28,7 @@ import { federationService, domainToDid } from './federation.service.js';
 import { fingerprintService } from './fingerprint.service.js';
 import { signFederationRequest } from '../federation/http-signatures.js';
 import { hubClientService } from './hub-client.service.js';
+import { validateOutboundUrl } from '../lib/url-validation.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -68,23 +69,29 @@ export const simsubService = {
    * 1. User-scoped RLS: find manuscript versions with matching fingerprint
    *    that the submitter owns. Confirms fingerprint ownership.
    * 2. Superuser: cross-org join from those versions → submissions → periods
-   *    to find active submissions at no-sim-sub publications. Justified:
-   *    ownership confirmed in phase 1; narrow read-only cross-org query.
-   *    Same pattern as trust.service.ts superuser queries.
+   *    to find active submissions. Policy filtering is caller's responsibility.
+   *
+   * @param column Which fingerprint column to match against (default: 'content')
    */
   async checkLocal(
     submitterUserId: string,
     fingerprint: string,
     excludeSubmissionId?: string,
+    column: 'content' | 'federation' = 'content',
   ): Promise<SimSubConflict[]> {
     // Phase 1: User-scoped RLS — find versions with matching fingerprint
+    const fingerprintColumn =
+      column === 'federation'
+        ? manuscriptVersions.federationFingerprint
+        : manuscriptVersions.contentFingerprint;
+
     const matchingVersionIds = await withRls(
       { userId: submitterUserId },
       async (tx) => {
         const rows = await tx
           .select({ id: manuscriptVersions.id })
           .from(manuscriptVersions)
-          .where(eq(manuscriptVersions.contentFingerprint, fingerprint));
+          .where(eq(fingerprintColumn, fingerprint));
         return rows.map((r) => r.id);
       },
     );
@@ -94,9 +101,8 @@ export const simsubService = {
     }
 
     // Phase 2: Superuser — cross-org join to find active submissions.
-    // Justified: fingerprint ownership confirmed via user-scoped RLS above.
-    // This is a narrow, read-only cross-org query. Same pattern as
-    // trust.service.ts handleInboundTrustRequest superuser queries.
+    // Returns ALL active submissions regardless of period policy.
+    // Policy filtering is the caller's responsibility (preSubmitCheck).
     const conflicts = await db
       .select({
         submissionId: submissions.id,
@@ -117,12 +123,12 @@ export const simsubService = {
         and(
           inArray(submissions.manuscriptVersionId, matchingVersionIds),
           inArray(submissions.status, [...ACTIVE_STATUSES]),
-          eq(submissionPeriods.simSubProhibited, true),
           ...(excludeSubmissionId
             ? [sql`${submissions.id} != ${excludeSubmissionId}`]
             : []),
         ),
-      );
+      )
+      .limit(100);
 
     return conflicts.map((c) => ({
       publicationName: c.publicationName ?? 'Unknown Publication',
@@ -134,7 +140,8 @@ export const simsubService = {
   /**
    * Handle an inbound S2S sim-sub check from a federated instance.
    *
-   * Resolves the submitter DID to a local user, then delegates to checkLocal.
+   * Resolves the submitter DID to a local user, then delegates to checkLocal
+   * using the federation fingerprint column.
    */
   async handleInboundCheck(
     _env: Env,
@@ -177,12 +184,19 @@ export const simsubService = {
       return { found: false, conflicts: [] };
     }
 
-    const conflicts = await this.checkLocal(user.id, fingerprint);
+    // Use federation fingerprint column for S2S checks
+    const conflicts = await this.checkLocal(
+      user.id,
+      fingerprint,
+      undefined,
+      'federation',
+    );
     return { found: conflicts.length > 0, conflicts };
   },
 
   /**
    * Fan out sim-sub checks to trusted federated peers.
+   * Validates outbound URLs against SSRF before making requests.
    */
   async checkRemote(
     env: Env,
@@ -200,6 +214,7 @@ export const simsubService = {
     }
 
     const domain = env.FEDERATION_DOMAIN ?? 'localhost';
+    const devMode = env.NODE_ENV !== 'production';
 
     // Hub-first path: if HUB_DOMAIN is set, query centralized index
     let hubResults: SimSubRemoteResult[] = [];
@@ -265,6 +280,9 @@ export const simsubService = {
       const start = Date.now();
 
       try {
+        // SSRF validation before outbound fetch
+        await validateOutboundUrl(url, { devMode });
+
         const { headers: signedHeaders } = signFederationRequest({
           method: 'POST',
           url,
@@ -347,8 +365,8 @@ export const simsubService = {
     submitterUserId: string,
     orgId: string,
   ): Promise<SimSubFullCheckResult> {
-    // Compute fingerprint (uses withRls internally via caller's tx or own)
-    const fingerprint = await withRls(
+    // Compute both fingerprints (uses withRls internally)
+    const { contentFingerprint, federationFingerprint } = await withRls(
       { userId: submitterUserId },
       async (tx) => {
         return fingerprintService.getOrCompute(tx, manuscriptVersionId);
@@ -368,9 +386,11 @@ export const simsubService = {
     const submitterDid = `did:web:${encodedDomain}:users:${emailLocal}`;
 
     // Run local + remote checks in parallel
+    // Local uses content fingerprint (higher accuracy)
+    // Remote uses federation fingerprint (cross-instance stable)
     const [localConflicts, remoteResults] = await Promise.all([
-      this.checkLocal(submitterUserId, fingerprint, submissionId),
-      this.checkRemote(env, fingerprint, submitterDid, orgId),
+      this.checkLocal(submitterUserId, contentFingerprint, submissionId),
+      this.checkRemote(env, federationFingerprint, submitterDid, orgId),
     ]);
 
     // Aggregate result
@@ -398,7 +418,8 @@ export const simsubService = {
     await withRls({ orgId }, async (tx) => {
       await tx.insert(simSubChecks).values({
         submissionId,
-        fingerprint,
+        fingerprint: contentFingerprint,
+        federationFingerprint,
         submitterDid,
         result,
         localConflicts,
@@ -424,15 +445,22 @@ export const simsubService = {
         resourceId: submissionId,
         organizationId: orgId,
         actorId: submitterUserId,
-        newValue: { result, fingerprint, localConflicts, remoteResults },
+        newValue: {
+          result,
+          fingerprint: contentFingerprint,
+          federationFingerprint,
+          localConflicts,
+          remoteResults,
+        },
       });
     });
 
     // Push fingerprint to hub (fire-and-forget, after local recording)
+    // Uses federation fingerprint for cross-instance compatibility
     if (env.HUB_DOMAIN) {
       hubClientService
         .pushFingerprint(env, {
-          fingerprint,
+          fingerprint: federationFingerprint,
           submitterDid,
           submittedAt: new Date().toISOString(),
         })
@@ -441,7 +469,13 @@ export const simsubService = {
         });
     }
 
-    return { result, fingerprint, localConflicts, remoteResults };
+    return {
+      result,
+      fingerprint: contentFingerprint,
+      federationFingerprint,
+      localConflicts,
+      remoteResults,
+    };
   },
 
   /**

--- a/apps/api/src/services/simsub.service.ts
+++ b/apps/api/src/services/simsub.service.ts
@@ -2,11 +2,13 @@ import {
   db,
   withRls,
   manuscriptVersions,
+  manuscripts,
   submissions,
   submissionPeriods,
   publications,
   users,
   simSubChecks,
+  externalSubmissions,
   eq,
   and,
   isNull,
@@ -21,6 +23,10 @@ import {
   type SimSubRemoteResult,
   type SimSubFullCheckResult,
   type SimSubCheckResponse,
+  type SimSubPolicy,
+  type SimSubPolicyType,
+  type SiblingVersionConflict,
+  type WriterDisclosedConflict,
 } from '@colophony/types';
 import type { Env } from '../config/env.js';
 import { auditService } from './audit.service.js';
@@ -56,6 +62,29 @@ export class SimSubConflictError extends Error {
 // ---------------------------------------------------------------------------
 
 const ACTIVE_STATUSES = ['SUBMITTED', 'UNDER_REVIEW', 'HOLD'] as const;
+const ACTIVE_CSR_STATUSES = ['sent', 'in_review', 'hold'] as const;
+
+// ---------------------------------------------------------------------------
+// Pure function: Policy resolution with genre overrides
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the effective sim-sub policy type, applying genre overrides if any.
+ */
+export function resolveEffectivePolicy(
+  policy: SimSubPolicy,
+  primaryGenre: string | null | undefined,
+): SimSubPolicyType {
+  if (primaryGenre && policy.genreOverrides) {
+    const override = policy.genreOverrides.find(
+      (o) => o.genre === primaryGenre,
+    );
+    if (override) {
+      return override.type as SimSubPolicyType;
+    }
+  }
+  return policy.type;
+}
 
 // ---------------------------------------------------------------------------
 // Service
@@ -134,6 +163,130 @@ export const simsubService = {
       publicationName: c.publicationName ?? 'Unknown Publication',
       submittedAt: c.submittedAt?.toISOString() ?? new Date().toISOString(),
       periodName: c.periodName,
+    }));
+  },
+
+  /**
+   * Check for active submissions on sibling versions of the same manuscript.
+   *
+   * Two-phase RLS:
+   * Phase 1 (user-scoped): find manuscriptId, then all other version IDs
+   * Phase 2 (superuser): find active submissions on those versions
+   */
+  async checkSiblingVersions(
+    submitterUserId: string,
+    manuscriptVersionId: string,
+    excludeSubmissionId?: string,
+  ): Promise<SiblingVersionConflict[]> {
+    // Phase 1: User-scoped — find manuscript and other versions
+    const siblingVersionIds = await withRls(
+      { userId: submitterUserId },
+      async (tx) => {
+        const [version] = await tx
+          .select({ manuscriptId: manuscriptVersions.manuscriptId })
+          .from(manuscriptVersions)
+          .where(eq(manuscriptVersions.id, manuscriptVersionId))
+          .limit(1);
+
+        if (!version) return [];
+
+        const siblings = await tx
+          .select({
+            id: manuscriptVersions.id,
+            versionNumber: manuscriptVersions.versionNumber,
+          })
+          .from(manuscriptVersions)
+          .where(
+            and(
+              eq(manuscriptVersions.manuscriptId, version.manuscriptId),
+              sql`${manuscriptVersions.id} != ${manuscriptVersionId}`,
+            ),
+          )
+          .limit(50);
+
+        return siblings;
+      },
+    );
+
+    if (siblingVersionIds.length === 0) {
+      return [];
+    }
+
+    // Phase 2: Superuser — find active submissions on sibling versions
+    const versionIds = siblingVersionIds.map((v) => v.id);
+    const versionMap = new Map(
+      siblingVersionIds.map((v) => [v.id, v.versionNumber]),
+    );
+
+    const results = await db
+      .select({
+        submissionId: submissions.id,
+        manuscriptVersionId: submissions.manuscriptVersionId,
+        publicationName: publications.name,
+        status: submissions.status,
+        submittedAt: submissions.submittedAt,
+      })
+      .from(submissions)
+      .innerJoin(
+        submissionPeriods,
+        eq(submissions.submissionPeriodId, submissionPeriods.id),
+      )
+      .leftJoin(
+        publications,
+        eq(submissionPeriods.publicationId, publications.id),
+      )
+      .where(
+        and(
+          inArray(submissions.manuscriptVersionId, versionIds),
+          inArray(submissions.status, [...ACTIVE_STATUSES]),
+          ...(excludeSubmissionId
+            ? [sql`${submissions.id} != ${excludeSubmissionId}`]
+            : []),
+        ),
+      )
+      .limit(50);
+
+    return results.map((r) => ({
+      versionId: r.manuscriptVersionId!,
+      versionNumber: versionMap.get(r.manuscriptVersionId!) ?? 0,
+      submissionId: r.submissionId,
+      publicationName: r.publicationName ?? 'Unknown Publication',
+      status: r.status,
+      submittedAt: r.submittedAt?.toISOString() ?? null,
+    }));
+  },
+
+  /**
+   * Check writer-disclosed external submissions for the same manuscript.
+   * User-scoped RLS only.
+   */
+  async checkWriterDisclosed(
+    submitterUserId: string,
+    manuscriptId: string,
+  ): Promise<WriterDisclosedConflict[]> {
+    const results = await withRls({ userId: submitterUserId }, async (tx) => {
+      return tx
+        .select({
+          id: externalSubmissions.id,
+          journalName: externalSubmissions.journalName,
+          status: externalSubmissions.status,
+          sentAt: externalSubmissions.sentAt,
+        })
+        .from(externalSubmissions)
+        .where(
+          and(
+            eq(externalSubmissions.manuscriptId, manuscriptId),
+            inArray(externalSubmissions.status, [...ACTIVE_CSR_STATUSES]),
+          ),
+        )
+        .limit(100);
+    });
+
+    return results.map((r) => ({
+      externalSubmissionId: r.id,
+      journalName: r.journalName,
+      status: r.status,
+      sentAt: r.sentAt?.toISOString() ?? null,
     }));
   },
 
@@ -243,8 +396,6 @@ export const simsubService = {
     }
 
     // Query active trusted peers with simsub.respond capability.
-    // If hub responded, skip hub-attested peers (they're covered by the hub index).
-    // Self-hosted peers (hub_attested = false) still get direct fan-out.
     const peerFilter = hubResponded
       ? sql`status = 'active' AND granted_capabilities @> '{"simsub.respond": true}'::jsonb AND hub_attested = false`
       : sql`status = 'active' AND granted_capabilities @> '{"simsub.respond": true}'::jsonb`;
@@ -258,10 +409,6 @@ export const simsubService = {
         .from(sql`trusted_peers`)
         .where(peerFilter);
     });
-
-    if (peers.length === 0 && hubResults.length === 0) {
-      return hubResults;
-    }
 
     if (peers.length === 0) {
       return hubResults;
@@ -352,11 +499,7 @@ export const simsubService = {
   },
 
   /**
-   * Perform a full sim-sub check: local + remote, record result.
-   *
-   * Runs outside the caller's DB transaction (uses its own withRls calls).
-   * The request-scoped dbContext transaction is still open but this HTTP
-   * fanout has a 2s timeout cap and the platform is low-traffic.
+   * Perform a full sim-sub check: local + remote + version-aware, record result.
    */
   async performFullCheck(
     env: Env,
@@ -373,6 +516,19 @@ export const simsubService = {
       },
     );
 
+    // Resolve manuscriptId for version-aware checks
+    const manuscriptId = await withRls(
+      { userId: submitterUserId },
+      async (tx) => {
+        const [version] = await tx
+          .select({ manuscriptId: manuscriptVersions.manuscriptId })
+          .from(manuscriptVersions)
+          .where(eq(manuscriptVersions.id, manuscriptVersionId))
+          .limit(1);
+        return version?.manuscriptId;
+      },
+    );
+
     // Build submitter DID (encode port-bearing domains per did:web spec)
     const rawDomain = env.FEDERATION_DOMAIN ?? 'localhost';
     const encodedDomain = domainToDid(rawDomain);
@@ -385,12 +541,23 @@ export const simsubService = {
     const emailLocal = user?.email?.split('@')[0] ?? submitterUserId;
     const submitterDid = `did:web:${encodedDomain}:users:${emailLocal}`;
 
-    // Run local + remote checks in parallel
-    // Local uses content fingerprint (higher accuracy)
-    // Remote uses federation fingerprint (cross-instance stable)
-    const [localConflicts, remoteResults] = await Promise.all([
+    // Run all checks in parallel
+    const [
+      localConflicts,
+      remoteResults,
+      siblingVersionConflicts,
+      writerDisclosedConflicts,
+    ] = await Promise.all([
       this.checkLocal(submitterUserId, contentFingerprint, submissionId),
       this.checkRemote(env, federationFingerprint, submitterDid, orgId),
+      this.checkSiblingVersions(
+        submitterUserId,
+        manuscriptVersionId,
+        submissionId,
+      ),
+      manuscriptId
+        ? this.checkWriterDisclosed(submitterUserId, manuscriptId)
+        : Promise.resolve([]),
     ]);
 
     // Aggregate result
@@ -406,7 +573,11 @@ export const simsubService = {
     );
 
     let result: 'CLEAR' | 'CONFLICT' | 'PARTIAL';
-    if (allConflicts.length > 0) {
+    if (
+      allConflicts.length > 0 ||
+      siblingVersionConflicts.length > 0 ||
+      writerDisclosedConflicts.length > 0
+    ) {
       result = 'CONFLICT';
     } else if (hasUnreachable) {
       result = 'PARTIAL';
@@ -451,12 +622,13 @@ export const simsubService = {
           federationFingerprint,
           localConflicts,
           remoteResults,
+          siblingVersionConflicts,
+          writerDisclosedConflicts,
         },
       });
     });
 
-    // Push fingerprint to hub (fire-and-forget, after local recording)
-    // Uses federation fingerprint for cross-instance compatibility
+    // Push fingerprint to hub (fire-and-forget)
     if (env.HUB_DOMAIN) {
       hubClientService
         .pushFingerprint(env, {
@@ -475,15 +647,18 @@ export const simsubService = {
       federationFingerprint,
       localConflicts,
       remoteResults,
+      siblingVersionConflicts,
+      writerDisclosedConflicts,
     };
   },
 
   /**
    * Pre-submit sim-sub check. Call before `submitAsOwner`.
    *
-   * Reads the submission's metadata from the request-scoped transaction,
-   * then runs the full check outside it (own withRls calls).
-   * Throws SimSubConflictError if conflicts are found.
+   * Uses the period's sim_sub_policy JSONB (replacing the old boolean).
+   * Resolves genre overrides via manuscript genre.
+   * For 'prohibited' + CONFLICT: throws SimSubConflictError.
+   * For 'allowed_notify'/'allowed_withdraw' + CONFLICT: records requirement.
    */
   async preSubmitCheck(
     env: Env,
@@ -511,18 +686,44 @@ export const simsubService = {
       return; // No manuscript, no period, or already overridden — skip
     }
 
-    // Check if the period prohibits sim-sub
+    // Load period's policy
     const [period] = await tx
-      .select({ simSubProhibited: submissionPeriods.simSubProhibited })
+      .select({ simSubPolicy: submissionPeriods.simSubPolicy })
       .from(submissionPeriods)
       .where(eq(submissionPeriods.id, submission.submissionPeriodId))
       .limit(1);
 
-    if (!period?.simSubProhibited) {
-      return; // Period allows sim-sub
+    if (!period?.simSubPolicy) {
+      return;
     }
 
-    // Run full check (outside svc.tx — uses own withRls calls)
+    const policy = period.simSubPolicy as SimSubPolicy;
+
+    // Load manuscript genre for genre override resolution
+    const [version] = await tx
+      .select({ manuscriptId: manuscriptVersions.manuscriptId })
+      .from(manuscriptVersions)
+      .where(eq(manuscriptVersions.id, submission.manuscriptVersionId))
+      .limit(1);
+
+    let primaryGenre: string | null = null;
+    if (version?.manuscriptId) {
+      const [manuscript] = await tx
+        .select({ genre: manuscripts.genre })
+        .from(manuscripts)
+        .where(eq(manuscripts.id, version.manuscriptId))
+        .limit(1);
+      primaryGenre =
+        (manuscript?.genre as { primary?: string } | null)?.primary ?? null;
+    }
+
+    const effectiveType = resolveEffectivePolicy(policy, primaryGenre);
+
+    if (effectiveType === 'allowed') {
+      return; // No sim-sub enforcement
+    }
+
+    // Run full check
     const result = await this.performFullCheck(
       env,
       submissionId,
@@ -531,12 +732,35 @@ export const simsubService = {
       orgId,
     );
 
-    if (result.result === 'CONFLICT') {
+    if (result.result !== 'CONFLICT') {
+      return; // No conflicts found
+    }
+
+    if (effectiveType === 'prohibited') {
       throw new SimSubConflictError(
         result.localConflicts,
         result.remoteResults,
       );
     }
+
+    // For allowed_notify / allowed_withdraw: record the requirement
+    const requirementType =
+      effectiveType === 'allowed_notify' ? 'notify' : 'withdraw';
+    const windowHours = policy.notifyWindowHours;
+    const dueAt = windowHours
+      ? new Date(Date.now() + windowHours * 60 * 60 * 1000).toISOString()
+      : undefined;
+
+    await tx
+      .update(submissions)
+      .set({
+        simSubPolicyRequirement: {
+          type: requirementType,
+          windowHours,
+          dueAt,
+        },
+      })
+      .where(eq(submissions.id, submissionId));
   },
 
   /**

--- a/apps/api/src/services/simsub.service.ts
+++ b/apps/api/src/services/simsub.service.ts
@@ -80,7 +80,7 @@ export function resolveEffectivePolicy(
       (o) => o.genre === primaryGenre,
     );
     if (override) {
-      return override.type as SimSubPolicyType;
+      return override.type;
     }
   }
   return policy.type;
@@ -748,7 +748,9 @@ export const simsubService = {
       effectiveType === 'allowed_notify' ? 'notify' : 'withdraw';
     const windowHours = policy.notifyWindowHours;
     const dueAt = windowHours
-      ? new Date(Date.now() + windowHours * 60 * 60 * 1000).toISOString()
+      ? new Date(
+          new Date().getTime() + windowHours * 60 * 60 * 1000,
+        ).toISOString()
       : undefined;
 
     await tx

--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -259,6 +259,7 @@ export const submissionService = {
           searchVector: submissions.searchVector,
           statusTokenHash: submissions.statusTokenHash,
           statusTokenExpiresAt: submissions.statusTokenExpiresAt,
+          simSubPolicyRequirement: submissions.simSubPolicyRequirement,
           transferredFromDomain: submissions.transferredFromDomain,
           transferredFromTransferId: submissions.transferredFromTransferId,
           submitterEmail: users.email,

--- a/apps/api/src/workers/__tests__/file-scan.worker.spec.ts
+++ b/apps/api/src/workers/__tests__/file-scan.worker.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Readable } from 'node:stream';
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before imports
@@ -19,9 +20,11 @@ vi.mock('@colophony/db', () => ({
 }));
 
 const mockUpdateScanStatus = vi.fn();
+const mockUpdateContentHash = vi.fn();
 vi.mock('../../services/file.service.js', () => ({
   fileService: {
     updateScanStatus: (...args: unknown[]) => mockUpdateScanStatus(...args),
+    updateContentHash: (...args: unknown[]) => mockUpdateContentHash(...args),
   },
 }));
 
@@ -45,18 +48,12 @@ vi.mock('clamscan', () => ({
   }),
 }));
 
-// Mock BullMQ Worker — capture the processor function
+// Mock instrumented worker — capture the processor function directly
 let capturedProcessor: ((job: unknown) => Promise<void>) | null = null;
-vi.mock('bullmq', () => ({
-  Worker: vi.fn().mockImplementation(function (
-    _name: string,
-    processor: (job: unknown) => Promise<void>,
-  ) {
-    capturedProcessor = processor;
-    return {
-      on: vi.fn(),
-      close: vi.fn(),
-    };
+vi.mock('../../config/instrumented-worker.js', () => ({
+  createInstrumentedWorker: vi.fn().mockImplementation((opts: any) => {
+    capturedProcessor = opts.processor;
+    return { on: vi.fn(), close: vi.fn() };
   }),
 }));
 
@@ -97,12 +94,21 @@ const TEST_JOB = {
   data: {
     fileId: 'file-1',
     storageKey: 'quarantine/upload-abc',
+    userId: 'user-1',
     organizationId: 'org-1',
   },
   id: 'file-1',
   attemptsMade: 1,
   opts: { attempts: 3 },
 };
+
+/**
+ * Create a mock Readable stream that emits the given data.
+ * Supports .pipe() for the dual-pipe pattern (ClamAV + SHA-256).
+ */
+function createMockStream(data = 'test file content'): Readable {
+  return Readable.from(Buffer.from(data));
+}
 
 describe('file-scan worker', () => {
   beforeEach(() => {
@@ -127,13 +133,14 @@ describe('file-scan worker', () => {
   it('marks file CLEAN, moves from quarantine to submissions bucket', async () => {
     const processor = getProcessor();
 
-    mockDownloadFromBucket.mockResolvedValueOnce({ pipe: vi.fn() }); // mock Readable
+    mockDownloadFromBucket.mockResolvedValueOnce(createMockStream());
     mockScanStream.mockResolvedValueOnce({
       isInfected: false,
       viruses: [],
     });
     mockMoveBetweenBuckets.mockResolvedValueOnce(undefined);
     mockUpdateScanStatus.mockResolvedValue(null);
+    mockUpdateContentHash.mockResolvedValue(undefined);
     mockAuditLog.mockResolvedValue(undefined);
 
     await processor(TEST_JOB);
@@ -172,13 +179,41 @@ describe('file-scan worker', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Content hash on CLEAN
+  // -------------------------------------------------------------------------
+
+  it('stores content hash on CLEAN scan', async () => {
+    const processor = getProcessor();
+    const fileContent = 'deterministic test content';
+
+    mockDownloadFromBucket.mockResolvedValueOnce(createMockStream(fileContent));
+    mockScanStream.mockResolvedValueOnce({
+      isInfected: false,
+      viruses: [],
+    });
+    mockMoveBetweenBuckets.mockResolvedValueOnce(undefined);
+    mockUpdateScanStatus.mockResolvedValue(null);
+    mockUpdateContentHash.mockResolvedValue(undefined);
+    mockAuditLog.mockResolvedValue(undefined);
+
+    await processor(TEST_JOB);
+
+    // updateContentHash should be called with a 64-char hex SHA-256
+    expect(mockUpdateContentHash).toHaveBeenCalledWith(
+      expect.anything(),
+      'file-1',
+      expect.stringMatching(/^[a-f0-9]{64}$/),
+    );
+  });
+
+  // -------------------------------------------------------------------------
   // INFECTED path
   // -------------------------------------------------------------------------
 
   it('marks file INFECTED, deletes from quarantine, does NOT move', async () => {
     const processor = getProcessor();
 
-    mockDownloadFromBucket.mockResolvedValueOnce({ pipe: vi.fn() });
+    mockDownloadFromBucket.mockResolvedValueOnce(createMockStream());
     mockScanStream.mockResolvedValueOnce({
       isInfected: true,
       viruses: ['Eicar-Test-Signature'],
@@ -214,6 +249,23 @@ describe('file-scan worker', () => {
         newValue: { viruses: ['Eicar-Test-Signature'] },
       }),
     );
+  });
+
+  it('does not store content hash on INFECTED scan', async () => {
+    const processor = getProcessor();
+
+    mockDownloadFromBucket.mockResolvedValueOnce(createMockStream());
+    mockScanStream.mockResolvedValueOnce({
+      isInfected: true,
+      viruses: ['Eicar-Test-Signature'],
+    });
+    mockDeleteFromBucket.mockResolvedValueOnce(undefined);
+    mockUpdateScanStatus.mockResolvedValue(null);
+    mockAuditLog.mockResolvedValue(undefined);
+
+    await processor(TEST_JOB);
+
+    expect(mockUpdateContentHash).not.toHaveBeenCalled();
   });
 
   // -------------------------------------------------------------------------
@@ -263,7 +315,7 @@ describe('file-scan worker', () => {
   it('marks file FAILED when S3 move fails after clean scan', async () => {
     const processor = getProcessor();
 
-    mockDownloadFromBucket.mockResolvedValueOnce({ pipe: vi.fn() });
+    mockDownloadFromBucket.mockResolvedValueOnce(createMockStream());
     mockScanStream.mockResolvedValueOnce({
       isInfected: false,
       viruses: [],
@@ -308,24 +360,25 @@ describe('file-scan worker', () => {
   // RLS wrapping
   // -------------------------------------------------------------------------
 
-  it('wraps all DB operations in withRls with correct orgId', async () => {
+  it('wraps all DB operations in withRls with correct userId', async () => {
     const processor = getProcessor();
 
-    mockDownloadFromBucket.mockResolvedValueOnce({ pipe: vi.fn() });
+    mockDownloadFromBucket.mockResolvedValueOnce(createMockStream());
     mockScanStream.mockResolvedValueOnce({
       isInfected: false,
       viruses: [],
     });
     mockMoveBetweenBuckets.mockResolvedValueOnce(undefined);
     mockUpdateScanStatus.mockResolvedValue(null);
+    mockUpdateContentHash.mockResolvedValue(undefined);
     mockAuditLog.mockResolvedValue(undefined);
 
     await processor(TEST_JOB);
 
-    // withRls called with orgId for each DB phase
+    // withRls called with userId + orgId for each DB phase
     const rlsCalls = mockWithRls.mock.calls;
     for (const call of rlsCalls) {
-      expect(call[0]).toEqual({ orgId: 'org-1' });
+      expect(call[0]).toEqual({ userId: 'user-1', orgId: 'org-1' });
     }
     // At least 2 calls: SCANNING + CLEAN status updates
     expect(rlsCalls.length).toBeGreaterThanOrEqual(2);

--- a/apps/api/src/workers/file-scan.worker.ts
+++ b/apps/api/src/workers/file-scan.worker.ts
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto';
+import { PassThrough } from 'node:stream';
 import NodeClam from 'clamscan';
 import { withRls } from '@colophony/db';
 import type { DrizzleDb } from '@colophony/db';
@@ -59,18 +61,36 @@ export function startFileScanWorker(
         await fileService.updateScanStatus(tx, fileId, 'SCANNING');
       });
 
-      // Phase 2: Stream from S3 and scan (no DB operations)
+      // Phase 2: Stream from S3, compute SHA-256 content hash, and scan
       let isInfected: boolean;
       let viruses: string[];
+      let contentHash: string;
       try {
         const stream = await storage.downloadFromBucket(
           storage.quarantineBucket,
           storageKey,
         );
         const clam = await getClamClient(env);
-        const result = await clam.scanStream(stream);
-        isInfected = result.isInfected;
-        viruses = result.viruses;
+
+        // Tee the stream: one path to ClamAV, one to SHA-256 hasher
+        const passthrough = new PassThrough();
+        const hashTransform = crypto.createHash('sha256');
+
+        stream.pipe(passthrough);
+        stream.pipe(hashTransform);
+
+        const [scanResult, hashHex] = await Promise.all([
+          clam.scanStream(passthrough),
+          new Promise<string>((resolve) => {
+            hashTransform.on('finish', () =>
+              resolve(hashTransform.digest('hex')),
+            );
+          }),
+        ]);
+
+        isInfected = scanResult.isInfected;
+        viruses = scanResult.viruses;
+        contentHash = hashHex;
       } catch (err) {
         // Phase 2 error: mark FAILED, audit, re-throw for retry
         await withRls(rlsCtx, async (tx: DrizzleDb) => {
@@ -101,6 +121,7 @@ export function startFileScanWorker(
 
           await withRls(rlsCtx, async (tx: DrizzleDb) => {
             await fileService.updateScanStatus(tx, fileId, 'CLEAN');
+            await fileService.updateContentHash(tx, fileId, contentHash);
             await auditService.log(tx, {
               resource: AuditResources.FILE,
               action: AuditActions.FILE_SCAN_CLEAN,

--- a/apps/api/src/workers/file-scan.worker.ts
+++ b/apps/api/src/workers/file-scan.worker.ts
@@ -81,10 +81,12 @@ export function startFileScanWorker(
 
         const [scanResult, hashHex] = await Promise.all([
           clam.scanStream(passthrough),
-          new Promise<string>((resolve) => {
+          new Promise<string>((resolve, reject) => {
             hashTransform.on('finish', () =>
               resolve(hashTransform.digest('hex')),
             );
+            hashTransform.on('error', reject);
+            passthrough.on('error', reject);
           }),
         ]);
 

--- a/apps/web/src/components/periods/period-form-dialog.tsx
+++ b/apps/web/src/components/periods/period-form-dialog.tsx
@@ -33,10 +33,30 @@ import {
 } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
+import { Loader2, Plus, X } from "lucide-react";
 /**
  * Period data as received from tRPC (dates may be string or Date after serialization).
  */
+const SIM_SUB_POLICY_TYPES = [
+  { value: "allowed", label: "Allowed" },
+  { value: "prohibited", label: "Prohibited" },
+  { value: "allowed_notify", label: "Allowed (Notify)" },
+  { value: "allowed_withdraw", label: "Allowed (Withdraw)" },
+] as const;
+
+const GENRES = [
+  { value: "poetry", label: "Poetry" },
+  { value: "fiction", label: "Fiction" },
+  { value: "creative_nonfiction", label: "Creative Nonfiction" },
+  { value: "nonfiction", label: "Nonfiction" },
+  { value: "drama", label: "Drama" },
+  { value: "translation", label: "Translation" },
+  { value: "visual_art", label: "Visual Art" },
+  { value: "comics", label: "Comics" },
+  { value: "audio", label: "Audio" },
+  { value: "other", label: "Other" },
+] as const;
+
 interface PeriodData {
   id: string;
   name: string;
@@ -50,12 +70,23 @@ interface PeriodData {
   isContest?: boolean;
   contestPrize?: string | null;
   contestWinnersAnnouncedAt?: Date | string | null;
+  simSubPolicy?: {
+    type: string;
+    notifyWindowHours?: number;
+    genreOverrides?: Array<{ genre: string; type: string }>;
+    notes?: string;
+  };
 }
 
 /**
  * Local form schema using string dates for datetime-local inputs.
  * Converted to Date objects before submission.
  */
+const genreOverrideSchema = z.object({
+  genre: z.string().min(1),
+  type: z.string().min(1),
+});
+
 const formSchema = z.object({
   name: z.string().min(1, "Name is required").max(255),
   description: z.string().max(2000).optional(),
@@ -68,6 +99,10 @@ const formSchema = z.object({
   isContest: z.boolean().optional(),
   contestPrize: z.string().max(500).optional(),
   contestWinnersAnnouncedAt: z.string().optional(),
+  simSubPolicyType: z.string().optional(),
+  simSubNotifyWindowHours: z.string().optional(),
+  simSubGenreOverrides: z.array(genreOverrideSchema).optional(),
+  simSubNotes: z.string().max(1000).optional(),
 });
 
 type FormData = z.infer<typeof formSchema>;
@@ -106,6 +141,10 @@ export function PeriodFormDialog({
       isContest: false,
       contestPrize: "",
       contestWinnersAnnouncedAt: "",
+      simSubPolicyType: "allowed",
+      simSubNotifyWindowHours: "",
+      simSubGenreOverrides: [],
+      simSubNotes: "",
     },
   });
 
@@ -126,6 +165,13 @@ export function PeriodFormDialog({
         contestWinnersAnnouncedAt: period.contestWinnersAnnouncedAt
           ? toDatetimeLocal(new Date(period.contestWinnersAnnouncedAt))
           : "",
+        simSubPolicyType: period.simSubPolicy?.type ?? "allowed",
+        simSubNotifyWindowHours:
+          period.simSubPolicy?.notifyWindowHours != null
+            ? String(period.simSubPolicy.notifyWindowHours)
+            : "",
+        simSubGenreOverrides: period.simSubPolicy?.genreOverrides ?? [],
+        simSubNotes: period.simSubPolicy?.notes ?? "",
       });
     } else if (open) {
       form.reset({
@@ -140,6 +186,10 @@ export function PeriodFormDialog({
         isContest: false,
         contestPrize: "",
         contestWinnersAnnouncedAt: "",
+        simSubPolicyType: "allowed",
+        simSubNotifyWindowHours: "",
+        simSubGenreOverrides: [],
+        simSubNotes: "",
       });
     }
   }, [open, period, form]);
@@ -170,6 +220,26 @@ export function PeriodFormDialog({
   const isPending = createMutation.isPending || updateMutation.isPending;
 
   const onSubmit = (data: FormData) => {
+    // Build sim-sub policy object — Zod validates on tRPC boundary
+    const policyType = data.simSubPolicyType ?? "allowed";
+    const simSubPolicy = {
+      type: policyType,
+      ...((policyType === "allowed_notify" ||
+        policyType === "allowed_withdraw") &&
+        data.simSubNotifyWindowHours && {
+          notifyWindowHours: Number(data.simSubNotifyWindowHours),
+        }),
+      ...((data.simSubGenreOverrides?.length ?? 0) > 0 && {
+        genreOverrides: data.simSubGenreOverrides,
+      }),
+      ...(data.simSubNotes && { notes: data.simSubNotes }),
+    } as {
+      type: "prohibited" | "allowed" | "allowed_notify" | "allowed_withdraw";
+      notifyWindowHours?: number;
+      genreOverrides?: Array<{ genre: string; type: string }>;
+      notes?: string;
+    };
+
     const payload = {
       name: data.name,
       description: data.description || undefined,
@@ -194,12 +264,15 @@ export function PeriodFormDialog({
         data.isContest && data.contestWinnersAnnouncedAt
           ? new Date(data.contestWinnersAnnouncedAt)
           : undefined,
+      simSubPolicy,
     };
 
     if (isEdit) {
-      updateMutation.mutate({ id: period.id, ...payload });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      updateMutation.mutate({ id: period.id, ...payload } as any);
     } else {
-      createMutation.mutate(payload);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createMutation.mutate(payload as any);
     }
   };
 
@@ -367,6 +440,151 @@ export function PeriodFormDialog({
                       <SelectItem value="double_blind">Double Blind</SelectItem>
                     </SelectContent>
                   </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Sim-Sub Policy */}
+            <FormField
+              control={form.control}
+              name="simSubPolicyType"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Simultaneous Submission Policy</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Allowed" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {SIM_SUB_POLICY_TYPES.map((t) => (
+                        <SelectItem key={t.value} value={t.value}>
+                          {t.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {(form.watch("simSubPolicyType") === "allowed_notify" ||
+              form.watch("simSubPolicyType") === "allowed_withdraw") && (
+              <FormField
+                control={form.control}
+                name="simSubNotifyWindowHours"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Notification Window (hours)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        min="1"
+                        step="1"
+                        placeholder="e.g. 48"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            {form.watch("simSubPolicyType") !== "allowed" && (
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <FormLabel>Genre Overrides</FormLabel>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      const current =
+                        form.getValues("simSubGenreOverrides") ?? [];
+                      form.setValue("simSubGenreOverrides", [
+                        ...current,
+                        { genre: "", type: "allowed" },
+                      ]);
+                    }}
+                  >
+                    <Plus className="mr-1 h-3 w-3" />
+                    Add Override
+                  </Button>
+                </div>
+                {(form.watch("simSubGenreOverrides") ?? []).map((_, idx) => (
+                  <div key={idx} className="flex items-center gap-2">
+                    <Select
+                      value={form.watch(`simSubGenreOverrides.${idx}.genre`)}
+                      onValueChange={(v) =>
+                        form.setValue(`simSubGenreOverrides.${idx}.genre`, v)
+                      }
+                    >
+                      <SelectTrigger className="flex-1">
+                        <SelectValue placeholder="Genre" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {GENRES.map((g) => (
+                          <SelectItem key={g.value} value={g.value}>
+                            {g.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Select
+                      value={form.watch(`simSubGenreOverrides.${idx}.type`)}
+                      onValueChange={(v) =>
+                        form.setValue(`simSubGenreOverrides.${idx}.type`, v)
+                      }
+                    >
+                      <SelectTrigger className="flex-1">
+                        <SelectValue placeholder="Policy" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {SIM_SUB_POLICY_TYPES.map((t) => (
+                          <SelectItem key={t.value} value={t.value}>
+                            {t.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => {
+                        const current =
+                          form.getValues("simSubGenreOverrides") ?? [];
+                        form.setValue(
+                          "simSubGenreOverrides",
+                          current.filter((_, i) => i !== idx),
+                        );
+                      }}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <FormField
+              control={form.control}
+              name="simSubNotes"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Sim-Sub Policy Notes</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Optional notes about your sim-sub policy..."
+                      rows={2}
+                      maxLength={1000}
+                      {...field}
+                    />
+                  </FormControl>
                   <FormMessage />
                 </FormItem>
               )}

--- a/apps/web/src/components/periods/period-form-dialog.tsx
+++ b/apps/web/src/components/periods/period-form-dialog.tsx
@@ -31,6 +31,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 /**
@@ -46,6 +47,9 @@ interface PeriodData {
   maxSubmissions: number | null;
   formDefinitionId: string | null;
   blindReviewMode?: string;
+  isContest?: boolean;
+  contestPrize?: string | null;
+  contestWinnersAnnouncedAt?: Date | string | null;
 }
 
 /**
@@ -61,6 +65,9 @@ const formSchema = z.object({
   maxSubmissions: z.string().optional(),
   formDefinitionId: z.string().optional(),
   blindReviewMode: z.string().optional(),
+  isContest: z.boolean().optional(),
+  contestPrize: z.string().max(500).optional(),
+  contestWinnersAnnouncedAt: z.string().optional(),
 });
 
 type FormData = z.infer<typeof formSchema>;
@@ -96,6 +103,9 @@ export function PeriodFormDialog({
       maxSubmissions: "",
       formDefinitionId: "__none__",
       blindReviewMode: "none",
+      isContest: false,
+      contestPrize: "",
+      contestWinnersAnnouncedAt: "",
     },
   });
 
@@ -111,6 +121,11 @@ export function PeriodFormDialog({
           period.maxSubmissions != null ? String(period.maxSubmissions) : "",
         formDefinitionId: period.formDefinitionId ?? "__none__",
         blindReviewMode: period.blindReviewMode ?? "none",
+        isContest: period.isContest ?? false,
+        contestPrize: period.contestPrize ?? "",
+        contestWinnersAnnouncedAt: period.contestWinnersAnnouncedAt
+          ? toDatetimeLocal(new Date(period.contestWinnersAnnouncedAt))
+          : "",
       });
     } else if (open) {
       form.reset({
@@ -122,6 +137,9 @@ export function PeriodFormDialog({
         maxSubmissions: "",
         formDefinitionId: "__none__",
         blindReviewMode: "none",
+        isContest: false,
+        contestPrize: "",
+        contestWinnersAnnouncedAt: "",
       });
     }
   }, [open, period, form]);
@@ -168,6 +186,13 @@ export function PeriodFormDialog({
       blindReviewMode:
         data.blindReviewMode && data.blindReviewMode !== "none"
           ? (data.blindReviewMode as "single_blind" | "double_blind")
+          : undefined,
+      isContest: data.isContest || undefined,
+      contestPrize:
+        data.isContest && data.contestPrize ? data.contestPrize : undefined,
+      contestWinnersAnnouncedAt:
+        data.isContest && data.contestWinnersAnnouncedAt
+          ? new Date(data.contestWinnersAnnouncedAt)
           : undefined,
     };
 
@@ -346,6 +371,60 @@ export function PeriodFormDialog({
                 </FormItem>
               )}
             />
+
+            <FormField
+              control={form.control}
+              name="isContest"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <div className="space-y-1 leading-none">
+                    <FormLabel>This is a contest</FormLabel>
+                  </div>
+                </FormItem>
+              )}
+            />
+
+            {form.watch("isContest") && (
+              <div className="space-y-4 rounded-md border p-4">
+                <FormField
+                  control={form.control}
+                  name="contestPrize"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Prize</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="$500 and publication"
+                          maxLength={500}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="contestWinnersAnnouncedAt"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Winners Announced</FormLabel>
+                      <FormControl>
+                        <Input type="datetime-local" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            )}
 
             <DialogFooter>
               <Button

--- a/apps/web/src/components/periods/period-list.tsx
+++ b/apps/web/src/components/periods/period-list.tsx
@@ -33,6 +33,7 @@ import {
   Pencil,
   Plus,
   Trash2,
+  Trophy,
   X,
 } from "lucide-react";
 
@@ -180,6 +181,15 @@ export function PeriodList() {
                     </TableCell>
                     <TableCell className="font-medium">
                       {item.name}
+                      {item.isContest && (
+                        <Badge
+                          variant="outline"
+                          className="ml-2 text-xs text-amber-600 border-amber-300"
+                        >
+                          <Trophy className="mr-1 h-3 w-3" />
+                          Contest
+                        </Badge>
+                      )}
                       {item.blindReviewMode &&
                         item.blindReviewMode !== "none" && (
                           <Badge variant="secondary" className="ml-2 text-xs">

--- a/apps/web/src/components/submissions/sim-sub-conflict-display.tsx
+++ b/apps/web/src/components/submissions/sim-sub-conflict-display.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { AlertTriangle, Eye, FileText, Globe, Info } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+
+interface SimSubConflict {
+  publicationName: string;
+  submittedAt: string;
+  periodName?: string;
+}
+
+interface SiblingVersionConflict {
+  versionId: string;
+  versionNumber: number;
+  submissionId: string;
+  publicationName: string;
+  status: string;
+  submittedAt: string | null;
+}
+
+interface WriterDisclosedConflict {
+  externalSubmissionId: string;
+  journalName: string;
+  status: string;
+  sentAt: string | null;
+}
+
+interface SimSubRemoteResult {
+  domain: string;
+  status: "checked" | "timeout" | "error" | "unreachable";
+  found?: boolean;
+  conflicts?: SimSubConflict[];
+  durationMs?: number;
+}
+
+interface PolicyRequirement {
+  type: "notify" | "withdraw";
+  windowHours?: number;
+  acknowledgedAt?: string;
+  dueAt?: string;
+}
+
+interface SimSubConflictDisplayProps {
+  policyRequirement?: PolicyRequirement | null;
+  localConflicts?: SimSubConflict[];
+  remoteResults?: SimSubRemoteResult[];
+  siblingVersionConflicts?: SiblingVersionConflict[];
+  writerDisclosedConflicts?: WriterDisclosedConflict[];
+  onAcknowledge?: () => void;
+}
+
+export function SimSubConflictDisplay({
+  policyRequirement,
+  localConflicts = [],
+  remoteResults = [],
+  siblingVersionConflicts = [],
+  writerDisclosedConflicts = [],
+  onAcknowledge,
+}: SimSubConflictDisplayProps) {
+  const remoteConflicts = remoteResults.filter((r) => r.found && r.conflicts);
+  const hasAnyConflicts =
+    writerDisclosedConflicts.length > 0 ||
+    siblingVersionConflicts.length > 0 ||
+    localConflicts.length > 0 ||
+    remoteConflicts.length > 0;
+
+  if (!hasAnyConflicts && !policyRequirement) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Policy requirement banner */}
+      {policyRequirement && !policyRequirement.acknowledgedAt && (
+        <Alert
+          variant="default"
+          className="border-amber-500 bg-amber-50 dark:bg-amber-950/20"
+        >
+          <AlertTriangle className="h-4 w-4 text-amber-600" />
+          <AlertTitle className="text-amber-800 dark:text-amber-200">
+            {policyRequirement.type === "withdraw"
+              ? "Withdrawal Required"
+              : "Notification Required"}
+          </AlertTitle>
+          <AlertDescription className="text-amber-700 dark:text-amber-300">
+            {policyRequirement.type === "withdraw" ? (
+              <>
+                This publication requires you to withdraw from other
+                publications if your work is accepted elsewhere.
+                {policyRequirement.windowHours && (
+                  <>
+                    {" "}
+                    You have {policyRequirement.windowHours} hours to comply.
+                  </>
+                )}
+              </>
+            ) : (
+              <>
+                This publication requires you to notify them if your work is
+                accepted elsewhere.
+                {policyRequirement.windowHours && (
+                  <>
+                    {" "}
+                    Please notify within {policyRequirement.windowHours} hours.
+                  </>
+                )}
+              </>
+            )}
+            {policyRequirement.dueAt && (
+              <span className="block mt-1 text-xs">
+                Due by:{" "}
+                {new Date(policyRequirement.dueAt).toLocaleDateString(
+                  undefined,
+                  { dateStyle: "medium" },
+                )}
+              </span>
+            )}
+            {onAcknowledge && (
+              <button
+                onClick={onAcknowledge}
+                className="mt-2 text-sm font-medium underline"
+              >
+                I acknowledge this requirement
+              </button>
+            )}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Writer-disclosed conflicts (highest confidence) */}
+      {writerDisclosedConflicts.length > 0 && (
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertTitle>Self-Reported Submissions</AlertTitle>
+          <AlertDescription>
+            <ul className="mt-2 space-y-1">
+              {writerDisclosedConflicts.map((c) => (
+                <li
+                  key={c.externalSubmissionId}
+                  className="flex items-center gap-2 text-sm"
+                >
+                  <Eye className="h-3 w-3 flex-shrink-0" />
+                  You indicated this was also submitted to{" "}
+                  <span className="font-medium">{c.journalName}</span>
+                  <Badge variant="outline" className="text-xs">
+                    {c.status}
+                  </Badge>
+                </li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Sibling version conflicts */}
+      {siblingVersionConflicts.length > 0 && (
+        <Alert>
+          <FileText className="h-4 w-4" />
+          <AlertTitle>Other Versions Active</AlertTitle>
+          <AlertDescription>
+            <ul className="mt-2 space-y-1">
+              {siblingVersionConflicts.map((c) => (
+                <li
+                  key={c.submissionId}
+                  className="flex items-center gap-2 text-sm"
+                >
+                  <FileText className="h-3 w-3 flex-shrink-0" />
+                  Version {c.versionNumber} is active at{" "}
+                  <span className="font-medium">{c.publicationName}</span>
+                  <Badge variant="outline" className="text-xs">
+                    {c.status}
+                  </Badge>
+                </li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Local fingerprint conflicts */}
+      {localConflicts.length > 0 && (
+        <Alert>
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>Detected at Other Publications</AlertTitle>
+          <AlertDescription>
+            <ul className="mt-2 space-y-1">
+              {localConflicts.map((c, idx) => (
+                <li key={idx} className="flex items-center gap-2 text-sm">
+                  <AlertTriangle className="h-3 w-3 flex-shrink-0" />
+                  This work was detected at{" "}
+                  <span className="font-medium">{c.publicationName}</span>
+                  {c.periodName && (
+                    <span className="text-muted-foreground">
+                      ({c.periodName})
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Federation conflicts (lowest confidence) */}
+      {remoteConflicts.length > 0 && (
+        <Alert>
+          <Globe className="h-4 w-4" />
+          <AlertTitle>Federated Instance Reports</AlertTitle>
+          <AlertDescription>
+            <ul className="mt-2 space-y-1">
+              {remoteConflicts.map((r) =>
+                r.conflicts?.map((c, idx) => (
+                  <li
+                    key={`${r.domain}-${idx}`}
+                    className="flex items-center gap-2 text-sm"
+                  >
+                    <Globe className="h-3 w-3 flex-shrink-0" />A federated
+                    instance ({r.domain}) reports a similar work under
+                    consideration
+                    {c.publicationName !== "Unknown" && (
+                      <>
+                        {" "}
+                        at{" "}
+                        <span className="font-medium">{c.publicationName}</span>
+                      </>
+                    )}
+                  </li>
+                )),
+              )}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -57,6 +57,7 @@ import {
   type SubmissionStatus,
 } from "@colophony/types";
 import { ReadOnlyFormFields } from "./form-renderer/read-only-form-fields";
+import { SimSubConflictDisplay } from "./sim-sub-conflict-display";
 
 interface SubmissionDetailProps {
   submissionId: string;
@@ -261,6 +262,20 @@ export function SubmissionDetail({
           )}
         </div>
       </div>
+
+      {/* Sim-sub policy requirement notice */}
+      {submission.simSubPolicyRequirement && (
+        <SimSubConflictDisplay
+          policyRequirement={
+            submission.simSubPolicyRequirement as {
+              type: "notify" | "withdraw";
+              windowHours?: number;
+              acknowledgedAt?: string;
+              dueAt?: string;
+            }
+          }
+        />
+      )}
 
       {/* Queue navigation */}
       {queueIds && queueIds.length > 0 && queueIdx != null && (

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -449,7 +449,7 @@
 - [ ] [P2] File drop zones: add keyboard focus handling, `role="button"`, `tabIndex` — (persona gap analysis 2026-02-27)
 - [ ] [P2] Scan status: add `aria-live` region for screen reader announcements during file scanning — (persona gap analysis 2026-02-27)
 - [ ] [P2] Sidebar: add `aria-label` to `<nav>` element — (persona gap analysis 2026-02-27)
-- [ ] [P3] Sim-sub error message: show human-readable explanation ("This manuscript appears to be under consideration at another publication that prohibits simultaneous submissions") instead of generic tRPC error — (persona gap analysis 2026-02-27)
+- [x] [P3] Sim-sub error message: show human-readable explanation ("This manuscript appears to be under consideration at another publication that prohibits simultaneous submissions") instead of generic tRPC error — (persona gap analysis 2026-02-27; done 2026-03-02 via SimSubConflictDisplay graduated confidence component)
 
 ---
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,25 @@ Newest entries first.
 
 ---
 
+## 2026-03-02 — Sim-Sub Policy Model + Version-Aware Checks (PR3)
+
+### Done
+
+- **PR3 (`feat/simsub-policy-versioning`)**: completed final PR in 3-PR sim-sub enhancement plan
+- **Schema**: replaced `simSubProhibited` boolean with `sim_sub_policy` JSONB supporting 4 policy types (`prohibited`, `allowed`, `allowed_notify`, `allowed_withdraw`) with genre overrides; added `sim_sub_policy_requirement` JSONB on submissions; added genre CHECK constraint on manuscripts; created `SimSubPolicyType` enum
+- **Service**: `resolveEffectivePolicy()` pure function for genre override resolution; `checkSiblingVersions()` two-phase RLS for cross-version conflicts; `checkWriterDisclosed()` user-scoped RLS for CSR external submissions; `performFullCheck()` runs all 4 checks in parallel; rewritten `preSubmitCheck()` with graduated policy responses
+- **Frontend**: policy type select + notify window + genre overrides + notes in period form; `SimSubConflictDisplay` graduated confidence component (writer-disclosed > sibling > local fingerprint > federation); policy requirement banner in submission detail
+- **Type fixes**: added `simSubPolicyRequirement` to `submissionSchema`, `listAll` select, GraphQL mock objects
+- **Tests**: 16 new tests covering policy resolution (5), sibling versions (3), writer-disclosed (2), preSubmitCheck policy model (5), performFullCheck version-aware (2); all 1552 pass
+- **Migration**: `0049_simsub_policy_model.sql` migrates existing boolean data to JSONB
+
+### Decisions
+
+- `simSubPolicyRequirement` added as `.nullable().optional()` on `submissionSchema` for backwards compat with existing submissions
+- Used `as any` cast at tRPC mutation call for form policy data — Zod validates at boundary, avoids complex generic propagation through react-hook-form
+
+---
+
 ## 2026-03-02 — Internal Documentation Audit
 
 ### Done

--- a/packages/db/migrations/0048_fingerprint_split_contest.sql
+++ b/packages/db/migrations/0048_fingerprint_split_contest.sql
@@ -1,0 +1,13 @@
+ALTER TABLE files ADD COLUMN content_hash varchar(64);
+CREATE INDEX files_content_hash_idx ON files (content_hash);
+--> statement-breakpoint
+ALTER TABLE manuscript_versions ADD COLUMN federation_fingerprint varchar(64);
+CREATE INDEX manuscript_versions_federation_fingerprint_idx ON manuscript_versions (federation_fingerprint);
+--> statement-breakpoint
+ALTER TABLE sim_sub_checks ADD COLUMN federation_fingerprint varchar(64);
+--> statement-breakpoint
+UPDATE manuscript_versions SET content_fingerprint = NULL WHERE content_fingerprint IS NOT NULL;
+--> statement-breakpoint
+ALTER TABLE submission_periods ADD COLUMN is_contest boolean NOT NULL DEFAULT false;
+ALTER TABLE submission_periods ADD COLUMN contest_prize varchar(500);
+ALTER TABLE submission_periods ADD COLUMN contest_winners_announced_at timestamptz;

--- a/packages/db/migrations/0049_simsub_policy_model.sql
+++ b/packages/db/migrations/0049_simsub_policy_model.sql
@@ -1,0 +1,28 @@
+-- SimSubPolicyType enum (for reference/validation; actual column is JSONB)
+CREATE TYPE "SimSubPolicyType" AS ENUM ('prohibited','allowed','allowed_notify','allowed_withdraw');
+--> statement-breakpoint
+
+-- Migrate simSubProhibited boolean to sim_sub_policy JSONB
+ALTER TABLE submission_periods ADD COLUMN sim_sub_policy jsonb;
+UPDATE submission_periods SET sim_sub_policy = CASE
+  WHEN sim_sub_prohibited = true THEN '{"type":"prohibited"}'::jsonb
+  ELSE '{"type":"allowed"}'::jsonb
+END;
+ALTER TABLE submission_periods ALTER COLUMN sim_sub_policy SET NOT NULL;
+ALTER TABLE submission_periods ALTER COLUMN sim_sub_policy SET DEFAULT '{"type":"allowed"}'::jsonb;
+--> statement-breakpoint
+
+-- Drop old boolean column
+ALTER TABLE submission_periods DROP COLUMN sim_sub_prohibited;
+--> statement-breakpoint
+
+-- Add policy requirement to submissions
+ALTER TABLE submissions ADD COLUMN sim_sub_policy_requirement jsonb;
+--> statement-breakpoint
+
+-- Genre CHECK constraint on manuscripts
+ALTER TABLE manuscripts ADD CONSTRAINT manuscripts_genre_primary_check
+  CHECK (genre IS NULL OR genre->>'primary' IN (
+    'poetry','fiction','creative_nonfiction','nonfiction',
+    'drama','translation','visual_art','comics','audio','other'
+  ));

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1778800000000,
       "tag": "0048_fingerprint_split_contest",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1779000000000,
+      "tag": "0049_simsub_policy_model",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1778600000000,
       "tag": "0047_status_token_expiry",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1778800000000,
+      "tag": "0048_fingerprint_split_contest",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -129,6 +129,13 @@ export const peerTrustStatusEnum = pgEnum("PeerTrustStatus", [
   "revoked",
 ]);
 
+export const simSubPolicyTypeEnum = pgEnum("SimSubPolicyType", [
+  "prohibited",
+  "allowed",
+  "allowed_notify",
+  "allowed_withdraw",
+]);
+
 export const simSubCheckResultEnum = pgEnum("SimSubCheckResult", [
   "CLEAR",
   "CONFLICT",

--- a/packages/db/src/schema/manuscripts.ts
+++ b/packages/db/src/schema/manuscripts.ts
@@ -64,6 +64,7 @@ export const manuscriptVersions = pgTable(
     versionNumber: integer("version_number").notNull(),
     label: varchar("label", { length: 255 }),
     contentFingerprint: varchar("content_fingerprint", { length: 64 }),
+    federationFingerprint: varchar("federation_fingerprint", { length: 64 }),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
@@ -71,6 +72,9 @@ export const manuscriptVersions = pgTable(
   (table) => [
     index("manuscript_versions_manuscript_id_idx").on(table.manuscriptId),
     index("manuscript_versions_fingerprint_idx").on(table.contentFingerprint),
+    index("manuscript_versions_federation_fingerprint_idx").on(
+      table.federationFingerprint,
+    ),
     unique("manuscript_versions_manuscript_version_unique").on(
       table.manuscriptId,
       table.versionNumber,
@@ -97,6 +101,7 @@ export const files = pgTable(
     mimeType: varchar("mime_type", { length: 255 }).notNull(),
     size: bigint("size", { mode: "number" }).notNull(),
     storageKey: varchar("storage_key", { length: 1000 }).notNull(),
+    contentHash: varchar("content_hash", { length: 64 }),
     scanStatus: scanStatusEnum("scan_status").notNull().default("PENDING"),
     scannedAt: timestamp("scanned_at", { withTimezone: true }),
     uploadedAt: timestamp("uploaded_at", { withTimezone: true })
@@ -104,6 +109,7 @@ export const files = pgTable(
       .notNull(),
   },
   (table) => [
+    index("files_content_hash_idx").on(table.contentHash),
     index("files_manuscript_version_id_idx").on(table.manuscriptVersionId),
     index("files_version_scan_status_idx").on(
       table.manuscriptVersionId,

--- a/packages/db/src/schema/submissions.ts
+++ b/packages/db/src/schema/submissions.ts
@@ -63,6 +63,11 @@ export const submissionPeriods = pgTable(
     blindReviewMode: blindReviewModeEnum("blind_review_mode")
       .notNull()
       .default("none"),
+    isContest: boolean("is_contest").notNull().default(false),
+    contestPrize: varchar("contest_prize", { length: 500 }),
+    contestWinnersAnnouncedAt: timestamp("contest_winners_announced_at", {
+      withTimezone: true,
+    }),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
@@ -207,6 +212,7 @@ export const simSubChecks = pgTable(
       .notNull()
       .references(() => submissions.id, { onDelete: "cascade" }),
     fingerprint: varchar("fingerprint", { length: 64 }).notNull(),
+    federationFingerprint: varchar("federation_fingerprint", { length: 64 }),
     submitterDid: varchar("submitter_did", { length: 512 }).notNull(),
     result: simSubCheckResultEnum("result").notNull(),
     localConflicts: jsonb("local_conflicts")

--- a/packages/db/src/schema/submissions.ts
+++ b/packages/db/src/schema/submissions.ts
@@ -59,7 +59,15 @@ export const submissionPeriods = pgTable(
     publicationId: uuid("publication_id").references(() => publications.id, {
       onDelete: "set null",
     }),
-    simSubProhibited: boolean("sim_sub_prohibited").notNull().default(false),
+    simSubPolicy: jsonb("sim_sub_policy")
+      .$type<{
+        type: "prohibited" | "allowed" | "allowed_notify" | "allowed_withdraw";
+        notifyWindowHours?: number;
+        genreOverrides?: Array<{ genre: string; type: string }>;
+        notes?: string;
+      }>()
+      .notNull()
+      .default(sql`'{"type": "allowed"}'::jsonb`),
     blindReviewMode: blindReviewModeEnum("blind_review_mode")
       .notNull()
       .default("none"),
@@ -135,6 +143,12 @@ export const submissions = pgTable(
     transferredFromTransferId: varchar("transferred_from_transfer_id", {
       length: 255,
     }),
+    simSubPolicyRequirement: jsonb("sim_sub_policy_requirement").$type<{
+      type: "notify" | "withdraw";
+      windowHours?: number;
+      acknowledgedAt?: string;
+      dueAt?: string;
+    } | null>(),
     statusTokenHash: varchar("status_token_hash", { length: 128 }),
     statusTokenExpiresAt: timestamp("status_token_expires_at", {
       withTimezone: true,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,6 +18,7 @@ export * from "./issue";
 export * from "./cms";
 export * from "./federation";
 export * from "./sim-sub";
+export * from "./sim-sub-policy";
 export * from "./transfer";
 export * from "./migration";
 export * from "./hub";

--- a/packages/types/src/sim-sub-policy.ts
+++ b/packages/types/src/sim-sub-policy.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import { primaryGenreSchema } from "./csr";
+
+// ---------------------------------------------------------------------------
+// Sim-sub policy types
+// ---------------------------------------------------------------------------
+
+export const simSubPolicyTypeSchema = z.enum([
+  "prohibited",
+  "allowed",
+  "allowed_notify",
+  "allowed_withdraw",
+]);
+export type SimSubPolicyType = z.infer<typeof simSubPolicyTypeSchema>;
+
+export const simSubGenreOverrideSchema = z.object({
+  genre: primaryGenreSchema,
+  type: simSubPolicyTypeSchema,
+});
+export type SimSubGenreOverride = z.infer<typeof simSubGenreOverrideSchema>;
+
+export const simSubPolicySchema = z.object({
+  type: simSubPolicyTypeSchema,
+  notifyWindowHours: z.number().int().min(1).optional(),
+  genreOverrides: z.array(simSubGenreOverrideSchema).optional(),
+  notes: z.string().max(1000).optional(),
+});
+export type SimSubPolicy = z.infer<typeof simSubPolicySchema>;
+
+export const simSubPolicyRequirementSchema = z.object({
+  type: z.enum(["notify", "withdraw"]),
+  windowHours: z.number().int().optional(),
+  acknowledgedAt: z.string().datetime().optional(),
+  dueAt: z.string().datetime().optional(),
+});
+export type SimSubPolicyRequirement = z.infer<
+  typeof simSubPolicyRequirementSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Version-aware conflict types
+// ---------------------------------------------------------------------------
+
+export const siblingVersionConflictSchema = z.object({
+  versionId: z.string().uuid(),
+  versionNumber: z.number().int(),
+  submissionId: z.string().uuid(),
+  publicationName: z.string(),
+  status: z.string(),
+  submittedAt: z.string().datetime().nullable(),
+});
+export type SiblingVersionConflict = z.infer<
+  typeof siblingVersionConflictSchema
+>;
+
+export const writerDisclosedConflictSchema = z.object({
+  externalSubmissionId: z.string().uuid(),
+  journalName: z.string(),
+  status: z.string(),
+  sentAt: z.string().datetime().nullable(),
+});
+export type WriterDisclosedConflict = z.infer<
+  typeof writerDisclosedConflictSchema
+>;

--- a/packages/types/src/sim-sub.ts
+++ b/packages/types/src/sim-sub.ts
@@ -70,7 +70,10 @@ export type SimSubRemoteResult = z.infer<typeof simSubRemoteResultSchema>;
 /** Full result of a sim-sub check (local + remote). */
 export const simSubFullCheckResultSchema = z.object({
   result: simSubCheckResultSchema.describe("Aggregated check result"),
-  fingerprint: z.string().describe("The fingerprint that was checked"),
+  fingerprint: z.string().describe("The content fingerprint that was checked"),
+  federationFingerprint: z
+    .string()
+    .describe("The federation fingerprint (filename:size based)"),
   localConflicts: z.array(simSubConflictSchema),
   remoteResults: z.array(simSubRemoteResultSchema),
 });

--- a/packages/types/src/sim-sub.ts
+++ b/packages/types/src/sim-sub.ts
@@ -1,4 +1,9 @@
 import { z } from "zod";
+import {
+  simSubPolicySchema,
+  siblingVersionConflictSchema,
+  writerDisclosedConflictSchema,
+} from "./sim-sub-policy";
 
 // ---------------------------------------------------------------------------
 // Sim-sub check result enum
@@ -67,7 +72,7 @@ export const simSubRemoteResultSchema = z.object({
 });
 export type SimSubRemoteResult = z.infer<typeof simSubRemoteResultSchema>;
 
-/** Full result of a sim-sub check (local + remote). */
+/** Full result of a sim-sub check (local + remote + version-aware). */
 export const simSubFullCheckResultSchema = z.object({
   result: simSubCheckResultSchema.describe("Aggregated check result"),
   fingerprint: z.string().describe("The content fingerprint that was checked"),
@@ -76,5 +81,16 @@ export const simSubFullCheckResultSchema = z.object({
     .describe("The federation fingerprint (filename:size based)"),
   localConflicts: z.array(simSubConflictSchema),
   remoteResults: z.array(simSubRemoteResultSchema),
+  siblingVersionConflicts: z
+    .array(siblingVersionConflictSchema)
+    .optional()
+    .describe("Active submissions on other versions of the same manuscript"),
+  writerDisclosedConflicts: z
+    .array(writerDisclosedConflictSchema)
+    .optional()
+    .describe("Active external submissions disclosed by the writer"),
+  effectivePolicy: simSubPolicySchema
+    .optional()
+    .describe("The policy that was applied for this check"),
 });
 export type SimSubFullCheckResult = z.infer<typeof simSubFullCheckResultSchema>;

--- a/packages/types/src/submission.ts
+++ b/packages/types/src/submission.ts
@@ -286,6 +286,15 @@ export const submissionPeriodSchema = z.object({
     .boolean()
     .describe("Whether simultaneous submissions are prohibited"),
   blindReviewMode: blindReviewModeSchema,
+  isContest: z.boolean().describe("Whether this period is a contest"),
+  contestPrize: z
+    .string()
+    .nullable()
+    .describe("Prize description for contests"),
+  contestWinnersAnnouncedAt: z
+    .date()
+    .nullable()
+    .describe("When contest winners will be announced"),
   createdAt: z.date().describe("When the period was created"),
   updatedAt: z.date().describe("When the period was last updated"),
 });
@@ -332,6 +341,19 @@ export const createSubmissionPeriodSchema = z.object({
     .describe(
       "Blind review mode: none, single_blind, or double_blind (default: none)",
     ),
+  isContest: z
+    .boolean()
+    .optional()
+    .describe("Whether this period is a contest (default: false)"),
+  contestPrize: z
+    .string()
+    .max(500)
+    .optional()
+    .describe("Prize description for contests (max 500 chars)"),
+  contestWinnersAnnouncedAt: z.coerce
+    .date()
+    .optional()
+    .describe("When contest winners will be announced (ISO-8601)"),
 });
 
 export type CreateSubmissionPeriodInput = z.infer<

--- a/packages/types/src/submission.ts
+++ b/packages/types/src/submission.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { scanStatusSchema, fileSchema } from "./file";
+import { simSubPolicySchema } from "./sim-sub-policy";
 
 export const submissionStatusSchema = z
   .enum([
@@ -60,6 +61,18 @@ export const submissionSchema = z.object({
     .describe("When the submission was formally submitted"),
   createdAt: z.date().describe("When the submission was created"),
   updatedAt: z.date().describe("When the submission was last updated"),
+  simSubPolicyRequirement: z
+    .object({
+      type: z.enum(["notify", "withdraw"]),
+      windowHours: z.number().int().optional(),
+      acknowledgedAt: z.string().datetime().optional(),
+      dueAt: z.string().datetime().optional(),
+    })
+    .nullable()
+    .optional()
+    .describe(
+      "Policy requirement recorded when sim-sub conflict detected under allowed_notify/allowed_withdraw",
+    ),
 });
 
 export type Submission = z.infer<typeof submissionSchema>;
@@ -282,9 +295,7 @@ export const submissionPeriodSchema = z.object({
     .uuid()
     .nullable()
     .describe("ID of the form definition linked to this period"),
-  simSubProhibited: z
-    .boolean()
-    .describe("Whether simultaneous submissions are prohibited"),
+  simSubPolicy: simSubPolicySchema.describe("Sim-sub policy for this period"),
   blindReviewMode: blindReviewModeSchema,
   isContest: z.boolean().describe("Whether this period is a contest"),
   contestPrize: z
@@ -330,12 +341,9 @@ export const createSubmissionPeriodSchema = z.object({
     .uuid()
     .optional()
     .describe("Form definition to link to this period"),
-  simSubProhibited: z
-    .boolean()
+  simSubPolicy: simSubPolicySchema
     .optional()
-    .describe(
-      "Whether simultaneous submissions are prohibited (default: false)",
-    ),
+    .describe("Sim-sub policy (default: allowed)"),
   blindReviewMode: blindReviewModeSchema
     .optional()
     .describe(


### PR DESCRIPTION
## Summary

- **PR1 — Fingerprint Split + Contest Flagging:** Split fingerprinting into content-based (SHA-256 of file bytes, computed during ClamAV scan) and federation-based (`filename:size`). Content fingerprints reduce false positives from generic filenames; federation fingerprints maintain backwards compatibility with S2S checks. Added contest fields (`isContest`, `contestPrize`, `contestWinnersAnnouncedAt`) to submission periods.
- **PR3 — Policy Model + Version-Aware Checks:** Replaced binary `simSubProhibited` with a rich JSONB policy model supporting 4 types (`prohibited`, `allowed`, `allowed_notify`, `allowed_withdraw`) with genre overrides and notification windows. Added `checkSiblingVersions` (cross-version detection) and `checkWriterDisclosed` (CSR external submissions) to `performFullCheck`. Built graduated confidence UI for conflict display.
- **Review fix:** Added stream error propagation in file-scan worker hash computation; fixed `Date.now()` consistency.

## Test plan

- [x] All 1552 unit tests pass
- [x] Type-check clean (14 workspace tasks)
- [x] Lint clean (0 errors)
- [ ] CI pipeline passes
- [ ] Manual: create period with `allowed_notify` policy + genre override → submit → verify obligation recorded
- [ ] Manual: submit manuscript with sibling version active → verify graduated conflict display

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| — | — | — | No overrides — all items matched plan |