### PR TITLE
feat: R&R resubmit flow for embed submitters with token rotation

### DIFF
--- a/apps/api/src/inngest/events.ts
+++ b/apps/api/src/inngest/events.ts
@@ -101,6 +101,7 @@ export interface HopperSubmissionSubmittedEvent {
     isEmbed?: boolean;
     submitterEmail?: string;
     statusToken?: string;
+    resubmit?: boolean;
   };
 }
 

--- a/apps/api/src/routes/embed.routes.ts
+++ b/apps/api/src/routes/embed.routes.ts
@@ -14,6 +14,11 @@ import {
 } from '../services/submission.service.js';
 import type { Env } from '../config/env.js';
 import {
+  ManuscriptVersionNotFoundError,
+  ManuscriptVersionOwnershipError,
+  NoFilesUploadedError,
+} from '../services/embed-submission.service.js';
+import {
   embedTokenService,
   type VerifiedEmbedToken,
 } from '../services/embed-token.service.js';
@@ -877,6 +882,24 @@ export async function registerEmbedRoutes(
         if (err instanceof NotReviseAndResubmitError) {
           return reply.status(409).send({
             error: 'conflict',
+            message: err.message,
+          });
+        }
+        if (err instanceof ManuscriptVersionNotFoundError) {
+          return reply.status(404).send({
+            error: 'not_found',
+            message: err.message,
+          });
+        }
+        if (err instanceof ManuscriptVersionOwnershipError) {
+          return reply.status(403).send({
+            error: 'forbidden',
+            message: err.message,
+          });
+        }
+        if (err instanceof NoFilesUploadedError) {
+          return reply.status(422).send({
+            error: 'unprocessable',
             message: err.message,
           });
         }

--- a/apps/api/src/routes/embed.routes.ts
+++ b/apps/api/src/routes/embed.routes.ts
@@ -4,8 +4,14 @@ import {
   embedSubmitSchema,
   embedPrepareUploadSchema,
   embedUploadStatusQuerySchema,
+  embedResubmitSubmitSchema,
   STATUS_TOKEN_PREFIX,
 } from '@colophony/types';
+import {
+  NotReviseAndResubmitError,
+  UnscannedFilesError,
+  InfectedFilesError,
+} from '../services/submission.service.js';
 import type { Env } from '../config/env.js';
 import {
   embedTokenService,
@@ -561,6 +567,330 @@ export async function registerEmbedRoutes(
         organizationName: result.organizationName,
         periodName: result.periodName,
       };
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Resubmit endpoints (R&R flow for embed submitters)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Verify status token from URL param for resubmit endpoints.
+   * Returns true if valid, sends error reply and returns false otherwise.
+   */
+  function verifyStatusTokenFormat(
+    statusToken: string,
+    reply: FastifyReply,
+  ): boolean {
+    if (
+      !statusToken.startsWith(STATUS_TOKEN_PREFIX) ||
+      statusToken.length < 20
+    ) {
+      void reply.status(404).send({
+        error: 'not_found',
+        message: 'Submission not found',
+      });
+      return false;
+    }
+    return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /embed/resubmit/:statusToken — resubmit context
+  // ---------------------------------------------------------------------------
+  app.get<{ Params: { statusToken: string } }>(
+    '/embed/resubmit/:statusToken',
+    {
+      preHandler: async function resubmitContextRateLimit(
+        request: FastifyRequest,
+        reply: FastifyReply,
+      ) {
+        const redisClient = getRedis();
+        if (!redisClient) return;
+
+        const windowMs = env.RATE_LIMIT_WINDOW_SECONDS * 1000;
+        const windowId = Math.floor(Date.now() / windowMs);
+        const key = `${env.RATE_LIMIT_KEY_PREFIX}:embed:resubmit:${request.ip}:${windowId}`;
+
+        try {
+          const result = (await redisClient.eval(
+            RATE_LIMIT_LUA,
+            1,
+            key,
+            windowMs,
+          )) as [number, number];
+
+          const limit = 30;
+          if (result[0] > limit) {
+            const remainingMs = windowMs - (Date.now() % windowMs);
+            reply.header('Retry-After', Math.ceil(remainingMs / 1000));
+            return reply.status(429).send({
+              error: 'rate_limit_exceeded',
+              message: 'Too many requests. Please try again later.',
+            });
+          }
+        } catch {
+          request.log.warn(
+            'Embed resubmit context rate limit Redis error — allowing request',
+          );
+        }
+      },
+    },
+    async (request, reply) => {
+      const { statusToken } = request.params;
+      if (!verifyStatusTokenFormat(statusToken, reply)) return;
+
+      const ctx = await embedSubmissionService.getResubmitContext(statusToken);
+
+      if (!ctx) {
+        return reply.status(404).send({
+          error: 'not_found',
+          message:
+            'Submission not found, token expired, or not in revision-requested status',
+        });
+      }
+
+      return ctx;
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // POST /embed/resubmit/:statusToken/prepare-upload — prepare file upload
+  // ---------------------------------------------------------------------------
+  app.post<{ Params: { statusToken: string } }>(
+    '/embed/resubmit/:statusToken/prepare-upload',
+    {
+      preHandler: async function resubmitPrepareRateLimit(
+        request: FastifyRequest,
+        reply: FastifyReply,
+      ) {
+        const redisClient = getRedis();
+        if (!redisClient) return;
+
+        const windowMs = env.RATE_LIMIT_WINDOW_SECONDS * 1000;
+        const windowId = Math.floor(Date.now() / windowMs);
+        const key = `${env.RATE_LIMIT_KEY_PREFIX}:embed:resubmit:${request.ip}:${windowId}`;
+
+        try {
+          const result = (await redisClient.eval(
+            RATE_LIMIT_LUA,
+            1,
+            key,
+            windowMs,
+          )) as [number, number];
+
+          const limit = 10;
+          if (result[0] > limit) {
+            const remainingMs = windowMs - (Date.now() % windowMs);
+            reply.header('Retry-After', Math.ceil(remainingMs / 1000));
+            return reply.status(429).send({
+              error: 'rate_limit_exceeded',
+              message: 'Too many requests. Please try again later.',
+            });
+          }
+        } catch {
+          request.log.warn(
+            'Embed resubmit prepare-upload rate limit Redis error — allowing request',
+          );
+        }
+      },
+    },
+    async (request, reply) => {
+      const { statusToken } = request.params;
+      if (!verifyStatusTokenFormat(statusToken, reply)) return;
+
+      const result = await embedSubmissionService.prepareResubmitUpload(
+        statusToken,
+        request.ip,
+        request.headers['user-agent'],
+      );
+
+      if (!result) {
+        return reply.status(404).send({
+          error: 'not_found',
+          message:
+            'Submission not found, token expired, or not in revision-requested status',
+        });
+      }
+
+      return {
+        manuscriptVersionId: result.manuscriptVersionId,
+        guestUserId: result.guestUserId,
+        tusEndpoint: result.tusEndpoint,
+        maxFileSize: result.maxFileSize,
+        maxFiles: result.maxFiles,
+        allowedMimeTypes: result.allowedMimeTypes,
+      };
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // GET /embed/resubmit/:statusToken/upload-status/:manuscriptVersionId
+  // ---------------------------------------------------------------------------
+  app.get<{
+    Params: { statusToken: string; manuscriptVersionId: string };
+  }>(
+    '/embed/resubmit/:statusToken/upload-status/:manuscriptVersionId',
+    {
+      preHandler: async function resubmitUploadStatusRateLimit(
+        request: FastifyRequest,
+        reply: FastifyReply,
+      ) {
+        const redisClient = getRedis();
+        if (!redisClient) return;
+
+        const windowMs = env.RATE_LIMIT_WINDOW_SECONDS * 1000;
+        const windowId = Math.floor(Date.now() / windowMs);
+        const key = `${env.RATE_LIMIT_KEY_PREFIX}:embed:resubmit:poll:${request.ip}:${windowId}`;
+
+        try {
+          const result = (await redisClient.eval(
+            RATE_LIMIT_LUA,
+            1,
+            key,
+            windowMs,
+          )) as [number, number];
+
+          const limit = 60;
+          if (result[0] > limit) {
+            const remainingMs = windowMs - (Date.now() % windowMs);
+            reply.header('Retry-After', Math.ceil(remainingMs / 1000));
+            return reply.status(429).send({
+              error: 'rate_limit_exceeded',
+              message: 'Too many requests. Please try again later.',
+            });
+          }
+        } catch {
+          request.log.warn(
+            'Embed resubmit upload-status rate limit Redis error — allowing request',
+          );
+        }
+      },
+    },
+    async (request, reply) => {
+      const { statusToken, manuscriptVersionId } = request.params;
+      if (!verifyStatusTokenFormat(statusToken, reply)) return;
+
+      const uuidRegex =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      if (!uuidRegex.test(manuscriptVersionId)) {
+        return reply.status(400).send({
+          error: 'validation_error',
+          message: 'Invalid manuscript version ID format',
+        });
+      }
+
+      const result = await embedSubmissionService.getResubmitUploadStatus(
+        statusToken,
+        manuscriptVersionId,
+      );
+
+      if (!result) {
+        return reply.status(404).send({
+          error: 'not_found',
+          message:
+            'Submission not found, token expired, or not in revision-requested status',
+        });
+      }
+
+      return result;
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // POST /embed/resubmit/:statusToken/submit — submit resubmission
+  // ---------------------------------------------------------------------------
+  app.post<{ Params: { statusToken: string } }>(
+    '/embed/resubmit/:statusToken/submit',
+    {
+      bodyLimit: 16 * 1024,
+      preHandler: async function resubmitSubmitRateLimit(
+        request: FastifyRequest,
+        reply: FastifyReply,
+      ) {
+        const redisClient = getRedis();
+        if (!redisClient) return;
+
+        const windowMs = env.RATE_LIMIT_WINDOW_SECONDS * 1000;
+        const windowId = Math.floor(Date.now() / windowMs);
+        const key = `${env.RATE_LIMIT_KEY_PREFIX}:embed:resubmit:${request.ip}:${windowId}`;
+
+        try {
+          const result = (await redisClient.eval(
+            RATE_LIMIT_LUA,
+            1,
+            key,
+            windowMs,
+          )) as [number, number];
+
+          const limit = 10;
+          if (result[0] > limit) {
+            const remainingMs = windowMs - (Date.now() % windowMs);
+            reply.header('Retry-After', Math.ceil(remainingMs / 1000));
+            return reply.status(429).send({
+              error: 'rate_limit_exceeded',
+              message: 'Too many submissions. Please try again later.',
+            });
+          }
+        } catch {
+          request.log.warn(
+            'Embed resubmit submit rate limit Redis error — allowing request',
+          );
+        }
+      },
+    },
+    async (request, reply) => {
+      const { statusToken } = request.params;
+      if (!verifyStatusTokenFormat(statusToken, reply)) return;
+
+      const parsed = embedResubmitSubmitSchema.safeParse(request.body);
+      if (!parsed.success) {
+        const errors = parsed.error.issues.map((i) => ({
+          path: i.path.join('.'),
+          message: i.message,
+        }));
+        return reply.status(400).send({
+          error: 'validation_error',
+          message: 'Invalid request data',
+          details: errors,
+        });
+      }
+
+      try {
+        const result = await embedSubmissionService.submitResubmission(
+          statusToken,
+          parsed.data.manuscriptVersionId,
+          request.ip,
+          request.headers['user-agent'],
+        );
+
+        if (!result) {
+          return reply.status(404).send({
+            error: 'not_found',
+            message:
+              'Submission not found, token expired, or not in revision-requested status',
+          });
+        }
+
+        return result;
+      } catch (err) {
+        if (err instanceof NotReviseAndResubmitError) {
+          return reply.status(409).send({
+            error: 'conflict',
+            message: err.message,
+          });
+        }
+        if (
+          err instanceof UnscannedFilesError ||
+          err instanceof InfectedFilesError
+        ) {
+          return reply.status(422).send({
+            error: 'unprocessable',
+            message: err.message,
+          });
+        }
+        throw err;
+      }
     },
   );
 }

--- a/apps/api/src/services/__tests__/embed-resubmit.service.spec.ts
+++ b/apps/api/src/services/__tests__/embed-resubmit.service.spec.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock dependencies before imports
+const mockGetResubmitContext = vi.fn();
+const mockGenerateAndStore = vi.fn();
+const mockVerifyToken = vi.fn();
+
+vi.mock('../status-token.service.js', () => ({
+  statusTokenService: {
+    getResubmitContext: (...args: unknown[]) => mockGetResubmitContext(...args),
+    generateAndStore: (...args: unknown[]) => mockGenerateAndStore(...args),
+    verifyToken: (...args: unknown[]) => mockVerifyToken(...args),
+  },
+}));
+
+const mockSubmissionCreate = vi.fn();
+const mockSubmissionUpdateStatus = vi.fn();
+const mockSubmissionGetById = vi.fn();
+
+vi.mock('../submission.service.js', () => ({
+  submissionService: {
+    create: (...args: unknown[]) => mockSubmissionCreate(...args),
+    updateStatus: (...args: unknown[]) => mockSubmissionUpdateStatus(...args),
+    getById: (...args: unknown[]) => mockSubmissionGetById(...args),
+  },
+  NotReviseAndResubmitError: class NotReviseAndResubmitError extends Error {
+    constructor() {
+      super('Submission must be in REVISE_AND_RESUBMIT status');
+      this.name = 'NotReviseAndResubmitError';
+    }
+  },
+  UnscannedFilesError: class UnscannedFilesError extends Error {
+    constructor() {
+      super('Files still pending scan');
+      this.name = 'UnscannedFilesError';
+    }
+  },
+  InfectedFilesError: class InfectedFilesError extends Error {
+    constructor() {
+      super('Files infected');
+      this.name = 'InfectedFilesError';
+    }
+  },
+}));
+
+const mockAuditLog = vi.fn();
+const mockAuditLogDirect = vi.fn();
+vi.mock('../audit.service.js', () => ({
+  auditService: {
+    log: (...args: unknown[]) => mockAuditLog(...args),
+    logDirect: (...args: unknown[]) => mockAuditLogDirect(...args),
+  },
+}));
+
+const mockFileServiceListByMV = vi.fn();
+vi.mock('../file.service.js', () => ({
+  fileService: {
+    listByManuscriptVersion: (...args: unknown[]) =>
+      mockFileServiceListByMV(...args),
+  },
+}));
+
+const mockEnqueueOutboxEvent = vi.fn();
+vi.mock('../outbox.js', () => ({
+  enqueueOutboxEvent: (...args: unknown[]) => mockEnqueueOutboxEvent(...args),
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: () => ({
+    STATUS_TOKEN_TTL_DAYS: 30,
+    TUS_ENDPOINT: 'http://localhost:1080/files/',
+  }),
+}));
+
+vi.mock('@colophony/db', () => {
+  const mockSelect = vi.fn();
+  const mockFrom = vi.fn();
+  const mockWhere = vi.fn();
+  const mockLimit = vi.fn();
+  const mockInnerJoin = vi.fn();
+  const mockInsert = vi.fn();
+  const mockValues = vi.fn();
+  const mockReturning = vi.fn();
+  const mockUpdate = vi.fn();
+  const mockSet = vi.fn();
+
+  // Build chain for select queries
+  mockSelect.mockReturnValue({ from: mockFrom });
+  mockFrom.mockReturnValue({ where: mockWhere, innerJoin: mockInnerJoin });
+  mockInnerJoin.mockReturnValue({ where: mockWhere });
+  mockWhere.mockReturnValue({ limit: mockLimit });
+  mockLimit.mockResolvedValue([]);
+
+  // Build chain for insert
+  mockInsert.mockReturnValue({ values: mockValues });
+  mockValues.mockReturnValue({ returning: mockReturning });
+  mockReturning.mockResolvedValue([{ id: 'new-id' }]);
+
+  // Build chain for update
+  mockUpdate.mockReturnValue({ set: mockSet });
+  mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+
+  const tx = {
+    select: mockSelect,
+    insert: mockInsert,
+    update: mockUpdate,
+  };
+
+  return {
+    db: {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ email: 'test@example.com' }]),
+          }),
+        }),
+      }),
+    },
+    users: { id: 'id', email: 'email' },
+    submissions: {
+      id: 'id',
+      status: 'status',
+      submitterId: 'submitter_id',
+      organizationId: 'organization_id',
+      manuscriptVersionId: 'manuscript_version_id',
+      updatedAt: 'updated_at',
+    },
+    manuscripts: { id: 'id', ownerId: 'owner_id' },
+    manuscriptVersions: { id: 'id', manuscriptId: 'manuscript_id' },
+    files: {
+      scanStatus: 'scan_status',
+      manuscriptVersionId: 'manuscript_version_id',
+    },
+    formDefinitions: { id: 'id', name: 'name' },
+    formPages: {
+      formDefinitionId: 'form_definition_id',
+      sortOrder: 'sort_order',
+    },
+    formFields: {
+      formDefinitionId: 'form_definition_id',
+      sortOrder: 'sort_order',
+    },
+    eq: vi.fn(),
+    and: vi.fn(),
+    sql: vi.fn(),
+    withRls: vi.fn(
+      async (_ctx: unknown, fn: (tx: unknown) => Promise<unknown>) => fn(tx),
+    ),
+  };
+});
+
+vi.mock('@colophony/types', async () => {
+  const actual =
+    await vi.importActual<typeof import('@colophony/types')>(
+      '@colophony/types',
+    );
+  return actual;
+});
+
+import { embedSubmissionService } from '../embed-submission.service.js';
+
+describe('embedSubmissionService — resubmit flow', () => {
+  const baseCtx = {
+    submissionId: 'sub-1',
+    title: 'My Poem',
+    organizationId: 'org-1',
+    organizationName: 'Poetry Review',
+    submitterId: 'user-1',
+    revisionNotes: 'Please fix the ending',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getResubmitContext', () => {
+    it('returns context when token is valid and submission is R&R', async () => {
+      mockGetResubmitContext.mockResolvedValue(baseCtx);
+
+      const result = await embedSubmissionService.getResubmitContext(
+        'col_sta_validtoken1234567890abcdef',
+      );
+
+      expect(result).toEqual({
+        submissionId: 'sub-1',
+        title: 'My Poem',
+        organizationName: 'Poetry Review',
+        revisionNotes: 'Please fix the ending',
+      });
+    });
+
+    it('returns null for invalid/expired/non-R&R token', async () => {
+      mockGetResubmitContext.mockResolvedValue(null);
+
+      const result = await embedSubmissionService.getResubmitContext(
+        'col_sta_invalidtoken000000000000',
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('defaults revisionNotes to empty string when null', async () => {
+      mockGetResubmitContext.mockResolvedValue({
+        ...baseCtx,
+        revisionNotes: null,
+      });
+
+      const result = await embedSubmissionService.getResubmitContext(
+        'col_sta_validtoken1234567890abcdef',
+      );
+
+      expect(result?.revisionNotes).toBe('');
+    });
+  });
+
+  describe('prepareResubmitUpload', () => {
+    it('returns upload context when token is valid', async () => {
+      mockGetResubmitContext.mockResolvedValue(baseCtx);
+
+      const result = await embedSubmissionService.prepareResubmitUpload(
+        'col_sta_validtoken1234567890abcdef',
+        '127.0.0.1',
+        'test-agent',
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.manuscriptVersionId).toBe('new-id');
+      expect(result!.tusEndpoint).toBe('http://localhost:1080/files/');
+      expect(result!.submitterId).toBe('user-1');
+      expect(mockAuditLog).toHaveBeenCalled();
+    });
+
+    it('returns null for invalid token', async () => {
+      mockGetResubmitContext.mockResolvedValue(null);
+
+      const result = await embedSubmissionService.prepareResubmitUpload(
+        'col_sta_invalid',
+        '127.0.0.1',
+        undefined,
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('submitResubmission', () => {
+    it('returns null for invalid token', async () => {
+      mockGetResubmitContext.mockResolvedValue(null);
+
+      const result = await embedSubmissionService.submitResubmission(
+        'col_sta_invalid',
+        'mv-1',
+        '127.0.0.1',
+        undefined,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when submitter email not found', async () => {
+      mockGetResubmitContext.mockResolvedValue(baseCtx);
+
+      // Override db.select to return empty
+      const { db } = await import('@colophony/db');
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- db.select is a mock
+      const dbSelectMock = vi.mocked(db.select);
+      dbSelectMock.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as never);
+
+      const result = await embedSubmissionService.submitResubmission(
+        'col_sta_validtoken1234567890abcdef',
+        'mv-1',
+        '127.0.0.1',
+        undefined,
+      );
+
+      expect(result).toBeNull();
+
+      // Restore
+      dbSelectMock.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ email: 'test@example.com' }]),
+          }),
+        }),
+      } as never);
+    });
+  });
+});

