### PR TITLE
chore(db): add PgBouncer connection pooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,11 @@
 # =============================================================================
 # DATABASE
 # =============================================================================
+# Direct connection (port 5432) — used for migrations: pnpm db:generate, pnpm db:migrate
 DATABASE_URL=postgresql://colophony:password@localhost:5432/colophony
-# Application connection (non-superuser, enforces RLS). Falls back to DATABASE_URL if unset.
-DATABASE_APP_URL=postgresql://app_user:app_password@localhost:5432/colophony
+# PgBouncer connection (port 6432) — used for runtime API queries with RLS
+# Run `docker compose up pgbouncer` for connection pooling
+DATABASE_APP_URL=postgresql://app_user:app_password@localhost:6432/colophony
 DATABASE_TEST_URL=postgresql://test:test@localhost:5433/colophony_test
 # DB_SSL=false            # false | true | no-verify
 # DB_SSL_CA_PATH=         # CA cert path (when DB_SSL=true)

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -22,6 +22,12 @@ DB_SSL=false
 DB_ADMIN_POOL_MAX=5
 DB_APP_POOL_MAX=20
 
+# === PGBOUNCER CONNECTION POOLING ===
+# Tune based on expected API instance count and PostgreSQL max_connections
+PGBOUNCER_DEFAULT_POOL_SIZE=20
+PGBOUNCER_MAX_CLIENT_CONN=200
+PGBOUNCER_MAX_DB_CONNECTIONS=50
+
 # Redis password
 REDIS_PASSWORD=CHANGE_ME_generate_with_openssl_rand_base64_48
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,7 @@ Domain-specific quirks are in per-directory CLAUDE.md files. Cross-cutting quirk
 | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Docker Compose env_file**                           | `env_file:` sets container env only. For YAML `${VAR}` substitution, use `--env-file .env` on CLI                                                                                                                                                                                                                                                                                                                                 |
 | **PostgreSQL init-db.sh**                             | Only runs on first DB creation. Must `docker compose down -v` to re-run after changes                                                                                                                                                                                                                                                                                                                                             |
+| **PgBouncer: migrations must bypass**                 | `drizzle-kit` and `pnpm db:migrate` use `DATABASE_URL` (direct port 5432). Only `DATABASE_APP_URL` routes through PgBouncer (port 6432). `SET LOCAL` is required (not `SET`) — transaction pooling reuses server connections                                                                                                                                                                                                      |
 | **WSL husky hooks need nvm PATH**                     | Husky v9 runs hooks under `sh`/`dash`; `nvm.sh` can't be sourced. Hooks add nvm node bin to PATH directly. `lint-staged` called without `npx`                                                                                                                                                                                                                                                                                     |
 | **CI: workspace deps need build before Vitest**       | Vitest resolves workspace packages via `exports` field (pointing to `dist/`). CI must build deps before running tests                                                                                                                                                                                                                                                                                                             |
 | **`drizzle-kit generate` TUI blocks automation**      | Interactive prompts (rename vs create) use a TUI that ignores piped stdin. Write manual migrations in non-interactive shells; snapshot files may need regeneration interactively                                                                                                                                                                                                                                                  |
@@ -190,7 +191,7 @@ All other version pins are in their respective per-directory CLAUDE.md files.
 
 - [x] Change `app_user` password from default (init script validation)
 - [x] PostgreSQL SSL/TLS support (`DB_SSL` env var)
-- [ ] Connection pooling (PgBouncer)
+- [x] Connection pooling (PgBouncer) — transaction mode, `DATABASE_APP_URL` routes through port 6432
 - [ ] Backups (WAL-G to S3)
 - [x] `pg_stat_statements` for query monitoring
 - [ ] Rotate credentials quarterly
