### PR TITLE
feat(scripts): add Zitadel Cloud webhook configuration script

### DIFF
--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,28 @@ Newest entries first.
 
 ---
 
+## 2026-03-23 — Zitadel Cloud Webhook Event Configuration
+
+### Done
+
+- Created `scripts/configure-zitadel-cloud-webhook.ts` — diagnostic and configuration script for Zitadel Cloud webhook event subscriptions (diagnose, dry-run, configure, delete-target modes)
+- Refactored `zitadelApi`, `findOrCreateTarget`, `setGroupExecution` in `scripts/zitadel-helpers.ts` to accept optional `baseUrl` parameter for targeting remote Zitadel instances
+- Exported `WEBHOOK_EVENT_TYPES` constant from helpers for diagnostic use
+- Added `pnpm zitadel:cloud-webhook` npm script
+- Diagnosed Zitadel Cloud: confirmed `user.human` group was configured but `user` group was missing — `user.deactivated`, `user.reactivated`, `user.removed` events were not covered
+- Applied fix: added `user` group execution to `colophony-staging-final` target — all 7 event types now covered
+- Deleted stale `colophony-staging-v2` target from Zitadel Cloud
+- Signing key rotated during configuration — user updated `ZITADEL_WEBHOOK_SECRET` on staging (pending redeploy)
+- Codex plan review: 2 Important findings addressed — fixed npm script pattern to use `pnpm --filter @colophony/db exec tsx`, dropped `--per-event` mode (execution condition names differ from payload names)
+
+### Decisions
+
+- Group-based execution over per-event: Zitadel execution condition names differ from webhook payload `event_type` names (documented in `zitadel-helpers.ts:342`); per-event deferred until API docs confirm correct condition names
+- Configure both `user` and `user.human` groups for belt-and-suspenders coverage
+- Reuse existing `colophony-staging-final` target rather than creating new one
+
+---
+
 ## 2026-03-23 — Harden nginx Proxy Resilience
 
 ### Done

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "sdk:generate": "pnpm --filter @colophony/api exec tsx ../../scripts/generate-sdks.ts",
     "docker:up": "bash scripts/docker-up.sh",
     "zitadel:setup": "pnpm --filter @colophony/db exec tsx ../../scripts/setup-zitadel-dev.ts",
+    "zitadel:cloud-webhook": "pnpm --filter @colophony/db exec tsx ../../scripts/configure-zitadel-cloud-webhook.ts",
     "clean": "turbo run clean && rm -rf node_modules",
     "prepare": "husky"
   },

