### PR TITLE
fix(deploy): remove duplicate /trpc from NEXT_PUBLIC_API_URL

### DIFF
--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -130,7 +130,7 @@ services:
       context: .
       dockerfile: apps/web/Dockerfile
       args:
-        NEXT_PUBLIC_API_URL: https://${DOMAIN}/trpc
+        NEXT_PUBLIC_API_URL: https://${DOMAIN}
         NEXT_PUBLIC_TUS_URL: https://${DOMAIN}/upload/files/
         NEXT_PUBLIC_ZITADEL_AUTHORITY: ${NEXT_PUBLIC_ZITADEL_AUTHORITY:-}
         NEXT_PUBLIC_ZITADEL_CLIENT_ID: ${NEXT_PUBLIC_ZITADEL_CLIENT_ID:-}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -120,7 +120,7 @@ services:
       context: .
       dockerfile: apps/web/Dockerfile
       args:
-        NEXT_PUBLIC_API_URL: https://${DOMAIN:-localhost}/trpc
+        NEXT_PUBLIC_API_URL: https://${DOMAIN:-localhost}
         NEXT_PUBLIC_TUS_URL: https://${DOMAIN:-localhost}/upload/files/
         NEXT_PUBLIC_ZITADEL_AUTHORITY: ${NEXT_PUBLIC_ZITADEL_AUTHORITY:-}
         NEXT_PUBLIC_ZITADEL_CLIENT_ID: ${NEXT_PUBLIC_ZITADEL_CLIENT_ID:-}


### PR DESCRIPTION
## Summary

- Remove `/trpc` suffix from `NEXT_PUBLIC_API_URL` in both `docker-compose.coolify.yml` and `docker-compose.prod.yml`
- The tRPC client (`apps/web/src/lib/trpc.ts:75`) already appends `/trpc` to the base URL, so the build arg was producing `/trpc/trpc/users.me` (404) on staging

## Test plan

- [ ] Merge, redeploy staging, verify `/trpc/users.me` returns 401/200 (not 404)
- [ ] Sign in as `david@mahaffey.me` — JIT provision should succeed