### PR TITLE
fix: nginx dynamic DNS resolution for Coolify redeploys

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -511,7 +511,7 @@
 - [x] [P3] Connect Inngest Cloud to staging — event key + signing key — (DEVLOG 2026-03-20; done 2026-03-22)
 - [x] [P3] Coolify IPv6 network bug — `coolify` Docker network gets malformed IPv6 gateway on Hetzner; manual recreate needed after Coolify install — (DEVLOG 2026-03-20; confirmed fixed 2026-03-22)
 - [x] [P3] Investigate webhook rate limit Redis error — every Zitadel webhook request logs "Webhook rate limit Redis error — allowing request"; non-fatal but indicates Redis connection issue for webhook-specific rate limiter — (DEVLOG 2026-03-22; done 2026-03-22)
-- [ ] [P3] Coolify proxy restart after redeploy — intermittent gateway timeouts after Coolify redeploys require manual proxy restart; investigate if Traefik config or Coolify bug — (DEVLOG 2026-03-22)
+- [x] [P3] Coolify proxy restart after redeploy — root cause: nginx cached upstream IPs at startup; fix: Docker DNS resolver + variable-based proxy_pass for dynamic re-resolution — (DEVLOG 2026-03-22; done 2026-03-22)
 - [x] [P3] `queue-preset.service.ts:49` — `listByUser()` missing explicit `organizationId` filter and LIMIT — (Codex plan review 2026-03-20; done 2026-03-21 PR #292)
 - [x] Monitoring stack: Prometheus + Grafana (Sentry for errors) — done 2026-02-27 PR pending; Loki deferred to production
 

--- a/docs/coolify-deployment.md
+++ b/docs/coolify-deployment.md
@@ -196,7 +196,9 @@ Check that the compose file paths are exactly: `docker-compose.staging.yml;docke
 
 ### 502 Bad Gateway after deploy
 
-Services may still be starting. Wait 30-60 seconds for healthchecks. Check Coolify logs for the `api` service.
+Services may still be starting. Wait for all healthchecks to go green in the Coolify dashboard (typically 30-60 seconds). Check Coolify logs for the `api` service.
+
+nginx uses Docker's embedded DNS resolver (`127.0.0.11`) with 10-second TTL to dynamically resolve upstream container IPs. This prevents stale routing after container recreation during redeploys. If you still see gateway timeouts, check that the nginx container itself restarted (it depends on `api` and `web` healthchecks).
 
 ### OIDC redirect fails
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,22 @@ Newest entries first.
 
 ---
 
+## 2026-03-22 — Fix Coolify Proxy Restart After Redeploy
+
+### Done
+
+- Diagnosed root cause of intermittent gateway timeouts after Coolify redeploys: nginx OSS caches upstream IPs at startup and never re-resolves them; when containers are recreated with new Docker-internal IPs, nginx routes to stale addresses
+- Fixed `nginx/nginx.conf`: replaced static `upstream` blocks with Docker DNS resolver (`127.0.0.11`, 10s TTL, ipv6=off) and variable-based `proxy_pass` directives that force per-request DNS re-resolution
+- Updated `docs/coolify-deployment.md` troubleshooting section with DNS resolver explanation
+
+### Decisions
+
+- 10s DNS TTL balances freshness vs DNS query load — standard Docker practice
+- `ipv6=off` on resolver matches existing Coolify IPv6 network bug workaround
+- Variable-based `proxy_pass` with `$request_uri` preserves URI passthrough behavior from the previous `upstream` block approach
+
+---
+
 ## 2026-03-22 — Code Quality Cleanup
 
 ### Done

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -33,18 +33,12 @@ http {
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=auth:10m rate=5r/s;
 
-    # Upstream definitions
-    upstream api_backend {
-        server api:4000;
-    }
-
-    upstream web_backend {
-        server web:3000;
-    }
-
-    upstream tusd_backend {
-        server tusd:1080;
-    }
+    # Dynamic DNS resolution via Docker's embedded DNS.
+    # nginx OSS caches upstream IPs at startup and never re-resolves them.
+    # Using resolver + variable-based proxy_pass forces re-resolution every 10s,
+    # preventing gateway timeouts when containers are recreated during redeploys.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    resolver_timeout 5s;
 
     server {
         listen 80;
@@ -61,7 +55,8 @@ http {
         location /trpc {
             limit_req zone=api burst=20 nodelay;
 
-            proxy_pass http://api_backend;
+            set $upstream_api http://api:4000;
+            proxy_pass $upstream_api$request_uri;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -74,7 +69,8 @@ http {
         location /api {
             limit_req zone=api burst=20 nodelay;
 
-            proxy_pass http://api_backend;
+            set $upstream_api http://api:4000;
+            proxy_pass $upstream_api$request_uri;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -85,13 +81,15 @@ http {
 
         # Health check (no rate limit)
         location = /health {
-            proxy_pass http://api_backend;
+            set $upstream_api http://api:4000;
+            proxy_pass $upstream_api/health;
             proxy_set_header Host $host;
         }
 
         # Stripe webhooks (no rate limit — Stripe sends these)
         location /webhooks {
-            proxy_pass http://api_backend;
+            set $upstream_api http://api:4000;
+            proxy_pass $upstream_api$request_uri;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -102,7 +100,8 @@ http {
 
         # tusd hooks (internal, from tusd sidecar)
         location /hooks {
-            proxy_pass http://api_backend;
+            set $upstream_api http://api:4000;
+            proxy_pass $upstream_api$request_uri;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -116,7 +115,8 @@ http {
             # No body size limit — tus handles chunked uploads
             client_max_body_size 0;
 
-            proxy_pass http://tusd_backend;
+            set $upstream_tusd http://tusd:1080;
+            proxy_pass $upstream_tusd$request_uri;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -134,7 +134,8 @@ http {
 
         # Next.js frontend (default)
         location / {
-            proxy_pass http://web_backend;
+            set $upstream_web http://web:3000;
+            proxy_pass $upstream_web$request_uri;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary

- Fixed intermittent gateway timeouts after Coolify redeploys by replacing nginx static `upstream` blocks with Docker DNS resolver (`127.0.0.11`, 10s TTL) and variable-based `proxy_pass` directives
- Root cause: nginx OSS caches upstream IPs at startup and never re-resolves them; when containers are recreated with new IPs during redeploys, nginx routes to stale addresses
- Updated deployment troubleshooting docs and marked backlog item done

## Test plan

- [x] nginx config syntax check passes (`nginx -t` via Docker)
- [ ] Trigger a Coolify redeploy on staging and verify no gateway timeouts without manual proxy restart
- [ ] Run `bash scripts/smoke-test.sh https://staging.colophony.pub` after redeploy

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `docs/coolify-deployment.md` | Remove "wait 30-60 seconds" workaround | Kept wait advice, added DNS resolver note | Waiting for healthchecks is still valid (startup time); DNS fix prevents stale routing, not slow startup |