### PR TITLE
chore: replace Overmind with hivemind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,9 +47,6 @@ Thumbs.db
 # Docker bind mounts (Zitadel PAT, etc.)
 .docker/
 
-# Overmind
-.overmind.sock
-
 # Session handoff (machine-readable, not for version control)
 session-handoff.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,16 +146,16 @@ Summary: Stripe Checkout only (zero PCI scope). Webhook handler built with two-s
 
 Domain-specific quirks are in per-directory CLAUDE.md files. Cross-cutting quirks below:
 
-| Quirk                                                 | Details                                                                                                                                                                                                                           |
-| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Docker Compose env_file**                           | `env_file:` sets container env only. For YAML `${VAR}` substitution, use `--env-file .env` on CLI                                                                                                                                 |
-| **PostgreSQL init-db.sh**                             | Only runs on first DB creation. Must `docker compose down -v` to re-run after changes                                                                                                                                             |
-| **WSL husky hooks need nvm PATH**                     | Husky v9 runs hooks under `sh`/`dash`; `nvm.sh` can't be sourced. Hooks add nvm node bin to PATH directly. `lint-staged` called without `npx`                                                                                     |
-| **CI: workspace deps need build before Vitest**       | Vitest resolves workspace packages via `exports` field (pointing to `dist/`). CI must build deps before running tests                                                                                                             |
-| **`drizzle-kit generate` TUI blocks automation**      | Interactive prompts (rename vs create) use a TUI that ignores piped stdin. Write manual migrations in non-interactive shells; snapshot files may need regeneration interactively                                                  |
-| **Playwright `webServer.env` replaces `process.env`** | `webServer.env` **replaces** (not merges) the child process environment. Must load `.env` files via `dotenv` and spread `...process.env` to ensure `DATABASE_URL` etc. reach dev servers                                          |
-| **Zitadel issuer ± trailing slash**                   | Zitadel v4.10.1 omits trailing slash in JWT `iss` claim. JWKS verifier uses array issuer `[base, base + "/"]` to match both. Don't normalize to one form                                                                          |
-| **Overmind requires tmux**                            | `pnpm dev` uses Overmind (tmux-based process manager). Install both `tmux` and `overmind`. Turbo stays for builds; Overmind replaces it for persistent dev servers only. Use `pnpm dev:clean` to kill orphans if Overmind crashes |
+| Quirk                                                 | Details                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Docker Compose env_file**                           | `env_file:` sets container env only. For YAML `${VAR}` substitution, use `--env-file .env` on CLI                                                                                                                                                                                                                                                                                                                                 |
+| **PostgreSQL init-db.sh**                             | Only runs on first DB creation. Must `docker compose down -v` to re-run after changes                                                                                                                                                                                                                                                                                                                                             |
+| **WSL husky hooks need nvm PATH**                     | Husky v9 runs hooks under `sh`/`dash`; `nvm.sh` can't be sourced. Hooks add nvm node bin to PATH directly. `lint-staged` called without `npx`                                                                                                                                                                                                                                                                                     |
+| **CI: workspace deps need build before Vitest**       | Vitest resolves workspace packages via `exports` field (pointing to `dist/`). CI must build deps before running tests                                                                                                                                                                                                                                                                                                             |
+| **`drizzle-kit generate` TUI blocks automation**      | Interactive prompts (rename vs create) use a TUI that ignores piped stdin. Write manual migrations in non-interactive shells; snapshot files may need regeneration interactively                                                                                                                                                                                                                                                  |
+| **Playwright `webServer.env` replaces `process.env`** | `webServer.env` **replaces** (not merges) the child process environment. Must load `.env` files via `dotenv` and spread `...process.env` to ensure `DATABASE_URL` etc. reach dev servers                                                                                                                                                                                                                                          |
+| **Zitadel issuer ± trailing slash**                   | Zitadel v4.10.1 omits trailing slash in JWT `iss` claim. JWKS verifier uses array issuer `[base, base + "/"]` to match both. Don't normalize to one form                                                                                                                                                                                                                                                                          |
+| **hivemind for dev servers**                          | `pnpm dev` uses hivemind (single Go binary, no tmux). Install `hivemind`. Turbo stays for builds; hivemind replaces it for persistent dev servers only. Use `pnpm dev:clean` to kill orphans if hivemind crashes. No per-process `connect`/`restart` — use Ctrl+C to stop all, rely on hot-reload for changes. hivemind always injects a PORT env var (base 5000); `Procfile.dev` sets `PORT=` explicitly per process to override |
 
 **Version pin (cross-cutting):**
 
