### PR TITLE
fix: add token diagnostic to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,6 +123,15 @@ jobs:
             exit 1
           fi
           echo "Token length: ${#COOLIFY_TOKEN} chars"
+          echo "Token first char: $(echo "$COOLIFY_TOKEN" | cut -c1)"
+          echo "Token char 2: $(echo "$COOLIFY_TOKEN" | cut -c2)"
+          # Test token against version endpoint first
+          TEST_CODE=$(curl -s -o /tmp/coolify-test.txt -w "%{http_code}" \
+            --max-time 10 \
+            -H "Authorization: Bearer ${COOLIFY_TOKEN}" \
+            "http://5.78.179.142:8000/api/v1/version" 2>/dev/null)
+          TEST_BODY=$(cat /tmp/coolify-test.txt 2>/dev/null || true)
+          echo "Token test against /version: HTTP ${TEST_CODE} — ${TEST_BODY}"
           if [ -z "$COOLIFY_URL" ]; then
             echo "ERROR: COOLIFY_WEBHOOK_URL secret is empty"
             exit 1


### PR DESCRIPTION
## Summary

Debug 401 from Coolify webhook. This adds:
- Token first 2 characters logged (to verify no corruption)
- Direct test of token against `/api/v1/version` endpoint before attempting deploy
- This will isolate whether the issue is the token itself or the webhook URL