### PR TITLE
test(web): Federation Admin E2E test suite (16 tests)

### DIFF
--- a/.github/scripts/detect-changes.sh
+++ b/.github/scripts/detect-changes.sh
@@ -26,6 +26,7 @@ run_oidc=false
 run_forms=false
 run_organization=false
 run_analytics=false
+run_federation=false
 run_all=false
 
 # --- Push to main always runs everything ---
@@ -129,6 +130,12 @@ analytics_prefixes=(
   "apps/web/src/app/(dashboard)/editor/analytics/"
 )
 
+federation_prefixes=(
+  "apps/web/e2e/federation/"
+  "apps/web/src/components/federation/"
+  "apps/web/src/app/(dashboard)/federation/"
+)
+
 # --- Known non-suite prefixes (docs, configs, etc. that don't need E2E) ---
 known_nonsuite_prefixes=(
   "docs/"
@@ -222,6 +229,10 @@ if [[ "$run_all" == "false" ]]; then
       run_analytics=true
       matched=true
     fi
+    if matches_any_prefix "$file" "${federation_prefixes[@]}"; then
+      run_federation=true
+      matched=true
+    fi
 
     # Known non-suite paths (docs, configs) — skip without triggering fail-open
     if [[ "$matched" == "false" ]]; then
@@ -255,6 +266,7 @@ if [[ "$run_all" == "true" ]]; then
   run_forms=true
   run_organization=true
   run_analytics=true
+  run_federation=true
 fi
 
 # --- Output ---
@@ -267,6 +279,7 @@ echo "run_oidc=$run_oidc"
 echo "run_forms=$run_forms"
 echo "run_organization=$run_organization"
 echo "run_analytics=$run_analytics"
+echo "run_federation=$run_federation"
 
 # Write to GITHUB_OUTPUT if available
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
@@ -280,5 +293,6 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     echo "run_forms=$run_forms"
     echo "run_organization=$run_organization"
     echo "run_analytics=$run_analytics"
+    echo "run_federation=$run_federation"
   } >> "$GITHUB_OUTPUT"
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       run_forms: ${{ steps.suites.outputs.run_forms }}
       run_organization: ${{ steps.suites.outputs.run_organization }}
       run_analytics: ${{ steps.suites.outputs.run_analytics }}
+      run_federation: ${{ steps.suites.outputs.run_federation }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -893,6 +894,91 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: playwright-analytics-report
+          path: apps/web/playwright-report/
+          retention-days: 30
+
+  # ──────────────────────────────────────────────────
+  # Playwright E2E tests: federation admin project
+  # Requires PostgreSQL + Redis
+  # ──────────────────────────────────────────────────
+  playwright-federation:
+    name: Playwright Federation E2E
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.run_federation == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: colophony
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: colophony
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U colophony"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Build workspace dependencies
+        run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/auth-client --filter=@colophony/types --filter=@colophony/api-contracts --filter=@colophony/plugin-sdk
+      - name: Create app_user role
+        run: |
+          PGPASSWORD=password psql -h localhost -p 5432 -U colophony -d colophony -c "
+            DO \$\$
+            BEGIN
+              IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'app_user') THEN
+                CREATE ROLE app_user WITH LOGIN PASSWORD 'app_password' NOSUPERUSER NOBYPASSRLS;
+              END IF;
+            END
+            \$\$;
+            GRANT CONNECT ON DATABASE colophony TO app_user;
+            GRANT USAGE ON SCHEMA public TO app_user;
+            GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_user;
+            GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_user;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO app_user;
+          "
+      - name: Run Drizzle migrations
+        run: pnpm db:migrate
+        env:
+          DATABASE_URL: postgresql://colophony:password@localhost:5432/colophony
+      - name: Seed test data
+        run: |
+          echo 'DATABASE_URL="postgresql://colophony:password@localhost:5432/colophony"' > packages/db/.env
+          pnpm db:seed
+      - name: Install Playwright browsers
+        run: pnpm --filter @colophony/web exec playwright install --with-deps chromium
+      - name: Run Playwright Federation E2E tests
+        run: pnpm --filter @colophony/web test:e2e:federation
+        env:
+          DATABASE_URL: postgresql://colophony:password@localhost:5432/colophony
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-federation-report
           path: apps/web/playwright-report/
           retention-days: 30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,7 @@ All other version pins are in their respective per-directory CLAUDE.md files.
 | **playwright-forms**        | Playwright E2E Form Builder project (16 tests)              |
 | **playwright-organization** | Playwright E2E Organization & Settings project (14 tests)   |
 | **playwright-analytics**    | Playwright E2E Submission Analytics project (6 tests)       |
+| **playwright-federation**   | Playwright E2E Federation Admin project (16 tests)          |
 | **build**                   | `pnpm build` (API + Web production build)                   |
 
 **Path filtering:** Playwright suites run selectively on PRs based on changed files (`.github/scripts/detect-changes.sh`). Shared paths (packages, API, shared hooks/lib/ui) trigger all suites. Suite-specific paths (e.g., `apps/web/e2e/slate/`, `apps/web/src/components/slate/`) trigger only that suite. Unknown paths fail-open (all suites run). Push to `main` always runs everything. Fast jobs (quality, unit-tests, rls-tests, queue-tests, build) are unaffected — they always run on non-docs PRs.

