### PR TITLE
feat(register): public instance identity page (Track 9 P3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -567,7 +567,7 @@ See [docs/architecture.md Section 6](docs/architecture.md) for full details.
 | 6     | Colophony Plugins                                        | **Complete** |
 | 7     | Monitoring & Observability (Sentry, Prometheus, metrics) | **Complete** |
 | 8     | Register Data Standard & Writer Tools (CSR, workspace)   | **Complete** |
-| 9     | Governance & Public Docs                                 | Not started  |
+| 9     | Governance & Public Docs                                 | **Complete** |
 | 10    | Analytics & Reporting (submission + writer analytics)    | **Complete** |
 | —     | Relay — Notifications (cross-cutting)                    | **Complete** |
 

--- a/apps/api/src/federation/discovery.routes.spec.ts
+++ b/apps/api/src/federation/discovery.routes.spec.ts
@@ -96,6 +96,7 @@ describe('Federation Discovery Routes', () => {
         mode: 'allowlist',
         contactEmail: null,
         publications: [],
+        trustedPeers: [],
       });
 
       const response = await app.inject({
@@ -136,6 +137,7 @@ describe('Federation Discovery Routes', () => {
         mode: 'allowlist',
         contactEmail: null,
         publications: [],
+        trustedPeers: [],
       });
 
       const response = await app.inject({
@@ -144,6 +146,30 @@ describe('Federation Discovery Routes', () => {
       });
 
       expect(response.headers['cache-control']).toBe('public, max-age=3600');
+    });
+
+    it('returns trustedPeers in response', async () => {
+      mockGetInstanceMetadata.mockResolvedValueOnce({
+        software: 'colophony',
+        version: '2.0.0-dev',
+        domain: 'magazine.example',
+        publicKey: 'pub-key',
+        keyId: 'magazine.example#main',
+        capabilities: ['identity'],
+        mode: 'allowlist',
+        contactEmail: null,
+        publications: [],
+        trustedPeers: ['peer.example'],
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/colophony',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.trustedPeers).toEqual(['peer.example']);
     });
   });
 

--- a/apps/api/src/services/federation.service.spec.ts
+++ b/apps/api/src/services/federation.service.spec.ts
@@ -16,6 +16,7 @@ const { testKeypairHoisted } = vi.hoisted(() => {
 vi.mock('@colophony/db', () => ({
   db: {
     select: vi.fn(),
+    selectDistinct: vi.fn(),
     insert: vi.fn(),
     update: vi.fn(),
     transaction: vi.fn(),
@@ -32,6 +33,11 @@ vi.mock('@colophony/db', () => ({
     id: 'id',
     slug: 'slug',
     federationOptedOut: 'federation_opted_out',
+  },
+  trustedPeers: {
+    domain: 'domain',
+    organizationId: 'organization_id',
+    status: 'status',
   },
   users: {
     id: 'id',
@@ -141,6 +147,19 @@ function mockSelectChainNoLimit(rows: unknown[]) {
   };
 }
 
+// Helper to build chained Drizzle selectDistinct mock (.from().innerJoin().where().limit())
+function mockSelectDistinctChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(rows),
+        }),
+      }),
+    }),
+  };
+}
+
 // Alias for readability in test data
 const testKeypair = testKeypairHoisted;
 
@@ -148,6 +167,7 @@ describe('federationService', () => {
   let dbModule: {
     db: {
       select: ReturnType<typeof vi.fn>;
+      selectDistinct: ReturnType<typeof vi.fn>;
       insert: ReturnType<typeof vi.fn>;
       update: ReturnType<typeof vi.fn>;
       transaction: ReturnType<typeof vi.fn>;
@@ -437,6 +457,10 @@ describe('federationService', () => {
         .mockReturnValueOnce(mockSelectChain([configRow]))
         // getInstanceMetadata -> select publications
         .mockReturnValueOnce(mockSelectChain(pubRows));
+      // getInstanceMetadata -> selectDistinct trusted peers
+      dbModule.db.selectDistinct.mockReturnValueOnce(
+        mockSelectDistinctChain([]),
+      );
 
       const metadata = await federationService.getInstanceMetadata(baseEnv);
 
@@ -465,6 +489,9 @@ describe('federationService', () => {
       dbModule.db.select
         .mockReturnValueOnce(mockSelectChain([configRow]))
         .mockReturnValueOnce(mockSelectChain([]));
+      dbModule.db.selectDistinct.mockReturnValueOnce(
+        mockSelectDistinctChain([]),
+      );
 
       const metadata = await federationService.getInstanceMetadata(baseEnv);
 
@@ -518,11 +545,69 @@ describe('federationService', () => {
       dbModule.db.select
         .mockReturnValueOnce(mockSelectChain([configRow]))
         .mockReturnValueOnce(mockSelectChain([activePub]));
+      dbModule.db.selectDistinct.mockReturnValueOnce(
+        mockSelectDistinctChain([]),
+      );
 
       const metadata = await federationService.getInstanceMetadata(baseEnv);
 
       expect(metadata.publications).toHaveLength(1);
       expect(metadata.publications[0].name).toBe('Active Pub');
+    });
+
+    it('includes trustedPeers in metadata', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      const configRow = {
+        id: 'cfg-id',
+        publicKey: 'pub-key',
+        privateKey: 'priv-key',
+        keyId: 'magazine.example#main',
+        mode: 'allowlist' as const,
+        contactEmail: null,
+        capabilities: ['identity'],
+        enabled: true,
+      };
+
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([configRow]))
+        .mockReturnValueOnce(mockSelectChain([]));
+      dbModule.db.selectDistinct.mockReturnValueOnce(
+        mockSelectDistinctChain([
+          { domain: 'peer1.example' },
+          { domain: 'peer2.example' },
+        ]),
+      );
+
+      const metadata = await federationService.getInstanceMetadata(baseEnv);
+
+      expect(metadata.trustedPeers).toEqual(['peer1.example', 'peer2.example']);
+    });
+
+    it('returns empty trustedPeers when no active peers', async () => {
+      const { federationService } = await import('./federation.service.js');
+
+      const configRow = {
+        id: 'cfg-id',
+        publicKey: 'pub-key',
+        privateKey: 'priv-key',
+        keyId: 'magazine.example#main',
+        mode: 'allowlist' as const,
+        contactEmail: null,
+        capabilities: ['identity'],
+        enabled: true,
+      };
+
+      dbModule.db.select
+        .mockReturnValueOnce(mockSelectChain([configRow]))
+        .mockReturnValueOnce(mockSelectChain([]));
+      dbModule.db.selectDistinct.mockReturnValueOnce(
+        mockSelectDistinctChain([]),
+      );
+
+      const metadata = await federationService.getInstanceMetadata(baseEnv);
+
+      expect(metadata.trustedPeers).toEqual([]);
     });
   });
 

--- a/apps/api/src/services/federation.service.ts
+++ b/apps/api/src/services/federation.service.ts
@@ -6,6 +6,7 @@ import {
   organizations,
   users,
   userKeys,
+  trustedPeers,
 } from '@colophony/db';
 import { eq, and, isNull, count } from 'drizzle-orm';
 import {
@@ -359,6 +360,22 @@ export const federationService = {
         ),
       );
 
+    // Query distinct active peer domains from non-opted-out orgs via superuser pool
+    const activePeerDomains = await db
+      .selectDistinct({ domain: trustedPeers.domain })
+      .from(trustedPeers)
+      .innerJoin(
+        organizations,
+        eq(trustedPeers.organizationId, organizations.id),
+      )
+      .where(
+        and(
+          eq(trustedPeers.status, 'active'),
+          eq(organizations.federationOptedOut, false),
+        ),
+      )
+      .limit(1000);
+
     return {
       software: 'colophony',
       version: '2.0.0-dev',
@@ -371,6 +388,7 @@ export const federationService = {
       mode: config.mode,
       contactEmail: config.contactEmail,
       publications: pubs,
+      trustedPeers: activePeerDomains.map((r) => r.domain),
     };
   },
 

--- a/apps/web/src/app/identity/page.tsx
+++ b/apps/web/src/app/identity/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import { InstanceIdentity } from "@/components/identity/instance-identity";
+
+export const metadata: Metadata = {
+  title: "Instance Identity - Colophony",
+  description:
+    "Federation status, trust relationships, and governance commitments",
+};
+
+export default function IdentityPage() {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+  return <InstanceIdentity apiUrl={apiUrl} />;
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -74,8 +74,15 @@ export default function Home() {
 
       {/* Footer */}
       <footer className="border-t py-6">
-        <div className="container text-center text-sm text-muted-foreground">
-          &copy; {new Date().getFullYear()} Colophony. All rights reserved.
+        <div className="container text-center text-sm text-muted-foreground space-y-2">
+          <div>
+            &copy; {new Date().getFullYear()} Colophony. All rights reserved.
+          </div>
+          <div>
+            <a href="/identity" className="underline hover:text-foreground">
+              Instance Identity
+            </a>
+          </div>
         </div>
       </footer>
     </div>

--- a/apps/web/src/components/identity/__tests__/instance-identity.spec.tsx
+++ b/apps/web/src/components/identity/__tests__/instance-identity.spec.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import "../../../../test/setup";
+import { InstanceIdentity } from "../instance-identity";
+
+const fullMetadata = {
+  software: "colophony",
+  version: "2.0.0-dev",
+  domain: "magazine.example",
+  publicKey: "-----BEGIN PUBLIC KEY-----\nMCowBQ...\n-----END PUBLIC KEY-----",
+  keyId: "magazine.example#main",
+  capabilities: ["identity.verify", "simsub.check"],
+  mode: "allowlist",
+  contactEmail: "admin@magazine.example",
+  publications: [
+    {
+      id: "pub-1",
+      name: "Literary Review",
+      slug: "literary-review",
+      organizationSlug: "lit-org",
+    },
+  ],
+  trustedPeers: ["peer1.example", "peer2.example"],
+};
+
+function mockFetchSuccess(data: unknown) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  } as Response);
+}
+
+function mockFetch503Disabled() {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status: 503,
+    json: () => Promise.resolve({ error: "federation_disabled" }),
+  } as unknown as Response);
+}
+
+function mockFetchFailure() {
+  global.fetch = jest.fn().mockRejectedValue(new Error("Network error"));
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("InstanceIdentity", () => {
+  it("renders loading skeletons initially", () => {
+    // Never-resolving fetch to keep loading state
+    global.fetch = jest.fn().mockReturnValue(new Promise(() => {}));
+
+    render(<InstanceIdentity apiUrl="http://localhost:4000" />);
+
+    expect(screen.getByTestId("loading-skeletons")).toBeInTheDocument();
+  });
+
+  it("renders instance metadata on successful fetch", async () => {
+    mockFetchSuccess(fullMetadata);
+
+    render(<InstanceIdentity apiUrl="http://localhost:4000" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("version-badge")).toHaveTextContent(
+        "v2.0.0-dev",
+      );
+    });
+
+    expect(screen.getByTestId("instance-domain")).toHaveTextContent(
+      "magazine.example",
+    );
+    expect(screen.getByTestId("mode-label")).toHaveTextContent("Allowlist");
+    expect(screen.getByText("Literary Review")).toBeInTheDocument();
+    expect(screen.getByText("peer1.example")).toBeInTheDocument();
+    expect(screen.getByText("peer2.example")).toBeInTheDocument();
+    expect(screen.getByText("AGPL-3.0-or-later")).toBeInTheDocument();
+    expect(screen.getByText("Contributing Guide")).toBeInTheDocument();
+  });
+
+  it("renders federation disabled state", async () => {
+    mockFetch503Disabled();
+
+    render(<InstanceIdentity apiUrl="http://localhost:4000" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Federation Not Enabled")).toBeInTheDocument();
+    });
+
+    // Governance section should still render
+    expect(screen.getByText("AGPL-3.0-or-later")).toBeInTheDocument();
+  });
+
+  it("renders error state on fetch failure", async () => {
+    mockFetchFailure();
+
+    render(<InstanceIdentity apiUrl="http://localhost:4000" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to Load")).toBeInTheDocument();
+    });
+  });
+
+  it("renders empty states for publications and peers", async () => {
+    mockFetchSuccess({
+      ...fullMetadata,
+      publications: [],
+      trustedPeers: [],
+    });
+
+    render(<InstanceIdentity apiUrl="http://localhost:4000" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No publications listed.")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("No trusted peers configured yet."),
+    ).toBeInTheDocument();
+  });
+
+  it("handles missing trustedPeers field", async () => {
+    const metadataWithoutPeers = { ...fullMetadata };
+    delete (metadataWithoutPeers as Record<string, unknown>).trustedPeers;
+    mockFetchSuccess(metadataWithoutPeers);
+
+    render(<InstanceIdentity apiUrl="http://localhost:4000" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("version-badge")).toBeInTheDocument();
+    });
+
+    // Should not crash — renders empty state for peers
+    expect(
+      screen.getByText("No trusted peers configured yet."),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/identity/instance-identity.tsx
+++ b/apps/web/src/components/identity/instance-identity.tsx
@@ -1,0 +1,496 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// ---------------------------------------------------------------------------
+// Local types (display-only — not shared with backend)
+// ---------------------------------------------------------------------------
+
+interface FederationPublication {
+  id: string;
+  name: string;
+  slug: string;
+  organizationSlug: string;
+}
+
+interface InstanceMetadata {
+  software: string;
+  version: string;
+  domain: string;
+  publicKey: string;
+  keyId: string;
+  capabilities: string[];
+  mode: "allowlist" | "open" | "managed_hub";
+  contactEmail: string | null;
+  publications: FederationPublication[];
+  trustedPeers?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CAPABILITY_DESCRIPTIONS: Record<string, string> = {
+  "identity.verify": "Verify writer identity across instances",
+  "identity.migrate": "Support writer identity migration",
+  "simsub.check": "Check simultaneous submission status",
+  "simsub.respond": "Respond to simultaneous submission queries",
+  "transfer.initiate": "Initiate piece transfers to other instances",
+  "transfer.receive": "Receive piece transfers from other instances",
+};
+
+const MODE_LABELS: Record<string, { label: string; description: string }> = {
+  allowlist: {
+    label: "Allowlist",
+    description:
+      "This instance federates with explicitly approved peer instances only.",
+  },
+  open: {
+    label: "Open",
+    description:
+      "This instance accepts federation requests from any compatible instance.",
+  },
+  managed_hub: {
+    label: "Managed Hub",
+    description:
+      "This instance federates through a managed hub for coordinated trust.",
+  },
+};
+
+const GITHUB_REPO = "https://github.com/wordshepherd/colophony/blob/main";
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface InstanceIdentityProps {
+  apiUrl: string;
+}
+
+type FetchState =
+  | { status: "loading" }
+  | { status: "federation_disabled" }
+  | { status: "fetch_failed" }
+  | { status: "success"; data: InstanceMetadata };
+
+export function InstanceIdentity({ apiUrl }: InstanceIdentityProps) {
+  const [state, setState] = useState<FetchState>({ status: "loading" });
+
+  useEffect(() => {
+    const url = `${apiUrl}/.well-known/colophony`;
+    fetch(url)
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          if (
+            res.status === 503 &&
+            (body as Record<string, unknown>).error === "federation_disabled"
+          ) {
+            setState({ status: "federation_disabled" });
+            return;
+          }
+          setState({ status: "fetch_failed" });
+          return;
+        }
+        const data = (await res.json()) as InstanceMetadata;
+        setState({ status: "success", data });
+      })
+      .catch(() => {
+        setState({ status: "fetch_failed" });
+      });
+  }, [apiUrl]);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-4xl mx-auto px-4 py-12 space-y-8">
+        {/* Header */}
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight">Colophony</h1>
+          <p className="text-muted-foreground text-lg">Instance Identity</p>
+        </div>
+
+        {/* Loading */}
+        {state.status === "loading" && <LoadingSkeletons />}
+
+        {/* Federation disabled */}
+        {state.status === "federation_disabled" && (
+          <>
+            <Alert>
+              <AlertTitle>Federation Not Enabled</AlertTitle>
+              <AlertDescription>
+                Federation is not enabled on this instance. The instance
+                operator has not configured cross-instance communication.
+              </AlertDescription>
+            </Alert>
+            <GovernanceSection />
+          </>
+        )}
+
+        {/* Fetch failed */}
+        {state.status === "fetch_failed" && (
+          <Alert variant="destructive">
+            <AlertTitle>Unable to Load</AlertTitle>
+            <AlertDescription>
+              Unable to load instance metadata. The API server may be
+              unavailable.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* Success */}
+        {state.status === "success" && (
+          <>
+            <InstanceInfoCard data={state.data} />
+            <CapabilitiesCard capabilities={state.data.capabilities} />
+            <PublicationsCard publications={state.data.publications} />
+            <TrustedPeersCard
+              peers={state.data.trustedPeers}
+              mode={state.data.mode}
+            />
+            <GovernanceSection />
+            <TechnicalEndpointsCard
+              apiUrl={apiUrl}
+              domain={state.data.domain}
+            />
+          </>
+        )}
+
+        {/* Footer */}
+        <footer className="text-center text-sm text-muted-foreground pt-4 border-t">
+          &copy; {new Date().getFullYear()} Colophony. Open-source
+          infrastructure for literary magazines.
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function LoadingSkeletons() {
+  return (
+    <div className="space-y-6" data-testid="loading-skeletons">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Card key={i}>
+          <CardHeader>
+            <Skeleton className="h-6 w-48" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function InstanceInfoCard({ data }: { data: InstanceMetadata }) {
+  const modeInfo = MODE_LABELS[data.mode] ?? {
+    label: data.mode,
+    description: "",
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Instance Information</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap gap-2 items-center">
+          <Badge variant="secondary" data-testid="version-badge">
+            v{data.version}
+          </Badge>
+          <Badge variant="outline">{data.software}</Badge>
+        </div>
+        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+          <div>
+            <dt className="font-medium text-muted-foreground">Domain</dt>
+            <dd data-testid="instance-domain">{data.domain}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-muted-foreground">
+              Federation Mode
+            </dt>
+            <dd>
+              <span data-testid="mode-label">{modeInfo.label}</span>
+              <p className="text-muted-foreground text-xs mt-1">
+                {modeInfo.description}
+              </p>
+            </dd>
+          </div>
+          {data.contactEmail && (
+            <div>
+              <dt className="font-medium text-muted-foreground">Contact</dt>
+              <dd>
+                <a
+                  href={`mailto:${data.contactEmail}`}
+                  className="text-primary underline"
+                >
+                  {data.contactEmail}
+                </a>
+              </dd>
+            </div>
+          )}
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}
+
+function CapabilitiesCard({ capabilities }: { capabilities: string[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Federation Capabilities</CardTitle>
+        <CardDescription>
+          Services this instance provides to the federation network
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {capabilities.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No capabilities advertised.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {capabilities.map((cap) => (
+              <li key={cap} className="flex items-start gap-2 text-sm">
+                <Badge variant="outline" className="shrink-0 mt-0.5">
+                  {cap}
+                </Badge>
+                <span className="text-muted-foreground">
+                  {CAPABILITY_DESCRIPTIONS[cap] ?? "Custom capability"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function PublicationsCard({
+  publications,
+}: {
+  publications: FederationPublication[];
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Publications</CardTitle>
+        <CardDescription>
+          Literary magazines hosted on this instance
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {publications.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No publications listed.
+          </p>
+        ) : (
+          <ul className="space-y-1">
+            {publications.map((pub) => (
+              <li key={pub.id} className="text-sm">
+                <span className="font-medium">{pub.name}</span>
+                <span className="text-muted-foreground ml-2">
+                  ({pub.organizationSlug}/{pub.slug})
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TrustedPeersCard({ peers, mode }: { peers?: string[]; mode: string }) {
+  const peerList = peers ?? [];
+  const emptyMessage =
+    mode === "allowlist"
+      ? "No trusted peers configured yet."
+      : mode === "managed_hub"
+        ? "Peers are managed through the federation hub."
+        : "No peers have established trust with this instance yet.";
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Trusted Peers</CardTitle>
+        <CardDescription>
+          Instances this server has established federation trust with
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {peerList.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+        ) : (
+          <ul className="space-y-1">
+            {peerList.map((domain) => (
+              <li key={domain} className="text-sm font-mono">
+                {domain}
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function GovernanceSection() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Governance</CardTitle>
+        <CardDescription>
+          How this project is developed and maintained
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <dl className="space-y-3">
+          <div>
+            <dt className="font-medium text-muted-foreground">License</dt>
+            <dd>
+              <a
+                href={`${GITHUB_REPO}/LICENSE`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary underline"
+              >
+                AGPL-3.0-or-later
+              </a>
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-muted-foreground">
+              Governance Model
+            </dt>
+            <dd>Solo-maintainer with open contribution</dd>
+          </div>
+        </dl>
+        <div className="flex flex-wrap gap-3 pt-2">
+          <a
+            href={`${GITHUB_REPO}/CONTRIBUTING.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline"
+          >
+            Contributing Guide
+          </a>
+          <a
+            href={`${GITHUB_REPO}/CODE_OF_CONDUCT.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline"
+          >
+            Code of Conduct
+          </a>
+          <a
+            href={`${GITHUB_REPO}/SECURITY.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline"
+          >
+            Security Policy
+          </a>
+          <a
+            href={`${GITHUB_REPO}/docs/governance.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline"
+          >
+            Governance
+          </a>
+          <a
+            href={`${GITHUB_REPO}/docs/licensing.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline"
+          >
+            Licensing
+          </a>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TechnicalEndpointsCard({
+  apiUrl,
+  domain,
+}: {
+  apiUrl: string;
+  domain: string;
+}) {
+  const baseUrl =
+    domain === "localhost" || domain.startsWith("localhost:")
+      ? apiUrl
+      : `https://${domain}`;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Technical Endpoints</CardTitle>
+        <CardDescription>Machine-readable federation endpoints</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2 text-sm">
+          <li>
+            <a
+              href={`${baseUrl}/.well-known/colophony`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline font-mono"
+            >
+              /.well-known/colophony
+            </a>
+            <span className="text-muted-foreground ml-2">
+              Instance metadata (JSON)
+            </span>
+          </li>
+          <li>
+            <a
+              href={`${baseUrl}/.well-known/did.json`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline font-mono"
+            >
+              /.well-known/did.json
+            </a>
+            <span className="text-muted-foreground ml-2">
+              DID Document (W3C)
+            </span>
+          </li>
+          <li>
+            <a
+              href={`${baseUrl}/v1/docs`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline font-mono"
+            >
+              /v1/docs
+            </a>
+            <span className="text-muted-foreground ml-2">
+              OpenAPI documentation
+            </span>
+          </li>
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -390,7 +390,7 @@
 
 ## Track 9 — Governance & Community Readiness (Pre-Launch)
 
-> **Status:** Not started. Non-code deliverables required for community publisher evaluation and open-source credibility.
+> **Status:** Complete. All governance and community readiness items done.
 
 - [x] [P0] AGPL license boundary documentation — clearly document what is AGPL (Zitadel), what license Colophony uses, obligations for self-hosters, and how the boundary works — (CLAUDE.md security checklist + persona gap analysis 2026-02-27; done 2026-03-02 `docs/licensing.md`)
 - [x] [P0] Choose and document Colophony's own license — AGPL-3.0-or-later for core, MIT for SDKs/plugin tooling — (persona gap analysis 2026-02-27; done 2026-03-02 `LICENSE` + `docs/licensing.md`)
@@ -399,7 +399,7 @@
 - [x] [P1] README.md rewrite — project description in brand voice, architecture overview, quick start, screenshots, link to docs — (persona gap analysis 2026-02-27; done 2026-03-02)
 - [x] [P2] Governance model documentation — who makes decisions, how contributions are evaluated, roadmap transparency — (persona gap analysis 2026-02-27; done 2026-03-02)
 - [x] [P2] Fix deployment docs NestJS reference — deployment guide references NestJS but the system is Fastify — (persona gap analysis 2026-02-27; done 2026-03-02 docs audit)
-- [ ] [P3] Public instance identity page — human-readable page showing federation status, trust relationships, and governance commitments (the `.well-known/colophony` endpoint is machine-only) — (persona gap analysis 2026-02-27)
+- [x] [P3] Public instance identity page — human-readable page showing federation status, trust relationships, and governance commitments (the `.well-known/colophony` endpoint is machine-only) — (persona gap analysis 2026-02-27; done 2026-03-02)
 
 ---
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,26 @@ Newest entries first.
 
 ---
 
+## 2026-03-02 — Track 9 P3: Public Instance Identity Page
+
+### Done
+
+- **`packages/types/src/federation.ts`**: Extended `federationMetadataSchema` with optional `trustedPeers: z.array(z.string())` field for backward-compatible peer discovery
+- **`apps/api/src/services/federation.service.ts`**: Added `selectDistinct` query in `getInstanceMetadata()` for active peer domains from non-opted-out orgs, with `.limit(1000)` guard
+- **`apps/web/src/app/identity/page.tsx`**: New server component at `/identity` with SEO metadata
+- **`apps/web/src/components/identity/instance-identity.tsx`**: Client component (~330 lines) with 7 sections — instance info, federation capabilities, publications, trusted peers, governance (AGPL + GitHub doc links), technical endpoints, footer
+- **`apps/web/src/app/page.tsx`**: Added "Instance Identity" link to landing page footer
+- **Tests**: 2 type schema tests, 2 federation service tests, 1 discovery route test, 6 frontend component tests — all passing
+- **Verification**: `pnpm type-check` 14/14, backend 48 tests, frontend identity 6 tests, types 9 tests — all green
+
+### Decisions
+
+- Local interfaces in frontend component (not shared `@colophony/types`) — per project convention for display-only components
+- `trustedPeers` optional in schema — backward compatible with older remote instances that don't expose this field
+- Hardcoded GitHub repo URL for governance links — no env var needed, repo is public
+
+---
+
 ## 2026-03-02 — Track 9: Governance Model Documentation
 
 ### Done

--- a/packages/types/src/federation.spec.ts
+++ b/packages/types/src/federation.spec.ts
@@ -61,6 +61,19 @@ describe("federationMetadataSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("accepts metadata with trustedPeers", () => {
+    const result = federationMetadataSchema.safeParse({
+      ...validMetadata,
+      trustedPeers: ["peer.example"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts metadata without trustedPeers", () => {
+    const result = federationMetadataSchema.safeParse(validMetadata);
+    expect(result.success).toBe(true);
+  });
+
   it("rejects empty version", () => {
     const result = federationMetadataSchema.safeParse({
       ...validMetadata,

--- a/packages/types/src/federation.ts
+++ b/packages/types/src/federation.ts
@@ -28,6 +28,7 @@ export const federationMetadataSchema = z.object({
   mode: z.enum(["allowlist", "open", "managed_hub"]),
   contactEmail: z.string().nullable(),
   publications: z.array(federationPublicationSchema),
+  trustedPeers: z.array(z.string()).optional(),
 });
 
 export type FederationMetadata = z.infer<typeof federationMetadataSchema>;


### PR DESCRIPTION
## Summary

- Add `/identity` page showing human-readable federation metadata, trust relationships, and governance commitments
- Extend `.well-known/colophony` response with `trustedPeers: string[]` listing active peer domains from non-opted-out orgs
- Add "Instance Identity" link to landing page footer
- **Completes Track 9 and all pre-launch development tracks**

## Changes

### Backend
- `packages/types/src/federation.ts` — Add optional `trustedPeers` to `federationMetadataSchema`
- `apps/api/src/services/federation.service.ts` — `selectDistinct` query for active peer domains in `getInstanceMetadata()` with `.limit(1000)` guard

### Frontend
- `apps/web/src/app/identity/page.tsx` — New server component page at `/identity`
- `apps/web/src/components/identity/instance-identity.tsx` — Client component with 7 sections: instance info, capabilities, publications, trusted peers, governance (AGPL + GitHub doc links), technical endpoints, footer
- `apps/web/src/app/page.tsx` — Added Instance Identity link to footer

### Tests
- 2 type schema tests (`trustedPeers` optionality)
- 2 federation service tests (peers in metadata, empty peers)
- 1 discovery route test (peers in response)
- 6 frontend component tests (loading, success, disabled, error, empty states, missing field)

## Test plan

- [x] `pnpm --filter @colophony/api test` — federation service + discovery route tests pass (48 tests)
- [x] `pnpm --filter @colophony/web test` — identity component tests pass (6 tests)
- [x] `pnpm --filter @colophony/types test` — federation schema tests pass (9 tests)
- [x] `pnpm type-check` — 14/14 tasks successful
- [ ] Manual: visit `http://localhost:3000/identity` — page renders with federation data or disabled state
- [ ] Manual: visit landing page, confirm "Instance Identity" link in footer