### PR TITLE
docs: devlog for webhook verification session

### DIFF
--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,25 @@ Newest entries first.
 
 ---
 
+## 2026-03-23 — Zitadel Cloud Webhook Verification & RTK Fix
+
+### Done
+
+- Verified Zitadel Cloud webhook configuration via diagnostic script — `user` and `user.human` groups confirmed wired to `colophony-staging-final` target at `https://staging.colophony.pub/webhooks/zitadel`
+- Confirmed staging API healthy (200 on `/health`) and webhook endpoint reachable (400 on malformed POST — correct rejection)
+- Triggered `user.human.profile.changed` events (sequences 3-4) on test user via Zitadel Management API; confirmed events visible in Zitadel event stream
+- Reverted test user profile change after verification
+- Diagnosed RTK (Rust Token Killer) `grep` and `curl` rewrites injecting emoji prefixes that corrupted piped output — caused auth header corruption (`ð` byte in Bearer token) and JSON POST body mangling
+- Disabled RTK `grep` and `curl` rewrites in `~/.claude/hooks/rtk-rewrite.sh`; kept all other rewrites (git, gh, docker, pnpm) for token savings
+- Cleaned up stale `feat/zitadel-webhook-events` local branch (PR #322 merged)
+
+### Decisions
+
+- RTK grep/curl disabled: emoji injection corrupts programmatic output (env var extraction, API tokens, JSON bodies); dedicated Grep tool and raw curl preferred for data integrity
+- Webhook verification deemed sufficient without direct staging log access: config confirmed, endpoint reachable, events visible in Zitadel event stream
+
+---
+
 ## 2026-03-23 — Zitadel Cloud Webhook Event Configuration
 
 ### Done


### PR DESCRIPTION
## Summary

- Devlog entry for 2026-03-23 ops session: Zitadel Cloud webhook verification and RTK grep/curl fix
- No code changes — doc-only update

## Test plan

- [x] Devlog entry follows format conventions
- [x] No code changes to validate