### PR TITLE
test(web): Organization & Settings E2E test suite (14 tests)

### DIFF
--- a/.github/scripts/detect-changes.sh
+++ b/.github/scripts/detect-changes.sh
@@ -24,6 +24,7 @@ run_workspace=false
 run_uploads=false
 run_oidc=false
 run_forms=false
+run_organization=false
 run_all=false
 
 # --- Push to main always runs everything ---
@@ -113,6 +114,14 @@ oidc_prefixes=(
   "apps/web/src/app/auth/"
 )
 
+organization_prefixes=(
+  "apps/web/e2e/organization/"
+  "apps/web/src/components/organizations/"
+  "apps/web/src/app/(dashboard)/organizations/"
+  "apps/web/src/app/(onboarding)/organizations/"
+  "apps/web/src/app/(dashboard)/settings/"
+)
+
 # --- Known non-suite prefixes (docs, configs, etc. that don't need E2E) ---
 known_nonsuite_prefixes=(
   "docs/"
@@ -121,9 +130,7 @@ known_nonsuite_prefixes=(
   ".vscode/"
   ".claude/"
   "apps/web/src/components/layout/"
-  "apps/web/src/components/organizations/"
   "apps/web/src/components/periods/"
-  "apps/web/src/app/(onboarding)/"
   "apps/web/src/app/page.tsx"
   "apps/web/src/app/favicon.ico"
   "apps/web/public/"
@@ -200,6 +207,10 @@ if [[ "$run_all" == "false" ]]; then
       run_forms=true
       matched=true
     fi
+    if matches_any_prefix "$file" "${organization_prefixes[@]}"; then
+      run_organization=true
+      matched=true
+    fi
 
     # Known non-suite paths (docs, configs) — skip without triggering fail-open
     if [[ "$matched" == "false" ]]; then
@@ -231,6 +242,7 @@ if [[ "$run_all" == "true" ]]; then
   run_uploads=true
   run_oidc=true
   run_forms=true
+  run_organization=true
 fi
 
 # --- Output ---
@@ -241,6 +253,7 @@ echo "run_workspace=$run_workspace"
 echo "run_uploads=$run_uploads"
 echo "run_oidc=$run_oidc"
 echo "run_forms=$run_forms"
+echo "run_organization=$run_organization"
 
 # Write to GITHUB_OUTPUT if available
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
@@ -252,5 +265,6 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     echo "run_uploads=$run_uploads"
     echo "run_oidc=$run_oidc"
     echo "run_forms=$run_forms"
+    echo "run_organization=$run_organization"
   } >> "$GITHUB_OUTPUT"
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       run_uploads: ${{ steps.suites.outputs.run_uploads }}
       run_oidc: ${{ steps.suites.outputs.run_oidc }}
       run_forms: ${{ steps.suites.outputs.run_forms }}
+      run_organization: ${{ steps.suites.outputs.run_organization }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -668,6 +669,91 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: playwright-forms-report
+          path: apps/web/playwright-report/
+          retention-days: 30
+
+  # ──────────────────────────────────────────────────
+  # Playwright E2E tests (~5 min): organization project
+  # Requires PostgreSQL + Redis
+  # ──────────────────────────────────────────────────
+  playwright-organization:
+    name: Playwright Organization E2E
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.run_organization == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: colophony
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: colophony
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U colophony"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Build workspace dependencies
+        run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/auth-client --filter=@colophony/types --filter=@colophony/api-contracts --filter=@colophony/plugin-sdk
+      - name: Create app_user role
+        run: |
+          PGPASSWORD=password psql -h localhost -p 5432 -U colophony -d colophony -c "
+            DO \$\$
+            BEGIN
+              IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'app_user') THEN
+                CREATE ROLE app_user WITH LOGIN PASSWORD 'app_password' NOSUPERUSER NOBYPASSRLS;
+              END IF;
+            END
+            \$\$;
+            GRANT CONNECT ON DATABASE colophony TO app_user;
+            GRANT USAGE ON SCHEMA public TO app_user;
+            GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_user;
+            GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_user;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO app_user;
+          "
+      - name: Run Drizzle migrations
+        run: pnpm db:migrate
+        env:
+          DATABASE_URL: postgresql://colophony:password@localhost:5432/colophony
+      - name: Seed test data
+        run: |
+          echo 'DATABASE_URL="postgresql://colophony:password@localhost:5432/colophony"' > packages/db/.env
+          pnpm db:seed
+      - name: Install Playwright browsers
+        run: pnpm --filter @colophony/web exec playwright install --with-deps chromium
+      - name: Run Playwright Organization E2E tests
+        run: pnpm --filter @colophony/web test:e2e:organization
+        env:
+          DATABASE_URL: postgresql://colophony:password@localhost:5432/colophony
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-organization-report
           path: apps/web/playwright-report/
           retention-days: 30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,19 +221,20 @@ All other version pins are in their respective per-directory CLAUDE.md files.
 
 ### CI Pipeline (GitHub Actions)
 
-| Job                      | Checks                                             |
-| ------------------------ | -------------------------------------------------- |
-| **quality**              | `format:check`, `lint`, `type-check`, `pnpm audit` |
-| **unit-tests**           | `pnpm test`                                        |
-| **rls-tests**            | RLS tenant isolation integration tests             |
-| **playwright-tests**     | Playwright E2E submissions project (20 tests)      |
-| **playwright-uploads**   | Playwright E2E uploads project (6 tests)           |
-| **playwright-oidc**      | Playwright E2E OIDC project (6 tests)              |
-| **playwright-embed**     | Playwright E2E embed project (10 tests)            |
-| **playwright-slate**     | Playwright E2E Slate pipeline project (30 tests)   |
-| **playwright-workspace** | Playwright E2E Writer Workspace project (21 tests) |
-| **playwright-forms**     | Playwright E2E Form Builder project (16 tests)     |
-| **build**                | `pnpm build` (API + Web production build)          |
+| Job                         | Checks                                                    |
+| --------------------------- | --------------------------------------------------------- |
+| **quality**                 | `format:check`, `lint`, `type-check`, `pnpm audit`        |
+| **unit-tests**              | `pnpm test`                                               |
+| **rls-tests**               | RLS tenant isolation integration tests                    |
+| **playwright-tests**        | Playwright E2E submissions project (20 tests)             |
+| **playwright-uploads**      | Playwright E2E uploads project (6 tests)                  |
+| **playwright-oidc**         | Playwright E2E OIDC project (6 tests)                     |
+| **playwright-embed**        | Playwright E2E embed project (10 tests)                   |
+| **playwright-slate**        | Playwright E2E Slate pipeline project (30 tests)          |
+| **playwright-workspace**    | Playwright E2E Writer Workspace project (21 tests)        |
+| **playwright-forms**        | Playwright E2E Form Builder project (16 tests)            |
+| **playwright-organization** | Playwright E2E Organization & Settings project (14 tests) |
+| **build**                   | `pnpm build` (API + Web production build)                 |
 
 **Path filtering:** Playwright suites run selectively on PRs based on changed files (`.github/scripts/detect-changes.sh`). Shared paths (packages, API, shared hooks/lib/ui) trigger all suites. Suite-specific paths (e.g., `apps/web/e2e/slate/`, `apps/web/src/components/slate/`) trigger only that suite. Unknown paths fail-open (all suites run). Push to `main` always runs everything. Fast jobs (quality, unit-tests, rls-tests, build) are unaffected — they always run on non-docs PRs.
 

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -44,6 +44,7 @@ function getRequestedProjects(): Set<string> {
     projects.add("slate");
     projects.add("workspace");
     projects.add("forms");
+    projects.add("organization");
   }
 
   return projects;

--- a/apps/web/e2e/helpers/organization-db.ts
+++ b/apps/web/e2e/helpers/organization-db.ts
@@ -1,0 +1,71 @@
+/**
+ * Organization-specific DB helpers for E2E test data setup/teardown.
+ *
+ * Uses the admin pool from db.ts to bypass RLS.
+ */
+
+import { eq, and } from "drizzle-orm";
+import { organizationMembers, users } from "@colophony/db";
+import { getDb } from "./db";
+
+/**
+ * Look up a member record by org ID and user email.
+ */
+export async function getMemberByEmail(
+  orgId: string,
+  email: string,
+): Promise<{
+  id: string;
+  userId: string;
+  role: string;
+} | null> {
+  const db = getDb();
+  const [row] = await db
+    .select({
+      id: organizationMembers.id,
+      userId: organizationMembers.userId,
+      role: organizationMembers.role,
+    })
+    .from(organizationMembers)
+    .innerJoin(users, eq(users.id, organizationMembers.userId))
+    .where(
+      and(
+        eq(organizationMembers.organizationId, orgId),
+        eq(users.email, email),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Remove a member by membership ID.
+ */
+export async function removeMember(memberId: string): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(organizationMembers)
+    .where(eq(organizationMembers.id, memberId))
+    .catch(() => {
+      // Ignore if already deleted
+    });
+}
+
+/**
+ * List all members for an organization.
+ */
+export async function getMembers(
+  orgId: string,
+): Promise<Array<{ id: string; userId: string; email: string; role: string }>> {
+  const db = getDb();
+  return db
+    .select({
+      id: organizationMembers.id,
+      userId: organizationMembers.userId,
+      email: users.email,
+      role: organizationMembers.role,
+    })
+    .from(organizationMembers)
+    .innerJoin(users, eq(users.id, organizationMembers.userId))
+    .where(eq(organizationMembers.organizationId, orgId));
+}

--- a/apps/web/e2e/helpers/organization-fixtures.ts
+++ b/apps/web/e2e/helpers/organization-fixtures.ts
@@ -1,0 +1,132 @@
+/**
+ * Organization-specific Playwright test fixtures.
+ *
+ * Uses the ADMIN user (editor@quarterlyreview.org) — org settings,
+ * member management, and org deletion all require ADMIN role.
+ *
+ * Provides `inviteTarget` fixture with a second test user for
+ * invite/remove tests, with automatic cleanup in teardown.
+ */
+
+import { test as base, expect, type Page, devices } from "@playwright/test";
+import { buildStorageState, setupPageAuth } from "./auth";
+import {
+  getOrgBySlug,
+  getUserByEmail,
+  createApiKey,
+  deleteApiKey,
+  createUser,
+  deleteUser,
+} from "./db";
+
+/** Admin user profile (ADMIN role in quarterly-review org) */
+const ADMIN_USER_PROFILE = {
+  sub: "seed-zitadel-admin-001",
+  email: "editor@quarterlyreview.org",
+  name: "Test Admin",
+};
+
+/** All scopes needed for Organization E2E tests */
+const ORG_E2E_SCOPES = [
+  "organizations:read",
+  "organizations:write",
+  "users:read",
+];
+
+interface SeedOrg {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+interface SeedUser {
+  id: string;
+  email: string;
+}
+
+interface TestApiKey {
+  id: string;
+  plainKey: string;
+}
+
+interface InviteTarget {
+  id: string;
+  email: string;
+}
+
+export const test = base.extend<{
+  seedOrg: SeedOrg;
+  seedAdmin: SeedUser;
+  testApiKey: TestApiKey;
+  authedPage: Page;
+  inviteTarget: InviteTarget;
+}>({
+  seedOrg: async ({}, use) => {
+    const org = await getOrgBySlug("quarterly-review");
+    if (!org) {
+      throw new Error(
+        'Seed org "quarterly-review" not found. Run `pnpm db:seed` first.',
+      );
+    }
+    await use(org);
+  },
+
+  seedAdmin: async ({}, use) => {
+    const user = await getUserByEmail("editor@quarterlyreview.org");
+    if (!user) {
+      throw new Error(
+        'Seed admin "editor@quarterlyreview.org" not found. Run `pnpm db:seed` first.',
+      );
+    }
+    await use(user);
+  },
+
+  testApiKey: async ({ seedOrg, seedAdmin }, use) => {
+    const key = await createApiKey({
+      orgId: seedOrg.id,
+      userId: seedAdmin.id,
+      scopes: ORG_E2E_SCOPES,
+      name: `e2e-org-${Date.now()}`,
+    });
+
+    await use(key);
+
+    await deleteApiKey(key.id);
+  },
+
+  authedPage: async ({ browser, seedOrg, testApiKey, baseURL }, use) => {
+    const context = await browser.newContext({
+      ...devices["Desktop Chrome"],
+      baseURL: baseURL ?? undefined,
+      storageState: buildStorageState(seedOrg.id, ADMIN_USER_PROFILE),
+    });
+
+    const page = await context.newPage();
+
+    await setupPageAuth(
+      page,
+      seedOrg.id,
+      testApiKey.plainKey,
+      ADMIN_USER_PROFILE,
+    );
+
+    await use(page);
+
+    await context.close();
+  },
+
+  inviteTarget: async ({}, use) => {
+    const suffix = Date.now().toString(36);
+    const email = `e2e-invite-${suffix}@test.example.com`;
+    const user = await createUser({
+      email,
+      zitadelUserId: `e2e-zitadel-invite-${suffix}`,
+    });
+
+    await use({ id: user.id, email: user.email });
+
+    await deleteUser(user.id);
+  },
+});
+
+export { expect };

--- a/apps/web/e2e/organization/members.spec.ts
+++ b/apps/web/e2e/organization/members.spec.ts
@@ -21,10 +21,9 @@ test.describe("Member Management (Members tab)", () => {
       authedPage.getByRole("columnheader", { name: "Actions" }),
     ).toBeVisible();
 
-    // At least one member row visible (the admin user)
-    await expect(authedPage.getByRole("row")).toHaveCount(
-      await authedPage.getByRole("row").count(),
-    );
+    // At least one member row visible (header + data rows, minimum 2)
+    const rowCount = await authedPage.getByRole("row").count();
+    expect(rowCount).toBeGreaterThanOrEqual(2);
     await expect(
       authedPage.getByRole("cell", { name: "editor@quarterlyreview.org" }),
     ).toBeVisible();

--- a/apps/web/e2e/organization/members.spec.ts
+++ b/apps/web/e2e/organization/members.spec.ts
@@ -45,9 +45,11 @@ test.describe("Member Management (Members tab)", () => {
       authedPage.getByRole("heading", { name: "Invite Member" }),
     ).toBeVisible();
 
-    // Assert Email input and Role select visible
-    await expect(authedPage.getByLabel("Email")).toBeVisible();
-    await expect(authedPage.getByLabel("Role")).toBeVisible();
+    // Assert Email input and Role select visible (scope to dialog to avoid
+    // "Email Templates" tab panel matching getByLabel('Email'))
+    const dialog = authedPage.getByRole("dialog");
+    await expect(dialog.getByLabel("Email")).toBeVisible();
+    await expect(dialog.getByLabel("Role")).toBeVisible();
 
     // Assert action buttons
     await expect(
@@ -68,8 +70,9 @@ test.describe("Member Management (Members tab)", () => {
 
     await authedPage.getByRole("button", { name: "Invite Member" }).click();
 
-    // Fill email
-    await authedPage.getByLabel("Email").fill(inviteTarget.email);
+    // Fill email (scope to dialog to avoid "Email Templates" tab panel match)
+    const dialog = authedPage.getByRole("dialog");
+    await dialog.getByLabel("Email").fill(inviteTarget.email);
 
     // Role defaults to READER — leave as-is
     // Click Add Member

--- a/apps/web/e2e/organization/members.spec.ts
+++ b/apps/web/e2e/organization/members.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect } from "../helpers/organization-fixtures";
+import { addMember } from "../helpers/db";
+import { removeMember, getMemberByEmail } from "../helpers/organization-db";
+
+test.describe("Member Management (Members tab)", () => {
+  test("displays member list with seeded members", async ({ authedPage }) => {
+    await authedPage.goto("/organizations/settings");
+    await authedPage.getByRole("tab", { name: "Members" }).click();
+
+    // Assert table headers
+    await expect(
+      authedPage.getByRole("columnheader", { name: "Email" }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("columnheader", { name: "Role" }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("columnheader", { name: "Joined" }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("columnheader", { name: "Actions" }),
+    ).toBeVisible();
+
+    // At least one member row visible (the admin user)
+    await expect(authedPage.getByRole("row")).toHaveCount(
+      await authedPage.getByRole("row").count(),
+    );
+    await expect(
+      authedPage.getByRole("cell", { name: "editor@quarterlyreview.org" }),
+    ).toBeVisible();
+
+    // Invite Member button visible
+    await expect(
+      authedPage.getByRole("button", { name: "Invite Member" }),
+    ).toBeVisible();
+  });
+
+  test("opens invite member dialog", async ({ authedPage }) => {
+    await authedPage.goto("/organizations/settings");
+    await authedPage.getByRole("tab", { name: "Members" }).click();
+
+    await authedPage.getByRole("button", { name: "Invite Member" }).click();
+
+    // Assert dialog title
+    await expect(
+      authedPage.getByRole("heading", { name: "Invite Member" }),
+    ).toBeVisible();
+
+    // Assert Email input and Role select visible
+    await expect(authedPage.getByLabel("Email")).toBeVisible();
+    await expect(authedPage.getByLabel("Role")).toBeVisible();
+
+    // Assert action buttons
+    await expect(
+      authedPage.getByRole("button", { name: "Add Member" }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("button", { name: "Cancel" }),
+    ).toBeVisible();
+  });
+
+  test("invites a member with READER role", async ({
+    authedPage,
+    seedOrg,
+    inviteTarget,
+  }) => {
+    await authedPage.goto("/organizations/settings");
+    await authedPage.getByRole("tab", { name: "Members" }).click();
+
+    await authedPage.getByRole("button", { name: "Invite Member" }).click();
+
+    // Fill email
+    await authedPage.getByLabel("Email").fill(inviteTarget.email);
+
+    // Role defaults to READER — leave as-is
+    // Click Add Member
+    await authedPage.getByRole("button", { name: "Add Member" }).click();
+
+    // Assert success toast
+    await expect(authedPage.getByText("Member added")).toBeVisible();
+
+    // Assert new member appears in table
+    await expect(
+      authedPage.getByRole("cell", { name: inviteTarget.email }),
+    ).toBeVisible();
+
+    // Cleanup: remove the member via DB
+    const member = await getMemberByEmail(seedOrg.id, inviteTarget.email);
+    if (member) {
+      await removeMember(member.id);
+    }
+  });
+
+  test("changes member role via dropdown", async ({
+    authedPage,
+    seedOrg,
+    inviteTarget,
+  }) => {
+    // Setup: invite target as READER via DB
+    await addMember(seedOrg.id, inviteTarget.id, "READER");
+
+    await authedPage.goto("/organizations/settings");
+    await authedPage.getByRole("tab", { name: "Members" }).click();
+
+    // Find the invited member row and its role dropdown
+    const memberRow = authedPage.getByRole("row").filter({
+      hasText: inviteTarget.email,
+    });
+    await expect(memberRow).toBeVisible();
+
+    // Open role select dropdown for that member
+    const roleSelect = memberRow.getByRole("combobox");
+    await roleSelect.click();
+
+    // Select "Editor"
+    await authedPage.getByRole("option", { name: "Editor" }).click();
+
+    // Assert success toast
+    await expect(authedPage.getByText("Role updated")).toBeVisible();
+
+    // Cleanup: remove the member via DB
+    const member = await getMemberByEmail(seedOrg.id, inviteTarget.email);
+    if (member) {
+      await removeMember(member.id);
+    }
+  });
+
+  test("removes a member with confirmation dialog", async ({
+    authedPage,
+    seedOrg,
+    inviteTarget,
+  }) => {
+    // Setup: invite target as READER via DB
+    await addMember(seedOrg.id, inviteTarget.id, "READER");
+
+    await authedPage.goto("/organizations/settings");
+    await authedPage.getByRole("tab", { name: "Members" }).click();
+
+    // Find the invited member row
+    const memberRow = authedPage.getByRole("row").filter({
+      hasText: inviteTarget.email,
+    });
+    await expect(memberRow).toBeVisible();
+
+    // Click the trash/remove button on that row
+    await memberRow.getByRole("button").click();
+
+    // Assert confirmation dialog
+    await expect(
+      authedPage.getByRole("heading", { name: "Remove member?" }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByText(`remove ${inviteTarget.email}`),
+    ).toBeVisible();
+
+    // Click "Remove" in dialog
+    await authedPage.getByRole("button", { name: "Remove" }).click();
+
+    // Assert success toast
+    await expect(authedPage.getByText("Member removed")).toBeVisible();
+
+    // Assert member no longer in table
+    await expect(
+      authedPage.getByRole("cell", { name: inviteTarget.email }),
+    ).not.toBeVisible();
+  });
+});

--- a/apps/web/e2e/organization/org-create.spec.ts
+++ b/apps/web/e2e/organization/org-create.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "../helpers/organization-fixtures";
+import { deleteOrg, getOrgBySlug } from "../helpers/db";
+
+test.describe("Create Organization (/organizations/new)", () => {
+  test("displays create org form", async ({ authedPage }) => {
+    await authedPage.goto("/organizations/new");
+
+    await expect(
+      authedPage.getByRole("heading", { name: "Create Organization" }),
+    ).toBeVisible();
+
+    await expect(authedPage.getByLabel("Organization Name")).toBeVisible();
+    await expect(authedPage.getByLabel("URL Slug")).toBeVisible();
+    await expect(
+      authedPage.getByRole("button", { name: "Create Organization" }),
+    ).toBeVisible();
+  });
+
+  test("auto-generates slug from name", async ({ authedPage }) => {
+    await authedPage.goto("/organizations/new");
+
+    const nameInput = authedPage.getByLabel("Organization Name");
+    const slugInput = authedPage.getByLabel("URL Slug");
+
+    await nameInput.fill("Test Literary Magazine");
+
+    // Slug should auto-populate
+    await expect(slugInput).toHaveValue("test-literary-magazine");
+  });
+
+  test("creates org and redirects to settings", async ({ authedPage }) => {
+    const suffix = Date.now().toString(36);
+    const orgName = `E2E Test Org ${suffix}`;
+    const expectedSlug = `e2e-test-org-${suffix}`;
+
+    await authedPage.goto("/organizations/new");
+
+    // Fill name (slug auto-generates)
+    await authedPage.getByLabel("Organization Name").fill(orgName);
+
+    // Wait for slug availability check to pass (button becomes enabled)
+    const createButton = authedPage.getByRole("button", {
+      name: "Create Organization",
+    });
+    await expect(createButton).toBeEnabled({ timeout: 5000 });
+
+    // Create the org
+    await createButton.click();
+
+    // Assert redirected to settings
+    await authedPage.waitForURL("**/organizations/settings", {
+      timeout: 10000,
+    });
+
+    // Assert success toast
+    await expect(authedPage.getByText("Organization created")).toBeVisible();
+
+    // Cleanup: delete the org via DB
+    const org = await getOrgBySlug(expectedSlug);
+    if (org) {
+      await deleteOrg(org.id);
+    }
+  });
+});

--- a/apps/web/e2e/organization/org-create.spec.ts
+++ b/apps/web/e2e/organization/org-create.spec.ts
@@ -4,9 +4,12 @@ import { deleteOrg, getOrgBySlug } from "../helpers/db";
 test.describe("Create Organization (/organizations/new)", () => {
   test("displays create org form", async ({ authedPage }) => {
     await authedPage.goto("/organizations/new");
+    await authedPage.waitForLoadState("networkidle");
 
+    // CardTitle renders as <div>, not a heading — check the card title text
+    // (also matches button, so use first() for the card title)
     await expect(
-      authedPage.getByRole("heading", { name: "Create Organization" }),
+      authedPage.getByText("Create Organization").first(),
     ).toBeVisible();
 
     await expect(authedPage.getByLabel("Organization Name")).toBeVisible();
@@ -18,6 +21,7 @@ test.describe("Create Organization (/organizations/new)", () => {
 
   test("auto-generates slug from name", async ({ authedPage }) => {
     await authedPage.goto("/organizations/new");
+    await authedPage.waitForLoadState("networkidle");
 
     const nameInput = authedPage.getByLabel("Organization Name");
     const slugInput = authedPage.getByLabel("URL Slug");
@@ -34,6 +38,7 @@ test.describe("Create Organization (/organizations/new)", () => {
     const expectedSlug = `e2e-test-org-${suffix}`;
 
     await authedPage.goto("/organizations/new");
+    await authedPage.waitForLoadState("networkidle");
 
     // Fill name (slug auto-generates)
     await authedPage.getByLabel("Organization Name").fill(orgName);

--- a/apps/web/e2e/organization/org-create.spec.ts
+++ b/apps/web/e2e/organization/org-create.spec.ts
@@ -13,7 +13,12 @@ test.describe("Create Organization (/organizations/new)", () => {
     ).toBeVisible();
 
     await expect(authedPage.getByLabel("Organization Name")).toBeVisible();
-    await expect(authedPage.getByLabel("URL Slug")).toBeVisible();
+    // Slug input is inside a wrapper <div> within FormControl, so Radix Slot
+    // assigns the id to the div rather than the input — getByLabel fails.
+    // Use placeholder instead.
+    await expect(
+      authedPage.getByPlaceholder("my-literary-magazine"),
+    ).toBeVisible();
     await expect(
       authedPage.getByRole("button", { name: "Create Organization" }),
     ).toBeVisible();
@@ -24,7 +29,8 @@ test.describe("Create Organization (/organizations/new)", () => {
     await authedPage.waitForLoadState("networkidle");
 
     const nameInput = authedPage.getByLabel("Organization Name");
-    const slugInput = authedPage.getByLabel("URL Slug");
+    // Slug input uses placeholder locator (see test above for rationale)
+    const slugInput = authedPage.getByPlaceholder("my-literary-magazine");
 
     await nameInput.fill("Test Literary Magazine");
 
@@ -52,13 +58,16 @@ test.describe("Create Organization (/organizations/new)", () => {
     // Create the org
     await createButton.click();
 
+    // Assert success toast (check before waitForURL — toast may auto-dismiss
+    // during navigation to the settings page)
+    await expect(authedPage.getByText("Organization created")).toBeVisible({
+      timeout: 10000,
+    });
+
     // Assert redirected to settings
     await authedPage.waitForURL("**/organizations/settings", {
       timeout: 10000,
     });
-
-    // Assert success toast
-    await expect(authedPage.getByText("Organization created")).toBeVisible();
 
     // Cleanup: delete the org via DB
     const org = await getOrgBySlug(expectedSlug);

--- a/apps/web/e2e/organization/org-delete.spec.ts
+++ b/apps/web/e2e/organization/org-delete.spec.ts
@@ -8,7 +8,7 @@
  * Each test creates its own disposable org + API key + authedPage.
  */
 
-import { test as base, expect, type Page, devices } from "@playwright/test";
+import { test as base, expect, devices, type Browser } from "@playwright/test";
 import { buildStorageState, setupPageAuth } from "../helpers/auth";
 import {
   createOrg,
@@ -36,7 +36,7 @@ const ORG_E2E_SCOPES = [
  * Create a disposable org with admin membership and API key,
  * returning an authedPage bound to that org.
  */
-async function createDisposableOrgContext(browser: any, baseURL: string) {
+async function createDisposableOrgContext(browser: Browser, baseURL: string) {
   const suffix =
     Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
   const orgName = `Delete Test Org ${suffix}`;

--- a/apps/web/e2e/organization/org-delete.spec.ts
+++ b/apps/web/e2e/organization/org-delete.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Organization deletion E2E tests.
+ *
+ * These tests create disposable orgs because:
+ * 1. We can't delete the seed org (it's used by other suites)
+ * 2. API keys are org-scoped — the seed org key won't work for a different org
+ *
+ * Each test creates its own disposable org + API key + authedPage.
+ */
+
+import { test as base, expect, type Page, devices } from "@playwright/test";
+import { buildStorageState, setupPageAuth } from "../helpers/auth";
+import {
+  createOrg,
+  deleteOrg,
+  addMember,
+  getUserByEmail,
+  createApiKey,
+  deleteApiKey,
+} from "../helpers/db";
+
+/** Admin user profile (ADMIN role) */
+const ADMIN_USER_PROFILE = {
+  sub: "seed-zitadel-admin-001",
+  email: "editor@quarterlyreview.org",
+  name: "Test Admin",
+};
+
+const ORG_E2E_SCOPES = [
+  "organizations:read",
+  "organizations:write",
+  "users:read",
+];
+
+/**
+ * Create a disposable org with admin membership and API key,
+ * returning an authedPage bound to that org.
+ */
+async function createDisposableOrgContext(browser: any, baseURL: string) {
+  const suffix =
+    Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+  const orgName = `Delete Test Org ${suffix}`;
+
+  // Create org
+  const org = await createOrg({
+    name: orgName,
+    slug: `delete-test-${suffix}`,
+  });
+
+  // Add admin user as ADMIN member
+  const admin = await getUserByEmail("editor@quarterlyreview.org");
+  if (!admin) throw new Error("Seed admin not found");
+  await addMember(org.id, admin.id, "ADMIN");
+
+  // Create API key scoped to this org
+  const apiKey = await createApiKey({
+    orgId: org.id,
+    userId: admin.id,
+    scopes: ORG_E2E_SCOPES,
+    name: `e2e-delete-${suffix}`,
+  });
+
+  // Create authed browser context
+  const context = await browser.newContext({
+    ...devices["Desktop Chrome"],
+    baseURL,
+    storageState: buildStorageState(org.id, ADMIN_USER_PROFILE),
+  });
+
+  const page = await context.newPage();
+  await setupPageAuth(page, org.id, apiKey.plainKey, ADMIN_USER_PROFILE);
+
+  return { org, apiKey, page, context };
+}
+
+base.describe("Delete Organization", () => {
+  base(
+    "delete button disabled until org name typed",
+    async ({ browser, baseURL }) => {
+      const { org, apiKey, page, context } = await createDisposableOrgContext(
+        browser,
+        baseURL ?? "http://localhost:3010",
+      );
+
+      try {
+        await page.goto("/organizations/settings");
+
+        // Click Delete Organization in Danger Zone
+        await page.getByRole("button", { name: "Delete Organization" }).click();
+
+        // Confirmation dialog opens
+        await expect(
+          page.getByRole("heading", { name: "Delete organization?" }),
+        ).toBeVisible();
+
+        // Confirm button should be disabled initially
+        const confirmButton = page.getByRole("button", {
+          name: "Yes, delete this organization",
+        });
+        await expect(confirmButton).toBeDisabled();
+
+        // Type partial name — still disabled
+        const confirmInput = page.getByPlaceholder(org.name);
+        await confirmInput.fill(org.name.slice(0, 5));
+        await expect(confirmButton).toBeDisabled();
+
+        // Type full org name — button becomes enabled
+        await confirmInput.clear();
+        await confirmInput.fill(org.name);
+        await expect(confirmButton).toBeEnabled();
+      } finally {
+        await context.close();
+        await deleteApiKey(apiKey.id);
+        await deleteOrg(org.id);
+      }
+    },
+  );
+
+  base("deletes org after confirmation", async ({ browser, baseURL }) => {
+    const { org, apiKey, page, context } = await createDisposableOrgContext(
+      browser,
+      baseURL ?? "http://localhost:3010",
+    );
+
+    try {
+      await page.goto("/organizations/settings");
+
+      // Click Delete Organization in Danger Zone
+      await page.getByRole("button", { name: "Delete Organization" }).click();
+
+      // Type exact org name
+      await page.getByPlaceholder(org.name).fill(org.name);
+
+      // Click confirm
+      await page
+        .getByRole("button", { name: "Yes, delete this organization" })
+        .click();
+
+      // Assert success toast
+      await expect(
+        page.getByText("Organization deleted successfully"),
+      ).toBeVisible();
+
+      // Assert redirected to home
+      await page.waitForURL("**/", { timeout: 10000 });
+    } finally {
+      await context.close();
+      await deleteApiKey(apiKey.id);
+      // Idempotent — org may already be deleted by the test
+      await deleteOrg(org.id);
+    }
+  });
+});

--- a/apps/web/e2e/organization/org-settings.spec.ts
+++ b/apps/web/e2e/organization/org-settings.spec.ts
@@ -66,12 +66,10 @@ test.describe("Organization Settings (/organizations/settings)", () => {
   }) => {
     await authedPage.goto("/organizations/settings");
 
-    // Scroll down to Danger Zone
-    const dangerZoneHeading = authedPage.getByRole("heading", {
-      name: "Danger Zone",
-    });
-    await dangerZoneHeading.scrollIntoViewIfNeeded();
-    await expect(dangerZoneHeading).toBeVisible();
+    // Scroll down to Danger Zone (CardTitle renders as <div>, not heading)
+    const dangerZoneText = authedPage.getByText("Danger Zone");
+    await dangerZoneText.scrollIntoViewIfNeeded();
+    await expect(dangerZoneText).toBeVisible();
 
     // Delete Organization button should be visible
     await expect(

--- a/apps/web/e2e/organization/org-settings.spec.ts
+++ b/apps/web/e2e/organization/org-settings.spec.ts
@@ -33,7 +33,7 @@ test.describe("Organization Settings (/organizations/settings)", () => {
     await expect(authedPage.getByText("Slug")).toBeVisible();
   });
 
-  test("updates org name", async ({ authedPage, seedOrg }) => {
+  test("updates org name", async ({ authedPage }) => {
     await authedPage.goto("/organizations/settings");
 
     const nameInput = authedPage.getByLabel("Organization Name");

--- a/apps/web/e2e/organization/org-settings.spec.ts
+++ b/apps/web/e2e/organization/org-settings.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "../helpers/organization-fixtures";
+
+test.describe("Organization Settings (/organizations/settings)", () => {
+  test("displays Organization Settings heading", async ({ authedPage }) => {
+    await authedPage.goto("/organizations/settings");
+
+    await expect(
+      authedPage.getByRole("heading", { name: "Organization Settings" }),
+    ).toBeVisible();
+
+    // Verify all tabs are present
+    await expect(
+      authedPage.getByRole("tab", { name: "General" }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("tab", { name: "Members" }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("tab", { name: "Email Templates" }),
+    ).toBeVisible();
+    await expect(authedPage.getByRole("tab", { name: "Voting" })).toBeVisible();
+  });
+
+  test("shows org name and slug on General tab", async ({ authedPage }) => {
+    await authedPage.goto("/organizations/settings");
+
+    // Wait for the form to load (name input should have a value)
+    const nameInput = authedPage.getByLabel("Organization Name");
+    await expect(nameInput).toBeVisible();
+    await expect(nameInput).not.toHaveValue("");
+
+    // Slug should be displayed as text (read-only)
+    await expect(authedPage.getByText("Slug")).toBeVisible();
+  });
+
+  test("updates org name", async ({ authedPage, seedOrg }) => {
+    await authedPage.goto("/organizations/settings");
+
+    const nameInput = authedPage.getByLabel("Organization Name");
+    await expect(nameInput).toBeVisible();
+
+    // Store original name for cleanup
+    const originalName = await nameInput.inputValue();
+
+    // Update the name
+    await nameInput.clear();
+    await nameInput.fill("Updated Quarterly Review");
+    await authedPage.getByRole("button", { name: "Save Changes" }).click();
+
+    // Assert success toast
+    await expect(authedPage.getByText("Organization updated")).toBeVisible();
+
+    // Reload and verify persistence
+    await authedPage.reload();
+    await expect(nameInput).toHaveValue("Updated Quarterly Review");
+
+    // Cleanup: restore original name
+    await nameInput.clear();
+    await nameInput.fill(originalName);
+    await authedPage.getByRole("button", { name: "Save Changes" }).click();
+    await expect(authedPage.getByText("Organization updated")).toBeVisible();
+  });
+
+  test("shows Danger Zone with delete button for admin", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto("/organizations/settings");
+
+    // Scroll down to Danger Zone
+    const dangerZoneHeading = authedPage.getByRole("heading", {
+      name: "Danger Zone",
+    });
+    await dangerZoneHeading.scrollIntoViewIfNeeded();
+    await expect(dangerZoneHeading).toBeVisible();
+
+    // Delete Organization button should be visible
+    await expect(
+      authedPage.getByRole("button", { name: "Delete Organization" }),
+    ).toBeVisible();
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "test:e2e:slate": "playwright test --project slate",
     "test:e2e:workspace": "playwright test --project workspace",
     "test:e2e:forms": "playwright test --project forms",
+    "test:e2e:organization": "playwright test --project organization",
     "test:e2e:all": "OIDC_E2E=true playwright test",
     "test:e2e:ui": "playwright test --ui",
     "e2e:setup-oidc": "tsx ../../scripts/setup-zitadel-e2e.ts",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -109,6 +109,11 @@ export default defineConfig({
       testDir: "./e2e/forms",
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "organization",
+      testDir: "./e2e/organization",
+      use: { ...devices["Desktop Chrome"] },
+    },
   ],
 
   webServer: [

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -292,7 +292,7 @@
 - [x] [P0] Writer Workspace E2E — dashboard, external submissions, portfolio, CSR import (21 Playwright tests) — (DEVLOG 2026-03-02; done 2026-03-02)
 - [ ] [P1] Queue/worker integration tests — email, webhook, file-scan workers with real Redis (~19 tests) — (test coverage plan 2026-03-02)
 - [x] [P1] Form builder E2E — create form, add fields, configure, submit through it (~16 Playwright tests) — (test coverage plan 2026-03-02; done 2026-03-03)
-- [ ] [P1] Organization & settings E2E — org management, member management, API keys (~15 Playwright tests) — (test coverage plan 2026-03-02)
+- [x] [P1] Organization & settings E2E — org management, member management (~14 Playwright tests) — (test coverage plan 2026-03-02; done 2026-03-03)
 - [ ] [P1] Submission analytics E2E — dashboard, charts, date range filter (~6 Playwright tests) — (test coverage plan 2026-03-02)
 - [ ] [P2] Federation admin E2E — peer management, sim-sub, transfers, audit log (~16 Playwright tests) — (test coverage plan 2026-03-02)
 - [ ] [P2] Federation S2S integration tests — two-instance HTTP signatures, trust handshake (~15 tests) — (test coverage plan 2026-03-02)

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,30 @@ Newest entries first.
 
 ---
 
+## 2026-03-03 — Organization & Settings E2E Test Suite (Phase 3 P1)
+
+### Done
+
+- **14 Playwright E2E tests** across 4 spec files covering organization management:
+  - Org Settings (4): heading/tabs, name/slug display, update name + persistence, danger zone visibility
+  - Members (5): member list with headers, invite dialog, invite member with READER role, change role via dropdown, remove member with confirmation
+  - Org Create (3): form display, auto-slug generation, create + redirect to settings
+  - Org Delete (2): confirm button disabled until name typed, delete + redirect to home
+- **Infrastructure**: `organization-db.ts` (getMemberByEmail, removeMember, getMembers), `organization-fixtures.ts` (seedOrg, seedAdmin, testApiKey, authedPage, inviteTarget)
+- **Delete tests**: disposable orgs with dedicated API keys — API keys are org-scoped so seed org key can't drive UI for a different org
+- **CI integration**: `playwright-organization` job in ci.yml, `run_organization` flag in detect-changes.sh, `test:e2e:organization` script
+- **Path filtering**: moved `organizations/` and `(onboarding)/` from `known_nonsuite_prefixes` to new `organization_prefixes`
+- Updated docs: backlog (checked off), testing.md (counts 109→123 Playwright, 1909→1923 total), CLAUDE.md (CI table)
+- Type-check passes clean
+
+### Decisions
+
+- No API key E2E tests — no frontend UI exists; API keys are API-only (tRPC/REST/GraphQL), covered by unit tests
+- Used admin user (`editor@quarterlyreview.org`) — org settings/members/deletion require ADMIN role
+- Org-delete tests create fresh disposable org + API key per test to handle org-scoped auth constraint
+
+---
+
 ## 2026-03-03 — Form Builder E2E Test Suite (Phase 3 P1)
 
 ### Done

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,6 +50,9 @@ pnpm --filter @colophony/web test:e2e:workspace
 # Playwright — Form Builder (16 tests, requires dev servers)
 pnpm --filter @colophony/web test:e2e:forms
 
+# Playwright — Organization & Settings (14 tests, requires dev servers)
+pnpm --filter @colophony/web test:e2e:organization
+
 # Playwright — all projects
 pnpm --filter @colophony/web test:e2e:all
 
@@ -68,7 +71,7 @@ pnpm --filter @colophony/web test:e2e:ui
 
 ## Current Test Status
 
-**~1909 tests passing** across 8 tiers:
+**~1923 tests passing** across 8 tiers:
 
 | Tier                      | Files | Tests | Runner          | Location                           |
 | ------------------------- | ----- | ----- | --------------- | ---------------------------------- |
@@ -79,7 +82,7 @@ pnpm --filter @colophony/web test:e2e:ui
 | Security invariant tests  | 3     | ~20   | Vitest (custom) | `apps/api/src/__tests__/security/` |
 | Service integration tests | 6     | ~63   | Vitest (custom) | `apps/api/src/__tests__/services/` |
 | Webhook integration tests | 4     | ~38   | Vitest (custom) | `apps/api/src/__tests__/webhooks/` |
-| Playwright browser E2E    | 19    | ~109  | Playwright      | `apps/web/e2e/`                    |
+| Playwright browser E2E    | 23    | ~123  | Playwright      | `apps/web/e2e/`                    |
 
 > Counts use `~` prefix because they shift as tests are added. Run `pnpm test` to get exact numbers.
 


### PR DESCRIPTION
## Summary

- **14 Playwright E2E tests** across 4 spec files covering organization management:
  - Org Settings (4): heading/tabs, name/slug display, update name + persistence, danger zone visibility
  - Members (5): member list with headers, invite dialog, invite member with READER role, change role via dropdown, remove member with confirmation
  - Org Create (3): form display, auto-slug generation, create + redirect to settings
  - Org Delete (2): confirm button disabled until name typed, delete + redirect to home
- DB helpers (`organization-db.ts`), Playwright fixtures (`organization-fixtures.ts`)
- CI job (`playwright-organization`), path-filtered detection in `detect-changes.sh`
- Delete tests use disposable orgs with dedicated API keys (org-scoped auth constraint)

## Test plan

- [ ] Run `pnpm --filter @colophony/web test:e2e:organization` locally
- [ ] Verify CI `playwright-organization` job passes
- [ ] Verify path filtering: org-only changes trigger only org suite
- [ ] Verify other E2E suites are unaffected