### PR TITLE
fix(db): warn on missing DATABASE_APP_URL + enforce in production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,13 +437,14 @@ Canonical env definition with Zod validation: `apps/api/src/config/env.ts` (55 v
 
 <!-- Core -->
 
-| Variable        | Required | Default                 | Used by |
-| --------------- | -------- | ----------------------- | ------- |
-| `DATABASE_URL`  | Yes      | —                       | API     |
-| `PORT` / `HOST` | No       | `4000` / `0.0.0.0`      | API     |
-| `NODE_ENV`      | No       | `development`           | API     |
-| `LOG_LEVEL`     | No       | `info`                  | API     |
-| `CORS_ORIGIN`   | No       | `http://localhost:3000` | API     |
+| Variable           | Required | Default                      | Used by |
+| ------------------ | -------- | ---------------------------- | ------- |
+| `DATABASE_URL`     | Yes      | —                            | API     |
+| `DATABASE_APP_URL` | Prod     | falls back to `DATABASE_URL` | API, DB |
+| `PORT` / `HOST`    | No       | `4000` / `0.0.0.0`           | API     |
+| `NODE_ENV`         | No       | `development`                | API     |
+| `LOG_LEVEL`        | No       | `info`                       | API     |
+| `CORS_ORIGIN`      | No       | `http://localhost:3000`      | API     |
 
 <!-- Redis -->
 

--- a/apps/api/src/config/env.spec.ts
+++ b/apps/api/src/config/env.spec.ts
@@ -36,6 +36,7 @@ describe('validateEnv', () => {
   it('accepts overridden values', () => {
     const env = validateEnv({
       ...validBase,
+      DATABASE_APP_URL: 'postgresql://app_user:pass@localhost:5432/colophony',
       PORT: '3000',
       NODE_ENV: 'production',
       LOG_LEVEL: 'error',
@@ -45,6 +46,23 @@ describe('validateEnv', () => {
     expect(env.NODE_ENV).toBe('production');
     expect(env.LOG_LEVEL).toBe('error');
     expect(env.CORS_ORIGIN).toBe('https://example.com');
+  });
+
+  it('requires DATABASE_APP_URL in production', () => {
+    expect(() => validateEnv({ ...validBase, NODE_ENV: 'production' })).toThrow(
+      'DATABASE_APP_URL is required in production',
+    );
+  });
+
+  it('allows missing DATABASE_APP_URL in development', () => {
+    const env = validateEnv({ ...validBase, NODE_ENV: 'development' });
+    expect(env.DATABASE_APP_URL).toBeUndefined();
+  });
+
+  it('validates DATABASE_APP_URL format', () => {
+    expect(() =>
+      validateEnv({ ...validBase, DATABASE_APP_URL: 'mysql://bad' }),
+    ).toThrow('postgresql://');
   });
 
   it('coerces PORT from string to number', () => {

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -1,145 +1,165 @@
 import { z } from 'zod';
 
-const envSchema = z.object({
-  // Required
-  DATABASE_URL: z
-    .string()
-    .min(1, 'DATABASE_URL is required')
-    .startsWith('postgresql://', 'DATABASE_URL must be a postgresql:// URL'),
+const envSchema = z
+  .object({
+    // Required
+    DATABASE_URL: z
+      .string()
+      .min(1, 'DATABASE_URL is required')
+      .startsWith('postgresql://', 'DATABASE_URL must be a postgresql:// URL'),
 
-  // With defaults
-  PORT: z.coerce.number().int().positive().default(4000),
-  HOST: z.string().default('0.0.0.0'),
-  NODE_ENV: z
-    .enum(['development', 'production', 'test'])
-    .default('development'),
-  LOG_LEVEL: z
-    .enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace'])
-    .default('info'),
-  REDIS_HOST: z.string().default('localhost'),
-  REDIS_PORT: z.coerce.number().int().positive().default(6379),
-  REDIS_PASSWORD: z.string().default(''),
-  CORS_ORIGIN: z.string().default('http://localhost:3000'),
+    // Application database connection (non-superuser, NOBYPASSRLS)
+    DATABASE_APP_URL: z
+      .string()
+      .startsWith(
+        'postgresql://',
+        'DATABASE_APP_URL must be a postgresql:// URL',
+      )
+      .optional(),
 
-  // Rate limiting
-  RATE_LIMIT_DEFAULT_MAX: z.coerce.number().int().positive().default(60),
-  RATE_LIMIT_AUTH_MAX: z.coerce.number().int().positive().default(200),
-  RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().int().positive().default(60),
-  RATE_LIMIT_KEY_PREFIX: z.string().default('colophony:rl'),
+    // With defaults
+    PORT: z.coerce.number().int().positive().default(4000),
+    HOST: z.string().default('0.0.0.0'),
+    NODE_ENV: z
+      .enum(['development', 'production', 'test'])
+      .default('development'),
+    LOG_LEVEL: z
+      .enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace'])
+      .default('info'),
+    REDIS_HOST: z.string().default('localhost'),
+    REDIS_PORT: z.coerce.number().int().positive().default(6379),
+    REDIS_PASSWORD: z.string().default(''),
+    CORS_ORIGIN: z.string().default('http://localhost:3000'),
 
-  // Per-IP auth failure throttle
-  AUTH_FAILURE_THROTTLE_MAX: z.coerce.number().int().positive().default(10),
-  AUTH_FAILURE_THROTTLE_WINDOW_SECONDS: z.coerce
-    .number()
-    .int()
-    .positive()
-    .default(300),
+    // Rate limiting
+    RATE_LIMIT_DEFAULT_MAX: z.coerce.number().int().positive().default(60),
+    RATE_LIMIT_AUTH_MAX: z.coerce.number().int().positive().default(200),
+    RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().int().positive().default(60),
+    RATE_LIMIT_KEY_PREFIX: z.string().default('colophony:rl'),
 
-  // Webhook hardening
-  WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS: z.coerce
-    .number()
-    .int()
-    .positive()
-    .default(300),
-  WEBHOOK_RATE_LIMIT_MAX: z.coerce.number().int().positive().default(100),
+    // Per-IP auth failure throttle
+    AUTH_FAILURE_THROTTLE_MAX: z.coerce.number().int().positive().default(10),
+    AUTH_FAILURE_THROTTLE_WINDOW_SECONDS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(300),
 
-  // S3 / MinIO
-  S3_ENDPOINT: z.string().default('http://localhost:9000'),
-  S3_BUCKET: z.string().default('submissions'),
-  S3_QUARANTINE_BUCKET: z.string().default('quarantine'),
-  S3_ACCESS_KEY: z.string().default('minioadmin'),
-  S3_SECRET_KEY: z.string().default('minioadmin'),
-  S3_REGION: z.string().default('us-east-1'),
-  TUS_ENDPOINT: z.string().default('http://localhost:1080/files/'),
+    // Webhook hardening
+    WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(300),
+    WEBHOOK_RATE_LIMIT_MAX: z.coerce.number().int().positive().default(100),
 
-  // ClamAV virus scanning
-  CLAMAV_HOST: z.string().default('localhost'),
-  CLAMAV_PORT: z.coerce.number().int().positive().default(3310),
-  VIRUS_SCAN_ENABLED: z
-    .enum(['true', 'false'])
-    .default('true')
-    .transform((v) => v === 'true'),
+    // S3 / MinIO
+    S3_ENDPOINT: z.string().default('http://localhost:9000'),
+    S3_BUCKET: z.string().default('submissions'),
+    S3_QUARANTINE_BUCKET: z.string().default('quarantine'),
+    S3_ACCESS_KEY: z.string().default('minioadmin'),
+    S3_SECRET_KEY: z.string().default('minioadmin'),
+    S3_REGION: z.string().default('us-east-1'),
+    TUS_ENDPOINT: z.string().default('http://localhost:1080/files/'),
 
-  // Optional — validated when modules wire up
-  STRIPE_SECRET_KEY: z.string().optional(),
-  STRIPE_WEBHOOK_SECRET: z.string().optional(),
-  ZITADEL_AUTHORITY: z.string().url().optional(),
-  ZITADEL_CLIENT_ID: z.string().optional(),
-  ZITADEL_WEBHOOK_SECRET: z.string().optional(),
-  DEV_AUTH_BYPASS: z
-    .enum(['true', 'false'])
-    .default('false')
-    .transform((v) => v === 'true'),
-  // Federation rate limiting (per-peer)
-  FEDERATION_RATE_LIMIT_MAX: z.coerce.number().int().positive().default(60),
-  FEDERATION_RATE_LIMIT_WINDOW_SECONDS: z.coerce
-    .number()
-    .int()
-    .positive()
-    .default(60),
+    // ClamAV virus scanning
+    CLAMAV_HOST: z.string().default('localhost'),
+    CLAMAV_PORT: z.coerce.number().int().positive().default(3310),
+    VIRUS_SCAN_ENABLED: z
+      .enum(['true', 'false'])
+      .default('true')
+      .transform((v) => v === 'true'),
 
-  // Status token TTL
-  STATUS_TOKEN_TTL_DAYS: z.coerce.number().int().positive().default(90),
+    // Optional — validated when modules wire up
+    STRIPE_SECRET_KEY: z.string().optional(),
+    STRIPE_WEBHOOK_SECRET: z.string().optional(),
+    ZITADEL_AUTHORITY: z.string().url().optional(),
+    ZITADEL_CLIENT_ID: z.string().optional(),
+    ZITADEL_WEBHOOK_SECRET: z.string().optional(),
+    DEV_AUTH_BYPASS: z
+      .enum(['true', 'false'])
+      .default('false')
+      .transform((v) => v === 'true'),
+    // Federation rate limiting (per-peer)
+    FEDERATION_RATE_LIMIT_MAX: z.coerce.number().int().positive().default(60),
+    FEDERATION_RATE_LIMIT_WINDOW_SECONDS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(60),
 
-  FEDERATION_RATE_LIMIT_FAIL_MODE: z
-    .enum(['open', 'closed', 'fallback'])
-    .default('open'),
+    // Status token TTL
+    STATUS_TOKEN_TTL_DAYS: z.coerce.number().int().positive().default(90),
 
-  FEDERATION_DOMAIN: z.string().optional(),
-  FEDERATION_ENABLED: z
-    .enum(['true', 'false'])
-    .default('false')
-    .transform((v) => v === 'true'),
-  FEDERATION_CONTACT: z.string().email().optional(),
-  FEDERATION_PRIVATE_KEY: z.string().optional(),
-  FEDERATION_PUBLIC_KEY: z.string().optional(),
+    FEDERATION_RATE_LIMIT_FAIL_MODE: z
+      .enum(['open', 'closed', 'fallback'])
+      .default('open'),
 
-  // Inngest workflow engine
-  INNGEST_EVENT_KEY: z.string().optional(),
-  INNGEST_SIGNING_KEY: z.string().optional(),
-  INNGEST_DEV: z
-    .enum(['true', 'false'])
-    .default('false')
-    .transform((v) => v === 'true'),
+    FEDERATION_DOMAIN: z.string().optional(),
+    FEDERATION_ENABLED: z
+      .enum(['true', 'false'])
+      .default('false')
+      .transform((v) => v === 'true'),
+    FEDERATION_CONTACT: z.string().email().optional(),
+    FEDERATION_PRIVATE_KEY: z.string().optional(),
+    FEDERATION_PUBLIC_KEY: z.string().optional(),
 
-  // Documenso contract signing
-  DOCUMENSO_API_URL: z.string().url().optional(),
-  DOCUMENSO_API_KEY: z.string().optional(),
-  DOCUMENSO_WEBHOOK_SECRET: z.string().optional(),
+    // Inngest workflow engine
+    INNGEST_EVENT_KEY: z.string().optional(),
+    INNGEST_SIGNING_KEY: z.string().optional(),
+    INNGEST_DEV: z
+      .enum(['true', 'false'])
+      .default('false')
+      .transform((v) => v === 'true'),
 
-  // Federation hub (managed hosting)
-  HUB_DOMAIN: z.string().optional(),
-  HUB_REGISTRATION_TOKEN: z.string().optional(),
+    // Documenso contract signing
+    DOCUMENSO_API_URL: z.string().url().optional(),
+    DOCUMENSO_API_KEY: z.string().optional(),
+    DOCUMENSO_WEBHOOK_SECRET: z.string().optional(),
 
-  // Email / Relay
-  EMAIL_PROVIDER: z.enum(['smtp', 'sendgrid', 'none']).default('none'),
-  SMTP_HOST: z.string().optional(),
-  SMTP_PORT: z.coerce.number().int().positive().optional(),
-  SMTP_USER: z.string().optional(),
-  SMTP_PASS: z.string().optional(),
-  SMTP_FROM: z.string().optional(),
-  SMTP_SECURE: z
-    .enum(['true', 'false'])
-    .default('false')
-    .transform((v) => v === 'true'),
-  SENDGRID_API_KEY: z.string().optional(),
-  SENDGRID_FROM: z.string().optional(),
+    // Federation hub (managed hosting)
+    HUB_DOMAIN: z.string().optional(),
+    HUB_REGISTRATION_TOKEN: z.string().optional(),
 
-  // Plugin registry
-  PLUGIN_REGISTRY_URL: z.string().url().optional(),
+    // Email / Relay
+    EMAIL_PROVIDER: z.enum(['smtp', 'sendgrid', 'none']).default('none'),
+    SMTP_HOST: z.string().optional(),
+    SMTP_PORT: z.coerce.number().int().positive().optional(),
+    SMTP_USER: z.string().optional(),
+    SMTP_PASS: z.string().optional(),
+    SMTP_FROM: z.string().optional(),
+    SMTP_SECURE: z
+      .enum(['true', 'false'])
+      .default('false')
+      .transform((v) => v === 'true'),
+    SENDGRID_API_KEY: z.string().optional(),
+    SENDGRID_FROM: z.string().optional(),
 
-  // Monitoring — Sentry
-  SENTRY_DSN: z.string().url().optional(),
-  SENTRY_ENVIRONMENT: z.string().default('development'),
-  SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0),
-  SENTRY_RELEASE: z.string().optional(),
+    // Plugin registry
+    PLUGIN_REGISTRY_URL: z.string().url().optional(),
 
-  // Monitoring — Prometheus
-  METRICS_ENABLED: z
-    .enum(['true', 'false'])
-    .default('false')
-    .transform((v) => v === 'true'),
-});
+    // Monitoring — Sentry
+    SENTRY_DSN: z.string().url().optional(),
+    SENTRY_ENVIRONMENT: z.string().default('development'),
+    SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0),
+    SENTRY_RELEASE: z.string().optional(),
+
+    // Monitoring — Prometheus
+    METRICS_ENABLED: z
+      .enum(['true', 'false'])
+      .default('false')
+      .transform((v) => v === 'true'),
+  })
+  .refine(
+    (env) =>
+      env.NODE_ENV !== 'production' || env.DATABASE_APP_URL !== undefined,
+    {
+      message:
+        'DATABASE_APP_URL is required in production to enforce RLS. ' +
+        'Set it to a non-superuser (NOBYPASSRLS) connection string.',
+      path: ['DATABASE_APP_URL'],
+    },
+  );
 
 export type Env = z.infer<typeof envSchema>;
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -31,7 +31,7 @@
 - [x] Audit query/list endpoints — wait for API surfaces — (DEVLOG 2026-02-13; done 2026-02-18 PR #101)
 - [x] Seed data (`packages/db/src/seed.ts` has TODO) — wait for API layer — (code TODO; done 2026-02-18 PR #104)
 - [x] [P2] Sliding window rate limiting — replaced fixed-window Lua script with sliding-window-log algorithm using Redis sorted sets; fixes burst-at-boundary 2x rate vulnerability; kept custom two-tier design (IP pre-auth + user post-auth) — (dev feedback 2026-02-25; done 2026-02-25)
-- [ ] [P2] RLS app connection fallback to superuser — packages/db/src/client.ts appPool falls back to DATABASE_URL when DATABASE_APP_URL is unset; production could silently use superuser credentials — (Codex review 2026-03-03)
+- [x] [P2] RLS app connection fallback to superuser — packages/db/src/client.ts appPool falls back to DATABASE_URL when DATABASE_APP_URL is unset; production could silently use superuser credentials — (Codex review 2026-03-03; done 2026-03-04)
 
 ### QA / Testing
 
@@ -313,7 +313,7 @@
 - [x] [P2] Federation S2S integration tests — simsub, transfer, migration (15 tests) — (test coverage plan 2026-03-02; done 2026-03-03)
 - [x] [P2] Notification prefs + writer analytics E2E (7 tests) — (test coverage plan 2026-03-02; done 2026-03-03)
 - [x] CI: Add service-integration-tests, security-tests jobs — (test coverage plan 2026-03-02; done 2026-03-03)
-- [ ] [P2] Fix flaky workspace analytics E2E — `workspace-analytics-correspondence.spec.ts` "Total Submissions" card times out intermittently (10s timeout); reproduces on both `main` and feature branches; likely slow tRPC query or rendering delay in CI — (CI flake 2026-03-03)
+- [x] [P2] Fix flaky workspace analytics E2E — `workspace-analytics-correspondence.spec.ts` "Total Submissions" card times out intermittently (10s timeout); reproduces on both `main` and feature branches; likely slow tRPC query or rendering delay in CI — (CI flake 2026-03-03; resolved 2026-03-04)
 
 ### Testing Infrastructure Hardening
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,22 @@ Newest entries first.
 
 ---
 
+## 2026-03-04 — Fix RLS App Connection Fallback
+
+### Done
+
+- Added security warning in `packages/db/src/client.ts` when `DATABASE_APP_URL` is unset (suppressed in test env)
+- Added `DATABASE_APP_URL` to `apps/api/src/config/env.ts` with `postgresql://` validation and `.refine()` requiring it in production
+- Added 3 new tests for production enforcement, dev allowance, and format validation; fixed 1 existing test
+- Updated `packages/db/CLAUDE.md` connection pool docs, root `CLAUDE.md` env table, and `docs/backlog.md`
+
+### Decisions
+
+- Keep `DATABASE_URL` fallback for dev convenience — breaking dev setup is worse than a warning
+- Enforce via Zod `.refine()` in env validation so production startup fails fast with a clear error message
+
+---
+
 ## 2026-03-04 — P3 Test Quality: Flakiness Detection + Risk Matrix
 
 ### Done

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -44,7 +44,7 @@ export const submissions = pgTable(
 ### Connection Pools (`src/client.ts`)
 
 - **`pool`** — superuser (`colophony`). Used for migrations, admin tasks, and the Drizzle `db` instance.
-- **`appPool`** — non-superuser (`app_user`, `NOBYPASSRLS`). Used by `withRls()` and the `dbContext` hook for all request-scoped queries. Configured via `DATABASE_APP_URL` (falls back to `DATABASE_URL`).
+- **`appPool`** — non-superuser (`app_user`, `NOBYPASSRLS`). Used by `withRls()` and the `dbContext` hook for all request-scoped queries. Configured via `DATABASE_APP_URL` (falls back to `DATABASE_URL` with a security warning). **Required in production** — API startup fails if `DATABASE_APP_URL` is unset when `NODE_ENV=production`.
 
 **Always use `appPool` for tenant data queries.** The superuser `pool` bypasses all RLS policies.
 

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -18,6 +18,13 @@ const pool = new Pool({
  * Uses DATABASE_APP_URL (app_user role, NOSUPERUSER NOBYPASSRLS).
  * Falls back to DATABASE_URL for backwards compatibility in dev.
  */
+if (!process.env.DATABASE_APP_URL && process.env.NODE_ENV !== "test") {
+  console.warn(
+    "[SECURITY WARNING] DATABASE_APP_URL is not set — appPool is using DATABASE_URL (superuser). " +
+      "RLS policies will be bypassed. Set DATABASE_APP_URL to a non-superuser connection string.",
+  );
+}
+
 const appPool = new Pool({
   connectionString: process.env.DATABASE_APP_URL || process.env.DATABASE_URL,
   max: parseInt(process.env.DB_POOL_MAX || "10", 10),


### PR DESCRIPTION
## Summary

- Added security warning in `packages/db/src/client.ts` when `DATABASE_APP_URL` is unset — appPool silently fell back to `DATABASE_URL` (superuser), bypassing all RLS protections
- Added `DATABASE_APP_URL` to `apps/api/src/config/env.ts` with `postgresql://` validation and `.refine()` requiring it when `NODE_ENV=production` — startup fails fast with a clear error
- Added 3 new tests, fixed 1 existing test that set `NODE_ENV: 'production'` without `DATABASE_APP_URL`
- Updated docs: `packages/db/CLAUDE.md`, root `CLAUDE.md` env table, `docs/backlog.md`

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `apps/api/src/config/env.spec.ts` | No changes needed | Fixed existing test + 3 new tests | Plan assumed tests already set `DATABASE_APP_URL`; one test set `NODE_ENV: 'production'` without it |

## Test plan

- [x] `pnpm test --filter @colophony/api -- src/config/env.spec.ts` — 18 tests pass (3 new)
- [x] `pnpm test --filter @colophony/api` — 1594 tests pass (156 files)
- [x] `pnpm type-check` — passes
- [x] `pnpm lint` — passes
- [ ] CI pipeline