### PR TITLE
fix(nginx): harden proxy resilience for production deploys

### DIFF
--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -9,16 +9,18 @@ services:
       dockerfile: Dockerfile
     depends_on:
       api:
-        condition: service_healthy
+        condition: service_started
       web:
-        condition: service_healthy
+        condition: service_started
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/health"]
-      interval: 30s
-      timeout: 10s
+      test: ["CMD", "curl", "-f", "http://localhost/nginx-health"]
+      interval: 10s
+      timeout: 5s
       retries: 3
-      start_period: 10s
+      start_period: 5s
+    stop_signal: SIGQUIT
+    stop_grace_period: 30s
     deploy:
       resources:
         limits:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,24 +1,26 @@
 services:
   # Reverse proxy — only externally exposed service
   nginx:
-    image: nginx:alpine
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
     container_name: colophony-nginx
     ports:
       - "${HTTP_PORT:-80}:80"
-    volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:
       api:
-        condition: service_healthy
+        condition: service_started
       web:
-        condition: service_healthy
+        condition: service_started
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/health"]
-      interval: 30s
-      timeout: 10s
+      test: ["CMD", "curl", "-f", "http://localhost/nginx-health"]
+      interval: 10s
+      timeout: 5s
       retries: 3
-      start_period: 10s
+      start_period: 5s
+    stop_signal: SIGQUIT
+    stop_grace_period: 30s
     deploy:
       resources:
         limits:

