### PR TITLE
fix(slate): pipeline defense-in-depth + QA docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,8 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **CSR service**          | `apps/api/src/services/csr.service.ts` (export/import for data portability)      |
 | **CSR format spec**      | `docs/csr-format.md`                                                             |
 | **Backlog**              | `docs/backlog.md` (track-organized, drives session focus)                        |
+| **QA log**               | `docs/qa-log.md`                                                                 |
+| **Release checklist**    | `docs/release-checklist.md`                                                      |
 
 Full project structure: [docs/architecture.md](docs/architecture.md)
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -311,6 +311,17 @@
 - [x] CI: Add service-integration-tests, security-tests jobs — (test coverage plan 2026-03-02; done 2026-03-03)
 - [ ] [P2] Fix flaky workspace analytics E2E — `workspace-analytics-correspondence.spec.ts` "Total Submissions" card times out intermittently (10s timeout); reproduces on both `main` and feature branches; likely slow tRPC query or rendering delay in CI — (CI flake 2026-03-03)
 
+### Testing Infrastructure Hardening
+
+- [ ] [P1] Console error/warn as test failures — add `vi.spyOn(console, 'error')` / `jest.spyOn(console, 'error')` in global setup files with `afterEach` assertions; allowlist intentional warnings; fix `act(...)` warnings in web tests and Vitest mock warnings — (Codex feedback 2026-03-03)
+- [ ] [P2] Add `test:cov` scripts to all packages — add `--coverage` with lcov.info + JSON output to api, web, api-client, auth-client, create-plugin, plugin-sdk, types; collect coverage artifacts in CI — (Codex feedback 2026-03-03)
+- [ ] [P2] Per-package coverage gates — add `coverageThreshold` in `apps/web/jest.config.ts` and Vitest thresholds in `apps/api/vitest.config.ts`; measure current coverage first, set floors at current minus 5% buffer, ratchet up monthly — (Codex feedback 2026-03-03; depends on test:cov scripts)
+- [ ] [P2] Changed-code coverage guardrails — enforce minimum coverage on changed files/lines in PRs (e.g., `diff-cover` or Codecov PR checks); prevents new low-coverage hotspots while legacy gaps burn down gradually — (Codex feedback 2026-03-03; depends on test:cov scripts)
+- [ ] [P3] Flakiness and determinism CI checks — run unit tests with retries disabled and `--sequence.shuffle` on at least one CI lane; add quarantine convention (`.flaky.test.ts` suffix or skip marker) and fail PRs that introduce new flaky markers — (Codex feedback 2026-03-03)
+- [ ] [P3] Risk-based test matrix — audit coverage per domain (pipeline, federation, workspace, forms) and document minimum test layers per domain (unit + service integration + API route + E2E happy path) in `docs/testing.md`; identify high-risk low-coverage hotspots — (Codex feedback 2026-03-03)
+- [ ] [P4] Ephemeral DB/queue per test worker — standardize `TestContext` factory for isolated schemas per worker; replace ad-hoc Redis db 1 patching in `vitest-setup.ts`; add explicit contract tests around external boundaries (webhooks, auth, adapters) with fixture replay — (Codex feedback 2026-03-03)
+- [x] [P4] Manual QA tracking — establish lightweight QA log (structured markdown or checklist) for pre-release smoke tests, exploratory testing sessions, and regression checks; track what was tested, time spent, and issues found — (Codex feedback 2026-03-03; done 2026-03-03)
+
 ### CI
 
 - [x] [P2] CI path filtering for Playwright suites — skip irrelevant E2E suites on PRs based on changed files; `.github/scripts/detect-changes.sh` with fail-open strategy — (DEVLOG 2026-02-24; done 2026-02-24)

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,24 @@ Newest entries first.
 
 ---
 
