### PR TITLE
fix(scripts): exclude tRPC GitHub URL from bundle check false positive

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -143,7 +143,7 @@ for page in "/" "/dashboard"; do
   CHUNK_URLS=$(echo "$PAGE_HTML" | grep -oE '/_next/static/[^"'"'"']+\.js' | sort -u | head -15)
   for chunk in $CHUNK_URLS; do
     CHUNK_BODY=$(curl -sf --max-time 5 "${BASE_URL}${chunk}" 2>/dev/null || true)
-    if echo "$CHUNK_BODY" | grep -q '/trpc/trpc'; then
+    if echo "$CHUNK_BODY" | grep -v 'github.com/trpc/trpc' | grep -q '/trpc/trpc'; then
       FOUND_DOUBLE=true
       break 2
     fi


### PR DESCRIPTION
## Summary

- The `/trpc/trpc` bundle check was matching `github.com/trpc/trpc/issues/new` embedded in the tRPC library's error messages
- Filter out `github.com/trpc/trpc` before grepping to eliminate the false positive
- This was the sole failure in the last deploy run (all other checks passed after proxy recovery)

## Test plan

- [ ] Deploy smoke tests pass (bundle check no longer false-positive)