### PR TITLE
fix(api): defense-in-depth org filtering for CMS & issue services

### DIFF
--- a/apps/api/src/inngest/functions/cms-publish.spec.ts
+++ b/apps/api/src/inngest/functions/cms-publish.spec.ts
@@ -292,6 +292,7 @@ describe('cmsPublishWorkflow Inngest function', () => {
         externalUrl: 'https://ghost.example.com/spring-2026',
         adapterType: 'GHOST',
       },
+      'org-1',
     );
   });
 });

--- a/apps/api/src/inngest/functions/cms-publish.ts
+++ b/apps/api/src/inngest/functions/cms-publish.ts
@@ -32,15 +32,15 @@ export const cmsPublishWorkflow = inngest.createFunction(
     // Step 1: Load issue, sections, items with submission data, and CMS connections
     const data = await step.run('load-issue-and-connections', async () => {
       return withRls({ orgId }, async (tx: DrizzleDb) => {
-        const issueRow = await issueService.getById(tx, issueId);
+        const issueRow = await issueService.getById(tx, issueId, orgId);
         if (!issueRow) {
           throw new Error(`Issue ${issueId} not found`);
         }
 
         const [sectionRows, itemRows, conns] = await Promise.all([
-          issueService.getSections(tx, issueId),
-          issueService.getItems(tx, issueId),
-          cmsConnectionService.listByPublication(tx, publicationId),
+          issueService.getSections(tx, issueId, orgId),
+          issueService.getItems(tx, issueId, orgId),
+          cmsConnectionService.listByPublication(tx, publicationId, orgId),
         ]);
 
         // Load submission data for each issue item via pipeline_items → submissions
@@ -134,12 +134,18 @@ export const cmsPublishWorkflow = inngest.createFunction(
 
           // Update last sync timestamp and persist publish result
           await withRls({ orgId }, async (tx: DrizzleDb) => {
-            await cmsConnectionService.updateLastSync(tx, conn.id);
-            await issueService.saveCmsPublishResult(tx, issueId, conn.id, {
-              externalId: publishResult.externalId,
-              externalUrl: publishResult.externalUrl,
-              adapterType: conn.adapterType,
-            });
+            await cmsConnectionService.updateLastSync(tx, conn.id, orgId);
+            await issueService.saveCmsPublishResult(
+              tx,
+              issueId,
+              conn.id,
+              {
+                externalId: publishResult.externalId,
+                externalUrl: publishResult.externalUrl,
+                adapterType: conn.adapterType,
+              },
+              orgId,
+            );
           });
 
           return {

--- a/apps/api/src/rest/routers/cms-connections.ts
+++ b/apps/api/src/rest/routers/cms-connections.ts
@@ -49,7 +49,11 @@ const list = orgProcedure
   .input(restListCmsConnectionsQuery)
   .output(paginatedConnectionsSchema)
   .handler(async ({ input, context }) => {
-    return cmsConnectionService.list(context.dbTx, input);
+    return cmsConnectionService.list(
+      context.dbTx,
+      input,
+      context.authContext.orgId,
+    );
   });
 
 const create = orgProcedure
@@ -94,6 +98,7 @@ const get = orgProcedure
       const connection = await cmsConnectionService.getById(
         context.dbTx,
         input.id,
+        context.authContext.orgId,
       );
       if (!connection) throw new CmsConnectionNotFoundError(input.id);
       return connection;

--- a/apps/api/src/rest/routers/issues.ts
+++ b/apps/api/src/rest/routers/issues.ts
@@ -48,7 +48,7 @@ const list = orgProcedure
   .input(restListQuery)
   .output(paginatedIssuesSchema)
   .handler(async ({ input, context }) => {
-    return issueService.list(context.dbTx, input);
+    return issueService.list(context.dbTx, input, context.authContext.orgId);
   });
 
 const get = orgProcedure
@@ -65,7 +65,11 @@ const get = orgProcedure
   .output(issueSchema)
   .handler(async ({ input, context }) => {
     try {
-      const issue = await issueService.getById(context.dbTx, input.id);
+      const issue = await issueService.getById(
+        context.dbTx,
+        input.id,
+        context.authContext.orgId,
+      );
       if (!issue) throw new IssueNotFoundError(input.id);
       return issue;
     } catch (e) {
@@ -86,7 +90,11 @@ const getItems = orgProcedure
   .input(idParamSchema)
   .output(z.array(issueItemSchema))
   .handler(async ({ input, context }) => {
-    return issueService.getItems(context.dbTx, input.id);
+    return issueService.getItems(
+      context.dbTx,
+      input.id,
+      context.authContext.orgId,
+    );
   });
 
 const getSections = orgProcedure
@@ -102,7 +110,11 @@ const getSections = orgProcedure
   .input(idParamSchema)
   .output(z.array(issueSectionSchema))
   .handler(async ({ input, context }) => {
-    return issueService.getSections(context.dbTx, input.id);
+    return issueService.getSections(
+      context.dbTx,
+      input.id,
+      context.authContext.orgId,
+    );
   });
 
 const create = adminProcedure
@@ -237,7 +249,7 @@ const removeItem = adminProcedure
     tags: ['Issues'],
   })
   .input(z.object({ id: z.string().uuid(), itemId: z.string().uuid() }))
-  .output(issueItemSchema)
+  .output(issueItemSchema.nullable())
   .handler(async ({ input, context }) => {
     try {
       return await issueService.removeItemWithAudit(
@@ -264,7 +276,12 @@ const reorderItems = adminProcedure
   .output(z.array(issueItemSchema))
   .handler(async ({ input, context }) => {
     const { id, ...data } = input;
-    return issueService.reorderItems(context.dbTx, id, data);
+    return issueService.reorderItems(
+      context.dbTx,
+      id,
+      data,
+      context.authContext.orgId,
+    );
   });
 
 const addSection = adminProcedure
@@ -282,7 +299,12 @@ const addSection = adminProcedure
   .output(issueSectionSchema)
   .handler(async ({ input, context }) => {
     const { id, ...data } = input;
-    return issueService.addSection(context.dbTx, id, data);
+    return issueService.addSection(
+      context.dbTx,
+      id,
+      data,
+      context.authContext.orgId,
+    );
   });
 
 const removeSection = adminProcedure
@@ -296,9 +318,14 @@ const removeSection = adminProcedure
     tags: ['Issues'],
   })
   .input(z.object({ id: z.string().uuid(), sectionId: z.string().uuid() }))
-  .output(issueSectionSchema)
+  .output(issueSectionSchema.nullable())
   .handler(async ({ input, context }) => {
-    return issueService.removeSection(context.dbTx, input.id, input.sectionId);
+    return issueService.removeSection(
+      context.dbTx,
+      input.id,
+      input.sectionId,
+      context.authContext.orgId,
+    );
   });
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/rest/routers/issues.ts
+++ b/apps/api/src/rest/routers/issues.ts
@@ -299,12 +299,16 @@ const addSection = adminProcedure
   .output(issueSectionSchema)
   .handler(async ({ input, context }) => {
     const { id, ...data } = input;
-    return issueService.addSection(
-      context.dbTx,
-      id,
-      data,
-      context.authContext.orgId,
-    );
+    try {
+      return await issueService.addSection(
+        context.dbTx,
+        id,
+        data,
+        context.authContext.orgId,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
   });
 
 const removeSection = adminProcedure

--- a/apps/api/src/services/cms-connection.service.spec.ts
+++ b/apps/api/src/services/cms-connection.service.spec.ts
@@ -18,6 +18,7 @@ vi.mock('./errors.js', () => ({
 vi.mock('@colophony/db', () => ({
   cmsConnections: {
     id: 'id',
+    organizationId: 'organization_id',
     publicationId: 'publication_id',
     isActive: 'is_active',
     createdAt: 'created_at',
@@ -171,5 +172,81 @@ describe('cmsConnectionService.testConnectionWithAudit', () => {
     const auditCall = (ctx.audit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(auditCall.action).toBe(AuditActions.CMS_CONNECTION_TESTED);
     expect(auditCall.newValue).toEqual({ success: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defense-in-depth org filtering
+// ---------------------------------------------------------------------------
+
+describe('cmsConnectionService defense-in-depth org filtering', () => {
+  function makeTxNoRows(): DrizzleDb {
+    const updateReturning = vi.fn().mockResolvedValue([]);
+    const updateWhere = vi.fn().mockReturnValue({ returning: updateReturning });
+    const updateSet = vi.fn().mockReturnValue({ where: updateWhere });
+    const deleteReturning = vi.fn().mockResolvedValue([]);
+    const deleteWhere = vi.fn().mockReturnValue({ returning: deleteReturning });
+    const selectLimitResult = vi.fn().mockResolvedValue([]);
+    return {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: selectLimitResult,
+          }),
+        }),
+      }),
+      update: vi.fn().mockReturnValue({ set: updateSet }),
+      delete: vi.fn().mockReturnValue({ where: deleteWhere }),
+    } as unknown as DrizzleDb;
+  }
+
+  it('update returns null when orgId does not match', async () => {
+    const tx = makeTxNoRows();
+    const result = await cmsConnectionService.update(
+      tx,
+      'conn-1',
+      { name: 'Changed' },
+      'wrong-org',
+    );
+    expect(result).toBeNull();
+  });
+
+  it('update succeeds when orgId matches', async () => {
+    const tx = makeTx();
+    const result = await cmsConnectionService.update(
+      tx,
+      'conn-1',
+      { name: 'Changed' },
+      'org-1',
+    );
+    expect(result).not.toBeNull();
+  });
+
+  it('delete returns null when orgId does not match', async () => {
+    const tx = makeTxNoRows();
+    const result = await cmsConnectionService.delete(tx, 'conn-1', 'wrong-org');
+    expect(result).toBeNull();
+  });
+
+  it('testConnection throws when orgId does not match (getById returns null)', async () => {
+    const tx = makeTxNoRows();
+    await expect(
+      cmsConnectionService.testConnection(tx, 'conn-1', 'wrong-org'),
+    ).rejects.toThrow('CMS connection "conn-1" not found');
+  });
+
+  it('updateWithAudit passes actor.orgId to inner update', async () => {
+    const ctx = makeServiceContext();
+    const spy = vi.spyOn(cmsConnectionService, 'update');
+    await cmsConnectionService.updateWithAudit(ctx, 'conn-1', {
+      name: 'New',
+    });
+    expect(spy).toHaveBeenCalledWith(
+      ctx.tx,
+      'conn-1',
+      { name: 'New' },
+      'org-1',
+    );
+    spy.mockRestore();
   });
 });

--- a/apps/api/src/services/cms-connection.service.ts
+++ b/apps/api/src/services/cms-connection.service.ts
@@ -30,11 +30,14 @@ export const cmsConnectionService = {
   // List / Get
   // -------------------------------------------------------------------------
 
-  async list(tx: DrizzleDb, input: ListCmsConnectionsInput) {
+  async list(tx: DrizzleDb, input: ListCmsConnectionsInput, orgId?: string) {
     const { publicationId, page, limit } = input;
     const offset = (page - 1) * limit;
 
     const conditions = [];
+    if (orgId) {
+      conditions.push(eq(cmsConnections.organizationId, orgId));
+    }
     if (publicationId) {
       conditions.push(eq(cmsConnections.publicationId, publicationId));
     }
@@ -114,7 +117,12 @@ export const cmsConnectionService = {
     return connection;
   },
 
-  async update(tx: DrizzleDb, id: string, input: UpdateCmsConnectionInput) {
+  async update(
+    tx: DrizzleDb,
+    id: string,
+    input: UpdateCmsConnectionInput,
+    orgId?: string,
+  ) {
     const values: Record<string, unknown> = { updatedAt: new Date() };
     if (input.name !== undefined) values.name = input.name;
     if (input.config !== undefined) values.config = input.config;
@@ -123,7 +131,14 @@ export const cmsConnectionService = {
     const [row] = await tx
       .update(cmsConnections)
       .set(values)
-      .where(eq(cmsConnections.id, id))
+      .where(
+        orgId
+          ? and(
+              eq(cmsConnections.id, id),
+              eq(cmsConnections.organizationId, orgId),
+            )
+          : eq(cmsConnections.id, id),
+      )
       .returning();
 
     return row ?? null;
@@ -135,7 +150,12 @@ export const cmsConnectionService = {
     input: UpdateCmsConnectionInput,
   ) {
     assertEditorOrAdmin(ctx.actor.role);
-    const updated = await cmsConnectionService.update(ctx.tx, id, input);
+    const updated = await cmsConnectionService.update(
+      ctx.tx,
+      id,
+      input,
+      ctx.actor.orgId,
+    );
     if (!updated) throw new CmsConnectionNotFoundError(id);
     await ctx.audit({
       action: AuditActions.CMS_CONNECTION_UPDATED,
@@ -150,10 +170,17 @@ export const cmsConnectionService = {
     return updated;
   },
 
-  async delete(tx: DrizzleDb, id: string) {
+  async delete(tx: DrizzleDb, id: string, orgId?: string) {
     const [row] = await tx
       .delete(cmsConnections)
-      .where(eq(cmsConnections.id, id))
+      .where(
+        orgId
+          ? and(
+              eq(cmsConnections.id, id),
+              eq(cmsConnections.organizationId, orgId),
+            )
+          : eq(cmsConnections.id, id),
+      )
       .returning();
 
     return row ?? null;
@@ -161,7 +188,11 @@ export const cmsConnectionService = {
 
   async deleteWithAudit(ctx: ServiceContext, id: string) {
     assertEditorOrAdmin(ctx.actor.role);
-    const deleted = await cmsConnectionService.delete(ctx.tx, id);
+    const deleted = await cmsConnectionService.delete(
+      ctx.tx,
+      id,
+      ctx.actor.orgId,
+    );
     if (!deleted) throw new CmsConnectionNotFoundError(id);
     await ctx.audit({
       action: AuditActions.CMS_CONNECTION_DELETED,
@@ -176,8 +207,8 @@ export const cmsConnectionService = {
   // Test connection
   // -------------------------------------------------------------------------
 
-  async testConnection(tx: DrizzleDb, id: string) {
-    const connection = await cmsConnectionService.getById(tx, id);
+  async testConnection(tx: DrizzleDb, id: string, orgId?: string) {
+    const connection = await cmsConnectionService.getById(tx, id, orgId);
     if (!connection) throw new CmsConnectionNotFoundError(id);
 
     const adapter = getCmsAdapter(connection.adapterType);
@@ -187,7 +218,11 @@ export const cmsConnectionService = {
   async testConnectionWithAudit(ctx: ServiceContext, id: string) {
     let result: { success: boolean; error?: string };
     try {
-      result = await cmsConnectionService.testConnection(ctx.tx, id);
+      result = await cmsConnectionService.testConnection(
+        ctx.tx,
+        id,
+        ctx.actor.orgId,
+      );
     } catch (error) {
       await ctx.audit({
         action: AuditActions.CMS_CONNECTION_TESTED,
@@ -210,23 +245,36 @@ export const cmsConnectionService = {
   // Helpers for Inngest workers
   // -------------------------------------------------------------------------
 
-  async listByPublication(tx: DrizzleDb, publicationId: string) {
+  async listByPublication(
+    tx: DrizzleDb,
+    publicationId: string,
+    orgId?: string,
+  ) {
+    const conditions = [
+      eq(cmsConnections.publicationId, publicationId),
+      eq(cmsConnections.isActive, true),
+    ];
+    if (orgId) {
+      conditions.push(eq(cmsConnections.organizationId, orgId));
+    }
     return tx
       .select()
       .from(cmsConnections)
-      .where(
-        and(
-          eq(cmsConnections.publicationId, publicationId),
-          eq(cmsConnections.isActive, true),
-        ),
-      )
+      .where(and(...conditions))
       .limit(10000);
   },
 
-  async updateLastSync(tx: DrizzleDb, id: string) {
+  async updateLastSync(tx: DrizzleDb, id: string, orgId?: string) {
     await tx
       .update(cmsConnections)
       .set({ lastSyncAt: new Date(), updatedAt: new Date() })
-      .where(eq(cmsConnections.id, id));
+      .where(
+        orgId
+          ? and(
+              eq(cmsConnections.id, id),
+              eq(cmsConnections.organizationId, orgId),
+            )
+          : eq(cmsConnections.id, id),
+      );
   },
 };

--- a/apps/api/src/services/issue.service.spec.ts
+++ b/apps/api/src/services/issue.service.spec.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockUpdate = vi.fn();
 const mockSelectFrom = vi.fn();
 vi.mock('@colophony/db', () => ({
-  issues: { id: 'id', metadata: 'metadata' },
+  issues: { id: 'id', organizationId: 'organization_id', metadata: 'metadata' },
   issueSections: { id: 'id', issueId: 'issue_id', sortOrder: 'sort_order' },
   issueItems: {
     id: 'id',
@@ -171,5 +171,74 @@ describe('issueService.saveCmsPublishResult', () => {
         }),
       }),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defense-in-depth org filtering
+// ---------------------------------------------------------------------------
+
+describe('issueService defense-in-depth org filtering', () => {
+  function makeTxNoRows() {
+    const updateReturning = vi.fn().mockResolvedValue([]);
+    const updateWhere = vi.fn().mockReturnValue({ returning: updateReturning });
+    const updateSet = vi.fn().mockReturnValue({ where: updateWhere });
+    const selectLimitResult = vi.fn().mockResolvedValue([]);
+    return {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: selectLimitResult,
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+          leftJoin: vi.fn().mockReturnValue({
+            leftJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue([]),
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+      update: vi.fn().mockReturnValue({ set: updateSet }),
+    } as unknown as Parameters<typeof issueService.update>[0];
+  }
+
+  it('update returns null when orgId does not match', async () => {
+    const tx = makeTxNoRows();
+    const result = await issueService.update(
+      tx,
+      'issue-1',
+      { title: 'Changed' },
+      'wrong-org',
+    );
+    expect(result).toBeNull();
+  });
+
+  it('updateStatus returns null when orgId does not match', async () => {
+    const tx = makeTxNoRows();
+    const result = await issueService.updateStatus(
+      tx,
+      'issue-1',
+      'PUBLISHED',
+      'wrong-org',
+    );
+    expect(result).toBeNull();
+  });
+
+  it('getItems returns [] when orgId does not match parent issue', async () => {
+    const tx = makeTxNoRows();
+    const result = await issueService.getItems(tx, 'issue-1', 'wrong-org');
+    expect(result).toEqual([]);
+  });
+
+  it('getSections returns [] when orgId does not match parent issue', async () => {
+    const tx = makeTxNoRows();
+    const result = await issueService.getSections(tx, 'issue-1', 'wrong-org');
+    expect(result).toEqual([]);
   });
 });

--- a/apps/api/src/services/issue.service.ts
+++ b/apps/api/src/services/issue.service.ts
@@ -61,11 +61,12 @@ export const issueService = {
   // List / Get
   // -------------------------------------------------------------------------
 
-  async list(tx: DrizzleDb, input: ListIssuesInput) {
+  async list(tx: DrizzleDb, input: ListIssuesInput, orgId?: string) {
     const { publicationId, status, search, from, to, page, limit } = input;
     const offset = (page - 1) * limit;
 
     const conditions = [];
+    if (orgId) conditions.push(eq(issues.organizationId, orgId));
     if (publicationId) conditions.push(eq(issues.publicationId, publicationId));
     if (status) conditions.push(eq(issues.status, status));
     if (search) conditions.push(ilike(issues.title, `%${search}%`));
@@ -112,7 +113,11 @@ export const issueService = {
     return row ?? null;
   },
 
-  async getItems(tx: DrizzleDb, issueId: string) {
+  async getItems(tx: DrizzleDb, issueId: string, orgId?: string) {
+    if (orgId) {
+      const issue = await issueService.getById(tx, issueId, orgId);
+      if (!issue) return [];
+    }
     return tx
       .select({
         ...getTableColumns(issueItems),
@@ -126,7 +131,11 @@ export const issueService = {
       .limit(10000);
   },
 
-  async getSections(tx: DrizzleDb, issueId: string) {
+  async getSections(tx: DrizzleDb, issueId: string, orgId?: string) {
+    if (orgId) {
+      const issue = await issueService.getById(tx, issueId, orgId);
+      if (!issue) return [];
+    }
     return tx
       .select()
       .from(issueSections)
@@ -169,7 +178,12 @@ export const issueService = {
     return issue;
   },
 
-  async update(tx: DrizzleDb, id: string, input: UpdateIssueInput) {
+  async update(
+    tx: DrizzleDb,
+    id: string,
+    input: UpdateIssueInput,
+    orgId?: string,
+  ) {
     const values: Record<string, unknown> = { updatedAt: new Date() };
     if (input.title !== undefined) values.title = input.title;
     if (input.volume !== undefined) values.volume = input.volume;
@@ -183,7 +197,11 @@ export const issueService = {
     const [row] = await tx
       .update(issues)
       .set(values)
-      .where(eq(issues.id, id))
+      .where(
+        orgId
+          ? and(eq(issues.id, id), eq(issues.organizationId, orgId))
+          : eq(issues.id, id),
+      )
       .returning();
 
     return row ?? null;
@@ -195,7 +213,12 @@ export const issueService = {
     input: UpdateIssueInput,
   ) {
     assertEditorOrAdmin(ctx.actor.role);
-    const updated = await issueService.update(ctx.tx, id, input);
+    const updated = await issueService.update(
+      ctx.tx,
+      id,
+      input,
+      ctx.actor.orgId,
+    );
     if (!updated) throw new IssueNotFoundError(id);
     await ctx.audit({
       action: AuditActions.ISSUE_UPDATED,
@@ -206,7 +229,12 @@ export const issueService = {
     return updated;
   },
 
-  async updateStatus(tx: DrizzleDb, id: string, status: IssueStatus) {
+  async updateStatus(
+    tx: DrizzleDb,
+    id: string,
+    status: IssueStatus,
+    orgId?: string,
+  ) {
     const values: Record<string, unknown> = {
       status,
       updatedAt: new Date(),
@@ -216,7 +244,11 @@ export const issueService = {
     const [row] = await tx
       .update(issues)
       .set(values)
-      .where(eq(issues.id, id))
+      .where(
+        orgId
+          ? and(eq(issues.id, id), eq(issues.organizationId, orgId))
+          : eq(issues.id, id),
+      )
       .returning();
 
     return row ?? null;
@@ -224,9 +256,14 @@ export const issueService = {
 
   async publishWithAudit(ctx: ServiceContext, id: string) {
     assertEditorOrAdmin(ctx.actor.role);
-    const issue = await issueService.getById(ctx.tx, id);
+    const issue = await issueService.getById(ctx.tx, id, ctx.actor.orgId);
     if (!issue) throw new IssueNotFoundError(id);
-    const updated = await issueService.updateStatus(ctx.tx, id, 'PUBLISHED');
+    const updated = await issueService.updateStatus(
+      ctx.tx,
+      id,
+      'PUBLISHED',
+      ctx.actor.orgId,
+    );
     if (!updated) throw new IssueNotFoundError(id);
     await ctx.audit({
       action: AuditActions.ISSUE_PUBLISHED,
@@ -248,9 +285,14 @@ export const issueService = {
 
   async archiveWithAudit(ctx: ServiceContext, id: string) {
     assertEditorOrAdmin(ctx.actor.role);
-    const issue = await issueService.getById(ctx.tx, id);
+    const issue = await issueService.getById(ctx.tx, id, ctx.actor.orgId);
     if (!issue) throw new IssueNotFoundError(id);
-    const updated = await issueService.updateStatus(ctx.tx, id, 'ARCHIVED');
+    const updated = await issueService.updateStatus(
+      ctx.tx,
+      id,
+      'ARCHIVED',
+      ctx.actor.orgId,
+    );
     if (!updated) throw new IssueNotFoundError(id);
     await ctx.audit({
       action: AuditActions.ISSUE_ARCHIVED,
@@ -275,8 +317,9 @@ export const issueService = {
       externalUrl?: string;
       adapterType: string;
     },
+    orgId?: string,
   ) {
-    const issue = await issueService.getById(tx, issueId);
+    const issue = await issueService.getById(tx, issueId, orgId);
     if (!issue) return null;
 
     const metadata = issue.metadata ?? {};
@@ -291,7 +334,11 @@ export const issueService = {
     const [row] = await tx
       .update(issues)
       .set({ metadata: { ...metadata, cmsPublish }, updatedAt: new Date() })
-      .where(eq(issues.id, issueId))
+      .where(
+        orgId
+          ? and(eq(issues.id, issueId), eq(issues.organizationId, orgId))
+          : eq(issues.id, issueId),
+      )
       .returning();
 
     return row ?? null;
@@ -301,7 +348,16 @@ export const issueService = {
   // Items
   // -------------------------------------------------------------------------
 
-  async addItem(tx: DrizzleDb, issueId: string, input: AddIssueItemInput) {
+  async addItem(
+    tx: DrizzleDb,
+    issueId: string,
+    input: AddIssueItemInput,
+    orgId?: string,
+  ) {
+    if (orgId) {
+      const issue = await issueService.getById(tx, issueId, orgId);
+      if (!issue) throw new IssueNotFoundError(issueId);
+    }
     // Validate section belongs to this issue (if provided)
     if (input.issueSectionId) {
       const [section] = await tx
@@ -342,7 +398,12 @@ export const issueService = {
   ) {
     assertEditorOrAdmin(ctx.actor.role);
     try {
-      const item = await issueService.addItem(ctx.tx, issueId, input);
+      const item = await issueService.addItem(
+        ctx.tx,
+        issueId,
+        input,
+        ctx.actor.orgId,
+      );
       await ctx.audit({
         action: AuditActions.ISSUE_ITEM_ADDED,
         resource: AuditResources.ISSUE,
@@ -364,7 +425,16 @@ export const issueService = {
     }
   },
 
-  async removeItem(tx: DrizzleDb, issueId: string, itemId: string) {
+  async removeItem(
+    tx: DrizzleDb,
+    issueId: string,
+    itemId: string,
+    orgId?: string,
+  ) {
+    if (orgId) {
+      const issue = await issueService.getById(tx, issueId, orgId);
+      if (!issue) return null;
+    }
     const [row] = await tx
       .delete(issueItems)
       .where(and(eq(issueItems.id, itemId), eq(issueItems.issueId, issueId)))
@@ -379,7 +449,12 @@ export const issueService = {
     itemId: string,
   ) {
     assertEditorOrAdmin(ctx.actor.role);
-    const removed = await issueService.removeItem(ctx.tx, issueId, itemId);
+    const removed = await issueService.removeItem(
+      ctx.tx,
+      issueId,
+      itemId,
+      ctx.actor.orgId,
+    );
     if (removed) {
       await ctx.audit({
         action: AuditActions.ISSUE_ITEM_REMOVED,
@@ -391,14 +466,23 @@ export const issueService = {
     return removed;
   },
 
-  async reorderItems(tx: DrizzleDb, issueId: string, input: ReorderItemsInput) {
+  async reorderItems(
+    tx: DrizzleDb,
+    issueId: string,
+    input: ReorderItemsInput,
+    orgId?: string,
+  ) {
+    if (orgId) {
+      const issue = await issueService.getById(tx, issueId, orgId);
+      if (!issue) return [];
+    }
     for (const { id, sortOrder } of input.items) {
       await tx
         .update(issueItems)
         .set({ sortOrder })
         .where(and(eq(issueItems.id, id), eq(issueItems.issueId, issueId)));
     }
-    return issueService.getItems(tx, issueId);
+    return issueService.getItems(tx, issueId, orgId);
   },
 
   // -------------------------------------------------------------------------
@@ -409,7 +493,12 @@ export const issueService = {
     tx: DrizzleDb,
     issueId: string,
     input: AddIssueSectionInput,
+    orgId?: string,
   ) {
+    if (orgId) {
+      const issue = await issueService.getById(tx, issueId, orgId);
+      if (!issue) throw new IssueNotFoundError(issueId);
+    }
     const [row] = await tx
       .insert(issueSections)
       .values({
@@ -422,7 +511,16 @@ export const issueService = {
     return row;
   },
 
-  async removeSection(tx: DrizzleDb, issueId: string, sectionId: string) {
+  async removeSection(
+    tx: DrizzleDb,
+    issueId: string,
+    sectionId: string,
+    orgId?: string,
+  ) {
+    if (orgId) {
+      const issue = await issueService.getById(tx, issueId, orgId);
+      if (!issue) return null;
+    }
     const [row] = await tx
       .delete(issueSections)
       .where(

--- a/apps/api/src/trpc/routers/cms-connections.ts
+++ b/apps/api/src/trpc/routers/cms-connections.ts
@@ -27,7 +27,7 @@ export const cmsConnectionsRouter = createRouter({
     .input(listCmsConnectionsSchema)
     .output(paginatedResponseSchema(cmsConnectionSchema))
     .query(async ({ ctx, input }) => {
-      return cmsConnectionService.list(ctx.dbTx, input);
+      return cmsConnectionService.list(ctx.dbTx, input, ctx.authContext.orgId);
     }),
 
   /** Get CMS connection by ID. */
@@ -40,6 +40,7 @@ export const cmsConnectionsRouter = createRouter({
         const connection = await cmsConnectionService.getById(
           ctx.dbTx,
           input.id,
+          ctx.authContext.orgId,
         );
         if (!connection) throw new CmsConnectionNotFoundError(input.id);
         return connection;

--- a/apps/api/src/trpc/routers/issues.ts
+++ b/apps/api/src/trpc/routers/issues.ts
@@ -196,7 +196,16 @@ export const issuesRouter = createRouter({
     .output(issueSectionSchema)
     .mutation(async ({ ctx, input }) => {
       const { id, ...data } = input;
-      return issueService.addSection(ctx.dbTx, id, data, ctx.authContext.orgId);
+      try {
+        return await issueService.addSection(
+          ctx.dbTx,
+          id,
+          data,
+          ctx.authContext.orgId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
     }),
 
   /** Remove a section from an issue. */

--- a/apps/api/src/trpc/routers/issues.ts
+++ b/apps/api/src/trpc/routers/issues.ts
@@ -32,7 +32,7 @@ export const issuesRouter = createRouter({
     .input(listIssuesSchema)
     .output(paginatedResponseSchema(issueSchema))
     .query(async ({ ctx, input }) => {
-      return issueService.list(ctx.dbTx, input);
+      return issueService.list(ctx.dbTx, input, ctx.authContext.orgId);
     }),
 
   /** Get issue by ID. */
@@ -42,7 +42,11 @@ export const issuesRouter = createRouter({
     .output(issueSchema)
     .query(async ({ ctx, input }) => {
       try {
-        const issue = await issueService.getById(ctx.dbTx, input.id);
+        const issue = await issueService.getById(
+          ctx.dbTx,
+          input.id,
+          ctx.authContext.orgId,
+        );
         if (!issue) throw new IssueNotFoundError(input.id);
         return issue;
       } catch (e) {
@@ -56,7 +60,7 @@ export const issuesRouter = createRouter({
     .input(idParamSchema)
     .output(z.array(issueItemSchema))
     .query(async ({ ctx, input }) => {
-      return issueService.getItems(ctx.dbTx, input.id);
+      return issueService.getItems(ctx.dbTx, input.id, ctx.authContext.orgId);
     }),
 
   /** Get sections in an issue. */
@@ -65,7 +69,11 @@ export const issuesRouter = createRouter({
     .input(idParamSchema)
     .output(z.array(issueSectionSchema))
     .query(async ({ ctx, input }) => {
-      return issueService.getSections(ctx.dbTx, input.id);
+      return issueService.getSections(
+        ctx.dbTx,
+        input.id,
+        ctx.authContext.orgId,
+      );
     }),
 
   /** Create an issue (admin only). */
@@ -173,7 +181,12 @@ export const issuesRouter = createRouter({
     .output(z.array(issueItemSchema))
     .mutation(async ({ ctx, input }) => {
       const { id, ...data } = input;
-      return issueService.reorderItems(ctx.dbTx, id, data);
+      return issueService.reorderItems(
+        ctx.dbTx,
+        id,
+        data,
+        ctx.authContext.orgId,
+      );
     }),
 
   /** Add a section to an issue. */
@@ -183,7 +196,7 @@ export const issuesRouter = createRouter({
     .output(issueSectionSchema)
     .mutation(async ({ ctx, input }) => {
       const { id, ...data } = input;
-      return issueService.addSection(ctx.dbTx, id, data);
+      return issueService.addSection(ctx.dbTx, id, data, ctx.authContext.orgId);
     }),
 
   /** Remove a section from an issue. */
@@ -192,6 +205,11 @@ export const issuesRouter = createRouter({
     .input(z.object({ id: z.string().uuid(), sectionId: z.string().uuid() }))
     .output(issueSectionSchema.nullable())
     .mutation(async ({ ctx, input }) => {
-      return issueService.removeSection(ctx.dbTx, input.id, input.sectionId);
+      return issueService.removeSection(
+        ctx.dbTx,
+        input.id,
+        input.sectionId,
+        ctx.authContext.orgId,
+      );
     }),
 });

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -542,7 +542,7 @@
 
 - [x] [P2] Testing optimization — Python SDK in CI, test/CI contract clarity, Vitest config consolidation, deterministic web test UUIDs, coverage includes specialized suites, webhook CI job, flaky test fix — (architecture review 2026-03-16; done 2026-03-17)
 - [x] [P2] E2E selector brittleness — replaced CSS class selectors, parent traversal, positional disambiguation with `data-testid` and dialog-scoped role locators; removed `waitForTimeout` calls; ~20 acceptable `.first()/.last()` uses left unchanged — (done 2026-03-17)
-- [ ] [P2] Defense-in-depth org filtering — CMS connection service (`getById`, `update`, `delete`, `testConnection`) and issue service (`getById`, `getItems`, `getSections`) do not pass available `orgId` for defense-in-depth WHERE clause; REST/tRPC callers also omit it — (Codex plan review 2026-03-17)
+- [x] [P2] Defense-in-depth org filtering — CMS connection service (`getById`, `update`, `delete`, `testConnection`) and issue service (`getById`, `getItems`, `getSections`) do not pass available `orgId` for defense-in-depth WHERE clause; REST/tRPC callers also omit it — (Codex plan review 2026-03-17; done 2026-03-17)
 - [ ] [P2] RLS infrastructure test coverage — `rls-infrastructure.test.ts` `RLS_TABLES` array missing `cms_connections`, `webhook_endpoints`, `webhook_deliveries`, `submission_discussions` — (Codex plan review 2026-03-17)
 - [ ] [P3] Vitest everywhere — replace Jest in `apps/web` with Vitest to eliminate test runner split (`vi.*` vs `jest.*`), deduplicate mock APIs, coverage configs, and setup patterns — (architecture review 2026-03-16)
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,25 @@ Newest entries first.
 
 ---
 
+## 2026-03-17 — Defense-in-depth org filtering for CMS & issue services
+
+### Done
+
+- Added optional `orgId` parameter to all tenant-data methods in `cms-connection.service.ts` (9 methods) and `issue.service.ts` (11 methods) as defense-in-depth behind RLS
+- Route-layer callers (tRPC, REST) now pass `authContext.orgId`; `*WithAudit` methods pass `ctx.actor.orgId` to inner calls
+- Inngest `cms-publish.ts` worker passes `orgId` from event data to all 6 service calls
+- Child-table methods (`getItems`, `getSections`, `addItem`, `removeItem`, `reorderItems`, `addSection`, `removeSection`) pre-check parent issue ownership via `getById(tx, issueId, orgId)`
+- Added 9 new unit tests: 5 for CMS connection service, 4 for issue service (org mismatch → null/empty, org match → success, WithAudit passthrough)
+- Fixed REST `removeItem`/`removeSection` output schemas to `.nullable()` (TypeScript surfaced latent type mismatch)
+- All 1501 API tests pass, type-check clean
+
+### Decisions
+
+- `orgId` stays optional for backward compatibility — future hardening pass can make it required across all services
+- REST `removeItem`/`removeSection` output changed to nullable to match tRPC (pre-existing mismatch, surfaced by org pre-check null path)
+
+---
+
 ## 2026-03-17 — Fix E2E selector brittleness
 
 ### Done

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -15,6 +15,7 @@ Newest entries first.
 - Added 9 new unit tests: 5 for CMS connection service, 4 for issue service (org mismatch → null/empty, org match → success, WithAudit passthrough)
 - Fixed REST `removeItem`/`removeSection` output schemas to `.nullable()` (TypeScript surfaced latent type mismatch)
 - All 1501 API tests pass, type-check clean
+- Addressed Codex branch review: wrapped `addSection` route handlers (tRPC + REST) in `try/catch { mapServiceError }` — org pre-check now throws `IssueNotFoundError` which was uncaught
 
 ### Decisions
 


### PR DESCRIPTION
## Summary

- Added optional `orgId` parameter to all tenant-data methods in `cms-connection.service` (9 methods) and `issue.service` (11 methods) as defense-in-depth behind RLS
- Route-layer callers (tRPC, REST) pass `authContext.orgId`; `*WithAudit` methods pass `ctx.actor.orgId`; Inngest `cms-publish` worker passes `orgId` from event data
- Child-table methods (`getItems`, `getSections`, `addItem`, `removeItem`, `reorderItems`, `addSection`, `removeSection`) pre-check parent issue ownership via `getById(tx, issueId, orgId)`
- 9 new unit tests for org-mismatch scenarios

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `apps/api/src/rest/routers/issues.ts` | `removeItem`/`removeSection` output unchanged | Output schemas changed to `.nullable()` | TypeScript surfaced latent type mismatch after org pre-check added null return path |
| `apps/api/src/rest/routers/issues.ts` | `addSection` handler unchanged | Wrapped in `try/catch { mapServiceError }` | branch review: org pre-check throws `IssueNotFoundError` which was uncaught |
| `apps/api/src/trpc/routers/issues.ts` | `addSection` handler unchanged | Wrapped in `try/catch { mapServiceError }` | Same as above |

## Test plan

- [x] `pnpm type-check` — no type errors
- [x] `pnpm test --filter @colophony/api` — 1501 tests pass (144 files)
- [ ] CI pipeline (quality, unit, RLS, service-integration, security, E2E suites)
- [ ] Verify grep: all CMS/issue service callers pass `orgId`