### PR TITLE
fix(scripts): handle empty --oidc-issuer in smoke tests

### DIFF
--- a/scripts/coolify-deploy.sh
+++ b/scripts/coolify-deploy.sh
@@ -100,7 +100,7 @@ while [ $# -gt 0 ]; do
       shift
       ;;
     --oidc-issuer)
-      OIDC_ISSUER="${2:?--oidc-issuer requires a value}"
+      OIDC_ISSUER="${2:-}"
       shift 2
       ;;
     -h|--help)

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -42,7 +42,7 @@ while [ $# -gt 0 ]; do
     --skip-tls)      SKIP_TLS=true; shift ;;
     --skip-grafana)  SKIP_GRAFANA=true; shift ;;
     --skip-webhooks) SKIP_WEBHOOKS=true; shift ;;
-    --oidc-issuer)   OIDC_ISSUER="${2:?--oidc-issuer requires a value}"; shift 2 ;;
+    --oidc-issuer)   OIDC_ISSUER="${2:-}"; shift 2 ;;
     *)               echo "Unknown option: $1"; exit 1 ;;
   esac
 done


### PR DESCRIPTION
## Summary

- Fix deploy workflow failure: `--oidc-issuer ""` (empty `vars.ZITADEL_AUTHORITY`) caused `${2:?}` to abort the entire smoke test
- Use `${2:-}` so empty value is treated as "not provided" — OIDC check skips with a warning instead of crashing
- Same fix applied to `coolify-deploy.sh`
- Also created missing `ops:uptime` label that caused the uptime workflow issue creation to fail

## Test plan

- [ ] Deploy workflow smoke tests pass with empty `vars.ZITADEL_AUTHORITY`
- [ ] OIDC check shows skip warning (not crash) when value is empty