+## 2026-03-03 — QA Log, Release Checklist, and Testing Docs
+
+### Done
+
+- Created `docs/qa-log.md` — structured log for manual/MCP QA sessions with template and "3+ times = automate" rule
+- Created `docs/release-checklist.md` — 5-section pre-release checklist (CI pipeline, critical path smoke, automation gaps, data integrity, visual/UX)
+- Added MCP-Assisted QA section to `docs/testing.md` — 5 MCP tools, decision matrix (MCP vs Playwright), automation promotion pipeline, QA session workflow
+- Updated `CLAUDE.md` Key File Locations with QA log and release checklist entries
+- Checked off `[P4] Manual QA tracking` backlog item
+
+### Decisions
+
+- QA log starts clean (no pre-populated entries) — filled by future sessions
+- MCP tools table in testing.md scoped to QA-relevant servers (chrome-devtools, playwright, postgres, redis, docker); dev-only servers (context7, stripe, github) excluded
+- Release checklist CI section matches actual CI jobs; test counts approximate with `~` prefix (same convention as testing.md)
+
+---
+
 ## 2026-03-03 — Pipeline Defense-in-Depth (P3 Hardening)
 
 ### Done

--- a/docs/qa-log.md
+++ b/docs/qa-log.md
@@ -1,0 +1,34 @@
+# QA Log
+
+> Track manual and MCP-assisted testing sessions. Each entry records what was tested,
+> how (Chrome DevTools MCP vs Playwright vs manual browser), issues found, and
+> automation candidates identified.
+>
+> **When to add an entry:** After any exploratory testing, pre-release smoke test,
+> or regression check done outside of automated test suites.
+>
+> **Automation rule:** If the same check appears 3+ times in this log, it should be
+> promoted to a Playwright E2E test. Tag it `[AUTOMATE]` and create a backlog item.
+
+## Template
+
+<!-- Copy this for new entries -->
+<!--
+## YYYY-MM-DD — [Focus Area]
+
+**Method:** Chrome DevTools MCP | Playwright MCP | Manual browser
+**Areas tested:**
+- [ ] [Area]: [what was verified] — [PASS|FAIL|ISSUE #N]
+
+**Issues found:**
+- None | #N: [description]
+
+**Automation candidates:**
+- None | [Check description] — [count of times tested manually]
+-->
+
+## Entries
+
+Newest first.
+
+---

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,59 @@
+# Release Checklist
+
+> Pre-release verification for Colophony. Run through before tagging a release.
+>
+> **Automated checks** are covered by CI — verify they pass on the release branch.
+> **MCP-assisted checks** use Chrome DevTools MCP for flows that aren't fully automated.
+> **Manual checks** require human judgment (visual, UX, copy review).
+>
+> After completing a release check, log results in `docs/qa-log.md`.
+
+## 1. CI Pipeline (automated)
+
+All CI jobs must pass on the release branch:
+
+- [ ] `quality` — lint, type-check, format, audit
+- [ ] `unit-tests` — ~1584 API + ~38 package tests
+- [ ] `rls-tests` — 122 RLS tenant isolation tests
+- [ ] `queue-tests` — 19 queue/worker integration tests
+- [ ] `service-integration-tests` — 63 service integration tests
+- [ ] `security-tests` — 20 security invariant tests
+- [ ] `build` — production build (API + Web)
+- [ ] `playwright-*` — all 10 E2E suites (145+ tests)
+
+## 2. Critical Path Smoke Tests (MCP-assisted)
+
+Flows covered by Playwright E2E but worth a quick MCP verification on staging:
+
+- [ ] **Submit a piece** — create submission with file upload, verify appears in list
+- [ ] **Review + accept** — change submission status to ACCEPTED, verify pipeline item created
+- [ ] **Pipeline flow** — advance item through COPYEDIT → AUTHOR_REVIEW → PROOFREAD → READY_TO_PUBLISH
+- [ ] **Embed form** — load public embed URL, complete submission as anonymous user
+- [ ] **Organization** — create org, invite member, verify member appears
+
+## 3. Gaps Not Covered by Automation (MCP-assisted)
+
+These flows have no Playwright coverage — verify manually or via MCP:
+
+- [ ] **Stripe checkout** — trigger payment flow, verify Stripe redirect and webhook processing
+- [ ] **Email delivery** — trigger a notification, verify email sent (check Ethereal or SMTP logs)
+- [ ] **File virus scan** — upload file, verify ClamAV scan completes (check file status in DB)
+- [ ] **Federation handshake** — if federation enabled: initiate trust request, verify peer appears
+- [ ] **CMS publish** — publish an issue to connected CMS, verify external content created
+- [ ] **Contract signing** — create contract, verify Documenso webhook processes signature
+- [ ] **OIDC login** — full Zitadel login flow on staging (E2E exists but requires live Zitadel)
+- [ ] **API key auth** — create API key, make authenticated REST/GraphQL request
+- [ ] **Mobile responsive** — check submission form + dashboard on 375px viewport
+
+## 4. Data Integrity Checks (MCP-assisted or DB query)
+
+- [ ] **RLS isolation** — query a tenant table as app_user without SET LOCAL, verify empty result
+- [ ] **Audit trail** — perform a sensitive action, verify audit_events row created
+- [ ] **Webhook idempotency** — replay a Stripe/Zitadel webhook, verify no duplicate processing
+
+## 5. Visual / UX Review (manual)
+
+- [ ] **Dark mode** — if applicable, check key pages render correctly
+- [ ] **Error states** — trigger 404, 403, 500 pages, verify user-friendly messages
+- [ ] **Loading states** — verify skeleton/spinner displays during data fetches
+- [ ] **Copy review** — scan user-facing text for typos, unclear language

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -399,6 +399,47 @@ pnpm --filter @colophony/web test:e2e:embed
 
 ---
 
+## MCP-Assisted QA
+
+### Available MCP Tools
+
+| Server            | Use Case                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------ |
+| `chrome-devtools` | Navigate flows, click/fill forms, inspect network requests, take screenshots, read console |
+| `playwright`      | Browser automation for repeatable test generation                                          |
+| `postgres`        | Direct DB queries for data integrity checks                                                |
+| `redis`           | BullMQ job inspection, queue state verification                                            |
+| `docker`          | Container health checks, log inspection                                                    |
+
+### When to Use MCP vs Playwright
+
+| Scenario                                 | Use                                                    |
+| ---------------------------------------- | ------------------------------------------------------ |
+| Exploratory testing, investigating a bug | Chrome DevTools MCP                                    |
+| Verifying a fix once                     | Chrome DevTools MCP                                    |
+| Pre-release smoke test (first time)      | Chrome DevTools MCP                                    |
+| Same smoke test repeated 3+ times        | Promote to Playwright E2E                              |
+| Visual/layout verification               | Chrome DevTools MCP (screenshot)                       |
+| Regression test for a fixed bug          | Playwright E2E                                         |
+| Complex multi-step flow verification     | Chrome DevTools MCP first, then Playwright if repeated |
+
+### Automation Promotion Pipeline
+
+1. **Manual/MCP check** — log in `docs/qa-log.md` with `[AUTOMATE]` tag when repeated
+2. **Backlog item** — create backlog entry: `[P3] Automate: [check description] — (qa-log YYYY-MM-DD)`
+3. **Playwright test** — scaffold with `/new-e2e`, add to appropriate project
+4. **Remove from release checklist** — move from "Gaps" to "CI Pipeline" section
+
+### QA Session Workflow
+
+1. Launch Chrome: `google-chrome --remote-debugging-port=9222`
+2. Navigate to dev server: `http://localhost:3000`
+3. Use Chrome DevTools MCP tools to interact with the application
+4. Log findings in `docs/qa-log.md`
+5. Tag repeated checks with `[AUTOMATE]` for future Playwright promotion
+
+---
+
 ## Critical Test Cases
 
 ### 1. Multi-Tenancy Isolation


### PR DESCRIPTION
## Summary

- Added explicit `organizationId` filters to 5 pipeline service queries as defense-in-depth (even though RLS already enforces isolation)
- Updated all 3 API surfaces (tRPC, REST, GraphQL) to pass orgId from auth context
- Added 7 defense-in-depth unit tests
- Created `docs/qa-log.md` — structured log for manual/MCP QA sessions with automation promotion rule
- Created `docs/release-checklist.md` — 5-section pre-release verification checklist
- Added MCP-Assisted QA section to `docs/testing.md` with decision matrix and promotion pipeline
- Checked off P4 Manual QA tracking backlog item

## Test plan

- [x] Existing pipeline E2E tests pass (30 tests in slate suite)
- [x] 7 new defense-in-depth unit tests pass
- [x] Lint + type-check pass
- [x] New markdown docs render correctly