@@ -383,18 +383,17 @@ pnpm install
 pnpm db:migrate               # Run Drizzle migrations
 pnpm db:seed                  # Seed dev data (orgs, submissions, Slate pipeline)
 pnpm zitadel:setup            # Provision Zitadel + patch .env files (after volume wipe)
-pnpm dev                      # Overmind: builds packages, then API: 4000, Web: 3000
+pnpm dev                      # hivemind: builds packages, then API: 4000, Web: 3000
 ```
 
-**Overmind commands** (run from project root while `pnpm dev` is running):
+**hivemind controls** (while `pnpm dev` is running):
 
 ```bash
-overmind connect api           # Attach to API logs (detach: Ctrl+B D)
-overmind connect web           # Attach to Web logs
-overmind restart api           # Restart API only (Web continues)
-overmind kill                  # Stop all dev servers
-pnpm dev:clean                # Kill orphaned processes + stale files (fallback)
+Ctrl+C                         # Stop all dev servers (hivemind forwards signals)
+pnpm dev:clean                 # Kill orphaned processes + stale files (fallback)
 ```
+
+Note: hivemind does not support per-process attach/restart. Both apps have hot-reload, so file changes trigger automatic restarts. Use `pnpm dev:clean && pnpm dev` for a full restart.
 
 ### Running Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 - Node.js >= 22
 - pnpm 9.15+
 - Docker and Docker Compose
-- tmux + [Overmind](https://github.com/DarthSim/overmind) — process supervisor for running the API and web dev servers concurrently with log multiplexing
+- [hivemind](https://github.com/DarthSim/hivemind) — process manager for running the API and web dev servers concurrently with labeled log output
 
 ### Setup
 
@@ -24,13 +24,7 @@ pnpm zitadel:setup    # Provision Zitadel auth (after first volume creation)
 pnpm dev              # Start dev servers (API: 4000, Web: 3000)
 ```
 