--- a/scripts/configure-zitadel-cloud-webhook.ts
+++ b/scripts/configure-zitadel-cloud-webhook.ts
@@ -1,0 +1,384 @@
+/**
+ * Zitadel Cloud webhook configuration script.
+ *
+ * Diagnoses and configures webhook event subscriptions on a Zitadel Cloud
+ * instance. Ensures the webhook target exists and is subscribed to all
+ * user lifecycle event groups.
+ *
+ * Usage:
+ *   pnpm zitadel:cloud-webhook --diagnose              # Read-only diagnostic
+ *   pnpm zitadel:cloud-webhook --webhook-url <url>      # Configure
+ *   pnpm zitadel:cloud-webhook --dry-run                # Show planned changes
+ *
+ * Environment variables (or CLI args):
+ *   ZITADEL_AUTHORITY          --authority     Zitadel Cloud instance URL
+ *   ZITADEL_CLOUD_PAT          --token         Service account PAT
+ *   ZITADEL_CLOUD_WEBHOOK_URL  --webhook-url   Production webhook endpoint
+ *
+ * Idempotent: safe to run multiple times.
+ */
+
+import {
+  zitadelApi,
+  findOrCreateTarget,
+  setGroupExecution,
+  WEBHOOK_EVENT_TYPES,
+} from "./zitadel-helpers";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Config {
+  authority: string;
+  token: string;
+  webhookUrl: string;
+  targetName: string;
+  diagnose: boolean;
+  dryRun: boolean;
+  deleteTargets: string[];
+}
+
+interface TargetInfo {
+  id: string;
+  name: string;
+  endpoint?: string;
+  targetType?: Record<string, unknown>;
+}
+
+interface ExecutionInfo {
+  condition: {
+    event?: { group?: string; event?: string };
+    request?: unknown;
+    response?: unknown;
+  };
+  targets?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+function parseConfig(): Config {
+  const args = process.argv.slice(2);
+
+  function getArg(flag: string): string | undefined {
+    const idx = args.indexOf(flag);
+    if (idx === -1 || idx + 1 >= args.length) return undefined;
+    return args[idx + 1];
+  }
+
+  const authority =
+    getArg("--authority") || process.env.ZITADEL_AUTHORITY || "";
+  const token = getArg("--token") || process.env.ZITADEL_CLOUD_PAT || "";
+  const webhookUrl =
+    getArg("--webhook-url") || process.env.ZITADEL_CLOUD_WEBHOOK_URL || "";
+  const targetName = getArg("--target-name") || "colophony-cloud-webhook";
+  const diagnose = args.includes("--diagnose");
+  const dryRun = args.includes("--dry-run");
+
+  // Collect all --delete-target values
+  const deleteTargets: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--delete-target" && i + 1 < args.length) {
+      deleteTargets.push(args[i + 1]);
+    }
+  }
+
+  // Strip trailing slash from authority
+  const cleanAuthority = authority.replace(/\/+$/, "");
+
+  if (!cleanAuthority) {
+    console.error(
+      "Error: --authority or ZITADEL_AUTHORITY is required.\n" +
+        "Usage: pnpm zitadel:cloud-webhook --authority https://your-instance.zitadel.cloud --token <PAT>",
+    );
+    process.exit(1);
+  }
+
+  if (!token) {
+    console.error(
+      "Error: --token or ZITADEL_CLOUD_PAT is required.\n" +
+        "Provide a Personal Access Token with IAM_OWNER or ORG_OWNER permissions.",
+    );
+    process.exit(1);
+  }
+
+  if (!diagnose && !dryRun && !webhookUrl) {
+    console.error(
+      "Error: --webhook-url or ZITADEL_CLOUD_WEBHOOK_URL is required for configuration.\n" +
+        "Use --diagnose for read-only mode.",
+    );
+    process.exit(1);
+  }
+
+  return {
+    authority: cleanAuthority,
+    token,
+    webhookUrl,
+    targetName,
+    diagnose,
+    dryRun,
+    deleteTargets,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostic functions
+// ---------------------------------------------------------------------------
+
+async function listTargets(
+  token: string,
+  baseUrl: string,
+): Promise<TargetInfo[]> {
+  const res = await zitadelApi<{
+    targets?: TargetInfo[];
+  }>(token, "/v2/actions/targets/search", "POST", {}, baseUrl);
+
+  if (!res.ok) {
+    console.error(`Failed to list targets (HTTP ${res.status}):`, res.data);
+    return [];
+  }
+
+  return res.data.targets ?? [];
+}
+
+async function listExecutions(
+  token: string,
+  baseUrl: string,
+): Promise<ExecutionInfo[]> {
+  const res = await zitadelApi<{
+    executions?: ExecutionInfo[];
+  }>(token, "/v2/actions/executions/search", "POST", {}, baseUrl);
+
+  if (!res.ok) {
+    console.error(`Failed to list executions (HTTP ${res.status}):`, res.data);
+    return [];
+  }
+
+  return res.data.executions ?? [];
+}
+
+async function deleteTarget(
+  token: string,
+  targetId: string,
+  baseUrl: string,
+): Promise<boolean> {
+  const res = await zitadelApi(
+    token,
+    `/v2/actions/targets/${targetId}`,
+    "DELETE",
+    undefined,
+    baseUrl,
+  );
+
+  if (!res.ok) {
+    console.error(
+      `  Failed to delete target ${targetId} (HTTP ${res.status}):`,
+      res.data,
+    );
+    return false;
+  }
+
+  console.log(`  Deleted target: ${targetId}`);
+  return true;
+}
+
+function printDiagnostic(
+  targets: TargetInfo[],
+  executions: ExecutionInfo[],
+): void {
+  console.log("\n--- Targets ---");
+  if (targets.length === 0) {
+    console.log("  (none)");
+  } else {
+    for (const t of targets) {
+      const endpoint = t.endpoint || "(no endpoint)";
+      const type = t.targetType
+        ? Object.keys(t.targetType).join(", ")
+        : "unknown";
+      console.log(`  ${t.id}  ${t.name}  ${endpoint}  [${type}]`);
+    }
+  }
+
+  console.log("\n--- Executions ---");
+  const eventExecutions = executions.filter((e) => e.condition?.event);
+  const otherExecutions = executions.filter((e) => !e.condition?.event);
+
+  if (eventExecutions.length === 0) {
+    console.log("  (no event executions)");
+  } else {
+    for (const e of eventExecutions) {
+      const event = e.condition.event!;
+      const label = event.group
+        ? `group: ${event.group}`
+        : event.event
+          ? `event: ${event.event}`
+          : "unknown";
+      const targetIds = e.targets?.join(", ") || "(no targets)";
+      console.log(`  [${label}] → targets: [${targetIds}]`);
+    }
+  }
+
+  if (otherExecutions.length > 0) {
+    console.log(`\n  (${otherExecutions.length} non-event executions omitted)`);
+  }
+
+  // Coverage analysis
+  console.log("\n--- Coverage Analysis ---");
+  const configuredGroups = eventExecutions
+    .filter((e) => e.condition.event?.group)
+    .map((e) => e.condition.event!.group!);
+
+  const hasUserGroup = configuredGroups.includes("user");
+  const hasUserHumanGroup = configuredGroups.includes("user.human");
+
+  console.log(
+    `  "user" group:       ${hasUserGroup ? "configured" : "MISSING"}`,
+  );
+  console.log(
+    `  "user.human" group: ${hasUserHumanGroup ? "configured" : "MISSING"}`,
+  );
+
+  if (hasUserGroup) {
+    console.log("\n  The 'user' group covers all user lifecycle events.");
+  } else if (hasUserHumanGroup) {
+    console.log(
+      "\n  The 'user.human' group covers user.human.* events but MISSES:",
+    );
+    console.log("    - user.deactivated");
+    console.log("    - user.reactivated");
+    console.log("    - user.removed");
+  } else {
+    console.log(
+      "\n  No user event groups configured. The webhook will not receive any user events.",
+    );
+  }
+
+  console.log("\n  Supported event types (from webhook handler):");
+  for (const et of WEBHOOK_EVENT_TYPES) {
+    const covered =
+      hasUserGroup || (hasUserHumanGroup && et.startsWith("user.human."));
+    console.log(`    ${covered ? "✓" : "✗"} ${et}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Event groups to configure — "user" is the broadest group covering all user events */
+const CLOUD_EVENT_GROUPS = ["user", "user.human"] as const;
+
+async function configure(config: Config): Promise<void> {
+  // Find or create target
+  console.log(`\nFinding/creating webhook target: ${config.targetName}`);
+  console.log(`  URL: ${config.webhookUrl}`);
+
+  const { targetId, signingKey } = await findOrCreateTarget(
+    config.token,
+    config.targetName,
+    config.webhookUrl,
+    "10s",
+    config.authority,
+  );
+
+  // Set group executions
+  console.log("\nConfiguring event group executions...");
+  for (const group of CLOUD_EVENT_GROUPS) {
+    console.log(`  Setting execution for group: ${group}`);
+    await setGroupExecution(config.token, group, targetId, config.authority);
+  }
+
+  // Signing key warning
+  if (signingKey) {
+    console.log("\n=== SIGNING KEY (save this — shown only once) ===");
+    console.log(`  ${signingKey}`);
+    console.log(
+      "  Set this as ZITADEL_WEBHOOK_SECRET in your production environment.",
+    );
+  } else {
+    console.log("\n  Target already existed — signing key was not returned.");
+    console.log(
+      "  Ensure ZITADEL_WEBHOOK_SECRET is set in your production environment.",
+    );
+    console.log(
+      "  To regenerate: delete the target in Zitadel Cloud Console (Actions → Targets), then rerun.",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const config = parseConfig();
+
+  console.log("=== Zitadel Cloud Webhook Configuration ===");
+  console.log(`  Authority:   ${config.authority}`);
+  console.log(`  Target name: ${config.targetName}`);
+  console.log(
+    `  Mode:        ${config.diagnose ? "diagnose" : config.dryRun ? "dry-run" : "configure"}`,
+  );
+
+  // Verify connectivity
+  console.log("\nVerifying API access...");
+  const targets = await listTargets(config.token, config.authority);
+  const executions = await listExecutions(config.token, config.authority);
+
+  // Always show diagnostic
+  printDiagnostic(targets, executions);
+
+  if (config.diagnose) {
+    console.log("\n=== Diagnose complete (read-only) ===");
+    return;
+  }
+
+  // Delete stale targets if requested
+  if (config.deleteTargets.length > 0) {
+    console.log("\n--- Deleting stale targets ---");
+    for (const targetId of config.deleteTargets) {
+      const target = targets.find((t) => t.id === targetId);
+      if (!target) {
+        console.error(`  Target ${targetId} not found — skipping`);
+        continue;
+      }
+      if (config.dryRun) {
+        console.log(`  Would delete: ${targetId} (${target.name})`);
+      } else {
+        await deleteTarget(config.token, targetId, config.authority);
+      }
+    }
+  }
+
+  if (config.dryRun) {
+    console.log("\n--- Dry Run: Planned Changes ---");
+    console.log(
+      `  1. Find or create target: ${config.targetName} → ${config.webhookUrl}`,
+    );
+    for (const group of CLOUD_EVENT_GROUPS) {
+      console.log(
+        `  2. Set execution: group "${group}" → target ${config.targetName}`,
+      );
+    }
+    console.log("\n=== Dry run complete (no changes made) ===");
+    return;
+  }
+
+  // Configure
+  await configure(config);
+
+  // Re-diagnose to verify
+  console.log("\n--- Verifying configuration ---");
+  const newTargets = await listTargets(config.token, config.authority);
+  const newExecutions = await listExecutions(config.token, config.authority);
+  printDiagnostic(newTargets, newExecutions);
+
+  console.log("\n=== Configuration complete ===");
+}
+
+main().catch((err) => {
+  console.error("\nConfiguration failed:", err);
+  process.exit(1);
+});

--- a/scripts/configure-zitadel-cloud-webhook.ts
+++ b/scripts/configure-zitadel-cloud-webhook.ts
@@ -136,8 +136,10 @@ async function listTargets(
   }>(token, "/v2/actions/targets/search", "POST", {}, baseUrl);
 
   if (!res.ok) {
-    console.error(`Failed to list targets (HTTP ${res.status}):`, res.data);
-    return [];
+    throw new Error(
+      `Failed to list targets (HTTP ${res.status}): ${JSON.stringify(res.data)}. ` +
+        "Check that --authority and --token are correct and the PAT has IAM_OWNER permissions.",
+    );
   }
 
   return res.data.targets ?? [];
@@ -152,8 +154,10 @@ async function listExecutions(
   }>(token, "/v2/actions/executions/search", "POST", {}, baseUrl);
 
   if (!res.ok) {
-    console.error(`Failed to list executions (HTTP ${res.status}):`, res.data);
-    return [];
+    throw new Error(
+      `Failed to list executions (HTTP ${res.status}): ${JSON.stringify(res.data)}. ` +
+        "Check that --authority and --token are correct and the PAT has IAM_OWNER permissions.",
+    );
   }
 
   return res.data.executions ?? [];
@@ -187,6 +191,7 @@ async function deleteTarget(
 function printDiagnostic(
   targets: TargetInfo[],
   executions: ExecutionInfo[],
+  scopeToTargetId?: string,
 ): void {
   console.log("\n--- Targets ---");
   if (targets.length === 0) {
@@ -224,9 +229,17 @@ function printDiagnostic(
     console.log(`\n  (${otherExecutions.length} non-event executions omitted)`);
   }
 
-  // Coverage analysis
+  // Coverage analysis — scope to a specific target if provided
   console.log("\n--- Coverage Analysis ---");
-  const configuredGroups = eventExecutions
+  const scopedExecutions = scopeToTargetId
+    ? eventExecutions.filter((e) => e.targets?.includes(scopeToTargetId))
+    : eventExecutions;
+
+  if (scopeToTargetId) {
+    console.log(`  (scoped to target: ${scopeToTargetId})`);
+  }
+
+  const configuredGroups = scopedExecutions
     .filter((e) => e.condition.event?.group)
     .map((e) => e.condition.event!.group!);
 
@@ -327,8 +340,9 @@ async function main() {
   const targets = await listTargets(config.token, config.authority);
   const executions = await listExecutions(config.token, config.authority);
 
-  // Always show diagnostic
-  printDiagnostic(targets, executions);
+  // Always show diagnostic — scope to configured target if it exists
+  const matchingTarget = targets.find((t) => t.name === config.targetName);
+  printDiagnostic(targets, executions, matchingTarget?.id);
 
   if (config.diagnose) {
     console.log("\n=== Diagnose complete (read-only) ===");
@@ -369,11 +383,12 @@ async function main() {
   // Configure
   await configure(config);
 
-  // Re-diagnose to verify
+  // Re-diagnose to verify — scope to the target we just configured
   console.log("\n--- Verifying configuration ---");
   const newTargets = await listTargets(config.token, config.authority);
   const newExecutions = await listExecutions(config.token, config.authority);
-  printDiagnostic(newTargets, newExecutions);
+  const configuredTarget = newTargets.find((t) => t.name === config.targetName);
+  printDiagnostic(newTargets, newExecutions, configuredTarget?.id);
 
   console.log("\n=== Configuration complete ===");
 }

--- a/scripts/zitadel-helpers.ts
+++ b/scripts/zitadel-helpers.ts
@@ -89,8 +89,9 @@ export async function zitadelApi<T>(
   path: string,
   method: string = "POST",
   body?: unknown,
+  baseUrl: string = ZITADEL_URL,
 ): Promise<ApiResponse<T>> {
-  const res = await fetch(`${ZITADEL_URL}${path}`, {
+  const res = await fetch(`${baseUrl}${path}`, {
     method,
     headers: {
       "Content-Type": "application/json",
@@ -347,6 +348,21 @@ export async function ensureColophonyUser(
 export const WEBHOOK_EVENT_GROUPS = ["user"] as const;
 
 /**
+ * Individual event types the webhook handler supports (for diagnostics).
+ * These are the `event_type` values in the webhook payload — note that
+ * execution condition names may differ from these payload names.
+ */
+export const WEBHOOK_EVENT_TYPES = [
+  "user.human.added",
+  "user.human.changed",
+  "user.human.profile.changed",
+  "user.human.email.verified",
+  "user.deactivated",
+  "user.reactivated",
+  "user.removed",
+] as const;
+
+/**
  * Find or create a Zitadel Actions v2 webhook target.
  *
  * When the target is created, Zitadel returns a one-time `signingKey` (HMAC
@@ -358,20 +374,27 @@ export async function findOrCreateTarget(
   name: string,
   url: string,
   timeout: string = "10s",
+  baseUrl?: string,
 ): Promise<{ targetId: string; signingKey: string | null }> {
   // Search for existing target by name
   const search = await zitadelApi<{
     targets?: Array<{ id: string; name: string; signingKey?: string }>;
-  }>(token, "/v2/actions/targets/search", "POST", {
-    queries: [
-      {
-        targetNameQuery: {
-          targetName: name,
-          method: "TEXT_QUERY_METHOD_EQUALS",
+  }>(
+    token,
+    "/v2/actions/targets/search",
+    "POST",
+    {
+      queries: [
+        {
+          targetNameQuery: {
+            targetName: name,
+            method: "TEXT_QUERY_METHOD_EQUALS",
+          },
         },
-      },
-    ],
-  });
+      ],
+    },
+    baseUrl,
+  );
 
   if (search.ok && search.data.targets?.length) {
     // Client-side exact match — Zitadel's targetNameQuery may not filter exactly
@@ -387,12 +410,18 @@ export async function findOrCreateTarget(
   const create = await zitadelApi<{
     id: string;
     signingKey: string;
-  }>(token, "/v2/actions/targets", "POST", {
-    name,
-    rest_webhook: { interrupt_on_error: false },
-    endpoint: url,
-    timeout,
-  });
+  }>(
+    token,
+    "/v2/actions/targets",
+    "POST",
+    {
+      name,
+      rest_webhook: { interrupt_on_error: false },
+      endpoint: url,
+      timeout,
+    },
+    baseUrl,
+  );
 
   if (!create.ok) {
     throw new Error(
@@ -415,6 +444,7 @@ export async function setGroupExecution(
   token: string,
   group: string,
   targetId: string,
+  baseUrl?: string,
 ): Promise<void> {
   // Read existing execution targets for this group
   const search = await zitadelApi<{
@@ -422,15 +452,21 @@ export async function setGroupExecution(
       condition: { event?: { group?: string } };
       targets?: string[];
     }>;
-  }>(token, "/v2/actions/executions/search", "POST", {
-    queries: [
-      {
-        eventConditionQuery: {
-          group,
+  }>(
+    token,
+    "/v2/actions/executions/search",
+    "POST",
+    {
+      queries: [
+        {
+          eventConditionQuery: {
+            group,
+          },
         },
-      },
-    ],
-  });
+      ],
+    },
+    baseUrl,
+  );
 
   const existingTargets: string[] = [];
   if (search.ok && search.data.executions?.length) {
@@ -445,14 +481,20 @@ export async function setGroupExecution(
     ? existingTargets
     : [...existingTargets, targetId];
 
-  const res = await zitadelApi(token, "/v2/actions/executions", "PUT", {
-    condition: {
-      event: {
-        group,
+  const res = await zitadelApi(
+    token,
+    "/v2/actions/executions",
+    "PUT",
+    {
+      condition: {
+        event: {
+          group,
+        },
       },
+      targets: mergedTargets,
     },
-    targets: mergedTargets,
-  });
+    baseUrl,
+  );
 
   if (!res.ok) {
     throw new Error(


### PR DESCRIPTION
## Summary

- Add `scripts/configure-zitadel-cloud-webhook.ts` — diagnostic and configuration script for Zitadel Cloud webhook event subscriptions (diagnose, dry-run, configure, delete-target modes)
- Refactor `zitadelApi`, `findOrCreateTarget`, `setGroupExecution` in `scripts/zitadel-helpers.ts` to accept optional `baseUrl` parameter for targeting remote Zitadel instances
- Add `pnpm zitadel:cloud-webhook` npm script

## Context

The Zitadel Cloud webhook was configured with the `user.human` event group, which missed `user.deactivated`, `user.reactivated`, and `user.removed` events. This script was used to diagnose the gap, add the broader `user` group execution, and clean up a stale target — all verified live against the Cloud instance.

## Test plan

- [x] `pnpm zitadel:cloud-webhook --diagnose` — confirmed current Cloud state
- [x] `pnpm zitadel:cloud-webhook --dry-run` — verified planned changes
- [x] `pnpm zitadel:cloud-webhook` — applied configuration, all 7 event types now covered
- [x] Stale target deletion verified
- [x] `pnpm type-check` — workspace passes
- [x] plan review: 2 findings addressed (npm script pattern, dropped --per-event)
- [x] branch review: 2 P2 findings addressed (abort on API failure, scope coverage to target)
- [ ] Verify webhook events fire after staging redeploy with new signing key