### PR TITLE
fix(coolify): use project-directory-relative build contexts

### DIFF
--- a/coolify/app.yml
+++ b/coolify/app.yml
@@ -6,7 +6,7 @@
 services:
   api:
     build:
-      context: ..
+      context: .
       dockerfile: apps/api/Dockerfile
       target: builder
     expose:
@@ -93,7 +93,7 @@ services:
 
   web:
     build:
-      context: ..
+      context: .
       dockerfile: apps/web/Dockerfile
       args:
         NEXT_PUBLIC_API_URL: https://${DOMAIN}

--- a/coolify/data.yml
+++ b/coolify/data.yml
@@ -6,7 +6,7 @@
 services:
   postgres:
     build:
-      context: ../docker/postgres
+      context: ./docker/postgres
       dockerfile: Dockerfile
     expose:
       - "5432"
@@ -55,7 +55,7 @@ services:
 
   pgbouncer:
     build:
-      context: ../docker/pgbouncer
+      context: ./docker/pgbouncer
       dockerfile: Dockerfile
     expose:
       - "6432"

--- a/coolify/gateway.yml
+++ b/coolify/gateway.yml
@@ -8,7 +8,7 @@
 services:
   nginx:
     build:
-      context: ../nginx
+      context: ./nginx
       dockerfile: Dockerfile
     restart: unless-stopped
     healthcheck:

--- a/coolify/monitoring.yml
+++ b/coolify/monitoring.yml
@@ -7,7 +7,7 @@
 services:
   prometheus:
     build:
-      context: ../docker/prometheus
+      context: ./docker/prometheus
       dockerfile: Dockerfile
     expose:
       - "9090"
@@ -23,7 +23,7 @@ services:
 
   alertmanager:
     build:
-      context: ../docker/alertmanager
+      context: ./docker/alertmanager
       dockerfile: Dockerfile
     expose:
       - "9093"
@@ -39,7 +39,7 @@ services:
 
   grafana:
     build:
-      context: ../docker/grafana
+      context: ./docker/grafana
       dockerfile: Dockerfile
     expose:
       - "3000"
@@ -63,7 +63,7 @@ services:
 
   loki:
     build:
-      context: ../docker/loki
+      context: ./docker/loki
       dockerfile: Dockerfile
     expose:
       - "3100"
@@ -79,7 +79,7 @@ services:
 
   promtail:
     build:
-      context: ../docker/promtail
+      context: ./docker/promtail
       dockerfile: Dockerfile
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
## Summary

- Fix build context paths in all 5 `coolify/*.yml` compose files
- Coolify sets `--project-directory` to the repo root clone, so build contexts must use `./docker/postgres` (not `../docker/postgres`)

Discovered during first Data resource deploy — Coolify clones to `/artifacts/<id>/` and runs compose from there, but `../` escapes the clone directory.

## Test plan

- [ ] Deploy Data resource on staging — postgres, pgbouncer, redis, minio all build and start