### PR TITLE
fix(deploy): auto-recover from stale Traefik proxy after Coolify redeploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,7 +157,7 @@ jobs:
           --oidc-issuer "${{ vars.ZITADEL_AUTHORITY }}"
 
       - name: Recover proxy and retry smoke tests
-        if: steps.smoke.outcome == 'failure'
+        if: steps.smoke.outcome == 'failure' && secrets.STAGING_SSH_KEY != ''
         env:
           SSH_KEY: ${{ secrets.STAGING_SSH_KEY }}
         run: |
@@ -175,6 +175,12 @@ jobs:
           bash scripts/smoke-test.sh \
             "https://${{ vars.STAGING_DOMAIN }}" \
             --oidc-issuer "${{ vars.ZITADEL_AUTHORITY }}"
+
+      - name: Fail if smoke tests failed without recovery
+        if: steps.smoke.outcome == 'failure' && secrets.STAGING_SSH_KEY == ''
+        run: |
+          echo "Smoke tests failed and no STAGING_SSH_KEY configured for proxy recovery"
+          exit 1
 
   # ──────────────────────────────────────────────────
   # Deploy to production (manual dispatch only)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,10 +149,32 @@ jobs:
           exit 1
 
       - name: Run smoke tests
+        id: smoke
+        continue-on-error: true
         run: >-
           bash scripts/smoke-test.sh
           "https://${{ vars.STAGING_DOMAIN }}"
           --oidc-issuer "${{ vars.ZITADEL_AUTHORITY }}"
+
+      - name: Recover proxy and retry smoke tests
+        if: steps.smoke.outcome == 'failure'
+        env:
+          SSH_KEY: ${{ secrets.STAGING_SSH_KEY }}
+        run: |
+          echo "Smoke tests failed — restarting Coolify proxy (stale container IPs)"
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
+            root@${{ vars.STAGING_DOMAIN }} \
+            "docker restart coolify-proxy"
+          rm -f ~/.ssh/deploy_key
+          echo "Waiting 10s for proxy to recover..."
+          sleep 10
+          echo "Retrying smoke tests..."
+          bash scripts/smoke-test.sh \
+            "https://${{ vars.STAGING_DOMAIN }}" \
+            --oidc-issuer "${{ vars.ZITADEL_AUTHORITY }}"
 
   # ──────────────────────────────────────────────────
   # Deploy to production (manual dispatch only)


### PR DESCRIPTION
## Summary

- When Coolify redeploys, Traefik's Docker provider can cache stale container IPs, causing all routing to hang
- Smoke tests now run with `continue-on-error`; if they fail, a recovery step SSHs into staging, restarts `coolify-proxy`, waits 10s, and retries the smoke tests
- If the retry also fails, it's a real failure (not stale proxy)
- Only applies to staging (Coolify). Production uses `docker compose` directly.

**Requires:** `secrets.STAGING_SSH_KEY` added to the staging GitHub environment (same key as `~/.ssh/colophony_hetzner`).

## Test plan

- [ ] Add `STAGING_SSH_KEY` secret to staging environment
- [ ] Trigger a deploy and verify smoke tests pass (either first try or after proxy recovery)
- [ ] Verify that a real smoke test failure (e.g., API down) still fails the workflow after retry