### PR TITLE
fix(relay): defense-in-depth org filtering for webhook service

### DIFF
--- a/apps/api/src/services/webhook.service.spec.ts
+++ b/apps/api/src/services/webhook.service.spec.ts
@@ -70,6 +70,114 @@ describe('webhookService', () => {
     /* eslint-enable @typescript-eslint/unbound-method */
   });
 
+  it('filters by organizationId in getEndpoint', async () => {
+    const mockLimit = vi
+      .fn()
+      .mockResolvedValue([{ id: 'ep-1', organization_id: 'org-1' }]);
+    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+    const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+    const mockTx = { select: mockSelect } as never;
+
+    await webhookService.getEndpoint(mockTx, 'ep-1', 'org-1');
+
+    expect(andFn).toHaveBeenCalled();
+    const andArgs = andFn.mock.calls[0];
+    expect(andArgs[0]).toEqual({ type: 'eq', args: ['id', 'ep-1'] });
+    expect(andArgs[1]).toEqual({
+      type: 'eq',
+      args: ['organization_id', 'org-1'],
+    });
+  });
+
+  it('filters by organizationId in listEndpoints', async () => {
+    const mockOffset = vi.fn().mockResolvedValue([]);
+    const mockItemsLimit = vi.fn().mockReturnValue({ offset: mockOffset });
+    const mockOrderBy = vi.fn().mockReturnValue({ limit: mockItemsLimit });
+    const mockItemsWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+    const mockFrom = vi.fn().mockReturnValue({ where: mockItemsWhere });
+    const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+
+    const mockCountWhere = vi.fn().mockResolvedValue([{ count: 0 }]);
+    const mockCountFrom = vi.fn().mockReturnValue({ where: mockCountWhere });
+    const mockCountSelect = vi.fn().mockReturnValue({ from: mockCountFrom });
+
+    let selectCallCount = 0;
+    const mockTx = {
+      select: vi.fn((...args: unknown[]) => {
+        selectCallCount++;
+        if (selectCallCount === 1) return mockSelect(...args);
+        return mockCountSelect(...args);
+      }),
+    } as never;
+
+    await webhookService.listEndpoints(mockTx, {
+      organizationId: 'org-1',
+      page: 1,
+      limit: 10,
+    });
+
+    expect(eqFn).toHaveBeenCalledWith('organization_id', 'org-1');
+  });
+
+  it('filters by organizationId in updateEndpoint', async () => {
+    const mockReturning = vi
+      .fn()
+      .mockResolvedValue([{ id: 'ep-1', organization_id: 'org-1' }]);
+    const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
+    const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+    const mockUpdate = vi.fn().mockReturnValue({ set: mockSet });
+    const mockTx = { update: mockUpdate } as never;
+
+    await webhookService.updateEndpoint(mockTx, 'ep-1', 'org-1', {
+      status: 'DISABLED',
+    });
+
+    expect(andFn).toHaveBeenCalled();
+    const andArgs = andFn.mock.calls[0];
+    expect(andArgs[0]).toEqual({ type: 'eq', args: ['id', 'ep-1'] });
+    expect(andArgs[1]).toEqual({
+      type: 'eq',
+      args: ['organization_id', 'org-1'],
+    });
+  });
+
+  it('filters by organizationId in deleteEndpoint', async () => {
+    const mockWhere = vi.fn().mockResolvedValue(undefined);
+    const mockDeleteFrom = vi.fn().mockReturnValue({ where: mockWhere });
+    const mockTx = { delete: mockDeleteFrom } as never;
+
+    await webhookService.deleteEndpoint(mockTx, 'ep-1', 'org-1');
+
+    expect(andFn).toHaveBeenCalled();
+    const andArgs = andFn.mock.calls[0];
+    expect(andArgs[0]).toEqual({ type: 'eq', args: ['id', 'ep-1'] });
+    expect(andArgs[1]).toEqual({
+      type: 'eq',
+      args: ['organization_id', 'org-1'],
+    });
+  });
+
+  it('filters by organizationId in rotateSecret', async () => {
+    const mockReturning = vi
+      .fn()
+      .mockResolvedValue([{ id: 'ep-1', secret: 'new-secret' }]);
+    const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
+    const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+    const mockUpdate = vi.fn().mockReturnValue({ set: mockSet });
+    const mockTx = { update: mockUpdate } as never;
+
+    await webhookService.rotateSecret(mockTx, 'ep-1', 'org-1');
+
+    expect(andFn).toHaveBeenCalled();
+    const andArgs = andFn.mock.calls[0];
+    expect(andArgs[0]).toEqual({ type: 'eq', args: ['id', 'ep-1'] });
+    expect(andArgs[1]).toEqual({
+      type: 'eq',
+      args: ['organization_id', 'org-1'],
+    });
+  });
+
   it('filters by organizationId in getActiveEndpointsForEvent', async () => {
     const mockWhere = vi.fn().mockResolvedValue([]);
     const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });

