### PR TITLE
fix: enforce READER role as read-only (Track 12)

### DIFF
--- a/apps/api/src/services/pipeline.service.spec.ts
+++ b/apps/api/src/services/pipeline.service.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { pipelineService } from './pipeline.service.js';
+import { ForbiddenError } from './errors.js';
+import type { ServiceContext } from './types.js';
+
+function makeCtx(role: string): ServiceContext {
+  return {
+    tx: {} as ServiceContext['tx'],
+    actor: {
+      userId: 'user-1',
+      orgId: 'org-1',
+      role: role as ServiceContext['actor']['role'],
+    },
+    audit: vi.fn(),
+  };
+}
+
+describe('pipeline.service', () => {
+  describe('addCommentWithAudit', () => {
+    it('rejects READER role', async () => {
+      const ctx = makeCtx('READER');
+      await expect(
+        pipelineService.addCommentWithAudit(ctx, 'item-1', {
+          content: 'test comment',
+        }),
+      ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('allows EDITOR role', async () => {
+      const ctx = makeCtx('EDITOR');
+      // Will fail with a different error (not ForbiddenError) because the
+      // mock tx has no query capabilities — but it should NOT throw ForbiddenError
+      await expect(
+        pipelineService.addCommentWithAudit(ctx, 'item-1', {
+          content: 'test comment',
+        }),
+      ).rejects.not.toThrow(ForbiddenError);
+    });
+
+    it('allows ADMIN role', async () => {
+      const ctx = makeCtx('ADMIN');
+      await expect(
+        pipelineService.addCommentWithAudit(ctx, 'item-1', {
+          content: 'test comment',
+        }),
+      ).rejects.not.toThrow(ForbiddenError);
+    });
+  });
+});

--- a/apps/api/src/services/pipeline.service.ts
+++ b/apps/api/src/services/pipeline.service.ts
@@ -494,6 +494,7 @@ export const pipelineService = {
     return comment;
   },
 
+  // TODO: Replace hard limit with proper pagination if usage grows beyond 1000 per item
   async listComments(tx: DrizzleDb, pipelineItemId: string) {
     return tx
       .select()
@@ -507,6 +508,7 @@ export const pipelineService = {
   // History
   // -------------------------------------------------------------------------
 
+  // TODO: Replace hard limit with proper pagination if usage grows beyond 1000 per item
   async getHistory(tx: DrizzleDb, pipelineItemId: string) {
     return tx
       .select()

--- a/apps/api/src/services/pipeline.service.ts
+++ b/apps/api/src/services/pipeline.service.ts
@@ -474,6 +474,7 @@ export const pipelineService = {
     pipelineItemId: string,
     input: AddPipelineCommentInput,
   ) {
+    assertEditorOrAdmin(ctx.actor.role);
     const item = await pipelineService.getById(ctx.tx, pipelineItemId);
     if (!item) throw new PipelineItemNotFoundError(pipelineItemId);
 
@@ -498,7 +499,8 @@ export const pipelineService = {
       .select()
       .from(pipelineComments)
       .where(eq(pipelineComments.pipelineItemId, pipelineItemId))
-      .orderBy(desc(pipelineComments.createdAt));
+      .orderBy(desc(pipelineComments.createdAt))
+      .limit(1000);
   },
 
   // -------------------------------------------------------------------------
@@ -510,6 +512,7 @@ export const pipelineService = {
       .select()
       .from(pipelineHistory)
       .where(eq(pipelineHistory.pipelineItemId, pipelineItemId))
-      .orderBy(desc(pipelineHistory.changedAt));
+      .orderBy(desc(pipelineHistory.changedAt))
+      .limit(1000);
   },
 };

--- a/apps/web/e2e/helpers/reader-fixtures.ts
+++ b/apps/web/e2e/helpers/reader-fixtures.ts
@@ -1,0 +1,105 @@
+/**
+ * Reader-specific Playwright test fixtures.
+ *
+ * Uses the WRITER user (writer@example.com) who has READER role in
+ * the quarterly-review org. Tests verify that READER-role users see
+ * restricted UI (no editor/admin navigation, read-only settings).
+ */
+
+import { test as base, expect, type Page, devices } from "@playwright/test";
+import { buildStorageState, setupPageAuth } from "./auth";
+import { getOrgBySlug, getUserByEmail, createApiKey, deleteApiKey } from "./db";
+
+/** Writer user profile (READER role in quarterly-review org) */
+const READER_USER_PROFILE = {
+  sub: "seed-zitadel-writer-001",
+  email: "writer@example.com",
+  name: "Test Reader",
+};
+
+/** Read-only scopes for READER E2E tests */
+const READER_E2E_SCOPES = [
+  "organizations:read",
+  "submissions:read",
+  "users:read",
+  "periods:read",
+];
+
+interface SeedOrg {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+interface SeedUser {
+  id: string;
+  email: string;
+}
+
+interface TestApiKey {
+  id: string;
+  plainKey: string;
+}
+
+export const test = base.extend<{
+  seedOrg: SeedOrg;
+  seedReader: SeedUser;
+  testApiKey: TestApiKey;
+  authedPage: Page;
+}>({
+  seedOrg: async ({}, use) => {
+    const org = await getOrgBySlug("quarterly-review");
+    if (!org) {
+      throw new Error(
+        'Seed org "quarterly-review" not found. Run `pnpm db:seed` first.',
+      );
+    }
+    await use(org);
+  },
+
+  seedReader: async ({}, use) => {
+    const user = await getUserByEmail("writer@example.com");
+    if (!user) {
+      throw new Error(
+        'Seed writer "writer@example.com" not found. Run `pnpm db:seed` first.',
+      );
+    }
+    await use(user);
+  },
+
+  testApiKey: async ({ seedOrg, seedReader }, use) => {
+    const key = await createApiKey({
+      orgId: seedOrg.id,
+      userId: seedReader.id,
+      scopes: READER_E2E_SCOPES,
+      name: `e2e-reader-${Date.now()}`,
+    });
+
+    await use(key);
+
+    await deleteApiKey(key.id);
+  },
+
+  authedPage: async ({ browser, seedOrg, testApiKey, baseURL }, use) => {
+    const context = await browser.newContext({
+      ...devices["Desktop Chrome"],
+      baseURL: baseURL ?? undefined,
+      storageState: buildStorageState(seedOrg.id, READER_USER_PROFILE),
+    });
+
+    const page = await context.newPage();
+
+    await setupPageAuth(
+      page,
+      seedOrg.id,
+      testApiKey.plainKey,
+      READER_USER_PROFILE,
+    );
+
+    await use(page);
+
+    await context.close();
+  },
+});
+
+export { expect };

--- a/apps/web/e2e/organization/reader-role.spec.ts
+++ b/apps/web/e2e/organization/reader-role.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "../helpers/reader-fixtures";
+
+test.describe("READER role restrictions", () => {
+  test("does not see editor sidebar navigation", async ({ authedPage }) => {
+    await authedPage.goto("/submissions");
+
+    // Wait for page to load
+    await expect(
+      authedPage.getByRole("link", { name: "My Submissions" }),
+    ).toBeVisible();
+
+    // Editor section should be hidden
+    await expect(
+      authedPage.getByRole("link", { name: "Editor Dashboard" }),
+    ).not.toBeVisible();
+
+    // Slate section should be hidden
+    await expect(
+      authedPage.getByRole("link", { name: "Slate Dashboard" }),
+    ).not.toBeVisible();
+
+    // Admin section should be hidden (Organization link)
+    await expect(
+      authedPage.getByRole("link", { name: "Organization" }),
+    ).not.toBeVisible();
+
+    // Submitter navigation should be visible
+    await expect(
+      authedPage.getByRole("link", { name: "Manuscripts" }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole("link", { name: "Settings" }),
+    ).toBeVisible();
+  });
+
+  test("sees org settings as read-only", async ({ authedPage }) => {
+    await authedPage.goto("/organizations/settings");
+
+    // Page should load
+    await expect(
+      authedPage.getByRole("heading", { name: "Organization Settings" }),
+    ).toBeVisible();
+
+    // Admin-only elements should be hidden
+    await expect(
+      authedPage.getByRole("button", { name: /save|update/i }),
+    ).not.toBeVisible();
+
+    // Danger Zone (delete org) should not be visible
+    await expect(authedPage.getByText("Danger Zone")).not.toBeVisible();
+  });
+
+  test("cannot see invite member button on Members tab", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto("/organizations/settings");
+
+    // Switch to Members tab
+    const membersTab = authedPage.getByRole("tab", { name: "Members" });
+    await expect(membersTab).toBeVisible();
+    await membersTab.click();
+
+    // Member list should load
+    await expect(authedPage.getByText("Email")).toBeVisible();
+
+    // Invite button should be hidden for non-admins
+    await expect(
+      authedPage.getByRole("button", { name: /invite member/i }),
+    ).not.toBeVisible();
+  });
+});

--- a/apps/web/src/components/layout/__tests__/sidebar.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/sidebar.spec.tsx
@@ -168,6 +168,19 @@ describe("Sidebar", () => {
     expect(link.closest("a")).toHaveAttribute("href", "/federation");
   });
 
+  it("should hide Editor, Slate, and Admin sections for READER (non-editor, non-admin)", () => {
+    mockIsEditor = false;
+    mockIsAdmin = false;
+    render(<Sidebar />);
+    expect(screen.queryByText("Editor Dashboard")).not.toBeInTheDocument();
+    expect(screen.queryByText("Slate Dashboard")).not.toBeInTheDocument();
+    expect(screen.queryByText("Organization")).not.toBeInTheDocument();
+    // Submitter navigation always visible
+    expect(screen.getByText("My Submissions")).toBeInTheDocument();
+    expect(screen.getByText("Manuscripts")).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
   it("should highlight Forms on sub-routes like /editor/forms/new", () => {
     mockIsEditor = true;
     mockPathname = "/editor/forms/new";

--- a/apps/web/src/hooks/__tests__/use-organization.spec.tsx
+++ b/apps/web/src/hooks/__tests__/use-organization.spec.tsx
@@ -146,7 +146,8 @@ describe("useOrganization", () => {
       const { result } = renderHook(() => useOrganization());
       expect(result.current.isAdmin).toBe(true);
       expect(result.current.isEditor).toBe(true); // Admin implies editor
-      expect(result.current.isReader).toBe(true);
+      expect(result.current.isReader).toBe(false);
+      expect(result.current.canWrite).toBe(true);
     });
 
     it("should detect EDITOR role", () => {
@@ -154,7 +155,8 @@ describe("useOrganization", () => {
       const { result } = renderHook(() => useOrganization());
       expect(result.current.isAdmin).toBe(false);
       expect(result.current.isEditor).toBe(true);
-      expect(result.current.isReader).toBe(true);
+      expect(result.current.isReader).toBe(false);
+      expect(result.current.canWrite).toBe(true);
     });
 
     it("should detect READER role", () => {
@@ -163,6 +165,7 @@ describe("useOrganization", () => {
       expect(result.current.isAdmin).toBe(false);
       expect(result.current.isEditor).toBe(false);
       expect(result.current.isReader).toBe(true);
+      expect(result.current.canWrite).toBe(false);
     });
 
     it("should recover to first org roles when stored org is stale", () => {
@@ -171,7 +174,8 @@ describe("useOrganization", () => {
       // Stale recovery switches to org-1 (ADMIN), so all role checks are true
       expect(result.current.isAdmin).toBe(true);
       expect(result.current.isEditor).toBe(true);
-      expect(result.current.isReader).toBe(true);
+      expect(result.current.isReader).toBe(false);
+      expect(result.current.canWrite).toBe(true);
     });
   });
 

--- a/apps/web/src/hooks/use-organization.ts
+++ b/apps/web/src/hooks/use-organization.ts
@@ -98,7 +98,8 @@ export function useOrganization() {
   const isAdmin = currentOrg?.role === "ADMIN";
   const isEditor =
     currentOrg?.role === "EDITOR" || currentOrg?.role === "ADMIN";
-  const isReader = !!currentOrg;
+  const isReader = currentOrg?.role === "READER";
+  const canWrite = !!currentOrg && currentOrg.role !== "READER";
 
   return {
     user,
@@ -108,6 +109,7 @@ export function useOrganization() {
     isAdmin,
     isEditor,
     isReader,
+    canWrite,
     hasOrganizations: organizations.length > 0,
   };
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -283,6 +283,7 @@
 - [x] [P2] Unbounded query: migration pending approvals — `apps/api/src/services/migration.service.ts:1119` — (Codex review 2026-03-03; done 2026-03-03)
 - [x] [P2] Defense-in-depth: sim-sub peer query lacks explicit `organizationId` filter — `apps/api/src/services/simsub.service.ts:403` — (Codex review 2026-03-03; done 2026-03-03)
 - [x] [P3] Notification preferences list has no `LIMIT` — `apps/api/src/services/notification-preference.service.ts:71` — (Codex review 2026-03-03; done 2026-03-03)
+- [ ] [P3] Defense-in-depth: pipeline service query methods missing explicit `organizationId` filter — `apps/api/src/services/pipeline.service.ts:113,196,500,512` — (Codex plan review 2026-03-03, deferred from READER role PR)
 
 ### Dev Workflow
 
@@ -463,7 +464,7 @@
 - [x] [P2] CMS external ID tracking — store `externalId`/`externalUrl` returned from CMS publish back on the issue/items — (codebase audit 2026-02-27; done 2026-03-03)
 - [ ] [P3] Additional CMS adapters — Substack, Contentful, or other targets based on early adopter needs — (codebase audit 2026-02-27)
 - [ ] [P3] In-browser copyediting or diff view between manuscript versions — (persona gap analysis 2026-02-27)
-- [ ] [P3] READER role enforcement — define what READER can and cannot do distinct from EDITOR; currently decorative — (persona gap analysis 2026-02-27)
+- [x] [P3] READER role enforcement — define what READER can and cannot do distinct from EDITOR; currently decorative — (persona gap analysis 2026-02-27; done 2026-03-03)
 - [ ] [P3] Email invitation workflow — invite by email link/token instead of requiring pre-existing Zitadel account — (persona gap analysis 2026-02-27)
 - [ ] [P3] Custom org roles beyond ADMIN/EDITOR/READER — named roles with configurable permission scopes — (persona gap analysis 2026-02-27)
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-03-03 — READER Role Enforcement (Track 12)
+
+### Done
+
+- Fixed `isReader` semantics in `useOrganization` hook: was `!!currentOrg` (always true for any org member), now correctly `role === "READER"`
+- Added `canWrite` convenience flag to `useOrganization` hook (inverse of `isReader`)
+- Added `assertEditorOrAdmin` guard to `pipeline.service.ts:addCommentWithAudit` — the only mutation missing a role check
+- Capped unbounded `listComments`/`listHistory` pipeline queries with `.limit(1000)` (Codex review finding)
+- Created pipeline comment role guard unit tests (3 tests: READER rejected, EDITOR/ADMIN allowed)
+- Updated `useOrganization` hook tests: 4 assertions corrected for `isReader`, 4 new `canWrite` assertions
+- Added sidebar READER navigation visibility test
+- Created READER role E2E fixtures (`reader-fixtures.ts`) and E2E spec (3 tests: sidebar nav, read-only settings, no invite button)
+- Codex plan review: addressed E2E fixture path convention, unbounded query cap; deferred pipeline defense-in-depth orgId filters
+
+### Decisions
+
+- Existing `isEditor` guard on sidebar already hides Editor/Slate/Admin sections for READER — no sidebar changes needed
+- Pipeline comments treated as mutations: READER cannot comment (matches sibling method pattern)
+- Pipeline defense-in-depth (explicit orgId on query methods) deferred to separate hardening pass — out of scope for role enforcement
+- Analytics endpoints left gated behind `assertEditorOrAdmin` — writer personal analytics already accessible without role checks
+
+---
+
 ## 2026-03-03 — P2 Code Gaps + Codex Security Hardening (3+3 Fixes)
 
 ### Done

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,7 @@ For architecture details, see [docs/architecture.md](./architecture.md).
 ## Running Tests
 
 ```bash
-# Unit tests — API + packages (~1581 tests, 155 suites)
+# Unit tests — API + packages (~1584 tests, 156 suites)
 pnpm test
 
 # Coverage report
@@ -84,7 +84,7 @@ pnpm --filter @colophony/web test:e2e:ui
 
 | Tier                      | Files | Tests | Runner          | Location                           |
 | ------------------------- | ----- | ----- | --------------- | ---------------------------------- |
-| API unit tests            | 155   | ~1581 | Vitest          | `apps/api/src/**/*.spec.ts`        |
+| API unit tests            | 156   | ~1584 | Vitest          | `apps/api/src/**/*.spec.ts`        |
 | Package unit tests        | 4     | ~38   | Vitest          | `packages/*/src/**/*.spec.ts`      |
 | Web unit tests            | 11    | ~108  | Jest + jsdom    | `apps/web/src/**/*.spec.*`         |
 | RLS integration tests     | 11    | ~122  | Vitest (custom) | `apps/api/src/__tests__/rls/`      |


### PR DESCRIPTION
## Summary

- Fix `isReader` semantics in `useOrganization` hook: was `!!currentOrg` (always true), now `role === "READER"`
- Add `canWrite` convenience flag to `useOrganization` hook
- Add `assertEditorOrAdmin` guard to pipeline `addCommentWithAudit` — the only mutation missing a role check
- Cap unbounded `listComments`/`listHistory` pipeline queries with `.limit(1000)`
- 3 pipeline comment role guard unit tests
- Updated `useOrganization` hook tests for `isReader`/`canWrite`
- Sidebar READER navigation visibility test
- 3 READER role E2E tests (sidebar nav, read-only settings, no invite button)

## Test plan

- [ ] API unit tests pass (`pnpm --filter @colophony/api test`)
- [ ] Web unit tests pass (`pnpm --filter @colophony/web test`)
- [ ] Type check passes (`pnpm type-check`)
- [ ] READER E2E tests pass (`pnpm --filter @colophony/web test:e2e -- reader-role`)
- [ ] Manual: switch to READER org, verify sidebar hides Editor/Slate/Admin
- [ ] Manual: verify Settings page is read-only for READER