@@ -433,18 +434,21 @@ Canonical env definition with Zod validation: `apps/api/src/config/env.ts` (55 v
 
 <!-- Core -->
 
-| Variable            | Required | Default                      | Used by |
-| ------------------- | -------- | ---------------------------- | ------- |
-| `DATABASE_URL`      | Yes      | —                            | API     |
-| `DATABASE_APP_URL`  | Prod     | falls back to `DATABASE_URL` | API, DB |
-| `DB_SSL`            | No       | `false`                      | DB      |
-| `DB_SSL_CA_PATH`    | No       | —                            | DB      |
-| `DB_ADMIN_POOL_MAX` | No       | `5`                          | DB      |
-| `DB_APP_POOL_MAX`   | No       | `20`                         | DB      |
-| `PORT` / `HOST`     | No       | `4000` / `0.0.0.0`           | API     |
-| `NODE_ENV`          | No       | `development`                | API     |
-| `LOG_LEVEL`         | No       | `info`                       | API     |
-| `CORS_ORIGIN`       | No       | `http://localhost:3000`      | API     |
+| Variable                       | Required | Default                      | Used by   |
+| ------------------------------ | -------- | ---------------------------- | --------- |
+| `DATABASE_URL`                 | Yes      | —                            | API       |
+| `DATABASE_APP_URL`             | Prod     | falls back to `DATABASE_URL` | API, DB   |
+| `DB_SSL`                       | No       | `false`                      | DB        |
+| `DB_SSL_CA_PATH`               | No       | —                            | DB        |
+| `DB_ADMIN_POOL_MAX`            | No       | `5`                          | DB        |
+| `DB_APP_POOL_MAX`              | No       | `20`                         | DB        |
+| `PGBOUNCER_DEFAULT_POOL_SIZE`  | No       | `20`                         | PgBouncer |
+| `PGBOUNCER_MAX_CLIENT_CONN`    | No       | `200`                        | PgBouncer |
+| `PGBOUNCER_MAX_DB_CONNECTIONS` | No       | `50`                         | PgBouncer |
+| `PORT` / `HOST`                | No       | `4000` / `0.0.0.0`           | API       |
+| `NODE_ENV`                     | No       | `development`                | API       |
+| `LOG_LEVEL`                    | No       | `info`                       | API       |
+| `CORS_ORIGIN`                  | No       | `http://localhost:3000`      | API       |
 
 <!-- Redis -->
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -72,7 +72,7 @@ services:
       NODE_ENV: production
       PORT: 4000
       DATABASE_URL: postgresql://${POSTGRES_USER:-colophony}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-colophony}
-      DATABASE_APP_URL: postgresql://app_user:${APP_USER_PASSWORD}@pgbouncer:6432/${POSTGRES_DB:-colophony}
+      DATABASE_APP_URL: postgresql://app_user:${APP_USER_PASSWORD}@pgbouncer:6432/${POSTGRES_DB:-colophony}?sslmode=disable
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
       REDIS_HOST: redis
       REDIS_PORT: 6379

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,6 +26,39 @@ services:
     networks:
       - colophony
 
+  # PgBouncer connection pooler (transaction mode for RLS SET LOCAL)
+  pgbouncer:
+    image: edoburu/pgbouncer:1.23.1-p2
+    container_name: colophony-pgbouncer
+    expose:
+      - "6432"
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-colophony}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-colophony}
+      APP_USER_PASSWORD: ${APP_USER_PASSWORD}
+      PGBOUNCER_DEFAULT_POOL_SIZE: ${PGBOUNCER_DEFAULT_POOL_SIZE:-20}
+      PGBOUNCER_MAX_CLIENT_CONN: ${PGBOUNCER_MAX_CLIENT_CONN:-200}
+      PGBOUNCER_MAX_DB_CONNECTIONS: ${PGBOUNCER_MAX_DB_CONNECTIONS:-50}
+    volumes:
+      - ./docker/pgbouncer/entrypoint.sh:/entrypoint.sh:ro
+    entrypoint: /entrypoint.sh
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 6432"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+    networks:
+      - colophony
+
   # Fastify API + tRPC server
   api:
     build:
@@ -39,7 +72,7 @@ services:
       NODE_ENV: production
       PORT: 4000
       DATABASE_URL: postgresql://${POSTGRES_USER:-colophony}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-colophony}
-      DATABASE_APP_URL: postgresql://app_user:${APP_USER_PASSWORD}@postgres:5432/${POSTGRES_DB:-colophony}
+      DATABASE_APP_URL: postgresql://app_user:${APP_USER_PASSWORD}@pgbouncer:6432/${POSTGRES_DB:-colophony}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
       REDIS_HOST: redis
       REDIS_PORT: 6379
@@ -58,6 +91,8 @@ services:
     depends_on:
       migrate:
         condition: service_completed_successfully
+      pgbouncer:
+        condition: service_healthy
       redis:
         condition: service_healthy
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,31 @@ services:
       timeout: 5s
       retries: 5
 
