### PR TITLE
fix(deploy): make LAST_DEPLOYED_SHA update non-fatal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -263,6 +263,10 @@ jobs:
           --oidc-issuer "${{ vars.ZITADEL_AUTHORITY }}"
 
       - name: Update last deployed SHA
+        # Non-fatal: GITHUB_TOKEN lacks permission to write environment variables.
+        # Smart deploy detection falls back to deploying all groups when LAST_DEPLOYED_SHA is unset.
+        # TODO: Either use a PAT with variables:write scope, or remove this step if Coolify is dropped.
+        continue-on-error: true
         if: >-
           success() &&
           steps.groups.outputs.deploy_data == 'true' &&


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to the LAST_DEPLOYED_SHA step
- `GITHUB_TOKEN` can't write environment variables (403 regardless of `--env` flag or `actions:write` permission)
- Smart deploy detection already falls back to deploying all groups when the var is unset — no functional impact
- Proper fix requires a PAT with `variables:write` scope, or removal of this step entirely if Coolify is dropped (P2 backlog)