### PR TITLE
fix(scripts): add Origin header to tusd OPTIONS smoke test

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -92,7 +92,9 @@ else
 fi
 
 # --- 5. tusd tus headers ---
-TUS_HEADERS=$(curl -sI --max-time 10 -X OPTIONS "${BASE_URL}/upload" 2>/dev/null || true)
+TUS_HEADERS=$(curl -sI --max-time 10 -X OPTIONS \
+  -H "Origin: ${BASE_URL}" \
+  "${BASE_URL}/upload" 2>/dev/null || true)
 if echo "$TUS_HEADERS" | grep -qi "Tus-Resumable"; then
   pass "OPTIONS /upload — Tus-Resumable header present"
 else


### PR DESCRIPTION
## Summary

- tusd only returns `Tus-Resumable` header on CORS preflight requests (which require `Origin` header)
- The smoke test was sending bare `OPTIONS /upload` without `Origin`, so tusd responded without tus headers
- Add `Origin` header to match real browser behavior, consistent with the CORS check on `/trpc` (check 8)

## Test plan

- [ ] Deploy workflow smoke tests pass (tusd check no longer fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)