### PR TITLE
fix: adapt Zitadel webhook to Actions v2 payload format

### DIFF
--- a/apps/api/src/__tests__/webhooks/helpers/zitadel-fixtures.ts
+++ b/apps/api/src/__tests__/webhooks/helpers/zitadel-fixtures.ts
@@ -10,20 +10,52 @@ interface ZitadelPayloadOptions {
   creationDate?: string;
 }
 
+let fixtureSequence = 0;
+
 /**
- * Create a Zitadel webhook payload matching `zitadelWebhookPayloadSchema`.
- * Defaults produce a valid, fresh `user.created` event.
+ * Create a Zitadel Actions v2 webhook payload matching `zitadelWebhookPayloadSchema`.
+ * Defaults produce a valid, fresh `user.human.added` event.
+ *
+ * Maps legacy option names to the v2 payload format:
+ * - eventType → event_type (with alias mapping)
+ * - userId → aggregateID
+ * - creationDate → created_at
+ * - email/displayName/emailVerified → event_payload fields
  */
 export function createZitadelPayload(opts: ZitadelPayloadOptions = {}) {
+  fixtureSequence++;
+
+  // Map legacy event types to Zitadel v2 names
+  const EVENT_TYPE_MAP: Record<string, string> = {
+    'user.created': 'user.human.added',
+    'user.changed': 'user.human.changed',
+    'user.deactivated': 'user.human.deactivated',
+    'user.reactivated': 'user.human.reactivated',
+    'user.removed': 'user.human.removed',
+    'user.email.verified': 'user.human.email.verified',
+  };
+
+  const rawEventType = opts.eventType ?? 'user.created';
+  const eventType = EVENT_TYPE_MAP[rawEventType] ?? rawEventType;
+  const aggregateID = opts.userId ?? faker.string.uuid();
+
   return {
-    eventType: opts.eventType ?? 'user.created',
-    eventId: opts.eventId ?? faker.string.uuid(),
-    creationDate: opts.creationDate ?? new Date().toISOString(),
-    user: {
-      userId: opts.userId ?? faker.string.uuid(),
+    aggregateID,
+    aggregateType: 'user',
+    resourceOwner: faker.string.uuid(),
+    instanceID: faker.string.uuid(),
+    version: 'v2',
+    sequence: fixtureSequence,
+    event_type: eventType,
+    created_at: opts.creationDate ?? new Date().toISOString(),
+    userID: faker.string.uuid(),
+    event_payload: {
+      userName: faker.internet.userName(),
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+      displayName: opts.displayName ?? faker.person.fullName(),
       email: opts.email ?? faker.internet.email(),
       emailVerified: opts.emailVerified ?? false,
-      displayName: opts.displayName ?? faker.person.fullName(),
     },
   };
 }

--- a/apps/api/src/__tests__/webhooks/zitadel-webhook.test.ts
+++ b/apps/api/src/__tests__/webhooks/zitadel-webhook.test.ts
@@ -80,9 +80,9 @@ describe('Zitadel webhook integration', () => {
     const [user] = await db
       .select()
       .from(users)
-      .where(eq(users.zitadelUserId, payload.user.userId));
+      .where(eq(users.zitadelUserId, payload.aggregateID));
     expect(user).toBeDefined();
-    expect(user.email).toBe(payload.user.email);
+    expect(user.email).toBe(payload.event_payload.email);
     expect(user.emailVerified).toBe(false);
 
     const [audit] = await db
@@ -240,7 +240,12 @@ describe('Zitadel webhook integration', () => {
     const rows = await db
       .select()
       .from(zitadelWebhookEvents)
-      .where(eq(zitadelWebhookEvents.eventId, payload.eventId));
+      .where(
+        eq(
+          zitadelWebhookEvents.eventId,
+          `${payload.aggregateID}:${payload.sequence}`,
+        ),
+      );
     expect(rows).toHaveLength(1);
   });
 

--- a/apps/api/src/webhooks/zitadel.webhook.spec.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.spec.ts
@@ -161,19 +161,35 @@ const testEnv: Env = {
 };
 
 function signPayload(body: string): string {
-  return createHmac('sha256', WEBHOOK_SECRET).update(body).digest('hex');
+  // Zitadel v2 uses timestamp-prefixed signature: t=<ts>,v1=<hmac>
+  // where HMAC is over `<ts>.<body>`
+  const ts = Math.floor(Date.now() / 1000).toString();
+  const hmac = createHmac('sha256', WEBHOOK_SECRET)
+    .update(`${ts}.${body}`)
+    .digest('hex');
+  return `t=${ts},v1=${hmac}`;
 }
 
+let sequenceCounter = 0;
 function makePayload(overrides: Record<string, unknown> = {}) {
+  sequenceCounter++;
   return {
-    eventId: 'evt-001',
-    eventType: 'user.created',
-    creationDate: new Date().toISOString(),
-    user: {
-      userId: 'zitadel-user-1',
+    aggregateID: 'zitadel-user-1',
+    aggregateType: 'user',
+    resourceOwner: 'org-1',
+    instanceID: 'instance-1',
+    version: 'v2',
+    sequence: sequenceCounter,
+    event_type: 'user.human.added',
+    created_at: new Date().toISOString(),
+    userID: 'system-user',
+    event_payload: {
+      userName: 'alice',
+      firstName: 'Alice',
+      lastName: 'Example',
+      displayName: 'Alice',
       email: 'alice@example.com',
       emailVerified: true,
-      displayName: 'Alice',
     },
     ...overrides,
   };
@@ -306,7 +322,9 @@ describe('Zitadel webhook handler', () => {
       return { rows: [] };
     });
 
-    const body = JSON.stringify(makePayload({ eventId: 'evt-duplicate' }));
+    const body = JSON.stringify(
+      makePayload({ aggregateID: 'evt-duplicate', sequence: 999 }),
+    );
     const sig = signPayload(body);
 
     const response = await app.inject({
@@ -347,7 +365,9 @@ describe('Zitadel webhook handler', () => {
       return { rows: [] };
     });
 
-    const body = JSON.stringify(makePayload({ eventId: 'evt-crash-recovery' }));
+    const body = JSON.stringify(
+      makePayload({ aggregateID: 'evt-crash-recovery', sequence: 998 }),
+    );
     const sig = signPayload(body);
 
     const response = await app.inject({
@@ -367,8 +387,8 @@ describe('Zitadel webhook handler', () => {
     expect(mockClientRelease).toHaveBeenCalledOnce();
   });
 
-  it('rejects invalid payload (missing eventId)', async () => {
-    const body = JSON.stringify({ eventType: 'user.created' });
+  it('rejects invalid payload (missing required fields)', async () => {
+    const body = JSON.stringify({ event_type: 'user.human.added' });
     const sig = signPayload(body);
 
     const response = await app.inject({
@@ -405,11 +425,12 @@ describe('Zitadel webhook handler', () => {
     expect(response.json().error).toBe('invalid_payload');
   });
 
-  it('rejects payload with empty eventType', async () => {
+  it('rejects payload with empty event_type', async () => {
     const body = JSON.stringify({
-      eventId: 'evt-empty-type',
-      eventType: '',
-      creationDate: new Date().toISOString(),
+      aggregateID: 'agg-1',
+      sequence: 1,
+      event_type: '',
+      created_at: new Date().toISOString(),
     });
     const sig = signPayload(body);
 
@@ -426,10 +447,8 @@ describe('Zitadel webhook handler', () => {
     expect(response.json().error).toBe('invalid_payload');
   });
 
-  it('accepts unknown eventType without user mutations or audit', async () => {
-    const body = JSON.stringify(
-      makePayload({ eventType: 'org.created', eventId: 'evt-unknown-type' }),
-    );
+  it('accepts unknown event_type without user mutations or audit', async () => {
+    const body = JSON.stringify(makePayload({ event_type: 'org.created' }));
     const sig = signPayload(body);
 
     const response = await app.inject({
@@ -448,12 +467,8 @@ describe('Zitadel webhook handler', () => {
     expect(mockAuditLog).not.toHaveBeenCalled();
   });
 
-  it('accepts payload with no user field without mutations or audit', async () => {
-    const body = JSON.stringify({
-      eventId: 'evt-no-user',
-      eventType: 'user.created',
-      creationDate: new Date().toISOString(),
-    });
+  it('upserts user with placeholder email when event_payload is missing', async () => {
+    const body = JSON.stringify(makePayload({ event_payload: undefined }));
     const sig = signPayload(body);
 
     const response = await app.inject({
@@ -467,9 +482,8 @@ describe('Zitadel webhook handler', () => {
     });
     expect(response.statusCode).toBe(200);
     expect(response.json().status).toBe('processed');
-    expect(mockTxInsert).not.toHaveBeenCalled();
-    expect(mockTxUpdate).not.toHaveBeenCalled();
-    expect(mockAuditLog).not.toHaveBeenCalled();
+    // Still upserts because aggregateID provides the userId
+    expect(mockTxInsert).toHaveBeenCalled();
   });
 
   it('logs audit event for user.created', async () => {
@@ -501,7 +515,7 @@ describe('Zitadel webhook handler', () => {
 
   it('logs audit event for user.deactivated', async () => {
     const body = JSON.stringify(
-      makePayload({ eventType: 'user.deactivated', eventId: 'evt-deact' }),
+      makePayload({ event_type: 'user.human.deactivated' }),
     );
     const sig = signPayload(body);
 
@@ -524,10 +538,9 @@ describe('Zitadel webhook handler', () => {
   it('syncs displayName on user.changed', async () => {
     const body = JSON.stringify(
       makePayload({
-        eventType: 'user.changed',
-        eventId: 'evt-display-name',
-        user: {
-          userId: 'zitadel-user-1',
+        event_type: 'user.human.changed',
+        event_payload: {
+          userName: 'alice',
           email: 'alice@example.com',
           emailVerified: true,
           displayName: 'Alice Smith',
@@ -556,7 +569,7 @@ describe('Zitadel webhook handler', () => {
 
   it('logs USER_UPDATED audit for user.changed', async () => {
     const body = JSON.stringify(
-      makePayload({ eventType: 'user.changed', eventId: 'evt-changed' }),
+      makePayload({ event_type: 'user.human.changed' }),
     );
     const sig = signPayload(body);
 
@@ -592,7 +605,7 @@ describe('Zitadel webhook handler', () => {
       return { rows: [] };
     });
 
-    const body = JSON.stringify(makePayload({ eventId: 'evt-dup-audit' }));
+    const body = JSON.stringify(makePayload());
     const sig = signPayload(body);
 
     await app.inject({
@@ -632,7 +645,7 @@ describe('Zitadel webhook handler', () => {
       return { rows: [] };
     });
 
-    const body = JSON.stringify(makePayload({ eventId: 'evt-error' }));
+    const body = JSON.stringify(makePayload());
     const sig = signPayload(body);
 
     const response = await app.inject({
@@ -655,8 +668,7 @@ describe('Zitadel webhook handler', () => {
       const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
       const body = JSON.stringify(
         makePayload({
-          eventId: 'evt-old',
-          creationDate: tenMinutesAgo,
+          created_at: tenMinutesAgo,
         }),
       );
       const sig = signPayload(body);
@@ -680,8 +692,7 @@ describe('Zitadel webhook handler', () => {
       ).toISOString();
       const body = JSON.stringify(
         makePayload({
-          eventId: 'evt-future',
-          creationDate: fiveMinutesAhead,
+          created_at: fiveMinutesAhead,
         }),
       );
       const sig = signPayload(body);
@@ -703,8 +714,7 @@ describe('Zitadel webhook handler', () => {
       const thirtySecondsAgo = new Date(Date.now() - 30 * 1000).toISOString();
       const body = JSON.stringify(
         makePayload({
-          eventId: 'evt-fresh',
-          creationDate: thirtySecondsAgo,
+          created_at: thirtySecondsAgo,
         }),
       );
       const sig = signPayload(body);
@@ -730,7 +740,7 @@ describe('Zitadel webhook handler', () => {
       // Simulate over-limit: count = 101, ttl = 30000ms
       mockRedisEval.mockResolvedValueOnce([101, 30000]);
 
-      const body = JSON.stringify(makePayload({ eventId: 'evt-rate-limited' }));
+      const body = JSON.stringify(makePayload());
       const sig = signPayload(body);
 
       const response = await app.inject({
@@ -750,7 +760,7 @@ describe('Zitadel webhook handler', () => {
     it('allows request when under rate limit', async () => {
       mockRedisEval.mockResolvedValueOnce([5, 60000]);
 
-      const body = JSON.stringify(makePayload({ eventId: 'evt-under-limit' }));
+      const body = JSON.stringify(makePayload());
       const sig = signPayload(body);
 
       const response = await app.inject({
@@ -768,7 +778,7 @@ describe('Zitadel webhook handler', () => {
     it('allows request when Redis errors (graceful degradation)', async () => {
       mockRedisEval.mockRejectedValueOnce(new Error('Redis connection failed'));
 
-      const body = JSON.stringify(makePayload({ eventId: 'evt-redis-err' }));
+      const body = JSON.stringify(makePayload());
       const sig = signPayload(body);
 
       const response = await app.inject({
@@ -794,7 +804,7 @@ describe('Zitadel webhook handler', () => {
       const values = vi.fn(() => ({ onConflictDoUpdate }));
       mockTxInsert.mockImplementation(() => ({ values }));
 
-      const body = JSON.stringify(makePayload({ eventId: 'evt-stale-upsert' }));
+      const body = JSON.stringify(makePayload());
       const sig = signPayload(body);
 
       const response = await app.inject({
@@ -817,7 +827,7 @@ describe('Zitadel webhook handler', () => {
       const values = vi.fn(() => ({ onConflictDoUpdate }));
       mockTxInsert.mockImplementation(() => ({ values }));
 
-      const body = JSON.stringify(makePayload({ eventId: 'evt-fresh-upsert' }));
+      const body = JSON.stringify(makePayload());
       const sig = signPayload(body);
 
       const response = await app.inject({
@@ -848,8 +858,7 @@ describe('Zitadel webhook handler', () => {
 
       const body = JSON.stringify(
         makePayload({
-          eventType: 'user.deactivated',
-          eventId: 'evt-stale-update',
+          event_type: 'user.human.deactivated',
         }),
       );
       const sig = signPayload(body);
@@ -869,11 +878,10 @@ describe('Zitadel webhook handler', () => {
       expect(mockTxSelect).toHaveBeenCalled();
     });
 
-    it('processes event with invalid creationDate without crash', async () => {
+    it('processes event with invalid created_at without crash', async () => {
       const body = JSON.stringify(
         makePayload({
-          eventId: 'evt-bad-date',
-          creationDate: 'not-a-date',
+          created_at: 'not-a-date',
         }),
       );
       const sig = signPayload(body);
@@ -887,7 +895,7 @@ describe('Zitadel webhook handler', () => {
         },
         payload: body,
       });
-      // Unparseable creationDate falls through freshness check and processing
+      // Unparseable created_at falls through freshness check and processing
       expect(response.statusCode).toBe(200);
       expect(response.json().status).toBe('processed');
     });

--- a/apps/api/src/webhooks/zitadel.webhook.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.ts
@@ -187,26 +187,28 @@ export async function registerZitadelWebhooks(
       }
       const payload: ZitadelWebhookPayload = parsed.data;
 
+      // Derive idempotency key from aggregateID + sequence (Zitadel v2 has no eventId)
+      const eventId = `${payload.aggregateID}:${payload.sequence}`;
+
       // Timestamp freshness check — fail fast before acquiring DB connection
-      const eventTime = new Date(payload.creationDate);
+      const eventTime = new Date(payload.created_at);
       if (!isNaN(eventTime.getTime())) {
         const ageSeconds = (Date.now() - eventTime.getTime()) / 1000;
         if (ageSeconds > env.WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS) {
           request.log.warn(
-            { eventId: payload.eventId, ageSeconds: Math.round(ageSeconds) },
+            { eventId, ageSeconds: Math.round(ageSeconds) },
             'Webhook event rejected: timestamp too old',
           );
           return reply.status(400).send({ error: 'event_too_old' });
         }
         if (ageSeconds < -60) {
           request.log.warn(
-            { eventId: payload.eventId, ageSeconds: Math.round(ageSeconds) },
+            { eventId, ageSeconds: Math.round(ageSeconds) },
             'Webhook event rejected: timestamp in the future',
           );
           return reply.status(400).send({ error: 'event_from_future' });
         }
       }
-      // Unparseable creationDate: fall through (Zod validated non-empty; format strictness not warranted)
 
       // SECURITY NOTE: Uses pool.connect() directly (bypasses RLS) because
       // webhooks are unauthenticated system events. The zitadel_webhook_events
@@ -216,20 +218,16 @@ export async function registerZitadelWebhooks(
         await client.query('BEGIN');
 
         // Two-step idempotency: INSERT then SELECT processed status.
-        // This handles crash recovery: if server crashes after INSERT but
-        // before marking processed, the row exists with processed = false.
-        // On retry, INSERT conflicts (no-op), SELECT finds processed = false,
-        // and we reprocess — preventing lost events.
         await client.query(
           `INSERT INTO zitadel_webhook_events (id, event_id, type, payload, processed, received_at)
            VALUES (gen_random_uuid(), $1, $2, $3, false, now())
            ON CONFLICT (event_id) DO NOTHING`,
-          [payload.eventId, payload.eventType, JSON.stringify(payload)],
+          [eventId, payload.event_type, JSON.stringify(payload)],
         );
 
         const statusResult = await client.query(
           `SELECT processed FROM zitadel_webhook_events WHERE event_id = $1`,
-          [payload.eventId],
+          [eventId],
         );
 
         if (statusResult.rows[0]?.processed === true) {
@@ -245,7 +243,7 @@ export async function registerZitadelWebhooks(
         // Mark as processed
         await client.query(
           `UPDATE zitadel_webhook_events SET processed = true, processed_at = now() WHERE event_id = $1`,
-          [payload.eventId],
+          [eventId],
         );
 
         await client.query('COMMIT');
@@ -280,47 +278,51 @@ async function processEvent(
   request: FastifyRequest,
   tx: DrizzleDb,
 ): Promise<void> {
-  const rawEventType = payload.eventType;
+  const rawEventType = payload.event_type;
   const eventType = EVENT_TYPE_ALIASES[rawEventType] ?? rawEventType;
-  const { user: userData } = payload;
+  const eventPayload = payload.event_payload;
 
-  if (!userData?.userId) {
-    request.log.warn({ eventType }, 'Webhook event missing user data');
+  // aggregateID is the user's ID for user.* events
+  const userId = payload.aggregateID;
+  if (!userId) {
+    request.log.warn({ eventType }, 'Webhook event missing aggregateID');
     return;
   }
 
   // Parse event timestamp for out-of-order guard
-  const eventTime = new Date(payload.creationDate);
+  const eventTime = new Date(payload.created_at);
   const hasValidTimestamp = !isNaN(eventTime.getTime());
 
   switch (eventType) {
     case 'user.created':
     case 'user.changed': {
+      const displayName =
+        eventPayload?.displayName ??
+        ([eventPayload?.firstName, eventPayload?.lastName]
+          .filter(Boolean)
+          .join(' ') ||
+          undefined);
       // Upsert with out-of-order guard: setWhere prevents stale overwrites
       const upsertResult = await tx
         .insert(users)
         .values({
-          email: userData.email ?? `${userData.userId}@placeholder.local`,
-          zitadelUserId: userData.userId,
-          ...(userData.displayName !== undefined
-            ? { displayName: userData.displayName }
-            : {}),
-          emailVerified: userData.emailVerified ?? false,
-          emailVerifiedAt: userData.emailVerified ? new Date() : undefined,
+          email: eventPayload?.email ?? `${userId}@placeholder.local`,
+          zitadelUserId: userId,
+          ...(displayName !== undefined ? { displayName } : {}),
+          emailVerified: eventPayload?.emailVerified ?? false,
+          emailVerifiedAt: eventPayload?.emailVerified ? new Date() : undefined,
           lastEventAt: hasValidTimestamp ? eventTime : undefined,
         })
         .onConflictDoUpdate({
           target: users.zitadelUserId,
           targetWhere: sql`${users.zitadelUserId} IS NOT NULL`,
           set: {
-            ...(userData.email ? { email: userData.email } : {}),
-            ...(userData.displayName !== undefined
-              ? { displayName: userData.displayName }
-              : {}),
-            ...(userData.emailVerified !== undefined
+            ...(eventPayload?.email ? { email: eventPayload.email } : {}),
+            ...(displayName !== undefined ? { displayName } : {}),
+            ...(eventPayload?.emailVerified !== undefined
               ? {
-                  emailVerified: userData.emailVerified,
-                  emailVerifiedAt: userData.emailVerified
+                  emailVerified: eventPayload.emailVerified,
+                  emailVerifiedAt: eventPayload.emailVerified
                     ? new Date()
                     : undefined,
                 }
@@ -336,7 +338,7 @@ async function processEvent(
       // rowCount === 0 means conflict + setWhere rejected (stale event)
       if (upsertResult.rowCount === 0) {
         request.log.info(
-          { zitadelUserId: userData.userId, eventType },
+          { zitadelUserId: userId, eventType },
           'Stale event skipped',
         );
         break;
@@ -349,15 +351,15 @@ async function processEvent(
             ? AuditActions.USER_CREATED
             : AuditActions.USER_UPDATED,
         newValue: {
-          zitadelUserId: userData.userId,
-          email: userData.email,
-          emailVerified: userData.emailVerified,
+          zitadelUserId: userId,
+          email: eventPayload?.email,
+          emailVerified: eventPayload?.emailVerified,
         },
         ipAddress: request.ip,
         userAgent: request.headers['user-agent'],
       });
       request.log.info(
-        { zitadelUserId: userData.userId, eventType },
+        { zitadelUserId: userId, eventType },
         'User upserted from webhook',
       );
       break;
@@ -373,7 +375,7 @@ async function processEvent(
         })
         .where(
           and(
-            eq(users.zitadelUserId, userData.userId),
+            eq(users.zitadelUserId, userId),
             hasValidTimestamp
               ? or(isNull(users.lastEventAt), lt(users.lastEventAt, eventTime))
               : undefined,
@@ -383,7 +385,7 @@ async function processEvent(
         await auditService.log(tx, {
           resource: AuditResources.USER,
           action: AuditActions.USER_DEACTIVATED,
-          newValue: { zitadelUserId: userData.userId },
+          newValue: { zitadelUserId: userId },
           ipAddress: request.ip,
           userAgent: request.headers['user-agent'],
         });
@@ -391,16 +393,16 @@ async function processEvent(
         const [existing] = await tx
           .select({ id: users.id })
           .from(users)
-          .where(eq(users.zitadelUserId, userData.userId))
+          .where(eq(users.zitadelUserId, userId))
           .limit(1);
         if (existing) {
           request.log.info(
-            { zitadelUserId: userData.userId, eventType },
+            { zitadelUserId: userId, eventType },
             'Stale event skipped',
           );
         } else {
           request.log.warn(
-            { zitadelUserId: userData.userId },
+            { zitadelUserId: userId },
             'user.deactivated: user not found locally',
           );
         }
@@ -418,7 +420,7 @@ async function processEvent(
         })
         .where(
           and(
-            eq(users.zitadelUserId, userData.userId),
+            eq(users.zitadelUserId, userId),
             hasValidTimestamp
               ? or(isNull(users.lastEventAt), lt(users.lastEventAt, eventTime))
               : undefined,
@@ -428,7 +430,7 @@ async function processEvent(
         await auditService.log(tx, {
           resource: AuditResources.USER,
           action: AuditActions.USER_REACTIVATED,
-          newValue: { zitadelUserId: userData.userId },
+          newValue: { zitadelUserId: userId },
           ipAddress: request.ip,
           userAgent: request.headers['user-agent'],
         });
@@ -436,16 +438,16 @@ async function processEvent(
         const [existing] = await tx
           .select({ id: users.id })
           .from(users)
-          .where(eq(users.zitadelUserId, userData.userId))
+          .where(eq(users.zitadelUserId, userId))
           .limit(1);
         if (existing) {
           request.log.info(
-            { zitadelUserId: userData.userId, eventType },
+            { zitadelUserId: userId, eventType },
             'Stale event skipped',
           );
         } else {
           request.log.warn(
-            { zitadelUserId: userData.userId },
+            { zitadelUserId: userId },
             'user.reactivated: user not found locally',
           );
         }
@@ -455,7 +457,7 @@ async function processEvent(
 
     case 'user.removed': {
       // GDPR: Anonymize email, preserve referential integrity
-      const anonymizedEmail = `deleted-${userData.userId}@anonymized.local`;
+      const anonymizedEmail = `deleted-${userId}@anonymized.local`;
       const result = await tx
         .update(users)
         .set({
@@ -468,7 +470,7 @@ async function processEvent(
         })
         .where(
           and(
-            eq(users.zitadelUserId, userData.userId),
+            eq(users.zitadelUserId, userId),
             hasValidTimestamp
               ? or(isNull(users.lastEventAt), lt(users.lastEventAt, eventTime))
               : undefined,
@@ -476,14 +478,14 @@ async function processEvent(
         );
       if (result.rowCount) {
         request.log.info(
-          { zitadelUserId: userData.userId },
+          { zitadelUserId: userId },
           'User anonymized (GDPR removal)',
         );
         await auditService.log(tx, {
           resource: AuditResources.USER,
           action: AuditActions.USER_REMOVED,
           newValue: {
-            zitadelUserId: userData.userId,
+            zitadelUserId: userId,
             email: anonymizedEmail,
           },
           ipAddress: request.ip,
@@ -493,16 +495,16 @@ async function processEvent(
         const [existing] = await tx
           .select({ id: users.id })
           .from(users)
-          .where(eq(users.zitadelUserId, userData.userId))
+          .where(eq(users.zitadelUserId, userId))
           .limit(1);
         if (existing) {
           request.log.info(
-            { zitadelUserId: userData.userId, eventType },
+            { zitadelUserId: userId, eventType },
             'Stale event skipped',
           );
         } else {
           request.log.warn(
-            { zitadelUserId: userData.userId },
+            { zitadelUserId: userId },
             'user.removed: user not found locally',
           );
         }
@@ -521,7 +523,7 @@ async function processEvent(
         })
         .where(
           and(
-            eq(users.zitadelUserId, userData.userId),
+            eq(users.zitadelUserId, userId),
             hasValidTimestamp
               ? or(isNull(users.lastEventAt), lt(users.lastEventAt, eventTime))
               : undefined,
@@ -531,7 +533,7 @@ async function processEvent(
         await auditService.log(tx, {
           resource: AuditResources.USER,
           action: AuditActions.USER_EMAIL_VERIFIED,
-          newValue: { zitadelUserId: userData.userId },
+          newValue: { zitadelUserId: userId },
           ipAddress: request.ip,
           userAgent: request.headers['user-agent'],
         });
@@ -539,16 +541,16 @@ async function processEvent(
         const [existing] = await tx
           .select({ id: users.id })
           .from(users)
-          .where(eq(users.zitadelUserId, userData.userId))
+          .where(eq(users.zitadelUserId, userId))
           .limit(1);
         if (existing) {
           request.log.info(
-            { zitadelUserId: userData.userId, eventType },
+            { zitadelUserId: userId, eventType },
             'Stale event skipped',
           );
         } else {
           request.log.warn(
-            { zitadelUserId: userData.userId },
+            { zitadelUserId: userId },
             'user.email.verified: user not found locally',
           );
         }

--- a/packages/auth-client/src/types.spec.ts
+++ b/packages/auth-client/src/types.spec.ts
@@ -1,15 +1,22 @@
 import { describe, it, expect } from "vitest";
 import {
   zitadelWebhookPayloadSchema,
+  zitadelEventPayloadSchema,
   zitadelWebhookUserSchema,
 } from "./types.js";
 
 describe("zitadelWebhookPayloadSchema", () => {
   const validPayload = {
-    eventType: "user.created",
-    eventId: "evt-001",
-    creationDate: "2026-01-01T00:00:00Z",
-    user: { userId: "u-1", email: "a@b.com" },
+    aggregateID: "agg-001",
+    aggregateType: "user",
+    resourceOwner: "org-1",
+    instanceID: "inst-1",
+    version: "v2",
+    sequence: 1,
+    event_type: "user.human.added",
+    created_at: "2026-01-01T00:00:00Z",
+    userID: "system-user",
+    event_payload: { userName: "alice", email: "a@b.com" },
   };
 
   it("accepts a valid payload", () => {
@@ -30,55 +37,55 @@ describe("zitadelWebhookPayloadSchema", () => {
     }
   });
 
-  it("rejects missing eventId", () => {
-    const { eventId: _, ...rest } = validPayload;
+  it("rejects missing aggregateID", () => {
+    const { aggregateID: _, ...rest } = validPayload;
     expect(zitadelWebhookPayloadSchema.safeParse(rest).success).toBe(false);
   });
 
-  it("rejects empty eventId", () => {
+  it("rejects empty aggregateID", () => {
     expect(
       zitadelWebhookPayloadSchema.safeParse({
         ...validPayload,
-        eventId: "",
+        aggregateID: "",
       }).success,
     ).toBe(false);
   });
 
-  it("rejects empty eventType", () => {
+  it("rejects empty event_type", () => {
     expect(
       zitadelWebhookPayloadSchema.safeParse({
         ...validPayload,
-        eventType: "",
+        event_type: "",
       }).success,
     ).toBe(false);
   });
 
-  it("rejects empty creationDate", () => {
+  it("rejects empty created_at", () => {
     expect(
       zitadelWebhookPayloadSchema.safeParse({
         ...validPayload,
-        creationDate: "",
+        created_at: "",
       }).success,
     ).toBe(false);
   });
 
-  it("accepts unknown eventType strings", () => {
+  it("accepts unknown event_type strings", () => {
     const result = zitadelWebhookPayloadSchema.safeParse({
       ...validPayload,
-      eventType: "org.created",
+      event_type: "org.created",
     });
     expect(result.success).toBe(true);
   });
 
-  it("accepts payload without user field", () => {
-    const { user: _, ...rest } = validPayload;
+  it("accepts payload without event_payload field", () => {
+    const { event_payload: _, ...rest } = validPayload;
     expect(zitadelWebhookPayloadSchema.safeParse(rest).success).toBe(true);
   });
 
-  it("accepts user object without userId (lenient ingress)", () => {
+  it("accepts event_payload without email (lenient ingress)", () => {
     const result = zitadelWebhookPayloadSchema.safeParse({
       ...validPayload,
-      user: { email: "a@b.com" },
+      event_payload: { userName: "alice" },
     });
     expect(result.success).toBe(true);
   });
@@ -91,6 +98,24 @@ describe("zitadelWebhookPayloadSchema", () => {
   });
 });
 
+describe("zitadelEventPayloadSchema", () => {
+  it("preserves unknown fields (.passthrough)", () => {
+    const result = zitadelEventPayloadSchema.safeParse({
+      userName: "alice",
+      unknownField: "keep-me",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.unknownField).toBe("keep-me");
+    }
+  });
+
+  it("accepts empty object (all fields optional)", () => {
+    expect(zitadelEventPayloadSchema.safeParse({}).success).toBe(true);
+  });
+});
+
+// Legacy schema — kept for backwards compatibility
 describe("zitadelWebhookUserSchema", () => {
   it("preserves unknown user fields (.passthrough)", () => {
     const result = zitadelWebhookUserSchema.safeParse({

--- a/packages/auth-client/src/types.ts
+++ b/packages/auth-client/src/types.ts
@@ -30,6 +30,46 @@ export const zitadelEventTypeSchema = z.enum([
 ]);
 export type ZitadelEventType = z.infer<typeof zitadelEventTypeSchema>;
 
+/**
+ * Zitadel Actions v2 event payload nested inside the webhook body.
+ * Contains user profile data for user.human.* events.
+ */
+export const zitadelEventPayloadSchema = z.looseObject({
+  userName: z.string().optional(),
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  displayName: z.string().optional(),
+  email: z.string().optional(),
+  emailVerified: z.boolean().optional(),
+  preferredLanguage: z.string().optional(),
+});
+
+/**
+ * Zitadel Actions v2 webhook payload format.
+ *
+ * Actual format discovered from staging (2026-03-22):
+ * - `event_type` (snake_case, e.g., "user.human.added")
+ * - `created_at` (ISO timestamp)
+ * - `aggregateID` + `sequence` (used as idempotency key)
+ * - `userID` (top-level, the acting user or Zitadel system)
+ * - `event_payload` (nested object with user profile data)
+ */
+export const zitadelWebhookPayloadSchema = z.looseObject({
+  aggregateID: z.string().min(1),
+  aggregateType: z.string().optional(),
+  resourceOwner: z.string().optional(),
+  instanceID: z.string().optional(),
+  version: z.string().optional(),
+  sequence: z.number(),
+  event_type: z.string().min(1),
+  created_at: z.string().min(1),
+  userID: z.string().optional(),
+  event_payload: zitadelEventPayloadSchema.optional(),
+});
+
+export type ZitadelWebhookPayload = z.infer<typeof zitadelWebhookPayloadSchema>;
+
+/** @deprecated Use zitadelEventPayloadSchema instead */
 export const zitadelWebhookUserSchema = z.looseObject({
   userId: z.string().optional(),
   username: z.string().optional(),
@@ -37,14 +77,3 @@ export const zitadelWebhookUserSchema = z.looseObject({
   emailVerified: z.boolean().optional(),
   displayName: z.string().optional(),
 });
-
-/** eventType is z.string() (not z.enum) so unknown types pass validation
- *  and reach the switch default case for logging + idempotency recording. */
-export const zitadelWebhookPayloadSchema = z.looseObject({
-  eventType: z.string().min(1),
-  eventId: z.string().min(1),
-  creationDate: z.string().min(1),
-  user: zitadelWebhookUserSchema.optional(),
-});
-
-export type ZitadelWebhookPayload = z.infer<typeof zitadelWebhookPayloadSchema>;


### PR DESCRIPTION
## Summary
- Zitadel Actions v2 sends a completely different payload structure than what we assumed
- `event_type` (not `eventType`), `created_at` (not `creationDate`), `aggregateID` + `sequence` for idempotency (no `eventId`), `event_payload` (not `user`)
- Updated Zod schema, webhook handler, event type aliases, and all 28 webhook tests

## Test plan
- [x] 82 webhook tests pass (28 Zitadel-specific)
- [x] 15 signature tests pass
- [x] Type-check + lint clean
- [ ] Deploy to staging, create Zitadel user, verify 200 + "User upserted from webhook"