+  # PgBouncer connection pooler (transaction mode for RLS SET LOCAL)
+  pgbouncer:
+    image: edoburu/pgbouncer:1.23.1-p2
+    container_name: colophony-pgbouncer
+    ports:
+      - '6432:6432'
+    environment:
+      POSTGRES_USER: colophony
+      POSTGRES_PASSWORD: password
+      APP_USER_PASSWORD: app_password
+      PGBOUNCER_DEFAULT_POOL_SIZE: 20
+      PGBOUNCER_MAX_CLIENT_CONN: 100
+      PGBOUNCER_MAX_DB_CONNECTIONS: 30
+    volumes:
+      - ./docker/pgbouncer/entrypoint.sh:/entrypoint.sh:ro
+    entrypoint: /entrypoint.sh
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -h 127.0.0.1 -p 6432']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   # Test PostgreSQL database (in-memory for speed)
   postgres-test:
     image: postgres:16-alpine

--- a/docker/pgbouncer/entrypoint.sh
+++ b/docker/pgbouncer/entrypoint.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -eu
+
+# PgBouncer entrypoint — generates config from environment variables.
+# Secrets stay in env vars, never committed to repo.
+
+if [ -z "${POSTGRES_PASSWORD:-}" ]; then
+  echo "ERROR: POSTGRES_PASSWORD is required" >&2
+  exit 1
+fi
+
+if [ -z "${APP_USER_PASSWORD:-}" ]; then
+  echo "ERROR: APP_USER_PASSWORD is required" >&2
+  exit 1
+fi
+
+POSTGRES_USER="${POSTGRES_USER:-colophony}"
+POSTGRES_DB="${POSTGRES_DB:-colophony}"
+PGBOUNCER_DEFAULT_POOL_SIZE="${PGBOUNCER_DEFAULT_POOL_SIZE:-20}"
+PGBOUNCER_MAX_CLIENT_CONN="${PGBOUNCER_MAX_CLIENT_CONN:-200}"
+PGBOUNCER_MAX_DB_CONNECTIONS="${PGBOUNCER_MAX_DB_CONNECTIONS:-50}"
+
+mkdir -p /etc/pgbouncer
+
+# Generate userlist with plaintext passwords (PgBouncer performs SCRAM auth to PostgreSQL)
+cat > /etc/pgbouncer/userlist.txt <<EOF
+"${POSTGRES_USER}" "${POSTGRES_PASSWORD}"
+"app_user" "${APP_USER_PASSWORD}"
+EOF
+
+# Generate pgbouncer.ini
+cat > /etc/pgbouncer/pgbouncer.ini <<EOF
+[databases]
+* = host=${PGBOUNCER_DB_HOST:-postgres} port=${PGBOUNCER_DB_PORT:-5432}
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 6432
+auth_type = scram-sha-256
+auth_file = /etc/pgbouncer/userlist.txt
+
+pool_mode = transaction
+
+default_pool_size = ${PGBOUNCER_DEFAULT_POOL_SIZE}
+max_client_conn = ${PGBOUNCER_MAX_CLIENT_CONN}
+max_db_connections = ${PGBOUNCER_MAX_DB_CONNECTIONS}
+reserve_pool_size = 5
+reserve_pool_timeout = 3
+
+server_idle_timeout = 600
+server_lifetime = 3600
+
+ignore_startup_parameters = extra_float_digits
+
+admin_users = ${POSTGRES_USER}
+stats_users = ${POSTGRES_USER}
+EOF
+
+echo "PgBouncer config generated (pool_mode=transaction, max_client_conn=${PGBOUNCER_MAX_CLIENT_CONN}, max_db_connections=${PGBOUNCER_MAX_DB_CONNECTIONS})"
+
+exec pgbouncer /etc/pgbouncer/pgbouncer.ini

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -508,7 +508,7 @@
 
 - [x] Change `app_user` password from default — (CLAUDE.md; done 2026-03-17 init script validation)
 - [x] PostgreSQL SSL/TLS (`DB_SSL` env var) — (CLAUDE.md; done 2026-03-17)
