### PR TITLE
chore(db): harden database config for production readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ DATABASE_URL=postgresql://colophony:password@localhost:5432/colophony
 # Application connection (non-superuser, enforces RLS). Falls back to DATABASE_URL if unset.
 DATABASE_APP_URL=postgresql://app_user:app_password@localhost:5432/colophony
 DATABASE_TEST_URL=postgresql://test:test@localhost:5433/colophony_test
+# DB_SSL=false            # false | true | no-verify
+# DB_SSL_CA_PATH=         # CA cert path (when DB_SSL=true)
+# DB_ADMIN_POOL_MAX=5     # Superuser pool (migrations, admin)
+# DB_APP_POOL_MAX=20      # App pool (request traffic, RLS)
 
 # =============================================================================
 # REDIS

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -16,6 +16,12 @@ POSTGRES_DB=colophony
 # Application database user (non-superuser, required for RLS)
 APP_USER_PASSWORD=CHANGE_ME_generate_with_openssl_rand_base64_48
 
+# === DATABASE HARDENING ===
+DB_SSL=false
+# DB_SSL_CA_PATH=/path/to/ca.pem
+DB_ADMIN_POOL_MAX=5
+DB_APP_POOL_MAX=20
+
 # Redis password
 REDIS_PASSWORD=CHANGE_ME_generate_with_openssl_rand_base64_48
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,9 +188,11 @@ All other version pins are in their respective per-directory CLAUDE.md files.
 
 ### Production Deployment Checklist
 
-- [ ] Change `app_user` password from default
-- [ ] PostgreSQL SSL/TLS (`sslmode=require`), connection pooling (PgBouncer), backups (WAL-G to S3)
-- [ ] `pg_stat_statements` for query monitoring
+- [x] Change `app_user` password from default (init script validation)
+- [x] PostgreSQL SSL/TLS support (`DB_SSL` env var)
+- [ ] Connection pooling (PgBouncer)
+- [ ] Backups (WAL-G to S3)
+- [x] `pg_stat_statements` for query monitoring
 - [ ] Rotate credentials quarterly
 - [x] AGPL license boundary documented — see `docs/licensing.md`
 - [x] Monitoring: Prometheus + Grafana (Sentry error tracking, `/metrics` endpoint, `--profile monitoring`)
