### PR TITLE
test(web): Writer Workspace E2E test suite (21 tests)

### DIFF
--- a/.github/scripts/detect-changes.sh
+++ b/.github/scripts/detect-changes.sh
@@ -6,7 +6,7 @@
 #     GITHUB_EVENT_NAME=pull_request GITHUB_OUTPUT=/dev/stdout bash .github/scripts/detect-changes.sh
 #
 # Outputs boolean flags to $GITHUB_OUTPUT:
-#   run_submissions, run_embed, run_slate, run_uploads, run_oidc
+#   run_submissions, run_embed, run_slate, run_workspace, run_uploads, run_oidc
 #
 # Behavior:
 #   - push events → all suites run (main branch always runs everything)
@@ -20,6 +20,7 @@ set -euo pipefail
 run_submissions=false
 run_embed=false
 run_slate=false
+run_workspace=false
 run_uploads=false
 run_oidc=false
 run_all=false
@@ -93,6 +94,12 @@ uploads_prefixes=(
   "apps/web/e2e/uploads/"
   "apps/web/src/components/submissions/file-upload"
   "apps/web/src/components/manuscripts/manuscript-version-files"
+)
+
+workspace_prefixes=(
+  "apps/web/e2e/workspace/"
+  "apps/web/src/components/workspace/"
+  "apps/web/src/app/(dashboard)/workspace/"
 )
 
 oidc_prefixes=(
@@ -171,6 +178,10 @@ if [[ "$run_all" == "false" ]]; then
       run_slate=true
       matched=true
     fi
+    if matches_any_prefix "$file" "${workspace_prefixes[@]}"; then
+      run_workspace=true
+      matched=true
+    fi
     if matches_any_prefix "$file" "${uploads_prefixes[@]}"; then
       run_uploads=true
       matched=true
@@ -206,6 +217,7 @@ if [[ "$run_all" == "true" ]]; then
   run_submissions=true
   run_embed=true
   run_slate=true
+  run_workspace=true
   run_uploads=true
   run_oidc=true
 fi
@@ -214,6 +226,7 @@ fi
 echo "run_submissions=$run_submissions"
 echo "run_embed=$run_embed"
 echo "run_slate=$run_slate"
+echo "run_workspace=$run_workspace"
 echo "run_uploads=$run_uploads"
 echo "run_oidc=$run_oidc"
 
@@ -223,6 +236,7 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     echo "run_submissions=$run_submissions"
     echo "run_embed=$run_embed"
     echo "run_slate=$run_slate"
+    echo "run_workspace=$run_workspace"
     echo "run_uploads=$run_uploads"
     echo "run_oidc=$run_oidc"
   } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       run_submissions: ${{ steps.suites.outputs.run_submissions }}
       run_embed: ${{ steps.suites.outputs.run_embed }}
       run_slate: ${{ steps.suites.outputs.run_slate }}
+      run_workspace: ${{ steps.suites.outputs.run_workspace }}
       run_uploads: ${{ steps.suites.outputs.run_uploads }}
       run_oidc: ${{ steps.suites.outputs.run_oidc }}
     steps:
@@ -496,6 +497,91 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: playwright-slate-report
+          path: apps/web/playwright-report/
+          retention-days: 30
+
+  # ──────────────────────────────────────────────────
+  # Playwright E2E tests (~5 min): workspace project
+  # Requires PostgreSQL + Redis
+  # ──────────────────────────────────────────────────
+  playwright-workspace:
+    name: Playwright Workspace E2E
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.run_workspace == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: colophony
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: colophony
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U colophony"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Build workspace dependencies
+        run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/auth-client --filter=@colophony/types --filter=@colophony/api-contracts --filter=@colophony/plugin-sdk
+      - name: Create app_user role
+        run: |
+          PGPASSWORD=password psql -h localhost -p 5432 -U colophony -d colophony -c "
+            DO \$\$
+            BEGIN
+              IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'app_user') THEN
+                CREATE ROLE app_user WITH LOGIN PASSWORD 'app_password' NOSUPERUSER NOBYPASSRLS;
+              END IF;
+            END
+            \$\$;
+            GRANT CONNECT ON DATABASE colophony TO app_user;
+            GRANT USAGE ON SCHEMA public TO app_user;
+            GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_user;
+            GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_user;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO app_user;
+          "
+      - name: Run Drizzle migrations
+        run: pnpm db:migrate
+        env:
+          DATABASE_URL: postgresql://colophony:password@localhost:5432/colophony
+      - name: Seed test data
+        run: |
+          echo 'DATABASE_URL="postgresql://colophony:password@localhost:5432/colophony"' > packages/db/.env
+          pnpm db:seed
+      - name: Install Playwright browsers
+        run: pnpm --filter @colophony/web exec playwright install --with-deps chromium
+      - name: Run Playwright Workspace E2E tests
+        run: pnpm --filter @colophony/web test:e2e:workspace
+        env:
+          DATABASE_URL: postgresql://colophony:password@localhost:5432/colophony
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-workspace-report
           path: apps/web/playwright-report/
           retention-days: 30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,17 +221,18 @@ All other version pins are in their respective per-directory CLAUDE.md files.
 
 ### CI Pipeline (GitHub Actions)
 
-| Job                    | Checks                                             |
-| ---------------------- | -------------------------------------------------- |
-| **quality**            | `format:check`, `lint`, `type-check`, `pnpm audit` |
-| **unit-tests**         | `pnpm test`                                        |
-| **rls-tests**          | RLS tenant isolation integration tests             |
-| **playwright-tests**   | Playwright E2E submissions project (20 tests)      |
-| **playwright-uploads** | Playwright E2E uploads project (6 tests)           |
-| **playwright-oidc**    | Playwright E2E OIDC project (6 tests)              |
-| **playwright-embed**   | Playwright E2E embed project (10 tests)            |
-| **playwright-slate**   | Playwright E2E Slate pipeline project (30 tests)   |
-| **build**              | `pnpm build` (API + Web production build)          |
+| Job                      | Checks                                             |
+| ------------------------ | -------------------------------------------------- |
+| **quality**              | `format:check`, `lint`, `type-check`, `pnpm audit` |
+| **unit-tests**           | `pnpm test`                                        |
+| **rls-tests**            | RLS tenant isolation integration tests             |
+| **playwright-tests**     | Playwright E2E submissions project (20 tests)      |
+| **playwright-uploads**   | Playwright E2E uploads project (6 tests)           |
+| **playwright-oidc**      | Playwright E2E OIDC project (6 tests)              |
+| **playwright-embed**     | Playwright E2E embed project (10 tests)            |
+| **playwright-slate**     | Playwright E2E Slate pipeline project (30 tests)   |
+| **playwright-workspace** | Playwright E2E Writer Workspace project (21 tests) |
+| **build**                | `pnpm build` (API + Web production build)          |
 
 **Path filtering:** Playwright suites run selectively on PRs based on changed files (`.github/scripts/detect-changes.sh`). Shared paths (packages, API, shared hooks/lib/ui) trigger all suites. Suite-specific paths (e.g., `apps/web/e2e/slate/`, `apps/web/src/components/slate/`) trigger only that suite. Unknown paths fail-open (all suites run). Push to `main` always runs everything. Fast jobs (quality, unit-tests, rls-tests, build) are unaffected — they always run on non-docs PRs.
 

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -42,6 +42,7 @@ function getRequestedProjects(): Set<string> {
     projects.add("oidc");
     projects.add("embed");
     projects.add("slate");
+    projects.add("workspace");
   }
 
   return projects;

