### PR TITLE
feat(scripts): enhanced post-deploy smoke tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,22 +148,11 @@ jobs:
           echo "Staging health check failed"
           exit 1
 
-      - name: Verify Grafana accessible
-        run: |
-          for i in $(seq 1 5); do
-            HTTP_CODE=$(curl -so /dev/null -w "%{http_code}" --max-time 10 \
-              "https://${{ vars.STAGING_DOMAIN }}/grafana/api/health" 2>/dev/null || echo "000")
-            if [ "$HTTP_CODE" = "200" ]; then
-              echo "Grafana is accessible"
-              exit 0
-            fi
-            echo "Attempt $i/5 — Grafana HTTP $HTTP_CODE, waiting..."
-            sleep 10
-          done
-          echo "::warning::Grafana not accessible after deploy (non-blocking)"
-
       - name: Run smoke tests
-        run: bash scripts/smoke-test.sh "https://${{ vars.STAGING_DOMAIN }}"
+        run: >-
+          bash scripts/smoke-test.sh
+          "https://${{ vars.STAGING_DOMAIN }}"
+          --oidc-issuer "${{ vars.ZITADEL_AUTHORITY }}"
 
   # ──────────────────────────────────────────────────
   # Deploy to production (manual dispatch only)
@@ -213,4 +202,7 @@ jobs:
           exit 1
 
       - name: Run smoke tests
-        run: bash scripts/smoke-test.sh "https://${{ vars.PRODUCTION_DOMAIN }}"
+        run: >-
+          bash scripts/smoke-test.sh
+          "https://${{ vars.PRODUCTION_DOMAIN }}"
+          --oidc-issuer "${{ vars.ZITADEL_AUTHORITY }}"

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -539,7 +539,7 @@
 ### Monitoring
 
 - [~] GitHub GraphQL rate limit passive drain (~60 pts/hr) — diagnosed 2026-02-19, likely GitHub-internal (Dependabot, security scanning). At ~1.2% budget/hr, not actionable unless large exhaustion recurs. If so, convert skills from `gh pr list/create` (GraphQL) to `gh api` (REST) — (DEVLOG 2026-02-19)