--- a/apps/api/src/services/webhook.service.ts
+++ b/apps/api/src/services/webhook.service.ts
@@ -93,6 +93,7 @@ export const webhookService = {
   async updateEndpoint(
     tx: DrizzleDb,
     id: string,
+    organizationId: string,
     params: UpdateEndpointParams,
   ) {
     if (params.url !== undefined) {
@@ -121,36 +122,59 @@ export const webhookService = {
     const [row] = await tx
       .update(webhookEndpoints)
       .set(update)
-      .where(eq(webhookEndpoints.id, id))
+      .where(
+        and(
+          eq(webhookEndpoints.id, id),
+          eq(webhookEndpoints.organizationId, organizationId),
+        ),
+      )
       .returning();
     return row ? redactSecret(row) : null;
   },
 
-  async deleteEndpoint(tx: DrizzleDb, id: string) {
-    await tx.delete(webhookEndpoints).where(eq(webhookEndpoints.id, id));
+  async deleteEndpoint(tx: DrizzleDb, id: string, organizationId: string) {
+    await tx
+      .delete(webhookEndpoints)
+      .where(
+        and(
+          eq(webhookEndpoints.id, id),
+          eq(webhookEndpoints.organizationId, organizationId),
+        ),
+      );
   },
 
-  async getEndpoint(tx: DrizzleDb, id: string) {
+  async getEndpoint(tx: DrizzleDb, id: string, organizationId: string) {
     const [row] = await tx
       .select()
       .from(webhookEndpoints)
-      .where(eq(webhookEndpoints.id, id))
+      .where(
+        and(
+          eq(webhookEndpoints.id, id),
+          eq(webhookEndpoints.organizationId, organizationId),
+        ),
+      )
       .limit(1);
     return row ? redactSecret(row) : null;
   },
 
-  async listEndpoints(tx: DrizzleDb, params: { page: number; limit: number }) {
-    const { page, limit } = params;
+  async listEndpoints(
+    tx: DrizzleDb,
+    params: { organizationId: string; page: number; limit: number },
+  ) {
+    const { organizationId, page, limit } = params;
     const offset = (page - 1) * limit;
+
+    const orgFilter = eq(webhookEndpoints.organizationId, organizationId);
 
     const [items, countResult] = await Promise.all([
       tx
         .select()
         .from(webhookEndpoints)
+        .where(orgFilter)
         .orderBy(desc(webhookEndpoints.createdAt))
         .limit(limit)
         .offset(offset),
-      tx.select({ count: count() }).from(webhookEndpoints),
+      tx.select({ count: count() }).from(webhookEndpoints).where(orgFilter),
     ]);
 
     const total = countResult[0]?.count ?? 0;
@@ -163,12 +187,17 @@ export const webhookService = {
     };
   },
 
-  async rotateSecret(tx: DrizzleDb, id: string) {
+  async rotateSecret(tx: DrizzleDb, id: string, organizationId: string) {
     const secret = crypto.randomBytes(32).toString('hex');
     const [row] = await tx
       .update(webhookEndpoints)
       .set({ secret, updatedAt: new Date() })
-      .where(eq(webhookEndpoints.id, id))
+      .where(
+        and(
+          eq(webhookEndpoints.id, id),
+          eq(webhookEndpoints.organizationId, organizationId),
+        ),
+      )
       .returning();
     return row;
   },

--- a/apps/api/src/trpc/routers/webhooks.spec.ts
+++ b/apps/api/src/trpc/routers/webhooks.spec.ts
@@ -41,8 +41,9 @@ vi.mock('../../config/env.js', () => ({
 }));
 
 vi.mock('@colophony/db', () => ({
-  webhookEndpoints: { id: 'id' },
+  webhookEndpoints: { id: 'id', organizationId: 'organization_id' },
   eq: vi.fn(),
+  and: vi.fn(),
 }));
 
 // Mock tRPC init with a passthrough stub

--- a/apps/api/src/trpc/routers/webhooks.ts
+++ b/apps/api/src/trpc/routers/webhooks.ts
@@ -6,7 +6,7 @@ import {
   AuditActions,
   AuditResources,
 } from '@colophony/types';
-import { webhookEndpoints, eq } from '@colophony/db';
+import { webhookEndpoints, eq, and } from '@colophony/db';
 import { adminProcedure, orgProcedure, createRouter } from '../init.js';
 import { webhookService } from '../../services/webhook.service.js';
 import { enqueueWebhook } from '../../queues/webhook.queue.js';
@@ -37,7 +37,12 @@ export const webhooksRouter = createRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { id, ...params } = input;
-      const row = await webhookService.updateEndpoint(ctx.dbTx, id, params);
+      const row = await webhookService.updateEndpoint(
+        ctx.dbTx,
+        id,
+        ctx.authContext.orgId,
+        params,
+      );
       await ctx.audit({
         action: AuditActions.WEBHOOK_ENDPOINT_UPDATED,
         resource: AuditResources.WEBHOOK_ENDPOINT,
@@ -50,7 +55,11 @@ export const webhooksRouter = createRouter({
   delete: adminProcedure
     .input(z.object({ id: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      await webhookService.deleteEndpoint(ctx.dbTx, input.id);
+      await webhookService.deleteEndpoint(
+        ctx.dbTx,
+        input.id,
+        ctx.authContext.orgId,
+      );
       await ctx.audit({
         action: AuditActions.WEBHOOK_ENDPOINT_DELETED,
         resource: AuditResources.WEBHOOK_ENDPOINT,
@@ -62,7 +71,11 @@ export const webhooksRouter = createRouter({
   getById: orgProcedure
     .input(z.object({ id: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
-      return webhookService.getEndpoint(ctx.dbTx, input.id);
+      return webhookService.getEndpoint(
+        ctx.dbTx,
+        input.id,
+        ctx.authContext.orgId,
+      );
     }),
 
   list: orgProcedure
@@ -73,13 +86,20 @@ export const webhooksRouter = createRouter({
       }),
     )
     .query(async ({ ctx, input }) => {
-      return webhookService.listEndpoints(ctx.dbTx, input);
+      return webhookService.listEndpoints(ctx.dbTx, {
+        ...input,
+        organizationId: ctx.authContext.orgId,
+      });
     }),
 
   rotateSecret: adminProcedure
     .input(z.object({ id: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      const row = await webhookService.rotateSecret(ctx.dbTx, input.id);
+      const row = await webhookService.rotateSecret(
+        ctx.dbTx,
+        input.id,
+        ctx.authContext.orgId,
+      );
       await ctx.audit({
         action: AuditActions.WEBHOOK_ENDPOINT_SECRET_ROTATED,
         resource: AuditResources.WEBHOOK_ENDPOINT,
@@ -98,7 +118,12 @@ export const webhooksRouter = createRouter({
       const [endpoint] = await ctx.dbTx
         .select()
         .from(webhookEndpoints)
-        .where(eq(webhookEndpoints.id, input.id))
+        .where(
+          and(
+            eq(webhookEndpoints.id, input.id),
+            eq(webhookEndpoints.organizationId, orgId),
+          ),
+        )
         .limit(1);
 
       if (!endpoint) {
@@ -170,7 +195,12 @@ export const webhooksRouter = createRouter({
       const [endpoint] = await ctx.dbTx
         .select()
         .from(webhookEndpoints)
-        .where(eq(webhookEndpoints.id, delivery.webhookEndpointId))
+        .where(
+          and(
+            eq(webhookEndpoints.id, delivery.webhookEndpointId),
+            eq(webhookEndpoints.organizationId, orgId),
+          ),
+        )
         .limit(1);
 
       if (!endpoint) {

--- a/apps/api/src/workers/__tests__/webhook.worker.spec.ts
+++ b/apps/api/src/workers/__tests__/webhook.worker.spec.ts
@@ -243,6 +243,40 @@ describe('webhook worker', () => {
     );
   });
 
+  it('auto-disables endpoint with orgId filter when failure threshold met', async () => {
+    const job = makeJob({ attemptsMade: 8 });
+    const err = new Error('HTTP 500');
+
+    mockWithRls.mockImplementation(
+      (_ctx: unknown, fn: (tx: unknown) => unknown) => {
+        const mockTx = {
+          select: vi.fn().mockReturnValue({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi
+                  .fn()
+                  .mockResolvedValue([{ webhookEndpointId: 'ep-1' }]),
+              }),
+            }),
+          }),
+        };
+        return fn(mockTx);
+      },
+    );
+
+    mockCountRecentFailures.mockResolvedValueOnce(5); // At threshold
+
+    await failedCallback(job, err);
+
+    // updateEndpoint should be called with orgId as 3rd arg
+    expect(mockUpdateEndpoint).toHaveBeenCalledWith(
+      expect.anything(),
+      'ep-1',
+      'org-1',
+      { status: 'DISABLED' },
+    );
+  });
+
   it('stops worker cleanly', async () => {
     await stopWebhookWorker();
     expect(mockClose).toHaveBeenCalled();

--- a/apps/api/src/workers/webhook.worker.ts
+++ b/apps/api/src/workers/webhook.worker.ts
@@ -188,7 +188,7 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
               endpointId,
             );
             if (failCount >= AUTO_DISABLE_THRESHOLD) {
-              await webhookService.updateEndpoint(tx, endpointId, {
+              await webhookService.updateEndpoint(tx, endpointId, orgId, {
                 status: 'DISABLED',
               });
               await auditService.log(tx, {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -233,7 +233,7 @@
 - [x] Notification preferences frontend — UI for users to manage email opt-in/opt-out per event type — (DEVLOG 2026-02-26; done 2026-02-26)
 - [x] Webhook delivery system (outbound) — (architecture doc, Relay; done 2026-02-26)
 - [x] In-app notification center — SSE + Redis pub/sub + bell UI + dual-channel preferences — (architecture doc, Relay; done 2026-02-26)
-- [ ] [P2] Defense-in-depth org filtering missing in webhook.service.ts — getEndpoint, listEndpoints, rotateSecret query by ID only (RLS-only, no explicit organizationId filter) — (Codex review 2026-03-03)
+- [x] [P2] Defense-in-depth org filtering missing in webhook.service.ts — getEndpoint, listEndpoints, rotateSecret query by ID only (RLS-only, no explicit organizationId filter) — (Codex review 2026-03-03; done 2026-03-04)
 
 ---
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,23 @@ Newest entries first.
 
 ---
 
+## 2026-03-04 — Defense-in-Depth Org Filtering for Webhook Service
+
+### Done
+
+- Added explicit `organizationId` filtering to 5 webhook endpoint methods (`getEndpoint`, `listEndpoints`, `updateEndpoint`, `deleteEndpoint`, `rotateSecret`) — defense-in-depth alongside RLS
+- Updated tRPC router to pass `ctx.authContext.orgId` to all service calls and inline endpoint lookups (`test`, `retryDelivery`)
+- Updated webhook worker auto-disable call to pass `orgId` through `updateEndpoint`
+- Added 6 new tests: 5 service-level org filtering assertions + 1 worker auto-disable org filtering test
+- Updated router and worker test mocks for new signatures
+
+### Decisions
+
+- Delivery methods (`updateDeliveryStatus`, `retryDelivery`, `countRecentFailures`) left unchanged — they run inside `withRls({ orgId })` contexts, making redundant params unnecessary
+- Kept post-fetch `delivery.organizationId !== orgId` check in `retryDelivery` router as belt-and-suspenders
+
+---
+
 ## 2026-03-04 — Fix RLS App Connection Fallback
 
 ### Done


### PR DESCRIPTION
## Summary

- Added explicit `organizationId` filtering to 5 webhook endpoint methods (`getEndpoint`, `listEndpoints`, `updateEndpoint`, `deleteEndpoint`, `rotateSecret`) — defense-in-depth alongside RLS
- Updated tRPC router to pass `ctx.authContext.orgId` to all service calls and inline endpoint lookups (`test`, `retryDelivery`)
- Updated webhook worker auto-disable call to pass `orgId` through `updateEndpoint`
- Added 6 new tests covering org filtering assertions

Closes backlog item: `[P2] Defense-in-depth org filtering missing in webhook.service.ts`

## Test plan

- [x] 5 service-level tests asserting `and(eq(id), eq(organizationId))` on each endpoint method
- [x] 1 worker test asserting auto-disable passes orgId to `updateEndpoint`
- [x] All 15 webhook tests pass (`service.spec`, `router.spec`, `worker.spec`)
- [x] Type-check passes
- [x] Lint passes