### PR TITLE
fix: bounded peer query + standardized SSRF in federation

### DIFF
--- a/apps/api/src/federation/__tests__/trust-handshake.integration.spec.ts
+++ b/apps/api/src/federation/__tests__/trust-handshake.integration.spec.ts
@@ -152,7 +152,7 @@ vi.mock('../../federation/http-signatures.js', () => ({
 }));
 
 vi.mock('../../lib/url-validation.js', () => ({
-  resolveAndCheckPrivateIp: vi.fn(),
+  validateOutboundUrl: vi.fn(),
   SsrfValidationError: class extends Error {},
 }));
 

--- a/apps/api/src/services/migration.service.spec.ts
+++ b/apps/api/src/services/migration.service.spec.ts
@@ -447,12 +447,11 @@ describe('migrationService', () => {
       // The implementation makes these db calls in order:
       // 1. db.select().from().where().limit() — find migration
       // 2. db.update(users).set({...}).where(...) — soft deactivate
-      // 3. db.select().from().where() — broadcast peers query (no .limit())
+      // 3. db.select().from().where().limit() — broadcast peers query
       // 4. db.update(identityMigrations).set({...}).where(...) — update migration status
       //
-      // We use mockResolvedValueOnce on .limit() for query #1, and
+      // We use mockResolvedValueOnce on .limit() for queries #1 and #3, and
       // mockReturnValueOnce on .set() for the two update chains.
-      // For the broadcast peers query (#3), .where() returns [] (no peers).
 
       // Query #1: find migration — terminates at .limit()
       mockDb.limit.mockResolvedValueOnce([
@@ -471,15 +470,15 @@ describe('migrationService', () => {
         where: vi.fn().mockResolvedValue(undefined),
       });
 
-      // Query #3: broadcast peers — db.select().from().where()
-      // .where() is the terminal call here (no .limit()).
-      // mockDb.where is called twice on mockDb:
-      //   1st for find migration (needs to return this for .limit() chain)
-      //   2nd for broadcast peers (needs to resolve to [])
-      // Queue: first returns mockDb (to preserve chain), second resolves to []
+      // Query #3: broadcast peers — db.select().from().where().limit()
+      // Both .where() calls chain to mockDb (for .limit()), .limit() resolves.
+      // Queue: 1st .where() chains for find migration, 2nd chains for peers
       mockDb.where
         .mockReturnValueOnce(mockDb) // 1st .where() — chain to .limit()
-        .mockResolvedValueOnce([]); // 2nd .where() — broadcast peers terminal
+        .mockReturnValueOnce(mockDb); // 2nd .where() — chain to .limit()
+
+      // Query #3: broadcast peers — terminates at .limit()
+      mockDb.limit.mockResolvedValueOnce([]); // no peers
 
       // Query #4: update migration status — db.update().set().where()
       mockDb.set.mockReturnValueOnce({

--- a/apps/api/src/services/migration.service.ts
+++ b/apps/api/src/services/migration.service.ts
@@ -868,6 +868,7 @@ export const migrationService = {
     const domain = env.FEDERATION_DOMAIN ?? 'localhost';
 
     // Query all active trusted peers with identity.migrate capability
+    const peerLimit = 500;
     const peers = await db
       .select({
         instanceUrl: trustedPeers.instanceUrl,
@@ -879,7 +880,15 @@ export const migrationService = {
           eq(trustedPeers.status, 'active'),
           sql`granted_capabilities @> '{"identity.migrate": true}'::jsonb`,
         ),
+      )
+      .limit(peerLimit);
+
+    if (peers.length >= peerLimit) {
+      console.warn(
+        'Migration broadcast peer limit reached (%d); some peers may not be notified',
+        peerLimit,
       );
+    }
 
     // Deduplicate by domain (may be trusted by multiple orgs)
     const uniquePeers = new Map<string, string>();

--- a/apps/api/src/services/trust.service.spec.ts
+++ b/apps/api/src/services/trust.service.spec.ts
@@ -80,7 +80,7 @@ vi.stubGlobal('fetch', mockFetch);
 // Mock url-validation — trampoline pattern so clearAllMocks doesn't wipe the
 // module-level mock binding. SSRF tests control this directly instead of going
 // through the fragile node:dns mock chain.
-const mockResolveAndCheckPrivateIp = vi.fn().mockResolvedValue(undefined);
+const mockValidateOutboundUrl = vi.fn().mockResolvedValue(undefined);
 vi.mock('../lib/url-validation.js', () => ({
   SsrfValidationError: class SsrfValidationError extends Error {
     override name = 'SsrfValidationError' as const;
@@ -90,9 +90,7 @@ vi.mock('../lib/url-validation.js', () => ({
   },
   isPrivateIPv4: vi.fn(),
   isPrivateIPv6: vi.fn(),
-  validateOutboundUrl: vi.fn(),
-  resolveAndCheckPrivateIp: (...args: unknown[]) =>
-    mockResolveAndCheckPrivateIp(...args),
+  validateOutboundUrl: (...args: unknown[]) => mockValidateOutboundUrl(...args),
 }));
 
 // Import mocked SsrfValidationError for use in SSRF test assertions
@@ -222,7 +220,7 @@ describe('trust.service', () => {
     vi.clearAllMocks();
     mockAuditLog.mockResolvedValue(undefined);
     // Restore url-validation default (allow all) cleared by clearAllMocks
-    mockResolveAndCheckPrivateIp.mockResolvedValue(undefined);
+    mockValidateOutboundUrl.mockResolvedValue(undefined);
     dbSelectResult = [];
     const mod = await import('./trust.service.js');
     trustService = mod.trustService;
@@ -818,9 +816,9 @@ describe('trust.service', () => {
 
   describe('SSRF protection', () => {
     it('rejects private IPv4 in production', async () => {
-      mockResolveAndCheckPrivateIp.mockRejectedValueOnce(
+      mockValidateOutboundUrl.mockRejectedValueOnce(
         new SsrfValidationError(
-          'Resolved to private IPv4 address: 192.168.1.1',
+          'URL resolves to private IP address: 192.168.1.1',
         ),
       );
 
@@ -836,8 +834,8 @@ describe('trust.service', () => {
     });
 
     it('rejects private IPv6 in production', async () => {
-      mockResolveAndCheckPrivateIp.mockRejectedValueOnce(
-        new SsrfValidationError('Resolved to private IPv6 address: ::1'),
+      mockValidateOutboundUrl.mockRejectedValueOnce(
+        new SsrfValidationError('URL resolves to private IP address: ::1'),
       );
 
       const original = process.env.NODE_ENV;
@@ -852,8 +850,10 @@ describe('trust.service', () => {
     });
 
     it('rejects localhost (127.0.0.1) in production', async () => {
-      mockResolveAndCheckPrivateIp.mockRejectedValueOnce(
-        new SsrfValidationError('Resolved to private IPv4 address: 127.0.0.1'),
+      mockValidateOutboundUrl.mockRejectedValueOnce(
+        new SsrfValidationError(
+          'URL resolves to private IP address: 127.0.0.1',
+        ),
       );
 
       const original = process.env.NODE_ENV;
@@ -878,8 +878,11 @@ describe('trust.service', () => {
         const result =
           await trustService.fetchRemoteMetadata('remote.example.com');
         expect(result.domain).toBe('remote.example.com');
-        // resolveAndCheckPrivateIp should NOT have been called in dev mode
-        expect(mockResolveAndCheckPrivateIp).not.toHaveBeenCalled();
+        // validateOutboundUrl called with devMode: true (returns early)
+        expect(mockValidateOutboundUrl).toHaveBeenCalledWith(
+          'https://remote.example.com/.well-known/colophony',
+          { devMode: true },
+        );
       } finally {
         process.env.NODE_ENV = original;
       }

--- a/apps/api/src/services/trust.service.ts
+++ b/apps/api/src/services/trust.service.ts
@@ -29,7 +29,6 @@ import {
   verifyFederationSignature,
 } from '../federation/http-signatures.js';
 import {
-  resolveAndCheckPrivateIp,
   validateOutboundUrl,
   SsrfValidationError,
 } from '../lib/url-validation.js';
@@ -88,26 +87,25 @@ const MAX_METADATA_RESPONSE_BYTES = 1_048_576;
 async function fetchAndValidateMetadata(
   domain: string,
 ): Promise<FederationMetadata> {
-  // SSRF check — skip in development/test for localhost
-  const nodeEnv = process.env.NODE_ENV;
-  if (nodeEnv !== 'development' && nodeEnv !== 'test') {
-    try {
-      await resolveAndCheckPrivateIp(domain);
-    } catch (err) {
-      if (err instanceof SsrfValidationError) {
-        // Sanitize: don't leak internal IPs in the outward-facing error
-        throw new RemoteMetadataFetchError(
-          domain,
-          new Error('Domain resolves to a private or reserved IP address'),
-        );
-      }
-      throw err;
+  // SSRF check — validateOutboundUrl handles dev/test bypass internally
+  const metadataUrl = `https://${domain}/.well-known/colophony`;
+  const devMode =
+    process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
+  try {
+    await validateOutboundUrl(metadataUrl, { devMode });
+  } catch (err) {
+    if (err instanceof SsrfValidationError) {
+      throw new RemoteMetadataFetchError(
+        domain,
+        new Error('Domain resolves to a private or reserved IP address'),
+      );
     }
+    throw err;
   }
 
   let response: Response;
   try {
-    response = await fetch(`https://${domain}/.well-known/colophony`, {
+    response = await fetch(metadataUrl, {
       signal: AbortSignal.timeout(10_000),
       headers: { accept: 'application/json' },
       redirect: 'error', // Prevent redirect-based SSRF

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -178,8 +178,8 @@
 - [x] [P4] Consider splitting schema migrations (enum changes vs new tables) for safer production rollback — documented as pattern + pre-flight validator instead of splitting 0031 (already applied) — (OpenCode review 2026-02-25, deferred pre-launch; done 2026-02-26)
 - [x] [P3] Federation rate limit fail mode: configurable fail-open/fail-closed + in-process fallback when Redis unavailable — (audit finding #4, 2026-03-01; done 2026-03-01 PR #225)
 - [x] [P3] Federation test gaps: integration tests for trust handshake flow and hub-first discovery path — (audit finding #5, 2026-03-01; done 2026-03-01 PR #225)
-- [ ] [P3] Unbounded peer query in migration broadcast — migration.service.ts:870 fetches all trusted peers with no LIMIT; small dataset in practice but violates pagination rule — (Codex review 2026-03-03)
-- [ ] [P3] Trust metadata SSRF uses custom resolveAndCheckPrivateIp instead of validateOutboundUrl — trust.service.ts:88; functionally equivalent but inconsistent with the standard pattern — (Codex review 2026-03-03)
+- [x] [P3] Unbounded peer query in migration broadcast — migration.service.ts:870 fetches all trusted peers with no LIMIT; small dataset in practice but violates pagination rule — (Codex review 2026-03-03; done 2026-03-04)
+- [x] [P3] Trust metadata SSRF uses custom resolveAndCheckPrivateIp instead of validateOutboundUrl — trust.service.ts:88; functionally equivalent but inconsistent with the standard pattern — (Codex review 2026-03-03; done 2026-03-04)
 
 ### Design Decisions
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,23 @@ Newest entries first.
 
 ---
 
+## 2026-03-04 — P3 Defensive Improvements (Migration + Trust SSRF)
+
+### Done
+
+- Added `.limit(500)` to unbounded trusted peers query in `migration.service.ts` broadcast with warning log when limit is hit
+- Replaced custom `resolveAndCheckPrivateIp` SSRF check in `trust.service.ts` with standard `validateOutboundUrl` — consistent with all other SSRF-protected callsites
+- Removed unused `resolveAndCheckPrivateIp` import from trust service
+- Updated test mocks in both `migration.service.spec.ts` and `trust.service.spec.ts`
+- Marked two P3 backlog items done; status token rotation stays open (blocked on embed resubmit flow)
+
+### Decisions
+
+- Used `console.warn` for peer limit warning since services don't have Fastify logger injected
+- Skipped status token rotation on R&R resubmission — no embed resubmit flow exists yet
+
+---
+
 ## 2026-03-04 — Defense-in-Depth Org Filtering for Webhook Service
 
 ### Done


### PR DESCRIPTION
## Summary

- Added `.limit(500)` to unbounded trusted peers query in migration broadcast (`migration.service.ts`) with `console.warn` when limit is hit
- Replaced custom `resolveAndCheckPrivateIp` SSRF check in trust metadata fetch (`trust.service.ts`) with standard `validateOutboundUrl` for consistency with all other SSRF-protected callsites
- Removed unused `resolveAndCheckPrivateIp` import
- Updated test mocks in both service spec files
- Marked two P3 backlog items done; status token rotation stays open (blocked on embed resubmit flow)

## Plan Overrides

| File | Planned | Actual | Rationale |
|---|---|---|---|
| `migration.service.ts` | `log.warn(...)` | `console.warn(...)` | Services don't have Fastify logger injected |
| `migration.service.spec.ts` | No changes | Updated mock chain | Test mock needed `.limit()` in chain for broadcast peers query |

## Test plan

- [x] `pnpm type-check` — no type errors
- [x] `pnpm --filter @colophony/api test -- --run migration.service` — 16 tests pass
- [x] `pnpm --filter @colophony/api test -- --run trust.service` — 29 tests pass
- [x] `pnpm lint` — no lint errors
- [x] branch review — LGTM, no actionable findings