### PR TITLE
fix(security): defense-in-depth hardening — 7 Codex review findings

### DIFF
--- a/apps/api/src/services/migration.service.spec.ts
+++ b/apps/api/src/services/migration.service.spec.ts
@@ -42,6 +42,7 @@ vi.mock('@colophony/db', () => ({
   submissions: {
     id: 'submissions.id',
     organizationId: 'submissions.organizationId',
+    submitterId: 'submissions.submitterId',
     title: 'submissions.title',
     coverLetter: 'submissions.coverLetter',
     content: 'submissions.content',
@@ -83,6 +84,7 @@ vi.mock('@colophony/db', () => ({
 
 vi.mock('drizzle-orm', () => ({
   count: vi.fn(),
+  getTableColumns: vi.fn().mockReturnValue({}),
 }));
 
 const { mockSignJWT } = vi.hoisted(() => ({
@@ -701,6 +703,9 @@ describe('migrationService', () => {
         },
       });
 
+      // Submission ownership check
+      mockDb.limit.mockResolvedValueOnce([{ id: validUuid3 }]);
+
       const result = await migrationService.verifyMigrationToken(
         testEnv,
         'valid.jwt.token',
@@ -727,6 +732,38 @@ describe('migrationService', () => {
         migrationService.verifyMigrationToken(
           testEnv,
           'expired.jwt.token',
+          validUuid,
+          validUuid3,
+          'file-1',
+        ),
+      ).rejects.toThrow(MigrationTokenError);
+    });
+
+    it('rejects when submissionId does not belong to migration user', async () => {
+      // Migration lookup
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: validUuid,
+          userId: validUuid2,
+          status: 'BUNDLE_SENT',
+        },
+      ]);
+
+      // JWT verify — valid token with fileId in allowlist
+      (jose.jwtVerify as any).mockResolvedValueOnce({
+        payload: {
+          jti: validUuid,
+          fileIds: ['file-1', 'file-2'],
+        },
+      });
+
+      // Submission ownership check — no match
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      await expect(
+        migrationService.verifyMigrationToken(
+          testEnv,
+          'valid.jwt.token',
           validUuid,
           validUuid3,
           'file-1',

--- a/apps/api/src/services/migration.service.ts
+++ b/apps/api/src/services/migration.service.ts
@@ -955,7 +955,7 @@ export const migrationService = {
     env: Env,
     token: string,
     migrationId: string,
-    _submissionId: string,
+    submissionId: string,
     fileId: string,
   ): Promise<{ userId: string }> {
     // Look up migration
@@ -1007,6 +1007,24 @@ export const migrationService = {
       | undefined;
     if (!allowedFileIds || !allowedFileIds.includes(fileId)) {
       throw new MigrationTokenError('File ID not in migration allowlist');
+    }
+
+    // Defense-in-depth: verify submissionId belongs to migration user
+    const [sub] = await db
+      .select({ id: submissions.id })
+      .from(submissions)
+      .where(
+        and(
+          eq(submissions.id, submissionId),
+          eq(submissions.submitterId, migration.userId),
+        ),
+      )
+      .limit(1);
+
+    if (!sub) {
+      throw new MigrationTokenError(
+        'Submission does not belong to migration user',
+      );
     }
 
     return { userId: migration.userId };
@@ -1126,7 +1144,8 @@ export const migrationService = {
             eq(identityMigrations.status, 'PENDING_APPROVAL'),
             eq(identityMigrations.direction, 'outbound'),
           ),
-        );
+        )
+        .limit(100);
       return rows as IdentityMigration[];
     });
   },

--- a/apps/api/src/services/migration.service.ts
+++ b/apps/api/src/services/migration.service.ts
@@ -1145,6 +1145,7 @@ export const migrationService = {
             eq(identityMigrations.direction, 'outbound'),
           ),
         )
+        .orderBy(sql`${identityMigrations.createdAt} DESC`)
         .limit(100);
       return rows as IdentityMigration[];
     });

--- a/apps/api/src/services/notification-preference.service.ts
+++ b/apps/api/src/services/notification-preference.service.ts
@@ -68,11 +68,17 @@ export const notificationPreferenceService = {
     return pref?.enabled ?? true;
   },
 
-  async listForUser(tx: DrizzleDb, userId: string) {
+  async listForUser(tx: DrizzleDb, orgId: string, userId: string) {
     return tx
       .select()
       .from(notificationPreferences)
-      .where(eq(notificationPreferences.userId, userId));
+      .where(
+        and(
+          eq(notificationPreferences.organizationId, orgId),
+          eq(notificationPreferences.userId, userId),
+        ),
+      )
+      .limit(200);
   },
 
   async upsert(tx: DrizzleDb, params: UpsertParams) {

--- a/apps/api/src/services/simsub.service.ts
+++ b/apps/api/src/services/simsub.service.ts
@@ -397,8 +397,8 @@ export const simsubService = {
 
     // Query active trusted peers with simsub.respond capability.
     const peerFilter = hubResponded
-      ? sql`status = 'active' AND granted_capabilities @> '{"simsub.respond": true}'::jsonb AND hub_attested = false`
-      : sql`status = 'active' AND granted_capabilities @> '{"simsub.respond": true}'::jsonb`;
+      ? sql`status = 'active' AND granted_capabilities @> '{"simsub.respond": true}'::jsonb AND hub_attested = false AND organization_id = current_org_id()`
+      : sql`status = 'active' AND granted_capabilities @> '{"simsub.respond": true}'::jsonb AND organization_id = current_org_id()`;
 
     const peers = await withRls({ orgId }, async (tx) => {
       return tx

--- a/apps/api/src/services/transfer.service.spec.ts
+++ b/apps/api/src/services/transfer.service.spec.ts
@@ -18,6 +18,7 @@ const { mockWithRls, mockDb } = vi.hoisted(() => {
     returning: vi.fn().mockReturnThis(),
     orderBy: vi.fn().mockReturnThis(),
     offset: vi.fn().mockReturnThis(),
+    innerJoin: vi.fn().mockReturnThis(),
   };
   return { mockWithRls, mockDb };
 });
@@ -80,6 +81,7 @@ vi.mock('@colophony/db', () => ({
 
 vi.mock('drizzle-orm', () => ({
   count: vi.fn(),
+  getTableColumns: vi.fn().mockReturnValue({}),
 }));
 
 const { mockSignJWT } = vi.hoisted(() => ({
@@ -741,6 +743,7 @@ describe('transferService', () => {
           select: vi.fn().mockReturnThis(),
           from: vi.fn().mockReturnThis(),
           where: vi.fn().mockReturnThis(),
+          innerJoin: vi.fn().mockReturnThis(),
           limit: vi.fn().mockResolvedValue([{ status: 'PENDING' }]),
           update: vi.fn().mockReturnThis(),
           set: vi.fn().mockReturnThis(),
@@ -763,6 +766,7 @@ describe('transferService', () => {
           select: vi.fn().mockReturnThis(),
           from: vi.fn().mockReturnThis(),
           where: vi.fn().mockReturnThis(),
+          innerJoin: vi.fn().mockReturnThis(),
           limit: vi.fn().mockResolvedValue([{ status: 'COMPLETED' }]),
         };
         return fn(mockTx);

--- a/apps/api/src/services/transfer.service.ts
+++ b/apps/api/src/services/transfer.service.ts
@@ -15,7 +15,7 @@ import {
   and,
   sql,
 } from '@colophony/db';
-import { count } from 'drizzle-orm';
+import { count, getTableColumns } from 'drizzle-orm';
 import {
   AuditActions,
   AuditResources,
@@ -339,13 +339,22 @@ export const transferService = {
   async getTransfersBySubmission(
     orgId: string,
     submissionId: string,
+    params?: { limit?: number },
   ): Promise<PieceTransfer[]> {
+    const queryLimit = params?.limit ?? 100;
     return withRls({ orgId }, async (tx) => {
       return tx
-        .select()
+        .select(getTableColumns(pieceTransfers))
         .from(pieceTransfers)
-        .where(eq(pieceTransfers.submissionId, submissionId))
-        .orderBy(sql`created_at DESC`);
+        .innerJoin(submissions, eq(pieceTransfers.submissionId, submissions.id))
+        .where(
+          and(
+            eq(pieceTransfers.submissionId, submissionId),
+            eq(submissions.organizationId, orgId),
+          ),
+        )
+        .orderBy(sql`${pieceTransfers.createdAt} DESC`)
+        .limit(queryLimit);
     });
   },
 
@@ -356,9 +365,15 @@ export const transferService = {
   ): Promise<PieceTransfer> {
     const [row] = await withRls({ orgId }, async (tx) => {
       return tx
-        .select()
+        .select(getTableColumns(pieceTransfers))
         .from(pieceTransfers)
-        .where(eq(pieceTransfers.id, transferId))
+        .innerJoin(submissions, eq(pieceTransfers.submissionId, submissions.id))
+        .where(
+          and(
+            eq(pieceTransfers.id, transferId),
+            eq(submissions.organizationId, orgId),
+          ),
+        )
         .limit(1);
     });
 
@@ -379,7 +394,13 @@ export const transferService = {
       const [existing] = await tx
         .select({ status: pieceTransfers.status })
         .from(pieceTransfers)
-        .where(eq(pieceTransfers.id, transferId))
+        .innerJoin(submissions, eq(pieceTransfers.submissionId, submissions.id))
+        .where(
+          and(
+            eq(pieceTransfers.id, transferId),
+            eq(submissions.organizationId, orgId),
+          ),
+        )
         .limit(1);
 
       if (!existing) {
@@ -422,12 +443,16 @@ export const transferService = {
     return withRls({ orgId }, async (tx) => {
       const [totalRow] = await tx
         .select({ count: count() })
-        .from(pieceTransfers);
+        .from(pieceTransfers)
+        .innerJoin(submissions, eq(pieceTransfers.submissionId, submissions.id))
+        .where(eq(submissions.organizationId, orgId));
 
       const rows = await tx
-        .select()
+        .select(getTableColumns(pieceTransfers))
         .from(pieceTransfers)
-        .orderBy(sql`created_at DESC`)
+        .innerJoin(submissions, eq(pieceTransfers.submissionId, submissions.id))
+        .where(eq(submissions.organizationId, orgId))
+        .orderBy(sql`${pieceTransfers.createdAt} DESC`)
         .limit(limit)
         .offset(offset);
 

--- a/apps/api/src/trpc/routers/notification-preferences.ts
+++ b/apps/api/src/trpc/routers/notification-preferences.ts
@@ -15,6 +15,7 @@ export const notificationPreferencesRouter = createRouter({
     .query(async ({ ctx }) => {
       return notificationPreferenceService.listForUser(
         ctx.dbTx,
+        ctx.authContext.orgId,
         ctx.authContext.userId,
       );
     }),

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -276,13 +276,13 @@
 
 ### Defense-in-Depth (Codex Review Findings 2026-03-03)
 
-- [ ] [Critical] `submission_discussions` missing `FORCE ROW LEVEL SECURITY` — `packages/db/migrations/0041_submission_discussions.sql` enables RLS but does not force it — (Codex review 2026-03-03)
-- [ ] [P2] Defense-in-depth: transfer service org-scoped methods missing explicit `organizationId` predicate — `apps/api/src/services/transfer.service.ts:347,361,382,423` — (Codex review 2026-03-03)
-- [ ] [P2] Unbounded query: transfer listing by submission has no pagination/limit — `apps/api/src/services/transfer.service.ts:339` — (Codex review 2026-03-03)
-- [ ] [P2] Migration token verification unused `_submissionId` parameter (missing binding check) — `apps/api/src/services/migration.service.ts:958` — (Codex review 2026-03-03)
-- [ ] [P2] Unbounded query: migration pending approvals — `apps/api/src/services/migration.service.ts:1119` — (Codex review 2026-03-03)
-- [ ] [P2] Defense-in-depth: sim-sub peer query lacks explicit `organizationId` filter — `apps/api/src/services/simsub.service.ts:403` — (Codex review 2026-03-03)
-- [ ] [P3] Notification preferences list has no `LIMIT` — `apps/api/src/services/notification-preference.service.ts:71` — (Codex review 2026-03-03)
+- [x] [Critical] `submission_discussions` missing `FORCE ROW LEVEL SECURITY` — `packages/db/migrations/0041_submission_discussions.sql` enables RLS but does not force it — (Codex review 2026-03-03; done 2026-03-03 migration 0050)
+- [x] [P2] Defense-in-depth: transfer service org-scoped methods missing explicit `organizationId` predicate — `apps/api/src/services/transfer.service.ts:347,361,382,423` — (Codex review 2026-03-03; done 2026-03-03)
+- [x] [P2] Unbounded query: transfer listing by submission has no pagination/limit — `apps/api/src/services/transfer.service.ts:339` — (Codex review 2026-03-03; done 2026-03-03)
+- [x] [P2] Migration token verification unused `_submissionId` parameter (missing binding check) — `apps/api/src/services/migration.service.ts:958` — (Codex review 2026-03-03; done 2026-03-03)
+- [x] [P2] Unbounded query: migration pending approvals — `apps/api/src/services/migration.service.ts:1119` — (Codex review 2026-03-03; done 2026-03-03)
+- [x] [P2] Defense-in-depth: sim-sub peer query lacks explicit `organizationId` filter — `apps/api/src/services/simsub.service.ts:403` — (Codex review 2026-03-03; done 2026-03-03)
+- [x] [P3] Notification preferences list has no `LIMIT` — `apps/api/src/services/notification-preference.service.ts:71` — (Codex review 2026-03-03; done 2026-03-03)
 
 ### Dev Workflow
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,27 @@ Newest entries first.
 
 ---
 
+## 2026-03-03 — Defense-in-Depth Hardening (Codex Review Findings)
+
+### Done
+
+- **1 Critical RLS fix:** migration 0050 adds `FORCE ROW LEVEL SECURITY` on `submission_discussions` (0041 had ENABLE but not FORCE)
+- **5 P2 defense-in-depth fixes:**
+  - Transfer service: added `innerJoin` to submissions with explicit `organizationId` predicate on `getTransfersBySubmission`, `getTransferById`, `cancelTransfer`, `listTransfersForOrg`; added default `limit(100)` on `getTransfersBySubmission`
+  - Migration service: renamed `_submissionId` → `submissionId` in `verifyMigrationToken`, added submission ownership check; added `limit(100)` on `getPendingApprovalForUser`
+  - Simsub service: added `organization_id = current_org_id()` to trusted peer query filter
+  - Notification preferences: added `orgId` parameter and filter + `limit(200)` on `listForUser`; updated tRPC router caller
+- **1 P3 fix:** notification preferences unbounded query (covered above)
+- **1 new test:** "rejects when submissionId does not belong to migration user" in migration.service.spec
+- All 36 affected tests passing, type-check clean, lint clean
+
+### Decisions
+
+- Used `getTableColumns(pieceTransfers)` for select columns after innerJoin to avoid column name ambiguity
+- Migration submissionId ownership check uses `db` (superuser) intentionally — pre-auth token validation context (same pattern as existing code)
+
+---
+
 ## 2026-03-03 — Federation S2S Integration + E2E + CI Jobs (P2 Test Gaps)
 
 ### Done

--- a/packages/db/migrations/0050_force_rls_submission_discussions.sql
+++ b/packages/db/migrations/0050_force_rls_submission_discussions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "submission_discussions" FORCE ROW LEVEL SECURITY;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1779000000000,
       "tag": "0049_simsub_policy_model",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1779200000000,
+      "tag": "0050_force_rls_submission_discussions",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **1 Critical:** FORCE ROW LEVEL SECURITY on `submission_discussions` (migration 0050)
- **5 P2 defense-in-depth:** explicit org predicates + query limits on transfer, migration, simsub, and notification preference services
- **1 P3:** notification preferences unbounded query + missing org filter

All findings from Codex code review (2026-03-03). Pre-launch hardening — no new features, no API surface changes.

## Changes

| Fix | Severity | File | Description |
|-----|----------|------|-------------|
| 1 | Critical | `packages/db/migrations/0050_*` | `FORCE ROW LEVEL SECURITY` on `submission_discussions` |
| 2+3 | P2 | `transfer.service.ts` | `innerJoin` to submissions + org filter on 4 methods; `limit(100)` default |
| 4 | P2 | `migration.service.ts` | `submissionId` ownership check in `verifyMigrationToken` |
| 5 | P2 | `migration.service.ts` | `limit(100)` + `orderBy` on `getPendingApprovalForUser` |
| 6 | P2 | `simsub.service.ts` | `organization_id = current_org_id()` on peer query |
| 7 | P3 | `notification-preference.service.ts` + router | `orgId` filter + `limit(200)` on `listForUser` |

## Test plan

- [x] 36 unit tests passing (1 new: "rejects when submissionId does not belong to migration user")
- [x] Type check clean
- [x] Lint clean
- [ ] CI: full suite
- [ ] Verify FORCE RLS: `SELECT relname, relforcerowsecurity FROM pg_class WHERE relname = 'submission_discussions';`

## Code review

- Codex plan drift: 10/10 items MATCH
- branch review: 1 P2 finding (missing orderBy on limit) — addressed in follow-up commit