### PR TITLE
fix(slate): pipeline defense-in-depth — explicit organizationId filters

### DIFF
--- a/apps/api/src/graphql/resolvers/pipeline.ts
+++ b/apps/api/src/graphql/resolvers/pipeline.ts
@@ -99,7 +99,7 @@ builder.queryFields((t) => ({
         page: args.page,
         limit: args.limit,
       });
-      return pipelineService.list(orgCtx.dbTx, input);
+      return pipelineService.list(orgCtx.dbTx, input, orgCtx.authContext.orgId);
     },
   }),
 
@@ -116,7 +116,11 @@ builder.queryFields((t) => ({
       await requireScopes(ctx, 'pipeline:read');
       const { id } = idParamSchema.parse({ id: args.id });
       try {
-        const item = await pipelineService.getById(orgCtx.dbTx, id);
+        const item = await pipelineService.getById(
+          orgCtx.dbTx,
+          id,
+          orgCtx.authContext.orgId,
+        );
         if (!item) throw new PipelineItemNotFoundError(id);
         return item;
       } catch (e) {
@@ -136,7 +140,11 @@ builder.queryFields((t) => ({
       const orgCtx = requireOrgContext(ctx);
       await requireScopes(ctx, 'pipeline:read');
       const { id } = idParamSchema.parse({ id: args.id });
-      return pipelineService.getHistory(orgCtx.dbTx, id);
+      return pipelineService.getHistory(
+        orgCtx.dbTx,
+        id,
+        orgCtx.authContext.orgId,
+      );
     },
   }),
 
@@ -151,7 +159,11 @@ builder.queryFields((t) => ({
       const orgCtx = requireOrgContext(ctx);
       await requireScopes(ctx, 'pipeline:read');
       const { id } = idParamSchema.parse({ id: args.id });
-      return pipelineService.listComments(orgCtx.dbTx, id);
+      return pipelineService.listComments(
+        orgCtx.dbTx,
+        id,
+        orgCtx.authContext.orgId,
+      );
     },
   }),
 }));

--- a/apps/api/src/rest/routers/pipeline.ts
+++ b/apps/api/src/rest/routers/pipeline.ts
@@ -48,7 +48,7 @@ const list = orgProcedure
   .input(restListPipelineQuery)
   .output(paginatedPipelineSchema)
   .handler(async ({ input, context }) => {
-    return pipelineService.list(context.dbTx, input);
+    return pipelineService.list(context.dbTx, input, context.authContext.orgId);
   });
 
 const create = orgProcedure
@@ -89,7 +89,11 @@ const get = orgProcedure
   .output(pipelineItemSchema)
   .handler(async ({ input, context }) => {
     try {
-      const item = await pipelineService.getById(context.dbTx, input.id);
+      const item = await pipelineService.getById(
+        context.dbTx,
+        input.id,
+        context.authContext.orgId,
+      );
       if (!item) throw new PipelineItemNotFoundError(input.id);
       return item;
     } catch (e) {
@@ -211,7 +215,11 @@ const listComments = orgProcedure
   .input(idParamSchema)
   .output(z.array(pipelineCommentSchema))
   .handler(async ({ input, context }) => {
-    return pipelineService.listComments(context.dbTx, input.id);
+    return pipelineService.listComments(
+      context.dbTx,
+      input.id,
+      context.authContext.orgId,
+    );
   });
 
 const getHistory = orgProcedure
@@ -227,7 +235,11 @@ const getHistory = orgProcedure
   .input(idParamSchema)
   .output(z.array(pipelineHistoryEntrySchema))
   .handler(async ({ input, context }) => {
-    return pipelineService.getHistory(context.dbTx, input.id);
+    return pipelineService.getHistory(
+      context.dbTx,
+      input.id,
+      context.authContext.orgId,
+    );
   });
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/services/pipeline.service.spec.ts
+++ b/apps/api/src/services/pipeline.service.spec.ts
@@ -46,4 +46,63 @@ describe('pipeline.service', () => {
       ).rejects.not.toThrow(ForbiddenError);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Defense-in-depth: explicit organizationId filters
+  // ---------------------------------------------------------------------------
+
+  describe('defense-in-depth: organizationId filters', () => {
+    it('list() requires orgId parameter', () => {
+      // TypeScript enforces the orgId parameter at compile time.
+      // Verify the function signature accepts 3 arguments (tx, input, orgId).
+      expect(pipelineService.list.length).toBe(3);
+    });
+
+    it('getById() requires orgId parameter', () => {
+      expect(pipelineService.getById.length).toBe(3);
+    });
+
+    it('listComments() requires orgId parameter', () => {
+      expect(pipelineService.listComments.length).toBe(3);
+    });
+
+    it('getHistory() requires orgId parameter', () => {
+      expect(pipelineService.getHistory.length).toBe(3);
+    });
+
+    it('updateStage() requires orgId parameter', () => {
+      // updateStage(tx, id, input, orgId, changedBy?)
+      expect(pipelineService.updateStage.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('addCommentWithAudit passes actor orgId to getById', async () => {
+      const ctx = makeCtx('EDITOR');
+      // getById will call tx.select().from().leftJoin()...where(and(eq(id), eq(orgId)))
+      // It will fail on the mock tx, but we can verify the call pattern
+      const getByIdSpy = vi.spyOn(pipelineService, 'getById');
+      try {
+        await pipelineService.addCommentWithAudit(ctx, 'item-1', {
+          content: 'test',
+        });
+      } catch {
+        // Expected: mock tx throws
+      }
+      expect(getByIdSpy).toHaveBeenCalledWith(ctx.tx, 'item-1', 'org-1');
+      getByIdSpy.mockRestore();
+    });
+
+    it('updateStageWithAudit passes actor orgId to getById and updateStage', async () => {
+      const ctx = makeCtx('EDITOR');
+      const getByIdSpy = vi.spyOn(pipelineService, 'getById');
+      try {
+        await pipelineService.updateStageWithAudit(ctx, 'item-1', {
+          stage: 'PROOFREAD',
+        });
+      } catch {
+        // Expected: mock tx throws
+      }
+      expect(getByIdSpy).toHaveBeenCalledWith(ctx.tx, 'item-1', 'org-1');
+      getByIdSpy.mockRestore();
+    });
+  });
 });

--- a/apps/api/src/services/pipeline.service.ts
+++ b/apps/api/src/services/pipeline.service.ts
@@ -72,7 +72,7 @@ export const pipelineService = {
   // List / Get
   // -------------------------------------------------------------------------
 
-  async list(tx: DrizzleDb, input: ListPipelineItemsInput) {
+  async list(tx: DrizzleDb, input: ListPipelineItemsInput, orgId: string) {
     const {
       stage,
       publicationId,
@@ -85,6 +85,7 @@ export const pipelineService = {
     const offset = (page - 1) * limit;
 
     const conditions = [];
+    conditions.push(eq(pipelineItems.organizationId, orgId));
     if (stage) conditions.push(eq(pipelineItems.stage, stage));
     if (publicationId)
       conditions.push(eq(pipelineItems.publicationId, publicationId));
@@ -170,7 +171,7 @@ export const pipelineService = {
     };
   },
 
-  async getById(tx: DrizzleDb, id: string) {
+  async getById(tx: DrizzleDb, id: string, orgId: string) {
     const copyeditors = alias(users, 'copyeditors');
     const proofreaders = alias(users, 'proofreaders');
 
@@ -193,7 +194,9 @@ export const pipelineService = {
         proofreaders,
         eq(pipelineItems.assignedProofreaderId, proofreaders.id),
       )
-      .where(eq(pipelineItems.id, id))
+      .where(
+        and(eq(pipelineItems.id, id), eq(pipelineItems.organizationId, orgId)),
+      )
       .limit(1);
 
     if (!row) return null;
@@ -294,9 +297,10 @@ export const pipelineService = {
     tx: DrizzleDb,
     id: string,
     input: UpdatePipelineStageInput,
+    orgId: string,
     changedBy?: string,
   ) {
-    const item = await pipelineService.getById(tx, id);
+    const item = await pipelineService.getById(tx, id, orgId);
     if (!item) throw new PipelineItemNotFoundError(id);
 
     if (!isValidPipelineTransition(item.stage, input.stage)) {
@@ -328,13 +332,14 @@ export const pipelineService = {
   ) {
     assertEditorOrAdmin(ctx.actor.role);
     // Capture the previous stage before the update for the audit trail
-    const current = await pipelineService.getById(ctx.tx, id);
+    const current = await pipelineService.getById(ctx.tx, id, ctx.actor.orgId);
     if (!current) throw new PipelineItemNotFoundError(id);
     const previousStage = current.stage;
     const updated = await pipelineService.updateStage(
       ctx.tx,
       id,
       input,
+      ctx.actor.orgId,
       ctx.actor.userId,
     );
     await ctx.audit({
@@ -475,7 +480,11 @@ export const pipelineService = {
     input: AddPipelineCommentInput,
   ) {
     assertEditorOrAdmin(ctx.actor.role);
-    const item = await pipelineService.getById(ctx.tx, pipelineItemId);
+    const item = await pipelineService.getById(
+      ctx.tx,
+      pipelineItemId,
+      ctx.actor.orgId,
+    );
     if (!item) throw new PipelineItemNotFoundError(pipelineItemId);
 
     const comment = await pipelineService.addComment(
@@ -495,11 +504,20 @@ export const pipelineService = {
   },
 
   // TODO: Replace hard limit with proper pagination if usage grows beyond 1000 per item
-  async listComments(tx: DrizzleDb, pipelineItemId: string) {
+  async listComments(tx: DrizzleDb, pipelineItemId: string, orgId: string) {
     return tx
-      .select()
+      .select(getTableColumns(pipelineComments))
       .from(pipelineComments)
-      .where(eq(pipelineComments.pipelineItemId, pipelineItemId))
+      .innerJoin(
+        pipelineItems,
+        eq(pipelineComments.pipelineItemId, pipelineItems.id),
+      )
+      .where(
+        and(
+          eq(pipelineComments.pipelineItemId, pipelineItemId),
+          eq(pipelineItems.organizationId, orgId),
+        ),
+      )
       .orderBy(desc(pipelineComments.createdAt))
       .limit(1000);
   },
@@ -509,11 +527,20 @@ export const pipelineService = {
   // -------------------------------------------------------------------------
 
   // TODO: Replace hard limit with proper pagination if usage grows beyond 1000 per item
-  async getHistory(tx: DrizzleDb, pipelineItemId: string) {
+  async getHistory(tx: DrizzleDb, pipelineItemId: string, orgId: string) {
     return tx
-      .select()
+      .select(getTableColumns(pipelineHistory))
       .from(pipelineHistory)
-      .where(eq(pipelineHistory.pipelineItemId, pipelineItemId))
+      .innerJoin(
+        pipelineItems,
+        eq(pipelineHistory.pipelineItemId, pipelineItems.id),
+      )
+      .where(
+        and(
+          eq(pipelineHistory.pipelineItemId, pipelineItemId),
+          eq(pipelineItems.organizationId, orgId),
+        ),
+      )
       .orderBy(desc(pipelineHistory.changedAt))
       .limit(1000);
   },

--- a/apps/api/src/trpc/routers/pipeline.ts
+++ b/apps/api/src/trpc/routers/pipeline.ts
@@ -31,7 +31,7 @@ export const pipelineRouter = createRouter({
     .input(listPipelineItemsSchema)
     .output(paginatedResponseSchema(pipelineItemSchema))
     .query(async ({ ctx, input }) => {
-      return pipelineService.list(ctx.dbTx, input);
+      return pipelineService.list(ctx.dbTx, input, ctx.authContext.orgId);
     }),
 
   /** Get pipeline item by ID. */
@@ -41,7 +41,11 @@ export const pipelineRouter = createRouter({
     .output(pipelineItemSchema)
     .query(async ({ ctx, input }) => {
       try {
-        const item = await pipelineService.getById(ctx.dbTx, input.id);
+        const item = await pipelineService.getById(
+          ctx.dbTx,
+          input.id,
+          ctx.authContext.orgId,
+        );
         if (!item) throw new PipelineItemNotFoundError(input.id);
         return item;
       } catch (e) {
@@ -143,7 +147,11 @@ export const pipelineRouter = createRouter({
     .input(idParamSchema)
     .output(z.array(pipelineCommentSchema))
     .query(async ({ ctx, input }) => {
-      return pipelineService.listComments(ctx.dbTx, input.id);
+      return pipelineService.listComments(
+        ctx.dbTx,
+        input.id,
+        ctx.authContext.orgId,
+      );
     }),
 
   /** Get stage transition history for a pipeline item. */
@@ -152,6 +160,10 @@ export const pipelineRouter = createRouter({
     .input(idParamSchema)
     .output(z.array(pipelineHistoryEntrySchema))
     .query(async ({ ctx, input }) => {
-      return pipelineService.getHistory(ctx.dbTx, input.id);
+      return pipelineService.getHistory(
+        ctx.dbTx,
+        input.id,
+        ctx.authContext.orgId,
+      );
     }),
 });

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -283,7 +283,7 @@
 - [x] [P2] Unbounded query: migration pending approvals — `apps/api/src/services/migration.service.ts:1119` — (Codex review 2026-03-03; done 2026-03-03)
 - [x] [P2] Defense-in-depth: sim-sub peer query lacks explicit `organizationId` filter — `apps/api/src/services/simsub.service.ts:403` — (Codex review 2026-03-03; done 2026-03-03)
 - [x] [P3] Notification preferences list has no `LIMIT` — `apps/api/src/services/notification-preference.service.ts:71` — (Codex review 2026-03-03; done 2026-03-03)
-- [ ] [P3] Defense-in-depth: pipeline service query methods missing explicit `organizationId` filter — `apps/api/src/services/pipeline.service.ts:113,196,500,512` — (Codex plan review 2026-03-03, deferred from READER role PR)
+- [x] [P3] Defense-in-depth: pipeline service query methods missing explicit `organizationId` filter — `apps/api/src/services/pipeline.service.ts:113,196,500,512` — (Codex plan review 2026-03-03, deferred from READER role PR)
 
 ### Dev Workflow
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,25 @@ Newest entries first.
 
 ---
 
+## 2026-03-03 — Pipeline Defense-in-Depth (P3 Hardening)
+
+### Done
+
+- Added explicit `organizationId` predicates to 5 pipeline service methods: `list()`, `getById()`, `listComments()`, `getHistory()`, `updateStage()`
+- `listComments` and `getHistory` use `innerJoin(pipelineItems)` + org filter to verify ownership via parent table
+- Updated all 3 API surfaces (tRPC, REST, GraphQL) to pass `orgId` from auth context
+- Internal callers (`updateStageWithAudit`, `addCommentWithAudit`) propagate `ctx.actor.orgId`
+- Inngest `pipeline-workflow.ts` already passed `orgId` — signature change corrected parameter mapping (was `changedBy`, now `orgId`)
+- Added 7 defense-in-depth unit tests (parameter arity checks + spy-based orgId propagation verification)
+- Checked off P3 backlog item
+
+### Decisions
+
+- Used `getTableColumns()` for select after innerJoin to avoid returning joined pipeline_items columns
+- Inngest workflow's existing `orgId` argument naturally maps to the new parameter position — no Inngest changes needed
+
+---
+
 ## 2026-03-03 — READER Role Enforcement (Track 12)
 
 ### Done


### PR DESCRIPTION
## Summary

- Added explicit `organizationId` predicates to 5 pipeline service query methods (`list`, `getById`, `listComments`, `getHistory`, `updateStage`) as defense-in-depth alongside RLS
- Updated all 3 API surfaces (tRPC, REST, GraphQL) to pass `orgId` from auth context
- Internal callers (`updateStageWithAudit`, `addCommentWithAudit`) propagate `ctx.actor.orgId`
- Added 7 unit tests verifying parameter signatures and orgId propagation

## Test plan

- [x] `pnpm type-check` — 14/14 packages clean
- [x] `pnpm test --filter @colophony/api -- src/services/pipeline.service.spec.ts` — 10/10 tests pass
- [x] `pnpm lint` — clean (3 pre-existing warnings in unrelated file)
- [ ] CI: full test suite (unit, RLS, queue, service-integration, security, E2E)