### PR TITLE
fix(coolify): add Traefik labels to gateway compose

### DIFF
--- a/coolify/gateway.yml
+++ b/coolify/gateway.yml
@@ -3,7 +3,8 @@
 # Deploy frequency: Rare (nginx.conf changes only)
 # This resource stays up during app deploys — Traefik always has a valid route.
 # nginx serves a maintenance page (502/503/504) when backends are restarting.
-# Configure Coolify UI "Domains" field on this resource for Traefik routing.
+# Traefik labels are defined here because Coolify doesn't inject them for Docker Compose resources.
+# To change the domain: update the labels below AND the Coolify UI "Domains" field.
 
 services:
   nginx:
@@ -19,6 +20,16 @@ services:
       start_period: 5s
     stop_signal: SIGQUIT
     stop_grace_period: 30s
+    labels:
+      - "traefik.enable=true"
+      # NOTE: Domain is hardcoded because Coolify doesn't substitute ${VAR} in labels.
+      - "traefik.http.routers.colophony-nginx-http.rule=Host(`staging.colophony.pub`)"
+      - "traefik.http.routers.colophony-nginx-http.entrypoints=http"
+      - "traefik.http.routers.colophony-nginx-https.rule=Host(`staging.colophony.pub`)"
+      - "traefik.http.routers.colophony-nginx-https.entrypoints=https"
+      - "traefik.http.routers.colophony-nginx-https.tls=true"
+      - "traefik.http.routers.colophony-nginx-https.tls.certresolver=letsencrypt"
+      - "traefik.http.services.colophony-nginx.loadbalancer.server.port=80"
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary

- Add explicit Traefik routing labels to `coolify/gateway.yml`
- Coolify doesn't inject Traefik labels on Docker Compose resources (only single-container resources)
- Domain hardcoded in labels because Coolify doesn't substitute `${VAR}` in labels

## Test plan

- [ ] Merge, redeploy Gateway resource, verify `https://staging.colophony.pub/health` returns 200