-- [ ] Connection pooling (PgBouncer) — (CLAUDE.md)
+- [x] Connection pooling (PgBouncer) — (CLAUDE.md, PR pending)
 - [ ] Backups (WAL-G to S3) — (CLAUDE.md)
 - [x] `pg_stat_statements` for query monitoring — (CLAUDE.md; done 2026-03-17)
 - [ ] Verify RLS in production — see `packages/db/CLAUDE.md` for verification queries — (CLAUDE.md)

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-03-19 — PgBouncer Connection Pooling
+
+### Done
+
+- Created `docker/pgbouncer/entrypoint.sh` — generates `pgbouncer.ini` and `userlist.txt` from env vars at container start
+- Added `pgbouncer` service to `docker-compose.prod.yml` (edoburu/pgbouncer:1.23.1-p2, 64M memory limit, SCRAM-SHA-256 auth)
+- Routed prod API `DATABASE_APP_URL` through `pgbouncer:6432`; `DATABASE_URL` stays direct for admin pool
+- `migrate` service unchanged — connects directly to `postgres:5432` (drizzle-kit compatibility)
+- Added `pgbouncer` service to `docker-compose.yml` for dev parity (port 6432 exposed, smaller limits)
+- Updated `.env.example` to default `DATABASE_APP_URL` to port 6432 with explanatory comments
+- Added PgBouncer tuning section to `.env.prod.example` (pool size, max client/db connections)
+- Updated `CLAUDE.md`: checked off PgBouncer, added 3 env vars to table, added quirk entry
+- Added PgBouncer transaction pooling section to `packages/db/CLAUDE.md`
+- Checked off PgBouncer in `docs/backlog.md`
+
+### Decisions
+
+- Transaction pooling mode chosen — compatible with existing `SET LOCAL` RLS pattern, no session state in codebase
+- Codex plan review (2026-03-17) found no critical issues; two Important findings addressed in plan (dev compose has no API service → env-based parity, hardcoded admin_users → env-driven)
+- No application code changes needed — connection strings are env-driven, `withRls()` already uses `SET LOCAL`
+
+---
+
 ## 2026-03-17 — DB Hardening for Production Readiness
 
 ### Done

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -48,6 +48,16 @@ export const submissions = pgTable(
 
 Both pools support SSL via `DB_SSL` env var (`false` | `true` | `no-verify`). SSL config is extracted to `src/ssl.ts` and shared with `drizzle.config.ts`.
 
+### PgBouncer (Transaction Pooling)
+
+In production (and optionally dev), `DATABASE_APP_URL` routes through PgBouncer on port 6432 in **transaction pooling mode**. This multiplexes many client connections onto fewer PostgreSQL server connections.
+
+**Why transaction mode works:** `withRls()` uses `SET LOCAL` (transaction-scoped), and the codebase has no session state, cursors, prepared statements, temp tables, or `LISTEN/NOTIFY`. Server connections are returned to the pool after each transaction, so `SET LOCAL` context is automatically cleared.
+
+**Migration bypass:** `DATABASE_URL` (direct port 5432) is used for `drizzle-kit` and `pnpm db:migrate`. `drizzle-kit` may use features incompatible with transaction pooling. The `migrate` service in `docker-compose.prod.yml` connects directly to `postgres:5432`.
+
+**NEVER** use session-level `SET` (without `LOCAL`) — in transaction pooling mode, session state leaks to other clients sharing the same server connection.
+
 **Always use `appPool` for tenant data queries.** The superuser `pool` bypasses all RLS policies.
 
 ### `withRls()` — RLS transaction helper (`src/context.ts`)


### PR DESCRIPTION
## Summary

- Add PgBouncer (transaction mode) between API and PostgreSQL for connection multiplexing
- `DATABASE_APP_URL` routes through `pgbouncer:6432`; `DATABASE_URL` stays direct for admin/migrations
- Entrypoint script generates config from env vars at container start (no secrets in repo)
- Dev and prod Docker Compose services with tunable pool sizes
- No application code changes — `withRls()` already uses `SET LOCAL`, connection strings are env-driven

## Plan Overrides

| File | Planned | Actual | Rationale |
|---|---|---|---|
| `docker-compose.prod.yml` | `DATABASE_URL` → `pgbouncer:6432` | `DATABASE_URL` → `postgres:5432` (direct) | Admin pool should bypass PgBouncer — drizzle-kit and admin tasks may use features incompatible with transaction pooling. Plan's Design Decisions section already specified this intent. |

## Test plan

- [ ] `docker compose up -d postgres pgbouncer` → `psql "postgresql://app_user:app_password@localhost:6432/colophony" -c "SELECT 1;"`
- [ ] RLS through PgBouncer: `BEGIN; SELECT set_config('app.current_org', '...', true); SELECT current_setting('app.current_org'); COMMIT; SELECT current_setting('app.current_org', true);` — NULL after COMMIT
- [ ] PgBouncer stats: `psql "postgresql://colophony:password@localhost:6432/pgbouncer" -c "SHOW POOLS;"`
- [ ] `pnpm test` (unit tests pass — no app code changes)
- [ ] Verify `migrate` service still connects direct to `postgres:5432`