### PR TITLE
fix(nginx): redirect bare /grafana + session docs

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -539,6 +539,7 @@
 ### Monitoring
 
 - [~] GitHub GraphQL rate limit passive drain (~60 pts/hr) — diagnosed 2026-02-19, likely GitHub-internal (Dependabot, security scanning). At ~1.2% budget/hr, not actionable unless large exhaustion recurs. If so, convert skills from `gh pr list/create` (GraphQL) to `gh api` (REST) — (DEVLOG 2026-02-19)
+- [ ] [P2] Enhanced post-deploy smoke tests — verify `NEXT_PUBLIC_API_URL` in built frontend bundle (no double `/trpc`), Grafana `/grafana/api/health`, OIDC discovery endpoint reachable, webhook provider freshness from `/webhooks/health`. Existing `scripts/smoke-test.sh` already checks `/health`, `/ready`, security headers, TLS, tus, tRPC 401, frontend HTML, CORS — extend it with these 4 checks. Triggered by duplicate `/trpc` bug (PR #328) that passed all tests because auth E2E tests don't make tRPC calls — (2026-03-24)
 
 ---
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,26 @@ Newest entries first.
 
 ---
 
+## 2026-03-24 — Remote Monitoring Visibility + Staging Verification
+
+### Done
+
+- **Grafana exposed at `/grafana`** — nginx reverse proxy location block with WebSocket support, Grafana sub-path hosting via `GF_SERVER_ROOT_URL` + `GF_SERVER_SERVE_FROM_SUB_PATH` (coolify + prod compose)
+- **Uptime monitoring workflow** — `.github/workflows/uptime.yml` cron every 5 min checking `/health`, `/webhooks/health`, `/grafana/api/health`; issue-based alerting (create on failure, close on recovery)
+- **Deploy workflow enhancement** — non-blocking Grafana health check after staging deploy, before smoke tests
+- **Monitoring documentation** — `docs/coolify-deployment.md` sections for Grafana access and AlertManager Slack configuration
+- **Backlog item: enhanced smoke tests** — triggered by analysis of why duplicate `/trpc` bug (PR #328) wasn't caught; auth E2E tests don't exercise tRPC calls, so env var misconfiguration was invisible
+- **Staging verification** — API healthy, DB connected, Grafana 200 OK, JIT user provisioned with ADMIN on both seed orgs
+- Codex plan review caught 2 issues (missing `GH_TOKEN` for `gh` CLI, wrong HTTPS default in prod compose) — both addressed before implementation
+
+### Decisions
+
+- Grafana via nginx `/grafana` path (not subdomain) — consistent with existing routing, no DNS changes needed
+- Uptime via GitHub Actions cron + issue alerting — no external service dependency, recovery auto-closes issues
+- Prod compose `GF_SERVER_ROOT_URL` uses env var override (`GRAFANA_ROOT_URL`) — avoids hardcoding HTTPS since prod nginx serves plain HTTP
+
+---
+
 ## 2026-03-24 — JIT User Provisioning for Staging Login Fix
 
 ### Done

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -159,6 +159,11 @@ http {
             proxy_buffering off;
         }
 
+        # Bare /grafana → /grafana/ (Grafana sub-path requires trailing slash)
+        location = /grafana {
+            return 301 $scheme://$host/grafana/;
+        }
+
         # Grafana dashboards (sub-path hosting, own auth)
         location /grafana/ {
             set $upstream_grafana http://grafana:3000;


### PR DESCRIPTION
## Summary

- Redirect bare `/grafana` → `/grafana/` so the documented URL works without trailing slash (code review finding from PR #329)
- Backlog: add enhanced post-deploy smoke tests item (P2, triggered by `/trpc` bug analysis)
- Devlog entry for 2026-03-24 remote monitoring session

## Test plan

- [ ] `curl -I https://staging.colophony.pub/grafana` returns 301 → `/grafana/`
- [ ] `https://staging.colophony.pub/grafana` in browser reaches Grafana login