### PR TITLE
fix: support Zitadel timestamp-prefixed webhook signature

### DIFF
--- a/apps/api/src/webhooks/zitadel.webhook.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.ts
@@ -151,7 +151,22 @@ export async function registerZitadelWebhooks(
         if (!env.ZITADEL_WEBHOOK_SECRET) {
           request.log.error('ZITADEL_WEBHOOK_SECRET not configured');
         } else {
-          request.log.warn('Invalid Zitadel webhook signature');
+          // Temporary debug logging for staging signature mismatch
+          const sigHeaders = Object.keys(request.headers)
+            .filter((h) => h.includes('zitadel') || h.includes('signature'))
+            .reduce(
+              (acc, h) => ({ ...acc, [h]: request.headers[h] }),
+              {} as Record<string, unknown>,
+            );
+          request.log.warn(
+            {
+              signatureHeadersFound: sigHeaders,
+              signatureValue: signature?.substring(0, 20) + '...',
+              bodyLength: rawBody.length,
+              secretLength: env.ZITADEL_WEBHOOK_SECRET.length,
+            },
+            'Invalid Zitadel webhook signature',
+          );
         }
         return reply.status(401).send({ error: 'invalid_signature' });
       }

--- a/apps/api/src/webhooks/zitadel.webhook.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.ts
@@ -131,10 +131,10 @@ export async function registerZitadelWebhooks(
       request: FastifyRequest,
       reply: FastifyReply,
     ) {
-      // Verify signature
-      const signature = request.headers['x-zitadel-signature'] as
-        | string
-        | undefined;
+      // Verify signature — Zitadel sends 'ZITADEL-Signature' header,
+      // which Node.js lowercases to 'zitadel-signature'.
+      const signature = (request.headers['zitadel-signature'] ??
+        request.headers['x-zitadel-signature']) as string | undefined;
 
       const rawBody = (request as FastifyRequest & { rawBody?: Buffer })
         .rawBody;
@@ -240,12 +240,28 @@ export async function registerZitadelWebhooks(
   );
 }
 
