### PR TITLE
feat(monitoring): Loki log aggregation + Grafana dashboards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,12 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **Metrics registry**     | `apps/api/src/config/metrics.ts` (Prometheus counters, histograms, gauges)       |
 | **Metrics plugin**       | `apps/api/src/hooks/metrics.ts` (Fastify plugin — HTTP request instrumentation)  |
 | **Instrumented worker**  | `apps/api/src/config/instrumented-worker.ts` (BullMQ wrapper with metrics)       |
+| **Webhook health**       | `apps/api/src/webhooks/webhook-health.route.ts`                                  |
+| **Alert rules**          | `docker/prometheus/alert-rules.yml`                                              |
+| **AlertManager config**  | `docker/alertmanager/alertmanager.yml`                                           |
+| **Loki config**          | `docker/loki/loki-config.yml` (dev), `loki-config.prod.yml` (prod)               |
+| **Promtail config**      | `docker/promtail/promtail-config.yml`                                            |
+| **Grafana dashboards**   | `docker/grafana/dashboards/` (API metrics + logs exploration)                    |
 | **Writer workspace**     | `packages/db/src/schema/writer-workspace.ts`                                     |
 | **CSR types**            | `packages/types/src/csr.ts`                                                      |
 | **CSR service**          | `apps/api/src/services/csr.service.ts` (export/import for data portability)      |
@@ -375,6 +381,12 @@ pnpm db:seed                  # Seed dev data (orgs, submissions, Slate pipeline
 pnpm db:seed:staging          # Rich staging/demo data (80 subs, forms, editorial, federation, etc.)
 pnpm zitadel:setup            # Provision Zitadel + patch .env files (after volume wipe)
 pnpm dev                      # hivemind: builds packages, then API: 4000, Web: 3000
