### PR TITLE
fix: staging deployment — tusd port, RLS permissions, queue-preset org filters

### DIFF
--- a/apps/api/src/services/__tests__/queue-preset.service.spec.ts
+++ b/apps/api/src/services/__tests__/queue-preset.service.spec.ts
@@ -5,9 +5,11 @@ let mockRows: Array<Record<string, unknown>> = [];
 
 const mockReturning = vi.fn().mockImplementation(() => mockRows);
 const mockWhere = vi.fn().mockImplementation(() => mockRows);
-const mockOrderBy = vi.fn().mockImplementation(() => mockRows);
+const mockLimit = vi.fn().mockImplementation(() => mockRows);
+const mockOrderBy = vi.fn().mockImplementation(() => ({ limit: mockLimit }));
 const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
-const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+const mockUpdateWhere = vi.fn().mockReturnValue({ returning: mockReturning });
+const mockSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
 
 const mockFrom = vi.fn().mockReturnValue({
   where: vi.fn().mockImplementation(() => mockRows),
@@ -77,14 +79,14 @@ describe('queuePresetService', () => {
         { id: 'p-1', name: 'Alpha' },
         { id: 'p-2', name: 'Beta' },
       ];
-      mockOrderBy.mockResolvedValue(presets);
+      mockLimit.mockResolvedValue(presets);
       mockFrom.mockReturnValue({
         where: vi.fn().mockReturnValue({
-          orderBy: mockOrderBy,
+          orderBy: vi.fn().mockReturnValue({ limit: mockLimit }),
         }),
       });
 
-      const result = await queuePresetService.list(makeTx(), 'user-1');
+      const result = await queuePresetService.list(makeTx(), 'user-1', 'org-1');
       expect(result).toEqual(presets);
     });
   });
@@ -131,7 +133,7 @@ describe('queuePresetService', () => {
       });
 
       await expect(
-        queuePresetService.delete(makeTx(), 'user-1', 'p-missing'),
+        queuePresetService.delete(makeTx(), 'user-1', 'org-1', 'p-missing'),
       ).rejects.toThrow(PresetNotFoundError);
     });
   });
