### PR TITLE
test(api): queue/worker integration tests (19 tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,60 @@ jobs:
           DATABASE_APP_URL: postgresql://app_user:app_password@localhost:5433/colophony_test
 
   # ──────────────────────────────────────────────────
+  # Queue/Worker integration tests: needs Postgres + Redis
+  # ──────────────────────────────────────────────────
+  queue-tests:
+    name: Queue Integration Tests
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: colophony_test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Build workspace dependencies
+        run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/types --filter=@colophony/api-contracts --filter=@colophony/plugin-sdk
+      - name: Run queue integration tests
+        run: pnpm --filter @colophony/api test:queues
+        env:
+          DATABASE_TEST_URL: postgresql://test:test@localhost:5433/colophony_test
+          DATABASE_APP_URL: postgresql://app_user:app_password@localhost:5433/colophony_test
+          REDIS_HOST: localhost
+          REDIS_PORT: "6379"
+          REDIS_PASSWORD: ""
+
+  # ──────────────────────────────────────────────────
   # Playwright E2E tests (~5 min): submissions project
   # ──────────────────────────────────────────────────
   playwright-tests:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,22 +221,23 @@ All other version pins are in their respective per-directory CLAUDE.md files.
 
 ### CI Pipeline (GitHub Actions)
 
-| Job                         | Checks                                                    |
-| --------------------------- | --------------------------------------------------------- |
-| **quality**                 | `format:check`, `lint`, `type-check`, `pnpm audit`        |
-| **unit-tests**              | `pnpm test`                                               |
-| **rls-tests**               | RLS tenant isolation integration tests                    |
-| **playwright-tests**        | Playwright E2E submissions project (20 tests)             |
-| **playwright-uploads**      | Playwright E2E uploads project (6 tests)                  |
-| **playwright-oidc**         | Playwright E2E OIDC project (6 tests)                     |
-| **playwright-embed**        | Playwright E2E embed project (10 tests)                   |
-| **playwright-slate**        | Playwright E2E Slate pipeline project (30 tests)          |
-| **playwright-workspace**    | Playwright E2E Writer Workspace project (21 tests)        |
-| **playwright-forms**        | Playwright E2E Form Builder project (16 tests)            |
-| **playwright-organization** | Playwright E2E Organization & Settings project (14 tests) |
-| **build**                   | `pnpm build` (API + Web production build)                 |
+| Job                         | Checks                                                      |
+| --------------------------- | ----------------------------------------------------------- |
+| **quality**                 | `format:check`, `lint`, `type-check`, `pnpm audit`          |
+| **unit-tests**              | `pnpm test`                                                 |
+| **rls-tests**               | RLS tenant isolation integration tests                      |
+| **queue-tests**             | Queue/worker integration tests (19 tests, Redis + Postgres) |
+| **playwright-tests**        | Playwright E2E submissions project (20 tests)               |
+| **playwright-uploads**      | Playwright E2E uploads project (6 tests)                    |
+| **playwright-oidc**         | Playwright E2E OIDC project (6 tests)                       |
+| **playwright-embed**        | Playwright E2E embed project (10 tests)                     |
+| **playwright-slate**        | Playwright E2E Slate pipeline project (30 tests)            |
+| **playwright-workspace**    | Playwright E2E Writer Workspace project (21 tests)          |
+| **playwright-forms**        | Playwright E2E Form Builder project (16 tests)              |
+| **playwright-organization** | Playwright E2E Organization & Settings project (14 tests)   |
+| **build**                   | `pnpm build` (API + Web production build)                   |
 
-**Path filtering:** Playwright suites run selectively on PRs based on changed files (`.github/scripts/detect-changes.sh`). Shared paths (packages, API, shared hooks/lib/ui) trigger all suites. Suite-specific paths (e.g., `apps/web/e2e/slate/`, `apps/web/src/components/slate/`) trigger only that suite. Unknown paths fail-open (all suites run). Push to `main` always runs everything. Fast jobs (quality, unit-tests, rls-tests, build) are unaffected — they always run on non-docs PRs.
+**Path filtering:** Playwright suites run selectively on PRs based on changed files (`.github/scripts/detect-changes.sh`). Shared paths (packages, API, shared hooks/lib/ui) trigger all suites. Suite-specific paths (e.g., `apps/web/e2e/slate/`, `apps/web/src/components/slate/`) trigger only that suite. Unknown paths fail-open (all suites run). Push to `main` always runs everything. Fast jobs (quality, unit-tests, rls-tests, queue-tests, build) are unaffected — they always run on non-docs PRs.
 
 ---
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,6 +28,7 @@
     "test:security": "vitest run --config vitest.config.security.ts",
     "test:services": "vitest run --config vitest.config.services.ts",
     "test:webhooks": "vitest run --config vitest.config.webhooks.ts",
+    "test:queues": "vitest run --config vitest.config.queues.ts",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/apps/api/src/__tests__/queues/email.queue.test.ts
+++ b/apps/api/src/__tests__/queues/email.queue.test.ts
@@ -1,0 +1,221 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from 'vitest';
+import { Queue } from 'bullmq';
+
+// Mock metrics, sentry, logger
+vi.mock('../../config/metrics.js', () => ({
+  bullmqJobDuration: { observe: vi.fn() },
+  bullmqJobTotal: { inc: vi.fn() },
+}));
+vi.mock('../../config/sentry.js', () => ({
+  captureException: vi.fn(),
+}));
+vi.mock('../../config/logger.js', () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// Mock email template rendering
+const mockRenderEmailTemplate = vi.fn();
+const mockRenderCustomTemplate = vi.fn();
+vi.mock('../../templates/email/index.js', () => ({
+  renderEmailTemplate: (...args: unknown[]) => mockRenderEmailTemplate(...args),
+  renderCustomTemplate: (...args: unknown[]) =>
+    mockRenderCustomTemplate(...args),
+}));
+
+// Mock email template service (for custom org templates)
+const mockGetActiveTemplate = vi.fn();
+vi.mock('../../services/email-template.service.js', () => ({
+  emailTemplateService: {
+    getActiveTemplate: (...args: unknown[]) => mockGetActiveTemplate(...args),
+  },
+}));
+
+import type { EmailJobData } from '../../queues/email.queue';
+import { startEmailWorker, stopEmailWorker } from '../../workers/email.worker';
+import { globalSetup } from '../rls/helpers/db-setup';
+import { truncateAllTables } from '../rls/helpers/cleanup';
+import { flushRedis, closeRedis, getRedisConfig } from './helpers/redis-setup';
+import {
+  waitForJobCompletion,
+  waitForJobFailure,
+  closeAllQueueEvents,
+} from './helpers/job-helpers';
+import {
+  createMockEmailAdapter,
+  createMockRegistry,
+  createTestEnv,
+} from './helpers/mock-adapters';
+import {
+  createOrganization,
+  createUser,
+  createOrgMember,
+} from '../rls/helpers/factories';
+import { createEmailSend } from './helpers/queue-factories';
+import { emailSends, eq } from '@colophony/db';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { getAdminPool } from '../rls/helpers/db-setup';
+
+function adminDb(): any {
+  return drizzle(getAdminPool());
+}
+
+describe('email queue integration', () => {
+  const env = createTestEnv();
+  const mockEmailAdapter = createMockEmailAdapter();
+  const mockRegistry = createMockRegistry({ email: mockEmailAdapter });
+  let queue: Queue<EmailJobData>;
+
+  beforeAll(async () => {
+    await globalSetup();
+    await flushRedis();
+    startEmailWorker(env, mockRegistry as any);
+    queue = new Queue<EmailJobData>('email', {
+      connection: getRedisConfig(),
+    });
+  });
+
+  afterAll(async () => {
+    await stopEmailWorker();
+    await queue.close();
+    await closeAllQueueEvents();
+    await closeRedis();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables();
+    vi.clearAllMocks();
+
+    // Default: no custom template, use built-in
+    mockGetActiveTemplate.mockResolvedValue(null);
+    mockRenderEmailTemplate.mockReturnValue({
+      html: '<p>Test email</p>',
+      text: 'Test email',
+      subject: 'Test Subject',
+    });
+  });
+
+  it('enqueue → email_sends transitions QUEUED → SENDING → SENT', async () => {
+    const org = await createOrganization();
+    const user = await createUser();
+    await createOrgMember(org.id, user.id);
+    const emailSend = await createEmailSend(org.id, {
+      recipientEmail: 'test@example.com',
+      recipientUserId: user.id,
+    });
+
+    mockEmailAdapter.send.mockResolvedValue({
+      success: true,
+      messageId: 'provider-msg-001',
+    });
+
+    const jobData: EmailJobData = {
+      emailSendId: emailSend.id,
+      orgId: org.id,
+      to: 'test@example.com',
+      from: 'noreply@colophony.dev',
+      templateName: 'submission-confirmation',
+      templateData: { title: 'My Submission' },
+    };
+
+    await queue.add('send', jobData, { jobId: emailSend.id });
+    await waitForJobCompletion(queue, emailSend.id);
+
+    const db = adminDb();
+    const [updated] = await db
+      .select()
+      .from(emailSends)
+      .where(eq(emailSends.id, emailSend.id));
+
+    expect(updated.status).toBe('SENT');
+    expect(updated.providerMessageId).toBe('provider-msg-001');
+    expect(updated.sentAt).toBeTruthy();
+    expect(mockEmailAdapter.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks FAILED on adapter error after retries exhausted', async () => {
+    const org = await createOrganization();
+    const user = await createUser();
+    await createOrgMember(org.id, user.id);
+    const emailSend = await createEmailSend(org.id);
+
+    mockEmailAdapter.send.mockRejectedValue(
+      new Error('SMTP connection refused'),
+    );
+
+    const jobData: EmailJobData = {
+      emailSendId: emailSend.id,
+      orgId: org.id,
+      to: emailSend.recipientEmail,
+      from: 'noreply@colophony.dev',
+      templateName: 'submission-confirmation',
+      templateData: { title: 'Test' },
+    };
+
+    await queue.add('send', jobData, {
+      jobId: emailSend.id,
+      attempts: 1,
+      backoff: { type: 'fixed', delay: 100 },
+    });
+    await waitForJobFailure(queue, emailSend.id);
+
+    // Allow onFailed callback to complete (it runs async after job failure)
+    await new Promise((r) => setTimeout(r, 500));
+
+    const db = adminDb();
+    const [updated] = await db
+      .select()
+      .from(emailSends)
+      .where(eq(emailSends.id, emailSend.id));
+
+    expect(updated.status).toBe('FAILED');
+    expect(updated.errorMessage).toContain('SMTP connection refused');
+  });
+
+  it('marks FAILED immediately on template render error (no retry)', async () => {
+    const org = await createOrganization();
+    const user = await createUser();
+    await createOrgMember(org.id, user.id);
+    const emailSend = await createEmailSend(org.id);
+
+    mockRenderEmailTemplate.mockImplementation(() => {
+      throw new Error('Invalid template variable');
+    });
+
+    const jobData: EmailJobData = {
+      emailSendId: emailSend.id,
+      orgId: org.id,
+      to: emailSend.recipientEmail,
+      from: 'noreply@colophony.dev',
+      templateName: 'submission-confirmation',
+      templateData: { title: 'Test' },
+    };
+
+    await queue.add('send', jobData, { jobId: emailSend.id });
+    // Template errors don't throw — job completes (returns early)
+    await waitForJobCompletion(queue, emailSend.id);
+
+    const db = adminDb();
+    const [updated] = await db
+      .select()
+      .from(emailSends)
+      .where(eq(emailSends.id, emailSend.id));
+
+    expect(updated.status).toBe('FAILED');
+    expect(updated.errorMessage).toContain('Template render error');
+    // Email adapter should NOT have been called
+    expect(mockEmailAdapter.send).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/__tests__/queues/file-scan.queue.test.ts
+++ b/apps/api/src/__tests__/queues/file-scan.queue.test.ts
@@ -1,0 +1,273 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from 'vitest';
+import { PassThrough } from 'node:stream';
+import { Queue } from 'bullmq';
+
+// Mock metrics, sentry, logger — must be before worker imports
+vi.mock('../../config/metrics.js', () => ({
+  bullmqJobDuration: { observe: vi.fn() },
+  bullmqJobTotal: { inc: vi.fn() },
+}));
+vi.mock('../../config/sentry.js', () => ({
+  captureException: vi.fn(),
+}));
+vi.mock('../../config/logger.js', () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// Mock ClamAV — module-level since worker does `new NodeClam().init()`
+const mockScanStream = vi.fn();
+vi.mock('clamscan', () => ({
+  default: function MockNodeClam() {
+    return {
+      init: vi.fn().mockResolvedValue({
+        scanStream: mockScanStream,
+      }),
+    };
+  },
+}));
+
+import type { FileScanJobData } from '../../queues/file-scan.queue';
+import {
+  startFileScanWorker,
+  stopFileScanWorker,
+} from '../../workers/file-scan.worker';
+import { globalSetup } from '../rls/helpers/db-setup';
+import { truncateAllTables } from '../rls/helpers/cleanup';
+import { flushRedis, closeRedis, getRedisConfig } from './helpers/redis-setup';
+import {
+  waitForJobCompletion,
+  waitForJobFailure,
+  closeAllQueueEvents,
+} from './helpers/job-helpers';
+import {
+  createMockStorage,
+  createMockRegistry,
+  createTestEnv,
+} from './helpers/mock-adapters';
+import {
+  createOrganization,
+  createUser,
+  createOrgMember,
+  createManuscript,
+  createManuscriptVersion,
+  createFile,
+} from '../rls/helpers/factories';
+import { files, eq } from '@colophony/db';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { getAdminPool } from '../rls/helpers/db-setup';
+
+function adminDb(): any {
+  return drizzle(getAdminPool());
+}
+
+describe('file-scan queue integration', () => {
+  const env = createTestEnv();
+  const mockStorage = createMockStorage();
+  const mockRegistry = createMockRegistry({ storage: mockStorage });
+  let queue: Queue<FileScanJobData>;
+
+  beforeAll(async () => {
+    await globalSetup();
+    await flushRedis();
+    startFileScanWorker(env, mockRegistry as any);
+    queue = new Queue<FileScanJobData>('file-scan', {
+      connection: getRedisConfig(),
+    });
+  });
+
+  afterAll(async () => {
+    await stopFileScanWorker();
+    await queue.close();
+    await closeAllQueueEvents();
+    await closeRedis();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables();
+    vi.clearAllMocks();
+  });
+
+  it('enqueue → file status transitions PENDING → SCANNING → CLEAN', async () => {
+    const org = await createOrganization();
+    const user = await createUser();
+    await createOrgMember(org.id, user.id);
+    const manuscript = await createManuscript(user.id);
+    const version = await createManuscriptVersion(manuscript.id);
+    const storageKey = `uploads/${Date.now()}/test.pdf`;
+    const file = await createFile(version.id, {
+      scanStatus: 'PENDING' as any,
+      storageKey,
+    });
+
+    // Mock ClamAV: file is clean
+    mockScanStream.mockResolvedValue({ isInfected: false, viruses: [] });
+
+    // Mock S3: return a readable stream
+    const stream = new PassThrough();
+    stream.end(Buffer.from('test file content'));
+    mockStorage.downloadFromBucket.mockResolvedValue(stream);
+
+    const jobData: FileScanJobData = {
+      fileId: file.id,
+      storageKey,
+      userId: user.id,
+      organizationId: org.id,
+    };
+
+    await queue.add('scan', jobData, { jobId: file.id });
+    await waitForJobCompletion(queue, file.id);
+
+    // Verify file status in DB
+    const db = adminDb();
+    const [updatedFile] = await db
+      .select()
+      .from(files)
+      .where(eq(files.id, file.id));
+
+    expect(updatedFile.scanStatus).toBe('CLEAN');
+    expect(updatedFile.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(mockStorage.moveBetweenBuckets).toHaveBeenCalledWith(
+      'quarantine',
+      storageKey,
+      'submissions',
+      storageKey,
+    );
+  });
+
+  it('marks file INFECTED and deletes from quarantine', async () => {
+    const org = await createOrganization();
+    const user = await createUser();
+    await createOrgMember(org.id, user.id);
+    const manuscript = await createManuscript(user.id);
+    const version = await createManuscriptVersion(manuscript.id);
+    const storageKey = `uploads/${Date.now()}/infected.pdf`;
+    const file = await createFile(version.id, {
+      scanStatus: 'PENDING' as any,
+      storageKey,
+    });
+
+    // Mock ClamAV: file is infected
+    mockScanStream.mockResolvedValue({
+      isInfected: true,
+      viruses: ['TestVirus'],
+    });
+
+    const stream = new PassThrough();
+    stream.end(Buffer.from('infected content'));
+    mockStorage.downloadFromBucket.mockResolvedValue(stream);
+
+    const jobData: FileScanJobData = {
+      fileId: file.id,
+      storageKey,
+      userId: user.id,
+      organizationId: org.id,
+    };
+
+    await queue.add('scan', jobData, { jobId: file.id });
+    await waitForJobCompletion(queue, file.id);
+
+    const db = adminDb();
+    const [updatedFile] = await db
+      .select()
+      .from(files)
+      .where(eq(files.id, file.id));
+
+    expect(updatedFile.scanStatus).toBe('INFECTED');
+    expect(mockStorage.deleteFromBucket).toHaveBeenCalledWith(
+      'quarantine',
+      storageKey,
+    );
+  });
+
+  it('marks file FAILED on scan error', async () => {
+    const org = await createOrganization();
+    const user = await createUser();
+    await createOrgMember(org.id, user.id);
+    const manuscript = await createManuscript(user.id);
+    const version = await createManuscriptVersion(manuscript.id);
+    const storageKey = `uploads/${Date.now()}/error.pdf`;
+    const file = await createFile(version.id, {
+      scanStatus: 'PENDING' as any,
+      storageKey,
+    });
+
+    // Mock S3: download fails
+    mockStorage.downloadFromBucket.mockRejectedValue(
+      new Error('S3 download error'),
+    );
+
+    const jobData: FileScanJobData = {
+      fileId: file.id,
+      storageKey,
+      userId: user.id,
+      organizationId: org.id,
+    };
+
+    await queue.add('scan', jobData, {
+      jobId: file.id,
+      attempts: 1,
+    });
+    await waitForJobFailure(queue, file.id);
+
+    const db = adminDb();
+    const [updatedFile] = await db
+      .select()
+      .from(files)
+      .where(eq(files.id, file.id));
+
+    expect(updatedFile.scanStatus).toBe('FAILED');
+  });
+
+  it('job idempotency — duplicate enqueue is no-op', async () => {
+    const org = await createOrganization();
+    const user = await createUser();
+    await createOrgMember(org.id, user.id);
+    const manuscript = await createManuscript(user.id);
+    const version = await createManuscriptVersion(manuscript.id);
+    const storageKey = `uploads/${Date.now()}/dedup.pdf`;
+    const file = await createFile(version.id, {
+      scanStatus: 'PENDING' as any,
+      storageKey,
+    });
+
+    mockScanStream.mockResolvedValue({ isInfected: false, viruses: [] });
+    const stream = new PassThrough();
+    stream.end(Buffer.from('dedup content'));
+    mockStorage.downloadFromBucket.mockResolvedValue(stream);
+
+    const jobData: FileScanJobData = {
+      fileId: file.id,
+      storageKey,
+      userId: user.id,
+      organizationId: org.id,
+    };
+
+    // Enqueue the same job twice (same jobId)
+    await queue.add('scan', jobData, { jobId: file.id });
+    await queue.add('scan', jobData, { jobId: file.id });
+    await waitForJobCompletion(queue, file.id);
+
+    const db = adminDb();
+    const [updatedFile] = await db
+      .select()
+      .from(files)
+      .where(eq(files.id, file.id));
+
+    expect(updatedFile.scanStatus).toBe('CLEAN');
+    // downloadFromBucket should only be called once (not twice)
+    expect(mockStorage.downloadFromBucket).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/__tests__/queues/helpers/job-helpers.ts
+++ b/apps/api/src/__tests__/queues/helpers/job-helpers.ts
@@ -1,0 +1,61 @@
+import { QueueEvents, type Queue, type Job } from 'bullmq';
+import { getRedisConfig } from './redis-setup';
+
+const queueEventsMap = new Map<string, QueueEvents>();
+
+export async function getQueueEvents(queueName: string): Promise<QueueEvents> {
+  let qe = queueEventsMap.get(queueName);
+  if (!qe) {
+    qe = new QueueEvents(queueName, { connection: getRedisConfig() });
+    queueEventsMap.set(queueName, qe);
+    // Wait for the QueueEvents to connect to Redis so we don't miss
+    // completion events emitted before the subscription is active.
+    await qe.waitUntilReady();
+  }
+  return qe;
+}
+
+export async function waitForJobCompletion<T>(
+  queue: Queue<T>,
+  jobId: string,
+  timeoutMs = 15_000,
+): Promise<Job<T>> {
+  const qe = await getQueueEvents(queue.name);
+  const job = await queue.getJob(jobId);
+  if (!job) throw new Error(`Job ${jobId} not found in queue ${queue.name}`);
+
+  await job.waitUntilFinished(qe, timeoutMs);
+
+  // Re-fetch to get final state
+  const finalJob = await queue.getJob(jobId);
+  if (!finalJob) throw new Error(`Job ${jobId} disappeared after completion`);
+  return finalJob as Job<T>;
+}
+
+export async function waitForJobFailure<T>(
+  queue: Queue<T>,
+  jobId: string,
+  timeoutMs = 15_000,
+): Promise<Job<T>> {
+  const qe = await getQueueEvents(queue.name);
+  const job = await queue.getJob(jobId);
+  if (!job) throw new Error(`Job ${jobId} not found in queue ${queue.name}`);
+
+  try {
+    await job.waitUntilFinished(qe, timeoutMs);
+  } catch {
+    // Expected — job failed
+  }
+
+  const finalJob = await queue.getJob(jobId);
+  if (!finalJob) throw new Error(`Job ${jobId} disappeared after failure`);
+  return finalJob as Job<T>;
+}
+
+export async function closeAllQueueEvents(): Promise<void> {
+  const closePromises = Array.from(queueEventsMap.values()).map((qe) =>
+    qe.close(),
+  );
+  await Promise.allSettled(closePromises);
+  queueEventsMap.clear();
+}

--- a/apps/api/src/__tests__/queues/helpers/job-helpers.ts
+++ b/apps/api/src/__tests__/queues/helpers/job-helpers.ts
@@ -49,6 +49,14 @@ export async function waitForJobFailure<T>(
 
   const finalJob = await queue.getJob(jobId);
   if (!finalJob) throw new Error(`Job ${jobId} disappeared after failure`);
+
+  const state = await finalJob.getState();
+  if (state !== 'failed') {
+    throw new Error(
+      `Expected job ${jobId} to be in 'failed' state but got '${state}'`,
+    );
+  }
+
   return finalJob as Job<T>;
 }
 

--- a/apps/api/src/__tests__/queues/helpers/mock-adapters.ts
+++ b/apps/api/src/__tests__/queues/helpers/mock-adapters.ts
@@ -1,0 +1,107 @@
+import { vi } from 'vitest';
+import type { Env } from '../../../config/env';
+
+export function createMockStorage() {
+  return {
+    id: 'mock-s3',
+    name: 'Mock S3',
+    version: '1.0.0',
+    configSchema: {} as any,
+    defaultBucket: 'submissions',
+    quarantineBucket: 'quarantine',
+    initialize: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue({ healthy: true, message: 'ok' }),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    upload: vi.fn().mockResolvedValue({ key: 'test', size: 100 }),
+    download: vi.fn(),
+    delete: vi.fn().mockResolvedValue(undefined),
+    exists: vi.fn().mockResolvedValue(true),
+    getSignedUrl: vi.fn().mockResolvedValue('https://example.com/signed'),
+    move: vi.fn().mockResolvedValue(undefined),
+    downloadFromBucket: vi.fn(),
+    deleteFromBucket: vi.fn().mockResolvedValue(undefined),
+    uploadToBucket: vi.fn().mockResolvedValue(undefined),
+    getSignedUrlFromBucket: vi
+      .fn()
+      .mockResolvedValue('https://example.com/signed'),
+    moveBetweenBuckets: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+export function createMockEmailAdapter() {
+  return {
+    id: 'mock-email',
+    name: 'Mock Email',
+    version: '1.0.0',
+    configSchema: {} as any,
+    initialize: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue({ healthy: true, message: 'ok' }),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    send: vi
+      .fn()
+      .mockResolvedValue({ success: true, messageId: 'msg-test-123' }),
+  };
+}
+
+export function createMockRegistry(adapters: Record<string, unknown>) {
+  return {
+    resolve: vi.fn((type: string) => {
+      const adapter = adapters[type];
+      if (!adapter) throw new Error(`No adapter registered for type: ${type}`);
+      return adapter;
+    }),
+    tryResolve: vi.fn((type: string) => adapters[type] ?? null),
+    has: vi.fn((type: string) => type in adapters),
+    register: vi.fn(),
+    listRegistered: vi.fn().mockReturnValue([]),
+    listAllTypes: vi.fn().mockReturnValue(Object.keys(adapters)),
+    destroyAll: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+export function createTestEnv(overrides?: Partial<Env>): Env {
+  return {
+    DATABASE_URL:
+      process.env.DATABASE_URL ??
+      'postgresql://app_user:app_password@localhost:5433/colophony_test',
+    PORT: 4000,
+    HOST: '0.0.0.0',
+    NODE_ENV: 'test',
+    LOG_LEVEL: 'error',
+    REDIS_HOST: process.env.REDIS_HOST ?? 'localhost',
+    REDIS_PORT: Number(process.env.REDIS_PORT ?? 6379),
+    REDIS_PASSWORD: process.env.REDIS_PASSWORD ?? '',
+    CORS_ORIGIN: 'http://localhost:3000',
+    RATE_LIMIT_DEFAULT_MAX: 60,
+    RATE_LIMIT_AUTH_MAX: 200,
+    RATE_LIMIT_WINDOW_SECONDS: 60,
+    RATE_LIMIT_KEY_PREFIX: 'colophony:rl',
+    AUTH_FAILURE_THROTTLE_MAX: 10,
+    AUTH_FAILURE_THROTTLE_WINDOW_SECONDS: 300,
+    WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS: 300,
+    WEBHOOK_RATE_LIMIT_MAX: 100,
+    S3_ENDPOINT: 'http://localhost:9000',
+    S3_BUCKET: 'submissions',
+    S3_QUARANTINE_BUCKET: 'quarantine',
+    S3_ACCESS_KEY: 'minioadmin',
+    S3_SECRET_KEY: 'minioadmin',
+    S3_REGION: 'us-east-1',
+    TUS_ENDPOINT: 'http://localhost:1080/files/',
+    CLAMAV_HOST: 'localhost',
+    CLAMAV_PORT: 3310,
+    VIRUS_SCAN_ENABLED: true,
+    DEV_AUTH_BYPASS: false,
+    FEDERATION_RATE_LIMIT_MAX: 60,
+    FEDERATION_RATE_LIMIT_WINDOW_SECONDS: 60,
+    STATUS_TOKEN_TTL_DAYS: 90,
+    FEDERATION_RATE_LIMIT_FAIL_MODE: 'open',
+    FEDERATION_ENABLED: false,
+    INNGEST_DEV: false,
+    SMTP_SECURE: false,
+    EMAIL_PROVIDER: 'none',
+    METRICS_ENABLED: false,
+    SENTRY_ENVIRONMENT: 'test',
+    SENTRY_TRACES_SAMPLE_RATE: 0,
+    ...overrides,
+  } as Env;
+}

--- a/apps/api/src/__tests__/queues/helpers/queue-factories.ts
+++ b/apps/api/src/__tests__/queues/helpers/queue-factories.ts
@@ -1,0 +1,126 @@
+import { faker } from '@faker-js/faker';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { getAdminPool } from '../../rls/helpers/db-setup';
+import {
+  emailSends,
+  webhookEndpoints,
+  webhookDeliveries,
+  outboxEvents,
+  trustedPeers,
+} from '@colophony/db';
+
+type EmailSend = typeof emailSends.$inferSelect;
+type WebhookEndpoint = typeof webhookEndpoints.$inferSelect;
+type WebhookDelivery = typeof webhookDeliveries.$inferSelect;
+type OutboxEvent = typeof outboxEvents.$inferSelect;
+type TrustedPeer = typeof trustedPeers.$inferSelect;
+
+function adminDb(): any {
+  return drizzle(getAdminPool());
+}
+
+export async function createEmailSend(
+  orgId: string,
+  overrides?: Partial<EmailSend>,
+): Promise<EmailSend> {
+  const db = adminDb();
+  const [row] = await db
+    .insert(emailSends)
+    .values({
+      organizationId: orgId,
+      recipientEmail: faker.internet.email(),
+      templateName: 'submission-confirmation',
+      eventType: 'submission.created',
+      subject: faker.lorem.sentence(),
+      status: 'QUEUED',
+      ...overrides,
+    })
+    .returning();
+  return row;
+}
+
+export async function createWebhookEndpoint(
+  orgId: string,
+  overrides?: Partial<WebhookEndpoint>,
+): Promise<WebhookEndpoint> {
+  const db = adminDb();
+  const [row] = await db
+    .insert(webhookEndpoints)
+    .values({
+      organizationId: orgId,
+      url: `https://hooks.example.com/${faker.string.alphanumeric(10)}`,
+      secret: faker.string.alphanumeric(32),
+      eventTypes: ['submission.created', 'submission.updated'],
+      status: 'ACTIVE',
+      ...overrides,
+    })
+    .returning();
+  return row;
+}
+
+export async function createWebhookDelivery(
+  orgId: string,
+  endpointId: string,
+  overrides?: Partial<WebhookDelivery>,
+): Promise<WebhookDelivery> {
+  const db = adminDb();
+  const [row] = await db
+    .insert(webhookDeliveries)
+    .values({
+      organizationId: orgId,
+      webhookEndpointId: endpointId,
+      eventType: 'submission.created',
+      eventId: faker.string.uuid(),
+      payload: {
+        id: faker.string.uuid(),
+        event: 'submission.created',
+        timestamp: new Date().toISOString(),
+        organizationId: orgId,
+        data: { submissionId: faker.string.uuid() },
+      },
+      status: 'QUEUED',
+      ...overrides,
+    })
+    .returning();
+  return row;
+}
+
+export async function createOutboxEvent(
+  overrides?: Partial<OutboxEvent>,
+): Promise<OutboxEvent> {
+  const db = adminDb();
+  const [row] = await db
+    .insert(outboxEvents)
+    .values({
+      eventType: 'submission/created',
+      payload: {
+        submissionId: faker.string.uuid(),
+        orgId: faker.string.uuid(),
+      },
+      processedAt: null,
+      ...overrides,
+    })
+    .returning();
+  return row;
+}
+
+export async function createTrustedPeer(
+  orgId: string,
+  overrides?: Partial<TrustedPeer>,
+): Promise<TrustedPeer> {
+  const db = adminDb();
+  const [row] = await db
+    .insert(trustedPeers)
+    .values({
+      organizationId: orgId,
+      domain: `peer-${faker.string.alphanumeric(8)}.example.com`,
+      instanceUrl: `http://localhost:${faker.number.int({ min: 4001, max: 9999 })}`,
+      publicKey: `-----BEGIN PUBLIC KEY-----\n${faker.string.alphanumeric(64)}\n-----END PUBLIC KEY-----`,
+      keyId: `${faker.string.alphanumeric(8)}#main-key`,
+      status: 'active',
+      initiatedBy: 'local',
+      ...overrides,
+    })
+    .returning();
+  return row;
+}

--- a/apps/api/src/__tests__/queues/helpers/redis-setup.ts
+++ b/apps/api/src/__tests__/queues/helpers/redis-setup.ts
@@ -1,0 +1,49 @@
+import { Redis } from 'ioredis';
+
+let redis: Redis | null = null;
+
+/**
+ * Redis database index reserved for queue integration tests.
+ * The dev server uses database 0 (default). Using a separate database
+ * prevents dev-server Workers from stealing test jobs.
+ */
+const TEST_REDIS_DB = 1;
+
+export function getRedisConfig(): {
+  host: string;
+  port: number;
+  password?: string;
+  db: number;
+} {
+  return {
+    host: process.env.REDIS_HOST ?? 'localhost',
+    port: Number(process.env.REDIS_PORT ?? 6379),
+    password: process.env.REDIS_PASSWORD || undefined,
+    db: TEST_REDIS_DB,
+  };
+}
+
+export function getRedisClient(): Redis {
+  if (!redis) {
+    const config = getRedisConfig();
+    redis = new Redis({
+      ...config,
+      maxRetriesPerRequest: null, // required for BullMQ
+      lazyConnect: true,
+    });
+  }
+  return redis;
+}
+
+export async function flushRedis(): Promise<void> {
+  const client = getRedisClient();
+  await client.connect().catch(() => {}); // idempotent
+  await client.flushdb();
+}
+
+export async function closeRedis(): Promise<void> {
+  if (redis) {
+    await redis.quit();
+    redis = null;
+  }
+}

--- a/apps/api/src/__tests__/queues/helpers/vitest-setup.ts
+++ b/apps/api/src/__tests__/queues/helpers/vitest-setup.ts
@@ -1,0 +1,33 @@
+/**
+ * Vitest setup file for queue integration tests.
+ *
+ * Patches BullMQ Worker connections to use a dedicated Redis database (db: 1)
+ * so that dev-server Workers (running on db: 0) don't steal test jobs.
+ */
+import { vi } from 'vitest';
+
+const TEST_REDIS_DB = 1;
+
+vi.mock('bullmq', async (importActual) => {
+  const actual = (await importActual()) as Record<string, unknown>;
+  const OriginalWorker = actual.Worker as new (...args: unknown[]) => unknown;
+
+  class TestWorker extends (OriginalWorker as any) {
+    constructor(
+      name: string,
+      processor: unknown,
+      opts: Record<string, unknown>,
+    ) {
+      const connection = (opts.connection ?? {}) as Record<string, unknown>;
+      super(name, processor, {
+        ...opts,
+        connection: { ...connection, db: TEST_REDIS_DB },
+      });
+    }
+  }
+
+  return {
+    ...actual,
+    Worker: TestWorker,
+  };
+});

--- a/apps/api/src/__tests__/queues/helpers/vitest-setup.ts
+++ b/apps/api/src/__tests__/queues/helpers/vitest-setup.ts
@@ -9,7 +9,7 @@ import { vi } from 'vitest';
 const TEST_REDIS_DB = 1;
 
 vi.mock('bullmq', async (importActual) => {
-  const actual = (await importActual()) as Record<string, unknown>;
+  const actual = await importActual<Record<string, unknown>>();
   const OriginalWorker = actual.Worker as new (...args: unknown[]) => unknown;
 
   class TestWorker extends (OriginalWorker as any) {

--- a/apps/api/src/__tests__/queues/outbox-poller.queue.test.ts
+++ b/apps/api/src/__tests__/queues/outbox-poller.queue.test.ts
@@ -1,0 +1,154 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from 'vitest';
+import { Queue } from 'bullmq';
+
+// Mock metrics, sentry, logger
+vi.mock('../../config/metrics.js', () => ({
+  bullmqJobDuration: { observe: vi.fn() },
+  bullmqJobTotal: { inc: vi.fn() },
+}));
+vi.mock('../../config/sentry.js', () => ({
+  captureException: vi.fn(),
+}));
+vi.mock('../../config/logger.js', () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// Mock inngest client via vi.mock trampoline
+const mockInngestSend = vi.fn();
+vi.mock('../../inngest/client.js', () => ({
+  inngest: {
+    send: (...args: unknown[]) => mockInngestSend(...args),
+  },
+}));
+
+import type { OutboxPollerJobData } from '../../queues/outbox-poller.queue';
+import {
+  startOutboxPollerWorker,
+  stopOutboxPollerWorker,
+} from '../../workers/outbox-poller.worker';
+import { globalSetup } from '../rls/helpers/db-setup';
+import { truncateAllTables } from '../rls/helpers/cleanup';
+import { flushRedis, closeRedis, getRedisConfig } from './helpers/redis-setup';
+import {
+  waitForJobCompletion,
+  closeAllQueueEvents,
+} from './helpers/job-helpers';
+import { createTestEnv } from './helpers/mock-adapters';
+import { createOutboxEvent } from './helpers/queue-factories';
+import { outboxEvents, eq } from '@colophony/db';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { getAdminPool } from '../rls/helpers/db-setup';
+
+function adminDb(): any {
+  return drizzle(getAdminPool());
+}
+
+describe('outbox-poller queue integration', () => {
+  const env = createTestEnv();
+  let queue: Queue<OutboxPollerJobData>;
+
+  beforeAll(async () => {
+    await globalSetup();
+    await flushRedis();
+    startOutboxPollerWorker(env);
+    queue = new Queue<OutboxPollerJobData>('outbox-poller', {
+      connection: getRedisConfig(),
+    });
+  });
+
+  afterAll(async () => {
+    await stopOutboxPollerWorker();
+    await queue.close();
+    await closeAllQueueEvents();
+    await closeRedis();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables();
+    vi.clearAllMocks();
+    mockInngestSend.mockResolvedValue(undefined);
+  });
+
+  it('processes unprocessed events and sends to Inngest', async () => {
+    const event1 = await createOutboxEvent({
+      eventType: 'submission/created',
+      payload: { submissionId: 'sub-1', orgId: 'org-1' },
+    });
+    const event2 = await createOutboxEvent({
+      eventType: 'submission/updated',
+      payload: { submissionId: 'sub-2', orgId: 'org-2' },
+    });
+
+    const job = await queue.add('poll', { trigger: 'scheduled' });
+    await waitForJobCompletion(queue, job.id!);
+
+    const db = adminDb();
+    const [updated1] = await db
+      .select()
+      .from(outboxEvents)
+      .where(eq(outboxEvents.id, event1.id));
+    const [updated2] = await db
+      .select()
+      .from(outboxEvents)
+      .where(eq(outboxEvents.id, event2.id));
+
+    expect(updated1.processedAt).toBeTruthy();
+    expect(updated1.processedAt!.getTime()).toBeGreaterThan(1000);
+    expect(updated2.processedAt).toBeTruthy();
+    expect(updated2.processedAt!.getTime()).toBeGreaterThan(1000);
+
+    expect(mockInngestSend).toHaveBeenCalledTimes(2);
+    expect(mockInngestSend).toHaveBeenCalledWith({
+      name: 'submission/created',
+      data: { submissionId: 'sub-1', orgId: 'org-1' },
+    });
+  });
+
+  it('Inngest failure unclaims event for retry', async () => {
+    const event = await createOutboxEvent({
+      eventType: 'submission/created',
+      payload: { submissionId: 'sub-fail' },
+    });
+
+    mockInngestSend.mockRejectedValue(new Error('Inngest unavailable'));
+
+    const job = await queue.add('poll', { trigger: 'scheduled' });
+    await waitForJobCompletion(queue, job.id!);
+
+    const db = adminDb();
+    const [updated] = await db
+      .select()
+      .from(outboxEvents)
+      .where(eq(outboxEvents.id, event.id));
+
+    expect(updated.processedAt).toBeNull();
+    expect(updated.retryCount).toBe(1);
+    expect(updated.error).toContain('Inngest unavailable');
+  });
+
+  it('skips already-processed events', async () => {
+    await createOutboxEvent({
+      eventType: 'submission/created',
+      payload: { submissionId: 'sub-done' },
+      processedAt: new Date(),
+    });
+
+    const job = await queue.add('poll', { trigger: 'scheduled' });
+    await waitForJobCompletion(queue, job.id!);
+
+    expect(mockInngestSend).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/__tests__/queues/s3-cleanup.queue.test.ts
+++ b/apps/api/src/__tests__/queues/s3-cleanup.queue.test.ts
@@ -1,0 +1,162 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from 'vitest';
+import { Queue } from 'bullmq';
+
+// Mock metrics, sentry, logger
+vi.mock('../../config/metrics.js', () => ({
+  bullmqJobDuration: { observe: vi.fn() },
+  bullmqJobTotal: { inc: vi.fn() },
+}));
+vi.mock('../../config/sentry.js', () => ({
+  captureException: vi.fn(),
+}));
+vi.mock('../../config/logger.js', () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// Mock auditService via vi.mock trampoline (same pattern as transfer-fetch)
+const mockLogDirect = vi.fn().mockResolvedValue(undefined);
+const mockLog = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../services/audit.service.js', () => ({
+  auditService: {
+    logDirect: (...args: unknown[]) => mockLogDirect(...args),
+    log: (...args: unknown[]) => mockLog(...args),
+  },
+}));
+
+import type { S3CleanupJobData } from '../../queues/s3-cleanup.queue';
+import {
+  startS3CleanupWorker,
+  stopS3CleanupWorker,
+} from '../../workers/s3-cleanup.worker';
+import { globalSetup } from '../rls/helpers/db-setup';
+import { flushRedis, closeRedis, getRedisConfig } from './helpers/redis-setup';
+import {
+  waitForJobCompletion,
+  waitForJobFailure,
+  closeAllQueueEvents,
+} from './helpers/job-helpers';
+import {
+  createMockStorage,
+  createMockRegistry,
+  createTestEnv,
+} from './helpers/mock-adapters';
+
+describe('s3-cleanup queue integration', () => {
+  const env = createTestEnv();
+  const mockStorage = createMockStorage();
+  const mockRegistry = createMockRegistry({ storage: mockStorage });
+  let queue: Queue<S3CleanupJobData>;
+
+  beforeAll(async () => {
+    await globalSetup();
+    await flushRedis();
+    startS3CleanupWorker(env, mockRegistry as any);
+    queue = new Queue<S3CleanupJobData>('s3-cleanup', {
+      connection: getRedisConfig(),
+    });
+  });
+
+  afterAll(async () => {
+    await stopS3CleanupWorker();
+    await queue.close();
+    await closeAllQueueEvents();
+    await closeRedis();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogDirect.mockResolvedValue(undefined);
+    mockLog.mockResolvedValue(undefined);
+  });
+
+  it('deletes all storage keys and logs audit', async () => {
+    mockStorage.deleteFromBucket.mockResolvedValue(undefined);
+
+    const jobData: S3CleanupJobData = {
+      storageKeys: [
+        { storageKey: 'uploads/file1.pdf', bucket: 'clean' },
+        { storageKey: 'uploads/file2.pdf', bucket: 'quarantine' },
+      ],
+      reason: 'user_gdpr_deletion',
+      sourceId: 'user-123',
+    };
+
+    const job = await queue.add('cleanup', jobData);
+    await waitForJobCompletion(queue, job.id!);
+
+    expect(mockStorage.deleteFromBucket).toHaveBeenCalledTimes(2);
+    expect(mockStorage.deleteFromBucket).toHaveBeenCalledWith(
+      'submissions',
+      'uploads/file1.pdf',
+    );
+    expect(mockStorage.deleteFromBucket).toHaveBeenCalledWith(
+      'quarantine',
+      'uploads/file2.pdf',
+    );
+    expect(mockLogDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'S3_CLEANUP_COMPLETED',
+        resourceId: 'user-123',
+      }),
+    );
+  });
+
+  it('partial failure throws and logs failed keys', async () => {
+    mockStorage.deleteFromBucket
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('S3 delete failed'));
+
+    const jobData: S3CleanupJobData = {
+      storageKeys: [
+        { storageKey: 'uploads/ok.pdf', bucket: 'clean' },
+        { storageKey: 'uploads/fail.pdf', bucket: 'clean' },
+      ],
+      reason: 'user_gdpr_deletion',
+      sourceId: 'user-456',
+    };
+
+    const job = await queue.add('cleanup', jobData, {
+      attempts: 1,
+    });
+    await waitForJobFailure(queue, job.id!);
+
+    expect(mockLogDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'S3_CLEANUP_FAILED',
+        resourceId: 'user-456',
+      }),
+    );
+  });
+
+  it('retries on total failure', async () => {
+    mockStorage.deleteFromBucket.mockRejectedValue(new Error('S3 unavailable'));
+
+    const jobData: S3CleanupJobData = {
+      storageKeys: [{ storageKey: 'uploads/file.pdf', bucket: 'clean' }],
+      reason: 'user_gdpr_deletion',
+      sourceId: 'user-789',
+    };
+
+    const job = await queue.add('cleanup', jobData, {
+      attempts: 2,
+      backoff: { type: 'fixed', delay: 100 },
+    });
+    await waitForJobFailure(queue, job.id!);
+
+    const finalJob = await queue.getJob(job.id!);
+    expect(finalJob!.attemptsMade).toBe(2);
+  });
+});

--- a/apps/api/src/__tests__/queues/transfer-fetch.queue.test.ts
+++ b/apps/api/src/__tests__/queues/transfer-fetch.queue.test.ts
@@ -1,0 +1,213 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from 'vitest';
+import { Queue } from 'bullmq';
+
+// Mock metrics, sentry, logger
+vi.mock('../../config/metrics.js', () => ({
+  bullmqJobDuration: { observe: vi.fn() },
+  bullmqJobTotal: { inc: vi.fn() },
+}));
+vi.mock('../../config/sentry.js', () => ({
+  captureException: vi.fn(),
+}));
+vi.mock('../../config/logger.js', () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// Mock SSRF validation
+const mockValidateOutboundUrl = vi.fn();
+vi.mock('../../lib/url-validation.js', () => ({
+  validateOutboundUrl: (...args: unknown[]) => mockValidateOutboundUrl(...args),
+}));
+
+// Mock auditService.logDirect (transfer-fetch uses it directly)
+const mockLogDirect = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../services/audit.service.js', () => ({
+  auditService: {
+    logDirect: (...args: unknown[]) => mockLogDirect(...args),
+    log: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import type { TransferFetchJobData } from '../../queues/transfer-fetch.queue';
+import {
+  startTransferFetchWorker,
+  stopTransferFetchWorker,
+} from '../../workers/transfer-fetch.worker';
+import { globalSetup } from '../rls/helpers/db-setup';
+import { truncateAllTables } from '../rls/helpers/cleanup';
+import { flushRedis, closeRedis, getRedisConfig } from './helpers/redis-setup';
+import {
+  waitForJobCompletion,
+  waitForJobFailure,
+  closeAllQueueEvents,
+} from './helpers/job-helpers';
+import {
+  createMockStorage,
+  createMockRegistry,
+  createTestEnv,
+} from './helpers/mock-adapters';
+import {
+  createOrganization,
+  createUser,
+  createOrgMember,
+  createSubmission,
+  createSubmissionPeriod,
+} from '../rls/helpers/factories';
+import { createTrustedPeer } from './helpers/queue-factories';
+import { submissions, eq } from '@colophony/db';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { getAdminPool } from '../rls/helpers/db-setup';
+
+function adminDb(): any {
+  return drizzle(getAdminPool());
+}
+
+// Mock globalThis.fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('transfer-fetch queue integration', () => {
+  const env = createTestEnv();
+  const mockStorage = createMockStorage();
+  const mockRegistry = createMockRegistry({ storage: mockStorage });
+  let queue: Queue<TransferFetchJobData>;
+
+  beforeAll(async () => {
+    await globalSetup();
+    await flushRedis();
+    startTransferFetchWorker(env, mockRegistry as any);
+    queue = new Queue<TransferFetchJobData>('transfer-fetch', {
+      connection: getRedisConfig(),
+    });
+  });
+
+  afterAll(async () => {
+    await stopTransferFetchWorker();
+    await queue.close();
+    await closeAllQueueEvents();
+    await closeRedis();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables();
+    vi.clearAllMocks();
+    mockValidateOutboundUrl.mockResolvedValue(undefined);
+  });
+
+  it('fetches files and updates submission formData', async () => {
+    const org = await createOrganization();
+    const user = await createUser();
+    await createOrgMember(org.id, user.id);
+    const period = await createSubmissionPeriod(org.id);
+    const submission = await createSubmission(org.id, user.id, {
+      submissionPeriodId: period.id,
+    });
+    const peer = await createTrustedPeer(org.id, {
+      domain: 'origin.example.com',
+      instanceUrl: 'http://localhost:4001',
+    });
+
+    // Mock fetch: return file content
+    mockFetch.mockImplementation(async () => {
+      const buf = Buffer.from('test file content');
+      return new Response(buf, { status: 200 });
+    });
+    mockStorage.uploadToBucket.mockResolvedValue(undefined);
+
+    const jobData: TransferFetchJobData = {
+      transferId: 'transfer-001',
+      orgId: org.id,
+      originDomain: 'origin.example.com',
+      transferToken: 'token-abc',
+      tokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+      fileManifest: [
+        {
+          fileId: 'file-1',
+          filename: 'story.pdf',
+          mimeType: 'application/pdf',
+          size: 1024,
+        },
+      ],
+      localSubmissionId: submission.id,
+    };
+
+    await queue.add('fetch', jobData, { jobId: jobData.transferId });
+    await waitForJobCompletion(queue, jobData.transferId);
+
+    // Verify submission formData was updated
+    const db = adminDb();
+    const [updated] = await db
+      .select()
+      .from(submissions)
+      .where(eq(submissions.id, submission.id));
+
+    const formData = updated.formData as Record<string, unknown>;
+    expect(formData._transferStatus).toBe('complete');
+    expect(formData._transferFiles).toBeDefined();
+    expect(mockStorage.uploadToBucket).toHaveBeenCalledTimes(1);
+    expect(mockLogDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'TRANSFER_FILES_FETCH_COMPLETED',
+      }),
+    );
+  });
+
+  it('fails permanently on expired transfer token', async () => {
+    const org = await createOrganization();
+    const user = await createUser();
+    await createOrgMember(org.id, user.id);
+    const period = await createSubmissionPeriod(org.id);
+    const submission = await createSubmission(org.id, user.id, {
+      submissionPeriodId: period.id,
+    });
+
+    const jobData: TransferFetchJobData = {
+      transferId: 'transfer-expired',
+      orgId: org.id,
+      originDomain: 'origin.example.com',
+      transferToken: 'token-expired',
+      tokenExpiresAt: new Date(Date.now() - 60_000).toISOString(), // past
+      fileManifest: [
+        {
+          fileId: 'file-1',
+          filename: 'story.pdf',
+          mimeType: 'application/pdf',
+          size: 1024,
+        },
+      ],
+      localSubmissionId: submission.id,
+    };
+
+    await queue.add('fetch', jobData, {
+      jobId: jobData.transferId,
+      attempts: 2,
+      backoff: { type: 'fixed', delay: 100 },
+    });
+    await waitForJobFailure(queue, jobData.transferId);
+
+    // UnrecoverableError means only 1 attempt even with attempts: 2
+    const finalJob = await queue.getJob(jobData.transferId);
+    expect(finalJob!.attemptsMade).toBe(1);
+
+    expect(mockLogDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'TRANSFER_FILES_FETCH_FAILED',
+      }),
+    );
+    // fetch should NOT have been called (token check fails first)
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/__tests__/queues/transfer-fetch.queue.test.ts
+++ b/apps/api/src/__tests__/queues/transfer-fetch.queue.test.ts
@@ -115,7 +115,7 @@ describe('transfer-fetch queue integration', () => {
     const submission = await createSubmission(org.id, user.id, {
       submissionPeriodId: period.id,
     });
-    const peer = await createTrustedPeer(org.id, {
+    await createTrustedPeer(org.id, {
       domain: 'origin.example.com',
       instanceUrl: 'http://localhost:4001',
     });

--- a/apps/api/src/__tests__/queues/webhook.queue.test.ts
+++ b/apps/api/src/__tests__/queues/webhook.queue.test.ts
@@ -1,0 +1,268 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from 'vitest';
+import { Queue } from 'bullmq';
+
+// Mock metrics, sentry, logger
+vi.mock('../../config/metrics.js', () => ({
+  bullmqJobDuration: { observe: vi.fn() },
+  bullmqJobTotal: { inc: vi.fn() },
+}));
+vi.mock('../../config/sentry.js', () => ({
+  captureException: vi.fn(),
+}));
+vi.mock('../../config/logger.js', () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// Mock SSRF validation via vi.mock trampoline
+const mockValidateOutboundUrl = vi.fn();
+vi.mock('../../lib/url-validation.js', () => ({
+  validateOutboundUrl: (...args: unknown[]) => mockValidateOutboundUrl(...args),
+}));
+
+// Mock auditService via vi.mock trampoline
+const mockAuditLog = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../services/audit.service.js', () => ({
+  auditService: {
+    log: (...args: unknown[]) => mockAuditLog(...args),
+    logDirect: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Mock globalThis.fetch via vi.stubGlobal
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import type { WebhookJobData } from '../../queues/webhook.queue';
+import {
+  startWebhookWorker,
+  stopWebhookWorker,
+} from '../../workers/webhook.worker';
+import { globalSetup } from '../rls/helpers/db-setup';
+import { truncateAllTables } from '../rls/helpers/cleanup';
+import { flushRedis, closeRedis, getRedisConfig } from './helpers/redis-setup';
+import {
+  waitForJobCompletion,
+  waitForJobFailure,
+  closeAllQueueEvents,
+} from './helpers/job-helpers';
+import { createTestEnv } from './helpers/mock-adapters';
+import {
+  createOrganization,
+  createUser,
+  createOrgMember,
+} from '../rls/helpers/factories';
+import {
+  createWebhookEndpoint,
+  createWebhookDelivery,
+} from './helpers/queue-factories';
+import { webhookDeliveries, eq } from '@colophony/db';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { getAdminPool } from '../rls/helpers/db-setup';
+
+function adminDb(): any {
+  return drizzle(getAdminPool());
+}
+
+describe('webhook queue integration', () => {
+  const env = createTestEnv();
+  let queue: Queue<WebhookJobData>;
+
+  beforeAll(async () => {
+    await globalSetup();
+    await flushRedis();
+    startWebhookWorker(env);
+    queue = new Queue<WebhookJobData>('webhook', {
+      connection: getRedisConfig(),
+    });
+  });
+
+  afterAll(async () => {
+    await stopWebhookWorker();
+    await queue.close();
+    await closeAllQueueEvents();
+    await closeRedis();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables();
+    vi.clearAllMocks();
+    // Re-apply default implementations after clearAllMocks
+    mockValidateOutboundUrl.mockResolvedValue(undefined);
+    mockAuditLog.mockResolvedValue(undefined);
+  });
+
+  function buildJobData(
+    orgId: string,
+    deliveryId: string,
+    endpointUrl: string,
+    secret: string,
+  ): WebhookJobData {
+    return {
+      deliveryId,
+      orgId,
+      endpointUrl,
+      secret,
+      payload: {
+        id: deliveryId,
+        event: 'submission.created',
+        timestamp: new Date().toISOString(),
+        organizationId: orgId,
+        data: { submissionId: 'sub-123' },
+      },
+    };
+  }
+
+  it('enqueue → webhook_deliveries transitions QUEUED → DELIVERED', async () => {
+    const org = await createOrganization();
+    const user = await createUser();
+    await createOrgMember(org.id, user.id);
+    const endpoint = await createWebhookEndpoint(org.id);
+    const delivery = await createWebhookDelivery(org.id, endpoint.id);
+
+    mockFetch.mockImplementation(
+      async () => new Response('OK', { status: 200 }),
+    );
+
+    const jobData = buildJobData(
+      org.id,
+      delivery.id,
+      endpoint.url,
+      endpoint.secret,
+    );
+    await queue.add('deliver', jobData, { jobId: delivery.id });
+    await waitForJobCompletion(queue, delivery.id);
+
+    const db = adminDb();
+    const [updated] = await db
+      .select()
+      .from(webhookDeliveries)
+      .where(eq(webhookDeliveries.id, delivery.id));
+
+    expect(updated.status).toBe('DELIVERED');
+    expect(updated.httpStatusCode).toBe(200);
+    expect(updated.deliveredAt).toBeTruthy();
+  });
+
+  it('retries on non-2xx then succeeds', async () => {
+    const org = await createOrganization();
+    const user = await createUser();
+    await createOrgMember(org.id, user.id);
+    const endpoint = await createWebhookEndpoint(org.id);
+    const delivery = await createWebhookDelivery(org.id, endpoint.id);
+
+    let callCount = 0;
+    mockFetch.mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response('Internal Server Error', { status: 500 });
+      }
+      return new Response('OK', { status: 200 });
+    });
+
+    const jobData = buildJobData(
+      org.id,
+      delivery.id,
+      endpoint.url,
+      endpoint.secret,
+    );
+    await queue.add('deliver', jobData, {
+      jobId: delivery.id,
+      attempts: 2,
+      backoff: { type: 'fixed', delay: 100 },
+    });
+    await waitForJobCompletion(queue, delivery.id);
+
+    const db = adminDb();
+    const [updated] = await db
+      .select()
+      .from(webhookDeliveries)
+      .where(eq(webhookDeliveries.id, delivery.id));
+
+    expect(updated.status).toBe('DELIVERED');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('marks FAILED after all retries exhausted', async () => {
+    const org = await createOrganization();
+    const user = await createUser();
+    await createOrgMember(org.id, user.id);
+    const endpoint = await createWebhookEndpoint(org.id);
+    const delivery = await createWebhookDelivery(org.id, endpoint.id);
+
+    mockFetch.mockImplementation(
+      async () => new Response('Server Error', { status: 500 }),
+    );
+
+    const jobData = buildJobData(
+      org.id,
+      delivery.id,
+      endpoint.url,
+      endpoint.secret,
+    );
+    await queue.add('deliver', jobData, {
+      jobId: delivery.id,
+      attempts: 1,
+      backoff: { type: 'fixed', delay: 100 },
+    });
+    await waitForJobFailure(queue, delivery.id);
+
+    // Allow onFailed callback to complete (it runs async after job failure)
+    await new Promise((r) => setTimeout(r, 500));
+
+    const db = adminDb();
+    const [updated] = await db
+      .select()
+      .from(webhookDeliveries)
+      .where(eq(webhookDeliveries.id, delivery.id));
+
+    expect(updated.status).toBe('FAILED');
+  });
+
+  it('SSRF validation rejects private IP (permanent failure, no retry)', async () => {
+    const org = await createOrganization();
+    const user = await createUser();
+    await createOrgMember(org.id, user.id);
+    const endpoint = await createWebhookEndpoint(org.id, {
+      url: 'http://192.168.1.1/webhook',
+    });
+    const delivery = await createWebhookDelivery(org.id, endpoint.id);
+
+    mockValidateOutboundUrl.mockRejectedValue(
+      new Error('URL validation failed: hostname resolves to private IP'),
+    );
+
+    const jobData = buildJobData(
+      org.id,
+      delivery.id,
+      endpoint.url,
+      endpoint.secret,
+    );
+    await queue.add('deliver', jobData, { jobId: delivery.id });
+    // SSRF failures don't throw — job completes (returns early, permanent fail)
+    await waitForJobCompletion(queue, delivery.id);
+
+    const db = adminDb();
+    const [updated] = await db
+      .select()
+      .from(webhookDeliveries)
+      .where(eq(webhookDeliveries.id, delivery.id));
+
+    expect(updated.status).toBe('FAILED');
+    expect(updated.errorMessage).toContain('URL validation');
+    // fetch should NOT have been called
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/vitest.config.queues.ts
+++ b/apps/api/vitest.config.queues.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/__tests__/queues/**/*.test.ts'],
+    globals: false,
+    testTimeout: 30_000,
+    setupFiles: ['src/__tests__/queues/helpers/vitest-setup.ts'],
+    fileParallelism: false,
+    pool: 'forks',
+    forks: {
+      singleFork: true,
+    },
+    env: {
+      // Point @colophony/db's pool at the test database so that
+      // workers using withRls() exercise the real DB path.
+      DATABASE_URL:
+        process.env.DATABASE_APP_URL ??
+        'postgresql://app_user:app_password@localhost:5433/colophony_test',
+      // Explicitly set DATABASE_APP_URL so appPool also uses test DB
+      DATABASE_APP_URL:
+        process.env.DATABASE_APP_URL ??
+        'postgresql://app_user:app_password@localhost:5433/colophony_test',
+      REDIS_HOST: process.env.REDIS_HOST ?? 'localhost',
+      REDIS_PORT: process.env.REDIS_PORT ?? '6379',
+      REDIS_PASSWORD: process.env.REDIS_PASSWORD ?? '',
+    },
+  },
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       'src/__tests__/webhooks/**',
       'src/__tests__/security/**',
       'src/__tests__/services/**',
+      'src/__tests__/queues/**',
     ],
     globals: false,
     testTimeout: 30_000,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -290,7 +290,7 @@
 - [x] [P0] Service integration tests — submission, form-validation, org, portfolio, CSR, contract (63 tests) — (DEVLOG 2026-03-02; done 2026-03-02)
 - [x] [P0] Documenso webhook integration tests (10 tests) — (DEVLOG 2026-03-02; done 2026-03-02)
 - [x] [P0] Writer Workspace E2E — dashboard, external submissions, portfolio, CSR import (21 Playwright tests) — (DEVLOG 2026-03-02; done 2026-03-02)
-- [ ] [P1] Queue/worker integration tests — email, webhook, file-scan workers with real Redis (~19 tests) — (test coverage plan 2026-03-02)
+- [x] [P1] Queue/worker integration tests — email, webhook, file-scan workers with real Redis (~19 tests) — (test coverage plan 2026-03-02; done 2026-03-03)
 - [x] [P1] Form builder E2E — create form, add fields, configure, submit through it (~16 Playwright tests) — (test coverage plan 2026-03-02; done 2026-03-03)
 - [x] [P1] Organization & settings E2E — org management, member management (~14 Playwright tests) — (test coverage plan 2026-03-02; done 2026-03-03)
 - [ ] [P1] Submission analytics E2E — dashboard, charts, date range filter (~6 Playwright tests) — (test coverage plan 2026-03-02)
@@ -298,6 +298,7 @@
 - [ ] [P2] Federation S2S integration tests — two-instance HTTP signatures, trust handshake (~15 tests) — (test coverage plan 2026-03-02)
 - [ ] [P2] Notification prefs + writer analytics E2E (~9 tests) — (test coverage plan 2026-03-02)
 - [ ] CI: Add service-integration-tests, security-tests, and new Playwright jobs — (test coverage plan 2026-03-02)
+- [ ] [P2] Fix flaky workspace analytics E2E — `workspace-analytics-correspondence.spec.ts` "Total Submissions" card times out intermittently (10s timeout); reproduces on both `main` and feature branches; likely slow tRPC query or rendering delay in CI — (CI flake 2026-03-03)
 
 ### CI
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,30 @@ Newest entries first.
 
 ---
 
+## 2026-03-03 — Queue/Worker Integration Tests (P1 Test Coverage)
+
+### Done
+
+- **19 integration tests** across 6 test files exercising real Redis + real Postgres with mocked external services:
+  - `email.queue.test.ts` (3): QUEUED→SENT lifecycle, adapter failure→FAILED, template error→FAILED (no retry)
+  - `webhook.queue.test.ts` (4): delivery→DELIVERED, retry on 500→success, exhaustion→FAILED, SSRF reject→FAILED
+  - `file-scan.queue.test.ts` (4): PENDING→CLEAN, infected→quarantine delete, scan error→FAILED, duplicate idempotency
+  - `s3-cleanup.queue.test.ts` (3): delete all keys + audit, partial failure throws, retry on total failure
+  - `outbox-poller.queue.test.ts` (3): process events→Inngest, Inngest failure unclaims for retry, skip processed
+  - `transfer-fetch.queue.test.ts` (2): fetch files→formData update, expired token→UnrecoverableError
+- **Test infrastructure**: `vitest.config.queues.ts` (singleFork, fileParallelism:false), shared helpers (redis-setup, job-helpers, mock-adapters, queue-factories)
+- **Key fix**: Redis db 1 isolation — dev-server Workers on db 0 were stealing test jobs; `vitest-setup.ts` patches BullMQ Worker constructor to inject `db: 1`
+- **CI**: `queue-tests` job added to ci.yml with Postgres + Redis services
+- Updated docs: backlog (checked off), testing.md (queue test tier + counts)
+
+### Decisions
+
+- Redis database isolation (db 1) via vitest setupFiles rather than modifying worker source code — keeps production code untouched
+- `vi.mock` trampoline pattern for all worker mocks — defers mock fn access past vi.mock hoisting
+- 500ms delay after `waitForJobFailure` for `onFailed` callback timing — BullMQ fires callback async after failure event
+
+---
+
 ## 2026-03-03 — Organization & Settings E2E Test Suite (Phase 3 P1)
 
 ### Done

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,6 +29,9 @@ pnpm --filter @colophony/api test:services
 # Webhook integration tests (~38 tests, requires postgres-test container)
 pnpm --filter @colophony/api test:webhooks
 
+# Queue/worker integration tests (~19 tests, requires postgres-test + redis)
+pnpm --filter @colophony/api test:queues
+
 # Playwright browser E2E — submissions only (20 tests, requires dev servers)
 pnpm --filter @colophony/web test:e2e
 
@@ -82,6 +85,7 @@ pnpm --filter @colophony/web test:e2e:ui
 | Security invariant tests  | 3     | ~20   | Vitest (custom) | `apps/api/src/__tests__/security/` |
 | Service integration tests | 6     | ~63   | Vitest (custom) | `apps/api/src/__tests__/services/` |
 | Webhook integration tests | 4     | ~38   | Vitest (custom) | `apps/api/src/__tests__/webhooks/` |
+| Queue integration tests   | 6     | ~19   | Vitest (custom) | `apps/api/src/__tests__/queues/`   |
 | Playwright browser E2E    | 23    | ~123  | Playwright      | `apps/web/e2e/`                    |
 
 > Counts use `~` prefix because they shift as tests are added. Run `pnpm test` to get exact numbers.
@@ -283,6 +287,34 @@ pnpm --filter @colophony/api test:webhooks
 - `buildWebhookApp()` creates a Fastify instance with all 3 webhook scopes (same registration as `main.ts`)
 - DB assertions use admin pool (bypasses RLS) to verify state changes
 - tusd tests exercise RLS via `withRls()` on submissions/submission_files tables
+
+### Queue/Worker Integration Tests
+
+**Location:** `apps/api/src/__tests__/queues/` (6 test files, ~19 tests)
+
+Tests verify the full enqueue → BullMQ picks up → processor runs → DB state changes pipeline for all queue workers: file-scan, email, webhook, s3-cleanup, outbox-poller, and transfer-fetch.
+
+**Real:** PostgreSQL (test DB, `app_user` connection via `withRls()`), Redis (BullMQ queues + workers), Drizzle ORM, audit logging.
+
+**Mocked:** S3 storage adapter, ClamAV (`clamscan`), email adapter, `globalThis.fetch`, Inngest client, SSRF validation, Prometheus metrics, Sentry, logger.
+
+**Config:** `apps/api/vitest.config.queues.ts` — `singleFork: true`, `fileParallelism: false`, `DATABASE_URL` + `REDIS_HOST`/`REDIS_PORT` pointed at test infra.
+
+**Running:**
+
+```bash
+# Requires postgres-test + redis containers
+docker compose up -d postgres-test redis
+pnpm --filter @colophony/api test:queues
+```
+
+**Key design:**
+
+- Each file starts its own worker in `beforeAll` and stops it in `afterAll`
+- `QueueEvents` + `job.waitUntilFinished()` for idiomatic wait (no polling)
+- Retry tests override default backoff with `{ type: 'fixed', delay: 100 }` to avoid 30s+ delays
+- Reuses RLS test helpers (db-setup, factories, cleanup) + adds queue-specific factories
+- Redis is flushed between test files via `flushRedis()` (FLUSHDB)
 
 ### Playwright Browser E2E Tests
 


### PR DESCRIPTION
## Summary

- **19 integration tests** across 6 test files exercising all BullMQ queue/worker pipelines with real Redis + real Postgres
- Tests: email (3), webhook (4), file-scan (4), s3-cleanup (3), outbox-poller (3), transfer-fetch (2)
- External services mocked: S3 storage, ClamAV, email adapter, fetch, Inngest
- Redis db 1 isolation prevents dev-server Workers from stealing test jobs
- CI `queue-tests` job with Postgres + Redis services

## Test plan

- [x] All 19 queue integration tests pass locally (~14s)
- [x] All 1555 unit tests pass (queue tests excluded from regular config)
- [x] Type-check clean
- [x] Lint clean
- [ ] CI passes on PR

## Plan Overrides

| File | Planned | Actual | Rationale |
|---|---|---|---|
| `helpers/job-helpers.ts` | `getQueueEvents` returns `QueueEvents` (sync) | Returns `Promise<QueueEvents>` (async) | Needed `waitUntilReady()` to avoid missing completion events |
| `email/webhook/file-scan tests` | Assert audit event actions | Audit assertions omitted | Audit service mocked; audit coverage in unit tests. s3-cleanup + transfer-fetch DO assert audit via `logDirect` |
| `s3-cleanup test` | `beforeEach` calls `truncateAllTables` | No `truncateAllTables` call | No DB records created; only mocked S3 ops + audit |
| `helpers/vitest-setup.ts` | Not in plan | Created | Redis db 1 isolation — discovered dev-server Workers steal test jobs on shared db 0 |