--- a/apps/web/e2e/helpers/workspace-db.ts
+++ b/apps/web/e2e/helpers/workspace-db.ts
@@ -1,0 +1,115 @@
+/**
+ * Workspace-specific database helpers for E2E test data setup/teardown.
+ *
+ * Uses the admin pool from ./db (bypasses RLS) to create and clean up
+ * Writer Workspace entities: external submissions, correspondence.
+ */
+
+import { eq } from "drizzle-orm";
+import { externalSubmissions, correspondence } from "@colophony/db";
+import { getDb } from "./db";
+
+// ── External Submissions ─────────────────────────────────────────
+
+export async function createExternalSubmission(data: {
+  userId: string;
+  journalName: string;
+  status?:
+    | "draft"
+    | "sent"
+    | "in_review"
+    | "hold"
+    | "accepted"
+    | "rejected"
+    | "withdrawn"
+    | "no_response"
+    | "revise";
+  manuscriptId?: string;
+  sentAt?: Date;
+  respondedAt?: Date;
+  method?: string;
+  notes?: string;
+  importedFrom?: string;
+}): Promise<{ id: string; journalName: string; status: string }> {
+  const db = getDb();
+  const [row] = await db
+    .insert(externalSubmissions)
+    .values({
+      userId: data.userId,
+      journalName: data.journalName,
+      status: (data.status as "sent") ?? "sent",
+      manuscriptId: data.manuscriptId ?? null,
+      sentAt: data.sentAt ?? null,
+      respondedAt: data.respondedAt ?? null,
+      method: data.method ?? null,
+      notes: data.notes ?? null,
+      importedFrom: data.importedFrom ?? null,
+    })
+    .returning({
+      id: externalSubmissions.id,
+      journalName: externalSubmissions.journalName,
+      status: externalSubmissions.status,
+    });
+  return row;
+}
+
+export async function deleteExternalSubmission(id: string): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(externalSubmissions)
+    .where(eq(externalSubmissions.id, id))
+    .catch(() => {});
+}
+
+// ── Correspondence ───────────────────────────────────────────────
+
+export async function createCorrespondence(data: {
+  userId: string;
+  externalSubmissionId: string;
+  direction: "inbound" | "outbound";
+  channel?: "email" | "portal" | "in_app" | "other";
+  sentAt: Date;
+  subject?: string;
+  body: string;
+  senderName?: string;
+  senderEmail?: string;
+  source?: "manual" | "colophony";
+}): Promise<{ id: string }> {
+  const db = getDb();
+  const [row] = await db
+    .insert(correspondence)
+    .values({
+      userId: data.userId,
+      externalSubmissionId: data.externalSubmissionId,
+      direction: data.direction,
+      channel: (data.channel as "email") ?? "email",
+      sentAt: data.sentAt,
+      subject: data.subject ?? null,
+      body: data.body,
+      senderName: data.senderName ?? null,
+      senderEmail: data.senderEmail ?? null,
+      source: data.source ?? "manual",
+    })
+    .returning({ id: correspondence.id });
+  return row;
+}
+
+export async function deleteCorrespondence(id: string): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(correspondence)
+    .where(eq(correspondence.id, id))
+    .catch(() => {});
+}
+
+// ── Bulk Cleanup (reverse dependency order) ──────────────────────
+
+export async function cleanupWorkspaceData(ids: {
+  correspondence?: string[];
+  externalSubmissions?: string[];
+}): Promise<void> {
+  // Delete correspondence first (depends on external submissions)
+  for (const id of ids.correspondence ?? []) await deleteCorrespondence(id);
+  for (const id of ids.externalSubmissions ?? [])
+    await deleteExternalSubmission(id);
+}

--- a/apps/web/e2e/helpers/workspace-fixtures.ts
+++ b/apps/web/e2e/helpers/workspace-fixtures.ts
@@ -1,0 +1,160 @@
+/**
+ * Workspace-specific Playwright test fixtures.
+ *
+ * Uses the WRITER user (writer@example.com) — workspace features are
+ * user-scoped (not org-admin-scoped like Slate).
+ *
+ * Provides `workspaceData` fixture with pre-created external submission
+ * and correspondence for test use, with automatic cleanup in teardown.
+ */
+
+import { test as base, expect, type Page, devices } from "@playwright/test";
+import { buildStorageState, setupPageAuth } from "./auth";
+import { getOrgBySlug, getUserByEmail, createApiKey, deleteApiKey } from "./db";
+import {
+  createExternalSubmission,
+  createCorrespondence,
+  cleanupWorkspaceData,
+} from "./workspace-db";
+
+/** Writer user profile (READER role in quarterly-review org) */
+const WRITER_USER_PROFILE = {
+  sub: "seed-zitadel-writer-001",
+  email: "writer@example.com",
+  name: "Test Writer",
+};
+
+/** All scopes needed for Workspace E2E tests */
+const WORKSPACE_E2E_SCOPES = [
+  "external-submissions:read",
+  "external-submissions:write",
+  "correspondence:read",
+  "correspondence:write",
+  "csr:read",
+  "csr:write",
+  "manuscripts:read",
+  "journal-directory:read",
+  "users:read",
+  "organizations:read",
+];
+
+interface SeedOrg {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+interface SeedUser {
+  id: string;
+  email: string;
+}
+
+interface TestApiKey {
+  id: string;
+  plainKey: string;
+}
+
+interface WorkspaceData {
+  externalSubmission: { id: string; journalName: string; status: string };
+  correspondence: { id: string };
+}
+
+export const test = base.extend<{
+  seedOrg: SeedOrg;
+  seedWriter: SeedUser;
+  testApiKey: TestApiKey;
+  authedPage: Page;
+  workspaceData: WorkspaceData;
+}>({
+  seedOrg: async ({}, use) => {
+    const org = await getOrgBySlug("quarterly-review");
+    if (!org) {
+      throw new Error(
+        'Seed org "quarterly-review" not found. Run `pnpm db:seed` first.',
+      );
+    }
+    await use(org);
+  },
+
+  seedWriter: async ({}, use) => {
+    const user = await getUserByEmail("writer@example.com");
+    if (!user) {
+      throw new Error(
+        'Seed writer "writer@example.com" not found. Run `pnpm db:seed` first.',
+      );
+    }
+    await use(user);
+  },
+
+  testApiKey: async ({ seedOrg, seedWriter }, use) => {
+    const key = await createApiKey({
+      orgId: seedOrg.id,
+      userId: seedWriter.id,
+      scopes: WORKSPACE_E2E_SCOPES,
+      name: `e2e-workspace-${Date.now()}`,
+    });
+
+    await use(key);
+
+    await deleteApiKey(key.id);
+  },
+
+  authedPage: async ({ browser, seedOrg, testApiKey, baseURL }, use) => {
+    const context = await browser.newContext({
+      ...devices["Desktop Chrome"],
+      baseURL: baseURL ?? undefined,
+      storageState: buildStorageState(seedOrg.id, WRITER_USER_PROFILE),
+    });
+
+    const page = await context.newPage();
+
+    await setupPageAuth(
+      page,
+      seedOrg.id,
+      testApiKey.plainKey,
+      WRITER_USER_PROFILE,
+    );
+
+    await use(page);
+
+    await context.close();
+  },
+
+  workspaceData: async ({ seedWriter }, use) => {
+    const suffix = Date.now().toString(36);
+
+    // Create external submission
+    const extSub = await createExternalSubmission({
+      userId: seedWriter.id,
+      journalName: `E2E Test Journal ${suffix}`,
+      status: "sent",
+      sentAt: new Date("2025-06-01"),
+      method: "Submittable",
+    });
+
+    // Create correspondence for that submission
+    const corr = await createCorrespondence({
+      userId: seedWriter.id,
+      externalSubmissionId: extSub.id,
+      direction: "inbound",
+      channel: "email",
+      sentAt: new Date("2025-06-15"),
+      subject: "Re: Your Submission",
+      body: "Thank you for your submission. We are currently reviewing it.",
+      senderName: "Editor Smith",
+    });
+
+    await use({
+      externalSubmission: extSub,
+      correspondence: corr,
+    });
+
+    // Cleanup in reverse dependency order
+    await cleanupWorkspaceData({
+      correspondence: [corr.id],
+      externalSubmissions: [extSub.id],
+    });
+  },
+});
+
+export { expect };

--- a/apps/web/e2e/workspace/workspace-analytics-correspondence.spec.ts
+++ b/apps/web/e2e/workspace/workspace-analytics-correspondence.spec.ts
@@ -6,23 +6,26 @@ test.describe("Writer Analytics (/workspace/analytics)", () => {
   }) => {
     await authedPage.goto("/workspace/analytics");
 
+    const main = authedPage.locator("main");
     await expect(
-      authedPage.getByRole("heading", { name: "Writer Analytics" }),
+      main.getByRole("heading", { name: "Writer Analytics" }),
     ).toBeVisible();
 
     // Overview stat labels
-    await expect(authedPage.getByText("Total Submissions")).toBeVisible({
+    await expect(main.getByText("Total Submissions")).toBeVisible({
       timeout: 10_000,
     });
-    await expect(authedPage.getByText("Acceptance Rate")).toBeVisible();
-    await expect(authedPage.getByText("Avg Response Time")).toBeVisible();
+    await expect(main.getByText("Acceptance Rate")).toBeVisible();
+    await expect(main.getByText("Avg Response Time")).toBeVisible();
   });
 
   test("shows date filter inputs", async ({ authedPage }) => {
     await authedPage.goto("/workspace/analytics");
 
-    await expect(authedPage.getByLabel("From")).toBeVisible();
-    await expect(authedPage.getByLabel("To")).toBeVisible();
+    const main = authedPage.locator("main");
+    await expect(main.getByLabel("From")).toBeVisible();
+    // Use the specific input ID to avoid matching other "To" text on page
+    await expect(main.locator("#end-date")).toBeVisible();
   });
 });
 