-- [ ] [P2] Enhanced post-deploy smoke tests — verify `NEXT_PUBLIC_API_URL` in built frontend bundle (no double `/trpc`), Grafana `/grafana/api/health`, OIDC discovery endpoint reachable, webhook provider freshness from `/webhooks/health`. Existing `scripts/smoke-test.sh` already checks `/health`, `/ready`, security headers, TLS, tus, tRPC 401, frontend HTML, CORS — extend it with these 4 checks. Triggered by duplicate `/trpc` bug (PR #328) that passed all tests because auth E2E tests don't make tRPC calls — (2026-03-24)
+- [x] [P2] Enhanced post-deploy smoke tests — verify `NEXT_PUBLIC_API_URL` in built frontend bundle (no double `/trpc`), Grafana `/grafana/api/health`, OIDC discovery endpoint reachable, webhook provider freshness from `/webhooks/health`. Existing `scripts/smoke-test.sh` already checks `/health`, `/ready`, security headers, TLS, tus, tRPC 401, frontend HTML, CORS — extend it with these 4 checks. Triggered by duplicate `/trpc` bug (PR #328) that passed all tests because auth E2E tests don't make tRPC calls — (2026-03-24; done 2026-03-24)
 
 ---
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,25 @@ Newest entries first.
 
 ---
 
+## 2026-03-24 — Enhanced Post-Deploy Smoke Tests
+
+### Done
+
+- **4 new smoke test checks** in `scripts/smoke-test.sh`: bundle `/trpc/trpc` detection (fetches JS chunks), Grafana `/grafana/api/health` (warning), OIDC discovery via `--oidc-issuer`, webhook provider freshness (delegates to `webhook-health.sh --quiet`)
+- **Expanded arg parsing** — `--skip-grafana`, `--skip-webhooks`, `--oidc-issuer <url>` flags; replaced `for` loop with `while` for value-taking args
+- **deploy.yml updated** — removed redundant standalone Grafana check step, passes `--oidc-issuer` via `vars.ZITADEL_AUTHORITY` to both staging and production smoke invocations
+- **coolify-deploy.sh updated** — forwards `--oidc-issuer` to smoke-test.sh
+- Codex plan review ran; 1 Important finding (bundle check needed JS chunk scanning, not just HTML grep) and 2 suggestions (use `ZITADEL_AUTHORITY` naming, delegate to `webhook-health.sh`) — all addressed before implementation
+
+### Decisions
+
+- OIDC check via `--oidc-issuer` CLI param (not new API endpoint) — simpler, tests external reachability directly from wherever smoke test runs
+- Grafana = warning not failure — monitoring stack is optional in some deployments, matches deploy.yml precedent
+- Webhook freshness delegates to existing `webhook-health.sh --quiet` — avoids reimplementing JSON parsing without `jq`
+- Bundle check fetches up to 10 JS chunk URLs from HTML — Next.js inlines `NEXT_PUBLIC_*` as string literals in webpack chunks, not in HTML
+
+---
+
 ## 2026-03-24 — Remote Monitoring Visibility + Staging Verification
 
 ### Done

--- a/scripts/coolify-deploy.sh
+++ b/scripts/coolify-deploy.sh
@@ -23,6 +23,7 @@ NO_WAIT=false
 SKIP_CONFIRM=false
 HEALTH_URL=""
 SKIP_SMOKE=false
+OIDC_ISSUER=""
 
 # Polling config (matches deploy.yml)
 POLL_ATTEMPTS=10
@@ -43,6 +44,7 @@ usage() {
   echo "  --no-wait             Fire and forget (no health check)"
   echo "  --health-url <url>    URL to poll for health (e.g., https://staging.example.com)"
   echo "  --skip-smoke          Skip smoke test after deploy"
+  echo "  --oidc-issuer <url>   Zitadel issuer URL (passed to smoke-test.sh)"
   echo "  -h, --help            Show this help"
   exit 1
 }
@@ -96,6 +98,10 @@ while [ $# -gt 0 ]; do
     --skip-smoke)
       SKIP_SMOKE=true
       shift
+      ;;
+    --oidc-issuer)
+      OIDC_ISSUER="${2:?--oidc-issuer requires a value}"
+      shift 2
       ;;
     -h|--help)
       usage
@@ -178,7 +184,11 @@ for i in $(seq 1 "$POLL_ATTEMPTS"); do
       SMOKE_SCRIPT="${SCRIPT_DIR}/smoke-test.sh"
       if [ -f "$SMOKE_SCRIPT" ]; then
         echo -e "\n${BOLD}Running smoke tests...${NC}"
-        bash "$SMOKE_SCRIPT" "${HEALTH_URL%/}"
+        SMOKE_ARGS=("${HEALTH_URL%/}")
+        if [ -n "$OIDC_ISSUER" ]; then
+          SMOKE_ARGS+=(--oidc-issuer "$OIDC_ISSUER")
+        fi
+        bash "$SMOKE_SCRIPT" "${SMOKE_ARGS[@]}"
       else
         echo -e "${YELLOW}⚠ smoke-test.sh not found at ${SMOKE_SCRIPT}${NC}"
       fi

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Post-deployment smoke test for Colophony staging.
-# Usage: bash scripts/smoke-test.sh https://staging.example.com [--skip-tls]
+# Usage: bash scripts/smoke-test.sh <base-url> [OPTIONS]
+#   Options:
+#     --skip-tls            Skip TLS certificate check
+#     --skip-grafana        Skip Grafana health check
+#     --skip-webhooks       Skip webhook freshness check
+#     --oidc-issuer <url>   Zitadel issuer URL for OIDC discovery check
 set -euo pipefail
 
 # --- Colors ---
@@ -15,20 +20,30 @@ warn() { echo -e "${YELLOW}⚠ $1${NC}"; }
 
 FAILURES=0
 SKIP_TLS=false
