### PR TITLE
fix: add Bearer token auth to Coolify webhook request

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,6 +118,7 @@ jobs:
           HTTP_CODE=$(curl -s -o /tmp/coolify-response.txt -w "%{http_code}" \
             --max-time 30 \
             -X GET \
+            -H "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}" \
             "${{ secrets.COOLIFY_WEBHOOK_URL }}" \
             2>/tmp/coolify-error.txt)
           BODY=$(cat /tmp/coolify-response.txt 2>/dev/null || true)


### PR DESCRIPTION
## Summary

Coolify API returns 401 `{"message":"Unauthenticated."}` without an Authorization header. Add `COOLIFY_API_TOKEN` as a Bearer token.

**Requires:** Add `COOLIFY_API_TOKEN` as a secret in GitHub → Settings → Environments → staging (create an API token in Coolify → Settings → API Tokens).