### PR TITLE
feat(monitoring): remote Grafana access + uptime health checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,6 +148,20 @@ jobs:
           echo "Staging health check failed"
           exit 1
 
+      - name: Verify Grafana accessible
+        run: |
+          for i in $(seq 1 5); do
+            HTTP_CODE=$(curl -so /dev/null -w "%{http_code}" --max-time 10 \
+              "https://${{ vars.STAGING_DOMAIN }}/grafana/api/health" 2>/dev/null || echo "000")
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "Grafana is accessible"
+              exit 0
+            fi
+            echo "Attempt $i/5 — Grafana HTTP $HTTP_CODE, waiting..."
+            sleep 10
+          done
+          echo "::warning::Grafana not accessible after deploy (non-blocking)"
+
       - name: Run smoke tests
         run: bash scripts/smoke-test.sh "https://${{ vars.STAGING_DOMAIN }}"
 

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,111 @@
+name: Uptime Check
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+env:
+  STAGING_URL: https://staging.colophony.pub
+  ISSUE_TITLE: 'Staging Down: Health Check Failure'
+  ISSUE_LABEL: 'ops:uptime'
+
+jobs:
+  check:
+    name: Health Check
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check health endpoint
+        id: health
+        run: |
+          HTTP_CODE=$(curl -so /dev/null -w "%{http_code}" \
+            --max-time 15 --retry 1 --retry-delay 5 \
+            "${{ env.STAGING_URL }}/health" 2>/dev/null || echo "000")
+          echo "status=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+
+      - name: Check webhook health endpoint
+        id: webhook
+        run: |
+          HTTP_CODE=$(curl -so /dev/null -w "%{http_code}" \
+            --max-time 15 --retry 1 --retry-delay 5 \
+            "${{ env.STAGING_URL }}/webhooks/health" 2>/dev/null || echo "000")
+          echo "status=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+
+      - name: Check Grafana
+        id: grafana
+        run: |
+          HTTP_CODE=$(curl -so /dev/null -w "%{http_code}" \
+            --max-time 15 --retry 1 --retry-delay 5 \
+            "${{ env.STAGING_URL }}/grafana/api/health" 2>/dev/null || echo "000")
+          echo "status=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate results
+        id: result
+        run: |
+          HEALTH="${{ steps.health.outputs.status }}"
+          WEBHOOK="${{ steps.webhook.outputs.status }}"
+          GRAFANA="${{ steps.grafana.outputs.status }}"
+
+          FAILURES=""
+          [ "$HEALTH" != "200" ] && FAILURES="${FAILURES}- /health: HTTP ${HEALTH}\n"
+          [ "$WEBHOOK" != "200" ] && FAILURES="${FAILURES}- /webhooks/health: HTTP ${WEBHOOK}\n"
+          [ "$GRAFANA" != "200" ] && FAILURES="${FAILURES}- /grafana/api/health: HTTP ${GRAFANA}\n"
+
+          if [ -n "$FAILURES" ]; then
+            echo "failed=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "details<<DELIM"
+              echo -e "$FAILURES"
+              echo "DELIM"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "failed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report failure
+        if: steps.result.outputs.failed == 'true'
+        run: |
+          ISSUE_NUM=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "${{ env.ISSUE_LABEL }}" \
+            --state all \
+            --json number \
+            --jq '.[0].number // empty' 2>/dev/null || true)
+
+          BODY="**$(date -u '+%Y-%m-%d %H:%M UTC')** — Health check failed:
+
+          ${{ steps.result.outputs.details }}
+          [Workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
+          if [ -z "$ISSUE_NUM" ]; then
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "${{ env.ISSUE_TITLE }}" \
+              --label "${{ env.ISSUE_LABEL }}" \
+              --body "$BODY"
+          else
+            gh issue reopen "$ISSUE_NUM" --repo "${{ github.repository }}" 2>/dev/null || true
+            gh issue comment "$ISSUE_NUM" --repo "${{ github.repository }}" --body "$BODY"
+          fi
+
+      - name: Report recovery
+        if: steps.result.outputs.failed == 'false'
+        run: |
+          ISSUE_NUM=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "${{ env.ISSUE_LABEL }}" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty' 2>/dev/null || true)
+
+          if [ -n "$ISSUE_NUM" ]; then
+            gh issue comment "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --body "**$(date -u '+%Y-%m-%d %H:%M UTC')** — Recovered. All endpoints healthy."
+            gh issue close "$ISSUE_NUM" --repo "${{ github.repository }}"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **CLI: Sentry issues**   | `scripts/sentry-issues.sh` (list Sentry issues via API)                          |
 | **CLI: Zitadel admin**   | `scripts/zitadel-admin.sh` (users, orgs, sessions, health)                       |
 | **CLI: Coolify deploy**  | `scripts/coolify-deploy.sh` (trigger deploy + health check + smoke test)         |
+| **Uptime workflow**      | `.github/workflows/uptime.yml` (cron health checks, issue-based alerting)        |
 | **Writer workspace**     | `packages/db/src/schema/writer-workspace.ts`                                     |
 | **CSR types**            | `packages/types/src/csr.ts`                                                      |
 | **CSR service**          | `apps/api/src/services/csr.service.ts` (export/import for data portability)      |

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -389,6 +389,8 @@ services:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
       GF_USERS_ALLOW_SIGN_UP: 'false'
+      GF_SERVER_ROOT_URL: https://${DOMAIN}/grafana
+      GF_SERVER_SERVE_FROM_SUB_PATH: 'true'
     depends_on:
       - prometheus
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -410,6 +410,8 @@ services:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
       GF_USERS_ALLOW_SIGN_UP: 'false'
+      GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-http://localhost:3001/grafana}
+      GF_SERVER_SERVE_FROM_SUB_PATH: 'true'
     volumes:
       - ./docker/grafana/provisioning:/etc/grafana/provisioning:ro
       - ./docker/grafana/dashboards:/var/lib/grafana/dashboards:ro

--- a/docs/coolify-deployment.md
+++ b/docs/coolify-deployment.md
@@ -189,6 +189,51 @@ BACKUP_S3_ENDPOINT=https://...  # for non-AWS providers
 
 See [docs/deployment.md — Backup & Restore](deployment.md#backup--restore-wal-g) for full documentation.
 
+## 10. Monitoring Access
+
+Grafana is accessible at `https://<your-domain>/grafana` (proxied through nginx).
+
+**Credentials:** `GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD` from Coolify environment variables. Change the admin password after first login.
+
+**Pre-provisioned dashboards:**
+
+- **API Metrics** — HTTP request rates, latency percentiles, error rates, BullMQ queue depth, DB pool stats
+- **Logs Exploration** — Loki log search across all containers (Pino JSON parsing for API logs)
+
+**Data sources** (auto-provisioned):
+
+- Prometheus (`http://prometheus:9090`)
+- Loki (`http://loki:3100`)
+
+Grafana's health endpoint (`/grafana/api/health`) is checked by the uptime workflow and post-deploy verification. It does not require authentication.
+
+## 11. AlertManager Slack Notifications
+
+Set `SLACK_WEBHOOK_URL` in Coolify environment variables to enable alert delivery to Slack.
+
+**Setup:**
+
+1. Create an Incoming Webhook in your Slack workspace (Apps → Incoming Webhooks)
+2. Set `SLACK_WEBHOOK_URL` to the webhook URL (format: `https://hooks.slack.com/services/T.../B.../xxx`)
+3. Alerts route to the channel configured in `docker/alertmanager/alertmanager.yml`
+
+**If `SLACK_WEBHOOK_URL` is not set:** AlertManager starts with a placeholder URL and alerts silently fail to deliver.
+
+**To verify configuration:**
+
+```bash
+ssh <staging-host> docker exec colophony-alertmanager wget -qO- http://localhost:9093/api/v2/status
+```
+
+**Active alert rules** (defined in `docker/prometheus/alert-rules.yml`):
+
+- HighErrorRate (5xx >5% for 5m) — critical
+- QueueDepthCritical (>100 jobs for 10m) — warning
+- DBPoolExhaustion (waiting clients >0 for 5m) — warning
+- HealthEndpointDown (unreachable for 2m) — critical
+- HighRequestLatency (p99 >5s for 5m) — warning
+- BullMQJobFailureSpike (>10% failure rate for 5m) — warning
+
 ## Troubleshooting
 
 ### Build fails in Coolify

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -159,6 +159,21 @@ http {
             proxy_buffering off;
         }
 
+        # Grafana dashboards (sub-path hosting, own auth)
+        location /grafana/ {
+            set $upstream_grafana http://grafana:3000;
+            proxy_pass $upstream_grafana$request_uri;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # WebSocket support (Grafana Live)
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_http_version 1.1;
+        }
+
         # Next.js frontend (default)
         location / {
             set $upstream_web http://web:3000;


### PR DESCRIPTION
## Summary

- Expose Grafana dashboards at `/grafana` via nginx reverse proxy with sub-path hosting and WebSocket support
- Add GitHub Actions cron workflow (`uptime.yml`) that checks `/health`, `/webhooks/health`, and `/grafana/api/health` every 5 minutes — creates/reopens a GitHub issue on failure, closes on recovery
- Add non-blocking Grafana verification step to the staging deploy workflow
- Document monitoring access and AlertManager Slack notification setup

## Test plan

- [ ] Verify nginx config syntax passes (`nginx -t` — validated locally via Docker)
- [ ] Deploy to staging and navigate to `https://staging.colophony.pub/grafana` — should show Grafana login
- [ ] Verify `curl https://staging.colophony.pub/grafana/api/health` returns 200
- [ ] Manually trigger uptime workflow (`gh workflow run uptime.yml`) and verify it completes without creating an issue
- [ ] Verify deploy workflow shows "Grafana is accessible" in staging job logs