### PR TITLE
fix: Zitadel webhook header and event type compatibility

### DIFF
--- a/apps/api/src/webhooks/zitadel.webhook.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.ts
@@ -131,10 +131,10 @@ export async function registerZitadelWebhooks(
       request: FastifyRequest,
       reply: FastifyReply,
     ) {
-      // Verify signature
-      const signature = request.headers['x-zitadel-signature'] as
-        | string
-        | undefined;
+      // Verify signature — Zitadel sends 'ZITADEL-Signature' header,
+      // which Node.js lowercases to 'zitadel-signature'.
+      const signature = (request.headers['zitadel-signature'] ??
+        request.headers['x-zitadel-signature']) as string | undefined;
 
       const rawBody = (request as FastifyRequest & { rawBody?: Buffer })
         .rawBody;
@@ -240,12 +240,28 @@ export async function registerZitadelWebhooks(
   );
 }
 
+/**
+ * Maps Zitadel's actual event type names (e.g., 'user.human.added') to our
+ * internal names (e.g., 'user.created'). Passthrough for unknown types so
+ * the switch default case still logs them.
+ */
+const EVENT_TYPE_ALIASES: Record<string, string> = {
+  'user.human.added': 'user.created',
+  'user.human.changed': 'user.changed',
+  'user.human.deactivated': 'user.deactivated',
+  'user.human.reactivated': 'user.reactivated',
+  'user.human.removed': 'user.removed',
+  'user.human.email.verified': 'user.email.verified',
+};
+
 async function processEvent(
   payload: ZitadelWebhookPayload,
   request: FastifyRequest,
   tx: DrizzleDb,
 ): Promise<void> {
-  const { eventType, user: userData } = payload;
+  const rawEventType = payload.eventType;
+  const eventType = EVENT_TYPE_ALIASES[rawEventType] ?? rawEventType;
+  const { user: userData } = payload;
 
   if (!userData?.userId) {
     request.log.warn({ eventType }, 'Webhook event missing user data');

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -502,12 +502,12 @@
 ### Infrastructure Setup
 
 - [x] Coolify + Hetzner managed hosting setup — done 2026-03-20, staging live at staging.colophony.pub — (architecture doc Track 1)
-- [ ] [P2] Fix tusd port mismatch — tusd listens on 8080, nginx proxies to 1080; add `-port 1080` to tusd command or update nginx upstream — (DEVLOG 2026-03-20, smoke test)
-- [ ] [P2] Fix pre-existing RLS permission failures — `journal_directory` has INSERT/UPDATE/DELETE (should be SELECT only), `audit_events` has direct INSERT + DELETE (should use audit_writer) — (DEVLOG 2026-03-20, staging verify-rls.sh)
+- [x] [P2] Fix tusd port mismatch — tusd listens on 8080, nginx proxies to 1080; add `-port 1080` to tusd command or update nginx upstream — (DEVLOG 2026-03-20, smoke test; done 2026-03-21 PR #292)
+- [x] [P2] Fix pre-existing RLS permission failures — `journal_directory` has INSERT/UPDATE/DELETE (should be SELECT only), `audit_events` has direct INSERT + DELETE (should use audit_writer) — (DEVLOG 2026-03-20, staging verify-rls.sh; done 2026-03-21 PR #292)
 - [ ] [P3] Configure Zitadel webhook for staging — Actions → Targets → user event group → staging endpoint — (DEVLOG 2026-03-20)
 - [ ] [P3] Connect Inngest Cloud to staging — event key + signing key — (DEVLOG 2026-03-20)
 - [ ] [P3] Coolify IPv6 network bug — `coolify` Docker network gets malformed IPv6 gateway on Hetzner; manual recreate needed after Coolify install — (DEVLOG 2026-03-20)
-- [ ] [P3] `queue-preset.service.ts:49` — `listByUser()` missing explicit `organizationId` filter and LIMIT — (Codex plan review 2026-03-20)
+- [x] [P3] `queue-preset.service.ts:49` — `listByUser()` missing explicit `organizationId` filter and LIMIT — (Codex plan review 2026-03-20; done 2026-03-21 PR #292)
 - [x] Monitoring stack: Prometheus + Grafana (Sentry for errors) — done 2026-02-27 PR pending; Loki deferred to production
 
 ### Database Hardening


### PR DESCRIPTION
## Summary
- Accept both `ZITADEL-Signature` (actual Zitadel header) and legacy `x-zitadel-signature` for signature verification
- Map Zitadel's real event names (`user.human.added`, etc.) to internal names (`user.created`, etc.) via alias table
- Mark completed backlog items from PR #292 (tusd port, RLS permissions, queue-preset org filter)

## Test plan
- [x] All 82 webhook tests pass (existing tests use `x-zitadel-signature` fallback)
- [x] Type-check passes
- [ ] Deploy to staging, trigger Zitadel user creation, verify 200 response in logs
- [ ] Verify event type alias works (logs should show `User upserted from webhook`)