### PR TITLE
fix(db): complete RLS infrastructure test coverage (46 tables)

### DIFF
--- a/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
+++ b/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { globalSetup, getAdminPool, getAppPool } from './helpers/db-setup';
 
 const RLS_TABLES = [
+  // Core
   'organization_members',
   'form_definitions',
   'form_fields',
@@ -24,9 +25,44 @@ const RLS_TABLES = [
   'external_submissions',
   'correspondence',
   'writer_profiles',
+  // Submissions domain
+  'sim_sub_checks',
+  'submission_reviewers',
+  'submission_discussions',
+  'submission_votes',
+  // Slate pipeline
+  'pipeline_items',
+  'pipeline_history',
+  'pipeline_comments',
+  // Issues
+  'issues',
+  'issue_sections',
+  'issue_items',
+  // Publications & contracts
+  'publications',
+  'contract_templates',
+  'contracts',
+  // CMS
+  'cms_connections',
+  // Webhooks
+  'webhook_endpoints',
+  'webhook_deliveries',
+  // Notifications
+  'notification_preferences',
+  'email_sends',
+  'notifications_inbox',
+  // Email
+  'email_templates',
+  // Federation
+  'trusted_peers',
+  'inbound_transfers',
+  // Editor tools
+  'saved_queue_presets',
 ];
 
-/** RLS tables where app_user has full DML (excludes audit_events which is SELECT-only + function, journal_directory which is SELECT-only). */
+/** RLS tables where app_user has full DML (excludes audit_events which is SELECT-only + function, journal_directory which is SELECT-only).
+ *  Note: init-db.sh sets ALTER DEFAULT PRIVILEGES ... GRANT SELECT, INSERT, UPDATE, DELETE
+ *  so all tables created after init get full DML regardless of per-migration GRANT statements. */
 const RLS_TABLES_FULL_DML = RLS_TABLES.filter(
   (t) => t !== 'audit_events' && t !== 'journal_directory',
 );
@@ -139,7 +175,7 @@ describe('RLS Infrastructure', () => {
       expect(rows[0].rolbypassrls).toBe(false);
     });
 
-    it('should have full DML permissions on RLS tables (except audit_events)', async () => {
+    it('should have full DML permissions on RLS tables with full access', async () => {
       const admin = getAdminPool();
       for (const table of RLS_TABLES_FULL_DML) {
         const { rows } = await admin.query<{ has_priv: boolean }>(
@@ -313,14 +349,35 @@ describe('RLS Infrastructure', () => {
       }
     });
 
-    it('direct isolation policies reference current_org_id()', async () => {
+    it('org-scoped tables have policies referencing org context', async () => {
       const admin = getAdminPool();
-      const directTables = [
-        'submissions',
-        'submission_periods',
-        'payments',
-        'form_definitions',
-      ];
+
+      // Tables excluded from the org-policy check:
+      // - Nullable org policies (tested separately): audit_events, retention_policies, user_consents
+      // - User-scoped (current_user_id()): manuscripts, manuscript_versions, files,
+      //   external_submissions, correspondence, writer_profiles, identity_migrations,
+      //   journal_directory
+      // - Subquery-based: sim_sub_checks, piece_transfers
+      const orgPolicyExceptions = new Set([
+        'audit_events',
+        'retention_policies',
+        'user_consents',
+        'manuscripts',
+        'manuscript_versions',
+        'files',
+        'external_submissions',
+        'correspondence',
+        'writer_profiles',
+        'identity_migrations',
+        'journal_directory',
+        'sim_sub_checks',
+        'piece_transfers',
+      ]);
+
+      const orgScopedTables = RLS_TABLES.filter(
+        (t) => !orgPolicyExceptions.has(t),
+      );
+
       const { rows } = await admin.query<{
         tablename: string;
         policyname: string;
@@ -332,26 +389,25 @@ describe('RLS Infrastructure', () => {
         WHERE schemaname = 'public'
           AND tablename = ANY($1)
       `,
-        [directTables],
+        [orgScopedTables],
       );
 
-      // Each direct table should have at least one policy referencing current_org_id().
-      // Some tables (e.g., submissions) also have user-scoped policies (submitter_read)
-      // that reference current_user_id() instead — those are excluded from this check.
       const tableMap = new Map<string, typeof rows>();
       for (const row of rows) {
         if (!tableMap.has(row.tablename)) tableMap.set(row.tablename, []);
         tableMap.get(row.tablename)!.push(row);
       }
 
-      for (const table of directTables) {
+      for (const table of orgScopedTables) {
         const policies = tableMap.get(table) ?? [];
-        const hasOrgPolicy = policies.some((p) =>
-          p.qual.includes('current_org_id()'),
+        const hasOrgPolicy = policies.some(
+          (p) =>
+            p.qual.includes('current_org_id()') ||
+            p.qual.includes("current_setting('app.current_org"),
         );
         expect(
           hasOrgPolicy,
-          `${table} should have at least one policy referencing current_org_id()`,
+          `${table} should have at least one policy referencing current_org_id() or current_setting('app.current_org')`,
         ).toBe(true);
       }
     });

--- a/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
+++ b/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
@@ -58,6 +58,8 @@ const RLS_TABLES = [
   'inbound_transfers',
   // Editor tools
   'saved_queue_presets',
+  // User keys (DID document)
+  'user_keys',
 ];
 
 /** RLS tables where app_user has full DML (excludes audit_events which is SELECT-only + function, journal_directory which is SELECT-only).
@@ -356,7 +358,7 @@ describe('RLS Infrastructure', () => {
       // - Nullable org policies (tested separately): audit_events, retention_policies, user_consents
       // - User-scoped (current_user_id()): manuscripts, manuscript_versions, files,
       //   external_submissions, correspondence, writer_profiles, identity_migrations,
-      //   journal_directory
+      //   journal_directory, user_keys
       // - Subquery-based: sim_sub_checks, piece_transfers
       const orgPolicyExceptions = new Set([
         'audit_events',
@@ -372,6 +374,7 @@ describe('RLS Infrastructure', () => {
         'journal_directory',
         'sim_sub_checks',
         'piece_transfers',
+        'user_keys',
       ]);
 
       const orgScopedTables = RLS_TABLES.filter(

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -543,7 +543,8 @@
 - [x] [P2] Testing optimization — Python SDK in CI, test/CI contract clarity, Vitest config consolidation, deterministic web test UUIDs, coverage includes specialized suites, webhook CI job, flaky test fix — (architecture review 2026-03-16; done 2026-03-17)
 - [x] [P2] E2E selector brittleness — replaced CSS class selectors, parent traversal, positional disambiguation with `data-testid` and dialog-scoped role locators; removed `waitForTimeout` calls; ~20 acceptable `.first()/.last()` uses left unchanged — (done 2026-03-17)
 - [x] [P2] Defense-in-depth org filtering — CMS connection service (`getById`, `update`, `delete`, `testConnection`) and issue service (`getById`, `getItems`, `getSections`) do not pass available `orgId` for defense-in-depth WHERE clause; REST/tRPC callers also omit it — (Codex plan review 2026-03-17; done 2026-03-17)
-- [ ] [P2] RLS infrastructure test coverage — `rls-infrastructure.test.ts` `RLS_TABLES` array missing `cms_connections`, `webhook_endpoints`, `webhook_deliveries`, `submission_discussions` — (Codex plan review 2026-03-17)
+- [x] [P2] RLS infrastructure test coverage — `rls-infrastructure.test.ts` `RLS_TABLES` array missing 23 of 45 RLS tables — added all, unified org-policy assertion — (Codex plan review 2026-03-17; done 2026-03-17)
+- [ ] [P3] Clean up redundant per-migration GRANTs — `init-db.sh` `ALTER DEFAULT PRIVILEGES` grants full DML to all tables, making per-migration `GRANT SELECT, INSERT, UPDATE` (without DELETE) on `sim_sub_checks`, `trusted_peers`, `inbound_transfers` effectively no-ops — (DEVLOG 2026-03-17)
 - [ ] [P3] Vitest everywhere — replace Jest in `apps/web` with Vitest to eliminate test runner split (`vi.*` vs `jest.*`), deduplicate mock APIs, coverage configs, and setup patterns — (architecture review 2026-03-16)
 
 ### Architecture Boundaries

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -12,6 +12,7 @@ Newest entries first.
 - Unified org-policy assertion to match both `current_org_id()` and `current_setting('app.current_org')` SQL variants, replacing hardcoded 4-table check
 - Extended org-policy exception list for user-scoped (7 tables), nullable (3), and subquery-based (2) policies
 - All 122 RLS tests pass across 11 files
+- Addressed Codex branch review: added `user_keys` table (missed in original audit) — now 46 tables total
 
 ### Decisions
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,22 @@ Newest entries first.
 
 ---
 
+## 2026-03-17 — Complete RLS infrastructure test coverage
+
+### Done
+
+- Added 23 missing tables to `RLS_TABLES` in `rls-infrastructure.test.ts` (22 → 45 total), covering all tables with `.enableRLS()` in Drizzle schema
+- Unified org-policy assertion to match both `current_org_id()` and `current_setting('app.current_org')` SQL variants, replacing hardcoded 4-table check
+- Extended org-policy exception list for user-scoped (7 tables), nullable (3), and subquery-based (2) policies
+- All 122 RLS tests pass across 11 files
+
+### Decisions
+
+- Dropped planned `RLS_TABLES_NO_DELETE` and `RLS_TABLES_NO_GRANT` test categories — `init-db.sh` `ALTER DEFAULT PRIVILEGES` grants full DML to all tables, making per-migration restricted GRANTs additive only (not security-relevant since RLS policies still enforce isolation)
+- Used prefix match `current_setting('app.current_org` for PostgreSQL's decompiled `::text` cast in `pg_policies.qual`
+
+---
+
 ## 2026-03-17 — Defense-in-depth org filtering for CMS & issue services
 
 ### Done


### PR DESCRIPTION
## Summary

- Added 24 missing tables to `RLS_TABLES` in `rls-infrastructure.test.ts` (22 → 46), covering all tables with `.enableRLS()` in Drizzle schema
- Unified org-policy assertion to match both `current_org_id()` and `current_setting('app.current_org')` SQL variants, replacing hardcoded 4-table check
- Extended org-policy exception list for user-scoped, nullable, and subquery-based policy tables

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `rls-infrastructure.test.ts` | Add `RLS_TABLES_NO_DELETE` and `RLS_TABLES_NO_GRANT` categories | Not added — kept simple `audit_events`/`journal_directory` exclusion | `init-db.sh` `ALTER DEFAULT PRIVILEGES` grants full DML to all tables, making per-migration restricted GRANTs no-ops |
| `rls-infrastructure.test.ts` | 7 org-policy exceptions | 13 org-policy exceptions | 6 additional tables (identity_migrations, piece_transfers, external_submissions, correspondence, writer_profiles, journal_directory, user_keys) discovered to use user-scoped/subquery policies during implementation |
| `rls-infrastructure.test.ts` | 45 tables total | 46 tables total | branch review caught `user_keys` table was missing from both the original audit and plan |

## Test plan

- [x] `pnpm db:reset --test` — test DB reset with all migrations
- [x] `pnpm --filter @colophony/api test:rls` — all 122 RLS tests pass across 11 files
- [x] branch review — addressed `user_keys` finding