### PR TITLE
fix(web): stabilize flaky workspace analytics E2E test

### DIFF
--- a/apps/web/e2e/workspace/workspace-analytics-correspondence.spec.ts
+++ b/apps/web/e2e/workspace/workspace-analytics-correspondence.spec.ts
@@ -5,6 +5,7 @@ test.describe("Writer Analytics (/workspace/analytics)", () => {
     authedPage,
   }) => {
     await authedPage.goto("/workspace/analytics");
+    await authedPage.waitForLoadState("networkidle");
 
     const main = authedPage.locator("main");
     await expect(
@@ -13,7 +14,7 @@ test.describe("Writer Analytics (/workspace/analytics)", () => {
 
     // Overview stat labels
     await expect(main.getByText("Total Submissions")).toBeVisible({
-      timeout: 10_000,
+      timeout: 15_000,
     });
     await expect(main.getByText("Acceptance Rate")).toBeVisible();
     await expect(main.getByText("Avg Response Time")).toBeVisible();
@@ -21,6 +22,7 @@ test.describe("Writer Analytics (/workspace/analytics)", () => {
 
   test("shows date filter inputs", async ({ authedPage }) => {
     await authedPage.goto("/workspace/analytics");
+    await authedPage.waitForLoadState("networkidle");
 
     const main = authedPage.locator("main");
     await expect(main.getByLabel("From")).toBeVisible();
@@ -30,28 +32,31 @@ test.describe("Writer Analytics (/workspace/analytics)", () => {
 
   test("displays Status Breakdown chart", async ({ authedPage }) => {
     await authedPage.goto("/workspace/analytics");
+    await authedPage.waitForLoadState("networkidle");
 
     const main = authedPage.locator("main");
     await expect(main.getByText("Status Breakdown")).toBeVisible({
-      timeout: 10_000,
+      timeout: 15_000,
     });
   });
 
   test("displays Submissions Over Time chart", async ({ authedPage }) => {
     await authedPage.goto("/workspace/analytics");
+    await authedPage.waitForLoadState("networkidle");
 
     const main = authedPage.locator("main");
     await expect(main.getByText("Submissions Over Time")).toBeVisible({
-      timeout: 10_000,
+      timeout: 15_000,
     });
   });
 
   test("displays Response Time Distribution chart", async ({ authedPage }) => {
     await authedPage.goto("/workspace/analytics");
+    await authedPage.waitForLoadState("networkidle");
 
     const main = authedPage.locator("main");
     await expect(main.getByText("Response Time Distribution")).toBeVisible({
-      timeout: 10_000,
+      timeout: 15_000,
     });
   });
 });

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,20 @@ Newest entries first.
 
 ---
 
+## 2026-03-03 — Fix Flaky Workspace Analytics E2E
+
+### Done
+
+- Added `waitForLoadState('networkidle')` after each `goto('/workspace/analytics')` in Writer Analytics E2E tests (5 tests) — waits for all tRPC batch requests to resolve before asserting
+- Bumped assertion timeouts from 10s to 15s as CI safety margin for Next.js on-demand compilation of heavy recharts dependency tree
+
+### Decisions
+
+- `networkidle` wait strategy over fixed delays — more reliable for CI runner variability
+- Only Writer Analytics block changed; Correspondence block unaffected by the flakiness
+
+---
+
 ## 2026-03-03 — Defense-in-Depth Hardening (Codex Review Findings)
 
 ### Done


### PR DESCRIPTION
## Summary

- Added `waitForLoadState('networkidle')` after each `goto('/workspace/analytics')` in Writer Analytics E2E tests — waits for all tRPC batch requests to resolve before asserting
- Bumped assertion timeouts from 10s to 15s as safety margin for CI runner variability during Next.js on-demand compilation of heavy recharts dependency tree

## Root Cause

The first test pays the full Next.js dev-mode on-demand compilation cost for the analytics page (3 recharts chart components + overview cards). On CI runners, this + 4 batched tRPC queries can push total page load past 10s.

## Test plan

- [ ] CI `playwright-workspace` job passes without timeout on "Total Submissions" card
- [ ] Local `pnpm --filter @colophony/web test:e2e -- --project workspace` passes