+SKIP_GRAFANA=false
+SKIP_WEBHOOKS=false
+OIDC_ISSUER=""
 
 # --- Parse args ---
 if [ $# -lt 1 ]; then
-  echo "Usage: bash scripts/smoke-test.sh <base-url> [--skip-tls]"
-  echo "  e.g. bash scripts/smoke-test.sh https://staging.example.com"
+  echo "Usage: bash scripts/smoke-test.sh <base-url> [OPTIONS]"
+  echo "  Options:"
+  echo "    --skip-tls            Skip TLS certificate check"
+  echo "    --skip-grafana        Skip Grafana health check"
+  echo "    --skip-webhooks       Skip webhook freshness check"
+  echo "    --oidc-issuer <url>   Zitadel issuer URL for OIDC discovery check"
   exit 1
 fi
 
 BASE_URL="${1%/}"  # strip trailing slash
 shift
-for arg in "$@"; do
-  case "$arg" in
-    --skip-tls) SKIP_TLS=true ;;
-    *) echo "Unknown option: $arg"; exit 1 ;;
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skip-tls)      SKIP_TLS=true; shift ;;
+    --skip-grafana)  SKIP_GRAFANA=true; shift ;;
+    --skip-webhooks) SKIP_WEBHOOKS=true; shift ;;
+    --oidc-issuer)   OIDC_ISSUER="${2:?--oidc-issuer requires a value}"; shift 2 ;;
+    *)               echo "Unknown option: $1"; exit 1 ;;
   esac
 done
 
@@ -112,6 +127,64 @@ if echo "$CORS_HEADERS" | grep -qi "Access-Control-Allow"; then
   pass "OPTIONS /trpc — CORS headers present"
 else
   fail "OPTIONS /trpc — CORS headers missing"
+fi
+
+# --- 9. NEXT_PUBLIC_API_URL — no doubled /trpc in JS bundle ---
+FRONT_HTML=$(curl -sf --max-time 10 "${BASE_URL}/" 2>/dev/null || true)
+if [ -z "$FRONT_HTML" ]; then
+  fail "Bundle check — could not fetch frontend HTML"
+else
+  CHUNK_URLS=$(echo "$FRONT_HTML" | grep -oE '/_next/static/[^"'"'"']+\.js' | sort -u | head -10)
+  FOUND_DOUBLE=false
+  for chunk in $CHUNK_URLS; do
+    CHUNK_BODY=$(curl -sf --max-time 5 "${BASE_URL}${chunk}" 2>/dev/null || true)
+    if echo "$CHUNK_BODY" | grep -q '/trpc/trpc'; then
+      FOUND_DOUBLE=true
+      break
+    fi
+  done
+  if [ "$FOUND_DOUBLE" = true ]; then
+    fail "Bundle check — found /trpc/trpc in JS bundle (NEXT_PUBLIC_API_URL likely ends in /trpc)"
+  else
+    pass "Bundle check — no /trpc/trpc in JS bundles"
+  fi
+fi
+
+# --- 10. Grafana health ---
+if [ "$SKIP_GRAFANA" = true ]; then
+  warn "Grafana check skipped (--skip-grafana)"
+else
+  GRAFANA_STATUS=$(curl -so /dev/null --max-time 10 -w "%{http_code}" "${BASE_URL}/grafana/api/health" 2>/dev/null || true)
+  if [ "$GRAFANA_STATUS" = "200" ]; then
+    pass "GET /grafana/api/health — 200"
+  else
+    warn "GET /grafana/api/health — got ${GRAFANA_STATUS:-no response} (monitoring may not be deployed)"
+  fi
+fi
+
+# --- 11. OIDC discovery ---
+if [ -z "$OIDC_ISSUER" ]; then
+  warn "OIDC discovery check skipped (no --oidc-issuer provided)"
+else
+  OIDC_URL="${OIDC_ISSUER%/}/.well-known/openid-configuration"
+  OIDC_STATUS=$(curl -so /dev/null --max-time 10 -w "%{http_code}" "$OIDC_URL" 2>/dev/null || true)
+  if [ "$OIDC_STATUS" = "200" ]; then
+    pass "OIDC discovery — ${OIDC_ISSUER} reachable"
+  else
+    fail "OIDC discovery — ${OIDC_URL} returned ${OIDC_STATUS:-no response}"
+  fi
+fi
+
+# --- 12. Webhook provider freshness ---
+if [ "$SKIP_WEBHOOKS" = true ]; then
+  warn "Webhook freshness check skipped (--skip-webhooks)"
+else
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if bash "$SCRIPT_DIR/webhook-health.sh" --url "$BASE_URL" --quiet 2>/dev/null; then
+    pass "GET /webhooks/health — all providers healthy"
+  else
+    warn "GET /webhooks/health — one or more providers stale/unknown"
+  fi
 fi
 
 # --- Results ---

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -130,24 +130,31 @@ else
 fi
 
 # --- 9. NEXT_PUBLIC_API_URL — no doubled /trpc in JS bundle ---
