### PR TITLE
build(deps): migrate Inngest from v3 to v4

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -56,7 +56,7 @@
     "fastify": "^5.8.2",
     "fastify-plugin": "^5.0.0",
     "fastify-raw-body": "^5.0.0",
-    "inngest": "^3.52.6",
+    "inngest": "^4.0.4",
     "ioredis": "^5.10.1",
     "jose": "^6.2.2",
     "mjml": "^4.18.0",

--- a/apps/api/src/inngest/functions/__tests__/embed-submission-confirmation.spec.ts
+++ b/apps/api/src/inngest/functions/__tests__/embed-submission-confirmation.spec.ts
@@ -45,9 +45,7 @@ vi.mock('../../../config/env.js', () => ({
 
 vi.mock('../../client.js', () => ({
   inngest: {
-    createFunction: vi.fn(
-      (_config: unknown, _trigger: unknown, handler: unknown) => handler,
-    ),
+    createFunction: vi.fn((_config: unknown, handler: unknown) => handler),
   },
 }));
 

--- a/apps/api/src/inngest/functions/__tests__/submission-notifications.spec.ts
+++ b/apps/api/src/inngest/functions/__tests__/submission-notifications.spec.ts
@@ -68,9 +68,7 @@ vi.mock('../../../config/env.js', () => ({
 // Mock Inngest client — return the handler function directly
 vi.mock('../../client.js', () => ({
   inngest: {
-    createFunction: vi.fn(
-      (_config: unknown, _trigger: unknown, handler: unknown) => handler,
-    ),
+    createFunction: vi.fn((_config: unknown, handler: unknown) => handler),
   },
 }));
 

--- a/apps/api/src/inngest/functions/__tests__/submission-response-reminder.spec.ts
+++ b/apps/api/src/inngest/functions/__tests__/submission-response-reminder.spec.ts
@@ -60,9 +60,7 @@ vi.mock('../../../config/env.js', () => ({
 
 vi.mock('../../client.js', () => ({
   inngest: {
-    createFunction: vi.fn(
-      (_config: unknown, _trigger: unknown, handler: unknown) => handler,
-    ),
+    createFunction: vi.fn((_config: unknown, handler: unknown) => handler),
   },
 }));
 

--- a/apps/api/src/inngest/functions/__tests__/webhook-delivery.spec.ts
+++ b/apps/api/src/inngest/functions/__tests__/webhook-delivery.spec.ts
@@ -29,8 +29,7 @@ vi.mock('@colophony/db', () => ({
 
 // Mock Inngest client — capture function config
 let capturedFunction: {
-  config: Record<string, unknown>;
-  triggers: unknown[];
+  config: Record<string, unknown> & { triggers?: unknown[] };
   handler: (args: {
     event: Record<string, unknown>;
     step: Record<string, unknown>;
@@ -41,11 +40,10 @@ vi.mock('../../client.js', () => ({
   inngest: {
     createFunction: (
       config: Record<string, unknown>,
-      triggers: unknown[],
       handler: (args: Record<string, unknown>) => Promise<unknown>,
     ) => {
-      capturedFunction = { config, triggers, handler };
-      return { config, triggers, handler };
+      capturedFunction = { config, handler };
+      return { config, handler };
     },
   },
 }));
@@ -61,8 +59,9 @@ describe('webhookDelivery Inngest function', () => {
   });
 
   it('listens to all expected event types', () => {
-    expect(capturedFunction.triggers).toHaveLength(10);
-    const eventNames = capturedFunction.triggers.map(
+    const triggers = capturedFunction.config.triggers as unknown[];
+    expect(triggers).toHaveLength(10);
+    const eventNames = triggers.map(
       (t: unknown) => (t as { event: string }).event,
     );
     expect(eventNames).toContain('hopper/submission.submitted');

--- a/apps/api/src/inngest/functions/cms-publish.spec.ts
+++ b/apps/api/src/inngest/functions/cms-publish.spec.ts
@@ -58,7 +58,6 @@ vi.mock('../client.js', () => ({
   inngest: {
     createFunction: (
       _config: Record<string, unknown>,
-      _triggers: unknown,
       handler: (args: Record<string, unknown>) => Promise<unknown>,
     ) => {
       capturedFunction = { handler };

--- a/apps/api/src/inngest/functions/cms-publish.ts
+++ b/apps/api/src/inngest/functions/cms-publish.ts
@@ -1,3 +1,4 @@
+import type { InngestFunction } from 'inngest';
 import { inngest } from '../client.js';
 import {
   withRls,
@@ -19,13 +20,13 @@ import type { CmsIssuePayload } from '../../adapters/cms/cms-adapter.interface.j
  * For each active CMS connection linked to the issue's publication,
  * publishes the issue content via the appropriate CMS adapter.
  */
-export const cmsPublishWorkflow = inngest.createFunction(
+export const cmsPublishWorkflow: InngestFunction.Any = inngest.createFunction(
   {
     id: 'slate-cms-publish',
     name: 'Slate: Publish issue to CMS',
     retries: 3,
+    triggers: [{ event: 'slate/issue.published' }],
   },
-  { event: 'slate/issue.published' },
   async ({ event, step }) => {
     const { orgId, issueId, publicationId } = event.data;
 
@@ -74,7 +75,34 @@ export const cmsPublishWorkflow = inngest.createFunction(
       });
     });
 
-    const { issue, sections, items, pieceData, connections } = data;
+    const { issue, sections, items, pieceData, connections } = data as {
+      issue: {
+        title: string;
+        volume: number | null;
+        issueNumber: number | null;
+        description: string | null;
+        coverImageUrl: string | null;
+        publicationDate: string | Date | null;
+      };
+      sections: { id: string; title: string }[];
+      items: {
+        pipelineItemId: string;
+        sortOrder: number;
+        issueSectionId: string | null;
+      }[];
+      pieceData: {
+        pipelineItemId: string;
+        title: string | null;
+        content: string | null;
+        submitterDisplayName: string | null;
+        submitterEmail: string;
+      }[];
+      connections: {
+        id: string;
+        adapterType: 'WORDPRESS' | 'GHOST';
+        config: unknown;
+      }[];
+    };
 
     if (connections.length === 0) {
       return { status: 'skipped', reason: 'No active CMS connections' };

--- a/apps/api/src/inngest/functions/contract-workflow.spec.ts
+++ b/apps/api/src/inngest/functions/contract-workflow.spec.ts
@@ -48,7 +48,6 @@ vi.mock('../client.js', () => ({
   inngest: {
     createFunction: (
       _config: Record<string, unknown>,
-      _triggers: unknown,
       handler: (args: Record<string, unknown>) => Promise<unknown>,
     ) => {
       capturedFunction = { handler };

--- a/apps/api/src/inngest/functions/contract-workflow.ts
+++ b/apps/api/src/inngest/functions/contract-workflow.ts
@@ -1,3 +1,4 @@
+import type { InngestFunction } from 'inngest';
 import {
   withRls,
   pipelineItems,
@@ -21,13 +22,13 @@ import { validateEnv } from '../../config/env.js';
  *
  *   DRAFT → SENT → SIGNED → COMPLETED
  */
-export const contractWorkflow = inngest.createFunction(
+export const contractWorkflow: InngestFunction.Any = inngest.createFunction(
   {
     id: 'contract-workflow',
     name: 'Contract Signing Workflow',
     retries: 3,
+    triggers: [{ event: 'slate/contract.generated' }],
   },
-  { event: 'slate/contract.generated' },
   async ({ event, step }) => {
     const { orgId, contractId, pipelineItemId } =
       event.data as ContractGeneratedEvent['data'];

--- a/apps/api/src/inngest/functions/discussion-notifications.ts
+++ b/apps/api/src/inngest/functions/discussion-notifications.ts
@@ -1,3 +1,4 @@
+import type { InngestFunction } from 'inngest';
 import {
   withRls,
   db,
@@ -107,68 +108,69 @@ async function queueEmailForRecipient(params: {
 // Inngest function
 // ---------------------------------------------------------------------------
 
-export const discussionCommentNotification = inngest.createFunction(
-  {
-    id: 'discussion-comment-notification',
-    name: 'Discussion Comment Notification',
-    retries: 3,
-  },
-  { event: 'hopper/discussion.comment_added' },
-  async ({ event, step }) => {
-    const { orgId, submissionId, authorId, recipientUserIds } =
-      event.data as HopperDiscussionCommentEvent['data'];
+export const discussionCommentNotification: InngestFunction.Any =
+  inngest.createFunction(
+    {
+      id: 'discussion-comment-notification',
+      name: 'Discussion Comment Notification',
+      retries: 3,
+      triggers: [{ event: 'hopper/discussion.comment_added' }],
+    },
+    async ({ event, step }) => {
+      const { orgId, submissionId, authorId, recipientUserIds } =
+        event.data as HopperDiscussionCommentEvent['data'];
 
-    const { submission, orgName } = await step.run('resolve-data', async () =>
-      getSubmissionAndOrg(orgId, submissionId),
-    );
-
-    if (!submission) return { skipped: true, reason: 'submission-not-found' };
-
-    const author = await step.run('get-author', async () =>
-      getUserEmail(authorId),
-    );
-
-    const authorName = author?.email ?? 'A team member';
-
-    let notified = 0;
-
-    for (const recipientId of recipientUserIds) {
-      const recipient = await step.run(
-        `get-recipient-${recipientId}`,
-        async () => getUserEmail(recipientId),
+      const { submission, orgName } = await step.run('resolve-data', async () =>
+        getSubmissionAndOrg(orgId, submissionId),
       );
 
-      if (!recipient) continue;
+      if (!submission) return { skipped: true, reason: 'submission-not-found' };
 
-      await step.run(`queue-email-${recipientId}`, async () => {
-        await queueEmailForRecipient({
-          orgId,
-          userId: recipientId,
-          email: recipient.email,
-          eventType: 'discussion.comment_added',
-          templateName: 'discussion-comment',
-          templateData: {
-            submissionTitle: submission.title,
-            orgName,
-            authorName,
-          },
-          subject: `New discussion comment on: ${submission.title}`,
+      const author = await step.run('get-author', async () =>
+        getUserEmail(authorId),
+      );
+
+      const authorName = author?.email ?? 'A team member';
+
+      let notified = 0;
+
+      for (const recipientId of recipientUserIds) {
+        const recipient = await step.run(
+          `get-recipient-${recipientId}`,
+          async () => getUserEmail(recipientId),
+        );
+
+        if (!recipient) continue;
+
+        await step.run(`queue-email-${recipientId}`, async () => {
+          await queueEmailForRecipient({
+            orgId,
+            userId: recipientId,
+            email: recipient.email,
+            eventType: 'discussion.comment_added',
+            templateName: 'discussion-comment',
+            templateData: {
+              submissionTitle: submission.title,
+              orgName,
+              authorName,
+            },
+            subject: `New discussion comment on: ${submission.title}`,
+          });
         });
-      });
 
-      await step.run(`queue-in-app-${recipientId}`, async () => {
-        await queueInAppNotification({
-          orgId,
-          userId: recipientId,
-          eventType: 'discussion.comment_added',
-          title: `${authorName} commented on the discussion for: ${submission.title}`,
-          link: `/submissions/${submissionId}`,
+        await step.run(`queue-in-app-${recipientId}`, async () => {
+          await queueInAppNotification({
+            orgId,
+            userId: recipientId,
+            eventType: 'discussion.comment_added',
+            title: `${authorName} commented on the discussion for: ${submission.title}`,
+            link: `/submissions/${submissionId}`,
+          });
         });
-      });
 
-      notified++;
-    }
+        notified++;
+      }
 
-    return { notified };
-  },
-);
+      return { notified };
+    },
+  );

--- a/apps/api/src/inngest/functions/embed-submission-confirmation.ts
+++ b/apps/api/src/inngest/functions/embed-submission-confirmation.ts
@@ -1,3 +1,4 @@
+import type { InngestFunction } from 'inngest';
 import { withRls, submissions, organizations, eq } from '@colophony/db';
 import { AuditActions, AuditResources } from '@colophony/types';
 import { inngest } from '../client.js';
@@ -7,87 +8,88 @@ import { auditService } from '../../services/audit.service.js';
 import { enqueueEmail } from '../../queues/email.queue.js';
 import { validateEnv } from '../../config/env.js';
 
-export const embedSubmissionConfirmation = inngest.createFunction(
-  {
-    id: 'embed-submission-confirmation',
-    name: 'Embed Submission Confirmation Email',
-    retries: 3,
-  },
-  { event: 'hopper/submission.submitted' },
-  async ({ event, step }) => {
-    const { orgId, submissionId, isEmbed, submitterEmail, statusToken } =
-      event.data as HopperSubmissionSubmittedEvent['data'];
+export const embedSubmissionConfirmation: InngestFunction.Any =
+  inngest.createFunction(
+    {
+      id: 'embed-submission-confirmation',
+      name: 'Embed Submission Confirmation Email',
+      retries: 3,
+      triggers: [{ event: 'hopper/submission.submitted' }],
+    },
+    async ({ event, step }) => {
+      const { orgId, submissionId, isEmbed, submitterEmail, statusToken } =
+        event.data as HopperSubmissionSubmittedEvent['data'];
 
-    // Only handle embed submissions
-    if (!isEmbed || !submitterEmail || !statusToken) {
-      return { skipped: true, reason: 'not-embed-submission' };
-    }
+      // Only handle embed submissions
+      if (!isEmbed || !submitterEmail || !statusToken) {
+        return { skipped: true, reason: 'not-embed-submission' };
+      }
 
-    const env = validateEnv();
-    if (env.EMAIL_PROVIDER === 'none') {
-      return { skipped: true, reason: 'email-disabled' };
-    }
+      const env = validateEnv();
+      if (env.EMAIL_PROVIDER === 'none') {
+        return { skipped: true, reason: 'email-disabled' };
+      }
 
-    const data = await step.run('resolve-data', async () => {
-      return withRls({ orgId }, async (tx) => {
-        const [submission] = await tx
-          .select({ title: submissions.title })
-          .from(submissions)
-          .where(eq(submissions.id, submissionId))
-          .limit(1);
+      const data = await step.run('resolve-data', async () => {
+        return withRls({ orgId }, async (tx) => {
+          const [submission] = await tx
+            .select({ title: submissions.title })
+            .from(submissions)
+            .where(eq(submissions.id, submissionId))
+            .limit(1);
 
-        const [org] = await tx
-          .select({ name: organizations.name })
-          .from(organizations)
-          .where(eq(organizations.id, orgId))
-          .limit(1);
+          const [org] = await tx
+            .select({ name: organizations.name })
+            .from(organizations)
+            .where(eq(organizations.id, orgId))
+            .limit(1);
 
-        return {
-          submissionTitle: submission?.title ?? 'Untitled',
-          orgName: org?.name ?? 'Unknown Organization',
-        };
-      });
-    });
-
-    const statusCheckUrl = `${env.CORS_ORIGIN}/embed/status/${statusToken}`;
-
-    await step.run('queue-confirmation-email', async () => {
-      const emailSend = await withRls({ orgId }, async (tx) => {
-        const row = await emailService.create(tx, {
-          organizationId: orgId,
-          recipientEmail: submitterEmail,
-          templateName: 'embed-submission-confirmation',
-          eventType: 'embed.submission.confirmation',
-          subject: `Submission received: ${data.submissionTitle}`,
+          return {
+            submissionTitle: submission?.title ?? 'Untitled',
+            orgName: org?.name ?? 'Unknown Organization',
+          };
         });
-        await auditService.log(tx, {
-          resource: AuditResources.EMAIL,
-          action: AuditActions.EMAIL_QUEUED,
-          resourceId: row.id,
-          organizationId: orgId,
-          newValue: {
-            to: submitterEmail,
+      });
+
+      const statusCheckUrl = `${env.CORS_ORIGIN}/embed/status/${statusToken}`;
+
+      await step.run('queue-confirmation-email', async () => {
+        const emailSend = await withRls({ orgId }, async (tx) => {
+          const row = await emailService.create(tx, {
+            organizationId: orgId,
+            recipientEmail: submitterEmail,
             templateName: 'embed-submission-confirmation',
             eventType: 'embed.submission.confirmation',
+            subject: `Submission received: ${data.submissionTitle}`,
+          });
+          await auditService.log(tx, {
+            resource: AuditResources.EMAIL,
+            action: AuditActions.EMAIL_QUEUED,
+            resourceId: row.id,
+            organizationId: orgId,
+            newValue: {
+              to: submitterEmail,
+              templateName: 'embed-submission-confirmation',
+              eventType: 'embed.submission.confirmation',
+            },
+          });
+          return row;
+        });
+
+        await enqueueEmail(env, {
+          emailSendId: emailSend.id,
+          orgId,
+          to: submitterEmail,
+          from: env.SMTP_FROM ?? env.SENDGRID_FROM ?? 'noreply@colophony.dev',
+          templateName: 'embed-submission-confirmation',
+          templateData: {
+            submissionTitle: data.submissionTitle,
+            orgName: data.orgName,
+            statusCheckUrl,
           },
         });
-        return row;
       });
 
-      await enqueueEmail(env, {
-        emailSendId: emailSend.id,
-        orgId,
-        to: submitterEmail,
-        from: env.SMTP_FROM ?? env.SENDGRID_FROM ?? 'noreply@colophony.dev',
-        templateName: 'embed-submission-confirmation',
-        templateData: {
-          submissionTitle: data.submissionTitle,
-          orgName: data.orgName,
-          statusCheckUrl,
-        },
-      });
-    });
-
-    return { sent: true, to: submitterEmail };
-  },
-);
+      return { sent: true, to: submitterEmail };
+    },
+  );

--- a/apps/api/src/inngest/functions/pipeline-workflow.ts
+++ b/apps/api/src/inngest/functions/pipeline-workflow.ts
@@ -1,3 +1,4 @@
+import type { InngestFunction } from 'inngest';
 import { withRls } from '@colophony/db';
 import { inngest } from '../client.js';
 import type { SubmissionAcceptedEvent } from '../events.js';
@@ -16,13 +17,13 @@ import { pipelineService } from '../../services/pipeline.service.js';
  * the corresponding Inngest event dispatched by the API when a user performs
  * an action (e.g., assigns a copyeditor, marks copyedit complete).
  */
-export const pipelineWorkflow = inngest.createFunction(
+export const pipelineWorkflow: InngestFunction.Any = inngest.createFunction(
   {
     id: 'pipeline-workflow',
     name: 'Publication Pipeline Workflow',
     retries: 3,
+    triggers: [{ event: 'slate/submission.accepted' }],
   },
-  { event: 'slate/submission.accepted' },
   async ({ event, step }) => {
     const { orgId, submissionId, publicationId } =
       event.data as SubmissionAcceptedEvent['data'];

--- a/apps/api/src/inngest/functions/reviewer-notifications.ts
+++ b/apps/api/src/inngest/functions/reviewer-notifications.ts
@@ -1,3 +1,4 @@
+import type { InngestFunction } from 'inngest';
 import {
   withRls,
   db,
@@ -107,59 +108,60 @@ async function queueEmailForRecipient(params: {
 // Inngest function
 // ---------------------------------------------------------------------------
 
-export const reviewerAssignedNotification = inngest.createFunction(
-  {
-    id: 'reviewer-assigned-notification',
-    name: 'Reviewer Assigned Notification',
-    retries: 3,
-  },
-  { event: 'hopper/reviewer.assigned' },
-  async ({ event, step }) => {
-    const { orgId, submissionId, reviewerUserId, assignedBy } =
-      event.data as HopperReviewerAssignedEvent['data'];
+export const reviewerAssignedNotification: InngestFunction.Any =
+  inngest.createFunction(
+    {
+      id: 'reviewer-assigned-notification',
+      name: 'Reviewer Assigned Notification',
+      retries: 3,
+      triggers: [{ event: 'hopper/reviewer.assigned' }],
+    },
+    async ({ event, step }) => {
+      const { orgId, submissionId, reviewerUserId, assignedBy } =
+        event.data as HopperReviewerAssignedEvent['data'];
 
-    const { submission, orgName } = await step.run('resolve-data', async () =>
-      getSubmissionAndOrg(orgId, submissionId),
-    );
+      const { submission, orgName } = await step.run('resolve-data', async () =>
+        getSubmissionAndOrg(orgId, submissionId),
+      );
 
-    if (!submission) return { skipped: true, reason: 'submission-not-found' };
+      if (!submission) return { skipped: true, reason: 'submission-not-found' };
 
-    const reviewer = await step.run('get-reviewer', async () =>
-      getUserEmail(reviewerUserId),
-    );
+      const reviewer = await step.run('get-reviewer', async () =>
+        getUserEmail(reviewerUserId),
+      );
 
-    if (!reviewer) return { skipped: true, reason: 'reviewer-not-found' };
+      if (!reviewer) return { skipped: true, reason: 'reviewer-not-found' };
 
-    const assigner = await step.run('get-assigner', async () =>
-      getUserEmail(assignedBy),
-    );
+      const assigner = await step.run('get-assigner', async () =>
+        getUserEmail(assignedBy),
+      );
 
-    await step.run('queue-email', async () => {
-      await queueEmailForRecipient({
-        orgId,
-        userId: reviewerUserId,
-        email: reviewer.email,
-        eventType: 'reviewer.assigned',
-        templateName: 'reviewer-assigned',
-        templateData: {
-          submissionTitle: submission.title,
-          orgName,
-          assignedByName: assigner?.email ?? 'An editor',
-        },
-        subject: `You've been assigned to review: ${submission.title}`,
+      await step.run('queue-email', async () => {
+        await queueEmailForRecipient({
+          orgId,
+          userId: reviewerUserId,
+          email: reviewer.email,
+          eventType: 'reviewer.assigned',
+          templateName: 'reviewer-assigned',
+          templateData: {
+            submissionTitle: submission.title,
+            orgName,
+            assignedByName: assigner?.email ?? 'An editor',
+          },
+          subject: `You've been assigned to review: ${submission.title}`,
+        });
       });
-    });
 
-    await step.run('queue-in-app', async () => {
-      await queueInAppNotification({
-        orgId,
-        userId: reviewerUserId,
-        eventType: 'reviewer.assigned',
-        title: `You've been assigned to review: ${submission.title}`,
-        link: `/submissions/${submissionId}`,
+      await step.run('queue-in-app', async () => {
+        await queueInAppNotification({
+          orgId,
+          userId: reviewerUserId,
+          eventType: 'reviewer.assigned',
+          title: `You've been assigned to review: ${submission.title}`,
+          link: `/submissions/${submissionId}`,
+        });
       });
-    });
 
-    return { notified: 1 };
-  },
-);
+      return { notified: 1 };
+    },
+  );

--- a/apps/api/src/inngest/functions/slate-notifications.ts
+++ b/apps/api/src/inngest/functions/slate-notifications.ts
@@ -1,3 +1,4 @@
+import type { InngestFunction } from 'inngest';
 import {
   withRls,
   db,
@@ -93,164 +94,166 @@ async function queueEmailForRecipient(params: {
 // Inngest functions
 // ---------------------------------------------------------------------------
 
-export const contractReadyNotification = inngest.createFunction(
-  {
-    id: 'contract-ready-notification',
-    name: 'Contract Ready Notification',
-    retries: 3,
-  },
-  { event: 'slate/contract.generated' },
-  async ({ event, step }) => {
-    const { orgId, pipelineItemId } =
-      event.data as ContractGeneratedEvent['data'];
+export const contractReadyNotification: InngestFunction.Any =
+  inngest.createFunction(
+    {
+      id: 'contract-ready-notification',
+      name: 'Contract Ready Notification',
+      retries: 3,
+      triggers: [{ event: 'slate/contract.generated' }],
+    },
+    async ({ event, step }) => {
+      const { orgId, pipelineItemId } =
+        event.data as ContractGeneratedEvent['data'];
 
-    const data = await step.run('resolve-data', async () => {
-      return withRls({ orgId }, async (tx) => {
-        // Get pipeline item → submission → submitter
-        const [item] = await tx
-          .select({ submissionId: pipelineItems.submissionId })
-          .from(pipelineItems)
-          .where(eq(pipelineItems.id, pipelineItemId))
-          .limit(1);
+      const data = await step.run('resolve-data', async () => {
+        return withRls({ orgId }, async (tx) => {
+          // Get pipeline item → submission → submitter
+          const [item] = await tx
+            .select({ submissionId: pipelineItems.submissionId })
+            .from(pipelineItems)
+            .where(eq(pipelineItems.id, pipelineItemId))
+            .limit(1);
 
-        if (!item) return null;
+          if (!item) return null;
 
-        const [submission] = await tx
-          .select({
-            title: submissions.title,
-            submitterId: submissions.submitterId,
-          })
-          .from(submissions)
-          .where(eq(submissions.id, item.submissionId))
-          .limit(1);
+          const [submission] = await tx
+            .select({
+              title: submissions.title,
+              submitterId: submissions.submitterId,
+            })
+            .from(submissions)
+            .where(eq(submissions.id, item.submissionId))
+            .limit(1);
 
-        const [org] = await tx
-          .select({ name: organizations.name })
-          .from(organizations)
-          .where(eq(organizations.id, orgId))
-          .limit(1);
+          const [org] = await tx
+            .select({ name: organizations.name })
+            .from(organizations)
+            .where(eq(organizations.id, orgId))
+            .limit(1);
 
-        return {
-          submissionTitle: submission?.title ?? 'Unknown',
-          submitterId: submission?.submitterId,
-          orgName: org?.name ?? 'Unknown Organization',
-        };
+          return {
+            submissionTitle: submission?.title ?? 'Unknown',
+            submitterId: submission?.submitterId,
+            orgName: org?.name ?? 'Unknown Organization',
+          };
+        });
       });
-    });
 
-    if (!data?.submitterId)
-      return { skipped: true, reason: 'no-submitter-found' };
+      if (!data?.submitterId)
+        return { skipped: true, reason: 'no-submitter-found' };
 
-    const submitter = await step.run('get-submitter', async () =>
-      getUserEmail(data.submitterId!),
-    );
+      const submitter = await step.run('get-submitter', async () =>
+        getUserEmail(data.submitterId),
+      );
 
-    if (!submitter) return { skipped: true, reason: 'submitter-not-found' };
+      if (!submitter) return { skipped: true, reason: 'submitter-not-found' };
 
-    await step.run('queue-email', async () => {
-      await queueEmailForRecipient({
-        orgId,
-        userId: data.submitterId!,
-        email: submitter.email,
-        eventType: 'contract.ready',
-        templateName: 'contract-ready',
-        templateData: {
-          submissionTitle: data.submissionTitle,
-          signerName: submitter.email,
-          orgName: data.orgName,
-        },
-        subject: `Contract ready for signing: ${data.submissionTitle}`,
+      await step.run('queue-email', async () => {
+        await queueEmailForRecipient({
+          orgId,
+          userId: data.submitterId!,
+          email: submitter.email,
+          eventType: 'contract.ready',
+          templateName: 'contract-ready',
+          templateData: {
+            submissionTitle: data.submissionTitle,
+            signerName: submitter.email,
+            orgName: data.orgName,
+          },
+          subject: `Contract ready for signing: ${data.submissionTitle}`,
+        });
       });
-    });
 
-    await step.run('queue-in-app', async () => {
-      await queueInAppNotification({
-        orgId,
-        userId: data.submitterId!,
-        eventType: 'contract.ready',
-        title: `Contract ready for signing: ${data.submissionTitle}`,
-        link: '/contracts',
+      await step.run('queue-in-app', async () => {
+        await queueInAppNotification({
+          orgId,
+          userId: data.submitterId!,
+          eventType: 'contract.ready',
+          title: `Contract ready for signing: ${data.submissionTitle}`,
+          link: '/contracts',
+        });
       });
-    });
 
-    return { notified: 1 };
-  },
-);
+      return { notified: 1 };
+    },
+  );
 
-export const copyeditorAssignedNotification = inngest.createFunction(
-  {
-    id: 'copyeditor-assigned-notification',
-    name: 'Copyeditor Assigned Notification',
-    retries: 3,
-  },
-  { event: 'slate/pipeline.copyeditor-assigned' },
-  async ({ event, step }) => {
-    const { orgId, pipelineItemId, copyeditorId } =
-      event.data as CopyeditorAssignedEvent['data'];
+export const copyeditorAssignedNotification: InngestFunction.Any =
+  inngest.createFunction(
+    {
+      id: 'copyeditor-assigned-notification',
+      name: 'Copyeditor Assigned Notification',
+      retries: 3,
+      triggers: [{ event: 'slate/pipeline.copyeditor-assigned' }],
+    },
+    async ({ event, step }) => {
+      const { orgId, pipelineItemId, copyeditorId } =
+        event.data as CopyeditorAssignedEvent['data'];
 
-    const data = await step.run('resolve-data', async () => {
-      return withRls({ orgId }, async (tx) => {
-        const [item] = await tx
-          .select({ submissionId: pipelineItems.submissionId })
-          .from(pipelineItems)
-          .where(eq(pipelineItems.id, pipelineItemId))
-          .limit(1);
+      const data = await step.run('resolve-data', async () => {
+        return withRls({ orgId }, async (tx) => {
+          const [item] = await tx
+            .select({ submissionId: pipelineItems.submissionId })
+            .from(pipelineItems)
+            .where(eq(pipelineItems.id, pipelineItemId))
+            .limit(1);
 
-        if (!item) return null;
+          if (!item) return null;
 
-        const [submission] = await tx
-          .select({ title: submissions.title })
-          .from(submissions)
-          .where(eq(submissions.id, item.submissionId))
-          .limit(1);
+          const [submission] = await tx
+            .select({ title: submissions.title })
+            .from(submissions)
+            .where(eq(submissions.id, item.submissionId))
+            .limit(1);
 
-        const [org] = await tx
-          .select({ name: organizations.name })
-          .from(organizations)
-          .where(eq(organizations.id, orgId))
-          .limit(1);
+          const [org] = await tx
+            .select({ name: organizations.name })
+            .from(organizations)
+            .where(eq(organizations.id, orgId))
+            .limit(1);
 
-        return {
-          submissionTitle: submission?.title ?? 'Unknown',
-          orgName: org?.name ?? 'Unknown Organization',
-        };
+          return {
+            submissionTitle: submission?.title ?? 'Unknown',
+            orgName: org?.name ?? 'Unknown Organization',
+          };
+        });
       });
-    });
 
-    if (!data) return { skipped: true, reason: 'pipeline-item-not-found' };
+      if (!data) return { skipped: true, reason: 'pipeline-item-not-found' };
 
-    const copyeditor = await step.run('get-copyeditor', async () =>
-      getUserEmail(copyeditorId),
-    );
+      const copyeditor = await step.run('get-copyeditor', async () =>
+        getUserEmail(copyeditorId),
+      );
 
-    if (!copyeditor) return { skipped: true, reason: 'copyeditor-not-found' };
+      if (!copyeditor) return { skipped: true, reason: 'copyeditor-not-found' };
 
-    await step.run('queue-email', async () => {
-      await queueEmailForRecipient({
-        orgId,
-        userId: copyeditorId,
-        email: copyeditor.email,
-        eventType: 'copyeditor.assigned',
-        templateName: 'copyeditor-assigned',
-        templateData: {
-          submissionTitle: data.submissionTitle,
-          copyeditorName: copyeditor.email,
-          orgName: data.orgName,
-        },
-        subject: `You've been assigned as copyeditor: ${data.submissionTitle}`,
+      await step.run('queue-email', async () => {
+        await queueEmailForRecipient({
+          orgId,
+          userId: copyeditorId,
+          email: copyeditor.email,
+          eventType: 'copyeditor.assigned',
+          templateName: 'copyeditor-assigned',
+          templateData: {
+            submissionTitle: data.submissionTitle,
+            copyeditorName: copyeditor.email,
+            orgName: data.orgName,
+          },
+          subject: `You've been assigned as copyeditor: ${data.submissionTitle}`,
+        });
       });
-    });
 
-    await step.run('queue-in-app', async () => {
-      await queueInAppNotification({
-        orgId,
-        userId: copyeditorId,
-        eventType: 'copyeditor.assigned',
-        title: `You've been assigned as copyeditor: ${data.submissionTitle}`,
-        link: '/pipeline',
+      await step.run('queue-in-app', async () => {
+        await queueInAppNotification({
+          orgId,
+          userId: copyeditorId,
+          eventType: 'copyeditor.assigned',
+          title: `You've been assigned as copyeditor: ${data.submissionTitle}`,
+          link: '/pipeline',
+        });
       });
-    });
 
-    return { notified: 1 };
-  },
-);
+      return { notified: 1 };
+    },
+  );

--- a/apps/api/src/inngest/functions/submission-notifications.ts
+++ b/apps/api/src/inngest/functions/submission-notifications.ts
@@ -1,3 +1,4 @@
+import type { InngestFunction } from 'inngest';
 import {
   withRls,
   db,
@@ -75,357 +76,362 @@ async function getOrgEditors(orgId: string) {
 // Inngest functions
 // ---------------------------------------------------------------------------
 
-export const submissionReceivedNotification = inngest.createFunction(
-  {
-    id: 'submission-received-notification',
-    name: 'Submission Received Notification',
-    retries: 3,
-  },
-  { event: 'hopper/submission.submitted' },
-  async ({ event, step }) => {
-    const { orgId, submissionId, submitterId } =
-      event.data as HopperSubmissionSubmittedEvent['data'];
+export const submissionReceivedNotification: InngestFunction.Any =
+  inngest.createFunction(
+    {
+      id: 'submission-received-notification',
+      name: 'Submission Received Notification',
+      retries: 3,
+      triggers: [{ event: 'hopper/submission.submitted' }],
+    },
+    async ({ event, step }) => {
+      const { orgId, submissionId, submitterId } =
+        event.data as HopperSubmissionSubmittedEvent['data'];
 
-    const { submission, orgName } = await step.run('resolve-data', async () =>
-      getSubmissionAndOrg(orgId, submissionId),
-    );
+      const { submission, orgName } = await step.run('resolve-data', async () =>
+        getSubmissionAndOrg(orgId, submissionId),
+      );
 
-    if (!submission) return { skipped: true, reason: 'submission-not-found' };
+      if (!submission) return { skipped: true, reason: 'submission-not-found' };
 
-    const submitter = await step.run('get-submitter', async () =>
-      getUserEmail(submitterId),
-    );
+      const submitter = await step.run('get-submitter', async () =>
+        getUserEmail(submitterId),
+      );
 
-    const editors = await step.run('get-editors', async () =>
-      getOrgEditors(orgId),
-    );
+      const editors = await step.run('get-editors', async () =>
+        getOrgEditors(orgId),
+      );
 
-    await step.run('queue-emails', async () => {
-      for (const editor of editors) {
+      await step.run('queue-emails', async () => {
+        for (const editor of editors) {
+          await queueEmailForRecipient({
+            orgId,
+            userId: editor.userId,
+            email: editor.email,
+            eventType: 'submission.received',
+            templateName: 'submission-received',
+            templateData: {
+              submissionTitle: submission.title,
+              submitterName: submitter?.email ?? 'Unknown',
+              submitterEmail: submitter?.email ?? 'unknown',
+              orgName,
+            },
+            subject: `New submission: ${submission.title}`,
+          });
+        }
+      });
+
+      await step.run('queue-in-app-notifications', async () => {
+        for (const editor of editors) {
+          await queueInAppNotification({
+            orgId,
+            userId: editor.userId,
+            eventType: 'submission.received',
+            title: `New submission: ${submission.title}`,
+            link: `/submissions/${submissionId}`,
+          });
+        }
+      });
+
+      return { notified: editors.length };
+    },
+  );
+
+export const submissionAcceptedNotification: InngestFunction.Any =
+  inngest.createFunction(
+    {
+      id: 'submission-accepted-notification',
+      name: 'Submission Accepted Notification',
+      retries: 3,
+      triggers: [{ event: 'hopper/submission.accepted' }],
+    },
+    async ({ event, step }) => {
+      const { orgId, submissionId, submitterId, comment } =
+        event.data as HopperSubmissionAcceptedEvent['data'];
+
+      const { submission, orgName } = await step.run('resolve-data', async () =>
+        getSubmissionAndOrg(orgId, submissionId),
+      );
+
+      if (!submission) return { skipped: true, reason: 'submission-not-found' };
+
+      const submitter = await step.run('get-submitter', async () =>
+        getUserEmail(submitterId),
+      );
+
+      if (!submitter) return { skipped: true, reason: 'submitter-not-found' };
+
+      await step.run('queue-email', async () => {
         await queueEmailForRecipient({
           orgId,
-          userId: editor.userId,
-          email: editor.email,
-          eventType: 'submission.received',
-          templateName: 'submission-received',
+          userId: submitterId,
+          email: submitter.email,
+          eventType: 'submission.accepted',
+          templateName: 'submission-accepted',
           templateData: {
             submissionTitle: submission.title,
-            submitterName: submitter?.email ?? 'Unknown',
-            submitterEmail: submitter?.email ?? 'unknown',
+            submitterName: submitter.email,
+            submitterEmail: submitter.email,
             orgName,
+            editorComment: comment,
           },
-          subject: `New submission: ${submission.title}`,
+          subject: `Your submission has been accepted: ${submission.title}`,
         });
-      }
-    });
+      });
 
-    await step.run('queue-in-app-notifications', async () => {
-      for (const editor of editors) {
+      await step.run('queue-in-app', async () => {
         await queueInAppNotification({
           orgId,
-          userId: editor.userId,
-          eventType: 'submission.received',
-          title: `New submission: ${submission.title}`,
+          userId: submitterId,
+          eventType: 'submission.accepted',
+          title: `Your submission has been accepted: ${submission.title}`,
           link: `/submissions/${submissionId}`,
         });
-      }
-    });
-
-    return { notified: editors.length };
-  },
-);
-
-export const submissionAcceptedNotification = inngest.createFunction(
-  {
-    id: 'submission-accepted-notification',
-    name: 'Submission Accepted Notification',
-    retries: 3,
-  },
-  { event: 'hopper/submission.accepted' },
-  async ({ event, step }) => {
-    const { orgId, submissionId, submitterId, comment } =
-      event.data as HopperSubmissionAcceptedEvent['data'];
-
-    const { submission, orgName } = await step.run('resolve-data', async () =>
-      getSubmissionAndOrg(orgId, submissionId),
-    );
-
-    if (!submission) return { skipped: true, reason: 'submission-not-found' };
-
-    const submitter = await step.run('get-submitter', async () =>
-      getUserEmail(submitterId),
-    );
-
-    if (!submitter) return { skipped: true, reason: 'submitter-not-found' };
-
-    await step.run('queue-email', async () => {
-      await queueEmailForRecipient({
-        orgId,
-        userId: submitterId,
-        email: submitter.email,
-        eventType: 'submission.accepted',
-        templateName: 'submission-accepted',
-        templateData: {
-          submissionTitle: submission.title,
-          submitterName: submitter.email,
-          submitterEmail: submitter.email,
-          orgName,
-          editorComment: comment,
-        },
-        subject: `Your submission has been accepted: ${submission.title}`,
       });
-    });
 
-    await step.run('queue-in-app', async () => {
-      await queueInAppNotification({
-        orgId,
-        userId: submitterId,
-        eventType: 'submission.accepted',
-        title: `Your submission has been accepted: ${submission.title}`,
-        link: `/submissions/${submissionId}`,
-      });
-    });
-
-    await step.run('capture-correspondence', async () => {
-      try {
-        await withRls({ orgId }, async (tx) => {
-          await correspondenceService.create(tx, {
-            userId: submitterId,
-            submissionId,
-            direction: 'outbound',
-            channel: 'email',
-            sentAt: new Date(),
-            subject: `Your submission has been accepted: ${submission.title}`,
-            body: comment
-              ? `Congratulations! Your submission has been accepted.\n\nNote from the editors:\n${comment}`
-              : 'Congratulations! Your submission has been accepted.',
-            senderName: null,
-            senderEmail: null,
-            isPersonalized: !!comment,
-            source: 'colophony',
+      await step.run('capture-correspondence', async () => {
+        try {
+          await withRls({ orgId }, async (tx) => {
+            await correspondenceService.create(tx, {
+              userId: submitterId,
+              submissionId,
+              direction: 'outbound',
+              channel: 'email',
+              sentAt: new Date(),
+              subject: `Your submission has been accepted: ${submission.title}`,
+              body: comment
+                ? `Congratulations! Your submission has been accepted.\n\nNote from the editors:\n${comment}`
+                : 'Congratulations! Your submission has been accepted.',
+              senderName: null,
+              senderEmail: null,
+              isPersonalized: !!comment,
+              source: 'colophony',
+            });
           });
-        });
-      } catch {
-        // Non-fatal: correspondence capture should not block notifications
-      }
-    });
-
-    return { notified: 1 };
-  },
-);
-
-export const submissionRejectedNotification = inngest.createFunction(
-  {
-    id: 'submission-rejected-notification',
-    name: 'Submission Rejected Notification',
-    retries: 3,
-  },
-  { event: 'hopper/submission.rejected' },
-  async ({ event, step }) => {
-    const { orgId, submissionId, submitterId, comment } =
-      event.data as HopperSubmissionRejectedEvent['data'];
-
-    const { submission, orgName } = await step.run('resolve-data', async () =>
-      getSubmissionAndOrg(orgId, submissionId),
-    );
-
-    if (!submission) return { skipped: true, reason: 'submission-not-found' };
-
-    const submitter = await step.run('get-submitter', async () =>
-      getUserEmail(submitterId),
-    );
-
-    if (!submitter) return { skipped: true, reason: 'submitter-not-found' };
-
-    await step.run('queue-email', async () => {
-      await queueEmailForRecipient({
-        orgId,
-        userId: submitterId,
-        email: submitter.email,
-        eventType: 'submission.rejected',
-        templateName: 'submission-rejected',
-        templateData: {
-          submissionTitle: submission.title,
-          submitterName: submitter.email,
-          submitterEmail: submitter.email,
-          orgName,
-          editorComment: comment,
-        },
-        subject: `Update on your submission: ${submission.title}`,
+        } catch {
+          // Non-fatal: correspondence capture should not block notifications
+        }
       });
-    });
 
-    await step.run('queue-in-app', async () => {
-      await queueInAppNotification({
-        orgId,
-        userId: submitterId,
-        eventType: 'submission.rejected',
-        title: `Update on your submission: ${submission.title}`,
-        link: `/submissions/${submissionId}`,
-      });
-    });
+      return { notified: 1 };
+    },
+  );
 
-    await step.run('capture-correspondence', async () => {
-      try {
-        await withRls({ orgId }, async (tx) => {
-          await correspondenceService.create(tx, {
-            userId: submitterId,
-            submissionId,
-            direction: 'outbound',
-            channel: 'email',
-            sentAt: new Date(),
-            subject: `Update on your submission: ${submission.title}`,
-            body: comment
-              ? `Thank you for your submission. After careful review, we are unable to accept it at this time.\n\nNote from the editors:\n${comment}`
-              : 'Thank you for your submission. After careful review, we are unable to accept it at this time.',
-            senderName: null,
-            senderEmail: null,
-            isPersonalized: !!comment,
-            source: 'colophony',
-          });
-        });
-      } catch {
-        // Non-fatal: correspondence capture should not block notifications
-      }
-    });
+export const submissionRejectedNotification: InngestFunction.Any =
+  inngest.createFunction(
+    {
+      id: 'submission-rejected-notification',
+      name: 'Submission Rejected Notification',
+      retries: 3,
+      triggers: [{ event: 'hopper/submission.rejected' }],
+    },
+    async ({ event, step }) => {
+      const { orgId, submissionId, submitterId, comment } =
+        event.data as HopperSubmissionRejectedEvent['data'];
 
-    return { notified: 1 };
-  },
-);
+      const { submission, orgName } = await step.run('resolve-data', async () =>
+        getSubmissionAndOrg(orgId, submissionId),
+      );
 
-export const submissionReviseAndResubmitNotification = inngest.createFunction(
-  {
-    id: 'submission-revise-and-resubmit-notification',
-    name: 'Submission Revise and Resubmit Notification',
-    retries: 3,
-  },
-  { event: 'hopper/submission.revise_and_resubmit' },
-  async ({ event, step }) => {
-    const { orgId, submissionId, submitterId, comment } =
-      event.data as HopperSubmissionReviseAndResubmitEvent['data'];
+      if (!submission) return { skipped: true, reason: 'submission-not-found' };
 
-    const { submission, orgName } = await step.run('resolve-data', async () =>
-      getSubmissionAndOrg(orgId, submissionId),
-    );
+      const submitter = await step.run('get-submitter', async () =>
+        getUserEmail(submitterId),
+      );
 
-    if (!submission) return { skipped: true, reason: 'submission-not-found' };
+      if (!submitter) return { skipped: true, reason: 'submitter-not-found' };
 
-    const submitter = await step.run('get-submitter', async () =>
-      getUserEmail(submitterId),
-    );
-
-    if (!submitter) return { skipped: true, reason: 'submitter-not-found' };
-
-    await step.run('queue-email', async () => {
-      await queueEmailForRecipient({
-        orgId,
-        userId: submitterId,
-        email: submitter.email,
-        eventType: 'submission.revise_and_resubmit',
-        templateName: 'submission-revise-resubmit',
-        templateData: {
-          submissionTitle: submission.title,
-          submitterName: submitter.email,
-          submitterEmail: submitter.email,
-          orgName,
-          editorComment: comment,
-        },
-        subject: `Revision requested for your submission: ${submission.title}`,
-      });
-    });
-
-    await step.run('queue-in-app', async () => {
-      await queueInAppNotification({
-        orgId,
-        userId: submitterId,
-        eventType: 'submission.revise_and_resubmit',
-        title: `Revisions requested for: ${submission.title}`,
-        link: `/submissions/${submissionId}`,
-      });
-    });
-
-    await step.run('capture-correspondence', async () => {
-      try {
-        await withRls({ orgId }, async (tx) => {
-          await correspondenceService.create(tx, {
-            userId: submitterId,
-            submissionId,
-            direction: 'outbound',
-            channel: 'email',
-            sentAt: new Date(),
-            subject: `Revision requested for your submission: ${submission.title}`,
-            body: `After careful review, the editors are interested in your work but are requesting revisions.\n\nRevision notes:\n${comment}`,
-            senderName: null,
-            senderEmail: null,
-            isPersonalized: true,
-            source: 'colophony',
-          });
-        });
-      } catch {
-        // Non-fatal: correspondence capture should not block notifications
-      }
-    });
-
-    return { notified: 1 };
-  },
-);
-
-export const submissionWithdrawnNotification = inngest.createFunction(
-  {
-    id: 'submission-withdrawn-notification',
-    name: 'Submission Withdrawn Notification',
-    retries: 3,
-  },
-  { event: 'hopper/submission.withdrawn' },
-  async ({ event, step }) => {
-    const { orgId, submissionId, submitterId } =
-      event.data as HopperSubmissionWithdrawnEvent['data'];
-
-    const { submission, orgName } = await step.run('resolve-data', async () =>
-      getSubmissionAndOrg(orgId, submissionId),
-    );
-
-    if (!submission) return { skipped: true, reason: 'submission-not-found' };
-
-    const submitter = await step.run('get-submitter', async () =>
-      getUserEmail(submitterId),
-    );
-
-    const editors = await step.run('get-editors', async () =>
-      getOrgEditors(orgId),
-    );
-
-    await step.run('queue-emails', async () => {
-      for (const editor of editors) {
+      await step.run('queue-email', async () => {
         await queueEmailForRecipient({
           orgId,
-          userId: editor.userId,
-          email: editor.email,
-          eventType: 'submission.withdrawn',
-          templateName: 'submission-withdrawn',
+          userId: submitterId,
+          email: submitter.email,
+          eventType: 'submission.rejected',
+          templateName: 'submission-rejected',
           templateData: {
             submissionTitle: submission.title,
-            submitterName: submitter?.email ?? 'Unknown',
-            submitterEmail: submitter?.email ?? 'unknown',
+            submitterName: submitter.email,
+            submitterEmail: submitter.email,
             orgName,
+            editorComment: comment,
           },
-          subject: `Submission withdrawn: ${submission.title}`,
+          subject: `Update on your submission: ${submission.title}`,
         });
-      }
-    });
+      });
 
-    await step.run('queue-in-app-notifications', async () => {
-      for (const editor of editors) {
+      await step.run('queue-in-app', async () => {
         await queueInAppNotification({
           orgId,
-          userId: editor.userId,
-          eventType: 'submission.withdrawn',
-          title: `Submission withdrawn: ${submission.title}`,
+          userId: submitterId,
+          eventType: 'submission.rejected',
+          title: `Update on your submission: ${submission.title}`,
           link: `/submissions/${submissionId}`,
         });
-      }
-    });
+      });
 
-    return { notified: editors.length };
-  },
-);
+      await step.run('capture-correspondence', async () => {
+        try {
+          await withRls({ orgId }, async (tx) => {
+            await correspondenceService.create(tx, {
+              userId: submitterId,
+              submissionId,
+              direction: 'outbound',
+              channel: 'email',
+              sentAt: new Date(),
+              subject: `Update on your submission: ${submission.title}`,
+              body: comment
+                ? `Thank you for your submission. After careful review, we are unable to accept it at this time.\n\nNote from the editors:\n${comment}`
+                : 'Thank you for your submission. After careful review, we are unable to accept it at this time.',
+              senderName: null,
+              senderEmail: null,
+              isPersonalized: !!comment,
+              source: 'colophony',
+            });
+          });
+        } catch {
+          // Non-fatal: correspondence capture should not block notifications
+        }
+      });
+
+      return { notified: 1 };
+    },
+  );
+
+export const submissionReviseAndResubmitNotification: InngestFunction.Any =
+  inngest.createFunction(
+    {
+      id: 'submission-revise-and-resubmit-notification',
+      name: 'Submission Revise and Resubmit Notification',
+      retries: 3,
+      triggers: [{ event: 'hopper/submission.revise_and_resubmit' }],
+    },
+    async ({ event, step }) => {
+      const { orgId, submissionId, submitterId, comment } =
+        event.data as HopperSubmissionReviseAndResubmitEvent['data'];
+
+      const { submission, orgName } = await step.run('resolve-data', async () =>
+        getSubmissionAndOrg(orgId, submissionId),
+      );
+
+      if (!submission) return { skipped: true, reason: 'submission-not-found' };
+
+      const submitter = await step.run('get-submitter', async () =>
+        getUserEmail(submitterId),
+      );
+
+      if (!submitter) return { skipped: true, reason: 'submitter-not-found' };
+
+      await step.run('queue-email', async () => {
+        await queueEmailForRecipient({
+          orgId,
+          userId: submitterId,
+          email: submitter.email,
+          eventType: 'submission.revise_and_resubmit',
+          templateName: 'submission-revise-resubmit',
+          templateData: {
+            submissionTitle: submission.title,
+            submitterName: submitter.email,
+            submitterEmail: submitter.email,
+            orgName,
+            editorComment: comment,
+          },
+          subject: `Revision requested for your submission: ${submission.title}`,
+        });
+      });
+
+      await step.run('queue-in-app', async () => {
+        await queueInAppNotification({
+          orgId,
+          userId: submitterId,
+          eventType: 'submission.revise_and_resubmit',
+          title: `Revisions requested for: ${submission.title}`,
+          link: `/submissions/${submissionId}`,
+        });
+      });
+
+      await step.run('capture-correspondence', async () => {
+        try {
+          await withRls({ orgId }, async (tx) => {
+            await correspondenceService.create(tx, {
+              userId: submitterId,
+              submissionId,
+              direction: 'outbound',
+              channel: 'email',
+              sentAt: new Date(),
+              subject: `Revision requested for your submission: ${submission.title}`,
+              body: `After careful review, the editors are interested in your work but are requesting revisions.\n\nRevision notes:\n${comment}`,
+              senderName: null,
+              senderEmail: null,
+              isPersonalized: true,
+              source: 'colophony',
+            });
+          });
+        } catch {
+          // Non-fatal: correspondence capture should not block notifications
+        }
+      });
+
+      return { notified: 1 };
+    },
+  );
+
+export const submissionWithdrawnNotification: InngestFunction.Any =
+  inngest.createFunction(
+    {
+      id: 'submission-withdrawn-notification',
+      name: 'Submission Withdrawn Notification',
+      retries: 3,
+      triggers: [{ event: 'hopper/submission.withdrawn' }],
+    },
+    async ({ event, step }) => {
+      const { orgId, submissionId, submitterId } =
+        event.data as HopperSubmissionWithdrawnEvent['data'];
+
+      const { submission, orgName } = await step.run('resolve-data', async () =>
+        getSubmissionAndOrg(orgId, submissionId),
+      );
+
+      if (!submission) return { skipped: true, reason: 'submission-not-found' };
+
+      const submitter = await step.run('get-submitter', async () =>
+        getUserEmail(submitterId),
+      );
+
+      const editors = await step.run('get-editors', async () =>
+        getOrgEditors(orgId),
+      );
+
+      await step.run('queue-emails', async () => {
+        for (const editor of editors) {
+          await queueEmailForRecipient({
+            orgId,
+            userId: editor.userId,
+            email: editor.email,
+            eventType: 'submission.withdrawn',
+            templateName: 'submission-withdrawn',
+            templateData: {
+              submissionTitle: submission.title,
+              submitterName: submitter?.email ?? 'Unknown',
+              submitterEmail: submitter?.email ?? 'unknown',
+              orgName,
+            },
+            subject: `Submission withdrawn: ${submission.title}`,
+          });
+        }
+      });
+
+      await step.run('queue-in-app-notifications', async () => {
+        for (const editor of editors) {
+          await queueInAppNotification({
+            orgId,
+            userId: editor.userId,
+            eventType: 'submission.withdrawn',
+            title: `Submission withdrawn: ${submission.title}`,
+            link: `/submissions/${submissionId}`,
+          });
+        }
+      });
+
+      return { notified: editors.length };
+    },
+  );

--- a/apps/api/src/inngest/functions/submission-response-reminder.ts
+++ b/apps/api/src/inngest/functions/submission-response-reminder.ts
@@ -1,3 +1,4 @@
+import type { InngestFunction } from 'inngest';
 import {
   withRls,
   db,
@@ -14,120 +15,122 @@ import { queueEmailForRecipient } from '../helpers/queue-email-for-recipient.js'
 import { submissionService } from '../../services/submission.service.js';
 import { validateEnv } from '../../config/env.js';
 
-export const submissionResponseReminderCron = inngest.createFunction(
-  {
-    id: 'submission-response-reminder-cron',
-    name: 'Submission Response Reminder (Weekly)',
-    retries: 1,
-  },
-  { cron: 'TZ=UTC 0 9 * * 1' },
-  async ({ step }) => {
-    const env = validateEnv();
-    if (env.EMAIL_PROVIDER === 'none') {
-      return { skipped: true, reason: 'email provider is none' };
-    }
+export const submissionResponseReminderCron: InngestFunction.Any =
+  inngest.createFunction(
+    {
+      id: 'submission-response-reminder-cron',
+      name: 'Submission Response Reminder (Weekly)',
+      retries: 1,
+      triggers: [{ cron: 'TZ=UTC 0 9 * * 1' }],
+    },
+    async ({ step }) => {
+      const env = validateEnv();
+      if (env.EMAIL_PROVIDER === 'none') {
+        return { skipped: true, reason: 'email provider is none' };
+      }
 
-    // Step 1: Find orgs with reminders enabled (superuser query — no RLS)
-    const eligibleOrgs = await step.run('find-eligible-orgs', async () => {
-      const allOrgs = await db
-        .select({
-          id: organizations.id,
-          name: organizations.name,
-          settings: organizations.settings,
-        })
-        .from(organizations);
+      // Step 1: Find orgs with reminders enabled (superuser query — no RLS)
+      const eligibleOrgs = await step.run('find-eligible-orgs', async () => {
+        const allOrgs = await db
+          .select({
+            id: organizations.id,
+            name: organizations.name,
+            settings: organizations.settings,
+          })
+          .from(organizations);
 
-      return allOrgs
-        .map((org) => {
-          const parsed = orgSettingsSchema.safeParse(org.settings ?? {});
-          const settings = parsed.success
-            ? parsed.data
-            : { responseReminderEnabled: false, responseReminderDays: 30 };
-          return { id: org.id, name: org.name, settings };
-        })
-        .filter((org) => org.settings.responseReminderEnabled);
-    });
-
-    if (eligibleOrgs.length === 0) {
-      return { skipped: true, reason: 'no orgs with reminders enabled' };
-    }
-
-    let totalEmails = 0;
-
-    // Step 2: Process each org
-    for (const org of eligibleOrgs) {
-      const result = await step.run(`process-org-${org.id}`, async () => {
-        // Get aging submissions (within RLS context)
-        const { submissions: agingList, totalCount: totalAging } =
-          await withRls({ orgId: org.id }, async (tx) => {
-            return submissionService.listAgingByOrg(
-              tx,
-              org.settings.responseReminderDays,
-            );
-          });
-
-        if (agingList.length === 0) {
-          return { emailsSent: 0 };
-        }
-
-        // Take top 10 for email, compute summary
-        const topSubmissions = agingList.slice(0, 10).map((s) => ({
-          title: s.title ?? '(Untitled)',
-          submitterEmail: s.submitterEmail ?? '[Anonymous]',
-          daysPending: s.daysPending,
-        }));
-        const oldestDays = agingList.length > 0 ? agingList[0].daysPending : 0;
-        const hasMore = totalAging > 10;
-
-        // Get editors for this org
-        const editors = await withRls({ orgId: org.id }, async (tx) => {
-          return tx
-            .select({
-              userId: organizationMembers.userId,
-              email: users.email,
-            })
-            .from(organizationMembers)
-            .innerJoin(users, eq(users.id, organizationMembers.userId))
-            .where(
-              and(
-                eq(organizationMembers.organizationId, org.id),
-                inArray(organizationMembers.role, ['ADMIN', 'EDITOR']),
-              ),
-            );
-        });
-
-        let emailsSent = 0;
-        for (const editor of editors) {
-          if (!editor.email) continue;
-
-          await queueEmailForRecipient({
-            orgId: org.id,
-            userId: editor.userId,
-            email: editor.email,
-            eventType: 'submission.response_reminder',
-            templateName: 'submission-response-reminder',
-            templateData: {
-              orgName: org.name,
-              editorName: editor.email,
-              totalAging,
-              oldestDays,
-              topSubmissions,
-              hasMore,
-            },
-            subject: `Response reminder: ${totalAging} submission${totalAging !== 1 ? 's' : ''} awaiting review (oldest: ${oldestDays}d)`,
-          });
-          emailsSent++;
-        }
-
-        return { emailsSent };
+        return allOrgs
+          .map((org) => {
+            const parsed = orgSettingsSchema.safeParse(org.settings ?? {});
+            const settings = parsed.success
+              ? parsed.data
+              : { responseReminderEnabled: false, responseReminderDays: 30 };
+            return { id: org.id, name: org.name, settings };
+          })
+          .filter((org) => org.settings.responseReminderEnabled);
       });
 
-      totalEmails += result.emailsSent;
-    }
+      if (eligibleOrgs.length === 0) {
+        return { skipped: true, reason: 'no orgs with reminders enabled' };
+      }
 
-    return {
-      processed: eligibleOrgs.length,
-      totalEmails,
-    };
-  },
-);
+      let totalEmails = 0;
+
+      // Step 2: Process each org
+      for (const org of eligibleOrgs) {
+        const result = await step.run(`process-org-${org.id}`, async () => {
+          // Get aging submissions (within RLS context)
+          const { submissions: agingList, totalCount: totalAging } =
+            await withRls({ orgId: org.id }, async (tx) => {
+              return submissionService.listAgingByOrg(
+                tx,
+                org.settings.responseReminderDays,
+              );
+            });
+
+          if (agingList.length === 0) {
+            return { emailsSent: 0 };
+          }
+
+          // Take top 10 for email, compute summary
+          const topSubmissions = agingList.slice(0, 10).map((s) => ({
+            title: s.title ?? '(Untitled)',
+            submitterEmail: s.submitterEmail ?? '[Anonymous]',
+            daysPending: s.daysPending,
+          }));
+          const oldestDays =
+            agingList.length > 0 ? agingList[0].daysPending : 0;
+          const hasMore = totalAging > 10;
+
+          // Get editors for this org
+          const editors = await withRls({ orgId: org.id }, async (tx) => {
+            return tx
+              .select({
+                userId: organizationMembers.userId,
+                email: users.email,
+              })
+              .from(organizationMembers)
+              .innerJoin(users, eq(users.id, organizationMembers.userId))
+              .where(
+                and(
+                  eq(organizationMembers.organizationId, org.id),
+                  inArray(organizationMembers.role, ['ADMIN', 'EDITOR']),
+                ),
+              );
+          });
+
+          let emailsSent = 0;
+          for (const editor of editors) {
+            if (!editor.email) continue;
+
+            await queueEmailForRecipient({
+              orgId: org.id,
+              userId: editor.userId,
+              email: editor.email,
+              eventType: 'submission.response_reminder',
+              templateName: 'submission-response-reminder',
+              templateData: {
+                orgName: org.name,
+                editorName: editor.email,
+                totalAging,
+                oldestDays,
+                topSubmissions,
+                hasMore,
+              },
+              subject: `Response reminder: ${totalAging} submission${totalAging !== 1 ? 's' : ''} awaiting review (oldest: ${oldestDays}d)`,
+            });
+            emailsSent++;
+          }
+
+          return { emailsSent };
+        });
+
+        totalEmails += result.emailsSent;
+      }
+
+      return {
+        processed: eligibleOrgs.length,
+        totalEmails,
+      };
+    },
+  );

--- a/apps/api/src/inngest/functions/webhook-delivery.ts
+++ b/apps/api/src/inngest/functions/webhook-delivery.ts
@@ -1,23 +1,28 @@
+import type { InngestFunction } from 'inngest';
 import { withRls } from '@colophony/db';
 import { inngest } from '../client.js';
 import { webhookService } from '../../services/webhook.service.js';
 import { enqueueWebhook } from '../../queues/webhook.queue.js';
 import { validateEnv } from '../../config/env.js';
 
-export const webhookDelivery = inngest.createFunction(
-  { id: 'webhook-delivery', name: 'Webhook Delivery', retries: 3 },
-  [
-    { event: 'hopper/submission.submitted' },
-    { event: 'hopper/submission.accepted' },
-    { event: 'hopper/submission.rejected' },
-    { event: 'hopper/submission.withdrawn' },
-    { event: 'slate/pipeline.copyeditor-assigned' },
-    { event: 'slate/pipeline.copyedit-completed' },
-    { event: 'slate/pipeline.author-review-completed' },
-    { event: 'slate/pipeline.proofread-completed' },
-    { event: 'slate/contract.generated' },
-    { event: 'slate/issue.published' },
-  ],
+export const webhookDelivery: InngestFunction.Any = inngest.createFunction(
+  {
+    id: 'webhook-delivery',
+    name: 'Webhook Delivery',
+    retries: 3,
+    triggers: [
+      { event: 'hopper/submission.submitted' },
+      { event: 'hopper/submission.accepted' },
+      { event: 'hopper/submission.rejected' },
+      { event: 'hopper/submission.withdrawn' },
+      { event: 'slate/pipeline.copyeditor-assigned' },
+      { event: 'slate/pipeline.copyedit-completed' },
+      { event: 'slate/pipeline.author-review-completed' },
+      { event: 'slate/pipeline.proofread-completed' },
+      { event: 'slate/contract.generated' },
+      { event: 'slate/issue.published' },
+    ],
+  },
   async ({ event, step }) => {
     const orgId = (event.data as { orgId: string }).orgId;
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -252,7 +252,7 @@
 - [x] Zod 3 → 4 — ground-up rewrite (stable May 2025); touches types package, all tRPC inputs, env config; largest migration surface — (dependabot #80; done 2026-02-17)
 - [x] TanStack Query 4 → 5 — upgraded with tRPC 11; `isPending` alias pattern used; `fetchStatus` workaround removed from `use-auth.ts` — (dependabot #74; done 2026-02-17)
 - [x] tRPC 10 → 11 — combined tRPC 11 + TQ5 + TS 5.7.2 migration; TS2742 quirk resolved — (CLAUDE.md version pin; done 2026-02-17)
-- [ ] Inngest 3 → 4 — hard breaking change (v4.0.3 errors on v3-style function config); ~15 function definitions across 11 files + client/serve config + 4 test files; mechanical but touches critical workflow orchestration (pipeline, contracts, notifications) — (dependabot #315, closed 2026-03-22)
+- [x] Inngest 3 → 4 — hard breaking change (v4.0.3 errors on v3-style function config); 15 function definitions across 11 files + 6 test files; TS2742 fix via `InngestFunction.Any` annotation — (dependabot #315; done 2026-03-22)
 
 ### [P2] Medium — Dev tooling, lower risk
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -252,6 +252,7 @@
 - [x] Zod 3 → 4 — ground-up rewrite (stable May 2025); touches types package, all tRPC inputs, env config; largest migration surface — (dependabot #80; done 2026-02-17)
 - [x] TanStack Query 4 → 5 — upgraded with tRPC 11; `isPending` alias pattern used; `fetchStatus` workaround removed from `use-auth.ts` — (dependabot #74; done 2026-02-17)
 - [x] tRPC 10 → 11 — combined tRPC 11 + TQ5 + TS 5.7.2 migration; TS2742 quirk resolved — (CLAUDE.md version pin; done 2026-02-17)
+- [ ] Inngest 3 → 4 — hard breaking change (v4.0.3 errors on v3-style function config); ~15 function definitions across 11 files + client/serve config + 4 test files; mechanical but touches critical workflow orchestration (pipeline, contracts, notifications) — (dependabot #315, closed 2026-03-22)
 
 ### [P2] Medium — Dev tooling, lower risk
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,26 @@ Newest entries first.
 
 ---
 
+## 2026-03-22 — Inngest v3 → v4 Migration
+
+### Done
+
+- Bumped `inngest` from `^3.52.6` to `^4.0.4` (major version, breaking changes)
+- Updated all 15 Inngest function definitions: moved triggers from 2nd argument to config object's `triggers` property
+- Updated 6 test file mocks: 3-arg handler extraction → 2-arg (trigger arg removed)
+- Fixed TS2742 declaration portability errors: added `InngestFunction.Any` type annotations on all 15 exported function constants (v4's internal `.cjs` type references aren't portable in `.d.ts` files)
+- Added inline type assertion in `cms-publish.ts` where `InngestFunction.Any` erased step return type inference
+- Updated webhook-delivery test to read triggers from `config.triggers` (v4 location) instead of separate `triggers` arg
+- All 1513 tests pass, type-check clean, build succeeds
+- Updated backlog: marked Inngest migration done, popped stashed backlog entry from previous session
+
+### Decisions
+
+- Used `InngestFunction.Any` type annotation (not `satisfies` or tsconfig changes) to resolve TS2742 — cleanest fix that preserves declaration emit while keeping handler code unchanged in most files
+- `cms-publish.ts` required inline `as` type assertion because `InngestFunction.Any` erases `step.run()` return type inference for the complex CMS payload — other files don't rely on complex step return types so no assertion needed
+
+---
+
 ## 2026-03-22 — Deployment Workflow: Staging/Prod Alignment
 
 ### Done

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       inngest:
-        specifier: ^3.52.6
-        version: 3.52.6(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(fastify@5.8.2)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(zod@4.3.6)
+        specifier: ^4.0.4
+        version: 4.0.4(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(fastify@5.8.2)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(zod@4.3.6)
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
@@ -4128,10 +4128,6 @@ packages:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
 
-  ansi-regex@4.1.1:
-    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
-    engines: {node: '>=6'}
-
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -5467,8 +5463,8 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  inngest@3.52.6:
-    resolution: {integrity: sha512-wDxA1I5CIL7anqyX3Vr0T/5kOHkWN8W5oeqbHhFKFbsFrM+M/J3OEFiRRgcdiGyhNHxPvWaRdQb4N2mfgwc7PQ==}
+  inngest@4.0.4:
+    resolution: {integrity: sha512-/VeT229n7q2f1YvVxIblGFFGYkfmaWAGmhEiLAKmnZCZkEB1UR9H6lXEdvy/xvicx3uBwfooL6P7pvpsfVMlow==}
     engines: {node: '>=20'}
     peerDependencies:
       '@sveltejs/kit': '>=1.27.3'
@@ -7053,10 +7049,6 @@ packages:
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
-  strip-ansi@5.2.0:
-    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
-    engines: {node: '>=6'}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -11622,8 +11614,6 @@ snapshots:
     dependencies:
       environment: 1.1.0
 
-  ansi-regex@4.1.1: {}
-
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -13158,7 +13148,7 @@ snapshots:
 
   ini@1.3.8: {}
 
-  inngest@3.52.6(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(fastify@5.8.2)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(zod@4.3.6):
+  inngest@4.0.4(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(fastify@5.8.2)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@inngest/ai': 0.1.7
@@ -13175,14 +13165,12 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/ms': 2.1.0
       canonicalize: 1.0.8
-      chalk: 4.1.2
       cross-fetch: 4.1.0
       debug: 4.4.3
       hash.js: 1.1.7
       json-stringify-safe: 5.0.1
       ms: 2.1.3
       serialize-error-cjs: 0.1.4
-      strip-ansi: 5.2.0
       temporal-polyfill: 0.2.5
       ulid: 2.4.0
       zod: 4.3.6
@@ -15132,10 +15120,6 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-
-  strip-ansi@5.2.0:
-    dependencies:
-      ansi-regex: 4.1.1
 
   strip-ansi@6.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Bump `inngest` from `^3.52.6` to `^4.0.4` (major version upgrade)
- Update all 15 Inngest function definitions: move triggers from 2nd argument to config object's `triggers` property (v4 breaking change — v4.0.3 errors on v3-style config)
- Update 6 test file mocks: 3-arg handler extraction → 2-arg
- Add `InngestFunction.Any` type annotations to fix TS2742 declaration portability errors from v4's internal `.cjs` type references
- Add inline type assertion in `cms-publish.ts` where `InngestFunction.Any` erases step return type inference

## Test plan

- [x] `pnpm type-check` — clean (all 13 packages)
- [x] `pnpm test` — 1513 tests pass, 0 fail
- [x] `pnpm build` — production build succeeds
- [x] Codex plan drift check — all 7 plan items match
- [x] branch review — LGTM, no findings

Closes #315