--- a/apps/web/e2e/federation/federation-admin.spec.ts
+++ b/apps/web/e2e/federation/federation-admin.spec.ts
@@ -1,0 +1,516 @@
+/**
+ * Federation Admin E2E test suite — 16 tests.
+ *
+ * Validates federation admin UI pages: overview, peer management, sim-sub,
+ * transfers, migrations, audit log, and hub admin.
+ *
+ * Data is seeded directly in the DB via federation-db.ts helpers.
+ * Tests cover UI rendering and local-only admin actions (revoke, cancel, etc.).
+ */
+
+import { test, expect } from "./fixtures";
+
+// ═══════════════════════════════════════════════════════════════════
+// Federation Overview (2 tests)
+// ═══════════════════════════════════════════════════════════════════
+
+test.describe("Federation Overview", () => {
+  test("renders federation overview with navigation cards", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto("/federation");
+
+    // Heading
+    await expect(page.getByRole("heading", { name: "Federation" })).toBeVisible(
+      { timeout: 10_000 },
+    );
+
+    // Instance Configuration card
+    await expect(page.getByText("Instance Configuration")).toBeVisible();
+
+    // Trusted Peers summary card
+    await expect(
+      page.getByRole("heading", { name: "Trusted Peers" }),
+    ).toBeVisible();
+
+    // Navigation cards
+    await expect(page.getByText("Sim-Sub Checks")).toBeVisible();
+    await expect(page.getByText("Piece Transfers")).toBeVisible();
+    await expect(page.getByText("Identity Migrations")).toBeVisible();
+    await expect(page.getByText("Hub Administration")).toBeVisible();
+    await expect(page.getByText("Audit Log")).toBeVisible();
+  });
+
+  test("shows instance configuration details", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto("/federation");
+
+    // Wait for config to load
+    await expect(page.getByText("Instance Configuration")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Status badge (Enabled or Disabled)
+    await expect(
+      page.getByText("Enabled").or(page.getByText("Disabled")),
+    ).toBeVisible();
+
+    // Mode value
+    await expect(page.getByText("Mode")).toBeVisible();
+    await expect(page.getByText("allowlist")).toBeVisible();
+
+    // Capabilities list
+    await expect(page.getByText("Capabilities")).toBeVisible();
+
+    // Public key area
+    await expect(page.getByText("Public Key")).toBeVisible();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Peer Management (4 tests)
+// ═══════════════════════════════════════════════════════════════════
+
+test.describe("Peer Management", () => {
+  test("renders peer list with tab filtering", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto("/federation/peers");
+
+    // Wait for heading
+    await expect(
+      page.getByRole("heading", { name: "Trusted Peers" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Table headers
+    await expect(
+      page.getByRole("columnheader", { name: "Domain" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Status" }),
+    ).toBeVisible();
+
+    // Filter tabs
+    const allTab = page.getByRole("tab", { name: "All" });
+    const activeTab = page.getByRole("tab", { name: "Active" });
+    const pendingTab = page.getByRole("tab", { name: "Pending" });
+    const revokedTab = page.getByRole("tab", { name: "Revoked" });
+
+    await expect(allTab).toBeVisible();
+    await expect(activeTab).toBeVisible();
+    await expect(pendingTab).toBeVisible();
+    await expect(revokedTab).toBeVisible();
+
+    // All peers visible on All tab
+    await expect(page.getByText("active-peer.example.com")).toBeVisible();
+    await expect(page.getByText("pending-peer.example.com")).toBeVisible();
+
+    // Click Active tab — only active peer
+    await activeTab.click();
+    await expect(page.getByText("active-peer.example.com")).toBeVisible();
+    await expect(page.getByText("pending-peer.example.com")).not.toBeVisible();
+
+    // Click All tab — all peers visible again
+    await allTab.click();
+    await expect(page.getByText("active-peer.example.com")).toBeVisible();
+    await expect(page.getByText("pending-peer.example.com")).toBeVisible();
+  });
+
+  test("navigates to peer detail page", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto("/federation/peers");
+
+    await expect(page.getByText("active-peer.example.com")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Click the peer row
+    await page.getByText("active-peer.example.com").click();
+
+    // Verify detail page
+    await expect(
+      page.getByRole("heading", { name: "active-peer.example.com" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Peer information card
+    await expect(page.getByText("Peer Information")).toBeVisible();
+    await expect(page.getByText("Public Key")).toBeVisible();
+
+    // Capabilities card
+    await expect(
+      page.getByRole("heading", { name: "Granted Capabilities" }),
+    ).toBeVisible();
+    await expect(page.getByText("identity.verify")).toBeVisible();
+    await expect(page.getByText("simsub.check")).toBeVisible();
+  });
+
+  test("revokes an active peer", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto(`/federation/peers/${federationData.activePeerId}`);
+
+    // Wait for detail page
+    await expect(
+      page.getByRole("heading", { name: "active-peer.example.com" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Click Revoke Trust button
+    await page.getByRole("button", { name: "Revoke Trust" }).click();
+
+    // Confirm in AlertDialog
+    await expect(
+      page.getByText("Revoke Trust", { exact: false }),
+    ).toBeVisible();
+    await page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Revoke" })
+      .click();
+
+    // Verify success toast
+    await expect(page.getByText("Trust revoked")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Verify status badge changes to revoked
+    await expect(page.getByText("revoked")).toBeVisible();
+  });
+
+  test("accepts a pending inbound peer", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto(`/federation/peers/${federationData.pendingPeerId}`);
+
+    // Wait for detail page
+    await expect(
+      page.getByRole("heading", { name: "pending-peer.example.com" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Click Accept button
+    await page.getByRole("button", { name: "Accept" }).click();
+
+    // Verify AcceptPeerDialog opens
+    await expect(page.getByText("Accept Trust Request")).toBeVisible();
+    await expect(page.getByText("Grant Capabilities")).toBeVisible();
+
+    // Capability checkboxes should be visible
+    await expect(page.getByText("Identity Verification")).toBeVisible();
+    await expect(page.getByText("Sim-Sub Check")).toBeVisible();
+
+    // Click accept button in dialog
+    await page
+      .getByRole("button", { name: /Accept.*Grant Capabilities/ })
+      .click();
+
+    // Verify success toast
+    await expect(page.getByText(/Trust accepted/)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Verify status changes to active
+    await expect(page.getByText("active")).toBeVisible();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Sim-Sub Admin (2 tests)
+// ═══════════════════════════════════════════════════════════════════
+
+test.describe("Sim-Sub Admin", () => {
+  test("renders sim-sub admin with lookup form", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto("/federation/sim-sub");
+
+    // Heading
+    await expect(
+      page.getByRole("heading", { name: "Sim-Sub Checks" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Lookup form
+    await expect(page.getByText("Look Up Submission")).toBeVisible();
+    await expect(page.getByPlaceholder("Submission UUID")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Look Up" })).toBeVisible();
+  });
+
+  test("shows check history for a submission", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto("/federation/sim-sub");
+
+    await expect(
+      page.getByRole("heading", { name: "Sim-Sub Checks" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Enter submission ID and search
+    await page
+      .getByPlaceholder("Submission UUID")
+      .fill(federationData.submissionId);
+    await page.getByRole("button", { name: "Look Up" }).click();
+
+    // Check history table appears
+    await expect(
+      page.getByRole("heading", { name: "Check History" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Result badges
+    await expect(page.getByText("CLEAR")).toBeVisible();
+    await expect(page.getByText("CONFLICT")).toBeVisible();
+
+    // CONFLICT row should show local conflicts
+    await expect(page.getByText("Local conflicts:")).toBeVisible();
+    await expect(page.getByText("Other Magazine")).toBeVisible();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Transfer Management (2 tests)
+// ═══════════════════════════════════════════════════════════════════
+
+test.describe("Transfer Management", () => {
+  test("renders transfer list with tab filtering", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto("/federation/transfers");
+
+    // Heading
+    await expect(
+      page.getByRole("heading", { name: "Piece Transfers" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Filter tabs
+    await expect(page.getByRole("tab", { name: "All" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Pending" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Completed" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Failed" })).toBeVisible();
+
+    // Seeded transfer visible
+    await expect(page.getByText("target-instance.example.com")).toBeVisible();
+    await expect(page.getByText("PENDING")).toBeVisible();
+  });
+
+  test("navigates to transfer detail and cancels", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto(`/federation/transfers/${federationData.transferId}`);
+
+    // Wait for detail page
+    await expect(
+      page.getByRole("heading", { name: "Transfer Detail" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Verify key fields
+    await expect(page.getByText("Submission ID")).toBeVisible();
+    await expect(page.getByText("Target Domain")).toBeVisible();
+    await expect(page.getByText("target-instance.example.com")).toBeVisible();
+    await expect(page.getByText("PENDING")).toBeVisible();
+
+    // Cancel transfer
+    await page.getByRole("button", { name: "Cancel Transfer" }).click();
+
+    // Confirm in dialog
+    await expect(
+      page.getByText("Are you sure you want to cancel this transfer"),
+    ).toBeVisible();
+    await page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Cancel Transfer" })
+      .click();
+
+    // Verify success toast
+    await expect(page.getByText("Transfer cancelled")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Status should change
+    await expect(page.getByText("CANCELLED")).toBeVisible();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Migration Management (2 tests)
+// ═══════════════════════════════════════════════════════════════════
+
+test.describe("Migration Management", () => {
+  test("renders migration list with direction filter", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto("/federation/migrations");
+
+    // Heading
+    await expect(
+      page.getByRole("heading", { name: "Identity Migrations" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Direction selector
+    await expect(page.getByText("All Directions")).toBeVisible();
+
+    // Status tabs
+    await expect(page.getByRole("tab", { name: "All" })).toBeVisible();
+    await expect(
+      page.getByRole("tab", { name: "Pending Approval" }),
+    ).toBeVisible();
+    await expect(page.getByRole("tab", { name: "In Progress" })).toBeVisible();
+
+    // Seeded migration visible
+    await expect(page.getByText("migration-peer.example.com")).toBeVisible();
+  });
+
+  test("shows migration detail with action buttons", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto(`/federation/migrations/${federationData.migrationId}`);
+
+    // Wait for detail page
+    await expect(
+      page.getByRole("heading", { name: "Migration Detail" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Verify key fields
+    await expect(page.getByText("Direction")).toBeVisible();
+    await expect(page.getByText("outbound")).toBeVisible();
+    await expect(page.getByText("User DID")).toBeVisible();
+    await expect(page.getByText("Peer Domain")).toBeVisible();
+    await expect(page.getByText("migration-peer.example.com")).toBeVisible();
+
+    // Action buttons visible for PENDING status (Cancel Migration)
+    await expect(
+      page.getByRole("button", { name: "Cancel Migration" }),
+    ).toBeVisible();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Audit Log (3 tests)
+// ═══════════════════════════════════════════════════════════════════
+
+test.describe("Audit Log", () => {
+  test("renders audit log with filter panel", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto("/federation/audit");
+
+    // Heading
+    await expect(page.getByRole("heading", { name: "Audit Log" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Collapsible filter panel
+    await expect(page.getByText("Filters")).toBeVisible();
+
+    // Open filters
+    await page.getByText("Filters").click();
+
+    // Filter fields
+    await expect(page.getByLabel("Action")).toBeVisible();
+    await expect(page.getByLabel("Resource")).toBeVisible();
+
+    // Events table
+    await expect(page.getByRole("heading", { name: "Events" })).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Timestamp" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Action" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Resource" }),
+    ).toBeVisible();
+  });
+
+  test("filters audit events by resource type", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto("/federation/audit");
+
+    await expect(page.getByRole("heading", { name: "Audit Log" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Open filters
+    await page.getByText("Filters").click();
+
+    // Open resource dropdown
+    const resourceTrigger = page.getByLabel("Resource");
+    await resourceTrigger.click();
+
+    // Select "federation"
+    await page.getByRole("option", { name: "federation" }).click();
+
+    // Table should update (may show events or "No audit events found")
+    await expect(
+      page
+        .getByRole("heading", { name: "Events" })
+        .or(page.getByText("No audit events found")),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("shows event detail in modal", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto("/federation/audit");
+
+    await expect(page.getByRole("heading", { name: "Audit Log" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Wait for events table to load
+    const firstRow = page.locator("table tbody tr").first();
+    const hasEvents = await firstRow.isVisible().catch(() => false);
+
+    if (hasEvents) {
+      // Click first event row
+      await firstRow.click();
+
+      // Verify modal opens
+      await expect(page.getByText("Audit Event Detail")).toBeVisible({
+        timeout: 5_000,
+      });
+
+      // Modal should contain key fields
+      await expect(page.getByText("Action")).toBeVisible();
+      await expect(page.getByText("Resource")).toBeVisible();
+    } else {
+      // No events — verify "No audit events found" message
+      await expect(page.getByText("No audit events found")).toBeVisible();
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Hub Admin (1 test)
+// ═══════════════════════════════════════════════════════════════════
+
+test.describe("Hub Admin", () => {
+  test("shows hub mode not enabled message", async ({
+    authedPage: page,
+    federationData,
+  }) => {
+    await page.goto("/federation/hub");
+
+    // Hub page should show not-enabled message (default mode is allowlist)
+    await expect(
+      page.getByRole("heading", { name: "Hub Administration" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    await expect(
+      page.getByText("Hub mode is not enabled on this instance"),
+    ).toBeVisible();
+  });
+});

--- a/apps/web/e2e/federation/federation-admin.spec.ts
+++ b/apps/web/e2e/federation/federation-admin.spec.ts
@@ -172,8 +172,8 @@ test.describe("Peer Management", () => {
       timeout: 10_000,
     });
 
-    // Verify status badge changes to revoked
-    await expect(page.getByText("revoked")).toBeVisible();
+    // Verify status badge changes to revoked (exact: avoid toast "Trust revoked" + description text)
+    await expect(page.getByText("revoked", { exact: true })).toBeVisible();
   });
 
   test("accepts a pending inbound peer", async ({
@@ -254,8 +254,8 @@ test.describe("Sim-Sub Admin", () => {
       .fill(federationData.submissionId);
     await page.getByRole("button", { name: "Look Up" }).click();
 
-    // Check history table appears (CardTitle, not semantic heading)
-    await expect(page.getByText("Check History")).toBeVisible({
+    // Check history table appears (exact: CardDescription contains "check history" substring)
+    await expect(page.getByText("Check History", { exact: true })).toBeVisible({
       timeout: 10_000,
     });
 
@@ -381,7 +381,10 @@ test.describe("Migration Management", () => {
     await expect(page.getByText("outbound")).toBeVisible();
     await expect(page.getByText("User DID", { exact: true })).toBeVisible();
     await expect(page.getByText("Peer Domain")).toBeVisible();
-    await expect(page.getByText("migration-peer.example.com")).toBeVisible();
+    // exact: "Peer Instance URL" field contains "https://migration-peer.example.com"
+    await expect(
+      page.getByText("migration-peer.example.com", { exact: true }),
+    ).toBeVisible();
 
     // Action buttons visible for PENDING status (Cancel Migration)
     await expect(
@@ -422,10 +425,10 @@ test.describe("Audit Log", () => {
       page.getByRole("columnheader", { name: "Timestamp" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("columnheader", { name: "Action" }),
+      page.getByRole("columnheader", { name: "Action", exact: true }),
     ).toBeVisible();
     await expect(
-      page.getByRole("columnheader", { name: "Resource" }),
+      page.getByRole("columnheader", { name: "Resource", exact: true }),
     ).toBeVisible();
   });
 
@@ -466,8 +469,11 @@ test.describe("Audit Log", () => {
       timeout: 10_000,
     });
 
-    // Wait for events table to load
+    // Wait for loading to finish — either table rows or empty state appears
     const firstRow = page.locator("table tbody tr").first();
+    const emptyState = page.getByText("No audit events found.");
+    await expect(firstRow.or(emptyState)).toBeVisible({ timeout: 10_000 });
+
     const hasEvents = await firstRow.isVisible().catch(() => false);
 
     if (hasEvents) {
@@ -484,8 +490,8 @@ test.describe("Audit Log", () => {
       await expect(eventDialog.getByText("Action")).toBeVisible();
       await expect(eventDialog.getByText("Resource")).toBeVisible();
     } else {
-      // No events — verify empty state message (includes trailing period)
-      await expect(page.getByText("No audit events found.")).toBeVisible();
+      // No events — verify empty state message
+      await expect(emptyState).toBeVisible();
     }
   });
 });

--- a/apps/web/e2e/federation/federation-admin.spec.ts
+++ b/apps/web/e2e/federation/federation-admin.spec.ts
@@ -29,10 +29,8 @@ test.describe("Federation Overview", () => {
     // Instance Configuration card
     await expect(page.getByText("Instance Configuration")).toBeVisible();
 
-    // Trusted Peers summary card
-    await expect(
-      page.getByRole("heading", { name: "Trusted Peers" }),
-    ).toBeVisible();
+    // Trusted Peers summary card (CardTitle, not semantic heading)
+    await expect(page.getByText("Trusted Peers")).toBeVisible();
 
     // Navigation cards
     await expect(page.getByText("Sim-Sub Checks")).toBeVisible();
@@ -58,8 +56,8 @@ test.describe("Federation Overview", () => {
       page.getByText("Enabled").or(page.getByText("Disabled")),
     ).toBeVisible();
 
-    // Mode value
-    await expect(page.getByText("Mode")).toBeVisible();
+    // Mode value (appears in config card + edit dialog; use .first())
+    await expect(page.getByText("Mode").first()).toBeVisible();
     await expect(page.getByText("allowlist")).toBeVisible();
 
     // Capabilities list
@@ -142,10 +140,8 @@ test.describe("Peer Management", () => {
     await expect(page.getByText("Peer Information")).toBeVisible();
     await expect(page.getByText("Public Key")).toBeVisible();
 
-    // Capabilities card
-    await expect(
-      page.getByRole("heading", { name: "Granted Capabilities" }),
-    ).toBeVisible();
+    // Capabilities card (CardTitle, not semantic heading)
+    await expect(page.getByText("Granted Capabilities")).toBeVisible();
     await expect(page.getByText("identity.verify")).toBeVisible();
     await expect(page.getByText("simsub.check")).toBeVisible();
   });
@@ -165,9 +161,7 @@ test.describe("Peer Management", () => {
     await page.getByRole("button", { name: "Revoke Trust" }).click();
 
     // Confirm in AlertDialog
-    await expect(
-      page.getByText("Revoke Trust", { exact: false }),
-    ).toBeVisible();
+    await expect(page.getByRole("alertdialog")).toBeVisible();
     await page
       .getByRole("alertdialog")
       .getByRole("button", { name: "Revoke" })
@@ -197,15 +191,18 @@ test.describe("Peer Management", () => {
     await page.getByRole("button", { name: "Accept" }).click();
 
     // Verify AcceptPeerDialog opens
-    await expect(page.getByText("Accept Trust Request")).toBeVisible();
-    await expect(page.getByText("Grant Capabilities")).toBeVisible();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText("Accept Trust Request")).toBeVisible();
+    await expect(
+      dialog.getByText("Grant Capabilities", { exact: true }),
+    ).toBeVisible();
 
     // Capability checkboxes should be visible
-    await expect(page.getByText("Identity Verification")).toBeVisible();
-    await expect(page.getByText("Sim-Sub Check")).toBeVisible();
+    await expect(dialog.getByText("Identity Verification")).toBeVisible();
+    await expect(dialog.getByText("Sim-Sub Check")).toBeVisible();
 
     // Click accept button in dialog
-    await page
+    await dialog
       .getByRole("button", { name: /Accept.*Grant Capabilities/ })
       .click();
 
@@ -257,10 +254,10 @@ test.describe("Sim-Sub Admin", () => {
       .fill(federationData.submissionId);
     await page.getByRole("button", { name: "Look Up" }).click();
 
-    // Check history table appears
-    await expect(
-      page.getByRole("heading", { name: "Check History" }),
-    ).toBeVisible({ timeout: 10_000 });
+    // Check history table appears (CardTitle, not semantic heading)
+    await expect(page.getByText("Check History")).toBeVisible({
+      timeout: 10_000,
+    });
 
     // Result badges
     await expect(page.getByText("CLEAR")).toBeVisible();
@@ -294,9 +291,11 @@ test.describe("Transfer Management", () => {
     await expect(page.getByRole("tab", { name: "Completed" })).toBeVisible();
     await expect(page.getByRole("tab", { name: "Failed" })).toBeVisible();
 
-    // Seeded transfer visible
+    // Seeded transfer visible (scope to table — "Pending" tab matches case-insensitively)
     await expect(page.getByText("target-instance.example.com")).toBeVisible();
-    await expect(page.getByText("PENDING")).toBeVisible();
+    await expect(
+      page.locator("table").getByText("PENDING").first(),
+    ).toBeVisible();
   });
 
   test("navigates to transfer detail and cancels", async ({
@@ -314,15 +313,13 @@ test.describe("Transfer Management", () => {
     await expect(page.getByText("Submission ID")).toBeVisible();
     await expect(page.getByText("Target Domain")).toBeVisible();
     await expect(page.getByText("target-instance.example.com")).toBeVisible();
-    await expect(page.getByText("PENDING")).toBeVisible();
+    await expect(page.getByText("PENDING").first()).toBeVisible();
 
     // Cancel transfer
     await page.getByRole("button", { name: "Cancel Transfer" }).click();
 
-    // Confirm in dialog
-    await expect(
-      page.getByText("Are you sure you want to cancel this transfer"),
-    ).toBeVisible();
+    // Confirm in AlertDialog
+    await expect(page.getByRole("alertdialog")).toBeVisible();
     await page
       .getByRole("alertdialog")
       .getByRole("button", { name: "Cancel Transfer" })
@@ -333,8 +330,8 @@ test.describe("Transfer Management", () => {
       timeout: 10_000,
     });
 
-    // Status should change
-    await expect(page.getByText("CANCELLED")).toBeVisible();
+    // Status should change (use .first() — toast "cancelled" matches case-insensitively)
+    await expect(page.getByText("CANCELLED").first()).toBeVisible();
   });
 });
 
@@ -382,7 +379,7 @@ test.describe("Migration Management", () => {
     // Verify key fields
     await expect(page.getByText("Direction")).toBeVisible();
     await expect(page.getByText("outbound")).toBeVisible();
-    await expect(page.getByText("User DID")).toBeVisible();
+    await expect(page.getByText("User DID", { exact: true })).toBeVisible();
     await expect(page.getByText("Peer Domain")).toBeVisible();
     await expect(page.getByText("migration-peer.example.com")).toBeVisible();
 
@@ -415,12 +412,12 @@ test.describe("Audit Log", () => {
     // Open filters
     await page.getByText("Filters").click();
 
-    // Filter fields
-    await expect(page.getByLabel("Action")).toBeVisible();
-    await expect(page.getByLabel("Resource")).toBeVisible();
+    // Filter fields (shadcn Select lacks htmlFor→id, so use select trigger text)
+    await expect(page.getByText("All Actions")).toBeVisible();
+    await expect(page.getByText("All Resources")).toBeVisible();
 
-    // Events table
-    await expect(page.getByRole("heading", { name: "Events" })).toBeVisible();
+    // Events table (CardTitle, not semantic heading)
+    await expect(page.getByText("Events", { exact: true })).toBeVisible();
     await expect(
       page.getByRole("columnheader", { name: "Timestamp" }),
     ).toBeVisible();
@@ -445,18 +442,17 @@ test.describe("Audit Log", () => {
     // Open filters
     await page.getByText("Filters").click();
 
-    // Open resource dropdown
-    const resourceTrigger = page.getByLabel("Resource");
-    await resourceTrigger.click();
+    // Open resource dropdown via its trigger text
+    await page.getByText("All Resources").click();
 
     // Select "federation"
     await page.getByRole("option", { name: "federation" }).click();
 
-    // Table should update (may show events or "No audit events found")
+    // Table should update (may show events or empty state with period)
     await expect(
       page
-        .getByRole("heading", { name: "Events" })
-        .or(page.getByText("No audit events found")),
+        .getByText("Events", { exact: true })
+        .or(page.getByText("No audit events found.")),
     ).toBeVisible({ timeout: 10_000 });
   });
 
@@ -479,16 +475,17 @@ test.describe("Audit Log", () => {
       await firstRow.click();
 
       // Verify modal opens
-      await expect(page.getByText("Audit Event Detail")).toBeVisible({
+      const eventDialog = page.getByRole("dialog");
+      await expect(eventDialog.getByText("Audit Event Detail")).toBeVisible({
         timeout: 5_000,
       });
 
-      // Modal should contain key fields
-      await expect(page.getByText("Action")).toBeVisible();
-      await expect(page.getByText("Resource")).toBeVisible();
+      // Modal should contain key fields (scope to dialog to avoid table header matches)
+      await expect(eventDialog.getByText("Action")).toBeVisible();
+      await expect(eventDialog.getByText("Resource")).toBeVisible();
     } else {
-      // No events — verify "No audit events found" message
-      await expect(page.getByText("No audit events found")).toBeVisible();
+      // No events — verify empty state message (includes trailing period)
+      await expect(page.getByText("No audit events found.")).toBeVisible();
     }
   });
 });

--- a/apps/web/e2e/federation/federation-admin.spec.ts
+++ b/apps/web/e2e/federation/federation-admin.spec.ts
@@ -17,7 +17,7 @@ import { test, expect } from "./fixtures";
 test.describe("Federation Overview", () => {
   test("renders federation overview with navigation cards", async ({
     authedPage: page,
-    federationData,
+    federationData: _federationData,
   }) => {
     await page.goto("/federation");
 
@@ -44,7 +44,7 @@ test.describe("Federation Overview", () => {
 
   test("shows instance configuration details", async ({
     authedPage: page,
-    federationData,
+    federationData: _federationData,
   }) => {
     await page.goto("/federation");
 
@@ -77,7 +77,7 @@ test.describe("Federation Overview", () => {
 test.describe("Peer Management", () => {
   test("renders peer list with tab filtering", async ({
     authedPage: page,
-    federationData,
+    federationData: _federationData,
   }) => {
     await page.goto("/federation/peers");
 
@@ -122,7 +122,7 @@ test.describe("Peer Management", () => {
 
   test("navigates to peer detail page", async ({
     authedPage: page,
-    federationData,
+    federationData: _federationData,
   }) => {
     await page.goto("/federation/peers");
 
@@ -226,7 +226,7 @@ test.describe("Peer Management", () => {
 test.describe("Sim-Sub Admin", () => {
   test("renders sim-sub admin with lookup form", async ({
     authedPage: page,
-    federationData,
+    federationData: _federationData,
   }) => {
     await page.goto("/federation/sim-sub");
 
@@ -279,7 +279,7 @@ test.describe("Sim-Sub Admin", () => {
 test.describe("Transfer Management", () => {
   test("renders transfer list with tab filtering", async ({
     authedPage: page,
-    federationData,
+    federationData: _federationData,
   }) => {
     await page.goto("/federation/transfers");
 
@@ -345,7 +345,7 @@ test.describe("Transfer Management", () => {
 test.describe("Migration Management", () => {
   test("renders migration list with direction filter", async ({
     authedPage: page,
-    federationData,
+    federationData: _federationData,
   }) => {
     await page.goto("/federation/migrations");
 
@@ -400,7 +400,7 @@ test.describe("Migration Management", () => {
 test.describe("Audit Log", () => {
   test("renders audit log with filter panel", async ({
     authedPage: page,
-    federationData,
+    federationData: _federationData,
   }) => {
     await page.goto("/federation/audit");
 
@@ -434,7 +434,7 @@ test.describe("Audit Log", () => {
 
   test("filters audit events by resource type", async ({
     authedPage: page,
-    federationData,
+    federationData: _federationData,
   }) => {
     await page.goto("/federation/audit");
 
@@ -462,7 +462,7 @@ test.describe("Audit Log", () => {
 
   test("shows event detail in modal", async ({
     authedPage: page,
-    federationData,
+    federationData: _federationData,
   }) => {
     await page.goto("/federation/audit");
 
@@ -500,7 +500,7 @@ test.describe("Audit Log", () => {
 test.describe("Hub Admin", () => {
   test("shows hub mode not enabled message", async ({
     authedPage: page,
-    federationData,
+    federationData: _federationData,
   }) => {
     await page.goto("/federation/hub");
 

--- a/apps/web/e2e/federation/federation-admin.spec.ts
+++ b/apps/web/e2e/federation/federation-admin.spec.ts
@@ -261,7 +261,7 @@ test.describe("Sim-Sub Admin", () => {
 
     // Result badges
     await expect(page.getByText("CLEAR")).toBeVisible();
-    await expect(page.getByText("CONFLICT")).toBeVisible();
+    await expect(page.getByText("CONFLICT", { exact: true })).toBeVisible();
 
     // CONFLICT row should show local conflicts
     await expect(page.getByText("Local conflicts:")).toBeVisible();
@@ -488,7 +488,9 @@ test.describe("Audit Log", () => {
 
       // Modal should contain key fields (scope to dialog to avoid table header matches)
       await expect(eventDialog.getByText("Action")).toBeVisible();
-      await expect(eventDialog.getByText("Resource")).toBeVisible();
+      await expect(
+        eventDialog.getByText("Resource", { exact: true }),
+      ).toBeVisible();
     } else {
       // No events — verify empty state message
       await expect(emptyState).toBeVisible();

--- a/apps/web/e2e/federation/federation-db.ts
+++ b/apps/web/e2e/federation/federation-db.ts
@@ -1,0 +1,245 @@
+/**
+ * Federation-specific database helpers for E2E test data setup/teardown.
+ *
+ * Uses the admin pool from e2e/helpers/db.ts (bypasses RLS).
+ * Co-located in e2e/federation/ (not e2e/helpers/) to avoid triggering
+ * all Playwright suites via detect-changes.sh shared prefix matching.
+ */
+
+import { randomBytes } from "crypto";
+import { eq } from "drizzle-orm";
+import {
+  federationConfig,
+  trustedPeers,
+  simSubChecks,
+  pieceTransfers,
+  identityMigrations,
+} from "@colophony/db";
+import { getDb } from "../helpers/db";
+
+// ---------------------------------------------------------------------------
+// Federation Config
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure federation_config singleton exists.
+ * Uses admin pool (federation_config has no RLS — app_user is REVOKE'd).
+ * Generates a dummy Ed25519 keypair for test purposes.
+ */
+export async function ensureFederationConfig(): Promise<{ id: string }> {
+  const db = getDb();
+
+  // Check if config already exists
+  const [existing] = await db
+    .select({ id: federationConfig.id })
+    .from(federationConfig)
+    .limit(1);
+
+  if (existing) return existing;
+
+  // Insert with dummy keys (not real cryptographic material — test-only placeholders)
+  const keyId = `e2e-key-${Date.now()}`;
+  const dummyPub = `e2e-test-pub-${randomBytes(16).toString("hex")}`;
+  const dummyPriv = `e2e-test-priv-${randomBytes(16).toString("hex")}`;
+  const [row] = await db
+    .insert(federationConfig)
+    .values({
+      publicKey: dummyPub,
+      privateKey: dummyPriv,
+      keyId,
+      mode: "allowlist",
+      contactEmail: "admin@test-instance.example",
+      capabilities: ["identity"],
+      enabled: true,
+    })
+    .returning({ id: federationConfig.id });
+
+  return row;
+}
+
+// ---------------------------------------------------------------------------
+// Trusted Peers
+// ---------------------------------------------------------------------------
+
+export async function createTrustedPeer(data: {
+  orgId: string;
+  domain: string;
+  status:
+    | "pending_outbound"
+    | "pending_inbound"
+    | "active"
+    | "rejected"
+    | "revoked";
+  capabilities?: Record<string, boolean>;
+  initiatedBy?: "local" | "remote";
+}): Promise<{ id: string; domain: string }> {
+  const db = getDb();
+  const [row] = await db
+    .insert(trustedPeers)
+    .values({
+      organizationId: data.orgId,
+      domain: data.domain,
+      instanceUrl: `https://${data.domain}`,
+      publicKey: `e2e-peer-pubkey-${randomBytes(8).toString("hex")}`,
+      keyId: `peer-key-${Date.now()}`,
+      grantedCapabilities: data.capabilities ?? {
+        "identity.verify": true,
+        "simsub.check": true,
+      },
+      status: data.status,
+      initiatedBy: data.initiatedBy ?? "local",
+      protocolVersion: "1.0",
+    })
+    .returning({
+      id: trustedPeers.id,
+      domain: trustedPeers.domain,
+    });
+  return row;
+}
+
+export async function deleteTrustedPeer(id: string): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(trustedPeers)
+    .where(eq(trustedPeers.id, id))
+    .catch(() => {});
+}
+
+// ---------------------------------------------------------------------------
+// Sim-Sub Checks
+// ---------------------------------------------------------------------------
+
+export async function createSimSubCheck(data: {
+  submissionId: string;
+  fingerprint?: string;
+  result: "CLEAR" | "CONFLICT" | "PARTIAL" | "SKIPPED";
+  submitterDid?: string;
+  localConflicts?: Array<{
+    publicationName: string;
+    submittedAt: string;
+  }>;
+}): Promise<{ id: string }> {
+  const db = getDb();
+  const [row] = await db
+    .insert(simSubChecks)
+    .values({
+      submissionId: data.submissionId,
+      fingerprint:
+        data.fingerprint ?? randomBytes(32).toString("hex").slice(0, 64),
+      submitterDid: data.submitterDid ?? `did:colophony:test-writer-001`,
+      result: data.result,
+      localConflicts: data.localConflicts ?? [],
+      remoteResults: [],
+    })
+    .returning({ id: simSubChecks.id });
+  return row;
+}
+
+export async function deleteSimSubCheck(id: string): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(simSubChecks)
+    .where(eq(simSubChecks.id, id))
+    .catch(() => {});
+}
+
+// ---------------------------------------------------------------------------
+// Piece Transfers
+// ---------------------------------------------------------------------------
+
+export async function createPieceTransfer(data: {
+  submissionId: string;
+  manuscriptVersionId: string;
+  userId: string;
+  targetDomain: string;
+  status?:
+    | "PENDING"
+    | "FILES_REQUESTED"
+    | "COMPLETED"
+    | "REJECTED"
+    | "FAILED"
+    | "CANCELLED"
+    | "EXPIRED";
+}): Promise<{ id: string }> {
+  const db = getDb();
+  const [row] = await db
+    .insert(pieceTransfers)
+    .values({
+      submissionId: data.submissionId,
+      manuscriptVersionId: data.manuscriptVersionId,
+      initiatedByUserId: data.userId,
+      targetDomain: data.targetDomain,
+      status: data.status ?? "PENDING",
+      transferToken: randomBytes(32).toString("hex"),
+      tokenExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      fileManifest: [
+        {
+          fileId: "test-file-001",
+          filename: "manuscript.docx",
+          mimeType:
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          size: 45000,
+        },
+      ],
+      contentFingerprint: randomBytes(32).toString("hex").slice(0, 64),
+      submitterDid: "did:colophony:test-writer-001",
+    })
+    .returning({ id: pieceTransfers.id });
+  return row;
+}
+
+export async function deletePieceTransfer(id: string): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(pieceTransfers)
+    .where(eq(pieceTransfers.id, id))
+    .catch(() => {});
+}
+
+// ---------------------------------------------------------------------------
+// Identity Migrations
+// ---------------------------------------------------------------------------
+
+export async function createIdentityMigration(data: {
+  userId: string;
+  orgId?: string;
+  direction: "inbound" | "outbound";
+  peerDomain: string;
+  status?:
+    | "PENDING"
+    | "PENDING_APPROVAL"
+    | "APPROVED"
+    | "BUNDLE_SENT"
+    | "PROCESSING"
+    | "COMPLETED"
+    | "REJECTED"
+    | "FAILED"
+    | "EXPIRED"
+    | "CANCELLED";
+}): Promise<{ id: string }> {
+  const db = getDb();
+  const [row] = await db
+    .insert(identityMigrations)
+    .values({
+      userId: data.userId,
+      organizationId: data.orgId ?? null,
+      direction: data.direction,
+      peerDomain: data.peerDomain,
+      peerInstanceUrl: `https://${data.peerDomain}`,
+      userDid: "did:colophony:test-writer-001",
+      peerUserDid: "did:colophony:remote-writer-001",
+      status: data.status ?? "PENDING",
+      migrationToken: randomBytes(32).toString("hex"),
+      tokenExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    })
+    .returning({ id: identityMigrations.id });
+  return row;
+}
+
+export async function deleteIdentityMigration(id: string): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(identityMigrations)
+    .where(eq(identityMigrations.id, id))
+    .catch(() => {});
+}

--- a/apps/web/e2e/federation/fixtures.ts
+++ b/apps/web/e2e/federation/fixtures.ts
@@ -1,0 +1,261 @@
+/**
+ * Federation-specific Playwright test fixtures.
+ *
+ * Uses the ADMIN user (editor@quarterlyreview.org) — federation endpoints
+ * require adminProcedure. Audit router requires audit:read scope.
+ *
+ * Co-located in e2e/federation/ (not e2e/helpers/) to avoid triggering
+ * all Playwright suites via detect-changes.sh shared prefix matching.
+ */
+
+import { test as base, expect, type Page, devices } from "@playwright/test";
+import { buildStorageState, setupPageAuth } from "../helpers/auth";
+import {
+  getOrgBySlug,
+  getUserByEmail,
+  createApiKey,
+  deleteApiKey,
+  createSubmission,
+  deleteSubmission,
+  createManuscript,
+  createManuscriptVersion,
+  deleteManuscript,
+  getOpenSubmissionPeriod,
+} from "../helpers/db";
+import {
+  ensureFederationConfig,
+  createTrustedPeer,
+  deleteTrustedPeer,
+  createSimSubCheck,
+  deleteSimSubCheck,
+  createPieceTransfer,
+  deletePieceTransfer,
+  createIdentityMigration,
+  deleteIdentityMigration,
+} from "./federation-db";
+
+/** Admin user profile (ADMIN role in quarterly-review org) */
+const ADMIN_USER_PROFILE = {
+  sub: "seed-zitadel-admin-001",
+  email: "editor@quarterlyreview.org",
+  name: "Test Admin",
+};
+
+/** All scopes needed for Federation E2E tests */
+const FEDERATION_SCOPES = [
+  "audit:read",
+  "submissions:read",
+  "organizations:read",
+];
+
+interface SeedOrg {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+interface SeedUser {
+  id: string;
+  email: string;
+}
+
+interface TestApiKey {
+  id: string;
+  plainKey: string;
+}
+
+interface FederationData {
+  configId: string;
+  activePeerId: string;
+  activePeerDomain: string;
+  pendingPeerId: string;
+  pendingPeerDomain: string;
+  revokedPeerId: string;
+  revokedPeerDomain: string;
+  submissionId: string;
+  manuscriptId: string;
+  manuscriptVersionId: string;
+  clearCheckId: string;
+  conflictCheckId: string;
+  transferId: string;
+  migrationId: string;
+}
+
+export const test = base.extend<{
+  seedOrg: SeedOrg;
+  seedAdmin: SeedUser;
+  testApiKey: TestApiKey;
+  authedPage: Page;
+  federationData: FederationData;
+}>({
+  seedOrg: async ({}, use) => {
+    const org = await getOrgBySlug("quarterly-review");
+    if (!org) {
+      throw new Error(
+        'Seed org "quarterly-review" not found. Run `pnpm db:seed` first.',
+      );
+    }
+    await use(org);
+  },
+
+  seedAdmin: async ({}, use) => {
+    const user = await getUserByEmail("editor@quarterlyreview.org");
+    if (!user) {
+      throw new Error(
+        'Seed admin "editor@quarterlyreview.org" not found. Run `pnpm db:seed` first.',
+      );
+    }
+    await use(user);
+  },
+
+  testApiKey: async ({ seedOrg, seedAdmin }, use) => {
+    const key = await createApiKey({
+      orgId: seedOrg.id,
+      userId: seedAdmin.id,
+      scopes: FEDERATION_SCOPES,
+      name: `e2e-federation-${Date.now()}`,
+    });
+
+    await use(key);
+
+    await deleteApiKey(key.id);
+  },
+
+  authedPage: async ({ browser, seedOrg, testApiKey, baseURL }, use) => {
+    const context = await browser.newContext({
+      ...devices["Desktop Chrome"],
+      baseURL: baseURL ?? undefined,
+      storageState: buildStorageState(seedOrg.id, ADMIN_USER_PROFILE),
+    });
+
+    const page = await context.newPage();
+
+    await setupPageAuth(
+      page,
+      seedOrg.id,
+      testApiKey.plainKey,
+      ADMIN_USER_PROFILE,
+    );
+
+    await use(page);
+
+    await context.close();
+  },
+
+  federationData: async ({ seedOrg, seedAdmin }, use) => {
+    // Ensure federation config exists
+    const config = await ensureFederationConfig();
+
+    // Create trusted peers (3 statuses)
+    const activePeer = await createTrustedPeer({
+      orgId: seedOrg.id,
+      domain: "active-peer.example.com",
+      status: "active",
+      capabilities: {
+        "identity.verify": true,
+        "simsub.check": true,
+        "transfer.initiate": true,
+      },
+    });
+
+    const pendingPeer = await createTrustedPeer({
+      orgId: seedOrg.id,
+      domain: "pending-peer.example.com",
+      status: "pending_inbound",
+      capabilities: {},
+      initiatedBy: "remote",
+    });
+
+    const revokedPeer = await createTrustedPeer({
+      orgId: seedOrg.id,
+      domain: "revoked-peer.example.com",
+      status: "revoked",
+      capabilities: { "identity.verify": true },
+    });
+
+    // Create a submission + manuscript version for transfers/sim-sub
+    const manuscript = await createManuscript({
+      ownerId: seedAdmin.id,
+      title: "Federation Test Manuscript",
+    });
+    const manuscriptVersion = await createManuscriptVersion({
+      manuscriptId: manuscript.id,
+      versionNumber: 1,
+      label: "v1",
+    });
+
+    const period = await getOpenSubmissionPeriod(seedOrg.id);
+    const submission = await createSubmission({
+      orgId: seedOrg.id,
+      submitterId: seedAdmin.id,
+      submissionPeriodId: period?.id,
+      manuscriptVersionId: manuscriptVersion.id,
+      title: "Federation Test Submission",
+      status: "SUBMITTED",
+    });
+
+    // Create sim-sub checks
+    const clearCheck = await createSimSubCheck({
+      submissionId: submission.id,
+      result: "CLEAR",
+    });
+    const conflictCheck = await createSimSubCheck({
+      submissionId: submission.id,
+      result: "CONFLICT",
+      localConflicts: [
+        {
+          publicationName: "Other Magazine",
+          submittedAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    // Create piece transfer
+    const transfer = await createPieceTransfer({
+      submissionId: submission.id,
+      manuscriptVersionId: manuscriptVersion.id,
+      userId: seedAdmin.id,
+      targetDomain: "target-instance.example.com",
+      status: "PENDING",
+    });
+
+    // Create identity migration
+    const migration = await createIdentityMigration({
+      userId: seedAdmin.id,
+      orgId: seedOrg.id,
+      direction: "outbound",
+      peerDomain: "migration-peer.example.com",
+      status: "PENDING",
+    });
+
+    await use({
+      configId: config.id,
+      activePeerId: activePeer.id,
+      activePeerDomain: activePeer.domain,
+      pendingPeerId: pendingPeer.id,
+      pendingPeerDomain: pendingPeer.domain,
+      revokedPeerId: revokedPeer.id,
+      revokedPeerDomain: revokedPeer.domain,
+      submissionId: submission.id,
+      manuscriptId: manuscript.id,
+      manuscriptVersionId: manuscriptVersion.id,
+      clearCheckId: clearCheck.id,
+      conflictCheckId: conflictCheck.id,
+      transferId: transfer.id,
+      migrationId: migration.id,
+    });
+
+    // Cleanup in reverse order (FK dependencies)
+    await deleteIdentityMigration(migration.id);
+    await deletePieceTransfer(transfer.id);
+    await deleteSimSubCheck(conflictCheck.id);
+    await deleteSimSubCheck(clearCheck.id);
+    await deleteSubmission(submission.id);
+    await deleteManuscript(manuscript.id);
+    await deleteTrustedPeer(activePeer.id);
+    await deleteTrustedPeer(pendingPeer.id);
+    await deleteTrustedPeer(revokedPeer.id);
+  },
+});
+
+export { expect };

--- a/apps/web/e2e/federation/fixtures.ts
+++ b/apps/web/e2e/federation/fixtures.ts
@@ -46,6 +46,7 @@ const FEDERATION_SCOPES = [
   "audit:read",
   "submissions:read",
   "organizations:read",
+  "users:read",
 ];
 
 interface SeedOrg {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "test:e2e:forms": "playwright test --project forms",
     "test:e2e:organization": "playwright test --project organization",
     "test:e2e:analytics": "playwright test --project analytics",
+    "test:e2e:federation": "playwright test --project federation",
     "test:e2e:all": "OIDC_E2E=true playwright test",
     "test:e2e:ui": "playwright test --ui",
     "e2e:setup-oidc": "tsx ../../scripts/setup-zitadel-e2e.ts",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -119,6 +119,11 @@ export default defineConfig({
       testDir: "./e2e/analytics",
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "federation",
+      testDir: "./e2e/federation",
+      use: { ...devices["Desktop Chrome"] },
+    },
   ],
 
   webServer: [

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -294,7 +294,7 @@
 - [x] [P1] Form builder E2E — create form, add fields, configure, submit through it (~16 Playwright tests) — (test coverage plan 2026-03-02; done 2026-03-03)
 - [x] [P1] Organization & settings E2E — org management, member management (~14 Playwright tests) — (test coverage plan 2026-03-02; done 2026-03-03)
 - [x] [P1] Submission analytics E2E — dashboard, charts, date range filter (~6 Playwright tests) — (test coverage plan 2026-03-02; done 2026-03-03)
-- [ ] [P2] Federation admin E2E — peer management, sim-sub, transfers, audit log (~16 Playwright tests) — (test coverage plan 2026-03-02)
+- [x] [P2] Federation admin E2E — peer management, sim-sub, transfers, audit log (~16 Playwright tests) — (test coverage plan 2026-03-02; done 2026-03-03)
 - [ ] [P2] Federation S2S integration tests — two-instance HTTP signatures, trust handshake (~15 tests) — (test coverage plan 2026-03-02)
 - [ ] [P2] Notification prefs + writer analytics E2E (~9 tests) — (test coverage plan 2026-03-02)
 - [ ] CI: Add service-integration-tests, security-tests, and new Playwright jobs — (test coverage plan 2026-03-02)

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,33 @@ Newest entries first.
 
 ---
 
+## 2026-03-03 — Federation Admin E2E Tests (P2 Test Coverage)
+
+### Done
+
+- **16 Playwright E2E tests** for all federation admin pages:
+  - **Federation Overview** (2): navigation cards, instance config details (status, mode, capabilities, public key)
+  - **Peer Management** (4): tab filtering (All/Active/Pending/Revoked), peer detail page, revoke active peer action, accept pending inbound peer with capability checkboxes
+  - **Sim-Sub Admin** (2): lookup form rendering, check history with CLEAR/CONFLICT result badges and local conflict details
+  - **Transfer Management** (2): transfer list with tab filtering, transfer detail page with cancel action
+  - **Migration Management** (2): migration list with direction filter and status tabs, migration detail with action buttons
+  - **Audit Log** (3): filter panel rendering, resource type filtering, event detail modal
+  - **Hub Admin** (1): hub mode not enabled fallback message
+- **Co-located DB helpers** (`e2e/federation/federation-db.ts`): `ensureFederationConfig`, `createTrustedPeer`, `createSimSubCheck`, `createPieceTransfer`, `createIdentityMigration` + cleanup functions
+- **Custom fixtures** (`e2e/federation/fixtures.ts`): ADMIN user with `audit:read`, `submissions:read`, `organizations:read` scopes; `federationData` fixture seeds 3 peers, 2 sim-sub checks, 1 transfer, 1 migration with full teardown
+- **CI infrastructure**: `playwright-federation` job in ci.yml, `federation_prefixes` in detect-changes.sh, `test:e2e:federation` script
+- Checked off P2 federation admin E2E backlog item
+
+### Decisions
+
+- Seed data directly in DB via admin pool — no live remote instance needed for E2E
+- Hub test verifies "not enabled" message — default mode is `allowlist`, changing to `managed_hub` mid-suite would risk interference
+- Used ADMIN user (`editor@quarterlyreview.org`) — federation tRPC routers use `adminProcedure`
+- Dummy keys use plain strings (not PEM format) to avoid pre-commit secret scanner false positives
+- Co-located helpers in `e2e/federation/` (not `e2e/helpers/`) per established pattern to avoid triggering all suites
+
+---
+
 ## 2026-03-03 — Submission Analytics E2E Tests (P1 Test Coverage)
 
 ### Done

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -59,6 +59,9 @@ pnpm --filter @colophony/web test:e2e:organization
 # Playwright — Submission Analytics (6 tests, requires dev servers)
 pnpm --filter @colophony/web test:e2e:analytics
 
+# Playwright — Federation Admin (16 tests, requires dev servers)
+pnpm --filter @colophony/web test:e2e:federation
+
 # Playwright — all projects
 pnpm --filter @colophony/web test:e2e:all
 
@@ -132,6 +135,7 @@ pnpm --filter @colophony/web test:e2e:ui
 - `slate/contracts.spec.ts` — 5 tests (heading, list, templates, create template, template detail)
 - `slate/cms-connections.spec.ts` — 4 tests (heading, list, filter, create)
 - `analytics/submission-analytics.spec.ts` — 6 tests (overview cards, filters, status/funnel charts, time series, response time/aging, date filter update)
+- `federation/federation-admin.spec.ts` — 16 tests (overview, peer management, sim-sub, transfers, migrations, audit log, hub admin)
 
 ---
 


### PR DESCRIPTION
## Summary
- Add 16 Playwright E2E tests covering all federation admin UI pages: overview, peer management, sim-sub, transfers, migrations, audit log, and hub admin
- Seed federation data directly in DB via co-located helpers (no live remote instance needed)
- Add CI job `playwright-federation` with path-based selective execution

## Test Coverage (16 tests across 7 describe blocks)
- **Federation Overview** (2): navigation cards, instance configuration details
- **Peer Management** (4): list with tab filtering, peer detail, revoke peer, accept pending peer
- **Sim-Sub Admin** (2): lookup form, check history with CLEAR/CONFLICT results
- **Transfer Management** (2): transfer list with tabs, transfer detail + cancel
- **Migration Management** (2): migration list with direction filter, migration detail with actions
- **Audit Log** (3): filter panel, filter by resource, event detail modal
- **Hub Admin** (1): hub mode not enabled message

## Files Created
- `apps/web/e2e/federation/federation-db.ts` — DB helpers for seeding federation test data
- `apps/web/e2e/federation/fixtures.ts` — Playwright fixtures (ADMIN user, federation data seeding)
- `apps/web/e2e/federation/federation-admin.spec.ts` — 16 E2E tests

## Files Modified
- `apps/web/playwright.config.ts` — added federation project entry
- `apps/web/package.json` — added `test:e2e:federation` script
- `.github/scripts/detect-changes.sh` — added `run_federation` flag + federation prefixes
- `.github/workflows/ci.yml` — added `playwright-federation` job
- `CLAUDE.md` — added `playwright-federation` to CI table
- `docs/testing.md` — added federation suite command + test count
- `docs/backlog.md` — checked off federation admin E2E item

## Design Decisions
- **DB seeding approach**: No live remote instance needed — seed data directly via admin pool
- **Co-located helpers**: `federation-db.ts` in `e2e/federation/` (not `e2e/helpers/`) to avoid triggering all CI suites
- **Plain string dummy keys**: Avoids secret scanner false positives (no PEM format)
- **Hub test**: Verifies "not enabled" message (default mode is allowlist)

## Test plan
- [ ] Run `pnpm --filter @colophony/web test:e2e:federation` locally
- [ ] Verify `playwright-federation` CI job passes
- [ ] Verify path filtering: federation-only changes trigger only federation job