--- a/docs/coolify-deployment.md
+++ b/docs/coolify-deployment.md
@@ -195,11 +195,23 @@ See [docs/deployment.md — Backup & Restore](deployment.md#backup--restore-wal-
 
 Check that the compose file path is exactly: `docker-compose.coolify.yml`.
 
-### 502 Bad Gateway after deploy
+### 502 Bad Gateway / maintenance page after deploy
 
-Services may still be starting. Wait for all healthchecks to go green in the Coolify dashboard (typically 30-60 seconds). Check Coolify logs for the `api` service.
+During a redeploy, nginx starts immediately and serves a maintenance page while backends initialize. The API can take up to 2 minutes on first deploy (migrations, RLS verification, optional seeding). The maintenance page auto-refreshes every 30 seconds.
 
-nginx uses Docker's embedded DNS resolver (`127.0.0.11`) with 10-second TTL to dynamically resolve upstream container IPs. This prevents stale routing after container recreation during redeploys. If you still see gateway timeouts, check that the nginx container itself restarted (it depends on `api` and `web` healthchecks).
+nginx's Docker healthcheck uses `/nginx-health` — a local endpoint that does not depend on backend availability. Coolify uses this health status for Traefik routing decisions.
+
+**If the maintenance page persists beyond 3 minutes:**
+
+1. Check API health: Coolify dashboard → api service → logs
+2. Check if `init-prod.sh` is still running (migrations, RLS verification)
+3. Verify database connectivity: check pgbouncer and postgres service logs
+
+**If you see raw 502 errors (not the maintenance page):**
+
+1. nginx itself may be down — check nginx service logs in Coolify
+2. Verify nginx container is healthy: `docker ps | grep nginx`
+3. Check that the nginx image built successfully (maintenance.html must be embedded)
 
 ### OIDC redirect fails
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -162,7 +162,7 @@ curl http://localhost/health
 
 **Services:**
 
-- **nginx** — Reverse proxy, TLS termination, rate limiting
+- **nginx** — Reverse proxy, TLS termination, rate limiting (built from `nginx/Dockerfile` — embeds config + maintenance page)
 - **web** — Next.js frontend (standalone output)
 - **api** — Fastify API with tRPC + REST + GraphQL, background jobs (BullMQ)
 - **tusd** — Resumable file upload server (tus protocol)
@@ -216,13 +216,17 @@ Mount the certificates volume in `docker-compose.prod.yml`:
 
 ```yaml
 nginx:
+  build:
+    context: ./nginx
+    dockerfile: Dockerfile
   volumes:
-    - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     - /etc/letsencrypt:/etc/letsencrypt:ro
   ports:
     - "80:80"
     - "443:443"
 ```
+
+> **Note:** nginx uses a built image (`nginx/Dockerfile`) that embeds `nginx.conf` and a maintenance page. The maintenance page is served automatically when backends are unavailable during deploys. nginx starts immediately without waiting for backend health checks — it will show the maintenance page until backends are ready.
 
 ### Certificate renewal
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,28 @@ Newest entries first.
 
 ---
 
+## 2026-03-23 — Harden nginx Proxy Resilience
+
+### Done
+
+- Decoupled nginx startup from backend health: `depends_on` changed from `service_healthy` to `service_started` in both Coolify and prod compose files
+- Added `/nginx-health` local endpoint — returns 200 without proxying to backend, used by Docker healthcheck and Coolify/Traefik health detection
+- Added branded maintenance page (`nginx/maintenance.html`) served via `error_page 502 503 504` when backends are unavailable — auto-refreshes every 30s
+- Added proxy timeouts: 5s connect (fail fast), 30s send, 60s read
+- Added graceful shutdown: `stop_signal: SIGQUIT` with 30s drain period for in-flight connections
+- Switched `docker-compose.prod.yml` nginx from `nginx:alpine` + bind-mount to built image (`nginx/Dockerfile`) — matches Coolify compose pattern, embeds config + maintenance page
+- Updated deployment docs (coolify-deployment.md troubleshooting, deployment.md nginx section)
+- Codex plan review: 2 Important findings addressed — removed Traefik labels (Coolify manages routing via UI, labels unreliable), added `docs/deployment.md` to update scope
+- Verified locally: Docker build + run without backends confirmed `/nginx-health` returns 200 and all proxied paths return maintenance page
+
+### Decisions
+
+- No Traefik labels in compose: Coolify manages Traefik routing via UI, compose label substitution is unreliable (documented in devlog 2026-03-22 and deployment history)
+- 30s auto-refresh on maintenance page (not 10s) to avoid excessive requests during 2-minute migration window
+- Built image for prod nginx: consistency with Coolify compose, embeds maintenance.html without extra bind-mount
+
+---
+
 ## 2026-03-23 — Fix init-prod.sh Seed for Production Containers
 
 ### Done

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY maintenance.html /usr/share/nginx/html/maintenance.html

--- a/nginx/maintenance.html
+++ b/nginx/maintenance.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="refresh" content="30">
+    <title>Colophony — Starting Up</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            background: #fafaf9;
+            color: #292524;
+        }
+        .container {
+            text-align: center;
+            max-width: 480px;
+            padding: 2rem;
+        }
+        h1 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 0.75rem;
+            letter-spacing: -0.01em;
+        }
+        p {
+            font-size: 1rem;
+            line-height: 1.6;
+            color: #57534e;
+        }
+        .subtle {
+            margin-top: 1.5rem;
+            font-size: 0.8rem;
+            color: #a8a29e;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Colophony</h1>
+        <p>The service is starting up or undergoing maintenance. This page will refresh automatically.</p>
+        <p class="subtle">If this persists beyond a few minutes, check the deployment logs.</p>
+    </div>
+</body>
+</html>

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -40,6 +40,11 @@ http {
     resolver 127.0.0.11 valid=10s ipv6=off;
     resolver_timeout 5s;
 
+    # Proxy timeouts — fail fast rather than hang when backends are restarting
+    proxy_connect_timeout 5s;
+    proxy_send_timeout 30s;
+    proxy_read_timeout 60s;
+
     server {
         listen 80;
         server_name _;
@@ -50,6 +55,21 @@ http {
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+        # Maintenance page for upstream failures (connection refused, timeout)
+        error_page 502 503 504 /maintenance.html;
+        location = /maintenance.html {
+            root /usr/share/nginx/html;
+            internal;
+        }
+
+        # nginx-local health check — does NOT proxy to backend.
+        # Used by Docker healthcheck and Coolify/Traefik health detection.
+        location = /nginx-health {
+            access_log off;
+            return 200 "ok\n";
+            add_header Content-Type text/plain;
+        }
 
         # tRPC API
         location /trpc {


### PR DESCRIPTION
## Summary

- Decouple nginx startup from backend health checks — nginx starts immediately and serves a branded maintenance page while backends initialize, eliminating the 2+ minute window where Traefik has nothing to route to during redeploys
- Add `/nginx-health` local endpoint for Docker/Traefik health detection independent of backend availability
- Add proxy timeouts (5s connect) and graceful shutdown (`SIGQUIT` with 30s drain)
- Switch prod compose from bind-mounted `nginx:alpine` to built image matching Coolify pattern

## Test plan

- [x] Build nginx image locally, run without backends — `/nginx-health` returns 200, all proxied paths return maintenance page HTML
- [ ] Deploy to staging via Coolify — maintenance page appears during API startup, clears once backends healthy
- [ ] Verify `/nginx-health` always returns 200 regardless of backend state
- [ ] Verify normal routing works after backends start