--- a/apps/api/src/services/embed-submission.service.ts
+++ b/apps/api/src/services/embed-submission.service.ts
@@ -1,12 +1,15 @@
 import {
   db,
   users,
+  submissions,
   formDefinitions,
   formPages,
   formFields,
   manuscripts,
   manuscriptVersions,
+  files,
   eq,
+  and,
   sql,
 } from '@colophony/db';
 import { withRls } from '@colophony/db';
@@ -15,6 +18,8 @@ import type { EmbedSubmitInput } from '@colophony/types';
 import type {
   EmbedPrepareUploadResponse,
   EmbedUploadStatusResponse,
+  EmbedResubmitContextResponse,
+  EmbedResubmitSubmitResponse,
 } from '@colophony/types';
 import {
   AuditActions,
@@ -25,7 +30,12 @@ import {
 } from '@colophony/types';
 import type { VerifiedEmbedToken } from './embed-token.service.js';
 import { auditService } from './audit.service.js';
-import { submissionService } from './submission.service.js';
+import {
+  submissionService,
+  NotReviseAndResubmitError,
+  UnscannedFilesError,
+  InfectedFilesError,
+} from './submission.service.js';
 import { fileService } from './file.service.js';
 import { statusTokenService } from './status-token.service.js';
 import { validateEnv } from '../config/env.js';
@@ -400,5 +410,270 @@ export const embedSubmissionService = {
         pages,
       };
     });
