### PR TITLE
fix(auth): JIT user provisioning for missed Zitadel webhooks

### DIFF
--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -11,7 +11,16 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import authPlugin from './auth.js';
 import type { Env } from '../config/env.js';
 
-// Mock @colophony/db
+// Mock @colophony/db — use trampoline pattern to avoid hoisting issues
+const mockReturning = vi.fn();
+const mockOnConflict = vi.fn(() => ({ returning: mockReturning }));
+const mockValues = vi.fn(() => ({ onConflictDoUpdate: mockOnConflict }));
+const mockInsert = vi.fn(() => ({ values: mockValues }));
+const mockUpdateReturning = vi.fn();
+const mockUpdateWhere = vi.fn(() => ({ returning: mockUpdateReturning }));
+const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }));
+const mockUpdate = vi.fn(() => ({ set: mockUpdateSet }));
+
 vi.mock('@colophony/db', () => ({
   db: {
     query: {
@@ -19,9 +28,16 @@ vi.mock('@colophony/db', () => ({
         findFirst: vi.fn(),
       },
     },
+    transaction: vi.fn((cb: (tx: unknown) => unknown) =>
+      cb({
+        insert: (...args: Parameters<typeof mockInsert>) => mockInsert(...args),
+      }),
+    ),
+    update: (...args: Parameters<typeof mockUpdate>) => mockUpdate(...args),
   },
   eq: vi.fn((_col: unknown, val: unknown) => val),
-  users: { zitadelUserId: 'zitadel_user_id' },
+  sql: (...a: unknown[]) => a,
+  users: { zitadelUserId: 'zitadel_user_id', email: 'email' },
   pool: {
     query: vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
   },
@@ -29,9 +45,15 @@ vi.mock('@colophony/db', () => ({
 
 // Mock audit service
 const mockLogDirect = vi.fn().mockResolvedValue(undefined);
+const mockAuditLog = vi.fn().mockResolvedValue(undefined);
 vi.mock('../services/audit.service.js', () => ({
   auditService: {
-    logDirect: (...args: unknown[]) => mockLogDirect(...args),
+    logDirect: function (...args: unknown[]) {
+      return mockLogDirect(...args);
+    },
+    log: function (...args: unknown[]) {
+      return mockAuditLog(...args);
+    },
   },
 }));
 
@@ -187,6 +209,12 @@ describe('auth plugin', () => {
       }));
     });
 
+    beforeEach(() => {
+      mockReturning.mockReset();
+      mockAuditLog.mockReset().mockResolvedValue(undefined);
+      mockUpdateReturning.mockReset();
+    });
+
     afterAll(async () => {
       await app.close();
     });
@@ -331,9 +359,14 @@ describe('auth plugin', () => {
       expect(response.json().error).toBe('token_expired');
     });
 
-    it('returns 403 when user not provisioned', async () => {
+    it('JIT provisions user when not found in DB', async () => {
       mockVerifyToken.mockResolvedValueOnce({
-        payload: { sub: 'zitadel-user-999' },
+        payload: {
+          sub: 'zitadel-user-999',
+          email: 'newuser@example.com',
+          name: 'New User',
+          email_verified: true,
+        },
         header: { alg: 'RS256' },
       });
 
@@ -343,13 +376,94 @@ describe('auth plugin', () => {
         undefined,
       );
 
+      const jitUser = {
+        id: 'jit-user-uuid',
+        email: 'newuser@example.com',
+        zitadelUserId: 'zitadel-user-999',
+        displayName: 'New User',
+        emailVerified: true,
+        emailVerifiedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        isGuest: false,
+        deletedAt: null,
+        lastEventAt: null,
+        migratedToDomain: null,
+        migratedToDid: null,
+        migratedAt: null,
+      };
+      mockReturning.mockResolvedValueOnce([jitUser]);
+
       const response = await app.inject({
         method: 'GET',
         url: '/protected',
         headers: { authorization: 'Bearer valid-token' },
       });
-      expect(response.statusCode).toBe(403);
-      expect(response.json().error).toBe('user_not_provisioned');
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.authContext.userId).toBe('jit-user-uuid');
+      expect(body.authContext.zitadelUserId).toBe('zitadel-user-999');
+      expect(body.authContext.email).toBe('newuser@example.com');
+      expect(mockAuditLog).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'USER_JIT_PROVISIONED',
+          resource: 'user',
+          resourceId: 'jit-user-uuid',
+        }),
+      );
+    });
+
+    it('JIT links to existing guest user on email conflict', async () => {
+      mockVerifyToken.mockResolvedValueOnce({
+        payload: {
+          sub: 'zitadel-user-888',
+          email: 'guest@example.com',
+        },
+        header: { alg: 'RS256' },
+      });
+
+      const dbModule = await import('@colophony/db');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(dbModule.db.query.users.findFirst).mockResolvedValueOnce(
+        undefined,
+      );
+
+      // Simulate email uniqueness conflict from the transaction
+      const conflictError = new Error('unique_violation') as Error & {
+        code: string;
+      };
+      conflictError.code = '23505';
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(dbModule.db.transaction).mockRejectedValueOnce(conflictError);
+
+      const linkedUser = {
+        id: 'guest-uuid',
+        email: 'guest@example.com',
+        zitadelUserId: 'zitadel-user-888',
+        displayName: null,
+        emailVerified: false,
+        emailVerifiedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        isGuest: false,
+        deletedAt: null,
+        lastEventAt: null,
+        migratedToDomain: null,
+        migratedToDid: null,
+        migratedAt: null,
+      };
+      mockUpdateReturning.mockResolvedValueOnce([linkedUser]);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/protected',
+        headers: { authorization: 'Bearer valid-token' },
+      });
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.authContext.userId).toBe('guest-uuid');
+      expect(body.authContext.zitadelUserId).toBe('zitadel-user-888');
     });
 
     it('returns 403 when user is deactivated', async () => {
@@ -530,6 +644,9 @@ describe('auth plugin', () => {
 
     beforeEach(() => {
       mockLogDirect.mockClear().mockResolvedValue(undefined);
+      mockAuditLog.mockClear().mockResolvedValue(undefined);
+      mockReturning.mockReset();
+      mockUpdateReturning.mockReset();
     });
 
     afterAll(async () => {
@@ -606,9 +723,9 @@ describe('auth plugin', () => {
       expect(params.actorId).toBeUndefined();
     });
 
-    it('audits user not provisioned as AUTH_USER_NOT_PROVISIONED with zitadelUserId', async () => {
+    it('audits JIT provisioning as USER_JIT_PROVISIONED', async () => {
       mockVerifyToken.mockResolvedValueOnce({
-        payload: { sub: 'zitadel-unknown-user' },
+        payload: { sub: 'zitadel-unknown-user', email: 'jit@example.com' },
         header: { alg: 'RS256' },
       });
 
@@ -618,6 +735,25 @@ describe('auth plugin', () => {
         undefined,
       );
 
+      mockReturning.mockResolvedValueOnce([
+        {
+          id: 'jit-audit-uuid',
+          email: 'jit@example.com',
+          zitadelUserId: 'zitadel-unknown-user',
+          displayName: null,
+          emailVerified: false,
+          emailVerifiedAt: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          isGuest: false,
+          deletedAt: null,
+          lastEventAt: null,
+          migratedToDomain: null,
+          migratedToDid: null,
+          migratedAt: null,
+        },
+      ]);
+
       await app.inject({
         method: 'GET',
         url: '/protected',
@@ -625,15 +761,19 @@ describe('auth plugin', () => {
       });
       await flushPromises();
 
-      expect(mockLogDirect).toHaveBeenCalledOnce();
-      const params = mockLogDirect.mock.calls[0][0];
-      expect(params.action).toBe('AUTH_USER_NOT_PROVISIONED');
-      expect(params.resource).toBe('auth');
-      expect(params.newValue).toEqual({
-        reason: 'not_provisioned',
-        zitadelUserId: 'zitadel-unknown-user',
-      });
-      expect(params.actorId).toBeUndefined();
+      expect(mockAuditLog).toHaveBeenCalledOnce();
+      expect(mockAuditLog).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'USER_JIT_PROVISIONED',
+          resource: 'user',
+          resourceId: 'jit-audit-uuid',
+          newValue: expect.objectContaining({
+            zitadelUserId: 'zitadel-unknown-user',
+            source: 'jit',
+          }),
+        }),
+      );
     });
 
     it('audits token missing sub claim as AUTH_TOKEN_INVALID', async () => {
@@ -756,6 +896,9 @@ describe('auth plugin', () => {
       mockVerifyKey.mockReset();
       mockTouchLastUsed.mockReset().mockResolvedValue(undefined);
       mockLogDirect.mockClear().mockResolvedValue(undefined);
+      mockAuditLog.mockClear().mockResolvedValue(undefined);
+      mockReturning.mockReset();
+      mockUpdateReturning.mockReset();
     });
 
     afterAll(async () => {

--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -36,8 +36,15 @@ vi.mock('@colophony/db', () => ({
     update: (...args: Parameters<typeof mockUpdate>) => mockUpdate(...args),
   },
   eq: vi.fn((_col: unknown, val: unknown) => val),
+  and: vi.fn((...conditions: unknown[]) => conditions),
+  isNull: vi.fn((col: unknown) => col),
   sql: (...a: unknown[]) => a,
-  users: { zitadelUserId: 'zitadel_user_id', email: 'email' },
+  users: {
+    zitadelUserId: 'zitadel_user_id',
+    email: 'email',
+    isGuest: 'is_guest',
+    deletedAt: 'deleted_at',
+  },
   pool: {
     query: vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
   },

--- a/apps/api/src/hooks/auth.ts
+++ b/apps/api/src/hooks/auth.ts
@@ -1,7 +1,8 @@
 import fp from 'fastify-plugin';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { createJwksVerifier } from '@colophony/auth-client';
-import { db, eq, users } from '@colophony/db';
+import { db, eq, sql, users, type DrizzleDb } from '@colophony/db';
+import type { JWTPayload } from 'jose';
 import type {
   AuthContext,
   AuthAuditParams,
@@ -327,8 +328,10 @@ export default fp(
 
         // Validate token
         let sub: string;
+        let payload: JWTPayload;
         try {
-          const { payload } = await verifyToken(token);
+          const result = await verifyToken(token);
+          payload = result.payload;
           if (!payload.sub) {
             void logAuthFailure(request, AuditActions.AUTH_TOKEN_INVALID, {
               reason: 'missing_sub_claim',
@@ -358,20 +361,93 @@ export default fp(
         }
 
         // Resolve local user by Zitadel user ID
-        const user = await db.query.users.findFirst({
+        let user = await db.query.users.findFirst({
           where: eq(users.zitadelUserId, sub),
         });
 
         if (!user) {
-          void logAuthFailure(request, AuditActions.AUTH_USER_NOT_PROVISIONED, {
-            reason: 'not_provisioned',
-            zitadelUserId: sub,
-          });
-          return reply.status(403).send({
-            error: 'user_not_provisioned',
-            message:
-              'User not found. Account may not have been synced yet. Please try again shortly.',
-          });
+          // JIT provisioning: create user from OIDC token claims
+          const jitEmail =
+            (payload.email as string | undefined) ?? `${sub}@placeholder.local`;
+          const jitDisplayName =
+            (payload.name as string | undefined) ?? undefined;
+          const jitEmailVerified =
+            (payload.email_verified as boolean | undefined) ?? false;
+
+          try {
+            const [jitUser] = await db.transaction(async (tx) => {
+              const [created] = await tx
+                .insert(users)
+                .values({
+                  email: jitEmail,
+                  zitadelUserId: sub,
+                  ...(jitDisplayName ? { displayName: jitDisplayName } : {}),
+                  emailVerified: jitEmailVerified,
+                  emailVerifiedAt: jitEmailVerified ? new Date() : undefined,
+                })
+                .onConflictDoUpdate({
+                  target: users.zitadelUserId,
+                  targetWhere: sql`${users.zitadelUserId} IS NOT NULL`,
+                  set: { updatedAt: new Date() },
+                })
+                .returning();
+
+              await auditService.log(tx as unknown as DrizzleDb, {
+                action: AuditActions.USER_JIT_PROVISIONED,
+                resource: AuditResources.USER,
+                resourceId: created.id,
+                newValue: {
+                  zitadelUserId: sub,
+                  email: created.email,
+                  source: 'jit',
+                },
+                ipAddress: request.ip,
+                userAgent: request.headers['user-agent'],
+              });
+
+              return [created];
+            });
+
+            request.log.info(
+              { zitadelUserId: sub, email: jitUser.email },
+              'JIT provisioned user',
+            );
+            user = jitUser;
+          } catch (err) {
+            // Email uniqueness conflict — a guest user with this email exists.
+            // Link the Zitadel identity to the existing guest record.
+            if ((err as { code?: string }).code === '23505') {
+              const [linked] = await db
+                .update(users)
+                .set({
+                  zitadelUserId: sub,
+                  isGuest: false,
+                  updatedAt: new Date(),
+                })
+                .where(eq(users.email, jitEmail))
+                .returning();
+
+              if (linked) {
+                request.log.info(
+                  { zitadelUserId: sub, email: linked.email },
+                  'JIT linked to existing guest user',
+                );
+                user = linked;
+              } else {
+                void logAuthFailure(
+                  request,
+                  AuditActions.AUTH_USER_NOT_PROVISIONED,
+                  { reason: 'jit_link_failed', zitadelUserId: sub },
+                );
+                return reply.status(403).send({
+                  error: 'user_not_provisioned',
+                  message: 'User provisioning failed. Please try again.',
+                });
+              }
+            } else {
+              throw err;
+            }
+          }
         }
 
         if (user.deletedAt) {

--- a/apps/api/src/hooks/auth.ts
+++ b/apps/api/src/hooks/auth.ts
@@ -1,7 +1,7 @@
 import fp from 'fastify-plugin';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { createJwksVerifier } from '@colophony/auth-client';
-import { db, eq, sql, users, type DrizzleDb } from '@colophony/db';
+import { db, eq, and, isNull, sql, users, type DrizzleDb } from '@colophony/db';
 import type { JWTPayload } from 'jose';
 import type {
   AuthContext,
@@ -367,8 +367,9 @@ export default fp(
 
         if (!user) {
           // JIT provisioning: create user from OIDC token claims
-          const jitEmail =
+          const rawEmail =
             (payload.email as string | undefined) ?? `${sub}@placeholder.local`;
+          const jitEmail = rawEmail.toLowerCase().trim();
           const jitDisplayName =
             (payload.name as string | undefined) ?? undefined;
           const jitEmailVerified =
@@ -424,7 +425,13 @@ export default fp(
                   isGuest: false,
                   updatedAt: new Date(),
                 })
-                .where(eq(users.email, jitEmail))
+                .where(
+                  and(
+                    eq(users.email, jitEmail),
+                    eq(users.isGuest, true),
+                    isNull(users.deletedAt),
+                  ),
+                )
                 .returning();
 
               if (linked) {

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,24 @@ Newest entries first.
 
 ---
 
+## 2026-03-24 — JIT User Provisioning for Staging Login Fix
+
+### Done
+
+- **JIT user provisioning in auth hook** — when a valid OIDC token has no matching local user (webhook missed creation), creates a minimal user record from JWT claims (email, name, email_verified) instead of returning 403
+- **Guest user email conflict handling** — catches Postgres `23505` on email unique constraint, promotes existing guest user by linking Zitadel identity (`isGuest: false`, sets `zitadelUserId`)
+- **Transactional audit logging** — JIT insert + audit wrapped in `db.transaction()` for atomicity; new `USER_JIT_PROVISIONED` audit action distinct from webhook-created `USER_CREATED`
+- **3 new/updated auth tests** — JIT provisioning, guest user linking, audit assertion; extended db mock with transaction/insert/update chains
+- Codex plan review caught 4 important issues (fire-and-forget audit, email uniqueness with guests, wrong type name, test location) — all addressed in implementation
+
+### Decisions
+
+- JIT in auth hook (not separate service) — minimal change surface, all imports already available
+- Guest user promotion via email conflict catch rather than separate lookup — reuses Postgres constraint enforcement
+- `tx as unknown as DrizzleDb` cast for audit log — pre-existing type mismatch between schema-aware `PgTransaction` and untyped `DrizzleDb`
+
+---
+
 ## 2026-03-24 — CLI Tooling Scripts & Monitoring Fixes
 
 ### Done

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 export const AuditActions = {
   // User lifecycle (synced from Zitadel webhooks)
   USER_CREATED: "USER_CREATED",
+  USER_JIT_PROVISIONED: "USER_JIT_PROVISIONED",
   USER_UPDATED: "USER_UPDATED",
   USER_DEACTIVATED: "USER_DEACTIVATED",
   USER_REACTIVATED: "USER_REACTIVATED",
@@ -314,6 +315,7 @@ export interface UserAuditParams extends BaseAuditParams {
   resource: typeof AuditResources.USER;
   action:
     | typeof AuditActions.USER_CREATED
+    | typeof AuditActions.USER_JIT_PROVISIONED
     | typeof AuditActions.USER_UPDATED
     | typeof AuditActions.USER_DEACTIVATED
     | typeof AuditActions.USER_REACTIVATED


### PR DESCRIPTION
## Summary

- When a user signs in with a valid OIDC token but has no local DB record (webhook missed their creation), creates a minimal user from JWT claims instead of returning 403
- Handles guest user email conflicts by promoting the guest record (restricted to `isGuest=true, deletedAt=null`)
- Normalizes JWT email to lowercase before insert/linking to match existing convention
- Audit logged as `USER_JIT_PROVISIONED`, distinct from webhook-created users

## Test plan

- [x] 88 auth hook tests pass (3 new: JIT provision, guest link, audit)
- [x] 1514 total API tests pass
- [x] Zero type errors
- [ ] Deploy to staging, sign in as `david@mahaffey.me` — should reach `/organizations/new`
- [ ] Verify webhook backfill updates JIT-created record with full profile data

## Code Review

- plan review: 4 findings, all addressed in implementation
- branch review: 2 findings (P1 guest-only linking, P2 email normalization), both addressed