@@ -431,14 +433,18 @@ Canonical env definition with Zod validation: `apps/api/src/config/env.ts` (55 v
 
 <!-- Core -->
 
-| Variable           | Required | Default                      | Used by |
-| ------------------ | -------- | ---------------------------- | ------- |
-| `DATABASE_URL`     | Yes      | —                            | API     |
-| `DATABASE_APP_URL` | Prod     | falls back to `DATABASE_URL` | API, DB |
-| `PORT` / `HOST`    | No       | `4000` / `0.0.0.0`           | API     |
-| `NODE_ENV`         | No       | `development`                | API     |
-| `LOG_LEVEL`        | No       | `info`                       | API     |
-| `CORS_ORIGIN`      | No       | `http://localhost:3000`      | API     |
+| Variable            | Required | Default                      | Used by |
+| ------------------- | -------- | ---------------------------- | ------- |
+| `DATABASE_URL`      | Yes      | —                            | API     |
+| `DATABASE_APP_URL`  | Prod     | falls back to `DATABASE_URL` | API, DB |
+| `DB_SSL`            | No       | `false`                      | DB      |
+| `DB_SSL_CA_PATH`    | No       | —                            | DB      |
+| `DB_ADMIN_POOL_MAX` | No       | `5`                          | DB      |
+| `DB_APP_POOL_MAX`   | No       | `20`                         | DB      |
+| `PORT` / `HOST`     | No       | `4000` / `0.0.0.0`           | API     |
+| `NODE_ENV`          | No       | `development`                | API     |
+| `LOG_LEVEL`         | No       | `info`                       | API     |
+| `CORS_ORIGIN`       | No       | `http://localhost:3000`      | API     |
 
 <!-- Redis -->
 

--- a/apps/api/src/__tests__/webhooks/helpers/webhook-app.ts
+++ b/apps/api/src/__tests__/webhooks/helpers/webhook-app.ts
@@ -16,6 +16,9 @@ export function createTestEnv(overrides?: Partial<Env>): Env {
     DATABASE_URL:
       process.env.DATABASE_APP_URL ??
       'postgresql://app_user:app_password@localhost:5433/colophony_test',
+    DB_SSL: 'false' as const,
+    DB_ADMIN_POOL_MAX: 5,
+    DB_APP_POOL_MAX: 20,
     PORT: 0,
     HOST: '127.0.0.1',
     NODE_ENV: 'test',

--- a/apps/api/src/config/env.spec.ts
+++ b/apps/api/src/config/env.spec.ts
@@ -144,6 +144,32 @@ describe('validateEnv', () => {
     expect(typeof env.CLAMAV_PORT).toBe('number');
   });
 
+  it('DB_SSL defaults to false', () => {
+    const env = validateEnv(validBase);
+    expect(env.DB_SSL).toBe('false');
+  });
+
+  it('DB_SSL accepts valid values', () => {
+    for (const value of ['true', 'false', 'no-verify'] as const) {
+      const env = validateEnv({ ...validBase, DB_SSL: value });
+      expect(env.DB_SSL).toBe(value);
+    }
+  });
+
+  it('DB_SSL rejects invalid values', () => {
+    expect(() => validateEnv({ ...validBase, DB_SSL: 'require' })).toThrow();
+  });
+
+  it('DB_ADMIN_POOL_MAX defaults to 5', () => {
+    const env = validateEnv(validBase);
+    expect(env.DB_ADMIN_POOL_MAX).toBe(5);
+  });
+
+  it('DB_APP_POOL_MAX defaults to 20', () => {
+    const env = validateEnv(validBase);
+    expect(env.DB_APP_POOL_MAX).toBe(20);
+  });
+
   it('transforms FEDERATION_ENABLED to boolean', () => {
     const envTrue = validateEnv({
       ...validBase,

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -17,6 +17,12 @@ const envSchema = z
       )
       .optional(),
 
+    // Database hardening
+    DB_SSL: z.enum(['true', 'false', 'no-verify']).default('false'),
+    DB_SSL_CA_PATH: z.string().optional(),
+    DB_ADMIN_POOL_MAX: z.coerce.number().int().positive().default(5),
+    DB_APP_POOL_MAX: z.coerce.number().int().positive().default(20),
+
     // With defaults
     PORT: z.coerce.number().int().positive().default(4000),
     HOST: z.string().default('0.0.0.0'),

--- a/apps/api/src/federation/did.routes.spec.ts
+++ b/apps/api/src/federation/did.routes.spec.ts
@@ -25,6 +25,9 @@ vi.mock('../services/federation.service.js', () => ({
 
 const testEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/apps/api/src/federation/discovery.routes.spec.ts
+++ b/apps/api/src/federation/discovery.routes.spec.ts
@@ -28,6 +28,9 @@ vi.mock('../services/federation.service.js', () => ({
 
 const testEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/apps/api/src/federation/migration.routes.spec.ts
+++ b/apps/api/src/federation/migration.routes.spec.ts
@@ -85,6 +85,9 @@ const validUuid3 = '00000000-0000-4000-a000-000000000003';
 
 const testEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/apps/api/src/federation/simsub-admin.routes.spec.ts
+++ b/apps/api/src/federation/simsub-admin.routes.spec.ts
@@ -29,6 +29,9 @@ vi.mock('../services/simsub.service.js', () => ({
 
 const testEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/apps/api/src/federation/simsub.routes.spec.ts
+++ b/apps/api/src/federation/simsub.routes.spec.ts
@@ -39,6 +39,9 @@ vi.mock('./federation-auth.js', () => ({
 
 const testEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/apps/api/src/federation/transfer-admin.routes.spec.ts
+++ b/apps/api/src/federation/transfer-admin.routes.spec.ts
@@ -34,6 +34,9 @@ const validUuid = '00000000-0000-4000-a000-000000000001';
 
 const testEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/apps/api/src/federation/transfer.routes.spec.ts
+++ b/apps/api/src/federation/transfer.routes.spec.ts
@@ -65,6 +65,9 @@ const validUuid2 = '00000000-0000-4000-a000-000000000002';
 
 const testEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/apps/api/src/federation/trust-admin.routes.spec.ts
+++ b/apps/api/src/federation/trust-admin.routes.spec.ts
@@ -58,6 +58,9 @@ vi.mock('../services/trust.service.js', () => ({
 
 const testEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/apps/api/src/federation/trust.routes.spec.ts
+++ b/apps/api/src/federation/trust.routes.spec.ts
@@ -23,6 +23,9 @@ vi.mock('../services/trust.service.js', () => ({
 
 const testEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -53,6 +53,9 @@ vi.mock('../services/api-key.service.js', () => ({
 
 const baseEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/apps/api/src/hooks/rate-limit-auth.spec.ts
+++ b/apps/api/src/hooks/rate-limit-auth.spec.ts
@@ -59,6 +59,9 @@ const fakeAuthPlugin = fp(
 
 const testEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/apps/api/src/hooks/rate-limit.spec.ts
+++ b/apps/api/src/hooks/rate-limit.spec.ts
@@ -58,6 +58,9 @@ const fakeAuthPlugin = fp(
 
 const testEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/apps/api/src/main.spec.ts
+++ b/apps/api/src/main.spec.ts
@@ -61,6 +61,9 @@ vi.mock('ioredis', () => {
 
 const testEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/apps/api/src/services/federation.service.spec.ts
+++ b/apps/api/src/services/federation.service.spec.ts
@@ -82,6 +82,9 @@ vi.mock('node:crypto', async () => {
 
 const baseEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 4000,
   HOST: '0.0.0.0',
   NODE_ENV: 'test',

--- a/apps/api/src/services/hub-client.service.spec.ts
+++ b/apps/api/src/services/hub-client.service.spec.ts
@@ -104,6 +104,9 @@ function makeMockTx(opts: {
 
 const baseEnv = {
   DATABASE_URL: 'postgresql://localhost/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 4000,
   HOST: '0.0.0.0',
   REDIS_HOST: 'localhost',

--- a/apps/api/src/services/hub.service.spec.ts
+++ b/apps/api/src/services/hub.service.spec.ts
@@ -101,6 +101,9 @@ vi.mock('./audit.service.js', () => ({
 
 const baseEnv = {
   DATABASE_URL: 'postgresql://localhost/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 4000,
   HOST: '0.0.0.0',
   REDIS_HOST: 'localhost',

--- a/apps/api/src/services/trust.service.spec.ts
+++ b/apps/api/src/services/trust.service.spec.ts
@@ -164,6 +164,9 @@ function setupWithRls(tx: unknown) {
 
 const baseEnv = {
   DATABASE_URL: 'postgresql://localhost/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 4000,
   HOST: '0.0.0.0',
   REDIS_HOST: 'localhost',

--- a/apps/api/src/webhooks/stripe.webhook.spec.ts
+++ b/apps/api/src/webhooks/stripe.webhook.spec.ts
@@ -113,6 +113,9 @@ const WEBHOOK_SECRET = 'whsec_test_secret';
 
 const testEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/apps/api/src/webhooks/tusd.webhook.spec.ts
+++ b/apps/api/src/webhooks/tusd.webhook.spec.ts
@@ -132,6 +132,9 @@ const mockAuditService = vi.mocked(auditService);
 
 const TEST_ENV = {
   DATABASE_URL: 'postgresql://test:test@localhost/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 4000,
   HOST: '0.0.0.0',
   NODE_ENV: 'test' as const,

--- a/apps/api/src/webhooks/zitadel.webhook.spec.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.spec.ts
@@ -116,6 +116,9 @@ const WEBHOOK_SECRET = 'test-webhook-secret';
 
 const testEnv: Env = {
   DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  DB_SSL: 'false' as const,
+  DB_ADMIN_POOL_MAX: 5,
+  DB_APP_POOL_MAX: 20,
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,7 +38,8 @@ services:
     environment:
       NODE_ENV: production
       PORT: 4000
-      DATABASE_URL: postgresql://app_user:${APP_USER_PASSWORD}@postgres:5432/${POSTGRES_DB:-colophony}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-colophony}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-colophony}
+      DATABASE_APP_URL: postgresql://app_user:${APP_USER_PASSWORD}@postgres:5432/${POSTGRES_DB:-colophony}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
       REDIS_HOST: redis
       REDIS_PORT: 6379
@@ -112,6 +113,12 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB:-colophony}
       APP_USER_PASSWORD: ${APP_USER_PASSWORD}
+    command:
+      - postgres
+      - -c
+      - shared_preload_libraries=pg_stat_statements
+      - -c
+      - pg_stat_statements.track=all
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./scripts/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh:ro
@@ -276,7 +283,7 @@ services:
         /app/scripts/init-prod.sh
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-colophony}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-colophony}
-      APP_DATABASE_URL: postgresql://app_user:${APP_USER_PASSWORD}@postgres:5432/${POSTGRES_DB:-colophony}
+      DATABASE_APP_URL: postgresql://app_user:${APP_USER_PASSWORD}@postgres:5432/${POSTGRES_DB:-colophony}
     volumes:
       - ./scripts/init-prod.sh:/app/scripts/init-prod.sh:ro
     depends_on:

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -506,11 +506,11 @@
 
 ### Database Hardening
 
-- [ ] Change `app_user` password from default — (CLAUDE.md)
-- [ ] PostgreSQL SSL/TLS (`sslmode=require`) — (CLAUDE.md)
+- [x] Change `app_user` password from default — (CLAUDE.md; done 2026-03-17 init script validation)
+- [x] PostgreSQL SSL/TLS (`DB_SSL` env var) — (CLAUDE.md; done 2026-03-17)
 - [ ] Connection pooling (PgBouncer) — (CLAUDE.md)
 - [ ] Backups (WAL-G to S3) — (CLAUDE.md)
-- [ ] `pg_stat_statements` for query monitoring — (CLAUDE.md)
+- [x] `pg_stat_statements` for query monitoring — (CLAUDE.md; done 2026-03-17)
 - [ ] Verify RLS in production — see `packages/db/CLAUDE.md` for verification queries — (CLAUDE.md)
 
 ### Security & Compliance

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,30 @@ Newest entries first.
 
 ---
 
+## 2026-03-17 — DB Hardening for Production Readiness
+
+### Done
+
+- Extracted `buildSslConfig()` to `packages/db/src/ssl.ts` — supports `DB_SSL=false|true|no-verify` with optional CA cert path
+- Updated `packages/db/src/client.ts` with separate admin/app pool sizes (`DB_ADMIN_POOL_MAX=5`, `DB_APP_POOL_MAX=20`) and SSL support
+- Added SSL support to `drizzle.config.ts` for migrations
+- Added 4 new env vars to Zod schema in `apps/api/src/config/env.ts`
+- Enabled `pg_stat_statements` in `docker-compose.prod.yml` (postgres command args), `init-db.sh`, and `init-prod.sh`
+- Added password validation: warning in `init-db.sh` (dev), hard block in `init-prod.sh` (prod rejects `app_password`/`CHANGE_ME`)
+- Fixed prod compose API `DATABASE_URL` bug — was only `app_user` connection, now superuser + separate `DATABASE_APP_URL`
+- Renamed `APP_DATABASE_URL` → `DATABASE_APP_URL` in `docker-compose.prod.yml` and `init-prod.sh` for env name convergence with `env.ts`
+- Created vitest config + 5 SSL unit tests for db package
+- Added 5 env validation tests to `apps/api/src/config/env.spec.ts`
+- Updated 21 test files with new required Env fields (`DB_SSL`, `DB_ADMIN_POOL_MAX`, `DB_APP_POOL_MAX`)
+- Updated `.env.example`, `.env.prod.example`, `CLAUDE.md` (env table + security checklist), `docs/backlog.md` (3 items checked off), `packages/db/CLAUDE.md` (pool defaults + SSL docs)
+
+### Decisions
+
+- PgBouncer and WAL-G backups deferred to separate PRs (as planned)
+- SSL config extracted to its own module to keep it testable without triggering Pool instantiation
+
+---
+
 ## 2026-03-17 — P3 Housekeeping: GRANTs Cleanup + BullMQ/Inngest Docs
 
 ### Done

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -43,8 +43,10 @@ export const submissions = pgTable(
 
 ### Connection Pools (`src/client.ts`)
 
-- **`pool`** — superuser (`colophony`). Used for migrations, admin tasks, and the Drizzle `db` instance.
-- **`appPool`** — non-superuser (`app_user`, `NOBYPASSRLS`). Used by `withRls()` and the `dbContext` hook for all request-scoped queries. Configured via `DATABASE_APP_URL` (falls back to `DATABASE_URL` with a security warning). **Required in production** — API startup fails if `DATABASE_APP_URL` is unset when `NODE_ENV=production`.
+- **`pool`** — superuser (`colophony`). Used for migrations, admin tasks, and the Drizzle `db` instance. Default max: **5** (`DB_ADMIN_POOL_MAX`).
+- **`appPool`** — non-superuser (`app_user`, `NOBYPASSRLS`). Used by `withRls()` and the `dbContext` hook for all request-scoped queries. Default max: **20** (`DB_APP_POOL_MAX`). Configured via `DATABASE_APP_URL` (falls back to `DATABASE_URL` with a security warning). **Required in production** — API startup fails if `DATABASE_APP_URL` is unset when `NODE_ENV=production`.
+
+Both pools support SSL via `DB_SSL` env var (`false` | `true` | `no-verify`). SSL config is extracted to `src/ssl.ts` and shared with `drizzle.config.ts`.
 
 **Always use `appPool` for tenant data queries.** The superuser `pool` bypasses all RLS policies.
 

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,5 +1,17 @@
+import fs from "node:fs";
 import { defineConfig } from "drizzle-kit";
-import { buildSslConfig } from "./src/ssl.js";
+import type { PoolConfig } from "pg";
+
+function buildSslConfig(): PoolConfig["ssl"] {
+  const mode = process.env.DB_SSL ?? "false";
+  if (mode === "false") return undefined;
+  if (mode === "no-verify") return { rejectUnauthorized: false };
+  const caPath = process.env.DB_SSL_CA_PATH;
+  return {
+    rejectUnauthorized: true,
+    ...(caPath ? { ca: fs.readFileSync(caPath, "utf8") } : {}),
+  };
+}
 
 export default defineConfig({
   dialect: "postgresql",

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "drizzle-kit";
+import { buildSslConfig } from "./src/ssl.js";
 
 export default defineConfig({
   dialect: "postgresql",
@@ -6,6 +7,7 @@ export default defineConfig({
   out: "./migrations",
   dbCredentials: {
     url: process.env.DATABASE_URL!,
+    ssl: buildSslConfig(),
   },
   verbose: true,
   strict: true,

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -27,6 +27,7 @@
     "verify": "tsx --env-file=.env src/verify-migrations.ts --check",
     "verify:repair": "tsx --env-file=.env src/verify-migrations.ts --repair",
     "validate-enums": "tsx --env-file=.env src/validate-enum-migration.ts",
+    "test": "vitest run",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
@@ -38,6 +39,7 @@
     "@types/node": "^25.5.0",
     "@types/pg": "^8.18.0",
     "drizzle-kit": "^0.31.9",
+    "vitest": "^3.2.1",
     "tsx": "^4.19.0",
     "typescript": "^5.7.2"
   }

--- a/packages/db/src/__tests__/ssl.test.ts
+++ b/packages/db/src/__tests__/ssl.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+
+describe("buildSslConfig", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.DB_SSL;
+    delete process.env.DB_SSL_CA_PATH;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  async function loadBuildSslConfig() {
+    const mod = await import("../ssl.js");
+    return mod.buildSslConfig;
+  }
+
+  it("returns undefined when DB_SSL=false", async () => {
+    process.env.DB_SSL = "false";
+    const buildSslConfig = await loadBuildSslConfig();
+    expect(buildSslConfig()).toBeUndefined();
+  });
+
+  it("returns undefined when DB_SSL is unset", async () => {
+    const buildSslConfig = await loadBuildSslConfig();
+    expect(buildSslConfig()).toBeUndefined();
+  });
+
+  it("returns rejectUnauthorized:false for no-verify", async () => {
+    process.env.DB_SSL = "no-verify";
+    const buildSslConfig = await loadBuildSslConfig();
+    expect(buildSslConfig()).toEqual({ rejectUnauthorized: false });
+  });
+
+  it("returns rejectUnauthorized:true when DB_SSL=true, no CA", async () => {
+    process.env.DB_SSL = "true";
+    const buildSslConfig = await loadBuildSslConfig();
+    expect(buildSslConfig()).toEqual({ rejectUnauthorized: true });
+  });
+
+  it("reads CA file when DB_SSL=true + CA path", async () => {
+    process.env.DB_SSL = "true";
+    process.env.DB_SSL_CA_PATH = "/path/to/ca.pem";
+    vi.spyOn(fs, "readFileSync").mockReturnValue("-----BEGIN CERTIFICATE-----");
+    const buildSslConfig = await loadBuildSslConfig();
+    expect(buildSslConfig()).toEqual({
+      rejectUnauthorized: true,
+      ca: "-----BEGIN CERTIFICATE-----",
+    });
+    expect(fs.readFileSync).toHaveBeenCalledWith("/path/to/ca.pem", "utf8");
+  });
+});

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,6 +1,9 @@
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import * as schema from "./schema/index";
+import { buildSslConfig } from "./ssl.js";
+
+const ssl = buildSslConfig();
 
 /**
  * Admin pool — superuser connection for migrations, seed, and admin operations.
@@ -8,9 +11,10 @@ import * as schema from "./schema/index";
  */
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
-  max: parseInt(process.env.DB_POOL_MAX || "10", 10),
+  max: parseInt(process.env.DB_ADMIN_POOL_MAX || "5", 10),
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 2000,
+  ssl,
 });
 
 /**
@@ -27,9 +31,10 @@ if (!process.env.DATABASE_APP_URL && process.env.NODE_ENV !== "test") {
 
 const appPool = new Pool({
   connectionString: process.env.DATABASE_APP_URL || process.env.DATABASE_URL,
-  max: parseInt(process.env.DB_POOL_MAX || "10", 10),
+  max: parseInt(process.env.DB_APP_POOL_MAX || "20", 10),
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 2000,
+  ssl,
 });
 
 export const db = drizzle(pool, { schema });

--- a/packages/db/src/ssl.ts
+++ b/packages/db/src/ssl.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+import type { PoolConfig } from "pg";
+
+/**
+ * Build SSL config from DB_SSL env var.
+ *   'false'     → undefined (no SSL)
+ *   'true'      → { rejectUnauthorized: true, ca?: Buffer } (verify CA)
+ *   'no-verify' → { rejectUnauthorized: false } (encrypt, skip CA check)
+ */
+export function buildSslConfig(): PoolConfig["ssl"] {
+  const mode = process.env.DB_SSL ?? "false";
+  if (mode === "false") return undefined;
+  if (mode === "no-verify") return { rejectUnauthorized: false };
+  const caPath = process.env.DB_SSL_CA_PATH;
+  return {
+    rejectUnauthorized: true,
+    ...(caPath ? { ca: fs.readFileSync(caPath, "utf8") } : {}),
+  };
+}

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/**/*.{test,spec}.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,6 +531,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/plugin-sdk:
     dependencies:
@@ -4122,8 +4125,22 @@ packages:
       '@vitest/browser':
         optional: true
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
   '@vitest/expect@4.1.0':
     resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@4.1.0':
     resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
@@ -4136,17 +4153,32 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
   '@vitest/pretty-format@4.1.0':
     resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
   '@vitest/runner@4.1.0':
     resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
 
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
   '@vitest/snapshot@4.1.0':
     resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/spy@4.1.0':
     resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
@@ -4411,6 +4443,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -4436,6 +4472,10 @@ packages:
   canonicalize@1.0.8:
     resolution: {integrity: sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -4443,6 +4483,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -4688,6 +4732,10 @@ packages:
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -4942,6 +4990,9 @@ packages:
   es-iterator-helpers@1.2.2:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -5801,6 +5852,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -6024,6 +6078,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lower-case@1.1.4:
     resolution: {integrity: sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==}
@@ -6447,6 +6504,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   peek-stream@1.1.3:
     resolution: {integrity: sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==}
@@ -7071,6 +7132,9 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
@@ -7161,6 +7225,9 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   stripe@20.4.1:
     resolution: {integrity: sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w==}
     engines: {node: '>=16'}
@@ -7248,6 +7315,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
@@ -7256,8 +7326,20 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
@@ -7471,6 +7553,11 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -7509,6 +7596,34 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@4.1.0:
@@ -11812,6 +11927,14 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@26.1.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/expect@4.1.0':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -11821,6 +11944,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.0
@@ -11829,13 +11960,29 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.1.0':
     dependencies:
       tinyrainbow: 3.1.0
 
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
   '@vitest/runner@4.1.0':
     dependencies:
       '@vitest/utils': 4.1.0
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.1.0':
@@ -11845,7 +11992,17 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
   '@vitest/spy@4.1.0': {}
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@4.1.0':
     dependencies:
@@ -12126,6 +12283,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -12154,12 +12313,22 @@ snapshots:
 
   canonicalize@1.0.8: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.3: {}
 
   cheerio-select@2.1.0:
     dependencies:
@@ -12410,6 +12579,8 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -12644,6 +12815,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
+
+  es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -13712,6 +13885,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -13941,6 +14116,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
 
   lower-case@1.1.4: {}
 
@@ -14547,6 +14724,8 @@ snapshots:
       minipass: 7.1.2
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   peek-stream@1.1.3:
     dependencies:
@@ -15307,6 +15486,8 @@ snapshots:
 
   statuses@2.0.2: {}
 
+  std-env@3.10.0: {}
+
   std-env@4.0.0: {}
 
   stop-iteration-iterator@1.1.0:
@@ -15430,6 +15611,10 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   stripe@20.4.1(@types/node@25.5.0):
     optionalDependencies:
       '@types/node': 25.5.0
@@ -15509,6 +15694,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
@@ -15516,7 +15703,13 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
   tinyrainbow@3.1.0: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@6.1.86: {}
 
@@ -15759,6 +15952,27 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.4
@@ -15775,6 +15989,49 @@ snapshots:
       terser: 5.46.0
       tsx: 4.21.0
       yaml: 2.8.2
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 25.5.0
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@26.1.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:

--- a/scripts/init-db.sh
+++ b/scripts/init-db.sh
@@ -4,6 +4,12 @@
 
 set -e
 
+# Warn if APP_USER_PASSWORD is unset or uses the default
+if [ -z "$APP_USER_PASSWORD" ] || [ "$APP_USER_PASSWORD" = "app_password" ]; then
+  echo "⚠️  WARNING: APP_USER_PASSWORD is unset or using the default 'app_password'."
+  echo "   For production, generate a strong password: openssl rand -base64 48"
+fi
+
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
     -- Create non-superuser role for application (required for RLS)
     DO \$\$
@@ -57,6 +63,9 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     \$\$;
 
     GRANT USAGE ON SCHEMA public TO audit_writer;
+
+    -- Enable pg_stat_statements for query monitoring
+    CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
 
     -- Verify roles are not superusers
     SELECT usename, usesuper,

--- a/scripts/init-db.sh
+++ b/scripts/init-db.sh
@@ -64,8 +64,16 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
 
     GRANT USAGE ON SCHEMA public TO audit_writer;
 
-    -- Enable pg_stat_statements for query monitoring
-    CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+    -- Enable pg_stat_statements for query monitoring (only if preloaded)
+    DO \$\$
+    BEGIN
+        IF current_setting('shared_preload_libraries', true) LIKE '%pg_stat_statements%' THEN
+            CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+        ELSE
+            RAISE NOTICE 'pg_stat_statements not in shared_preload_libraries — skipping extension creation';
+        END IF;
+    END
+    \$\$;
 
     -- Verify roles are not superusers
     SELECT usename, usesuper,

--- a/scripts/init-prod.sh
+++ b/scripts/init-prod.sh
@@ -36,11 +36,21 @@ echo "Step 1: Running Drizzle migrations..."
 pnpm --filter @colophony/db migrate
 echo "Migrations complete."
 
-# Step 1.5: Enable pg_stat_statements (idempotent — covers existing databases)
+# Step 1.5: Enable pg_stat_statements (idempotent — only if preloaded)
 echo ""
 echo "Step 1.5: Enabling pg_stat_statements..."
-psql "$DATABASE_URL" -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"
-echo "pg_stat_statements enabled."
+psql "$DATABASE_URL" -c "
+DO \$\$
+BEGIN
+    IF current_setting('shared_preload_libraries', true) LIKE '%pg_stat_statements%' THEN
+        CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+        RAISE NOTICE 'pg_stat_statements extension enabled';
+    ELSE
+        RAISE NOTICE 'pg_stat_statements not in shared_preload_libraries — skipping';
+    END IF;
+END
+\$\$;"
+echo "pg_stat_statements check complete."
 
 # Step 2: Grant permissions to app_user (GRANT is idempotent)
 # Drizzle migrations handle schema, RLS policies, helper functions, indexes, and triggers.

--- a/scripts/init-prod.sh
+++ b/scripts/init-prod.sh
@@ -12,15 +12,35 @@ if [ -z "$DATABASE_URL" ]; then
   exit 1
 fi
 
-if [ -z "$APP_DATABASE_URL" ]; then
-  echo "WARNING: APP_DATABASE_URL not set, skipping RLS verification"
+if [ -z "$DATABASE_APP_URL" ]; then
+  echo "WARNING: DATABASE_APP_URL not set, skipping RLS verification"
 fi
+
+# Block default/placeholder credentials in production
+for url_var in DATABASE_URL DATABASE_APP_URL; do
+  eval url_val=\$$url_var
+  if [ -n "$url_val" ]; then
+    case "$url_val" in
+      *app_password*|*CHANGE_ME*)
+        echo "ERROR: $url_var contains a default/placeholder password."
+        echo "  Generate a strong password: openssl rand -base64 48"
+        exit 1
+        ;;
+    esac
+  fi
+done
 
 # Step 1: Run Drizzle migrations (idempotent — tracks applied migrations in journal)
 echo ""
 echo "Step 1: Running Drizzle migrations..."
 pnpm --filter @colophony/db migrate
 echo "Migrations complete."
+
+# Step 1.5: Enable pg_stat_statements (idempotent — covers existing databases)
+echo ""
+echo "Step 1.5: Enabling pg_stat_statements..."
+psql "$DATABASE_URL" -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"
+echo "pg_stat_statements enabled."
 
 # Step 2: Grant permissions to app_user (GRANT is idempotent)
 # Drizzle migrations handle schema, RLS policies, helper functions, indexes, and triggers.


### PR DESCRIPTION
## Summary

- **SSL/TLS support**: `DB_SSL` env var (`false` | `true` | `no-verify`) with optional CA cert path, applied to both connection pools and drizzle-kit migrations
- **Separate pool sizes**: Admin pool (`DB_ADMIN_POOL_MAX=5`) and app pool (`DB_APP_POOL_MAX=20`) instead of shared `DB_POOL_MAX=10`
- **`pg_stat_statements`**: Enabled in prod compose via `shared_preload_libraries`; guarded `CREATE EXTENSION` in init scripts (only runs when preloaded)
- **Password validation**: Warning in `init-db.sh` (dev), hard block in `init-prod.sh` (rejects `app_password`/`CHANGE_ME`)
- **Fix prod compose `DATABASE_URL` bug**: API service was only getting `app_user` connection — now gets superuser `DATABASE_URL` + separate `DATABASE_APP_URL`
- **Env name convergence**: Renamed `APP_DATABASE_URL` → `DATABASE_APP_URL` throughout prod compose + init-prod.sh to match `env.ts`

## Test plan

- [x] `pnpm --filter @colophony/db test` — 5 SSL config tests pass
- [x] `pnpm --filter @colophony/api test` — 1506 tests pass (5 new env tests + 21 fixture updates)
- [x] `pnpm type-check` — clean (db + api)
- [x] `pnpm lint` — clean
- [x] `docker compose -f docker-compose.prod.yml config` — valid YAML
- [ ] CI pipeline