+/**
+ * Maps Zitadel's actual event type names (e.g., 'user.human.added') to our
+ * internal names (e.g., 'user.created'). Passthrough for unknown types so
+ * the switch default case still logs them.
+ */
+const EVENT_TYPE_ALIASES: Record<string, string> = {
+  'user.human.added': 'user.created',
+  'user.human.changed': 'user.changed',
+  'user.human.deactivated': 'user.deactivated',
+  'user.human.reactivated': 'user.reactivated',
+  'user.human.removed': 'user.removed',
+  'user.human.email.verified': 'user.email.verified',
+};
+
 async function processEvent(
   payload: ZitadelWebhookPayload,
   request: FastifyRequest,
   tx: DrizzleDb,
 ): Promise<void> {
-  const { eventType, user: userData } = payload;
+  const rawEventType = payload.eventType;
+  const eventType = EVENT_TYPE_ALIASES[rawEventType] ?? rawEventType;
+  const { user: userData } = payload;
 
   if (!userData?.userId) {
     request.log.warn({ eventType }, 'Webhook event missing user data');

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -502,12 +502,12 @@
 ### Infrastructure Setup
 
 - [x] Coolify + Hetzner managed hosting setup — done 2026-03-20, staging live at staging.colophony.pub — (architecture doc Track 1)
-- [ ] [P2] Fix tusd port mismatch — tusd listens on 8080, nginx proxies to 1080; add `-port 1080` to tusd command or update nginx upstream — (DEVLOG 2026-03-20, smoke test)
-- [ ] [P2] Fix pre-existing RLS permission failures — `journal_directory` has INSERT/UPDATE/DELETE (should be SELECT only), `audit_events` has direct INSERT + DELETE (should use audit_writer) — (DEVLOG 2026-03-20, staging verify-rls.sh)
+- [x] [P2] Fix tusd port mismatch — tusd listens on 8080, nginx proxies to 1080; add `-port 1080` to tusd command or update nginx upstream — (DEVLOG 2026-03-20, smoke test; done 2026-03-21 PR #292)
+- [x] [P2] Fix pre-existing RLS permission failures — `journal_directory` has INSERT/UPDATE/DELETE (should be SELECT only), `audit_events` has direct INSERT + DELETE (should use audit_writer) — (DEVLOG 2026-03-20, staging verify-rls.sh; done 2026-03-21 PR #292)
 - [ ] [P3] Configure Zitadel webhook for staging — Actions → Targets → user event group → staging endpoint — (DEVLOG 2026-03-20)
 - [ ] [P3] Connect Inngest Cloud to staging — event key + signing key — (DEVLOG 2026-03-20)
 - [ ] [P3] Coolify IPv6 network bug — `coolify` Docker network gets malformed IPv6 gateway on Hetzner; manual recreate needed after Coolify install — (DEVLOG 2026-03-20)
-- [ ] [P3] `queue-preset.service.ts:49` — `listByUser()` missing explicit `organizationId` filter and LIMIT — (Codex plan review 2026-03-20)
+- [x] [P3] `queue-preset.service.ts:49` — `listByUser()` missing explicit `organizationId` filter and LIMIT — (Codex plan review 2026-03-20; done 2026-03-21 PR #292)
 - [x] Monitoring stack: Prometheus + Grafana (Sentry for errors) — done 2026-02-27 PR pending; Loki deferred to production
 
 ### Database Hardening

--- a/packages/auth-client/src/webhook-signature.spec.ts
+++ b/packages/auth-client/src/webhook-signature.spec.ts
@@ -9,7 +9,40 @@ function sign(body: string, secret: string, format: "hex" | "base64"): string {
   return createHmac("sha256", secret).update(body).digest(format);
 }
 
+function signTimestamped(
+  body: string,
+  secret: string,
+  timestamp: string,
+): string {
+  const hmac = createHmac("sha256", secret)
+    .update(`${timestamp}.${body}`)
+    .digest("hex");
+  return `t=${timestamp},v1=${hmac}`;
+}
+
 describe("verifyZitadelSignature", () => {
+  // Timestamp-prefixed format (Zitadel Actions v2)
+  it("accepts valid timestamp-prefixed signature", () => {
+    const sig = signTimestamped(BODY, SECRET, "1774150830");
+    expect(verifyZitadelSignature(BODY, sig, SECRET)).toBe(true);
+  });
+
+  it("accepts timestamp-prefixed signature with Buffer body", () => {
+    const sig = signTimestamped(BODY, SECRET, "1774150830");
+    expect(verifyZitadelSignature(Buffer.from(BODY), sig, SECRET)).toBe(true);
+  });
+
+  it("rejects timestamp-prefixed signature with wrong secret", () => {
+    const sig = signTimestamped(BODY, SECRET, "1774150830");
+    expect(verifyZitadelSignature(BODY, sig, "wrong-secret")).toBe(false);
+  });
+
+  it("rejects timestamp-prefixed signature with tampered body", () => {
+    const sig = signTimestamped(BODY, SECRET, "1774150830");
+    expect(verifyZitadelSignature("tampered", sig, SECRET)).toBe(false);
+  });
+
+  // Simple format (legacy)
   it("accepts valid hex signature", () => {
     const sig = sign(BODY, SECRET, "hex");
     expect(verifyZitadelSignature(BODY, sig, SECRET)).toBe(true);
@@ -35,6 +68,7 @@ describe("verifyZitadelSignature", () => {
     expect(verifyZitadelSignature(Buffer.from(BODY), sig, SECRET)).toBe(true);
   });
 
+  // Rejection cases
   it("rejects invalid signature", () => {
     expect(verifyZitadelSignature(BODY, "deadbeef", SECRET)).toBe(false);
   });

--- a/packages/auth-client/src/webhook-signature.ts
+++ b/packages/auth-client/src/webhook-signature.ts
@@ -13,9 +13,25 @@ function parseSignature(sig: string): Buffer {
 }
 
 /**
+ * Parses Zitadel's timestamp-prefixed signature format: `t=<timestamp>,v1=<hex-hmac>`.
+ * Returns the timestamp and hex signature, or null if format doesn't match.
+ */
+function parseTimestampSignature(
+  sig: string,
+): { timestamp: string; hmac: string } | null {
+  const match = sig.match(/^t=(\d+),v1=([a-f0-9]+)$/i);
+  if (!match) return null;
+  return { timestamp: match[1], hmac: match[2] };
+}
+
+/**
  * Verifies a Zitadel webhook signature using HMAC-SHA256.
  *
- * Handles hex, base64, and `sha256=`-prefixed signature formats.
+ * Supports two formats:
+ * 1. Timestamp-prefixed (Zitadel Actions v2): `t=<timestamp>,v1=<hex-hmac>`
+ *    HMAC is computed over `<timestamp>.<body>`
+ * 2. Simple: hex, base64, or `sha256=`-prefixed HMAC of body
+ *
  * Uses timing-safe comparison to prevent timing attacks.
  */
 export function verifyZitadelSignature(
@@ -25,6 +41,17 @@ export function verifyZitadelSignature(
 ): boolean {
   if (!signature || !secret) return false;
 
+  // Try timestamp-prefixed format first (Zitadel Actions v2)
+  const tsSig = parseTimestampSignature(signature);
+  if (tsSig) {
+    const received = Buffer.from(tsSig.hmac, "hex");
+    const payload = `${tsSig.timestamp}.${typeof rawBody === "string" ? rawBody : rawBody.toString("utf8")}`;
+    const expected = createHmac("sha256", secret).update(payload).digest();
+    if (received.length !== expected.length) return false;
+    return timingSafeEqual(received, expected);
+  }
+
+  // Fallback: simple HMAC of body
   const received = parseSignature(signature);
   const expected = createHmac("sha256", secret).update(rawBody).digest();
 


### PR DESCRIPTION
## Summary
- Zitadel Actions v2 sends signatures as `t=<timestamp>,v1=<hex-hmac>` (similar to Stripe)
- HMAC is computed over `<timestamp>.<body>`, not just the body
- Updated `verifyZitadelSignature` to parse and verify this format
- Retains fallback to simple HMAC format for backwards compatibility
- Includes debug logging from PR #294 (to be removed after verification)

## Test plan
- [x] 15 signature unit tests pass (4 new for timestamp format)
- [x] 82 webhook integration tests pass
- [x] Type-check passes
- [ ] Deploy to staging, create Zitadel user, verify 200 response