### PR TITLE
docs: governance model documentation (Track 9 P2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Prerequisites: Node.js >= 22, pnpm 9.15+, Docker, tmux + Overmind. See [CONTRIBU
 
 - [Architecture](docs/architecture.md) — system design, component breakdown, development tracks
 - [Licensing](docs/licensing.md) — AGPL/MIT boundary, obligations, FAQ
+- [Governance](docs/governance.md) — decision-making, proposing changes, project direction
 - [Testing](docs/testing.md) — test strategy, running tests, CI pipeline
 - [Deployment](docs/deployment.md) — Docker Compose setup, managed hosting
 - [Contributing](CONTRIBUTING.md) — development setup, workflow, PR process

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -397,7 +397,7 @@
 - [x] [P1] CONTRIBUTING.md — how to contribute, development setup, PR process, code of conduct reference — (persona gap analysis 2026-02-27; done 2026-03-02)
 - [x] [P1] CODE_OF_CONDUCT.md — (persona gap analysis 2026-02-27; done 2026-03-02 Contributor Covenant v3.0)
 - [x] [P1] README.md rewrite — project description in brand voice, architecture overview, quick start, screenshots, link to docs — (persona gap analysis 2026-02-27; done 2026-03-02)
-- [ ] [P2] Governance model documentation — who makes decisions, how contributions are evaluated, roadmap transparency — (persona gap analysis 2026-02-27)
+- [x] [P2] Governance model documentation — who makes decisions, how contributions are evaluated, roadmap transparency — (persona gap analysis 2026-02-27; done 2026-03-02)
 - [x] [P2] Fix deployment docs NestJS reference — deployment guide references NestJS but the system is Fastify — (persona gap analysis 2026-02-27; done 2026-03-02 docs audit)
 - [ ] [P3] Public instance identity page — human-readable page showing federation status, trust relationships, and governance commitments (the `.well-known/colophony` endpoint is machine-only) — (persona gap analysis 2026-02-27)
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,21 @@ Newest entries first.
 
 ---
 
+## 2026-03-02 — Track 9: Governance Model Documentation
+
+### Done
+
+- **`docs/governance.md`**: Created governance model doc covering overview (solo-maintainer), current roles, decision-making process, proposing changes (GitHub Issues + `proposal` label), roadmap visibility (tracks, P0–P3 priorities, semver), code review focus areas, evolution commitment, and references
+- **`README.md`**: Added governance link to Documentation section (between Licensing and Testing)
+- **Backlog**: Marked Track 9 P2 governance item complete
+
+### Decisions
+
+- Solo-maintainer model — honest about current reality, no aspirational contributor tiers or committees
+- Lightweight proposal process via `proposal`-labeled Issues, no formal RFC numbering system
+
+---
+
 ## 2026-03-02 — Track 9: Community Documentation
 
 ### Done

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,85 @@
+# Governance
+
+> How decisions are made in Colophony and how that will evolve.
+
+---
+
+## Overview
+
+Colophony uses a **solo-maintainer** governance model. David Mahaffey is the project lead with final decision authority on architecture, releases, and project direction.
+
+This is intentionally lightweight. The project is young (v2 rewrite launched early 2026) and adding formal governance structures before there is a community to govern would be premature. The model will evolve as contributors join — see [Evolution](#evolution) below.
+
+## Current Roles
+
+- **Maintainer** (David) — architecture decisions, code review, merge authority, release management, and project direction.
+
+There are no formal contributor tiers or committees. Contributors who demonstrate sustained, high-quality engagement may be invited to take on more responsibility over time (e.g., triaging issues, reviewing PRs in specific areas), but this will happen organically rather than through a predefined ladder.
+
+## Decision-Making
+
+**Day-to-day decisions** — maintainer discretion. Bug fixes, dependency updates, minor features, and refactors are decided during development and documented in the devlog.
+
+**Architectural decisions** — documented in [docs/architecture.md](architecture.md), which tracks the component structure, development tracks, and a decision log. Significant architectural choices are recorded there so future contributors can understand the rationale.
+
+**Product priorities** — driven by the [backlog](backlog.md) (`docs/backlog.md`), which organizes work into tracks with priority levels (P0–P3). Community input via GitHub Issues influences prioritization, but the maintainer makes final scheduling decisions.
+
+**Licensing** — settled. AGPL-3.0-or-later for core, MIT for SDKs and plugin tooling. See [docs/licensing.md](licensing.md) for the full boundary and rationale.
+
+## Proposing Changes
+
+**Bug reports and feature requests** — open a [GitHub Issue](https://github.com/colophony-project/colophony/issues). Provide enough context for someone unfamiliar with the problem to understand it.
+
+**Major changes** — new components, architectural shifts, federation protocol changes, or anything that would affect multiple tracks — should be proposed as a GitHub Issue with the `proposal` label. A good proposal includes:
+
+- **Problem statement** — what is the current limitation or need
+- **Proposed approach** — what you want to build or change
+- **Alternatives considered** — what else was evaluated and why it was set aside
+
+The maintainer will respond within a reasonable timeframe. There will be a discussion period before implementation begins to surface concerns and refine the approach. There is no formal RFC numbering system or accept/reject ceremony — this is a conversation, not a bureaucracy.
+
+## Roadmap
+
+Development is organized into **tracks** that group related work by component or concern. Track status and scope are documented in [docs/architecture.md](architecture.md) Section 6.
+
+Deferred work is tracked in [docs/backlog.md](backlog.md) with priority levels:
+
+| Priority | Meaning                               |
+| -------- | ------------------------------------- |
+| **P0**   | Blocking — must resolve before moving |
+| **P1**   | Important — next session or soon      |
+| **P2**   | Wanted — schedule when bandwidth fits |
+| **P3**   | Nice-to-have — backlog indefinitely   |
+
+There is no fixed release cadence. Releases happen when a coherent set of changes is ready. Versioning follows [semver](https://semver.org/) (`v{major}.{minor}.{patch}`).
+
+## Code Review
+
+All changes go through pull request review. Reviewers look for:
+
+- **RLS policies** on tenant tables (multi-tenancy correctness)
+- **Audit logging** for sensitive operations
+- **Input validation** (Zod) on all API surfaces
+- **Tests** for new functionality
+- **Conventional commit messages** with component scope
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full PR process and development workflow.
+
+## Evolution
+
+This governance model will evolve as the project grows. Possible future changes include:
+
+- Formal contributor roles (e.g., component maintainers, triagers)
+- A decision-making process that includes more voices on architectural questions
+- A steering group if the project reaches a scale that warrants one
+
+Community input on governance changes is welcome via [GitHub Issues](https://github.com/colophony-project/colophony/issues). This document will be updated to reflect reality as it changes — not to describe aspirations.
+
+## References
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — development setup, workflow, PR process
+- [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) — community standards
+- [SECURITY.md](../SECURITY.md) — vulnerability reporting
+- [docs/licensing.md](licensing.md) — AGPL/MIT boundary
+- [docs/architecture.md](architecture.md) — system design, tracks, decision log
+- [docs/backlog.md](backlog.md) — deferred work, priorities

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -32,11 +32,11 @@ There are no formal contributor tiers or committees. Contributors who demonstrat
 
 **Major changes** — new components, architectural shifts, federation protocol changes, or anything that would affect multiple tracks — should be proposed as a GitHub Issue with the `proposal` label. A good proposal includes:
 
-- **Problem statement** — what is the current limitation or need
+- **Problem statement** — the current limitation or need
 - **Proposed approach** — what you want to build or change
 - **Alternatives considered** — what else was evaluated and why it was set aside
 
-The maintainer will respond within a reasonable timeframe. There will be a discussion period before implementation begins to surface concerns and refine the approach. There is no formal RFC numbering system or accept/reject ceremony — this is a conversation, not a bureaucracy.
+The maintainer will typically respond within a week. There will be a discussion period before implementation begins to surface concerns and refine the approach. There is no formal RFC numbering system or accept/reject ceremony — this is a conversation, not a bureaucracy.
 
 ## Roadmap
 
@@ -72,6 +72,8 @@ This governance model will evolve as the project grows. Possible future changes 
 - Formal contributor roles (e.g., component maintainers, triagers)
 - A decision-making process that includes more voices on architectural questions
 - A steering group if the project reaches a scale that warrants one
+
+Colophony is licensed under AGPL-3.0-or-later, which ensures the codebase remains forkable regardless of project status or maintainer availability.
 
 Community input on governance changes is welcome via [GitHub Issues](https://github.com/colophony-project/colophony/issues). This document will be updated to reflect reality as it changes — not to describe aspirations.
 


### PR DESCRIPTION
## Summary

- Created `docs/governance.md` — solo-maintainer governance model covering decision-making, proposing changes, roadmap visibility, code review focus areas, and evolution commitment
- Added governance link to README.md Documentation section
- Marked Track 9 P2 governance backlog item complete

## Test plan

- [x] All internal links resolve to existing files
- [x] `pnpm format` passes
- [x] Tone check: honest/inviting, not bureaucratic or aspirational beyond reality