-FRONT_HTML=$(curl -sf --max-time 10 "${BASE_URL}/" 2>/dev/null || true)
-if [ -z "$FRONT_HTML" ]; then
-  fail "Bundle check — could not fetch frontend HTML"
-else
-  CHUNK_URLS=$(echo "$FRONT_HTML" | grep -oE '/_next/static/[^"'"'"']+\.js' | sort -u | head -10)
-  FOUND_DOUBLE=false
+# Fetch multiple pages to cover route-specific bundles. The home page (/) doesn't
+# use tRPC, so we also fetch /dashboard which loads the tRPC client bundle.
+FOUND_DOUBLE=false
+FETCH_FAILED=true
+for page in "/" "/dashboard"; do
+  PAGE_HTML=$(curl -sf --max-time 10 "${BASE_URL}${page}" 2>/dev/null || true)
+  if [ -z "$PAGE_HTML" ]; then
+    continue
+  fi
+  FETCH_FAILED=false
+  CHUNK_URLS=$(echo "$PAGE_HTML" | grep -oE '/_next/static/[^"'"'"']+\.js' | sort -u | head -15)
   for chunk in $CHUNK_URLS; do
     CHUNK_BODY=$(curl -sf --max-time 5 "${BASE_URL}${chunk}" 2>/dev/null || true)
     if echo "$CHUNK_BODY" | grep -q '/trpc/trpc'; then
       FOUND_DOUBLE=true
-      break
+      break 2
     fi
   done
-  if [ "$FOUND_DOUBLE" = true ]; then
-    fail "Bundle check — found /trpc/trpc in JS bundle (NEXT_PUBLIC_API_URL likely ends in /trpc)"
-  else
-    pass "Bundle check — no /trpc/trpc in JS bundles"
-  fi
+done
+if [ "$FETCH_FAILED" = true ]; then
+  fail "Bundle check — could not fetch frontend HTML"
+elif [ "$FOUND_DOUBLE" = true ]; then
+  fail "Bundle check — found /trpc/trpc in JS bundle (NEXT_PUBLIC_API_URL likely ends in /trpc)"
+else
+  pass "Bundle check — no /trpc/trpc in JS bundles"
 fi
 
 # --- 10. Grafana health ---


### PR DESCRIPTION
## Summary

- Add 4 new checks to `scripts/smoke-test.sh`: bundle `/trpc/trpc` detection (JS chunk scanning), Grafana health (warning), OIDC discovery via `--oidc-issuer`, webhook provider freshness (delegates to `webhook-health.sh`)
- Expand arg parsing with `--skip-grafana`, `--skip-webhooks`, `--oidc-issuer <url>`
- Update `deploy.yml` to pass `--oidc-issuer` and remove redundant Grafana step
- Update `coolify-deploy.sh` to forward `--oidc-issuer`

Closes backlog P2 item triggered by PR #328 `/trpc` duplication bug that passed all tests.

**Note:** `vars.ZITADEL_AUTHORITY` must be added as a GitHub Actions variable in staging + production environments for the OIDC discovery check to run in CI.

## Test plan

- [ ] Run `bash scripts/smoke-test.sh https://staging.colophony.pub --oidc-issuer <zitadel-url>` — all 4 new checks pass/warn
- [ ] Run with `--skip-grafana --skip-webhooks` — skip warnings shown
- [ ] Run with `--oidc-issuer https://nonexistent.example.com` — OIDC check fails
- [ ] Run without `--oidc-issuer` — OIDC check shows skip warning
- [ ] Backward compat: `bash scripts/smoke-test.sh <url> --skip-tls` still works
- [ ] CI passes on this PR