-Overmind manages the dev servers. Useful commands while `pnpm dev` is running:
-
-```bash
-overmind connect api   # Attach to API logs (detach: Ctrl+B D)
-overmind connect web   # Attach to Web logs
-overmind restart api   # Restart API only
-```
+hivemind manages the dev servers. Ctrl+C stops both. Both apps have hot-reload for file changes. Use `pnpm dev:clean` to kill orphaned processes if needed.
 
 ## Development Workflow
 

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-api: pnpm --filter @colophony/api dev
-web: pnpm --filter @colophony/web dev
+api: PORT=4000 pnpm --filter @colophony/api dev
+web: PORT=3000 pnpm --filter @colophony/web dev

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pnpm zitadel:setup
 pnpm dev              # API on :4000, Web on :3000
 ```
 
-Prerequisites: Node.js >= 22, pnpm 9.15+, Docker, tmux + Overmind. See [CONTRIBUTING.md](CONTRIBUTING.md) for full setup instructions.
+Prerequisites: Node.js >= 22, pnpm 9.15+, Docker, [hivemind](https://github.com/DarthSim/hivemind). See [CONTRIBUTING.md](CONTRIBUTING.md) for full setup instructions.
 
 ## Tech Stack
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,7 +115,7 @@ The original plan proposed 6 separate services. In practice, all backend logic r
 | ------------------- | ------------------------- | ----------------------------------------------- |
 | **Self-hosted**     | Docker Compose            | Small magazine with a VPS                       |
 | **Managed hosting** | Coolify + Hetzner         | Magazines that don't want to run infrastructure |
-| **Development**     | Docker Compose + Overmind | Contributors                                    |
+| **Development**     | Docker Compose + hivemind | Contributors                                    |
 
 ### Monorepo Structure (Actual)
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -535,7 +535,7 @@
 
 ### Dev Tooling
 
-- [ ] [P2] Replace Overmind with hivemind or concurrently — Overmind solves signal handling but tmux dependency, `dev:clean` escape hatch, and WSL quirks are operational drag. hivemind (Go binary, no tmux, proper signal handling) preferred; concurrently as fallback. Test on macOS, Linux, WSL before standardizing. Keep `dev:clean` as escape hatch, not normal workflow. Turbo `--watch` only if shutdown behavior verified in this repo — (architecture review 2026-03-16)
+- [ ] [P2] Replace Overmind with hivemind or concurrently — Overmind solves signal handling but tmux dependency, `dev:clean` escape hatch, and WSL quirks are operational drag. hivemind (Go binary, no tmux, proper signal handling) preferred; concurrently as fallback. Test on macOS, Linux, WSL before standardizing. Keep `dev:clean` as escape hatch, not normal workflow. Turbo `--watch` only if shutdown behavior verified in this repo — (architecture review 2026-03-16; code changes done 2026-03-16; pending cross-platform validation)
 - [x] [P3] Remove `packages/eslint-config` — unused v1 legacy configs (`base.js`, `nextjs.js`, `nestjs.js`), neither app imports from it. Moved `eslint` and `eslint-config-next` to direct app devDependencies — (architecture review 2026-03-16; done 2026-03-16)
 
 ### Testing & CI

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,28 @@ Newest entries first.
 
 ---
 
+## 2026-03-16 — Replace Overmind with hivemind
+
+### Done
+
+- Replaced Overmind (tmux-based) with hivemind (single Go binary, no tmux) as dev process manager
+- Updated `scripts/dev.sh`: single hivemind binary check replaces tmux + overmind checks, `exec hivemind Procfile.dev` replaces `exec overmind start -f Procfile.dev --no-port`
+- Updated `scripts/dev-clean.sh`: removed Overmind socket cleanup block (10 lines), kept port killing and Next.js lock cleanup
+- Updated `Procfile.dev`: added explicit `PORT=4000`/`PORT=3000` per process — hivemind always injects PORT (base 5000, step 100) with no `--no-port` equivalent (plan override)
+- Updated `.gitignore`: removed `.overmind.sock` entry
+- Updated CLAUDE.md (quirks, starting dev, commands), CONTRIBUTING.md (prerequisites, commands), README.md (prerequisites), docs/architecture.md (deployment table)
+- Updated docs/backlog.md: added "code changes done 2026-03-16; pending cross-platform validation" note
+- Installed hivemind v1.1.0 to `~/.local/bin/hivemind`
+- Verified: API on :4000, Web on :3000, Ctrl+C clean shutdown, no `.overmind.sock`, `pnpm dev:clean` works
+- Net reduction: 31 lines across 9 files
+
+### Decisions
+
+- Procfile.dev changed despite plan saying it wouldn't — hivemind PORT injection has no opt-out, inline PORT= is the standard workaround
+- Backlog item stays unchecked until cross-platform (macOS, Linux, WSL) validation done
+
+---
+
 ## 2026-03-16 — Dependabot Triage, ESLint 10, Architecture Review, GraphQL Extraction
 
 ### Done

--- a/scripts/dev-clean.sh
+++ b/scripts/dev-clean.sh
@@ -18,17 +18,6 @@ for port in 4000 3000; do
   fi
 done
 
-# Stop Overmind session (project-scoped via .overmind.sock)
-if [ -S .overmind.sock ]; then
-  echo "Stopping Overmind session..."
-  overmind kill 2>/dev/null || true
-  # Remove stale socket if overmind kill didn't clean up
-  if [ -S .overmind.sock ]; then
-    echo "Removing stale Overmind socket..."
-    rm -f .overmind.sock
-  fi
-fi
-
 # Remove stale Next.js dev lock
 if [ -f apps/web/.next/dev/lock ]; then
   echo "Removing stale Next.js lock..."

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # Check for required binary
 if ! command -v hivemind &>/dev/null; then
   echo "Error: hivemind is required but not installed."
-  echo "  Linux: curl -L https://github.com/DarthSim/hivemind/releases/latest/download/hivemind-v1.1.0-linux-amd64.gz | gunzip > ~/.local/bin/hivemind && chmod +x ~/.local/bin/hivemind"
+  echo "  Linux: https://github.com/DarthSim/hivemind/releases/latest (download linux-amd64.gz, gunzip, chmod +x, add to PATH)"
   echo "  macOS: brew install hivemind"
   exit 1
 fi

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,22 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Overmind process manager wrapper for dev servers.
-# Builds workspace packages first (via Turbo), then starts API + Web via Overmind.
+# hivemind process manager wrapper for dev servers.
+# Builds workspace packages first (via Turbo), then starts API + Web via hivemind.
 
-# Check for required binaries
-if ! command -v tmux &>/dev/null; then
-  echo "Error: tmux is required but not installed."
-  echo "  Ubuntu/Debian: sudo apt install tmux"
-  echo "  macOS: brew install tmux"
-  exit 1
-fi
-
-if ! command -v overmind &>/dev/null; then
-  echo "Error: overmind is required but not installed."
-  echo "  Install: https://github.com/DarthSim/overmind#installation"
-  echo "  Ubuntu/Debian: sudo apt install overmind (or download binary from releases)"
-  echo "  macOS: brew install overmind"
+# Check for required binary
+if ! command -v hivemind &>/dev/null; then
+  echo "Error: hivemind is required but not installed."
+  echo "  Linux: curl -L https://github.com/DarthSim/hivemind/releases/latest/download/hivemind-v1.1.0-linux-amd64.gz | gunzip > ~/.local/bin/hivemind && chmod +x ~/.local/bin/hivemind"
+  echo "  macOS: brew install hivemind"
   exit 1
 fi
 
@@ -27,7 +19,5 @@ bash scripts/dev-clean.sh 2>/dev/null || true
 echo "Building workspace packages..."
 pnpm exec turbo run build --filter='./packages/*'
 
-# Start dev servers via Overmind (exec replaces shell for clean signal handling)
-# --no-port: let each process use its own PORT (API from .env, Next.js default 3000)
-# Without this, Overmind sets PORT=5000/5100 which breaks Zitadel OIDC redirect URIs
-exec overmind start -f Procfile.dev --no-port
+# Start dev servers via hivemind (exec replaces shell for clean signal handling)
+exec hivemind Procfile.dev


### PR DESCRIPTION
## Summary

- Replaces Overmind (tmux-based) with hivemind (single Go binary, no tmux dependency) as the dev process manager
- Removes Overmind socket cleanup from `dev-clean.sh`, `.overmind.sock` from `.gitignore`
- Adds explicit `PORT=` per process in `Procfile.dev` (hivemind always injects PORT with no opt-out)
- Updates all docs: CLAUDE.md, CONTRIBUTING.md, README.md, architecture.md, backlog.md

## Plan Overrides

| File | Planned | Actual | Rationale |
| --- | --- | --- | --- |
| `Procfile.dev` | No changes | Added `PORT=4000`/`PORT=3000` per entry | hivemind always injects PORT (base 5000, step 100); no `--no-port` flag like Overmind had |

## Test plan

- [x] `pnpm dev` starts both API (:4000) and Web (:3000) with interleaved labeled logs
- [x] Ctrl+C cleanly stops both processes, no orphans on ports 4000/3000
- [x] `pnpm dev:clean` works as fallback
- [x] No `.overmind.sock` file created
- [ ] Cross-platform: test on macOS
- [ ] Cross-platform: test on native Linux (non-WSL)