@@ -143,7 +145,7 @@ describe('queuePresetService', () => {
       });
 
       await expect(
-        queuePresetService.update(makeTx(), 'user-1', {
+        queuePresetService.update(makeTx(), 'user-1', 'org-1', {
           id: 'p-missing',
           name: 'New name',
         }),

--- a/apps/api/src/services/queue-preset.service.spec.ts
+++ b/apps/api/src/services/queue-preset.service.spec.ts
@@ -142,7 +142,7 @@ describe('queuePresetService', () => {
       } as never;
 
       await expect(
-        queuePresetService.update(tx, 'user-1', {
+        queuePresetService.update(tx, 'user-1', 'org-1', {
           id: 'preset-1',
           isDefault: true,
         }),

--- a/apps/api/src/services/queue-preset.service.ts
+++ b/apps/api/src/services/queue-preset.service.ts
@@ -46,12 +46,18 @@ function isUniqueViolation(err: unknown): boolean {
 const MAX_PRESETS = 20;
 
 export const queuePresetService = {
-  async list(tx: DrizzleDb, userId: string) {
+  async list(tx: DrizzleDb, userId: string, organizationId: string) {
     return tx
       .select()
       .from(savedQueuePresets)
-      .where(eq(savedQueuePresets.userId, userId))
-      .orderBy(asc(savedQueuePresets.name));
+      .where(
+        and(
+          eq(savedQueuePresets.userId, userId),
+          eq(savedQueuePresets.organizationId, organizationId),
+        ),
+      )
+      .orderBy(asc(savedQueuePresets.name))
+      .limit(100);
   },
 
   async create(
@@ -68,6 +74,7 @@ export const queuePresetService = {
         .where(
           and(
             eq(savedQueuePresets.userId, userId),
+            eq(savedQueuePresets.organizationId, organizationId),
             eq(savedQueuePresets.isDefault, true),
           ),
         );
@@ -88,7 +95,8 @@ export const queuePresetService = {
       INSERT INTO saved_queue_presets (organization_id, user_id, name, filters, is_default)
       SELECT ${organizationId}, ${userId}, ${input.name}, ${JSON.stringify(input.filters)}::jsonb, ${isDefault}
       WHERE (
-        SELECT count(*) FROM saved_queue_presets WHERE user_id = ${userId}
+        SELECT count(*) FROM saved_queue_presets
+        WHERE user_id = ${userId} AND organization_id = ${organizationId}
       ) < ${MAX_PRESETS}
       RETURNING *
     `);
@@ -101,7 +109,12 @@ export const queuePresetService = {
     return row;
   },
 
-  async update(tx: DrizzleDb, userId: string, input: UpdateQueuePresetInput) {
+  async update(
+    tx: DrizzleDb,
+    userId: string,
+    organizationId: string,
+    input: UpdateQueuePresetInput,
+  ) {
     // Check ownership
     const [existing] = await tx
       .select({ id: savedQueuePresets.id })
@@ -110,6 +123,7 @@ export const queuePresetService = {
         and(
           eq(savedQueuePresets.id, input.id),
           eq(savedQueuePresets.userId, userId),
+          eq(savedQueuePresets.organizationId, organizationId),
         ),
       );
 
@@ -125,6 +139,7 @@ export const queuePresetService = {
         .where(
           and(
             eq(savedQueuePresets.userId, userId),
+            eq(savedQueuePresets.organizationId, organizationId),
             eq(savedQueuePresets.isDefault, true),
             ne(savedQueuePresets.id, input.id),
           ),
@@ -140,7 +155,12 @@ export const queuePresetService = {
       const [row] = await tx
         .update(savedQueuePresets)
         .set(updates)
-        .where(eq(savedQueuePresets.id, input.id))
+        .where(
+          and(
+            eq(savedQueuePresets.id, input.id),
+            eq(savedQueuePresets.organizationId, organizationId),
+          ),
+        )
         .returning();
 
       return row;
@@ -152,19 +172,35 @@ export const queuePresetService = {
     }
   },
 
-  async delete(tx: DrizzleDb, userId: string, id: string) {
+  async delete(
+    tx: DrizzleDb,
+    userId: string,
+    organizationId: string,
+    id: string,
+  ) {
     const [existing] = await tx
       .select({ id: savedQueuePresets.id })
       .from(savedQueuePresets)
       .where(
-        and(eq(savedQueuePresets.id, id), eq(savedQueuePresets.userId, userId)),
+        and(
+          eq(savedQueuePresets.id, id),
+          eq(savedQueuePresets.userId, userId),
+          eq(savedQueuePresets.organizationId, organizationId),
+        ),
       );
 
     if (!existing) {
       throw new PresetNotFoundError(id);
     }
 
-    await tx.delete(savedQueuePresets).where(eq(savedQueuePresets.id, id));
+    await tx
+      .delete(savedQueuePresets)
+      .where(
+        and(
+          eq(savedQueuePresets.id, id),
+          eq(savedQueuePresets.organizationId, organizationId),
+        ),
+      );
 
     return { deleted: true };
   },

--- a/apps/api/src/trpc/routers/queue-presets.ts
+++ b/apps/api/src/trpc/routers/queue-presets.ts
@@ -30,6 +30,7 @@ export const queuePresetsRouter = createRouter({
         const rows = await queuePresetService.list(
           ctx.dbTx,
           ctx.authContext.userId,
+          ctx.authContext.orgId,
         );
         return rows.map(toPreset);
       } catch (e) {
@@ -64,6 +65,7 @@ export const queuePresetsRouter = createRouter({
         const row = await queuePresetService.update(
           ctx.dbTx,
           ctx.authContext.userId,
+          ctx.authContext.orgId,
           input,
         );
         return toPreset(row);
@@ -81,6 +83,7 @@ export const queuePresetsRouter = createRouter({
         return await queuePresetService.delete(
           ctx.dbTx,
           ctx.authContext.userId,
+          ctx.authContext.orgId,
           input.id,
         );
       } catch (e) {

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -278,6 +278,8 @@ services:
       AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
       AWS_REGION: us-east-1
     command:
+      - -port
+      - "1080"
       - -s3-endpoint
       - http://minio:9000
       - -s3-bucket

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -269,6 +269,8 @@ services:
       AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
       AWS_REGION: us-east-1
     command:
+      - -port
+      - "1080"
       - -s3-endpoint
       - http://minio:9000
       - -s3-bucket

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -221,6 +221,8 @@ services:
       AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
       AWS_REGION: us-east-1
     command:
+      - -port
+      - "1080"
       - -s3-endpoint
       - http://minio:9000
       - -s3-bucket

--- a/docker/postgres/init-db.sh
+++ b/docker/postgres/init-db.sh
@@ -52,6 +52,23 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     END
     \$\$;
 
+    -- Revoke INSERT, UPDATE, DELETE on SELECT-only tables (if they exist).
+    -- journal_directory: writes via superuser pool only.
+    -- audit_events: writes via insert_audit_event() SECURITY DEFINER only.
+    -- Keep in sync with migration 0054_revoke_journal_audit_permissions.sql.
+    DO \$\$
+    DECLARE
+        tbl TEXT;
+    BEGIN
+        FOREACH tbl IN ARRAY ARRAY['journal_directory','audit_events']
+        LOOP
+            IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = tbl) THEN
+                EXECUTE format('REVOKE INSERT, UPDATE, DELETE ON %I FROM app_user', tbl);
+            END IF;
+        END LOOP;
+    END
+    \$\$;
+
     -- Create audit_writer role for tamper-proof audit trail
     -- NOLOGIN: only used as SECURITY DEFINER function owner, never connects directly
     DO \$\$

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,20 @@ Newest entries first.
 
 ---
 
+## 2026-03-21 — Staging Deployment Fixes
+
+### Done
+
+- Fixed tusd file upload port mismatch: added `-port 1080` to tusd command in coolify/staging/prod compose files (tusd defaults to 8080, nginx/API expect 1080)
+- Fixed RLS permission failures on `journal_directory` and `audit_events`: new migration 0054 REVOKEs INSERT/UPDATE/DELETE (SELECT-only for app_user); updated `docker/postgres/init-db.sh`, `scripts/init-db.sh`, `scripts/init-prod.sh` to re-apply on restart; added missing UPDATE check to `verify-rls.sh`
+- Added defense-in-depth org filters to queue-preset service: threaded `organizationId` through all four methods (list/create/update/delete), added `.limit(100)` to list query, updated tRPC router and all test files
+
+### Decisions
+
+- Used separate REVOKE block for SELECT-only tables (journal_directory, audit_events) rather than merging into existing append-only FOREACH loop — different restriction level (no INSERT/UPDATE/DELETE vs no DELETE only)
+
+---
+
 ## 2026-03-20 — Coolify + Hetzner Staging Deployment
 
 ### Done

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -131,7 +131,9 @@ See migration 0031 (`federation_cleanup`) and its test suite (`migration-enum-ca
 2. **`scripts/init-db.sh`** — so fresh dev databases are correct from first boot
 3. **`scripts/init-prod.sh`** — so production re-grants don't restore DELETE
 
-Current restricted tables: `user_keys`, `trusted_peers`, `sim_sub_checks`, `inbound_transfers`, `documenso_webhook_events`. See migration `0052_revoke_delete_restricted_tables.sql`.
+Current restricted tables (DELETE-only revoke): `user_keys`, `trusted_peers`, `sim_sub_checks`, `inbound_transfers`, `documenso_webhook_events`. See migration `0052_revoke_delete_restricted_tables.sql`.
+
+**SELECT-only tables** (REVOKE INSERT, UPDATE, DELETE): `journal_directory` (writes via superuser pool), `audit_events` (writes via `insert_audit_event()` SECURITY DEFINER). See migration `0054_revoke_journal_audit_permissions.sql`. Same three-place pattern applies.
 
 ### Production RLS Verification
 

--- a/packages/db/migrations/0054_revoke_journal_audit_permissions.sql
+++ b/packages/db/migrations/0054_revoke_journal_audit_permissions.sql
@@ -1,0 +1,5 @@
+-- journal_directory: SELECT-only for app_user (writes via superuser pool)
+REVOKE INSERT, UPDATE, DELETE ON "journal_directory" FROM app_user;
+
+-- audit_events: SELECT-only for app_user (writes via insert_audit_event() SECURITY DEFINER)
+REVOKE INSERT, UPDATE, DELETE ON "audit_events" FROM app_user;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1779800000000,
       "tag": "0053_user_keys_enable_rls",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1780000000000,
+      "tag": "0054_revoke_journal_audit_permissions",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/init-db.sh
+++ b/scripts/init-db.sh
@@ -52,6 +52,23 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     END
     \$\$;
 
+    -- Revoke INSERT, UPDATE, DELETE on SELECT-only tables (if they exist).
+    -- journal_directory: writes via superuser pool only.
+    -- audit_events: writes via insert_audit_event() SECURITY DEFINER only.
+    -- Keep in sync with migration 0054_revoke_journal_audit_permissions.sql.
+    DO \$\$
+    DECLARE
+        tbl TEXT;
+    BEGIN
+        FOREACH tbl IN ARRAY ARRAY['journal_directory','audit_events']
+        LOOP
+            IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = tbl) THEN
+                EXECUTE format('REVOKE INSERT, UPDATE, DELETE ON %I FROM app_user', tbl);
+            END IF;
+        END LOOP;
+    END
+    \$\$;
+
     -- Create audit_writer role for tamper-proof audit trail
     -- NOLOGIN: only used as SECURITY DEFINER function owner, never connects directly
     DO \$\$

--- a/scripts/init-prod.sh
+++ b/scripts/init-prod.sh
@@ -78,6 +78,13 @@ REVOKE DELETE ON "trusted_peers" FROM app_user;
 REVOKE DELETE ON "sim_sub_checks" FROM app_user;
 REVOKE DELETE ON "inbound_transfers" FROM app_user;
 REVOKE DELETE ON "documenso_webhook_events" FROM app_user;
+
+-- Revoke INSERT, UPDATE, DELETE on SELECT-only tables.
+-- journal_directory: writes via superuser pool only.
+-- audit_events: writes via insert_audit_event() SECURITY DEFINER only.
+-- Keep in sync with migration 0054_revoke_journal_audit_permissions.sql.
+REVOKE INSERT, UPDATE, DELETE ON "journal_directory" FROM app_user;
+REVOKE INSERT, UPDATE, DELETE ON "audit_events" FROM app_user;
 EOSQL
 
 echo "Permissions granted."

--- a/scripts/verify-rls.sh
+++ b/scripts/verify-rls.sh
@@ -227,15 +227,17 @@ fi
 
 # audit_events: app_user should have SELECT only (INSERT via audit_writer function)
 AE_INSERT=$(psql_cmd -c "SELECT has_table_privilege('app_user', 'audit_events', 'INSERT');" 2>/dev/null || echo "")
+AE_UPDATE=$(psql_cmd -c "SELECT has_table_privilege('app_user', 'audit_events', 'UPDATE');" 2>/dev/null || echo "")
 AE_DELETE=$(psql_cmd -c "SELECT has_table_privilege('app_user', 'audit_events', 'DELETE');" 2>/dev/null || echo "")
 AE_SELECT=$(psql_cmd -c "SELECT has_table_privilege('app_user', 'audit_events', 'SELECT');" 2>/dev/null || echo "")
 
 if [ -z "$AE_SELECT" ]; then
   info "audit_events table not found — skipping privilege check"
-elif [ "$AE_SELECT" = "t" ] && [ "$AE_INSERT" = "f" ] && [ "$AE_DELETE" = "f" ]; then
+elif [ "$AE_SELECT" = "t" ] && [ "$AE_INSERT" = "f" ] && [ "$AE_UPDATE" = "f" ] && [ "$AE_DELETE" = "f" ]; then
   pass "audit_events: app_user has SELECT only (INSERT via audit_writer function)"
 else
   [ "$AE_INSERT" = "t" ] && fail "audit_events: app_user has direct INSERT (should use audit_writer function)"
+  [ "$AE_UPDATE" = "t" ] && fail "audit_events: app_user has UPDATE (should be SELECT only)"
   [ "$AE_DELETE" = "t" ] && fail "audit_events: app_user has DELETE on audit_events"
 fi
 


### PR DESCRIPTION
## Summary

- **tusd port mismatch**: Added `-port 1080` to tusd command in coolify/staging/prod compose files (tusd defaults to 8080, nginx/API expect 1080)
- **RLS permission failures**: New migration 0054 REVOKEs INSERT/UPDATE/DELETE on `journal_directory` and `audit_events` (SELECT-only for app_user). Updated init-db.sh (both), init-prod.sh, and verify-rls.sh to match.
- **queue-preset defense-in-depth**: Threaded `organizationId` through all four service methods (list/create/update/delete), added `.limit(100)` to list query, updated tRPC router and tests

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (1506 tests)
- [ ] Deploy to staging and run `scripts/smoke-test.sh` — verify tusd uploads work
- [ ] Run `scripts/verify-rls.sh` on staging — confirm no permission failures
- [ ] Test queue preset CRUD in UI