### PR TITLE
feat(db): add comprehensive staging seed for demo and QA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,7 @@ pnpm docker:up                # Core infra + Zitadel (or --full for ClamAV, --co
 pnpm install
 pnpm db:migrate               # Run Drizzle migrations
 pnpm db:seed                  # Seed dev data (orgs, submissions, Slate pipeline)
+pnpm db:seed:staging          # Rich staging/demo data (80 subs, forms, editorial, federation, etc.)
 pnpm zitadel:setup            # Provision Zitadel + patch .env files (after volume wipe)
 pnpm dev                      # hivemind: builds packages, then API: 4000, Web: 3000
 ```
@@ -401,6 +402,7 @@ Full testing guide: [docs/testing.md](docs/testing.md)
 pnpm db:migrate               # Validate journal + run Drizzle migrations
 pnpm db:generate              # Generate migration from schema changes
 pnpm db:seed                  # Seed test data
+pnpm db:seed:staging          # Seed rich staging/demo data (all feature areas)
 pnpm db:reset                 # Drop and recreate with migrations + RLS
 pnpm db:validate-migrations   # Check SQL files ↔ journal consistency
 pnpm db:add-migration <name>  # Add journal entry for a manual migration

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,32 @@ Newest entries first.
 
 ---
 
+## 2026-03-23 — Comprehensive Staging Seed
+
+### Done
+
+- Created `seed-staging.ts` — comprehensive staging seed covering 21 additional tables beyond the base seed
+- Refactored `seed.ts` to export `seedBase()` returning `SeedResult`, date helpers, and guarded `main()` from running on import
+- Staging seed creates ~80 submissions with realistic status distribution across 6 months for meaningful analytics dashboards
+- Added form definitions (3: 2 published with pages/fields, 1 draft), editorial workflow data (40 reviewer assignments, 15 discussion threads, 30 votes)
+- Added writer workspace data: 15 journal directory entries, 20 external submissions, ~8 correspondence entries, 4 writer profiles
+- Added federation data: 1 federation config with real Ed25519 keys, 2 trusted peers
+- Added notification infrastructure: 10 email templates (5/org), 24 notification preferences, 10 inbox notifications
+- Added webhook endpoints (4, all DISABLED) with 8 historical deliveries, 2 embed tokens, 3 saved queue presets, 4 user consents
+- Added `pnpm db:seed:staging` script and Coolify integration via `SEED_STAGING=true` env var in `init-prod.sh`
+- Verified: staging seed runs clean on fresh DB, idempotent on second run, base seed still works independently
+- Codex plan review: addressed all findings (audit_events idempotency marker → org settings flag, submission count correction, webhook endpoints DISABLED, DrizzleDb type fix, internal consistency fix)
+
+### Decisions
+
+- Separate `seed-staging.ts` over extending `seed.ts`: clean separation, base seed stays fast for daily dev
+- Idempotency via org settings `stagingSeeded` flag instead of audit_events marker: immune to retention policy cleanup (90-day global policy)
+- Webhook endpoints seeded as DISABLED: avoids webhook worker attempting delivery to fake URLs, which would bypass SSRF validation in the service layer
+- Real Ed25519 keys via `crypto.generateKeyPairSync`: makes federation admin UI and DID document routes functional in staging
+- Skipped runtime-only tables (outbox_events, webhook events, email_sends, sim_sub_checks) and complex federation flows (transfers, migrations, hub tables)
+
+---
+
 ## 2026-03-22 — Inngest v3 → v4 Migration
 
 ### Done

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "db:check": "pnpm --filter @colophony/db check",
     "db:studio": "pnpm --filter @colophony/db studio",
     "db:seed": "pnpm --filter @colophony/db seed",
+    "db:seed:staging": "pnpm --filter @colophony/db seed:staging",
     "db:verify": "pnpm --filter @colophony/db verify",
     "db:verify:repair": "pnpm --filter @colophony/db verify:repair",
     "db:validate-enums": "pnpm --filter @colophony/db validate-enums",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -24,6 +24,7 @@
     "check": "drizzle-kit check",
     "studio": "drizzle-kit studio",
     "seed": "tsx --env-file=.env src/seed.ts",
+    "seed:staging": "tsx --env-file=.env src/seed-staging.ts",
     "verify": "tsx --env-file=.env src/verify-migrations.ts --check",
     "verify:repair": "tsx --env-file=.env src/verify-migrations.ts --repair",
     "validate-enums": "tsx --env-file=.env src/validate-enum-migration.ts",

--- a/packages/db/src/seed-staging.ts
+++ b/packages/db/src/seed-staging.ts
@@ -32,6 +32,10 @@ import {
   submissionReviewers,
   submissionDiscussions,
   submissionVotes,
+  publications,
+  contractTemplates,
+  issues,
+  issueSections,
   pipelineItems,
   pipelineComments,
   pipelineHistory,
@@ -296,16 +300,144 @@ async function main() {
     return;
   }
 
+  // Check if base seed already ran (org exists but no stagingSeeded flag)
+  const baseAlreadyRan = existing.length > 0;
+
   console.log("Seeding staging data...\n");
 
   await db.transaction(async (rawTx) => {
     const tx = rawTx as unknown as DrizzleDb;
 
     // -----------------------------------------------------------------------
-    // Run base seed first (creates orgs, users, submissions, pipeline, etc.)
+    // Run base seed first, or load existing entities if base already ran
     // -----------------------------------------------------------------------
-    const base = await seedBase(tx);
-    console.log("  Base seed complete.\n");
+    let base: import("./seed").SeedResult;
+
+    if (baseAlreadyRan) {
+      console.log("  Base seed already present — loading existing entities.\n");
+      // Query all the entities that seedBase() would have created
+      const [org1] = await tx
+        .select()
+        .from(organizations)
+        .where(eq(organizations.slug, "quarterly-review"));
+      const [org2] = await tx
+        .select()
+        .from(organizations)
+        .where(eq(organizations.slug, "inkwell-press"));
+      const [adminUser] = await tx
+        .select()
+        .from(users)
+        .where(eq(users.email, "editor@quarterlyreview.org"));
+      const [editorUser] = await tx
+        .select()
+        .from(users)
+        .where(eq(users.email, "reader@quarterlyreview.org"));
+      const [writerUser] = await tx
+        .select()
+        .from(users)
+        .where(eq(users.email, "writer@example.com"));
+      const [inkwellAdmin] = await tx
+        .select()
+        .from(users)
+        .where(eq(users.email, "admin@inkwellpress.org"));
+      const [openPeriod] = await tx
+        .select()
+        .from(submissionPeriods)
+        .where(eq(submissionPeriods.name, "Spring 2026 Reading Period"));
+      const [winterPeriod] = await tx
+        .select()
+        .from(submissionPeriods)
+        .where(eq(submissionPeriods.name, "Winter 2025 Reading Period"));
+      const [inkwellPeriod] = await tx
+        .select()
+        .from(submissionPeriods)
+        .where(eq(submissionPeriods.name, "Open Submissions 2026"));
+      const [submittedSub] = await tx
+        .select()
+        .from(submissions)
+        .where(eq(submissions.title, "The Weight of Small Things"));
+      const [underReviewSub] = await tx
+        .select()
+        .from(submissions)
+        .where(eq(submissions.title, "Cartography of Absence"));
+      const [acceptedSub] = await tx
+        .select()
+        .from(submissions)
+        .where(eq(submissions.title, "Field Notes on Disappearing"));
+      const [acceptedSub2] = await tx
+        .select()
+        .from(submissions)
+        .where(eq(submissions.title, "The Architecture of Longing"));
+      const [manuscript1] = await tx
+        .select()
+        .from(manuscripts)
+        .where(eq(manuscripts.title, "The Weight of Small Things"));
+      const [version1] = await tx
+        .select()
+        .from(manuscriptVersions)
+        .where(eq(manuscriptVersions.manuscriptId, manuscript1!.id));
+      const [pub1] = await tx
+        .select()
+        .from(publications)
+        .where(eq(publications.slug, "the-quarterly-review"));
+      const [pub2] = await tx
+        .select()
+        .from(publications)
+        .where(eq(publications.slug, "quarterly-online"));
+      const allPipeItems = await tx
+        .select()
+        .from(pipelineItems)
+        .where(eq(pipelineItems.organizationId, org1!.id));
+      const pipeItem1 = allPipeItems.find(
+        (p) => p.submissionId === acceptedSub!.id,
+      )!;
+      const pipeItem2 = allPipeItems.find(
+        (p) => p.submissionId === acceptedSub2!.id,
+      )!;
+      const [template1] = await tx
+        .select()
+        .from(contractTemplates)
+        .where(eq(contractTemplates.organizationId, org1!.id));
+      const [issue1] = await tx
+        .select()
+        .from(issues)
+        .where(eq(issues.title, "Spring 2026"));
+      const allSections = await tx
+        .select()
+        .from(issueSections)
+        .where(eq(issueSections.issueId, issue1!.id));
+      const poetrySection = allSections.find((s) => s.title === "Poetry")!;
+      const fictionSection = allSections.find((s) => s.title === "Fiction")!;
+
+      base = {
+        org1: org1!,
+        org2: org2!,
+        adminUser: adminUser!,
+        editorUser: editorUser!,
+        writerUser: writerUser!,
+        inkwellAdmin: inkwellAdmin!,
+        openPeriod: openPeriod!,
+        winterPeriod: winterPeriod!,
+        inkwellPeriod: inkwellPeriod!,
+        submittedSub: submittedSub!,
+        underReviewSub: underReviewSub!,
+        acceptedSub: acceptedSub!,
+        acceptedSub2: acceptedSub2!,
+        manuscript1: manuscript1!,
+        version1: version1!,
+        pub1: pub1!,
+        pub2: pub2!,
+        pipeItem1,
+        pipeItem2,
+        template1: template1!,
+        issue1: issue1!,
+        poetrySection,
+        fictionSection,
+      };
+    } else {
+      base = await seedBase(tx);
+      console.log("  Base seed complete.\n");
+    }
 
     // -----------------------------------------------------------------------
     // Section A: Additional users

--- a/packages/db/src/seed-staging.ts
+++ b/packages/db/src/seed-staging.ts
@@ -11,7 +11,11 @@
  * Usage: pnpm --filter @colophony/db seed:staging
  */
 
-import { createHash, generateKeyPairSync } from "node:crypto";
+import {
+  createHash,
+  generateKeyPairSync,
+  randomInt as cryptoRandomInt,
+} from "node:crypto";
 import { eq, sql } from "drizzle-orm";
 import { db, pool } from "./client";
 import type { DrizzleDb } from "./context";
@@ -60,11 +64,11 @@ import {
 // ---------------------------------------------------------------------------
 
 function randomInt(min: number, max: number): number {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
+  return cryptoRandomInt(min, max + 1);
 }
 
 function randomFrom<T>(arr: T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)]!;
+  return arr[cryptoRandomInt(0, arr.length)]!;
 }
 
 /** Generate an Ed25519 keypair in PEM format */

--- a/packages/db/src/seed-staging.ts
+++ b/packages/db/src/seed-staging.ts
@@ -1,0 +1,1473 @@
+/**
+ * Staging seed — comprehensive demo/test data for staging and QA.
+ *
+ * Calls the base seed (seedBase), then layers rich data across all feature
+ * areas: forms, editorial workflow, analytics-worthy submission volume,
+ * writer workspace, federation, notifications, webhooks, and more.
+ *
+ * Runs as superuser (DATABASE_URL) so RLS does not apply.
+ * Idempotent: skips if staging data already exists (org1 settings.stagingSeeded).
+ *
+ * Usage: pnpm --filter @colophony/db seed:staging
+ */
+
+import { createHash, generateKeyPairSync } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { db, pool } from "./client";
+import type { DrizzleDb } from "./context";
+import { seedBase, daysAgo } from "./seed";
+import {
+  organizations,
+  users,
+  organizationMembers,
+  submissionPeriods,
+  submissions,
+  manuscripts,
+  manuscriptVersions,
+  files,
+  submissionHistory,
+  formDefinitions,
+  formPages,
+  formFields,
+  submissionReviewers,
+  submissionDiscussions,
+  submissionVotes,
+  pipelineItems,
+  pipelineComments,
+  pipelineHistory,
+  emailTemplates,
+  notificationPreferences,
+  notificationsInbox,
+  webhookEndpoints,
+  webhookDeliveries,
+  journalDirectory,
+  externalSubmissions,
+  correspondence,
+  writerProfiles,
+  federationConfig,
+  trustedPeers,
+  embedTokens,
+  savedQueuePresets,
+  userConsents,
+} from "./schema";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function randomInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function randomFrom<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)]!;
+}
+
+/** Generate an Ed25519 keypair in PEM format */
+function generateEd25519() {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  return {
+    publicKey: publicKey.export({ type: "spki", format: "pem" }) as string,
+    privateKey: privateKey.export({ type: "pkcs8", format: "pem" }) as string,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Curated content for realistic submissions
+// ---------------------------------------------------------------------------
+
+const SUBMISSION_TITLES = [
+  "Meridians of Light",
+  "What the River Remembers",
+  "A Catalogue of Vanishing",
+  "The Beekeeper's Almanac",
+  "Trespass",
+  "Notes Toward a Theory of Grief",
+  "The Cartographer's Wife",
+  "Vespers at Low Tide",
+  "Small Gods of the Kitchen",
+  "The Understudy",
+  "Lacuna",
+  "Praise Song for the Morning",
+  "After the Orchard",
+  "The Emigrant's Compass",
+  "Foxglove",
+  "The Museum of Lost Causes",
+  "Saltwater Liturgy",
+  "Instructions for Departure",
+  "The Naturalist's Notebook",
+  "An Incomplete Map of Tenderness",
+  "The Lamplighter's Daughter",
+  "Threshing",
+  "Birdsong in a Minor Key",
+  "The Glass Menagerie of Memory",
+  "At the Edge of the Clearing",
+  "Nocturne for a Demolished House",
+  "The Correspondence",
+  "Watershed",
+  "What We Carry When We Go",
+  "The Archivist's Dream",
+  "Littoral",
+  "A Field Guide to Longing",
+  "The Porcelain Year",
+  "Ember and Ash",
+  "The Threadbare Season",
+  "Matins",
+  "At the Mouth of the Cave",
+  "Inventory of Absences",
+  "The Watchmaker's Grief",
+  "Tidal",
+  "The Republic of Silence",
+  "Crepuscule",
+  "Ghost Nets",
+  "The Apothecary's Garden",
+  "Still Life with Smoke",
+  "The Mapmaker's Error",
+  "Canticle",
+  "Where the Fence Line Ends",
+  "The Vintner's Calendar",
+  "At Rest in Moving Water",
+  "The Book of Hours",
+  "Chimera",
+  "Root Systems",
+  "The Ornithologist's Confession",
+  "Palimpsest",
+  "Song for a Difficult Country",
+  "The Upholsterer's Art",
+  "Winter Fen",
+  "A Theory of Ruins",
+  "Tidepool",
+  "The Taxidermist's Sorrow",
+  "Equinox",
+  "The Hedgerow Psalms",
+  "Undertow",
+  "The Lapidary's Secret",
+  "Compline",
+  "At the Heart of the Gyre",
+  "The Papermaker's Lament",
+  "Solstice",
+  "The Spindle Tree",
+  "Marginal Notes",
+  "The Chandler's Wife",
+  "Backwater",
+  "A Bestiary of Small Griefs",
+];
+
+const SUBMISSION_STATUSES_SPRING = [
+  ...Array(7).fill("SUBMITTED"),
+  ...Array(6).fill("UNDER_REVIEW"),
+  ...Array(3).fill("ACCEPTED"),
+  ...Array(7).fill("REJECTED"),
+  ...Array(2).fill("HOLD"),
+  ...Array(2).fill("WITHDRAWN"),
+  ...Array(1).fill("REVISE_AND_RESUBMIT"),
+] as const;
+
+const SUBMISSION_STATUSES_WINTER = [
+  ...Array(10).fill("ACCEPTED"),
+  ...Array(15).fill("REJECTED"),
+  ...Array(3).fill("WITHDRAWN"),
+  ...Array(2).fill("HOLD"),
+] as const;
+
+const SUBMISSION_STATUSES_INKWELL = [
+  ...Array(4).fill("SUBMITTED"),
+  ...Array(3).fill("UNDER_REVIEW"),
+  ...Array(2).fill("ACCEPTED"),
+  ...Array(4).fill("REJECTED"),
+  ...Array(1).fill("HOLD"),
+  ...Array(1).fill("WITHDRAWN"),
+  ...Array(1).fill("REVISE_AND_RESUBMIT"),
+] as const;
+
+const JOURNAL_NAMES: {
+  name: string;
+  url: string;
+  ids: Record<string, string>;
+}[] = [
+  {
+    name: "The Paris Review",
+    url: "https://www.theparisreview.org",
+    ids: { chillsubs: "paris-review" },
+  },
+  {
+    name: "Ploughshares",
+    url: "https://www.pshares.org",
+    ids: { chillsubs: "ploughshares" },
+  },
+  { name: "Granta", url: "https://granta.com", ids: { chillsubs: "granta" } },
+  {
+    name: "Tin House",
+    url: "https://tinhouse.com",
+    ids: { chillsubs: "tin-house" },
+  },
+  {
+    name: "The Kenyon Review",
+    url: "https://kenyonreview.org",
+    ids: { chillsubs: "kenyon-review", duotrope: "kr-001" },
+  },
+  {
+    name: "AGNI",
+    url: "https://agnionline.bu.edu",
+    ids: { chillsubs: "agni" },
+  },
+  {
+    name: "The Georgia Review",
+    url: "https://thegeorgiareview.com",
+    ids: { chillsubs: "georgia-review" },
+  },
+  {
+    name: "Narrative Magazine",
+    url: "https://www.narrativemagazine.com",
+    ids: { chillsubs: "narrative" },
+  },
+  {
+    name: "Conjunctions",
+    url: "https://www.conjunctions.com",
+    ids: { chillsubs: "conjunctions" },
+  },
+  {
+    name: "The Gettysburg Review",
+    url: "https://www.gettysburgreview.com",
+    ids: { chillsubs: "gettysburg-review" },
+  },
+  {
+    name: "The Southern Review",
+    url: "https://thesouthernreview.org",
+    ids: { chillsubs: "southern-review" },
+  },
+  {
+    name: "Prairie Schooner",
+    url: "https://prairieschooner.unl.edu",
+    ids: { chillsubs: "prairie-schooner" },
+  },
+  {
+    name: "The Missouri Review",
+    url: "https://www.missourireview.com",
+    ids: { chillsubs: "missouri-review" },
+  },
+  {
+    name: "Zyzzyva",
+    url: "https://www.zyzzyva.org",
+    ids: { chillsubs: "zyzzyva" },
+  },
+  {
+    name: "One Story",
+    url: "https://www.one-story.com",
+    ids: { chillsubs: "one-story" },
+  },
+];
+
+const DISCUSSION_COMMENTS = [
+  "Strong opening — the imagery in the first paragraph is striking.",
+  "I think this needs tighter editing in the middle section. The pacing slows around the midpoint.",
+  "Agree with the above. The ending, however, is very strong.",
+  "I'm not sure the metaphor in section three quite lands. Thoughts?",
+  "This is one of the best submissions we've received this period.",
+  "The voice is distinctive but I wonder if it's consistent throughout.",
+  "Love the structure here — the fragmented sections mirror the theme beautifully.",
+  "Technically accomplished but it left me emotionally cold.",
+  "I'd recommend accepting this with minor revisions to the final stanza.",
+  "The research is evident without being heavy-handed. Well-crafted essay.",
+  "We should discuss this one at the next editorial meeting.",
+  "Reminds me of early Claudia Rankine. Very promising.",
+  "The line breaks in the poetry feel deliberate and effective.",
+  "This would be a perfect fit for the Spring issue's theme.",
+  "Not quite right for us, but this writer clearly has talent.",
+];
+
+// ---------------------------------------------------------------------------
+// Main staging seed
+// ---------------------------------------------------------------------------
+
+async function main() {
+  // Idempotency: check if staging data was already seeded
+  const existing = await db
+    .select({ settings: organizations.settings })
+    .from(organizations)
+    .where(eq(organizations.slug, "quarterly-review"))
+    .limit(1);
+
+  if (
+    existing.length > 0 &&
+    (existing[0]!.settings as Record<string, unknown>)?.stagingSeeded === true
+  ) {
+    console.log("Staging seed data already exists. Skipping.");
+    return;
+  }
+
+  console.log("Seeding staging data...\n");
+
+  await db.transaction(async (rawTx) => {
+    const tx = rawTx as unknown as DrizzleDb;
+
+    // -----------------------------------------------------------------------
+    // Run base seed first (creates orgs, users, submissions, pipeline, etc.)
+    // -----------------------------------------------------------------------
+    const base = await seedBase(tx);
+    console.log("  Base seed complete.\n");
+
+    // -----------------------------------------------------------------------
+    // Section A: Additional users
+    // -----------------------------------------------------------------------
+    const [writer2] = await tx
+      .insert(users)
+      .values({
+        email: "poet@example.com",
+        zitadelUserId: "seed-zitadel-writer-002",
+        emailVerified: true,
+        emailVerifiedAt: daysAgo(60),
+      })
+      .returning();
+
+    const [writer3] = await tx
+      .insert(users)
+      .values({
+        email: "novelist@example.com",
+        zitadelUserId: "seed-zitadel-writer-003",
+        emailVerified: true,
+        emailVerifiedAt: daysAgo(45),
+      })
+      .returning();
+
+    const [writer4] = await tx
+      .insert(users)
+      .values({
+        email: "essayist@example.com",
+        zitadelUserId: "seed-zitadel-writer-004",
+        emailVerified: true,
+        emailVerifiedAt: daysAgo(30),
+      })
+      .returning();
+
+    const [writer5] = await tx
+      .insert(users)
+      .values({
+        email: "playwright@example.com",
+        zitadelUserId: "seed-zitadel-writer-005",
+        emailVerified: true,
+        emailVerifiedAt: daysAgo(20),
+      })
+      .returning();
+
+    const [editor2] = await tx
+      .insert(users)
+      .values({
+        email: "poetry-editor@quarterlyreview.org",
+        zitadelUserId: "seed-zitadel-editor-002",
+        emailVerified: true,
+        emailVerifiedAt: daysAgo(90),
+      })
+      .returning();
+
+    const [editor3] = await tx
+      .insert(users)
+      .values({
+        email: "fiction-editor@quarterlyreview.org",
+        zitadelUserId: "seed-zitadel-editor-003",
+        emailVerified: true,
+        emailVerifiedAt: daysAgo(85),
+      })
+      .returning();
+
+    // Add new editors to org1
+    await tx.insert(organizationMembers).values([
+      { organizationId: base.org1.id, userId: editor2!.id, role: "EDITOR" },
+      { organizationId: base.org1.id, userId: editor3!.id, role: "EDITOR" },
+    ]);
+
+    const allWriters = [
+      base.writerUser,
+      writer2!,
+      writer3!,
+      writer4!,
+      writer5!,
+    ];
+    const allEditors = [base.adminUser, base.editorUser, editor2!, editor3!];
+
+    console.log("  Additional users: 6 (4 writers, 2 editors)");
+
+    // -----------------------------------------------------------------------
+    // Section B: Form definitions
+    // -----------------------------------------------------------------------
+    const [generalForm] = await tx
+      .insert(formDefinitions)
+      .values({
+        organizationId: base.org1.id,
+        name: "General Submission Form",
+        status: "PUBLISHED",
+        version: 1,
+        createdBy: base.adminUser.id,
+        publishedAt: daysAgo(30),
+      })
+      .returning();
+
+    const [generalPage] = await tx
+      .insert(formPages)
+      .values({
+        formDefinitionId: generalForm!.id,
+        title: "Submission Details",
+        sortOrder: 0,
+      })
+      .returning();
+
+    await tx.insert(formFields).values([
+      {
+        formDefinitionId: generalForm!.id,
+        pageId: generalPage!.id,
+        fieldKey: "title",
+        fieldType: "text",
+        label: "Title of Work",
+        required: true,
+        sortOrder: 0,
+      },
+      {
+        formDefinitionId: generalForm!.id,
+        pageId: generalPage!.id,
+        fieldKey: "genre",
+        fieldType: "select",
+        label: "Genre",
+        required: true,
+        sortOrder: 1,
+        config: {
+          options: ["Poetry", "Fiction", "Creative Nonfiction", "Translation"],
+        },
+      },
+      {
+        formDefinitionId: generalForm!.id,
+        pageId: generalPage!.id,
+        fieldKey: "cover_letter",
+        fieldType: "textarea",
+        label: "Cover Letter",
+        required: true,
+        sortOrder: 2,
+        placeholder: "Introduce your work...",
+      },
+      {
+        formDefinitionId: generalForm!.id,
+        pageId: generalPage!.id,
+        fieldKey: "bio",
+        fieldType: "textarea",
+        label: "Author Bio",
+        required: true,
+        sortOrder: 3,
+        placeholder: "Brief bio (100 words)...",
+      },
+      {
+        formDefinitionId: generalForm!.id,
+        pageId: generalPage!.id,
+        fieldKey: "simultaneous_submission",
+        fieldType: "checkbox",
+        label: "This is a simultaneous submission",
+        sortOrder: 4,
+      },
+      {
+        formDefinitionId: generalForm!.id,
+        pageId: generalPage!.id,
+        fieldKey: "word_count",
+        fieldType: "number",
+        label: "Word Count",
+        required: true,
+        sortOrder: 5,
+      },
+      {
+        formDefinitionId: generalForm!.id,
+        pageId: generalPage!.id,
+        fieldKey: "previous_publications",
+        fieldType: "textarea",
+        label: "Previous Publications",
+        sortOrder: 6,
+      },
+      {
+        formDefinitionId: generalForm!.id,
+        pageId: generalPage!.id,
+        fieldKey: "agree_terms",
+        fieldType: "checkbox",
+        label: "I agree to the submission terms",
+        required: true,
+        sortOrder: 7,
+      },
+    ]);
+
+    // Link Spring period to general form
+    await tx
+      .update(submissionPeriods)
+      .set({ formDefinitionId: generalForm!.id })
+      .where(eq(submissionPeriods.id, base.openPeriod.id));
+
+    // Poetry form (2 pages)
+    const [poetryForm] = await tx
+      .insert(formDefinitions)
+      .values({
+        organizationId: base.org1.id,
+        name: "Poetry Submission Form",
+        status: "PUBLISHED",
+        version: 1,
+        createdBy: base.adminUser.id,
+        publishedAt: daysAgo(25),
+      })
+      .returning();
+
+    const [poetryPage1] = await tx
+      .insert(formPages)
+      .values({
+        formDefinitionId: poetryForm!.id,
+        title: "Poem Details",
+        sortOrder: 0,
+      })
+      .returning();
+
+    const [poetryPage2] = await tx
+      .insert(formPages)
+      .values({
+        formDefinitionId: poetryForm!.id,
+        title: "About You",
+        sortOrder: 1,
+      })
+      .returning();
+
+    await tx.insert(formFields).values([
+      {
+        formDefinitionId: poetryForm!.id,
+        pageId: poetryPage1!.id,
+        fieldKey: "title",
+        fieldType: "text",
+        label: "Poem Title",
+        required: true,
+        sortOrder: 0,
+      },
+      {
+        formDefinitionId: poetryForm!.id,
+        pageId: poetryPage1!.id,
+        fieldKey: "poet_statement",
+        fieldType: "textarea",
+        label: "Poet's Statement",
+        sortOrder: 1,
+      },
+      {
+        formDefinitionId: poetryForm!.id,
+        pageId: poetryPage1!.id,
+        fieldKey: "poem_count",
+        fieldType: "number",
+        label: "Number of Poems",
+        required: true,
+        sortOrder: 2,
+      },
+      {
+        formDefinitionId: poetryForm!.id,
+        pageId: poetryPage2!.id,
+        fieldKey: "bio",
+        fieldType: "textarea",
+        label: "Bio",
+        required: true,
+        sortOrder: 0,
+      },
+      {
+        formDefinitionId: poetryForm!.id,
+        pageId: poetryPage2!.id,
+        fieldKey: "previous_publications",
+        fieldType: "textarea",
+        label: "Previous Publications",
+        sortOrder: 1,
+      },
+    ]);
+
+    // Contest form (draft)
+    await tx.insert(formDefinitions).values({
+      organizationId: base.org1.id,
+      name: "Contest Entry Form",
+      status: "DRAFT",
+      version: 1,
+      createdBy: base.adminUser.id,
+    });
+
+    console.log("  Form definitions: 3 (2 published, 1 draft)");
+
+    // -----------------------------------------------------------------------
+    // Section C: Bulk submissions (~74 new)
+    // -----------------------------------------------------------------------
+    let titleIdx = 0;
+    const allStagingSubs: (typeof submissions.$inferSelect)[] = [];
+
+    type SubmissionStatus =
+      | "DRAFT"
+      | "SUBMITTED"
+      | "UNDER_REVIEW"
+      | "ACCEPTED"
+      | "REJECTED"
+      | "HOLD"
+      | "WITHDRAWN"
+      | "REVISE_AND_RESUBMIT";
+
+    async function createBulkSubmissions(
+      orgId: string,
+      periodId: string,
+      statuses: readonly string[],
+      writerPool: (typeof users.$inferSelect)[],
+      dayRange: [number, number],
+    ) {
+      for (const rawStatus of statuses) {
+        const status = rawStatus as SubmissionStatus;
+        const writer = randomFrom(writerPool);
+        const title = SUBMISSION_TITLES[titleIdx % SUBMISSION_TITLES.length]!;
+        titleIdx++;
+        const submittedDays = randomInt(dayRange[0], dayRange[1]);
+
+        const [sub] = await tx
+          .insert(submissions)
+          .values({
+            organizationId: orgId,
+            submitterId: writer.id,
+            submissionPeriodId: periodId,
+            title,
+            content: `Submission content for "${title}".`,
+            coverLetter: `Dear Editors, I am pleased to submit "${title}" for your consideration.`,
+            status,
+            submittedAt:
+              status !== "DRAFT" ? daysAgo(submittedDays) : undefined,
+          })
+          .returning();
+
+        allStagingSubs.push(sub!);
+
+        // Create history entries based on status
+        const histories: {
+          submissionId: string;
+          fromStatus: SubmissionStatus | null;
+          toStatus: SubmissionStatus;
+          changedBy: string;
+          changedAt: Date;
+          comment?: string;
+        }[] = [];
+
+        if (status !== "DRAFT") {
+          histories.push({
+            submissionId: sub!.id,
+            fromStatus: "DRAFT" as SubmissionStatus,
+            toStatus: "SUBMITTED" as SubmissionStatus,
+            changedBy: writer.id,
+            changedAt: daysAgo(submittedDays),
+          });
+        }
+
+        if (
+          [
+            "UNDER_REVIEW",
+            "ACCEPTED",
+            "REJECTED",
+            "HOLD",
+            "WITHDRAWN",
+            "REVISE_AND_RESUBMIT",
+          ].includes(status)
+        ) {
+          histories.push({
+            submissionId: sub!.id,
+            fromStatus: "SUBMITTED" as SubmissionStatus,
+            toStatus: "UNDER_REVIEW" as SubmissionStatus,
+            changedBy: randomFrom(allEditors).id,
+            changedAt: daysAgo(submittedDays - randomInt(1, 5)),
+          });
+        }
+
+        if (
+          ["ACCEPTED", "REJECTED", "HOLD", "REVISE_AND_RESUBMIT"].includes(
+            status,
+          )
+        ) {
+          histories.push({
+            submissionId: sub!.id,
+            fromStatus: "UNDER_REVIEW" as SubmissionStatus,
+            toStatus: status as SubmissionStatus,
+            changedBy: randomFrom(allEditors).id,
+            changedAt: daysAgo(Math.max(1, submittedDays - randomInt(5, 15))),
+            comment:
+              status === "ACCEPTED"
+                ? "Accepted for publication."
+                : status === "REJECTED"
+                  ? "Does not fit our current needs."
+                  : status === "HOLD"
+                    ? "Holding for further discussion."
+                    : status === "REVISE_AND_RESUBMIT"
+                      ? "Strong work — we'd like to see a revised version."
+                      : undefined,
+          });
+        }
+
+        if (status === "WITHDRAWN") {
+          histories.push({
+            submissionId: sub!.id,
+            fromStatus: "UNDER_REVIEW" as SubmissionStatus,
+            toStatus: "WITHDRAWN" as SubmissionStatus,
+            changedBy: writer.id,
+            changedAt: daysAgo(Math.max(1, submittedDays - randomInt(3, 10))),
+            comment: "Withdrawn by author.",
+          });
+        }
+
+        if (histories.length > 0) {
+          await tx.insert(submissionHistory).values(histories);
+        }
+
+        // Create manuscript + version + file for non-draft submissions
+        if (status !== "DRAFT") {
+          const [ms] = await tx
+            .insert(manuscripts)
+            .values({
+              ownerId: writer.id,
+              title,
+              description: `Manuscript for "${title}".`,
+            })
+            .returning();
+
+          const [ver] = await tx
+            .insert(manuscriptVersions)
+            .values({
+              manuscriptId: ms!.id,
+              versionNumber: 1,
+              label: "Submitted version",
+            })
+            .returning();
+
+          await tx
+            .update(submissions)
+            .set({ manuscriptVersionId: ver!.id })
+            .where(eq(submissions.id, sub!.id));
+
+          await tx.insert(files).values({
+            manuscriptVersionId: ver!.id,
+            filename: `${title.toLowerCase().replace(/\s+/g, "-")}.pdf`,
+            mimeType: "application/pdf",
+            size: randomInt(50_000, 500_000),
+            storageKey: `manuscripts/${writer.id}/${ms!.id}/v1/submission.pdf`,
+            scanStatus: "CLEAN",
+            scannedAt: daysAgo(submittedDays - 1),
+          });
+        }
+      }
+    }
+
+    // Spring 2026 (open period, org1) — 28 new
+    await createBulkSubmissions(
+      base.org1.id,
+      base.openPeriod.id,
+      SUBMISSION_STATUSES_SPRING,
+      allWriters,
+      [3, 90],
+    );
+
+    // Winter 2025 (closed period, org1) — 30 new
+    await createBulkSubmissions(
+      base.org1.id,
+      base.winterPeriod.id,
+      SUBMISSION_STATUSES_WINTER,
+      allWriters,
+      [60, 180],
+    );
+
+    // Inkwell rolling (org2) — 16 new
+    await createBulkSubmissions(
+      base.org2.id,
+      base.inkwellPeriod.id,
+      SUBMISSION_STATUSES_INKWELL,
+      [base.writerUser, writer2!, writer3!],
+      [5, 120],
+    );
+
+    console.log(
+      `  Submissions: ${allStagingSubs.length} new (${allStagingSubs.length + 6} total)`,
+    );
+
+    // -----------------------------------------------------------------------
+    // Section D: Editorial workflow (reviewers, discussions, votes)
+    // -----------------------------------------------------------------------
+    // Get org1 submissions that are UNDER_REVIEW or later (not DRAFT/SUBMITTED)
+    const reviewableSubs = allStagingSubs.filter(
+      (s) =>
+        s.organizationId === base.org1.id &&
+        !["DRAFT", "SUBMITTED"].includes(s.status),
+    );
+
+    // Reviewer assignments — 2 reviewers per first 20 reviewable submissions
+    const subsForReview = reviewableSubs.slice(0, 20);
+    for (const sub of subsForReview) {
+      const reviewers = [randomFrom(allEditors), randomFrom(allEditors)];
+      // Ensure different reviewers
+      if (reviewers[0]!.id === reviewers[1]!.id) {
+        reviewers[1] = allEditors.find((e) => e.id !== reviewers[0]!.id)!;
+      }
+
+      for (const reviewer of reviewers) {
+        await tx.insert(submissionReviewers).values({
+          organizationId: base.org1.id,
+          submissionId: sub.id,
+          reviewerUserId: reviewer.id,
+          assignedBy: base.adminUser.id,
+          assignedAt: daysAgo(randomInt(1, 30)),
+          readAt: Math.random() > 0.3 ? daysAgo(randomInt(1, 15)) : null,
+        });
+      }
+    }
+
+    console.log(`  Reviewer assignments: ${subsForReview.length * 2}`);
+
+    // Discussion threads — 15 threads on 10 submissions (some with replies)
+    const subsForDiscussion = reviewableSubs.slice(0, 10);
+    let discussionCount = 0;
+    for (let i = 0; i < subsForDiscussion.length; i++) {
+      const sub = subsForDiscussion[i]!;
+      const author = randomFrom(allEditors);
+      const [thread] = await tx
+        .insert(submissionDiscussions)
+        .values({
+          organizationId: base.org1.id,
+          submissionId: sub.id,
+          authorId: author.id,
+          content: DISCUSSION_COMMENTS[i % DISCUSSION_COMMENTS.length]!,
+          createdAt: daysAgo(randomInt(1, 20)),
+        })
+        .returning();
+      discussionCount++;
+
+      // Add replies to first 5 threads
+      if (i < 5) {
+        const replier = allEditors.find((e) => e.id !== author.id)!;
+        await tx.insert(submissionDiscussions).values({
+          organizationId: base.org1.id,
+          submissionId: sub.id,
+          authorId: replier.id,
+          parentId: thread!.id,
+          content: DISCUSSION_COMMENTS[(i + 5) % DISCUSSION_COMMENTS.length]!,
+          createdAt: daysAgo(randomInt(1, 10)),
+        });
+        discussionCount++;
+      }
+    }
+
+    console.log(`  Discussion comments: ${discussionCount}`);
+
+    // Votes — 30 votes across 15 submissions
+    const subsForVotes = reviewableSubs.slice(0, 15);
+    const decisions = ["ACCEPT", "REJECT", "MAYBE"] as const;
+    let voteCount = 0;
+    for (const sub of subsForVotes) {
+      const voters = [randomFrom(allEditors), randomFrom(allEditors)];
+      if (voters[0]!.id === voters[1]!.id) {
+        voters[1] = allEditors.find((e) => e.id !== voters[0]!.id)!;
+      }
+      for (const voter of voters) {
+        await tx.insert(submissionVotes).values({
+          organizationId: base.org1.id,
+          submissionId: sub.id,
+          voterUserId: voter.id,
+          decision: randomFrom([...decisions]),
+          score: String(randomInt(1, 10)),
+        });
+        voteCount++;
+      }
+    }
+
+    console.log(`  Votes: ${voteCount}`);
+
+    // -----------------------------------------------------------------------
+    // Section E: Slate pipeline comments + additional pipeline items
+    // -----------------------------------------------------------------------
+    // Add comments to existing pipeline items
+    await tx.insert(pipelineComments).values([
+      {
+        pipelineItemId: base.pipeItem1.id,
+        authorId: base.editorUser.id,
+        content:
+          "Light copyedit needed — mostly punctuation and a few word choices.",
+        stage: "COPYEDIT_IN_PROGRESS",
+      },
+      {
+        pipelineItemId: base.pipeItem2.id,
+        authorId: base.adminUser.id,
+        content: "Proofread complete. Ready for layout.",
+        stage: "READY_TO_PUBLISH",
+      },
+    ]);
+
+    // Create pipeline items from newly accepted submissions
+    const newAccepted = allStagingSubs.filter(
+      (s) => s.status === "ACCEPTED" && s.organizationId === base.org1.id,
+    );
+    const pipelineStages = [
+      "COPYEDIT_PENDING",
+      "COPYEDIT_IN_PROGRESS",
+      "AUTHOR_REVIEW",
+      "PROOFREAD",
+    ] as const;
+
+    for (let i = 0; i < Math.min(4, newAccepted.length); i++) {
+      const sub = newAccepted[i]!;
+      const stage = pipelineStages[i % pipelineStages.length]!;
+      const [pi] = await tx
+        .insert(pipelineItems)
+        .values({
+          organizationId: base.org1.id,
+          submissionId: sub.id,
+          publicationId: base.pub1.id,
+          stage,
+          assignedCopyeditorId:
+            stage === "COPYEDIT_IN_PROGRESS" ? base.editorUser.id : undefined,
+        })
+        .returning();
+
+      await tx.insert(pipelineHistory).values({
+        pipelineItemId: pi!.id,
+        fromStage: null,
+        toStage: stage,
+        changedBy: base.adminUser.id,
+        comment: "Moved to publication pipeline.",
+        changedAt: daysAgo(randomInt(1, 10)),
+      });
+    }
+
+    console.log("  Pipeline: 2 comments + 4 new items");
+
+    // -----------------------------------------------------------------------
+    // Section F: Email templates
+    // -----------------------------------------------------------------------
+    const templateEvents = [
+      {
+        name: "submission_received",
+        subject: "We received your submission: {{title}}",
+        body: "<h1>Thank you</h1><p>We have received your submission &ldquo;{{title}}&rdquo; and it is now in our reading queue.</p>",
+      },
+      {
+        name: "submission_accepted",
+        subject: "Congratulations! Your work has been accepted",
+        body: "<h1>Wonderful news</h1><p>We are delighted to accept &ldquo;{{title}}&rdquo; for publication in {{publicationName}}.</p>",
+      },
+      {
+        name: "submission_rejected",
+        subject: "Update on your submission to {{orgName}}",
+        body: "<h1>Thank you for submitting</h1><p>After careful consideration, we have decided not to accept &ldquo;{{title}}&rdquo; at this time. We wish you the best.</p>",
+      },
+      {
+        name: "under_review",
+        subject: "Your submission is under review",
+        body: "<h1>Under Review</h1><p>Your submission &ldquo;{{title}}&rdquo; has moved to our review stage.</p>",
+      },
+      {
+        name: "revise_and_resubmit",
+        subject: "Revision requested for your submission",
+        body: "<h1>Revision Requested</h1><p>We enjoyed reading &ldquo;{{title}}&rdquo; and would like to see a revised version.</p>",
+      },
+    ];
+
+    for (const org of [base.org1, base.org2]) {
+      for (const tmpl of templateEvents) {
+        await tx.insert(emailTemplates).values({
+          organizationId: org.id,
+          templateName: tmpl.name,
+          subjectTemplate: tmpl.subject,
+          bodyHtml: tmpl.body,
+          isActive: true,
+        });
+      }
+    }
+
+    console.log("  Email templates: 10 (5 per org)");
+
+    // -----------------------------------------------------------------------
+    // Section G: Notification preferences
+    // -----------------------------------------------------------------------
+    const notifEventTypes = [
+      "submission.received",
+      "submission.status_changed",
+      "discussion.new_comment",
+    ];
+    const channels = ["email", "in_app"] as const;
+
+    for (const user of [base.adminUser, base.editorUser, editor2!, editor3!]) {
+      for (const eventType of notifEventTypes) {
+        for (const channel of channels) {
+          await tx.insert(notificationPreferences).values({
+            organizationId: base.org1.id,
+            userId: user.id,
+            channel,
+            eventType,
+            enabled: true,
+          });
+        }
+      }
+    }
+
+    console.log("  Notification preferences: 24");
+
+    // Inbox notifications (sample)
+    const inboxItems = [
+      {
+        userId: base.adminUser.id,
+        eventType: "submission.received",
+        title: "New submission received",
+        body: "A new submission has been submitted to Spring 2026 Reading Period.",
+        read: false,
+      },
+      {
+        userId: base.adminUser.id,
+        eventType: "submission.received",
+        title: "New submission received",
+        body: "Another submission for the Spring period.",
+        read: true,
+      },
+      {
+        userId: base.editorUser.id,
+        eventType: "discussion.new_comment",
+        title: "New comment on submission",
+        body: "A new comment was added to a submission you're reviewing.",
+        read: false,
+      },
+      {
+        userId: base.editorUser.id,
+        eventType: "submission.status_changed",
+        title: "Submission accepted",
+        body: "A submission you reviewed has been accepted.",
+        read: true,
+      },
+      {
+        userId: editor2!.id,
+        eventType: "submission.received",
+        title: "New submission received",
+        body: "A poetry submission has been received.",
+        read: false,
+      },
+      {
+        userId: editor2!.id,
+        eventType: "discussion.new_comment",
+        title: "Reply to your comment",
+        body: "Someone replied to your editorial comment.",
+        read: false,
+      },
+      {
+        userId: editor3!.id,
+        eventType: "submission.status_changed",
+        title: "Submission rejected",
+        body: "A submission you reviewed was rejected.",
+        read: true,
+      },
+      {
+        userId: base.adminUser.id,
+        eventType: "submission.status_changed",
+        title: "Submission moved to review",
+        body: "A submission was moved to Under Review.",
+        read: false,
+      },
+      {
+        userId: base.editorUser.id,
+        eventType: "submission.received",
+        title: "New submission",
+        body: "New fiction submission received.",
+        read: false,
+      },
+      {
+        userId: editor3!.id,
+        eventType: "discussion.new_comment",
+        title: "New discussion thread",
+        body: "A new discussion was started on a submission.",
+        read: false,
+      },
+    ];
+
+    for (const item of inboxItems) {
+      await tx.insert(notificationsInbox).values({
+        organizationId: base.org1.id,
+        userId: item.userId,
+        eventType: item.eventType,
+        title: item.title,
+        body: item.body,
+        readAt: item.read ? daysAgo(randomInt(1, 5)) : null,
+        createdAt: daysAgo(randomInt(1, 14)),
+      });
+    }
+
+    console.log("  Inbox notifications: 10");
+
+    // -----------------------------------------------------------------------
+    // Section H: Webhook endpoints (DISABLED) + historical deliveries
+    // -----------------------------------------------------------------------
+    for (const org of [base.org1, base.org2]) {
+      const [ep1] = await tx
+        .insert(webhookEndpoints)
+        .values({
+          organizationId: org.id,
+          url: "https://hooks.example.com/colophony/submissions",
+          secret: createHash("sha256")
+            .update(`webhook-secret-${org.slug}`)
+            .digest("hex"),
+          description: "Submission lifecycle events",
+          eventTypes: [
+            "submission.created",
+            "submission.status_changed",
+            "submission.accepted",
+          ],
+          status: "DISABLED",
+        })
+        .returning();
+
+      await tx.insert(webhookEndpoints).values({
+        organizationId: org.id,
+        url: "https://hooks.example.com/colophony/pipeline",
+        secret: createHash("sha256")
+          .update(`webhook-secret-pipe-${org.slug}`)
+          .digest("hex"),
+        description: "Pipeline stage changes",
+        eventTypes: ["pipeline.stage_changed", "pipeline.published"],
+        status: "DISABLED",
+      });
+
+      // Historical deliveries on the first endpoint (org1 only)
+      if (org.id === base.org1.id) {
+        const deliveryStatuses = [
+          "DELIVERED",
+          "DELIVERED",
+          "DELIVERED",
+          "DELIVERED",
+          "FAILED",
+          "DELIVERED",
+          "DELIVERED",
+          "FAILED",
+        ] as const;
+        for (let i = 0; i < deliveryStatuses.length; i++) {
+          const status = deliveryStatuses[i]!;
+          await tx.insert(webhookDeliveries).values({
+            organizationId: base.org1.id,
+            webhookEndpointId: ep1!.id,
+            eventType: "submission.status_changed",
+            eventId: `evt_staging_${i + 1}`,
+            payload: { submissionId: "example-uuid", status: "ACCEPTED" },
+            status,
+            httpStatusCode: status === "DELIVERED" ? 200 : 500,
+            responseBody:
+              status === "DELIVERED"
+                ? '{"ok":true}'
+                : '{"error":"Internal Server Error"}',
+            errorMessage: status === "FAILED" ? "HTTP 500 from endpoint" : null,
+            attempts: status === "FAILED" ? 3 : 1,
+            deliveredAt:
+              status === "DELIVERED" ? daysAgo(randomInt(1, 14)) : null,
+            createdAt: daysAgo(randomInt(1, 14)),
+          });
+        }
+      }
+    }
+
+    console.log(
+      "  Webhook endpoints: 4 (all DISABLED) + 8 historical deliveries",
+    );
+
+    // -----------------------------------------------------------------------
+    // Section I: Writer workspace
+    // -----------------------------------------------------------------------
+    // Journal directory (15 entries, written as superuser)
+    for (const journal of JOURNAL_NAMES) {
+      await tx.insert(journalDirectory).values({
+        name: journal.name,
+        normalizedName: journal.name.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+        externalUrl: journal.url,
+        directoryIds: journal.ids,
+      });
+    }
+
+    console.log("  Journal directory: 15 journals");
+
+    // External submissions (20 across 3 writers)
+    const extStatuses = [
+      "sent",
+      "in_review",
+      "accepted",
+      "rejected",
+      "no_response",
+    ] as const;
+    let extCount = 0;
+    for (const writer of [writer2!, writer3!, writer4!]) {
+      const count =
+        writer.id === writer2!.id ? 8 : writer.id === writer3!.id ? 7 : 5;
+      for (let i = 0; i < count; i++) {
+        const journal = randomFrom(JOURNAL_NAMES);
+        const status = randomFrom([...extStatuses]);
+        const sentDays = randomInt(10, 180);
+        await tx.insert(externalSubmissions).values({
+          userId: writer.id,
+          journalName: journal.name,
+          status,
+          sentAt: daysAgo(sentDays),
+          respondedAt: ["accepted", "rejected"].includes(status)
+            ? daysAgo(sentDays - randomInt(30, 90))
+            : null,
+          method: randomFrom(["Submittable", "email", "online form"]),
+          notes: status === "accepted" ? "Accepted for upcoming issue!" : null,
+        });
+        extCount++;
+      }
+    }
+
+    console.log(`  External submissions: ${extCount}`);
+
+    // Correspondence (10 entries)
+    const corrSubs = allStagingSubs
+      .filter(
+        (s) => s.organizationId === base.org1.id && s.status === "ACCEPTED",
+      )
+      .slice(0, 3);
+
+    for (const sub of corrSubs) {
+      // Outbound acceptance letter
+      await tx.insert(correspondence).values({
+        userId: sub.submitterId!,
+        submissionId: sub.id,
+        direction: "outbound",
+        channel: "email",
+        sentAt: daysAgo(randomInt(1, 10)),
+        subject: `Acceptance: ${sub.title}`,
+        body: `Dear author, we are pleased to accept "${sub.title}" for publication in The Quarterly Review.`,
+        senderName: "The Quarterly Review",
+        senderEmail: "editor@quarterlyreview.org",
+        isPersonalized: true,
+        source: "auto",
+      });
+
+      // Inbound thank-you reply
+      await tx.insert(correspondence).values({
+        userId: sub.submitterId!,
+        submissionId: sub.id,
+        direction: "inbound",
+        channel: "email",
+        sentAt: daysAgo(randomInt(1, 5)),
+        subject: `Re: Acceptance: ${sub.title}`,
+        body: "Thank you so much for this wonderful news! I'm thrilled to have my work included.",
+        senderName: "Author",
+        isPersonalized: true,
+        source: "manual",
+      });
+    }
+
+    // A few external submission correspondences
+    const extSubs = await tx.select().from(externalSubmissions).limit(2);
+    for (const ext of extSubs) {
+      await tx.insert(correspondence).values({
+        userId: ext.userId,
+        externalSubmissionId: ext.id,
+        direction: "inbound",
+        channel: "email",
+        sentAt: daysAgo(randomInt(10, 60)),
+        subject: "Thank you for your submission",
+        body: "We appreciate your submission. Unfortunately, it does not meet our current editorial needs.",
+        senderName: ext.journalName,
+        isPersonalized: false,
+        source: "manual",
+      });
+    }
+
+    console.log("  Correspondence: ~8 entries");
+
+    // Writer profiles
+    await tx.insert(writerProfiles).values([
+      {
+        userId: writer2!.id,
+        platform: "chillsubs",
+        externalId: "writer2-cs",
+        profileUrl: "https://chillsubs.com/user/writer2",
+      },
+      {
+        userId: writer2!.id,
+        platform: "submittable",
+        externalId: "w2-submittable",
+        profileUrl: "https://submittable.com/profile/w2",
+      },
+      {
+        userId: writer3!.id,
+        platform: "chillsubs",
+        externalId: "writer3-cs",
+        profileUrl: "https://chillsubs.com/user/writer3",
+      },
+      {
+        userId: writer3!.id,
+        platform: "duotrope",
+        externalId: "w3-duotrope",
+        profileUrl: "https://duotrope.com/account/w3",
+      },
+    ]);
+
+    console.log("  Writer profiles: 4");
+
+    // -----------------------------------------------------------------------
+    // Section J: Federation (config + trusted peers)
+    // -----------------------------------------------------------------------
+    const instanceKeys = generateEd25519();
+    await tx.insert(federationConfig).values({
+      publicKey: instanceKeys.publicKey,
+      privateKey: instanceKeys.privateKey,
+      keyId: "did:web:staging.colophony.dev#key-1",
+      mode: "allowlist",
+      contactEmail: "admin@staging.colophony.dev",
+      capabilities: ["identity", "simsub", "transfer"],
+      enabled: true,
+    });
+
+    // Trusted peers — org1 and org2 trust a fictional peer instance
+    const peerKeys1 = generateEd25519();
+    const peerKeys2 = generateEd25519();
+
+    await tx.insert(trustedPeers).values({
+      organizationId: base.org1.id,
+      domain: "literary-hub.example.com",
+      instanceUrl: "https://literary-hub.example.com",
+      publicKey: peerKeys1.publicKey,
+      keyId: "did:web:literary-hub.example.com#key-1",
+      grantedCapabilities: { identity: true, simsub: true, transfer: false },
+      status: "active",
+      initiatedBy: "local",
+      lastVerifiedAt: daysAgo(2),
+    });
+
+    await tx.insert(trustedPeers).values({
+      organizationId: base.org2.id,
+      domain: "indie-press-collective.example.org",
+      instanceUrl: "https://indie-press-collective.example.org",
+      publicKey: peerKeys2.publicKey,
+      keyId: "did:web:indie-press-collective.example.org#key-1",
+      grantedCapabilities: { identity: true, simsub: false, transfer: false },
+      status: "active",
+      initiatedBy: "remote",
+      lastVerifiedAt: daysAgo(5),
+    });
+
+    console.log("  Federation: 1 config + 2 trusted peers");
+
+    // -----------------------------------------------------------------------
+    // Section K: Embed tokens
+    // -----------------------------------------------------------------------
+    const embedToken1 = "emb_staging_token_active_001";
+    const embedToken2 = "emb_staging_token_expired_002";
+
+    await tx.insert(embedTokens).values([
+      {
+        organizationId: base.org1.id,
+        submissionPeriodId: base.openPeriod.id,
+        tokenHash: createHash("sha256").update(embedToken1).digest("hex"),
+        tokenPrefix: "emb_stag",
+        allowedOrigins: [
+          "https://www.example.com",
+          "https://staging.example.com",
+        ],
+        themeConfig: {
+          primaryColor: "#2563eb",
+          fontFamily: "Inter",
+          borderRadius: "8px",
+        },
+        active: true,
+        createdBy: base.adminUser.id,
+      },
+      {
+        organizationId: base.org1.id,
+        submissionPeriodId: base.openPeriod.id,
+        tokenHash: createHash("sha256").update(embedToken2).digest("hex"),
+        tokenPrefix: "emb_exp_",
+        allowedOrigins: ["https://old.example.com"],
+        active: false,
+        createdBy: base.adminUser.id,
+        expiresAt: daysAgo(7),
+      },
+    ]);
+
+    console.log("  Embed tokens: 2 (1 active, 1 expired)");
+
+    // -----------------------------------------------------------------------
+    // Section L: Saved queue presets
+    // -----------------------------------------------------------------------
+    await tx.insert(savedQueuePresets).values([
+      {
+        organizationId: base.org1.id,
+        userId: base.adminUser.id,
+        name: "Pending Review",
+        filters: {
+          status: ["SUBMITTED", "UNDER_REVIEW"],
+          sortBy: "submittedAt",
+          sortOrder: "asc",
+        },
+        isDefault: true,
+      },
+      {
+        organizationId: base.org1.id,
+        userId: base.adminUser.id,
+        name: "Accepted — Needs Pipeline",
+        filters: {
+          status: ["ACCEPTED"],
+          sortBy: "submittedAt",
+          sortOrder: "desc",
+        },
+      },
+      {
+        organizationId: base.org1.id,
+        userId: base.editorUser.id,
+        name: "My Review Queue",
+        filters: {
+          status: ["UNDER_REVIEW"],
+          sortBy: "submittedAt",
+          sortOrder: "asc",
+        },
+        isDefault: true,
+      },
+    ]);
+
+    console.log("  Saved queue presets: 3");
+
+    // -----------------------------------------------------------------------
+    // Section M: User consents
+    // -----------------------------------------------------------------------
+    await tx.insert(userConsents).values([
+      {
+        userId: base.adminUser.id,
+        consentType: "terms_of_service",
+        granted: true,
+        ipAddress: "203.0.113.1",
+      },
+      {
+        userId: base.adminUser.id,
+        consentType: "privacy_policy",
+        granted: true,
+        ipAddress: "203.0.113.1",
+      },
+      {
+        userId: base.writerUser.id,
+        consentType: "terms_of_service",
+        granted: true,
+        ipAddress: "198.51.100.42",
+      },
+      {
+        userId: base.writerUser.id,
+        consentType: "privacy_policy",
+        granted: true,
+        ipAddress: "198.51.100.42",
+      },
+    ]);
+
+    console.log("  User consents: 4");
+
+    // -----------------------------------------------------------------------
+    // Section N: Mark staging as seeded (idempotency flag)
+    // -----------------------------------------------------------------------
+    await tx
+      .update(organizations)
+      .set({
+        settings: sql`jsonb_set(COALESCE(settings, '{}'::jsonb), '{stagingSeeded}', 'true')`,
+      })
+      .where(eq(organizations.slug, "quarterly-review"));
+
+    console.log("  Staging flag set on quarterly-review org.");
+  });
+
+  console.log("\nStaging seed complete.");
+}
+
+main()
+  .catch((e) => {
+    console.error("Staging seed failed:", e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await pool.end();
+  });

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -11,6 +11,7 @@
 import { createHash } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { db, pool } from "./client";
+import type { DrizzleDb } from "./context";
 import {
   organizations,
   users,
@@ -46,14 +47,791 @@ const SEED_API_KEY_HASH = createHash("sha256")
   .digest("hex");
 
 // ---------------------------------------------------------------------------
-// Date helpers
+// Date helpers (exported for reuse by seed-staging.ts)
 // ---------------------------------------------------------------------------
-const now = new Date();
-const daysAgo = (n: number) => new Date(now.getTime() - n * 86_400_000);
-const daysFromNow = (n: number) => new Date(now.getTime() + n * 86_400_000);
+export const now = new Date();
+export const daysAgo = (n: number) => new Date(now.getTime() - n * 86_400_000);
+export const daysFromNow = (n: number) =>
+  new Date(now.getTime() + n * 86_400_000);
 
+// ---------------------------------------------------------------------------
+// SeedResult — all entities created by the base seed
+// ---------------------------------------------------------------------------
+export interface SeedResult {
+  org1: typeof organizations.$inferSelect;
+  org2: typeof organizations.$inferSelect;
+  adminUser: typeof users.$inferSelect;
+  editorUser: typeof users.$inferSelect;
+  writerUser: typeof users.$inferSelect;
+  inkwellAdmin: typeof users.$inferSelect;
+  openPeriod: typeof submissionPeriods.$inferSelect;
+  winterPeriod: typeof submissionPeriods.$inferSelect;
+  inkwellPeriod: typeof submissionPeriods.$inferSelect;
+  submittedSub: typeof submissions.$inferSelect;
+  underReviewSub: typeof submissions.$inferSelect;
+  acceptedSub: typeof submissions.$inferSelect;
+  acceptedSub2: typeof submissions.$inferSelect;
+  manuscript1: typeof manuscripts.$inferSelect;
+  version1: typeof manuscriptVersions.$inferSelect;
+  pub1: typeof publications.$inferSelect;
+  pub2: typeof publications.$inferSelect;
+  pipeItem1: typeof pipelineItems.$inferSelect;
+  pipeItem2: typeof pipelineItems.$inferSelect;
+  template1: typeof contractTemplates.$inferSelect;
+  issue1: typeof issues.$inferSelect;
+  poetrySection: typeof issueSections.$inferSelect;
+  fictionSection: typeof issueSections.$inferSelect;
+}
+
+/**
+ * Core seed logic — creates base dev/test data inside a transaction.
+ * Exported so seed-staging.ts can call it and layer additional data.
+ */
+export async function seedBase(tx: DrizzleDb): Promise<SeedResult> {
+  // ----- Organizations -----
+  const [org1] = await tx
+    .insert(organizations)
+    .values({
+      name: "The Quarterly Review",
+      slug: "quarterly-review",
+      settings: {
+        maxFileSize: 10_485_760,
+        allowedMimeTypes: ["application/pdf", "application/msword"],
+      },
+    })
+    .returning();
+
+  const [org2] = await tx
+    .insert(organizations)
+    .values({
+      name: "Inkwell Press",
+      slug: "inkwell-press",
+      settings: { maxFileSize: 5_242_880 },
+    })
+    .returning();
+
+  console.log(`  Organizations: ${org1!.name}, ${org2!.name}`);
+
+  // ----- Users -----
+  const [adminUser] = await tx
+    .insert(users)
+    .values({
+      email: "editor@quarterlyreview.org",
+      zitadelUserId: "seed-zitadel-admin-001",
+      emailVerified: true,
+      emailVerifiedAt: daysAgo(90),
+    })
+    .returning();
+
+  const [editorUser] = await tx
+    .insert(users)
+    .values({
+      email: "reader@quarterlyreview.org",
+      zitadelUserId: "seed-zitadel-editor-001",
+      emailVerified: true,
+      emailVerifiedAt: daysAgo(60),
+    })
+    .returning();
+
+  const [writerUser] = await tx
+    .insert(users)
+    .values({
+      email: "writer@example.com",
+      zitadelUserId: "seed-zitadel-writer-001",
+      emailVerified: true,
+      emailVerifiedAt: daysAgo(30),
+    })
+    .returning();
+
+  const [inkwellAdmin] = await tx
+    .insert(users)
+    .values({
+      email: "admin@inkwellpress.org",
+      zitadelUserId: "seed-zitadel-inkwell-001",
+      emailVerified: true,
+      emailVerifiedAt: daysAgo(45),
+    })
+    .returning();
+
+  console.log(
+    `  Users: ${[adminUser, editorUser, writerUser, inkwellAdmin].map((u) => u!.email).join(", ")}`,
+  );
+
+  // ----- Organization Members -----
+  // Org 1: admin, editor, reader (submitter)
+  await tx.insert(organizationMembers).values([
+    {
+      organizationId: org1!.id,
+      userId: adminUser!.id,
+      role: "ADMIN",
+    },
+    {
+      organizationId: org1!.id,
+      userId: editorUser!.id,
+      role: "EDITOR",
+    },
+    {
+      organizationId: org1!.id,
+      userId: writerUser!.id,
+      role: "READER",
+    },
+  ]);
+
+  // Org 2: admin + shared writer (cross-org membership)
+  await tx.insert(organizationMembers).values([
+    {
+      organizationId: org2!.id,
+      userId: inkwellAdmin!.id,
+      role: "ADMIN",
+    },
+    {
+      organizationId: org2!.id,
+      userId: writerUser!.id,
+      role: "READER",
+    },
+  ]);
+
+  console.log(
+    "  Organization members: 5 (3 in quarterly-review, 2 in inkwell-press)",
+  );
+
+  // ----- Submission Periods -----
+  const [openPeriod] = await tx
+    .insert(submissionPeriods)
+    .values({
+      organizationId: org1!.id,
+      name: "Spring 2026 Reading Period",
+      description: "Open call for poetry and short fiction, up to 5,000 words.",
+      opensAt: daysAgo(14),
+      closesAt: daysFromNow(45),
+      fee: "5.00",
+      maxSubmissions: 500,
+    })
+    .returning();
+
+  const [winterPeriod] = await tx
+    .insert(submissionPeriods)
+    .values({
+      organizationId: org1!.id,
+      name: "Winter 2025 Reading Period",
+      description: "Closed. Thank you for your submissions.",
+      opensAt: daysAgo(120),
+      closesAt: daysAgo(60),
+      fee: "3.00",
+      maxSubmissions: 300,
+    })
+    .returning();
+
+  const [inkwellPeriod] = await tx
+    .insert(submissionPeriods)
+    .values({
+      organizationId: org2!.id,
+      name: "Open Submissions 2026",
+      description: "Rolling submissions for flash fiction under 1,000 words.",
+      opensAt: daysAgo(7),
+      closesAt: daysFromNow(180),
+    })
+    .returning();
+
+  console.log(
+    "  Submission periods: 3 (2 in quarterly-review, 1 in inkwell-press)",
+  );
+
+  // ----- Submissions (Org 1) -----
+  const [submittedSub] = await tx
+    .insert(submissions)
+    .values({
+      organizationId: org1!.id,
+      submitterId: writerUser!.id,
+      submissionPeriodId: openPeriod!.id,
+      title: "The Weight of Small Things",
+      content:
+        "A short story about the objects we carry and the memories they hold.",
+      coverLetter:
+        "Dear Editors, I am submitting my short story for your consideration. It explores themes of memory and loss through everyday objects.",
+      status: "SUBMITTED",
+      submittedAt: daysAgo(5),
+    })
+    .returning();
+
+  const [underReviewSub] = await tx
+    .insert(submissions)
+    .values({
+      organizationId: org1!.id,
+      submitterId: writerUser!.id,
+      submissionPeriodId: openPeriod!.id,
+      title: "Cartography of Absence",
+      content:
+        "A cycle of poems mapping the spaces left behind by those who have departed.",
+      coverLetter:
+        "These poems emerged from a residency in the Outer Hebrides. They attempt to chart absence as a kind of presence.",
+      status: "UNDER_REVIEW",
+      submittedAt: daysAgo(10),
+    })
+    .returning();
+
+  const [acceptedSub] = await tx
+    .insert(submissions)
+    .values({
+      organizationId: org1!.id,
+      submitterId: writerUser!.id,
+      submissionPeriodId: openPeriod!.id,
+      title: "Field Notes on Disappearing",
+      content:
+        "An essay on ecological grief and the language we use to describe environmental loss.",
+      coverLetter:
+        "This essay was a finalist for the Pushcart Prize and is previously unpublished.",
+      status: "ACCEPTED",
+      submittedAt: daysAgo(20),
+    })
+    .returning();
+
+  // Submission (Org 2) — DRAFT
+  await tx.insert(submissions).values({
+    organizationId: org2!.id,
+    submitterId: writerUser!.id,
+    submissionPeriodId: inkwellPeriod!.id,
+    title: "Untitled Flash Piece",
+    content: null,
+    status: "DRAFT",
+  });
+
+  console.log("  Submissions: 4 (3 in quarterly-review, 1 in inkwell-press)");
+
+  // ----- Manuscripts + Versions + Files -----
+  // Create a manuscript for the writer's submitted work
+  const [manuscript1] = await tx
+    .insert(manuscripts)
+    .values({
+      ownerId: writerUser!.id,
+      title: "The Weight of Small Things",
+      description:
+        "A short story about the objects we carry and the memories they hold.",
+    })
+    .returning();
+
+  const [version1] = await tx
+    .insert(manuscriptVersions)
+    .values({
+      manuscriptId: manuscript1!.id,
+      versionNumber: 1,
+      label: "Initial submission",
+    })
+    .returning();
+
+  // Link the submitted submission to this manuscript version
+  await tx
+    .update(submissions)
+    .set({ manuscriptVersionId: version1!.id })
+    .where(eq(submissions.id, submittedSub!.id));
+
+  // Create files on the manuscript version (replaces submission_files)
+  await tx.insert(files).values([
+    {
+      manuscriptVersionId: version1!.id,
+      filename: "the-weight-of-small-things.pdf",
+      mimeType: "application/pdf",
+      size: 245_760,
+      storageKey: `manuscripts/${writerUser!.id}/${manuscript1!.id}/v1/the-weight-of-small-things.pdf`,
+      scanStatus: "CLEAN",
+      scannedAt: daysAgo(4),
+    },
+    {
+      manuscriptVersionId: version1!.id,
+      filename: "cover-letter.pdf",
+      mimeType: "application/pdf",
+      size: 51_200,
+      storageKey: `manuscripts/${writerUser!.id}/${manuscript1!.id}/v1/cover-letter.pdf`,
+      scanStatus: "CLEAN",
+      scannedAt: daysAgo(4),
+    },
+  ]);
+
+  console.log("  Manuscripts: 1, versions: 1, files: 2");
+
+  // ----- Submission History -----
+  // SUBMITTED submission: DRAFT → SUBMITTED
+  await tx.insert(submissionHistory).values({
+    submissionId: submittedSub!.id,
+    fromStatus: "DRAFT",
+    toStatus: "SUBMITTED",
+    changedBy: writerUser!.id,
+    comment: "Submitted for review.",
+    changedAt: daysAgo(5),
+  });
+
+  // UNDER_REVIEW submission: DRAFT → SUBMITTED → UNDER_REVIEW
+  await tx.insert(submissionHistory).values([
+    {
+      submissionId: underReviewSub!.id,
+      fromStatus: "DRAFT",
+      toStatus: "SUBMITTED",
+      changedBy: writerUser!.id,
+      changedAt: daysAgo(10),
+    },
+    {
+      submissionId: underReviewSub!.id,
+      fromStatus: "SUBMITTED",
+      toStatus: "UNDER_REVIEW",
+      changedBy: editorUser!.id,
+      comment: "Moved to review queue.",
+      changedAt: daysAgo(7),
+    },
+  ]);
+
+  // ACCEPTED submission: DRAFT → SUBMITTED → UNDER_REVIEW → ACCEPTED
+  await tx.insert(submissionHistory).values([
+    {
+      submissionId: acceptedSub!.id,
+      fromStatus: "DRAFT",
+      toStatus: "SUBMITTED",
+      changedBy: writerUser!.id,
+      changedAt: daysAgo(20),
+    },
+    {
+      submissionId: acceptedSub!.id,
+      fromStatus: "SUBMITTED",
+      toStatus: "UNDER_REVIEW",
+      changedBy: editorUser!.id,
+      changedAt: daysAgo(15),
+    },
+    {
+      submissionId: acceptedSub!.id,
+      fromStatus: "UNDER_REVIEW",
+      toStatus: "ACCEPTED",
+      changedBy: adminUser!.id,
+      comment: "Unanimously accepted by editorial board.",
+      changedAt: daysAgo(3),
+    },
+  ]);
+
+  console.log("  Submission history: 6 entries");
+
+  // ----- Payment (on SUBMITTED submission — fee payment) -----
+  await tx.insert(payments).values({
+    organizationId: org1!.id,
+    submissionId: submittedSub!.id,
+    stripePaymentId: "pi_seed_001",
+    stripeSessionId: "cs_seed_001",
+    amount: 500, // $5.00 in cents
+    currency: "usd",
+    status: "SUCCEEDED",
+    metadata: { submissionTitle: "The Weight of Small Things" },
+  });
+
+  console.log("  Payments: 1");
+
+  // ----- API Key (Org 1 — all read scopes) -----
+  await tx.insert(apiKeys).values({
+    organizationId: org1!.id,
+    createdBy: adminUser!.id,
+    name: "Seed Read-Only Key",
+    keyHash: SEED_API_KEY_HASH,
+    keyPrefix: SEED_API_KEY_PREFIX,
+    scopes: [
+      "submissions:read",
+      "files:read",
+      "organizations:read",
+      "users:read",
+      "api-keys:read",
+      "payments:read",
+      "audit:read",
+      "periods:read",
+      "periods:write",
+    ],
+  });
+
+  console.log("  API keys: 1");
+
+  // ----- Audit Events -----
+  await tx.insert(auditEvents).values([
+    {
+      organizationId: org1!.id,
+      actorId: adminUser!.id,
+      action: "organization.create",
+      resource: "organizations",
+      resourceId: org1!.id,
+      createdAt: daysAgo(90),
+    },
+    {
+      organizationId: org1!.id,
+      actorId: adminUser!.id,
+      action: "submission_period.create",
+      resource: "submission_periods",
+      resourceId: openPeriod!.id,
+      createdAt: daysAgo(14),
+    },
+    {
+      organizationId: org1!.id,
+      actorId: writerUser!.id,
+      action: "submission.submit",
+      resource: "submissions",
+      resourceId: submittedSub!.id,
+      createdAt: daysAgo(5),
+    },
+    {
+      organizationId: org1!.id,
+      actorId: adminUser!.id,
+      action: "submission.accept",
+      resource: "submissions",
+      resourceId: acceptedSub!.id,
+      createdAt: daysAgo(3),
+    },
+    {
+      organizationId: org2!.id,
+      actorId: inkwellAdmin!.id,
+      action: "organization.create",
+      resource: "organizations",
+      resourceId: org2!.id,
+      createdAt: daysAgo(45),
+    },
+  ]);
+
+  console.log("  Audit events: 5");
+
+  // ----- Retention Policies -----
+  // Org 1: submissions retained 365 days
+  await tx.insert(retentionPolicies).values({
+    organizationId: org1!.id,
+    resource: "submissions",
+    retentionDays: 365,
+  });
+
+  // Global: audit events retained 90 days
+  await tx.insert(retentionPolicies).values({
+    organizationId: null,
+    resource: "audit_events",
+    retentionDays: 90,
+  });
+
+  console.log("  Retention policies: 2 (1 org-scoped, 1 global)");
+
+  // =====================================================================
+  // Slate — Publication Pipeline seed data
+  // =====================================================================
+
+  // ----- Second ACCEPTED submission (for two pipeline-eligible pieces) -----
+  const [acceptedSub2] = await tx
+    .insert(submissions)
+    .values({
+      organizationId: org1!.id,
+      submitterId: writerUser!.id,
+      submissionPeriodId: openPeriod!.id,
+      title: "The Architecture of Longing",
+      content:
+        "A sequence of prose poems exploring the spaces between desire and memory.",
+      coverLetter:
+        "These prose poems were written during a fellowship at the Vermont Studio Center.",
+      status: "ACCEPTED",
+      submittedAt: daysAgo(18),
+    })
+    .returning();
+
+  await tx.insert(submissionHistory).values([
+    {
+      submissionId: acceptedSub2!.id,
+      fromStatus: "DRAFT",
+      toStatus: "SUBMITTED",
+      changedBy: writerUser!.id,
+      changedAt: daysAgo(18),
+    },
+    {
+      submissionId: acceptedSub2!.id,
+      fromStatus: "SUBMITTED",
+      toStatus: "UNDER_REVIEW",
+      changedBy: editorUser!.id,
+      changedAt: daysAgo(12),
+    },
+    {
+      submissionId: acceptedSub2!.id,
+      fromStatus: "UNDER_REVIEW",
+      toStatus: "ACCEPTED",
+      changedBy: adminUser!.id,
+      comment: "Strong work — accepted for Spring issue.",
+      changedAt: daysAgo(2),
+    },
+  ]);
+
+  console.log("  Second accepted submission: The Architecture of Longing");
+
+  // ----- Publications -----
+  const [pub1] = await tx
+    .insert(publications)
+    .values({
+      organizationId: org1!.id,
+      name: "The Quarterly Review",
+      slug: "the-quarterly-review",
+      description:
+        "Flagship print journal publishing poetry, fiction, and essays since 1985.",
+      status: "ACTIVE",
+    })
+    .returning();
+
+  const [pub2] = await tx
+    .insert(publications)
+    .values({
+      organizationId: org1!.id,
+      name: "Quarterly Online",
+      slug: "quarterly-online",
+      description:
+        "Digital companion to The Quarterly Review, featuring web-exclusive content.",
+      status: "ACTIVE",
+    })
+    .returning();
+
+  console.log(`  Publications: ${pub1!.name}, ${pub2!.name}`);
+
+  // ----- Pipeline Items -----
+  const [pipeItem1] = await tx
+    .insert(pipelineItems)
+    .values({
+      organizationId: org1!.id,
+      submissionId: acceptedSub!.id,
+      publicationId: pub1!.id,
+      stage: "COPYEDIT_IN_PROGRESS",
+      assignedCopyeditorId: editorUser!.id,
+      copyeditDueAt: daysFromNow(14),
+    })
+    .returning();
+
+  const [pipeItem2] = await tx
+    .insert(pipelineItems)
+    .values({
+      organizationId: org1!.id,
+      submissionId: acceptedSub2!.id,
+      publicationId: pub1!.id,
+      stage: "READY_TO_PUBLISH",
+    })
+    .returning();
+
+  console.log("  Pipeline items: 2 (COPYEDIT_IN_PROGRESS, READY_TO_PUBLISH)");
+
+  // ----- Pipeline History -----
+  await tx.insert(pipelineHistory).values([
+    // Item 1: entered pipeline → copyedit started
+    {
+      pipelineItemId: pipeItem1!.id,
+      fromStage: null,
+      toStage: "COPYEDIT_PENDING",
+      changedBy: adminUser!.id,
+      comment: "Moved to publication pipeline.",
+      changedAt: daysAgo(2),
+    },
+    {
+      pipelineItemId: pipeItem1!.id,
+      fromStage: "COPYEDIT_PENDING",
+      toStage: "COPYEDIT_IN_PROGRESS",
+      changedBy: editorUser!.id,
+      comment: "Copyedit started.",
+      changedAt: daysAgo(1),
+    },
+    // Item 2: full pipeline progression to READY_TO_PUBLISH
+    {
+      pipelineItemId: pipeItem2!.id,
+      fromStage: null,
+      toStage: "COPYEDIT_PENDING",
+      changedBy: adminUser!.id,
+      changedAt: daysAgo(10),
+    },
+    {
+      pipelineItemId: pipeItem2!.id,
+      fromStage: "COPYEDIT_PENDING",
+      toStage: "COPYEDIT_IN_PROGRESS",
+      changedBy: editorUser!.id,
+      changedAt: daysAgo(8),
+    },
+    {
+      pipelineItemId: pipeItem2!.id,
+      fromStage: "COPYEDIT_IN_PROGRESS",
+      toStage: "AUTHOR_REVIEW",
+      changedBy: editorUser!.id,
+      changedAt: daysAgo(5),
+    },
+    {
+      pipelineItemId: pipeItem2!.id,
+      fromStage: "AUTHOR_REVIEW",
+      toStage: "PROOFREAD",
+      changedBy: adminUser!.id,
+      changedAt: daysAgo(3),
+    },
+    {
+      pipelineItemId: pipeItem2!.id,
+      fromStage: "PROOFREAD",
+      toStage: "READY_TO_PUBLISH",
+      changedBy: adminUser!.id,
+      comment: "Proofread complete, ready for issue assembly.",
+      changedAt: daysAgo(1),
+    },
+  ]);
+
+  console.log("  Pipeline history: 7 entries");
+
+  // ----- Contract Template -----
+  const [template1] = await tx
+    .insert(contractTemplates)
+    .values({
+      organizationId: org1!.id,
+      name: "Standard Publication Agreement",
+      description: "Default contract template for first publication rights.",
+      body: [
+        "PUBLICATION AGREEMENT",
+        "",
+        "This agreement is between {{authorName}} (Author) and {{publicationName}} (Publisher).",
+        "",
+        'The Author grants the Publisher first serial rights to the work titled "{{title}}".',
+        "",
+        "Date: {{date}}",
+        "",
+        "Signature: ________________________",
+      ].join("\n"),
+      mergeFields: [
+        { key: "authorName", label: "Author Name", source: "auto" as const },
+        { key: "title", label: "Work Title", source: "auto" as const },
+        {
+          key: "publicationName",
+          label: "Publication Name",
+          source: "auto" as const,
+          defaultValue: "The Quarterly Review",
+        },
+        { key: "date", label: "Date", source: "auto" as const },
+      ],
+      isDefault: true,
+    })
+    .returning();
+
+  console.log(`  Contract templates: ${template1!.name}`);
+
+  // ----- Contract (DRAFT, linked to pipeline item 1) -----
+  await tx.insert(contracts).values({
+    organizationId: org1!.id,
+    pipelineItemId: pipeItem1!.id,
+    contractTemplateId: template1!.id,
+    status: "DRAFT",
+    renderedBody: [
+      "PUBLICATION AGREEMENT",
+      "",
+      "This agreement is between Writer Example (Author) and The Quarterly Review (Publisher).",
+      "",
+      'The Author grants the Publisher first serial rights to the work titled "Field Notes on Disappearing".',
+      "",
+      `Date: ${new Date().toISOString().split("T")[0]}`,
+      "",
+      "Signature: ________________________",
+    ].join("\n"),
+    mergeData: {
+      authorName: "Writer Example",
+      title: "Field Notes on Disappearing",
+      publicationName: "The Quarterly Review",
+      date: new Date().toISOString().split("T")[0],
+    },
+  });
+
+  console.log("  Contracts: 1 (DRAFT)");
+
+  // ----- Issue -----
+  const [issue1] = await tx
+    .insert(issues)
+    .values({
+      organizationId: org1!.id,
+      publicationId: pub1!.id,
+      title: "Spring 2026",
+      volume: 41,
+      issueNumber: 2,
+      description:
+        "Spring 2026 issue featuring new poetry, fiction, and essays.",
+      status: "ASSEMBLING",
+      publicationDate: daysFromNow(60),
+    })
+    .returning();
+
+  console.log(`  Issues: ${issue1!.title} (ASSEMBLING)`);
+
+  // ----- Issue Sections -----
+  const [poetrySection] = await tx
+    .insert(issueSections)
+    .values({
+      issueId: issue1!.id,
+      title: "Poetry",
+      sortOrder: 0,
+    })
+    .returning();
+
+  const [fictionSection] = await tx
+    .insert(issueSections)
+    .values({
+      issueId: issue1!.id,
+      title: "Fiction",
+      sortOrder: 1,
+    })
+    .returning();
+
+  console.log("  Issue sections: Poetry, Fiction");
+
+  // ----- Issue Items -----
+  await tx.insert(issueItems).values([
+    {
+      issueId: issue1!.id,
+      pipelineItemId: pipeItem2!.id,
+      issueSectionId: poetrySection!.id,
+      sortOrder: 0,
+    },
+    {
+      issueId: issue1!.id,
+      pipelineItemId: pipeItem1!.id,
+      issueSectionId: fictionSection!.id,
+      sortOrder: 0,
+    },
+  ]);
+
+  console.log("  Issue items: 2 (one per section)");
+
+  // ----- CMS Connection -----
+  await tx.insert(cmsConnections).values({
+    organizationId: org1!.id,
+    publicationId: pub2!.id,
+    adapterType: "WORDPRESS",
+    name: "QR WordPress",
+    config: {
+      siteUrl: "https://example.com/wp-json",
+      username: "admin",
+      applicationPassword: "xxxx-xxxx-xxxx",
+    },
+    isActive: true,
+  });
+
+  console.log("  CMS connections: 1 (QR WordPress)");
+
+  return {
+    org1: org1!,
+    org2: org2!,
+    adminUser: adminUser!,
+    editorUser: editorUser!,
+    writerUser: writerUser!,
+    inkwellAdmin: inkwellAdmin!,
+    openPeriod: openPeriod!,
+    winterPeriod: winterPeriod!,
+    inkwellPeriod: inkwellPeriod!,
+    submittedSub: submittedSub!,
+    underReviewSub: underReviewSub!,
+    acceptedSub: acceptedSub!,
+    acceptedSub2: acceptedSub2!,
+    manuscript1: manuscript1!,
+    version1: version1!,
+    pub1: pub1!,
+    pub2: pub2!,
+    pipeItem1: pipeItem1!,
+    pipeItem2: pipeItem2!,
+    template1: template1!,
+    issue1: issue1!,
+    poetrySection: poetrySection!,
+    fictionSection: fictionSection!,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point — runs seedBase inside a transaction with idempotency check
+// ---------------------------------------------------------------------------
 async function main() {
-  // Idempotency check
   const existing = await db
     .select({ id: organizations.id })
     .from(organizations)
@@ -70,727 +848,25 @@ async function main() {
   console.log("Seeding database...\n");
 
   await db.transaction(async (tx) => {
-    // ----- Organizations -----
-    const [org1] = await tx
-      .insert(organizations)
-      .values({
-        name: "The Quarterly Review",
-        slug: "quarterly-review",
-        settings: {
-          maxFileSize: 10_485_760,
-          allowedMimeTypes: ["application/pdf", "application/msword"],
-        },
-      })
-      .returning();
-
-    const [org2] = await tx
-      .insert(organizations)
-      .values({
-        name: "Inkwell Press",
-        slug: "inkwell-press",
-        settings: { maxFileSize: 5_242_880 },
-      })
-      .returning();
-
-    console.log(`  Organizations: ${org1!.name}, ${org2!.name}`);
-
-    // ----- Users -----
-    const [adminUser] = await tx
-      .insert(users)
-      .values({
-        email: "editor@quarterlyreview.org",
-        zitadelUserId: "seed-zitadel-admin-001",
-        emailVerified: true,
-        emailVerifiedAt: daysAgo(90),
-      })
-      .returning();
-
-    const [editorUser] = await tx
-      .insert(users)
-      .values({
-        email: "reader@quarterlyreview.org",
-        zitadelUserId: "seed-zitadel-editor-001",
-        emailVerified: true,
-        emailVerifiedAt: daysAgo(60),
-      })
-      .returning();
-
-    const [writerUser] = await tx
-      .insert(users)
-      .values({
-        email: "writer@example.com",
-        zitadelUserId: "seed-zitadel-writer-001",
-        emailVerified: true,
-        emailVerifiedAt: daysAgo(30),
-      })
-      .returning();
-
-    const [inkwellAdmin] = await tx
-      .insert(users)
-      .values({
-        email: "admin@inkwellpress.org",
-        zitadelUserId: "seed-zitadel-inkwell-001",
-        emailVerified: true,
-        emailVerifiedAt: daysAgo(45),
-      })
-      .returning();
-
-    console.log(
-      `  Users: ${[adminUser, editorUser, writerUser, inkwellAdmin].map((u) => u!.email).join(", ")}`,
-    );
-
-    // ----- Organization Members -----
-    // Org 1: admin, editor, reader (submitter)
-    await tx.insert(organizationMembers).values([
-      {
-        organizationId: org1!.id,
-        userId: adminUser!.id,
-        role: "ADMIN",
-      },
-      {
-        organizationId: org1!.id,
-        userId: editorUser!.id,
-        role: "EDITOR",
-      },
-      {
-        organizationId: org1!.id,
-        userId: writerUser!.id,
-        role: "READER",
-      },
-    ]);
-
-    // Org 2: admin + shared writer (cross-org membership)
-    await tx.insert(organizationMembers).values([
-      {
-        organizationId: org2!.id,
-        userId: inkwellAdmin!.id,
-        role: "ADMIN",
-      },
-      {
-        organizationId: org2!.id,
-        userId: writerUser!.id,
-        role: "READER",
-      },
-    ]);
-
-    console.log(
-      "  Organization members: 5 (3 in quarterly-review, 2 in inkwell-press)",
-    );
-
-    // ----- Submission Periods -----
-    const [openPeriod] = await tx
-      .insert(submissionPeriods)
-      .values({
-        organizationId: org1!.id,
-        name: "Spring 2026 Reading Period",
-        description:
-          "Open call for poetry and short fiction, up to 5,000 words.",
-        opensAt: daysAgo(14),
-        closesAt: daysFromNow(45),
-        fee: "5.00",
-        maxSubmissions: 500,
-      })
-      .returning();
-
-    await tx.insert(submissionPeriods).values({
-      organizationId: org1!.id,
-      name: "Winter 2025 Reading Period",
-      description: "Closed. Thank you for your submissions.",
-      opensAt: daysAgo(120),
-      closesAt: daysAgo(60),
-      fee: "3.00",
-      maxSubmissions: 300,
-    });
-
-    const [inkwellPeriod] = await tx
-      .insert(submissionPeriods)
-      .values({
-        organizationId: org2!.id,
-        name: "Open Submissions 2026",
-        description: "Rolling submissions for flash fiction under 1,000 words.",
-        opensAt: daysAgo(7),
-        closesAt: daysFromNow(180),
-      })
-      .returning();
-
-    console.log(
-      "  Submission periods: 3 (2 in quarterly-review, 1 in inkwell-press)",
-    );
-
-    // ----- Submissions (Org 1) -----
-    const [submittedSub] = await tx
-      .insert(submissions)
-      .values({
-        organizationId: org1!.id,
-        submitterId: writerUser!.id,
-        submissionPeriodId: openPeriod!.id,
-        title: "The Weight of Small Things",
-        content:
-          "A short story about the objects we carry and the memories they hold.",
-        coverLetter:
-          "Dear Editors, I am submitting my short story for your consideration. It explores themes of memory and loss through everyday objects.",
-        status: "SUBMITTED",
-        submittedAt: daysAgo(5),
-      })
-      .returning();
-
-    const [underReviewSub] = await tx
-      .insert(submissions)
-      .values({
-        organizationId: org1!.id,
-        submitterId: writerUser!.id,
-        submissionPeriodId: openPeriod!.id,
-        title: "Cartography of Absence",
-        content:
-          "A cycle of poems mapping the spaces left behind by those who have departed.",
-        coverLetter:
-          "These poems emerged from a residency in the Outer Hebrides. They attempt to chart absence as a kind of presence.",
-        status: "UNDER_REVIEW",
-        submittedAt: daysAgo(10),
-      })
-      .returning();
-
-    const [acceptedSub] = await tx
-      .insert(submissions)
-      .values({
-        organizationId: org1!.id,
-        submitterId: writerUser!.id,
-        submissionPeriodId: openPeriod!.id,
-        title: "Field Notes on Disappearing",
-        content:
-          "An essay on ecological grief and the language we use to describe environmental loss.",
-        coverLetter:
-          "This essay was a finalist for the Pushcart Prize and is previously unpublished.",
-        status: "ACCEPTED",
-        submittedAt: daysAgo(20),
-      })
-      .returning();
-
-    // Submission (Org 2) — DRAFT
-    await tx.insert(submissions).values({
-      organizationId: org2!.id,
-      submitterId: writerUser!.id,
-      submissionPeriodId: inkwellPeriod!.id,
-      title: "Untitled Flash Piece",
-      content: null,
-      status: "DRAFT",
-    });
-
-    console.log("  Submissions: 4 (3 in quarterly-review, 1 in inkwell-press)");
-
-    // ----- Manuscripts + Versions + Files -----
-    // Create a manuscript for the writer's submitted work
-    const [manuscript1] = await tx
-      .insert(manuscripts)
-      .values({
-        ownerId: writerUser!.id,
-        title: "The Weight of Small Things",
-        description:
-          "A short story about the objects we carry and the memories they hold.",
-      })
-      .returning();
-
-    const [version1] = await tx
-      .insert(manuscriptVersions)
-      .values({
-        manuscriptId: manuscript1!.id,
-        versionNumber: 1,
-        label: "Initial submission",
-      })
-      .returning();
-
-    // Link the submitted submission to this manuscript version
-    await tx
-      .update(submissions)
-      .set({ manuscriptVersionId: version1!.id })
-      .where(eq(submissions.id, submittedSub!.id));
-
-    // Create files on the manuscript version (replaces submission_files)
-    await tx.insert(files).values([
-      {
-        manuscriptVersionId: version1!.id,
-        filename: "the-weight-of-small-things.pdf",
-        mimeType: "application/pdf",
-        size: 245_760,
-        storageKey: `manuscripts/${writerUser!.id}/${manuscript1!.id}/v1/the-weight-of-small-things.pdf`,
-        scanStatus: "CLEAN",
-        scannedAt: daysAgo(4),
-      },
-      {
-        manuscriptVersionId: version1!.id,
-        filename: "cover-letter.pdf",
-        mimeType: "application/pdf",
-        size: 51_200,
-        storageKey: `manuscripts/${writerUser!.id}/${manuscript1!.id}/v1/cover-letter.pdf`,
-        scanStatus: "CLEAN",
-        scannedAt: daysAgo(4),
-      },
-    ]);
-
-    console.log("  Manuscripts: 1, versions: 1, files: 2");
-
-    // ----- Submission History -----
-    // SUBMITTED submission: DRAFT → SUBMITTED
-    await tx.insert(submissionHistory).values({
-      submissionId: submittedSub!.id,
-      fromStatus: "DRAFT",
-      toStatus: "SUBMITTED",
-      changedBy: writerUser!.id,
-      comment: "Submitted for review.",
-      changedAt: daysAgo(5),
-    });
-
-    // UNDER_REVIEW submission: DRAFT → SUBMITTED → UNDER_REVIEW
-    await tx.insert(submissionHistory).values([
-      {
-        submissionId: underReviewSub!.id,
-        fromStatus: "DRAFT",
-        toStatus: "SUBMITTED",
-        changedBy: writerUser!.id,
-        changedAt: daysAgo(10),
-      },
-      {
-        submissionId: underReviewSub!.id,
-        fromStatus: "SUBMITTED",
-        toStatus: "UNDER_REVIEW",
-        changedBy: editorUser!.id,
-        comment: "Moved to review queue.",
-        changedAt: daysAgo(7),
-      },
-    ]);
-
-    // ACCEPTED submission: DRAFT → SUBMITTED → UNDER_REVIEW → ACCEPTED
-    await tx.insert(submissionHistory).values([
-      {
-        submissionId: acceptedSub!.id,
-        fromStatus: "DRAFT",
-        toStatus: "SUBMITTED",
-        changedBy: writerUser!.id,
-        changedAt: daysAgo(20),
-      },
-      {
-        submissionId: acceptedSub!.id,
-        fromStatus: "SUBMITTED",
-        toStatus: "UNDER_REVIEW",
-        changedBy: editorUser!.id,
-        changedAt: daysAgo(15),
-      },
-      {
-        submissionId: acceptedSub!.id,
-        fromStatus: "UNDER_REVIEW",
-        toStatus: "ACCEPTED",
-        changedBy: adminUser!.id,
-        comment: "Unanimously accepted by editorial board.",
-        changedAt: daysAgo(3),
-      },
-    ]);
-
-    console.log("  Submission history: 6 entries");
-
-    // ----- Payment (on SUBMITTED submission — fee payment) -----
-    await tx.insert(payments).values({
-      organizationId: org1!.id,
-      submissionId: submittedSub!.id,
-      stripePaymentId: "pi_seed_001",
-      stripeSessionId: "cs_seed_001",
-      amount: 500, // $5.00 in cents
-      currency: "usd",
-      status: "SUCCEEDED",
-      metadata: { submissionTitle: "The Weight of Small Things" },
-    });
-
-    console.log("  Payments: 1");
-
-    // ----- API Key (Org 1 — all read scopes) -----
-    await tx.insert(apiKeys).values({
-      organizationId: org1!.id,
-      createdBy: adminUser!.id,
-      name: "Seed Read-Only Key",
-      keyHash: SEED_API_KEY_HASH,
-      keyPrefix: SEED_API_KEY_PREFIX,
-      scopes: [
-        "submissions:read",
-        "files:read",
-        "organizations:read",
-        "users:read",
-        "api-keys:read",
-        "payments:read",
-        "audit:read",
-        "periods:read",
-        "periods:write",
-      ],
-    });
-
-    console.log("  API keys: 1");
-
-    // ----- Audit Events -----
-    await tx.insert(auditEvents).values([
-      {
-        organizationId: org1!.id,
-        actorId: adminUser!.id,
-        action: "organization.create",
-        resource: "organizations",
-        resourceId: org1!.id,
-        createdAt: daysAgo(90),
-      },
-      {
-        organizationId: org1!.id,
-        actorId: adminUser!.id,
-        action: "submission_period.create",
-        resource: "submission_periods",
-        resourceId: openPeriod!.id,
-        createdAt: daysAgo(14),
-      },
-      {
-        organizationId: org1!.id,
-        actorId: writerUser!.id,
-        action: "submission.submit",
-        resource: "submissions",
-        resourceId: submittedSub!.id,
-        createdAt: daysAgo(5),
-      },
-      {
-        organizationId: org1!.id,
-        actorId: adminUser!.id,
-        action: "submission.accept",
-        resource: "submissions",
-        resourceId: acceptedSub!.id,
-        createdAt: daysAgo(3),
-      },
-      {
-        organizationId: org2!.id,
-        actorId: inkwellAdmin!.id,
-        action: "organization.create",
-        resource: "organizations",
-        resourceId: org2!.id,
-        createdAt: daysAgo(45),
-      },
-    ]);
-
-    console.log("  Audit events: 5");
-
-    // ----- Retention Policies -----
-    // Org 1: submissions retained 365 days
-    await tx.insert(retentionPolicies).values({
-      organizationId: org1!.id,
-      resource: "submissions",
-      retentionDays: 365,
-    });
-
-    // Global: audit events retained 90 days
-    await tx.insert(retentionPolicies).values({
-      organizationId: null,
-      resource: "audit_events",
-      retentionDays: 90,
-    });
-
-    console.log("  Retention policies: 2 (1 org-scoped, 1 global)");
-
-    // =====================================================================
-    // Slate — Publication Pipeline seed data
-    // =====================================================================
-
-    // ----- Second ACCEPTED submission (for two pipeline-eligible pieces) -----
-    const [acceptedSub2] = await tx
-      .insert(submissions)
-      .values({
-        organizationId: org1!.id,
-        submitterId: writerUser!.id,
-        submissionPeriodId: openPeriod!.id,
-        title: "The Architecture of Longing",
-        content:
-          "A sequence of prose poems exploring the spaces between desire and memory.",
-        coverLetter:
-          "These prose poems were written during a fellowship at the Vermont Studio Center.",
-        status: "ACCEPTED",
-        submittedAt: daysAgo(18),
-      })
-      .returning();
-
-    await tx.insert(submissionHistory).values([
-      {
-        submissionId: acceptedSub2!.id,
-        fromStatus: "DRAFT",
-        toStatus: "SUBMITTED",
-        changedBy: writerUser!.id,
-        changedAt: daysAgo(18),
-      },
-      {
-        submissionId: acceptedSub2!.id,
-        fromStatus: "SUBMITTED",
-        toStatus: "UNDER_REVIEW",
-        changedBy: editorUser!.id,
-        changedAt: daysAgo(12),
-      },
-      {
-        submissionId: acceptedSub2!.id,
-        fromStatus: "UNDER_REVIEW",
-        toStatus: "ACCEPTED",
-        changedBy: adminUser!.id,
-        comment: "Strong work — accepted for Spring issue.",
-        changedAt: daysAgo(2),
-      },
-    ]);
-
-    console.log("  Second accepted submission: The Architecture of Longing");
-
-    // ----- Publications -----
-    const [pub1] = await tx
-      .insert(publications)
-      .values({
-        organizationId: org1!.id,
-        name: "The Quarterly Review",
-        slug: "the-quarterly-review",
-        description:
-          "Flagship print journal publishing poetry, fiction, and essays since 1985.",
-        status: "ACTIVE",
-      })
-      .returning();
-
-    const [pub2] = await tx
-      .insert(publications)
-      .values({
-        organizationId: org1!.id,
-        name: "Quarterly Online",
-        slug: "quarterly-online",
-        description:
-          "Digital companion to The Quarterly Review, featuring web-exclusive content.",
-        status: "ACTIVE",
-      })
-      .returning();
-
-    console.log(`  Publications: ${pub1!.name}, ${pub2!.name}`);
-
-    // ----- Pipeline Items -----
-    const [pipeItem1] = await tx
-      .insert(pipelineItems)
-      .values({
-        organizationId: org1!.id,
-        submissionId: acceptedSub!.id,
-        publicationId: pub1!.id,
-        stage: "COPYEDIT_IN_PROGRESS",
-        assignedCopyeditorId: editorUser!.id,
-        copyeditDueAt: daysFromNow(14),
-      })
-      .returning();
-
-    const [pipeItem2] = await tx
-      .insert(pipelineItems)
-      .values({
-        organizationId: org1!.id,
-        submissionId: acceptedSub2!.id,
-        publicationId: pub1!.id,
-        stage: "READY_TO_PUBLISH",
-      })
-      .returning();
-
-    console.log("  Pipeline items: 2 (COPYEDIT_IN_PROGRESS, READY_TO_PUBLISH)");
-
-    // ----- Pipeline History -----
-    await tx.insert(pipelineHistory).values([
-      // Item 1: entered pipeline → copyedit started
-      {
-        pipelineItemId: pipeItem1!.id,
-        fromStage: null,
-        toStage: "COPYEDIT_PENDING",
-        changedBy: adminUser!.id,
-        comment: "Moved to publication pipeline.",
-        changedAt: daysAgo(2),
-      },
-      {
-        pipelineItemId: pipeItem1!.id,
-        fromStage: "COPYEDIT_PENDING",
-        toStage: "COPYEDIT_IN_PROGRESS",
-        changedBy: editorUser!.id,
-        comment: "Copyedit started.",
-        changedAt: daysAgo(1),
-      },
-      // Item 2: full pipeline progression to READY_TO_PUBLISH
-      {
-        pipelineItemId: pipeItem2!.id,
-        fromStage: null,
-        toStage: "COPYEDIT_PENDING",
-        changedBy: adminUser!.id,
-        changedAt: daysAgo(10),
-      },
-      {
-        pipelineItemId: pipeItem2!.id,
-        fromStage: "COPYEDIT_PENDING",
-        toStage: "COPYEDIT_IN_PROGRESS",
-        changedBy: editorUser!.id,
-        changedAt: daysAgo(8),
-      },
-      {
-        pipelineItemId: pipeItem2!.id,
-        fromStage: "COPYEDIT_IN_PROGRESS",
-        toStage: "AUTHOR_REVIEW",
-        changedBy: editorUser!.id,
-        changedAt: daysAgo(5),
-      },
-      {
-        pipelineItemId: pipeItem2!.id,
-        fromStage: "AUTHOR_REVIEW",
-        toStage: "PROOFREAD",
-        changedBy: adminUser!.id,
-        changedAt: daysAgo(3),
-      },
-      {
-        pipelineItemId: pipeItem2!.id,
-        fromStage: "PROOFREAD",
-        toStage: "READY_TO_PUBLISH",
-        changedBy: adminUser!.id,
-        comment: "Proofread complete, ready for issue assembly.",
-        changedAt: daysAgo(1),
-      },
-    ]);
-
-    console.log("  Pipeline history: 7 entries");
-
-    // ----- Contract Template -----
-    const [template1] = await tx
-      .insert(contractTemplates)
-      .values({
-        organizationId: org1!.id,
-        name: "Standard Publication Agreement",
-        description: "Default contract template for first publication rights.",
-        body: [
-          "PUBLICATION AGREEMENT",
-          "",
-          "This agreement is between {{authorName}} (Author) and {{publicationName}} (Publisher).",
-          "",
-          'The Author grants the Publisher first serial rights to the work titled "{{title}}".',
-          "",
-          "Date: {{date}}",
-          "",
-          "Signature: ________________________",
-        ].join("\n"),
-        mergeFields: [
-          { key: "authorName", label: "Author Name", source: "auto" as const },
-          { key: "title", label: "Work Title", source: "auto" as const },
-          {
-            key: "publicationName",
-            label: "Publication Name",
-            source: "auto" as const,
-            defaultValue: "The Quarterly Review",
-          },
-          { key: "date", label: "Date", source: "auto" as const },
-        ],
-        isDefault: true,
-      })
-      .returning();
-
-    console.log(`  Contract templates: ${template1!.name}`);
-
-    // ----- Contract (DRAFT, linked to pipeline item 1) -----
-    await tx.insert(contracts).values({
-      organizationId: org1!.id,
-      pipelineItemId: pipeItem1!.id,
-      contractTemplateId: template1!.id,
-      status: "DRAFT",
-      renderedBody: [
-        "PUBLICATION AGREEMENT",
-        "",
-        "This agreement is between Writer Example (Author) and The Quarterly Review (Publisher).",
-        "",
-        'The Author grants the Publisher first serial rights to the work titled "Field Notes on Disappearing".',
-        "",
-        `Date: ${new Date().toISOString().split("T")[0]}`,
-        "",
-        "Signature: ________________________",
-      ].join("\n"),
-      mergeData: {
-        authorName: "Writer Example",
-        title: "Field Notes on Disappearing",
-        publicationName: "The Quarterly Review",
-        date: new Date().toISOString().split("T")[0],
-      },
-    });
-
-    console.log("  Contracts: 1 (DRAFT)");
-
-    // ----- Issue -----
-    const [issue1] = await tx
-      .insert(issues)
-      .values({
-        organizationId: org1!.id,
-        publicationId: pub1!.id,
-        title: "Spring 2026",
-        volume: 41,
-        issueNumber: 2,
-        description:
-          "Spring 2026 issue featuring new poetry, fiction, and essays.",
-        status: "ASSEMBLING",
-        publicationDate: daysFromNow(60),
-      })
-      .returning();
-
-    console.log(`  Issues: ${issue1!.title} (ASSEMBLING)`);
-
-    // ----- Issue Sections -----
-    const [poetrySection] = await tx
-      .insert(issueSections)
-      .values({
-        issueId: issue1!.id,
-        title: "Poetry",
-        sortOrder: 0,
-      })
-      .returning();
-
-    const [fictionSection] = await tx
-      .insert(issueSections)
-      .values({
-        issueId: issue1!.id,
-        title: "Fiction",
-        sortOrder: 1,
-      })
-      .returning();
-
-    console.log("  Issue sections: Poetry, Fiction");
-
-    // ----- Issue Items -----
-    await tx.insert(issueItems).values([
-      {
-        issueId: issue1!.id,
-        pipelineItemId: pipeItem2!.id,
-        issueSectionId: poetrySection!.id,
-        sortOrder: 0,
-      },
-      {
-        issueId: issue1!.id,
-        pipelineItemId: pipeItem1!.id,
-        issueSectionId: fictionSection!.id,
-        sortOrder: 0,
-      },
-    ]);
-
-    console.log("  Issue items: 2 (one per section)");
-
-    // ----- CMS Connection -----
-    await tx.insert(cmsConnections).values({
-      organizationId: org1!.id,
-      publicationId: pub2!.id,
-      adapterType: "WORDPRESS",
-      name: "QR WordPress",
-      config: {
-        siteUrl: "https://example.com/wp-json",
-        username: "admin",
-        applicationPassword: "xxxx-xxxx-xxxx",
-      },
-      isActive: true,
-    });
-
-    console.log("  CMS connections: 1 (QR WordPress)");
+    await seedBase(tx as unknown as DrizzleDb);
   });
 
   console.log("\nSeed complete.");
   console.log(`\nSeed API key (quarterly-review, read-only): ${SEED_API_KEY}`);
 }
 
-main()
-  .catch((e) => {
-    console.error("Seed failed:", e);
-    process.exit(1);
-  })
-  .finally(async () => {
-    await pool.end();
-  });
+// Only run main() when this file is the direct entry point (not imported by seed-staging.ts)
+const isDirectEntryPoint =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("/seed.ts") === true;
+
+if (isDirectEntryPoint) {
+  main()
+    .catch((e) => {
+      console.error("Seed failed:", e);
+      process.exit(1);
+    })
+    .finally(async () => {
+      await pool.end();
+    });
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -855,12 +855,11 @@ async function main() {
   console.log(`\nSeed API key (quarterly-review, read-only): ${SEED_API_KEY}`);
 }
 
-// Only run main() when this file is the direct entry point (not imported by seed-staging.ts)
-const isDirectEntryPoint =
-  import.meta.url === `file://${process.argv[1]}` ||
-  process.argv[1]?.endsWith("/seed.ts") === true;
-
-if (isDirectEntryPoint) {
+// Only run main() when this file is the direct entry point (not imported by seed-staging.ts).
+// Check argv[1] to detect if seed.ts is the script being run by tsx.
+const isSeedEntryPoint =
+  process.argv[1]?.replace(/\\/g, "/").endsWith("/seed.ts") ?? false;
+if (isSeedEntryPoint) {
   main()
     .catch((e) => {
       console.error("Seed failed:", e);

--- a/scripts/init-prod.sh
+++ b/scripts/init-prod.sh
@@ -108,5 +108,15 @@ else
   fi
 fi
 
+# Step 4 (optional): Seed staging demo data
+# Set SEED_STAGING=true in Coolify env to populate rich demo/QA data.
+# Idempotent — safe to run on every deploy.
+if [ "${SEED_STAGING:-}" = "true" ]; then
+  echo ""
+  echo "Step 4: Seeding staging demo data..."
+  pnpm db:seed:staging
+  echo "Staging seed complete."
+fi
+
 echo ""
 echo "=== Production initialization complete ==="


### PR DESCRIPTION
## Summary

- Add `seed-staging.ts` — comprehensive staging/demo seed covering 21 additional tables beyond the base seed
- Refactor `seed.ts` to export `seedBase()` so staging seed can layer data on top
- Add `pnpm db:seed:staging` script and Coolify integration via `SEED_STAGING=true` env var

**Data created:** ~80 submissions (6-month spread for analytics), 3 form definitions, 40 reviewer assignments, 15 discussion threads, 30 votes, 15 journal directory entries, 20 external submissions, federation config + 2 trusted peers, email templates, notification preferences, webhook endpoints, embed tokens, queue presets, correspondence, writer profiles, user consents.

## Test plan

- [x] Fresh DB → `pnpm db:seed:staging` succeeds
- [x] Base seed → staging seed on top succeeds (upgrade path)
- [x] Second staging seed run skips (idempotent)
- [x] `pnpm db:seed` still works independently
- [x] Type-check passes
- [x] branch review: P1 (CJS compat) and P2 (upgrade idempotency) addressed