+  },
+
+  // ---------------------------------------------------------------------------
+  // Resubmit flow (R&R for embed submitters)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Get resubmit context for an R&R submission.
+   * Uses status token for auth (via SECURITY DEFINER function).
+   */
+  async getResubmitContext(
+    statusToken: string,
+  ): Promise<EmbedResubmitContextResponse | null> {
+    const ctx = await statusTokenService.getResubmitContext(statusToken);
+    if (!ctx) return null;
+
+    return {
+      submissionId: ctx.submissionId,
+      title: ctx.title,
+      organizationName: ctx.organizationName,
+      revisionNotes: ctx.revisionNotes ?? '',
+    };
+  },
+
+  /**
+   * Prepare file upload for an R&R resubmission.
+   * Authenticated via status token — creates manuscript + version under RLS.
+   */
+  async prepareResubmitUpload(
+    statusToken: string,
+    ipAddress: string,
+    userAgent: string | undefined,
+  ): Promise<(EmbedPrepareUploadResponse & { submitterId: string }) | null> {
+    const ctx = await statusTokenService.getResubmitContext(statusToken);
+    if (!ctx) return null;
+
+    const env = validateEnv();
+
+    const result = await withRls(
+      { orgId: ctx.organizationId, userId: ctx.submitterId },
+      async (tx) => {
+        const [manuscript] = await tx
+          .insert(manuscripts)
+          .values({
+            ownerId: ctx.submitterId,
+            title: `Resubmission — ${ctx.title ?? ctx.submissionId}`,
+          })
+          .returning({ id: manuscripts.id });
+
+        const [version] = await tx
+          .insert(manuscriptVersions)
+          .values({
+            manuscriptId: manuscript.id,
+            versionNumber: 1,
+          })
+          .returning({ id: manuscriptVersions.id });
+
+        await auditService.log(tx, {
+          action: AuditActions.MANUSCRIPT_CREATED,
+          resource: AuditResources.MANUSCRIPT,
+          resourceId: manuscript.id,
+          actorId: ctx.submitterId,
+          organizationId: ctx.organizationId,
+          ipAddress,
+          userAgent,
+          newValue: { resubmit: true, submissionId: ctx.submissionId },
+        });
+
+        return { manuscriptVersionId: version.id };
+      },
+    );
+
+    return {
+      manuscriptVersionId: result.manuscriptVersionId,
+      guestUserId: ctx.submitterId,
+      tusEndpoint: env.TUS_ENDPOINT,
+      maxFileSize: MAX_FILE_SIZE,
+      maxFiles: MAX_FILES_PER_MANUSCRIPT_VERSION,
+      allowedMimeTypes: [...ALLOWED_MIME_TYPES],
+      submitterId: ctx.submitterId,
+    };
+  },
+
+  /**
+   * Get upload status for files in a manuscript version during resubmission.
+   * Authenticated via status token.
+   */
+  async getResubmitUploadStatus(
+    statusToken: string,
+    manuscriptVersionId: string,
+  ): Promise<EmbedUploadStatusResponse | null> {
+    const ctx = await statusTokenService.getResubmitContext(statusToken);
+    if (!ctx) return null;
+
+    const fileList = await withRls(
+      { orgId: ctx.organizationId, userId: ctx.submitterId },
+      async (tx) => {
+        return fileService.listByManuscriptVersion(tx, manuscriptVersionId);
+      },
+    );
+
+    return {
+      files: fileList.map((f) => ({
+        id: f.id,
+        filename: f.filename,
+        size: Number(f.size),
+        mimeType: f.mimeType,
+        scanStatus: f.scanStatus,
+      })),
+      allClean:
+        fileList.length > 0 && fileList.every((f) => f.scanStatus === 'CLEAN'),
+    };
+  },
+
+  /**
+   * Submit an R&R resubmission with a new manuscript version.
+   *
+   * 1. Verify status token → get submission context
+   * 2. Under RLS: verify R&R status, file scans, update manuscript version
+   * 3. Transition status → SUBMITTED
+   * 4. Rotate status token
+   * 5. Enqueue outbox event (triggers confirmation email with new token)
+   */
+  async submitResubmission(
+    statusToken: string,
+    manuscriptVersionId: string,
+    ipAddress: string,
+    userAgent: string | undefined,
+  ): Promise<EmbedResubmitSubmitResponse | null> {
+    const ctx = await statusTokenService.getResubmitContext(statusToken);
+    if (!ctx) return null;
+
+    const env = validateEnv();
+
+    // Look up submitter email for the confirmation event
+    const [submitterRecord] = await db
+      .select({ email: users.email })
+      .from(users)
+      .where(eq(users.id, ctx.submitterId))
+      .limit(1);
+
+    if (!submitterRecord) return null;
+
+    const result = await withRls(
+      { orgId: ctx.organizationId, userId: ctx.submitterId },
+      async (tx) => {
+        // Defense-in-depth: explicit organizationId filter
+        const [existing] = await tx
+          .select({
+            id: submissions.id,
+            status: submissions.status,
+            submitterId: submissions.submitterId,
+            organizationId: submissions.organizationId,
+          })
+          .from(submissions)
+          .where(
+            and(
+              eq(submissions.id, ctx.submissionId),
+              eq(submissions.organizationId, ctx.organizationId),
+            ),
+          )
+          .limit(1);
+
+        if (!existing) return null;
+        if (existing.status !== 'REVISE_AND_RESUBMIT') {
+          throw new NotReviseAndResubmitError();
+        }
+
+        // Verify manuscript version ownership
+        const [version] = await tx
+          .select({
+            id: manuscriptVersions.id,
+            ownerId: manuscripts.ownerId,
+          })
+          .from(manuscriptVersions)
+          .innerJoin(
+            manuscripts,
+            eq(manuscriptVersions.manuscriptId, manuscripts.id),
+          )
+          .where(eq(manuscriptVersions.id, manuscriptVersionId))
+          .limit(1);
+
+        if (!version) {
+          throw new Error('Manuscript version not found');
+        }
+        if (version.ownerId !== ctx.submitterId) {
+          throw new Error(
+            'Manuscript version does not belong to the submitter',
+          );
+        }
+
+        // Validate file scan status
+        const versionFiles = await tx
+          .select({ scanStatus: files.scanStatus })
+          .from(files)
+          .where(eq(files.manuscriptVersionId, manuscriptVersionId));
+
+        if (
+          versionFiles.some(
+            (f) => f.scanStatus === 'PENDING' || f.scanStatus === 'SCANNING',
+          )
+        ) {
+          throw new UnscannedFilesError();
+        }
+        if (versionFiles.some((f) => f.scanStatus === 'INFECTED')) {
+          throw new InfectedFilesError();
+        }
+
+        // Update manuscript version on submission
+        await tx
+          .update(submissions)
+          .set({ manuscriptVersionId, updatedAt: new Date() })
+          .where(eq(submissions.id, ctx.submissionId));
+
+        // Transition to SUBMITTED
+        await submissionService.updateStatus(
+          tx,
+          ctx.submissionId,
+          'SUBMITTED',
+          ctx.submitterId,
+          undefined,
+          'submitter',
+        );
+
+        // Rotate status token
+        const newToken = await statusTokenService.generateAndStore(
+          tx,
+          ctx.submissionId,
+          env.STATUS_TOKEN_TTL_DAYS,
+        );
+
+        // Audit log
+        await auditService.log(tx, {
+          action: AuditActions.EMBED_SUBMISSION_RESUBMITTED,
+          resource: AuditResources.EMBED_TOKEN,
+          resourceId: ctx.submissionId,
+          actorId: ctx.submitterId,
+          organizationId: ctx.organizationId,
+          ipAddress,
+          userAgent,
+          newValue: { manuscriptVersionId, resubmit: true },
+        });
+
+        // Enqueue outbox event — triggers editor notification + embed confirmation email
+        await enqueueOutboxEvent(tx, 'hopper/submission.submitted', {
+          orgId: ctx.organizationId,
+          submissionId: ctx.submissionId,
+          submitterId: ctx.submitterId,
+          isEmbed: true,
+          submitterEmail: submitterRecord.email,
+          statusToken: newToken,
+          resubmit: true,
+        });
+
+        return { submissionId: ctx.submissionId, statusToken: newToken };
+      },
+    );
+
+    if (!result) return null;
+
+    return {
+      success: true as const,
+      submissionId: result.submissionId,
+      statusToken: result.statusToken,
+    };
   },
 };