+```
+
+**Optional monitoring stack** (Prometheus + Grafana + AlertManager + Loki):
+
+```bash
+docker compose --profile monitoring up -d  # Prometheus:9090, Grafana:3001, AlertManager:9093, Loki:3100
 ```
 
 **hivemind controls** (while `pnpm dev` is running):

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -217,6 +217,10 @@ services:
       - archive_timeout=60
       - -c
       - wal_level=replica
+      - -c
+      - log_min_duration_statement=1000
+      - -c
+      - "log_line_prefix=%m [%p] %q%u@%d "
     volumes:
       - staging_postgres_data:/var/lib/postgresql/data
     restart: unless-stopped
@@ -397,6 +401,40 @@ services:
     networks:
       - colophony-staging
 
+  # Loki log aggregation
+  loki:
+    build:
+      context: ./docker/loki
+      dockerfile: Dockerfile
+    expose:
+      - "3100"
+    volumes:
+      - staging_loki_data:/loki
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    networks:
+      - colophony-staging
+
+  # Promtail log shipper
+  promtail:
+    build:
+      context: ./docker/promtail
+      dockerfile: Dockerfile
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      - loki
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+    networks:
+      - colophony-staging
+
 volumes:
   staging_postgres_data:
   staging_redis_data:
@@ -404,6 +442,7 @@ volumes:
   staging_clamav_data:
   staging_prometheus_data:
   staging_grafana_data:
+  staging_loki_data:
 
 networks:
   colophony-staging:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -184,6 +184,10 @@ services:
       - archive_timeout=60
       - -c
       - wal_level=replica
+      - -c
+      - log_min_duration_statement=1000
+      - -c
+      - "log_line_prefix=%m [%p] %q%u@%d "
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./scripts/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh:ro
@@ -420,6 +424,42 @@ services:
     networks:
       - colophony
 
+  # Loki log aggregation
+  loki:
+    image: grafana/loki:3.5.0
+    container_name: colophony-loki
+    expose:
+      - "3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - ./docker/loki/loki-config.prod.yml:/etc/loki/local-config.yaml:ro
+      - loki_data:/loki
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    networks:
+      - colophony
+
+  # Promtail log shipper
+  promtail:
+    image: grafana/promtail:3.5.0
+    container_name: colophony-promtail
+    volumes:
+      - ./docker/promtail/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      - loki
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+    networks:
+      - colophony
+
 volumes:
   postgres_data:
   redis_data:
@@ -427,6 +467,7 @@ volumes:
   clamav_data:
   prometheus_data:
   grafana_data:
+  loki_data:
 
 networks:
   colophony:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,6 +238,32 @@ services:
     profiles:
       - monitoring
 
+  # Loki log aggregation (optional — for monitoring)
+  loki:
+    image: grafana/loki:3.5.0
+    container_name: colophony-loki
+    ports:
+      - '3100:3100'
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - ./docker/loki/loki-config.yml:/etc/loki/local-config.yaml:ro
+      - loki_data:/loki
+    profiles:
+      - monitoring
+
+  # Promtail log shipper (optional — for monitoring)
+  promtail:
+    image: grafana/promtail:3.5.0
+    container_name: colophony-promtail
+    volumes:
+      - ./docker/promtail/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      - loki
+    profiles:
+      - monitoring
+
   # Grafana dashboards (optional — for monitoring)
   grafana:
     image: grafana/grafana:12.0.1
@@ -284,3 +310,4 @@ volumes:
   clamav_data:
   prometheus_data:
   grafana_data:
+  loki_data:

--- a/docker/grafana/dashboards/colophony-api.json
+++ b/docker/grafana/dashboards/colophony-api.json
@@ -153,6 +153,37 @@
       "fieldConfig": {
         "defaults": { "unit": "bytes" }
       }
+    },
+    {
+      "title": "Webhook Activity (Loki)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(count_over_time({service=\"colophony-api\"} |= \"webhook\" [5m]))",
+          "legendFormat": "webhook events",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short" }
+      }
+    },
+    {
+      "title": "Process CPU",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total[5m])",
+          "legendFormat": "CPU seconds/s",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit" }
+      }
     }
   ],
   "schemaVersion": 39,

--- a/docker/grafana/dashboards/colophony-logs.json
+++ b/docker/grafana/dashboards/colophony-logs.json
@@ -1,0 +1,113 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "title": "Log Volume by Service",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(count_over_time({project=~\".+\"} [5m])) by (service)",
+          "legendFormat": "{{ service }}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "fillOpacity": 30, "stacking": { "mode": "normal" } }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" } }
+    },
+    {
+      "title": "Error Logs",
+      "type": "logs",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{service=~\".+\"} | json | level=~\"error|fatal|50|60\"",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      }
+    },
+    {
+      "title": "API Request Logs",
+      "type": "logs",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 18 },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{service=\"colophony-api\"} | json",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      }
+    },
+    {
+      "title": "Slow Queries (>1s)",
+      "type": "logs",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 28 },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{service=~\".*postgres.*\"} |= \"duration:\"",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      }
+    },
+    {
+      "title": "Webhook Activity",
+      "type": "logs",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 38 },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{service=\"colophony-api\"} |= \"webhook\"",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["colophony", "logs"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Colophony — Logs",
+  "uid": "colophony-logs"
+}

--- a/docker/grafana/provisioning/datasources/loki.yml
+++ b/docker/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: true

--- a/docker/loki/Dockerfile
+++ b/docker/loki/Dockerfile
@@ -1,0 +1,2 @@
+FROM grafana/loki:3.5.0
+COPY loki-config.prod.yml /etc/loki/local-config.yaml

--- a/docker/loki/loki-config.prod.yml
+++ b/docker/loki/loki-config.prod.yml
@@ -1,0 +1,39 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  filesystem:
+    directory: /loki/chunks
+
+limits_config:
+  retention_period: 720h  # 30 days (production)
+  max_query_length: 721h
+  ingestion_rate_mb: 10
+  ingestion_burst_size_mb: 20
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  delete_request_cancel_period: 10m
+  retention_delete_delay: 2h

--- a/docker/loki/loki-config.yml
+++ b/docker/loki/loki-config.yml
@@ -1,0 +1,39 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  filesystem:
+    directory: /loki/chunks
+
+limits_config:
+  retention_period: 168h  # 7 days (dev)
+  max_query_length: 721h
+  ingestion_rate_mb: 10
+  ingestion_burst_size_mb: 20
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  delete_request_cancel_period: 10m
+  retention_delete_delay: 2h

--- a/docker/promtail/Dockerfile
+++ b/docker/promtail/Dockerfile
@@ -1,0 +1,2 @@
+FROM grafana/promtail:3.5.0
+COPY promtail-config.yml /etc/promtail/config.yml

--- a/docker/promtail/promtail-config.yml
+++ b/docker/promtail/promtail-config.yml
@@ -1,0 +1,34 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      # Extract container name (strip leading /)
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/?(.+)'
+        target_label: 'container'
+      # Extract compose service name
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: 'service'
+      # Extract compose project name
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_project']
+        target_label: 'project'
+    pipeline_stages:
+      # Try to parse JSON logs (Pino structured output from API)
+      - json:
+          expressions:
+            level: level
+            msg: msg
+      - labels:
+          level:

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-03-23 — Monitoring, Observability & Alerting (PRs #324, #325)
+
+### Done
+
+- **Webhook health endpoint** (`GET /webhooks/health`) — queries `MAX(received_at)` from Zitadel, Stripe, and Documenso webhook event tables; returns freshness status (healthy/stale/unknown) with configurable staleness thresholds; 4 integration tests
+- **Sentry in Next.js web app** — `@sentry/nextjs` with client/server/edge configs, `instrumentation.ts` hook, source map upload gated on `SENTRY_AUTH_TOKEN`, `/monitoring` tunnel route in production
+- **AlertManager + Prometheus alert rules** — 6 rules (high error rate, queue depth, DB pool exhaustion, health endpoint down, high latency, job failure spike) with Slack webhook receiver and envsubst entrypoint for Coolify compatibility
+- **Monitoring stack in all 3 Docker Compose files** — dev (monitoring profile), prod (always-on), Coolify (custom Dockerfiles for bind-mount quirk). Pinned: Prometheus v3.3.0, AlertManager v0.28.1, Grafana 12.0.1
+- **Loki + Promtail log aggregation** — Docker socket discovery, Pino JSON pipeline stage, service/container labels. 7-day retention (dev), 30-day (prod). Loki datasource auto-provisioned in Grafana
+- **Grafana log exploration dashboard** — log volume by service, error logs, API request logs, slow queries (>1s), webhook activity
+- **Enhanced API dashboard** — added webhook activity panel (Loki query) + process CPU panel
+- **PostgreSQL slow query logging** — `log_min_duration_statement=1000` in prod and Coolify compose files
+- Codex plan review caught 4 issues (test path, Sentry runtime env vars, missing prod compose, unsupported Grafana datasource) — all addressed before implementation
+
+### Decisions
+
+- Loki + Promtail for log aggregation over external services (DataDog, etc.) — fits existing self-hosted Grafana/Prometheus stack, no vendor dependency
+- Slack webhook for alerting over email or custom endpoint — low friction, immediate visibility
+- Wrapper scripts (bash + curl + jq) for CLI tooling over custom MCP servers — simpler, auditable, no maintenance overhead
+- Phased PRs: PR 1 (#324, merged) covers application code + alerting; PR 2 (#325) covers log aggregation + dashboards; PR 3 (CLI scripts) deferred to next session
+
+---
+
 ## 2026-03-23 — Zitadel Cloud Webhook Verification & RTK Fix
 
 ### Done


### PR DESCRIPTION
## Summary

- **Loki + Promtail** for centralized log aggregation — Docker socket discovery, Pino JSON pipeline stage, service/container labels. 7-day retention (dev), 30-day (prod)
- **Grafana log exploration dashboard** — log volume by service, error logs, API request logs, slow queries, webhook activity
- **Enhanced API dashboard** — webhook activity panel (Loki query) + process CPU panel
- **PostgreSQL slow query logging** — `log_min_duration_statement=1000` in prod and staging
- Pinned: Loki 3.5.0, Promtail 3.5.0

**Stacked on #324** (webhook health + Sentry web + AlertManager)

## Test plan

- [ ] `docker compose --profile monitoring up -d` starts Loki + Promtail alongside Prometheus/Grafana/AlertManager
- [ ] Grafana datasources page shows both Prometheus and Loki
- [ ] Grafana Explore: `{service="colophony-api"}` returns API logs
- [ ] Both dashboards (colophony-api, colophony-logs) load in Grafana
- [ ] All 3 compose files validate (`docker compose -f <file> config --quiet`)