@@ -30,8 +33,9 @@ test.describe("Correspondence (/workspace/correspondence)", () => {
   test("displays Correspondence heading", async ({ authedPage }) => {
     await authedPage.goto("/workspace/correspondence");
 
+    const main = authedPage.locator("main");
     await expect(
-      authedPage.getByRole("heading", { name: "Correspondence" }),
+      main.getByRole("heading", { name: "Correspondence" }),
     ).toBeVisible();
   });
 
@@ -41,10 +45,11 @@ test.describe("Correspondence (/workspace/correspondence)", () => {
   }) => {
     await authedPage.goto("/workspace/correspondence");
 
-    await expect(authedPage.getByText("Re: Your Submission")).toBeVisible({
+    const main = authedPage.locator("main");
+    await expect(main.getByText("Re: Your Submission")).toBeVisible({
       timeout: 10_000,
     });
-    await expect(authedPage.getByText("Editor Smith")).toBeVisible();
+    await expect(main.getByText("Editor Smith")).toBeVisible();
   });
 
   test("log correspondence from detail page", async ({
@@ -56,17 +61,19 @@ test.describe("Correspondence (/workspace/correspondence)", () => {
       `/workspace/external/${workspaceData.externalSubmission.id}`,
     );
 
+    const main = authedPage.locator("main");
+
     // Wait for page to load
     await expect(
-      authedPage.getByRole("heading", {
+      main.getByRole("heading", {
         name: workspaceData.externalSubmission.journalName,
       }),
     ).toBeVisible({ timeout: 10_000 });
 
     // Click Log Message
-    await authedPage.getByRole("button", { name: /Log Message/ }).click();
+    await main.getByRole("button", { name: /Log Message/ }).click();
 
-    // Fill the correspondence form
+    // Fill the correspondence form — dialog is outside main, use page-level
     await expect(authedPage.getByText(/Log Correspondence/)).toBeVisible();
 
     // Fill required body/message field

--- a/apps/web/e2e/workspace/workspace-analytics-correspondence.spec.ts
+++ b/apps/web/e2e/workspace/workspace-analytics-correspondence.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "../helpers/workspace-fixtures";
+
+test.describe("Writer Analytics (/workspace/analytics)", () => {
+  test("displays Writer Analytics heading and overview cards", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto("/workspace/analytics");
+
+    await expect(
+      authedPage.getByRole("heading", { name: "Writer Analytics" }),
+    ).toBeVisible();
+
+    // Overview stat labels
+    await expect(authedPage.getByText("Total Submissions")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(authedPage.getByText("Acceptance Rate")).toBeVisible();
+    await expect(authedPage.getByText("Avg Response Time")).toBeVisible();
+  });
+
+  test("shows date filter inputs", async ({ authedPage }) => {
+    await authedPage.goto("/workspace/analytics");
+
+    await expect(authedPage.getByLabel("From")).toBeVisible();
+    await expect(authedPage.getByLabel("To")).toBeVisible();
+  });
+});
+
+test.describe("Correspondence (/workspace/correspondence)", () => {
+  test("displays Correspondence heading", async ({ authedPage }) => {
+    await authedPage.goto("/workspace/correspondence");
+
+    await expect(
+      authedPage.getByRole("heading", { name: "Correspondence" }),
+    ).toBeVisible();
+  });
+
+  test("shows seeded correspondence item", async ({
+    authedPage,
+    workspaceData: _workspaceData,
+  }) => {
+    await authedPage.goto("/workspace/correspondence");
+
+    await expect(authedPage.getByText("Re: Your Submission")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(authedPage.getByText("Editor Smith")).toBeVisible();
+  });
+
+  test("log correspondence from detail page", async ({
+    authedPage,
+    workspaceData,
+  }) => {
+    // Navigate to external submission detail
+    await authedPage.goto(
+      `/workspace/external/${workspaceData.externalSubmission.id}`,
+    );
+
+    // Wait for page to load
+    await expect(
+      authedPage.getByRole("heading", {
+        name: workspaceData.externalSubmission.journalName,
+      }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Click Log Message
+    await authedPage.getByRole("button", { name: /Log Message/ }).click();
+
+    // Fill the correspondence form
+    await expect(authedPage.getByText(/Log Correspondence/)).toBeVisible();
+
+    // Fill required body/message field
+    await authedPage
+      .getByPlaceholder(/Paste or type the message content/)
+      .fill("Test correspondence message from E2E");
+
+    // Submit
+    await authedPage
+      .getByRole("button", { name: "Log Message", exact: true })
+      .click();
+
+    // Wait for success toast
+    await expect(authedPage.getByText(/Correspondence logged/i)).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/apps/web/e2e/workspace/workspace-dashboard.spec.ts
+++ b/apps/web/e2e/workspace/workspace-dashboard.spec.ts
@@ -42,16 +42,10 @@ test.describe("Writer Workspace Dashboard (/workspace)", () => {
     // Scope to main content to avoid sidebar "Manuscripts" link
     const main = authedPage.locator("main");
 
-    // At least one stat card text should be visible
-    const statLabels = ["Manuscripts", "Pending", "Accepted", "Rejected"];
-    let found = false;
-    for (const label of statLabels) {
-      const count = await main.getByText(label, { exact: true }).count();
-      if (count > 0) {
-        found = true;
-        break;
-      }
-    }
-    expect(found).toBe(true);
+    // Stat card titles are rendered even while loading (skeleton for values).
+    // Wait for at least one stat card title to appear with a timeout.
+    await expect(
+      main.getByText("Manuscripts", { exact: true }).first(),
+    ).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/apps/web/e2e/workspace/workspace-dashboard.spec.ts
+++ b/apps/web/e2e/workspace/workspace-dashboard.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "../helpers/workspace-fixtures";
+
+test.describe("Writer Workspace Dashboard (/workspace)", () => {
+  test("displays Writer Workspace heading", async ({ authedPage }) => {
+    await authedPage.goto("/workspace");
+
+    await expect(
+      authedPage.getByRole("heading", { name: "Writer Workspace" }),
+    ).toBeVisible();
+  });
+
+  test("shows Track Submission link", async ({ authedPage }) => {
+    await authedPage.goto("/workspace");
+
+    const link = authedPage.getByRole("link", { name: /Track Submission/ });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", /\/workspace\/external\/new/);
+  });
+
+  test("renders quick action buttons", async ({ authedPage }) => {
+    await authedPage.goto("/workspace");
+
+    await expect(
+      authedPage.getByRole("link", { name: /View External Submissions/ }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("link", { name: /View Correspondence/ }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("link", { name: /View Portfolio/ }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("link", { name: /Analytics/ }),
+    ).toBeVisible();
+  });
+
+  test("renders stat cards", async ({ authedPage }) => {
+    await authedPage.goto("/workspace");
+
+    // At least one stat card text should be visible
+    const statLabels = ["Manuscripts", "Pending", "Accepted", "Rejected"];
+    let found = false;
+    for (const label of statLabels) {
+      const count = await authedPage.getByText(label, { exact: true }).count();
+      if (count > 0) {
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+  });
+});

--- a/apps/web/e2e/workspace/workspace-dashboard.spec.ts
+++ b/apps/web/e2e/workspace/workspace-dashboard.spec.ts
@@ -12,7 +12,9 @@ test.describe("Writer Workspace Dashboard (/workspace)", () => {
   test("shows Track Submission link", async ({ authedPage }) => {
     await authedPage.goto("/workspace");
 
-    const link = authedPage.getByRole("link", { name: /Track Submission/ });
+    // Scope to main content to avoid sidebar matches
+    const main = authedPage.locator("main");
+    const link = main.getByRole("link", { name: /Track Submission/ });
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute("href", /\/workspace\/external\/new/);
   });
@@ -20,28 +22,31 @@ test.describe("Writer Workspace Dashboard (/workspace)", () => {
   test("renders quick action buttons", async ({ authedPage }) => {
     await authedPage.goto("/workspace");
 
+    // Scope to main content to avoid sidebar link duplicates
+    const main = authedPage.locator("main");
     await expect(
-      authedPage.getByRole("link", { name: /View External Submissions/ }),
+      main.getByRole("link", { name: /View External Submissions/ }),
     ).toBeVisible();
     await expect(
-      authedPage.getByRole("link", { name: /View Correspondence/ }),
+      main.getByRole("link", { name: /View Correspondence/ }),
     ).toBeVisible();
     await expect(
-      authedPage.getByRole("link", { name: /View Portfolio/ }),
+      main.getByRole("link", { name: /View Portfolio/ }),
     ).toBeVisible();
-    await expect(
-      authedPage.getByRole("link", { name: /Analytics/ }),
-    ).toBeVisible();
+    await expect(main.getByRole("link", { name: /Analytics/ })).toBeVisible();
   });
 
   test("renders stat cards", async ({ authedPage }) => {
     await authedPage.goto("/workspace");
 
+    // Scope to main content to avoid sidebar "Manuscripts" link
+    const main = authedPage.locator("main");
+
     // At least one stat card text should be visible
     const statLabels = ["Manuscripts", "Pending", "Accepted", "Rejected"];
     let found = false;
     for (const label of statLabels) {
-      const count = await authedPage.getByText(label, { exact: true }).count();
+      const count = await main.getByText(label, { exact: true }).count();
       if (count > 0) {
         found = true;
         break;

--- a/apps/web/e2e/workspace/workspace-external.spec.ts
+++ b/apps/web/e2e/workspace/workspace-external.spec.ts
@@ -41,7 +41,8 @@ test.describe("External Submissions (/workspace/external)", () => {
 
       // JournalAutocomplete is a combobox (popover + search), not a plain input.
       // Click the trigger, type the name, then pick the "Use as journal name" option.
-      await main.getByRole("combobox").click();
+      // Target by placeholder text to avoid strict mode (multiple comboboxes on form).
+      await main.getByText("Select or type journal name...").click();
       await authedPage.getByPlaceholder("Search journals...").fill(journalName);
       // Wait for the "Use '<name>' as journal name" option and click it
       await authedPage

--- a/apps/web/e2e/workspace/workspace-external.spec.ts
+++ b/apps/web/e2e/workspace/workspace-external.spec.ts
@@ -39,8 +39,14 @@ test.describe("External Submissions (/workspace/external)", () => {
         main.getByRole("heading", { name: /Track External Submission/ }),
       ).toBeVisible();
 
-      // Fill journal name — use the form input, not the label
-      await main.getByLabel("Journal Name").fill(journalName);
+      // JournalAutocomplete is a combobox (popover + search), not a plain input.
+      // Click the trigger, type the name, then pick the "Use as journal name" option.
+      await main.getByRole("combobox").click();
+      await authedPage.getByPlaceholder("Search journals...").fill(journalName);
+      // Wait for the "Use '<name>' as journal name" option and click it
+      await authedPage
+        .getByText(new RegExp(`Use.*${suffix}.*as journal name`, "i"))
+        .click();
 
       // Submit
       await main.getByRole("button", { name: "Track Submission" }).click();

--- a/apps/web/e2e/workspace/workspace-external.spec.ts
+++ b/apps/web/e2e/workspace/workspace-external.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from "../helpers/workspace-fixtures";
+import { deleteExternalSubmission } from "../helpers/workspace-db";
+
+test.describe("External Submissions (/workspace/external)", () => {
+  test("shows heading and Track Submission button", async ({ authedPage }) => {
+    await authedPage.goto("/workspace/external");
+
+    await expect(
+      authedPage.getByRole("heading", { name: "External Submissions" }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("link", { name: /Track Submission/ }),
+    ).toBeVisible();
+  });
+
+  test("displays external submission in list", async ({
+    authedPage,
+    workspaceData,
+  }) => {
+    await authedPage.goto("/workspace/external");
+
+    await expect(
+      authedPage.getByText(workspaceData.externalSubmission.journalName),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("creates new external submission", async ({ authedPage }) => {
+    const suffix = Date.now().toString(36);
+    const journalName = `E2E Created Journal ${suffix}`;
+    let createdId: string | undefined;
+
+    try {
+      await authedPage.goto("/workspace/external/new");
+
+      await expect(
+        authedPage.getByRole("heading", {
+          name: /Track External Submission/,
+        }),
+      ).toBeVisible();
+
+      // Fill journal name
+      await authedPage.getByLabel("Journal Name").fill(journalName);
+
+      // Submit
+      await authedPage
+        .getByRole("button", { name: "Track Submission" })
+        .click();
+
+      // Should redirect to external submissions list
+      await expect(authedPage).toHaveURL(/\/workspace\/external/, {
+        timeout: 10_000,
+      });
+
+      // Extract created ID from the list for cleanup — navigate to find it
+      await expect(authedPage.getByText(journalName)).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // Click to get to detail page for the ID
+      await authedPage.getByText(journalName).click();
+      const url = authedPage.url();
+      const match = url.match(/\/workspace\/external\/([0-9a-f-]+)/);
+      createdId = match?.[1];
+    } finally {
+      if (createdId) {
+        await deleteExternalSubmission(createdId);
+      }
+    }
+  });
+
+  test("requires journal name", async ({ authedPage }) => {
+    await authedPage.goto("/workspace/external/new");
+
+    // Click submit without filling anything
+    await authedPage.getByRole("button", { name: "Track Submission" }).click();
+
+    // Should show validation error
+    await expect(authedPage.getByText(/journal name|required/i)).toBeVisible();
+  });
+
+  test("detail page shows info and action buttons", async ({
+    authedPage,
+    workspaceData,
+  }) => {
+    await authedPage.goto(
+      `/workspace/external/${workspaceData.externalSubmission.id}`,
+    );
+
+    // Heading shows journal name
+    await expect(
+      authedPage.getByRole("heading", {
+        name: workspaceData.externalSubmission.journalName,
+      }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Action buttons
+    await expect(
+      authedPage.getByRole("button", { name: /Edit/ }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("button", { name: /Delete/ }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("button", { name: /Log Message/ }),
+    ).toBeVisible();
+  });
+
+  test("deletes external submission", async ({ authedPage, workspaceData }) => {
+    await authedPage.goto(
+      `/workspace/external/${workspaceData.externalSubmission.id}`,
+    );
+
+    // Wait for page to load
+    await expect(
+      authedPage.getByRole("heading", {
+        name: workspaceData.externalSubmission.journalName,
+      }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Click Delete
+    await authedPage.getByRole("button", { name: /Delete/ }).click();
+
+    // Confirm in dialog
+    await expect(authedPage.getByText("Delete submission?")).toBeVisible();
+    await authedPage
+      .getByRole("button", { name: "Delete", exact: true })
+      .click();
+
+    // Should redirect to list
+    await expect(authedPage).toHaveURL(/\/workspace\/external$/, {
+      timeout: 10_000,
+    });
+
+    // Journal name should no longer be visible
+    await expect(
+      authedPage.getByText(workspaceData.externalSubmission.journalName),
+    ).not.toBeVisible();
+  });
+});

--- a/apps/web/e2e/workspace/workspace-external.spec.ts
+++ b/apps/web/e2e/workspace/workspace-external.spec.ts
@@ -5,11 +5,12 @@ test.describe("External Submissions (/workspace/external)", () => {
   test("shows heading and Track Submission button", async ({ authedPage }) => {
     await authedPage.goto("/workspace/external");
 
+    const main = authedPage.locator("main");
     await expect(
-      authedPage.getByRole("heading", { name: "External Submissions" }),
+      main.getByRole("heading", { name: "External Submissions" }),
     ).toBeVisible();
     await expect(
-      authedPage.getByRole("link", { name: /Track Submission/ }),
+      main.getByRole("link", { name: /Track Submission/ }),
     ).toBeVisible();
   });
 
@@ -19,8 +20,9 @@ test.describe("External Submissions (/workspace/external)", () => {
   }) => {
     await authedPage.goto("/workspace/external");
 
+    const main = authedPage.locator("main");
     await expect(
-      authedPage.getByText(workspaceData.externalSubmission.journalName),
+      main.getByText(workspaceData.externalSubmission.journalName),
     ).toBeVisible({ timeout: 10_000 });
   });
 
@@ -32,32 +34,31 @@ test.describe("External Submissions (/workspace/external)", () => {
     try {
       await authedPage.goto("/workspace/external/new");
 
+      const main = authedPage.locator("main");
       await expect(
-        authedPage.getByRole("heading", {
-          name: /Track External Submission/,
-        }),
+        main.getByRole("heading", { name: /Track External Submission/ }),
       ).toBeVisible();
 
-      // Fill journal name
-      await authedPage.getByLabel("Journal Name").fill(journalName);
+      // Fill journal name — use the form input, not the label
+      await main.getByLabel("Journal Name").fill(journalName);
 
       // Submit
-      await authedPage
-        .getByRole("button", { name: "Track Submission" })
-        .click();
+      await main.getByRole("button", { name: "Track Submission" }).click();
 
-      // Should redirect to external submissions list
+      // Should redirect to external submissions list or detail
       await expect(authedPage).toHaveURL(/\/workspace\/external/, {
         timeout: 10_000,
       });
 
-      // Extract created ID from the list for cleanup — navigate to find it
-      await expect(authedPage.getByText(journalName)).toBeVisible({
+      // Wait for the new entry to appear
+      await expect(
+        authedPage.locator("main").getByText(journalName),
+      ).toBeVisible({
         timeout: 10_000,
       });
 
       // Click to get to detail page for the ID
-      await authedPage.getByText(journalName).click();
+      await authedPage.locator("main").getByText(journalName).click();
       const url = authedPage.url();
       const match = url.match(/\/workspace\/external\/([0-9a-f-]+)/);
       createdId = match?.[1];
@@ -71,11 +72,16 @@ test.describe("External Submissions (/workspace/external)", () => {
   test("requires journal name", async ({ authedPage }) => {
     await authedPage.goto("/workspace/external/new");
 
-    // Click submit without filling anything
-    await authedPage.getByRole("button", { name: "Track Submission" }).click();
+    const main = authedPage.locator("main");
 
-    // Should show validation error
-    await expect(authedPage.getByText(/journal name|required/i)).toBeVisible();
+    // Click submit without filling anything
+    await main.getByRole("button", { name: "Track Submission" }).click();
+
+    // Should show validation error — use .first() since the error message
+    // text "Journal name is required" also partial-matches the "Journal Name" label
+    await expect(
+      main.getByText("Journal name is required").first(),
+    ).toBeVisible();
   });
 
   test("detail page shows info and action buttons", async ({
@@ -86,22 +92,20 @@ test.describe("External Submissions (/workspace/external)", () => {
       `/workspace/external/${workspaceData.externalSubmission.id}`,
     );
 
+    const main = authedPage.locator("main");
+
     // Heading shows journal name
     await expect(
-      authedPage.getByRole("heading", {
+      main.getByRole("heading", {
         name: workspaceData.externalSubmission.journalName,
       }),
     ).toBeVisible({ timeout: 10_000 });
 
     // Action buttons
+    await expect(main.getByRole("button", { name: /Edit/ })).toBeVisible();
+    await expect(main.getByRole("button", { name: /Delete/ })).toBeVisible();
     await expect(
-      authedPage.getByRole("button", { name: /Edit/ }),
-    ).toBeVisible();
-    await expect(
-      authedPage.getByRole("button", { name: /Delete/ }),
-    ).toBeVisible();
-    await expect(
-      authedPage.getByRole("button", { name: /Log Message/ }),
+      main.getByRole("button", { name: /Log Message/ }),
     ).toBeVisible();
   });
 
@@ -110,17 +114,19 @@ test.describe("External Submissions (/workspace/external)", () => {
       `/workspace/external/${workspaceData.externalSubmission.id}`,
     );
 
+    const main = authedPage.locator("main");
+
     // Wait for page to load
     await expect(
-      authedPage.getByRole("heading", {
+      main.getByRole("heading", {
         name: workspaceData.externalSubmission.journalName,
       }),
     ).toBeVisible({ timeout: 10_000 });
 
     // Click Delete
-    await authedPage.getByRole("button", { name: /Delete/ }).click();
+    await main.getByRole("button", { name: /Delete/ }).click();
 
-    // Confirm in dialog
+    // Confirm in dialog — dialog is outside main, use page-level
     await expect(authedPage.getByText("Delete submission?")).toBeVisible();
     await authedPage
       .getByRole("button", { name: "Delete", exact: true })
@@ -131,9 +137,11 @@ test.describe("External Submissions (/workspace/external)", () => {
       timeout: 10_000,
     });
 
-    // Journal name should no longer be visible
+    // Journal name should no longer be visible in main content
     await expect(
-      authedPage.getByText(workspaceData.externalSubmission.journalName),
+      authedPage
+        .locator("main")
+        .getByText(workspaceData.externalSubmission.journalName),
     ).not.toBeVisible();
   });
 });

--- a/apps/web/e2e/workspace/workspace-import.spec.ts
+++ b/apps/web/e2e/workspace/workspace-import.spec.ts
@@ -9,29 +9,32 @@ test.describe("Import Submissions (/workspace/import)", () => {
   test("displays heading and stepper steps", async ({ authedPage }) => {
     await authedPage.goto("/workspace/import");
 
+    const main = authedPage.locator("main");
     await expect(
-      authedPage.getByRole("heading", { name: "Import Submissions" }),
+      main.getByRole("heading", { name: "Import Submissions" }),
     ).toBeVisible();
 
-    // Stepper step labels
-    await expect(authedPage.getByText("Select File")).toBeVisible();
-    await expect(authedPage.getByText("Map Columns")).toBeVisible();
-    await expect(authedPage.getByText("Map Statuses")).toBeVisible();
-    await expect(authedPage.getByText("Review")).toBeVisible();
+    // Stepper step labels — scope to main and use exact match for "Review"
+    await expect(main.getByText("Select File")).toBeVisible();
+    await expect(main.getByText("Map Columns")).toBeVisible();
+    await expect(main.getByText("Map Statuses")).toBeVisible();
+    await expect(main.getByText("Review", { exact: true })).toBeVisible();
   });
 
   test("rejects empty CSV", async ({ authedPage }) => {
     await authedPage.goto("/workspace/import");
 
+    const main = authedPage.locator("main");
+
     // Upload empty CSV
-    await authedPage.locator('input[type="file"]').setInputFiles({
+    await main.locator('input[type="file"]').setInputFiles({
       name: "test.csv",
       mimeType: "text/csv",
       buffer: Buffer.from(EMPTY_CSV),
     });
 
     // Should show error about no data rows
-    await expect(authedPage.getByText(/no data|empty|no rows/i)).toBeVisible({
+    await expect(main.getByText(/no data|empty|no rows/i)).toBeVisible({
       timeout: 5_000,
     });
   });
@@ -42,57 +45,60 @@ test.describe("Import Submissions (/workspace/import)", () => {
     try {
       await authedPage.goto("/workspace/import");
 
+      const main = authedPage.locator("main");
+
       // Upload valid CSV
-      await authedPage.locator('input[type="file"]').setInputFiles({
+      await main.locator('input[type="file"]').setInputFiles({
         name: "test.csv",
         mimeType: "text/csv",
         buffer: Buffer.from(VALID_CSV),
       });
 
       // Wait for preview to show
-      await expect(authedPage.getByText(/preview/i)).toBeVisible({
+      await expect(main.getByText(/preview/i)).toBeVisible({
         timeout: 5_000,
       });
 
-      // Click Next to move to Map Columns
-      await authedPage.getByRole("button", { name: /Next/ }).click();
+      // Click Next to move to Map Columns — use first() for potential duplicates
+      await main.getByRole("button", { name: /Next/ }).first().click();
 
       // Wait for Map Columns step
-      await expect(authedPage.getByText("Column Mapping")).toBeVisible({
+      await expect(main.getByText("Column Mapping")).toBeVisible({
         timeout: 5_000,
       });
 
       // Click Next to Map Statuses
-      await authedPage.getByRole("button", { name: /Next/ }).click();
+      await main.getByRole("button", { name: /Next/ }).first().click();
 
       // Wait for Map Statuses step
-      await expect(authedPage.getByText("Status Mapping")).toBeVisible({
+      await expect(main.getByText("Status Mapping")).toBeVisible({
         timeout: 5_000,
       });
 
       // Click Next to Review
-      await authedPage.getByRole("button", { name: /Next/ }).click();
+      await main.getByRole("button", { name: /Next/ }).first().click();
 
-      // Wait for Review step
-      await expect(
-        authedPage.getByRole("button", { name: /Import/ }),
-      ).toBeVisible({ timeout: 5_000 });
+      // Wait for Review step — look for the Import button
+      await expect(main.getByRole("button", { name: /^Import$/ })).toBeVisible({
+        timeout: 5_000,
+      });
 
       // Click Import
-      await authedPage.getByRole("button", { name: /Import/ }).click();
+      await main.getByRole("button", { name: /^Import$/ }).click();
 
       // Wait for success
-      await expect(
-        authedPage.getByText(/success|imported|complete/i),
-      ).toBeVisible({ timeout: 10_000 });
+      await expect(main.getByText(/success|imported|complete/i)).toBeVisible({
+        timeout: 10_000,
+      });
 
       // Navigate to external submissions list to find created entries
       await authedPage.goto("/workspace/external");
       await authedPage.waitForTimeout(2_000);
 
       // Look for our imported entries and capture IDs for cleanup
+      const listMain = authedPage.locator("main");
       for (const name of ["The Paris Review", "Ploughshares"]) {
-        const link = authedPage.getByText(name).first();
+        const link = listMain.getByText(name).first();
         if ((await link.count()) > 0) {
           await link.click();
           const url = authedPage.url();

--- a/apps/web/e2e/workspace/workspace-import.spec.ts
+++ b/apps/web/e2e/workspace/workspace-import.spec.ts
@@ -86,13 +86,14 @@ test.describe("Import Submissions (/workspace/import)", () => {
       await expect(nextBtn3).toBeEnabled({ timeout: 5_000 });
       await nextBtn3.click();
 
-      // Wait for Review step — look for the Import button
-      await expect(main.getByRole("button", { name: /^Import$/ })).toBeVisible({
-        timeout: 5_000,
+      // Wait for Review step — Import button text includes row count: "Import 2 Submissions"
+      const importBtn = main.getByRole("button", {
+        name: /Import \d+ Submission/,
       });
+      await expect(importBtn).toBeVisible({ timeout: 5_000 });
 
       // Click Import
-      await main.getByRole("button", { name: /^Import$/ }).click();
+      await importBtn.click();
 
       // Wait for success
       await expect(main.getByText(/success|imported|complete/i)).toBeVisible({

--- a/apps/web/e2e/workspace/workspace-import.spec.ts
+++ b/apps/web/e2e/workspace/workspace-import.spec.ts
@@ -1,9 +1,11 @@
 import { test, expect } from "../helpers/workspace-fixtures";
 import { deleteExternalSubmission } from "../helpers/workspace-db";
 
+// Headers must match Submittable preset patterns: /publication|category/i → journalName,
+// /^status$/i → status, /date\s*submitted/i → sentAt
 const VALID_CSV =
-  "Title,Status,Date Submitted\nThe Paris Review,New,2025-01-15\nPloughshares,Accepted,2025-02-01\n";
-const EMPTY_CSV = "Title,Status,Date Submitted\n";
+  "Publication,Status,Date Submitted\nThe Paris Review,New,2025-01-15\nPloughshares,Accepted,2025-02-01\n";
+const EMPTY_CSV = "Publication,Status,Date Submitted\n";
 
 test.describe("Import Submissions (/workspace/import)", () => {
   test("displays heading and stepper steps", async ({ authedPage }) => {
@@ -59,16 +61,20 @@ test.describe("Import Submissions (/workspace/import)", () => {
         timeout: 5_000,
       });
 
-      // Click Next to move to Map Columns — use first() for potential duplicates
-      await main.getByRole("button", { name: /Next/ }).first().click();
+      // Click Next to move to Map Columns — wait for enabled first
+      const nextBtn = main.getByRole("button", { name: /Next/ }).first();
+      await expect(nextBtn).toBeEnabled({ timeout: 5_000 });
+      await nextBtn.click();
 
       // Wait for Map Columns step
       await expect(main.getByText("Column Mapping")).toBeVisible({
         timeout: 5_000,
       });
 
-      // Click Next to Map Statuses
-      await main.getByRole("button", { name: /Next/ }).first().click();
+      // Next is enabled only when journalName is mapped (auto-mapped via preset)
+      const nextBtn2 = main.getByRole("button", { name: /Next/ }).first();
+      await expect(nextBtn2).toBeEnabled({ timeout: 5_000 });
+      await nextBtn2.click();
 
       // Wait for Map Statuses step
       await expect(main.getByText("Status Mapping")).toBeVisible({
@@ -76,7 +82,9 @@ test.describe("Import Submissions (/workspace/import)", () => {
       });
 
       // Click Next to Review
-      await main.getByRole("button", { name: /Next/ }).first().click();
+      const nextBtn3 = main.getByRole("button", { name: /Next/ }).first();
+      await expect(nextBtn3).toBeEnabled({ timeout: 5_000 });
+      await nextBtn3.click();
 
       // Wait for Review step — look for the Import button
       await expect(main.getByRole("button", { name: /^Import$/ })).toBeVisible({

--- a/apps/web/e2e/workspace/workspace-import.spec.ts
+++ b/apps/web/e2e/workspace/workspace-import.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from "../helpers/workspace-fixtures";
+import { deleteExternalSubmission } from "../helpers/workspace-db";
+
+const VALID_CSV =
+  "Title,Status,Date Submitted\nThe Paris Review,New,2025-01-15\nPloughshares,Accepted,2025-02-01\n";
+const EMPTY_CSV = "Title,Status,Date Submitted\n";
+
+test.describe("Import Submissions (/workspace/import)", () => {
+  test("displays heading and stepper steps", async ({ authedPage }) => {
+    await authedPage.goto("/workspace/import");
+
+    await expect(
+      authedPage.getByRole("heading", { name: "Import Submissions" }),
+    ).toBeVisible();
+
+    // Stepper step labels
+    await expect(authedPage.getByText("Select File")).toBeVisible();
+    await expect(authedPage.getByText("Map Columns")).toBeVisible();
+    await expect(authedPage.getByText("Map Statuses")).toBeVisible();
+    await expect(authedPage.getByText("Review")).toBeVisible();
+  });
+
+  test("rejects empty CSV", async ({ authedPage }) => {
+    await authedPage.goto("/workspace/import");
+
+    // Upload empty CSV
+    await authedPage.locator('input[type="file"]').setInputFiles({
+      name: "test.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(EMPTY_CSV),
+    });
+
+    // Should show error about no data rows
+    await expect(authedPage.getByText(/no data|empty|no rows/i)).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("full wizard import with Submittable preset", async ({ authedPage }) => {
+    const createdIds: string[] = [];
+
+    try {
+      await authedPage.goto("/workspace/import");
+
+      // Upload valid CSV
+      await authedPage.locator('input[type="file"]').setInputFiles({
+        name: "test.csv",
+        mimeType: "text/csv",
+        buffer: Buffer.from(VALID_CSV),
+      });
+
+      // Wait for preview to show
+      await expect(authedPage.getByText(/preview/i)).toBeVisible({
+        timeout: 5_000,
+      });
+
+      // Click Next to move to Map Columns
+      await authedPage.getByRole("button", { name: /Next/ }).click();
+
+      // Wait for Map Columns step
+      await expect(authedPage.getByText("Column Mapping")).toBeVisible({
+        timeout: 5_000,
+      });
+
+      // Click Next to Map Statuses
+      await authedPage.getByRole("button", { name: /Next/ }).click();
+
+      // Wait for Map Statuses step
+      await expect(authedPage.getByText("Status Mapping")).toBeVisible({
+        timeout: 5_000,
+      });
+
+      // Click Next to Review
+      await authedPage.getByRole("button", { name: /Next/ }).click();
+
+      // Wait for Review step
+      await expect(
+        authedPage.getByRole("button", { name: /Import/ }),
+      ).toBeVisible({ timeout: 5_000 });
+
+      // Click Import
+      await authedPage.getByRole("button", { name: /Import/ }).click();
+
+      // Wait for success
+      await expect(
+        authedPage.getByText(/success|imported|complete/i),
+      ).toBeVisible({ timeout: 10_000 });
+
+      // Navigate to external submissions list to find created entries
+      await authedPage.goto("/workspace/external");
+      await authedPage.waitForTimeout(2_000);
+
+      // Look for our imported entries and capture IDs for cleanup
+      for (const name of ["The Paris Review", "Ploughshares"]) {
+        const link = authedPage.getByText(name).first();
+        if ((await link.count()) > 0) {
+          await link.click();
+          const url = authedPage.url();
+          const match = url.match(/\/workspace\/external\/([0-9a-f-]+)/);
+          if (match?.[1]) {
+            createdIds.push(match[1]);
+          }
+          await authedPage.goto("/workspace/external");
+          await authedPage.waitForTimeout(1_000);
+        }
+      }
+    } finally {
+      for (const id of createdIds) {
+        await deleteExternalSubmission(id);
+      }
+    }
+  });
+});

--- a/apps/web/e2e/workspace/workspace-import.spec.ts
+++ b/apps/web/e2e/workspace/workspace-import.spec.ts
@@ -95,8 +95,8 @@ test.describe("Import Submissions (/workspace/import)", () => {
       // Click Import
       await importBtn.click();
 
-      // Wait for success
-      await expect(main.getByText(/success|imported|complete/i)).toBeVisible({
+      // Wait for success — target the exact heading to avoid strict mode (2 elements match)
+      await expect(main.getByText("Import Complete")).toBeVisible({
         timeout: 10_000,
       });
 

--- a/apps/web/e2e/workspace/workspace-portfolio.spec.ts
+++ b/apps/web/e2e/workspace/workspace-portfolio.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "../helpers/workspace-fixtures";
+
+test.describe("Portfolio (/workspace/portfolio)", () => {
+  test("displays Portfolio heading and filter controls", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto("/workspace/portfolio");
+
+    await expect(
+      authedPage.getByRole("heading", { name: "Portfolio" }),
+    ).toBeVisible();
+
+    // Filter controls
+    await expect(
+      authedPage.getByPlaceholder("Search titles, journals..."),
+    ).toBeVisible();
+
+    // Group by piece toggle
+    await expect(authedPage.getByText("Group by piece")).toBeVisible();
+  });
+
+  test("shows external submission in portfolio", async ({
+    authedPage,
+    workspaceData,
+  }) => {
+    await authedPage.goto("/workspace/portfolio");
+
+    await expect(
+      authedPage.getByText(workspaceData.externalSubmission.journalName),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("source filter Colophony hides external items", async ({
+    authedPage,
+    workspaceData,
+  }) => {
+    await authedPage.goto("/workspace/portfolio");
+
+    // Wait for data to load
+    await expect(
+      authedPage.getByText(workspaceData.externalSubmission.journalName),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Select "Colophony" source filter
+    await authedPage.getByRole("combobox").last().click();
+    await authedPage.getByRole("option", { name: "Colophony" }).click();
+
+    // External item should no longer be visible
+    await expect(
+      authedPage.getByText(workspaceData.externalSubmission.journalName),
+    ).not.toBeVisible();
+  });
+});

--- a/apps/web/e2e/workspace/workspace-portfolio.spec.ts
+++ b/apps/web/e2e/workspace/workspace-portfolio.spec.ts
@@ -6,17 +6,18 @@ test.describe("Portfolio (/workspace/portfolio)", () => {
   }) => {
     await authedPage.goto("/workspace/portfolio");
 
+    const main = authedPage.locator("main");
     await expect(
-      authedPage.getByRole("heading", { name: "Portfolio" }),
+      main.getByRole("heading", { name: "Portfolio" }),
     ).toBeVisible();
 
     // Filter controls
     await expect(
-      authedPage.getByPlaceholder("Search titles, journals..."),
+      main.getByPlaceholder("Search titles, journals..."),
     ).toBeVisible();
 
     // Group by piece toggle
-    await expect(authedPage.getByText("Group by piece")).toBeVisible();
+    await expect(main.getByText("Group by piece")).toBeVisible();
   });
 
   test("shows external submission in portfolio", async ({
@@ -25,8 +26,9 @@ test.describe("Portfolio (/workspace/portfolio)", () => {
   }) => {
     await authedPage.goto("/workspace/portfolio");
 
+    const main = authedPage.locator("main");
     await expect(
-      authedPage.getByText(workspaceData.externalSubmission.journalName),
+      main.getByText(workspaceData.externalSubmission.journalName).first(),
     ).toBeVisible({ timeout: 10_000 });
   });
 
@@ -36,18 +38,20 @@ test.describe("Portfolio (/workspace/portfolio)", () => {
   }) => {
     await authedPage.goto("/workspace/portfolio");
 
+    const main = authedPage.locator("main");
+
     // Wait for data to load
     await expect(
-      authedPage.getByText(workspaceData.externalSubmission.journalName),
+      main.getByText(workspaceData.externalSubmission.journalName).first(),
     ).toBeVisible({ timeout: 10_000 });
 
-    // Select "Colophony" source filter
-    await authedPage.getByRole("combobox").last().click();
+    // Select "Colophony" source filter — use last combobox (source, not status)
+    await main.getByRole("combobox").last().click();
     await authedPage.getByRole("option", { name: "Colophony" }).click();
 
     // External item should no longer be visible
     await expect(
-      authedPage.getByText(workspaceData.externalSubmission.journalName),
+      main.getByText(workspaceData.externalSubmission.journalName),
     ).not.toBeVisible();
   });
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "test:e2e:oidc": "OIDC_E2E=true playwright test --project oidc",
     "test:e2e:embed": "playwright test --project embed",
     "test:e2e:slate": "playwright test --project slate",
+    "test:e2e:workspace": "playwright test --project workspace",
     "test:e2e:all": "OIDC_E2E=true playwright test",
     "test:e2e:ui": "playwright test --ui",
     "e2e:setup-oidc": "tsx ../../scripts/setup-zitadel-e2e.ts",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -99,6 +99,11 @@ export default defineConfig({
       testDir: "./e2e/slate",
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "workspace",
+      testDir: "./e2e/workspace",
+      use: { ...devices["Desktop Chrome"] },
+    },
   ],
 
   webServer: [

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -289,7 +289,7 @@
 - [x] [P0] Security invariant tests — SSRF validation, defense-in-depth, pagination bounds (20 tests) — (DEVLOG 2026-03-02; done 2026-03-02)
 - [x] [P0] Service integration tests — submission, form-validation, org, portfolio, CSR, contract (63 tests) — (DEVLOG 2026-03-02; done 2026-03-02)
 - [x] [P0] Documenso webhook integration tests (10 tests) — (DEVLOG 2026-03-02; done 2026-03-02)
-- [ ] [P0] Writer Workspace E2E — dashboard, external submissions, portfolio, CSR import (~21 Playwright tests) — (test coverage plan 2026-03-02)
+- [x] [P0] Writer Workspace E2E — dashboard, external submissions, portfolio, CSR import (21 Playwright tests) — (DEVLOG 2026-03-02; done 2026-03-02)
 - [ ] [P1] Queue/worker integration tests — email, webhook, file-scan workers with real Redis (~19 tests) — (test coverage plan 2026-03-02)
 - [ ] [P1] Form builder E2E — create form, add fields, configure, submit through it (~16 Playwright tests) — (test coverage plan 2026-03-02)
 - [ ] [P1] Organization & settings E2E — org management, member management, API keys (~15 Playwright tests) — (test coverage plan 2026-03-02)

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,27 @@ Newest entries first.
 
 ---
 
+## 2026-03-02 — Writer Workspace E2E Test Suite (Phase 3 P0)
+
+### Done
+
+- **21 Playwright E2E tests** across 5 spec files covering the full Writer Workspace feature set:
+  - Dashboard (4): heading, Track Submission link, quick action buttons, stat cards
+  - External Submissions (6): list, create, validation, detail page, delete with confirmation
+  - Portfolio (3): heading/filters, external items visible, Colophony source filter hides external
+  - Import (3): stepper UI, empty CSV rejection, full wizard import flow
+  - Analytics + Correspondence (5): analytics heading/cards, date filters, correspondence list, seeded items, log from detail page
+- **Infrastructure**: `workspace-db.ts` (externalSubmissions + correspondence CRUD helpers), `workspace-fixtures.ts` (writer user fixtures with auto-cleanup workspaceData)
+- **CI integration**: `playwright-workspace` job in ci.yml, `run_workspace` flag in detect-changes.sh with workspace-specific path prefixes, `test:e2e:workspace` script in package.json
+- Type-check and lint pass clean
+
+### Decisions
+
+- Used writer user (`writer@example.com`) not admin — workspace features are user-scoped, not org-admin-scoped
+- Workspace fixtures separate from base fixtures (don't modify `e2e/helpers/fixtures.ts`)
+
+---
+
 ## 2026-03-02 — Test Coverage Improvement (Phases 0–2) + Webhook Test Fixes
 
 ### Done

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,6 +44,9 @@ pnpm --filter @colophony/web test:e2e:oidc
 # Playwright — Slate pipeline (30 tests, requires dev servers)
 pnpm --filter @colophony/web test:e2e:slate
 
+# Playwright — Writer Workspace (21 tests, requires dev servers)
+pnpm --filter @colophony/web test:e2e:workspace
+
 # Playwright — all projects
 pnpm --filter @colophony/web test:e2e:all
 
@@ -73,7 +76,7 @@ pnpm --filter @colophony/web test:e2e:ui
 | Security invariant tests  | 3     | ~20   | Vitest (custom) | `apps/api/src/__tests__/security/` |
 | Service integration tests | 6     | ~63   | Vitest (custom) | `apps/api/src/__tests__/services/` |
 | Webhook integration tests | 4     | ~38   | Vitest (custom) | `apps/api/src/__tests__/webhooks/` |
-| Playwright browser E2E    | 14    | ~72   | Playwright      | `apps/web/e2e/`                    |
+| Playwright browser E2E    | 15    | ~93   | Playwright      | `apps/web/e2e/`                    |
 
 > Counts use `~` prefix because they shift as tests are added. Run `pnpm test` to get exact numbers.
 


### PR DESCRIPTION
## Summary

- Add 21 Playwright E2E tests for the Writer Workspace feature set (Phase 3, P0)
- 5 spec files: dashboard (4), external submissions (6), portfolio (3), import wizard (3), analytics + correspondence (5)
- DB helpers (`workspace-db.ts`) and fixtures (`workspace-fixtures.ts`) with auto-cleanup
- CI: `playwright-workspace` job with path-filtered detection via `detect-changes.sh`

## Test plan

- [ ] `pnpm --filter @colophony/web test:e2e:workspace` — all 21 tests pass
- [ ] `pnpm type-check` — passes clean
- [ ] `pnpm lint` — passes clean
- [ ] Existing E2E suites unaffected (submissions, uploads, oidc, embed, slate)
- [ ] `detect-changes.sh` correctly outputs `run_workspace=true` for workspace-only files

## Plan Overrides

| File | Planned | Actual | Rationale |
|---|---|---|---|
| `workspace-external.spec.ts` | Destructure `seedWriter` in create test | Removed unused `seedWriter` destructuring | Variable not referenced in test body — lint warning |
| `workspace-portfolio.spec.ts` | Assert status/source select dropdowns | Assert heading, search, group-by toggle only | Selects are comboboxes with complex ARIA; covered by source filter test instead |
| `workspace-import.spec.ts` | Explicitly select Submittable preset | No preset selection | Auto-mapping works without preset; preset selection adds fragility |