### PR TITLE
fix(db): use compiled JS for staging seed in production containers

### DIFF
--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,20 @@ Newest entries first.
 
 ---
 
+## 2026-03-23 — Fix init-prod.sh Seed for Production Containers
+
+### Done
+
+- Fixed `init-prod.sh` Step 4: replaced `pnpm db:seed:staging` with `node /app/packages/db/dist/seed-staging.js`
+- Root cause: Coolify production containers (Dockerfile `target: builder`) don't have `.env` file or reliable `tsx` binary; the compiled JS reads `DATABASE_URL` from `process.env` directly
+
+### Decisions
+
+- Direct `node` call rather than adding a `seed:prod` npm script — simpler, no pnpm overhead in prod init context
+- Dev workflow unchanged: `pnpm db:seed:staging` still works locally with tsx + .env
+
+---
+
 ## 2026-03-23 — Comprehensive Staging Seed
 
 ### Done

--- a/scripts/init-prod.sh
+++ b/scripts/init-prod.sh
@@ -114,7 +114,7 @@ fi
 if [ "${SEED_STAGING:-}" = "true" ]; then
   echo ""
   echo "Step 4: Seeding staging demo data..."
-  pnpm db:seed:staging
+  node /app/packages/db/dist/seed-staging.js
   echo "Staging seed complete."
 fi
 


### PR DESCRIPTION
## Summary

- `init-prod.sh` Step 4 called `pnpm db:seed:staging` which requires `tsx` (devDep) and `.env` file — neither available in Coolify production containers
- Replaced with `node /app/packages/db/dist/seed-staging.js` which uses the already-compiled output and reads `DATABASE_URL` from `process.env` directly
- Dev workflow unchanged: `pnpm db:seed:staging` still works locally with tsx + .env

## Test plan

- [ ] Deploy to staging with `SEED_STAGING=true` and verify seed runs successfully in container logs
- [ ] Verify idempotency: redeploy and confirm seed skips on second run