--- a/apps/api/src/services/embed-submission.service.ts
+++ b/apps/api/src/services/embed-submission.service.ts
@@ -45,6 +45,27 @@ import { enqueueOutboxEvent } from './outbox.js';
 // Error classes
 // ---------------------------------------------------------------------------
 
+export class ManuscriptVersionNotFoundError extends Error {
+  constructor() {
+    super('Manuscript version not found');
+    this.name = 'ManuscriptVersionNotFoundError';
+  }
+}
+
+export class ManuscriptVersionOwnershipError extends Error {
+  constructor() {
+    super('Manuscript version does not belong to the submitter');
+    this.name = 'ManuscriptVersionOwnershipError';
+  }
+}
+
+export class NoFilesUploadedError extends Error {
+  constructor() {
+    super('Cannot submit: no files have been uploaded');
+    this.name = 'NoFilesUploadedError';
+  }
+}
+
 export class PeriodClosedError extends Error {
   constructor(periodName: string) {
     super(`Submission period "${periodName}" is not currently open`);
@@ -593,12 +614,10 @@ export const embedSubmissionService = {
           .limit(1);
 
         if (!version) {
-          throw new Error('Manuscript version not found');
+          throw new ManuscriptVersionNotFoundError();
         }
         if (version.ownerId !== ctx.submitterId) {
-          throw new Error(
-            'Manuscript version does not belong to the submitter',
-          );
+          throw new ManuscriptVersionOwnershipError();
         }
 
         // Validate file scan status
@@ -606,6 +625,11 @@ export const embedSubmissionService = {
           .select({ scanStatus: files.scanStatus })
           .from(files)
           .where(eq(files.manuscriptVersionId, manuscriptVersionId));
+
+        // P1: Reject resubmissions with no uploaded files
+        if (versionFiles.length === 0) {
+          throw new NoFilesUploadedError();
+        }
 
         if (
           versionFiles.some(

--- a/apps/api/src/services/status-token.service.ts
+++ b/apps/api/src/services/status-token.service.ts
@@ -10,6 +10,17 @@ export interface StatusCheckResult {
   organizationName: string;
   periodName: string | null;
   expired: boolean;
+  organizationId: string;
+  submitterId: string;
+}
+
+export interface ResubmitContext {
+  submissionId: string;
+  title: string | null;
+  organizationId: string;
+  organizationName: string;
+  submitterId: string;
+  revisionNotes: string | null;
 }
 
 function hashToken(plainText: string): string {
@@ -81,6 +92,8 @@ export const statusTokenService = {
       organization_name: string;
       period_name: string | null;
       token_expired: boolean;
+      organization_id: string;
+      submitter_id: string;
     }>('SELECT * FROM verify_status_token($1)', [tokenHash]);
 
     if (result.rows.length === 0) return null;
@@ -94,6 +107,39 @@ export const statusTokenService = {
       organizationName: row.organization_name,
       periodName: row.period_name,
       expired: row.token_expired,
+      organizationId: row.organization_id,
+      submitterId: row.submitter_id,
+    };
+  },
+
+  /**
+   * Get resubmit context for an R&R submission via SECURITY DEFINER function.
+   * Returns null if token is invalid, expired, or submission is not in R&R status.
+   */
+  async getResubmitContext(
+    plainTextToken: string,
+  ): Promise<ResubmitContext | null> {
+    const tokenHash = hashToken(plainTextToken);
+
+    const result = await pool.query<{
+      submission_id: string;
+      submission_title: string | null;
+      organization_id: string;
+      organization_name: string;
+      submitter_id: string;
+      revision_notes: string | null;
+    }>('SELECT * FROM get_resubmit_context($1)', [tokenHash]);
+
+    if (result.rows.length === 0) return null;
+
+    const row = result.rows[0];
+    return {
+      submissionId: row.submission_id,
+      title: row.submission_title,
+      organizationId: row.organization_id,
+      organizationName: row.organization_name,
+      submitterId: row.submitter_id,
+      revisionNotes: row.revision_notes,
     };
   },
 };

--- a/apps/api/src/webhooks/tusd.webhook.ts
+++ b/apps/api/src/webhooks/tusd.webhook.ts
@@ -21,6 +21,7 @@ import type { TusdPreCreateResponse } from '@colophony/types';
 import type { Env } from '../config/env.js';
 import { apiKeyService } from '../services/api-key.service.js';
 import { embedTokenService } from '../services/embed-token.service.js';
+import { statusTokenService } from '../services/status-token.service.js';
 import { fileService } from '../services/file.service.js';
 import { auditService } from '../services/audit.service.js';
 import { enqueueFileScan } from '../queues/file-scan.queue.js';
@@ -225,8 +226,12 @@ export async function registerTusdWebhooks(
       forwardedHeaders,
       'X-Embed-Token',
     );
+    const statusTokenHeader = getForwardedHeader(
+      forwardedHeaders,
+      'X-Status-Token',
+    );
 
-    // Extract guest-user-id from metadata (used by embed token auth)
+    // Extract guest-user-id from metadata (used by embed/status token auth)
     const guestUserId = metadata['guest-user-id'];
 
     // Validate token and resolve local user UUID
@@ -321,6 +326,15 @@ export async function registerTusdWebhooks(
         return;
       }
       userId = guestUserId;
+    } else if (statusTokenHeader) {
+      // Status token auth (R&R resubmission by embed submitters)
+      const resubmitCtx =
+        await statusTokenService.getResubmitContext(statusTokenHeader);
+      if (!resubmitCtx) {
+        await reply.status(200).send(rejectUpload(401, 'invalid_status_token'));
+        return;
+      }
+      userId = resubmitCtx.submitterId;
     } else if (env.NODE_ENV === 'test') {
       // Test mode: extract from forwarded test headers
       const testUserId = getForwardedHeader(forwardedHeaders, 'X-Test-User-Id');
@@ -424,10 +438,14 @@ export async function registerTusdWebhooks(
       forwardedHeaders,
       'X-Embed-Token',
     );
+    const postFinishStatusTokenHeader = getForwardedHeader(
+      forwardedHeaders,
+      'X-Status-Token',
+    );
     // orgId is optional — manuscript uploads are user-scoped, not org-scoped
     const orgId = getForwardedHeader(forwardedHeaders, 'X-Organization-Id');
 
-    // Extract guest-user-id from metadata (used by embed token auth)
+    // Extract guest-user-id from metadata (used by embed/status token auth)
     const postFinishGuestUserId = metadata['guest-user-id'];
 
     // Resolve userId from forwarded auth — fail closed if auth is invalid
@@ -500,6 +518,15 @@ export async function registerTusdWebhooks(
         return reply.status(400).send({ error: 'missing_guest_user_id' });
       }
       userId = postFinishGuestUserId;
+    } else if (postFinishStatusTokenHeader) {
+      // Status token auth (R&R resubmission by embed submitters)
+      const resubmitCtx = await statusTokenService.getResubmitContext(
+        postFinishStatusTokenHeader,
+      );
+      if (!resubmitCtx) {
+        return reply.status(401).send({ error: 'invalid_status_token' });
+      }
+      userId = resubmitCtx.submitterId;
     } else if (env.NODE_ENV === 'test') {
       const testUserId = getForwardedHeader(forwardedHeaders, 'X-Test-User-Id');
       if (!testUserId) {

--- a/apps/web/src/app/embed/resubmit/[statusToken]/page.tsx
+++ b/apps/web/src/app/embed/resubmit/[statusToken]/page.tsx
@@ -1,0 +1,12 @@
+import { EmbedResubmit } from "@/components/embed/embed-resubmit";
+
+export default async function EmbedResubmitPage({
+  params,
+}: {
+  params: Promise<{ statusToken: string }>;
+}) {
+  const { statusToken } = await params;
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+
+  return <EmbedResubmit statusToken={statusToken} apiUrl={apiUrl} />;
+}

--- a/apps/web/src/components/embed/embed-resubmit.tsx
+++ b/apps/web/src/components/embed/embed-resubmit.tsx
@@ -1,0 +1,405 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import {
+  fetchResubmitContext,
+  prepareResubmitUpload,
+  fetchResubmitUploadStatus,
+  submitResubmission,
+  type EmbedApiError,
+} from "@/lib/embed-api";
+import type {
+  EmbedResubmitContextResponse,
+  EmbedPrepareUploadResponse,
+  EmbedUploadStatusResponse,
+} from "@colophony/types";
+import { useEmbedFileUpload } from "@/hooks/use-embed-file-upload";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import {
+  Loader2,
+  CheckCircle,
+  AlertCircle,
+  Clock,
+  Upload,
+  File as FileIcon,
+  RefreshCw,
+} from "lucide-react";
+
+type Step = "loading" | "form" | "submitting" | "success" | "error";
+
+interface EmbedResubmitProps {
+  statusToken: string;
+  apiUrl: string;
+}
+
+export function EmbedResubmit({ statusToken, apiUrl }: EmbedResubmitProps) {
+  const [step, setStep] = useState<Step>("loading");
+  const [context, setContext] = useState<EmbedResubmitContextResponse | null>(
+    null,
+  );
+  const [uploadContext, setUploadContext] =
+    useState<EmbedPrepareUploadResponse | null>(null);
+  const [scanFiles, setScanFiles] = useState<
+    EmbedUploadStatusResponse["files"]
+  >([]);
+  const [allClean, setAllClean] = useState(false);
+  const [newStatusToken, setNewStatusToken] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState("");
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Load context + prepare upload on mount
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const ctx = await fetchResubmitContext(apiUrl, statusToken);
+        if (cancelled) return;
+        setContext(ctx);
+
+        const upload = await prepareResubmitUpload(apiUrl, statusToken);
+        if (cancelled) return;
+        setUploadContext(upload);
+        setStep("form");
+      } catch (err) {
+        if (cancelled) return;
+        const apiErr = err as EmbedApiError;
+        if (apiErr.status === 404 || apiErr.status === 410) {
+          setErrorMessage(
+            "This resubmission link is no longer valid. The submission may have already been resubmitted, or the status link has expired.",
+          );
+        } else {
+          setErrorMessage(
+            "Unable to load resubmission form. Please try again.",
+          );
+        }
+        setStep("error");
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [apiUrl, statusToken]);
+
+  // File upload hook — uses status token for tusd auth (not embed token)
+  const { uploadFiles, uploads, isUploading } = useEmbedFileUpload({
+    tusEndpoint: uploadContext?.tusEndpoint ?? "",
+    manuscriptVersionId: uploadContext?.manuscriptVersionId ?? "",
+    guestUserId: uploadContext?.guestUserId ?? "",
+    statusToken,
+    maxFileSize: uploadContext?.maxFileSize ?? 0,
+    maxFiles: uploadContext?.maxFiles ?? 0,
+    allowedMimeTypes: uploadContext?.allowedMimeTypes ?? [],
+  });
+
+  // Poll scan status
+  const startPolling = useCallback(() => {
+    if (!uploadContext?.manuscriptVersionId) return;
+
+    async function poll() {
+      try {
+        const result = await fetchResubmitUploadStatus(
+          apiUrl,
+          statusToken,
+          uploadContext!.manuscriptVersionId,
+        );
+        setScanFiles(result.files);
+        setAllClean(result.allClean);
+
+        const allTerminal =
+          result.files.length > 0 &&
+          result.files.every(
+            (f) =>
+              f.scanStatus === "CLEAN" ||
+              f.scanStatus === "INFECTED" ||
+              f.scanStatus === "FAILED",
+          );
+        if (allTerminal && pollRef.current) {
+          clearInterval(pollRef.current);
+          pollRef.current = null;
+        }
+      } catch {
+        // Silently retry on next interval
+      }
+    }
+
+    poll();
+    pollRef.current = setInterval(poll, 3000);
+  }, [apiUrl, statusToken, uploadContext]);
+
+  // Start polling when uploads complete
+  useEffect(() => {
+    if (uploads.length > 0 && !isUploading) {
+      startPolling();
+    }
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [uploads.length, isUploading, startPolling]);
+
+  // Handle file drop/selection
+  const handleFiles = useCallback(
+    (fileList: FileList | File[]) => {
+      const filesArray = Array.from(fileList);
+      uploadFiles(filesArray);
+    },
+    [uploadFiles],
+  );
+
+  // Handle submit
+  const handleSubmit = useCallback(async () => {
+    if (!uploadContext) return;
+    setStep("submitting");
+
+    try {
+      const result = await submitResubmission(apiUrl, statusToken, {
+        manuscriptVersionId: uploadContext.manuscriptVersionId,
+      });
+      setNewStatusToken(result.statusToken);
+      setStep("success");
+    } catch (err) {
+      const apiErr = err as EmbedApiError;
+      setErrorMessage(apiErr.message || "Failed to submit. Please try again.");
+      setStep("error");
+    }
+  }, [apiUrl, statusToken, uploadContext]);
+
+  const hasInfected = scanFiles.some((f) => f.scanStatus === "INFECTED");
+  const hasPending = scanFiles.some(
+    (f) => f.scanStatus === "PENDING" || f.scanStatus === "SCANNING",
+  );
+  const canSubmit =
+    !isUploading &&
+    !hasInfected &&
+    !hasPending &&
+    scanFiles.length > 0 &&
+    allClean;
+
+  // --- Loading ---
+  if (step === "loading") {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  // --- Error ---
+  if (step === "error") {
+    return (
+      <div className="max-w-md mx-auto text-center py-16 px-4">
+        <AlertCircle className="h-12 w-12 text-destructive mx-auto mb-4" />
+        <h2 className="text-lg font-semibold">Something Went Wrong</h2>
+        <p className="text-sm text-muted-foreground mt-2">{errorMessage}</p>
+      </div>
+    );
+  }
+
+  // --- Success ---
+  if (step === "success") {
+    return (
+      <div className="max-w-md mx-auto text-center py-16 px-4">
+        <CheckCircle className="h-12 w-12 text-green-600 mx-auto mb-4" />
+        <h2 className="text-lg font-semibold">Resubmission Received</h2>
+        <p className="text-sm text-muted-foreground mt-2">
+          Your revised manuscript has been submitted successfully. A new
+          confirmation email has been sent with an updated status link.
+        </p>
+        {newStatusToken && (
+          <a
+            href={`/embed/status/${newStatusToken}`}
+            className="inline-flex items-center gap-2 mt-4 text-sm text-primary hover:underline"
+          >
+            Check submission status
+          </a>
+        )}
+      </div>
+    );
+  }
+
+  // --- Submitting ---
+  if (step === "submitting") {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 gap-3">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">
+          Submitting your revision...
+        </p>
+      </div>
+    );
+  }
+
+  // --- Form ---
+  return (
+    <div className="max-w-lg mx-auto py-8 px-4">
+      <div className="border rounded-lg p-6 space-y-6">
+        {/* Header */}
+        <div className="text-center">
+          <p className="text-sm text-muted-foreground">
+            {context?.organizationName}
+          </p>
+          <h2 className="text-lg font-semibold mt-1">
+            Resubmit Revised Manuscript
+          </h2>
+          {context?.title && (
+            <p className="text-sm text-muted-foreground mt-1">
+              {context.title}
+            </p>
+          )}
+        </div>
+
+        {/* Revision Notes */}
+        {context?.revisionNotes && (
+          <div className="rounded-md bg-blue-50 p-4">
+            <p className="text-xs font-medium text-blue-800 uppercase tracking-wide mb-1">
+              Editor&apos;s Revision Notes
+            </p>
+            <p className="text-sm text-blue-900 whitespace-pre-wrap">
+              {context.revisionNotes}
+            </p>
+          </div>
+        )}
+
+        {/* File Upload */}
+        <div className="space-y-3">
+          <p className="text-sm font-medium">Upload Revised Files</p>
+
+          {/* Drop zone */}
+          <div
+            role="button"
+            tabIndex={0}
+            className={cn(
+              "border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors",
+              "hover:border-primary hover:bg-muted/50",
+              isUploading && "pointer-events-none opacity-50",
+            )}
+            onClick={() => {
+              const input = document.createElement("input");
+              input.type = "file";
+              input.multiple = true;
+              if (uploadContext?.allowedMimeTypes) {
+                input.accept = uploadContext.allowedMimeTypes.join(",");
+              }
+              input.onchange = () => {
+                if (input.files) handleFiles(input.files);
+              };
+              input.click();
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                (e.target as HTMLElement).click();
+              }
+            }}
+            onDragOver={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            onDrop={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              if (e.dataTransfer.files.length > 0) {
+                handleFiles(e.dataTransfer.files);
+              }
+            }}
+          >
+            <Upload className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
+            <p className="text-sm text-muted-foreground">
+              Drop files here or click to browse
+            </p>
+            {uploadContext && (
+              <p className="text-xs text-muted-foreground mt-1">
+                Max {uploadContext.maxFiles} files, up to{" "}
+                {Math.round(uploadContext.maxFileSize / 1024 / 1024)}MB each
+              </p>
+            )}
+          </div>
+
+          {/* Upload progress */}
+          {uploads.map((u) => (
+            <div key={u.id} className="flex items-center gap-2 text-sm">
+              <FileIcon className="h-4 w-4 shrink-0" />
+              <span className="truncate flex-1">{u.file.name}</span>
+              {u.progress < 100 ? (
+                <Progress value={u.progress} className="w-20 h-2" />
+              ) : (
+                <CheckCircle className="h-4 w-4 text-green-600 shrink-0" />
+              )}
+            </div>
+          ))}
+
+          {/* Scan status */}
+          {scanFiles.map((f) => (
+            <div key={f.id} className="flex items-center gap-2 text-sm">
+              <FileIcon className="h-4 w-4 shrink-0" />
+              <span className="truncate flex-1">{f.filename}</span>
+              <ScanBadge status={f.scanStatus} />
+            </div>
+          ))}
+        </div>
+
+        {/* Submit */}
+        <Button onClick={handleSubmit} disabled={!canSubmit} className="w-full">
+          <RefreshCw className="h-4 w-4 mr-2" />
+          Submit Revision
+        </Button>
+
+        {hasInfected && (
+          <p className="text-xs text-destructive text-center">
+            One or more files were flagged as infected. Please upload clean
+            files.
+          </p>
+        )}
+        {hasPending && (
+          <p className="text-xs text-muted-foreground text-center">
+            Waiting for file scanning to complete...
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ScanBadge({ status }: { status: string }) {
+  switch (status) {
+    case "CLEAN":
+      return (
+        <Badge variant="outline" className="bg-green-100 text-green-800 gap-1">
+          <CheckCircle className="h-3 w-3" />
+          Clean
+        </Badge>
+      );
+    case "INFECTED":
+      return (
+        <Badge variant="outline" className="bg-red-100 text-red-800 gap-1">
+          <AlertCircle className="h-3 w-3" />
+          Infected
+        </Badge>
+      );
+    case "SCANNING":
+      return (
+        <Badge
+          variant="outline"
+          className="bg-yellow-100 text-yellow-800 gap-1"
+        >
+          <Loader2 className="h-3 w-3 animate-spin" />
+          Scanning
+        </Badge>
+      );
+    default:
+      return (
+        <Badge variant="outline" className="bg-gray-100 text-gray-800 gap-1">
+          <Clock className="h-3 w-3" />
+          Pending
+        </Badge>
+      );
+  }
+}

--- a/apps/web/src/components/embed/embed-status-check.tsx
+++ b/apps/web/src/components/embed/embed-status-check.tsx
@@ -9,6 +9,7 @@ import {
   XCircle,
   Clock,
   AlertCircle,
+  RefreshCw,
 } from "lucide-react";
 
 type ViewState = "loading" | "loaded" | "not_found" | "token_expired" | "error";
@@ -177,6 +178,22 @@ export function EmbedStatusCheck({
             </div>
           )}
         </div>
+
+        {data.status === "Revision Requested" && (
+          <div className="border-t pt-4">
+            <p className="text-sm text-muted-foreground mb-3">
+              The editors have requested revisions to your submission. You can
+              upload a revised manuscript using the link below.
+            </p>
+            <a
+              href={`/embed/resubmit/${statusToken}`}
+              className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Resubmit Revised Manuscript
+            </a>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/hooks/use-embed-file-upload.ts
+++ b/apps/web/src/hooks/use-embed-file-upload.ts
@@ -8,8 +8,10 @@ interface UseEmbedFileUploadOptions {
   manuscriptVersionId: string;
   guestUserId: string;
   tusEndpoint: string;
-  embedToken: string;
+  embedToken?: string;
+  statusToken?: string;
   maxFileSize: number;
+  maxFiles?: number;
   allowedMimeTypes: string[];
   onUploadComplete?: () => void;
   onError?: (error: string) => void;
@@ -32,6 +34,7 @@ export function useEmbedFileUpload({
   guestUserId,
   tusEndpoint,
   embedToken,
+  statusToken,
   maxFileSize,
   allowedMimeTypes,
   onUploadComplete,
@@ -138,7 +141,8 @@ export function useEmbedFileUpload({
           "manuscript-version-id": manuscriptVersionId,
         },
         headers: {
-          "X-Embed-Token": embedToken,
+          ...(embedToken ? { "X-Embed-Token": embedToken } : {}),
+          ...(statusToken ? { "X-Status-Token": statusToken } : {}),
         },
         onProgress: (bytesUploaded, bytesTotal) => {
           const progress = Math.round((bytesUploaded / bytesTotal) * 100);
@@ -172,6 +176,7 @@ export function useEmbedFileUpload({
       guestUserId,
       tusEndpoint,
       embedToken,
+      statusToken,
       maxFileSize,
       allowedMimeTypes,
       updateUpload,

--- a/apps/web/src/lib/embed-api.ts
+++ b/apps/web/src/lib/embed-api.ts
@@ -5,6 +5,9 @@ import type {
   EmbedPrepareUploadResponse,
   EmbedUploadStatusResponse,
   EmbedStatusCheckResponse,
+  EmbedResubmitContextResponse,
+  EmbedResubmitSubmitInput,
+  EmbedResubmitSubmitResponse,
 } from "@colophony/types";
 
 export interface EmbedApiError {
@@ -104,4 +107,65 @@ export async function fetchSubmissionStatus(
     headers: { Accept: "application/json" },
   });
   return handleResponse<EmbedStatusCheckResponse>(res);
+}
+
+// ---------------------------------------------------------------------------
+// Resubmit (R&R flow)
+// ---------------------------------------------------------------------------
+
+export async function fetchResubmitContext(
+  apiUrl: string,
+  statusToken: string,
+): Promise<EmbedResubmitContextResponse> {
+  const res = await fetch(`${apiUrl}/embed/resubmit/${statusToken}`, {
+    headers: { Accept: "application/json" },
+  });
+  return handleResponse<EmbedResubmitContextResponse>(res);
+}
+
+export async function prepareResubmitUpload(
+  apiUrl: string,
+  statusToken: string,
+): Promise<EmbedPrepareUploadResponse> {
+  const res = await fetch(
+    `${apiUrl}/embed/resubmit/${statusToken}/prepare-upload`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+    },
+  );
+  return handleResponse<EmbedPrepareUploadResponse>(res);
+}
+
+export async function fetchResubmitUploadStatus(
+  apiUrl: string,
+  statusToken: string,
+  manuscriptVersionId: string,
+): Promise<EmbedUploadStatusResponse> {
+  const res = await fetch(
+    `${apiUrl}/embed/resubmit/${statusToken}/upload-status/${manuscriptVersionId}`,
+    {
+      headers: { Accept: "application/json" },
+    },
+  );
+  return handleResponse<EmbedUploadStatusResponse>(res);
+}
+
+export async function submitResubmission(
+  apiUrl: string,
+  statusToken: string,
+  body: EmbedResubmitSubmitInput,
+): Promise<EmbedResubmitSubmitResponse> {
+  const res = await fetch(`${apiUrl}/embed/resubmit/${statusToken}/submit`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  return handleResponse<EmbedResubmitSubmitResponse>(res);
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -361,7 +361,7 @@
 - [x] [P2] Embed submitter confirmation email — send a receipt email to the address provided in the embed identity step; include submission title, journal name, and a status-check token/link — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [x] [P2] Embed submitter status check — public page at `/embed/status/:token` where embed submitters (no account) can check their submission status — (persona gap analysis 2026-02-27; done 2026-02-28)
 - [x] [P3] Embed status check: handle 410 Gone for expired tokens — show user-friendly "token expired" message in `embed-status-check.tsx` — (audit remediation P2/P3, 2026-03-01; done 2026-03-01)
-- [ ] [P3] Status token rotation on R&R resubmission — generate new token when embed submitter resubmits after revise-and-resubmit; no resubmit flow in embed service yet — (audit remediation P2/P3, 2026-03-01)
+- [x] [P3] Status token rotation on R&R resubmission — full embed resubmit flow (backend endpoints + frontend page + token rotation + tusd auth) — (audit remediation P2/P3, 2026-03-01; done 2026-03-22)
 
 ### Editorial Workflow
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-03-22 — R&R Resubmit Flow for Embed Submitters
+
+### Done
+
+- Built full end-to-end R&R resubmit flow for embed (anonymous) submitters — backend endpoints, service layer, frontend page, status token rotation
+- Migration 0055: extended `verify_status_token()` to return `organization_id`/`submitter_id`; added `get_resubmit_context()` SECURITY DEFINER function
+- 4 new embed resubmit endpoints: GET context, POST prepare-upload, GET upload-status, POST submit (all rate-limited, status-token authenticated)
+- 3 new service methods in `embed-submission.service.ts` with defense-in-depth org filtering
+- Added `X-Status-Token` auth to tusd webhook for resubmit file uploads (plan override — tusd needs auth, embed token unavailable in resubmit flow)
+- Frontend: resubmit link on status check page, `/embed/resubmit/[statusToken]` page with file upload + submit
+- Extended `useEmbedFileUpload` hook to support `statusToken` alongside `embedToken`
+- Added `EMBED_SUBMISSION_RESUBMITTED` audit action, `resubmit` flag on `hopper/submission.submitted` event
+- 7 unit tests for resubmit service, 1513 total passing, 13/13 packages type-check clean
+- Codex plan review: 2 Important findings addressed (frontend gap, defense-in-depth), 2 Suggestions addressed (event reuse noted as intentional, audit resource changed to SUBMISSION)
+
+### Decisions
+
+- Status token as resubmit auth mechanism (embed submitters don't retain embed tokens after initial submission)
+- Separate `/embed/resubmit` page rather than modifying existing embed form widget (resubmit is simpler — just file upload, no form fields)
+- Reuse `hopper/submission.submitted` event with `resubmit: true` flag — editors should be notified of resubmissions; embed confirmation function already handles `isEmbed + statusToken`
+
+---
+
 ## 2026-03-22 — Fix Coolify Proxy Restart After Redeploy
 
 ### Done

--- a/packages/db/migrations/0055_status_token_resubmit.sql
+++ b/packages/db/migrations/0055_status_token_resubmit.sql
@@ -39,7 +39,7 @@ RETURNS TABLE(
       SELECT sh.comment
       FROM public.submission_history sh
       WHERE sh.submission_id = s.id
-        AND sh.to_status = 'REVISE_AND_RESUBMIT'
+        AND sh.to_status::text = 'REVISE_AND_RESUBMIT'
       ORDER BY sh.changed_at DESC
       LIMIT 1
     )

--- a/packages/db/migrations/0055_status_token_resubmit.sql
+++ b/packages/db/migrations/0055_status_token_resubmit.sql
@@ -1,0 +1,55 @@
+-- Extend verify_status_token() to also return organization_id and submitter_id.
+-- DROP required: return type changed (added two columns).
+DROP FUNCTION IF EXISTS verify_status_token(varchar);
+--> statement-breakpoint
+CREATE FUNCTION verify_status_token(p_token_hash varchar)
+RETURNS TABLE(
+  submission_id uuid, submission_title varchar,
+  submission_status text, submitted_at timestamptz,
+  organization_name varchar, period_name varchar,
+  token_expired boolean,
+  organization_id uuid, submitter_id uuid
+) LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT s.id, s.title, s.status::text, s.submitted_at, o.name, sp.name,
+    CASE WHEN s.status_token_expires_at IS NOT NULL
+         AND s.status_token_expires_at < NOW()
+    THEN true ELSE false END,
+    s.organization_id, s.submitter_id
+  FROM public.submissions s
+  JOIN public.organizations o ON o.id = s.organization_id
+  LEFT JOIN public.submission_periods sp ON sp.id = s.submission_period_id
+  WHERE s.status_token_hash = p_token_hash
+$$;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION verify_status_token(varchar) FROM PUBLIC;
+--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION verify_status_token(varchar) TO app_user;
+--> statement-breakpoint
+-- get_resubmit_context(): returns submission context for R&R resubmissions.
+-- Only returns data if status is REVISE_AND_RESUBMIT and token is valid + not expired.
+-- SECURITY DEFINER: intentional — same rationale as verify_status_token().
+CREATE FUNCTION get_resubmit_context(p_token_hash varchar)
+RETURNS TABLE(
+  submission_id uuid, submission_title varchar,
+  organization_id uuid, organization_name varchar,
+  submitter_id uuid, revision_notes text
+) LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT s.id, s.title, s.organization_id, o.name, s.submitter_id,
+    (
+      SELECT sh.comment
+      FROM public.submission_history sh
+      WHERE sh.submission_id = s.id
+        AND sh.to_status = 'REVISE_AND_RESUBMIT'
+      ORDER BY sh.changed_at DESC
+      LIMIT 1
+    )
+  FROM public.submissions s
+  JOIN public.organizations o ON o.id = s.organization_id
+  WHERE s.status_token_hash = p_token_hash
+    AND s.status::text = 'REVISE_AND_RESUBMIT'
+    AND (s.status_token_expires_at IS NULL OR s.status_token_expires_at >= NOW())
+$$;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION get_resubmit_context(varchar) FROM PUBLIC;
+--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION get_resubmit_context(varchar) TO app_user;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1780000000000,
       "tag": "0054_revoke_journal_audit_permissions",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1780200000000,
+      "tag": "0055_status_token_resubmit",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -92,6 +92,7 @@ export const AuditActions = {
 
   // Embed submission
   EMBED_SUBMISSION_CREATED: "EMBED_SUBMISSION_CREATED",
+  EMBED_SUBMISSION_RESUBMITTED: "EMBED_SUBMISSION_RESUBMITTED",
 
   // Guest user
   GUEST_USER_CREATED: "GUEST_USER_CREATED",
@@ -431,6 +432,7 @@ export interface EmbedTokenAuditParams extends BaseAuditParams {
     | typeof AuditActions.EMBED_TOKEN_CREATED
     | typeof AuditActions.EMBED_TOKEN_REVOKED
     | typeof AuditActions.EMBED_SUBMISSION_CREATED
+    | typeof AuditActions.EMBED_SUBMISSION_RESUBMITTED
     | typeof AuditActions.GUEST_USER_CREATED;
 }
 

--- a/packages/types/src/embed.ts
+++ b/packages/types/src/embed.ts
@@ -184,6 +184,46 @@ export type EmbedStatusCheckResponse = z.infer<
 >;
 
 // ---------------------------------------------------------------------------
+// Resubmit schemas (R&R flow for embed submitters)
+// ---------------------------------------------------------------------------
+
+export const embedResubmitSubmitSchema = z.object({
+  manuscriptVersionId: z
+    .string()
+    .uuid()
+    .describe("New manuscript version with revised files"),
+});
+
+export type EmbedResubmitSubmitInput = z.infer<
+  typeof embedResubmitSubmitSchema
+>;
+
+export const embedResubmitContextResponseSchema = z.object({
+  submissionId: z.string().uuid().describe("Submission ID"),
+  title: z.string().nullable().describe("Submission title"),
+  organizationName: z.string().describe("Organization name"),
+  revisionNotes: z
+    .string()
+    .describe("Editor's revision notes from R&R transition"),
+});
+
+export type EmbedResubmitContextResponse = z.infer<
+  typeof embedResubmitContextResponseSchema
+>;
+
+export const embedResubmitSubmitResponseSchema = z.object({
+  success: z.literal(true),
+  submissionId: z.string().uuid().describe("Resubmitted submission ID"),
+  statusToken: z
+    .string()
+    .describe("New status check token (rotated on resubmit)"),
+});
+
+export type EmbedResubmitSubmitResponse = z.infer<
+  typeof embedResubmitSubmitResponseSchema
+>;
+
+// ---------------------------------------------------------------------------
 // Revoke schema
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Full end-to-end revise-and-resubmit flow for anonymous embed submitters
- Status check page shows "Resubmit" link when status is "Revision Requested"
- Dedicated `/embed/resubmit/[statusToken]` page with file upload and submit
- Status token rotated on resubmission — new confirmation email with updated status URL
- Backend: migration 0055, 4 new endpoints, 3 service methods, tusd X-Status-Token auth
- code review fixes: reject empty uploads (P1), proper 4xx error responses (P2)

## Test plan

- [x] 7 unit tests for resubmit service (all passing)
- [x] 1513 total unit tests passing, no regressions
- [x] 13/13 packages type-check clean
- [x] plan review: 2 Important + 2 Suggestions addressed
- [x] branch review: 1 P1 + 2 P2 addressed
- [ ] Manual test: create embed submission → editor marks R&R → check status page → resubmit → verify new token

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `tusd.webhook.ts` | Not planned | Added X-Status-Token auth | File uploads require tusd auth; embed token unavailable in resubmit flow |
| `use-embed-file-upload.ts` | Not planned | Extended with statusToken option | tus client needs status token header for resubmit uploads |
| `embed-submission.service.ts` | Audit resource SUBMISSION | Uses EMBED_TOKEN | Consistent with existing embed audit patterns |
| `embed.routes.ts` | 410 for expired, 409 for wrong status | 404 for all invalid-token cases | Simpler — status token auth collapses invalid/expired/wrong-status into single null check |