### PR TITLE
feat(gateway): add Caddy rate limiting as defense-in-depth

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -55,8 +55,15 @@ SMTP_FROM=noreply@example.com
 
 # === OPTIONAL: Rate Limiting ===
 
-RATE_LIMIT_DEFAULT_MAX=100
-RATE_LIMIT_AUTH_MAX=20
+# API rate limiting (Fastify + Redis)
+RATE_LIMIT_DEFAULT_MAX=60
+RATE_LIMIT_AUTH_MAX=200
+
+# Gateway rate limiting (Caddy — defense-in-depth, higher than API limits)
+# CADDY_RL_GENERAL_MAX=300
+# CADDY_RL_GENERAL_WINDOW=1m
+# CADDY_RL_UPLOAD_MAX=30
+# CADDY_RL_UPLOAD_WINDOW=1m
 
 # === OPTIONAL: Monitoring ===
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,11 @@ services:
       - "${HTTPS_PORT:-443}:443/udp"
     environment:
       DOMAIN: ${DOMAIN:-localhost}
+      # Gateway rate limiting (defense-in-depth — API has its own limits)
+      CADDY_RL_GENERAL_MAX: ${CADDY_RL_GENERAL_MAX:-300}
+      CADDY_RL_GENERAL_WINDOW: ${CADDY_RL_GENERAL_WINDOW:-1m}
+      CADDY_RL_UPLOAD_MAX: ${CADDY_RL_UPLOAD_MAX:-30}
+      CADDY_RL_UPLOAD_WINDOW: ${CADDY_RL_UPLOAD_WINDOW:-1m}
     volumes:
       - caddy_data:/data
       - caddy_config:/config

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -517,7 +517,7 @@
 - [x] Monitoring stack: Prometheus + Grafana (Sentry for errors) — done 2026-02-27 PR pending; Loki deferred to production
 - [x] [P1] Split Coolify deployment into individual services — split monolithic docker-compose.coolify.yml into 5 Coolify resources (data, app, gateway, uploads, monitoring) on shared `colophony-net` network. Smart deploy detection via LAST_DEPLOYED_SHA. Eliminates Traefik stale routing and proxy restart workaround — (2026-03-24, deploy debugging session; done 2026-03-24)
 - [x] [P2] Drop Coolify in favor of direct SSH + Docker Compose deploy — replaced nginx with Caddy (automatic HTTPS), unified staging/production on single `docker-compose.prod.yml` + SSH deploy, removed 5 Coolify compose files + Coolify quirks + LAST_DEPLOYED_SHA smart detection — (2026-03-24; done 2026-03-25)
-- [ ] [P3] Gateway-level rate limiting via Caddy `rate_limit` module — API already has sliding-window rate limiting at Fastify level; gateway-level rate limiting deferred as defense-in-depth — (2026-03-25, Coolify removal)
+- [x] [P3] Gateway-level rate limiting via Caddy `rate_limit` module — API already has sliding-window rate limiting at Fastify level; gateway-level rate limiting deferred as defense-in-depth — (2026-03-25, Coolify removal)
 
 ### Database Hardening
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,25 @@ Newest entries first.
 
 ---
 
+## 2026-03-25 — Gateway Rate Limiting (Caddy)
+
+### Done
+
+- **Added Caddy rate limiting** as defense-in-depth via `mholt/caddy-ratelimit` module — two zones: general (300 req/min/IP for API + frontend) and uploads (30 req/min/IP for tus endpoints)
+- **Multi-stage Dockerfile** — xcaddy build stage compiles Caddy with rate-limit module, runtime stays on `caddy:2-alpine`
+- **Configurable via env vars** — `CADDY_RL_GENERAL_MAX`, `CADDY_RL_GENERAL_WINDOW`, `CADDY_RL_UPLOAD_MAX`, `CADDY_RL_UPLOAD_WINDOW` with sensible defaults
+- **Excluded routes** — health, webhook, and Grafana endpoints bypass gateway rate limiting (trusted/internal traffic)
+- **Fixed stale `.env.prod.example`** — API rate limit defaults were 100/20 instead of actual 60/200 from `env.ts`
+- Codex plan review: 2 Important (NAT false positive risk at 200/min, stale env example values), 3 Suggestions — all addressed
+
+### Decisions
+
+- **300 req/min general limit**: set above API's 200/min authenticated user limit to avoid false positives for multiple users behind shared NAT/proxy
+- **Separate upload zone**: tus uploads have fundamentally different traffic patterns (few but long requests)
+- **`order rate_limit before reverse_proxy`**: ensures rate limiting runs before proxying; Codex caught unnecessary `before basicauth`
+
+---
+
 ## 2026-03-25 — Drop Coolify, Replace nginx with Caddy
 
 ### Done

--- a/gateway/Caddyfile
+++ b/gateway/Caddyfile
@@ -1,6 +1,6 @@
 {
 	admin localhost:2019
-	order rate_limit before reverse_proxy
+	order rate_limit before header
 }
 
 {$DOMAIN:localhost} {

--- a/gateway/Caddyfile
+++ b/gateway/Caddyfile
@@ -1,5 +1,6 @@
 {
 	admin localhost:2019
+	order rate_limit before reverse_proxy
 }
 
 {$DOMAIN:localhost} {
@@ -13,6 +14,27 @@
 		X-XSS-Protection "1; mode=block"
 		Referrer-Policy "strict-origin-when-cross-origin"
 		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+	}
+
+	# Gateway rate limiting (defense-in-depth — API has its own limits)
+	@rate_limited {
+		not path /caddy-health /health /ready /webhooks /webhooks/* /hooks /hooks/* /grafana /grafana/* /upload /upload/*
+	}
+	rate_limit @rate_limited {
+		zone general {
+			key    {remote_host}
+			events {$CADDY_RL_GENERAL_MAX:300}
+			window {$CADDY_RL_GENERAL_WINDOW:1m}
+		}
+	}
+
+	@upload_limited path /upload /upload/*
+	rate_limit @upload_limited {
+		zone uploads {
+			key    {remote_host}
+			events {$CADDY_RL_UPLOAD_MAX:30}
+			window {$CADDY_RL_UPLOAD_WINDOW:1m}
+		}
 	}
 
 	# Gateway health check (local, no proxy)

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,3 +1,9 @@
+# Build Caddy with rate-limit module
+FROM caddy:2-builder AS builder
+RUN xcaddy build --with github.com/mholt/caddy-ratelimit
+
+# Runtime
 FROM caddy:2-alpine
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY maintenance.html /srv/maintenance.html


### PR DESCRIPTION
## Summary

- Build custom Caddy with `mholt/caddy-ratelimit` via xcaddy multi-stage Docker build
- Two rate limit zones: **general** (300 req/min/IP for API + tRPC + frontend) and **uploads** (30 req/min/IP for tus endpoints)
- Health, webhook, and monitoring routes excluded from gateway rate limiting
- Configurable via `CADDY_RL_*` env vars with sensible defaults
- Fix stale rate limit defaults in `.env.prod.example` (100/20 → 60/200 to match `env.ts`)

## Test plan

- [ ] Verify Docker build succeeds: `cd gateway && docker build -t caddy-test .`
- [ ] Confirm `http.handlers.rate_limit` in module list: `docker run --rm caddy-test caddy list-modules | grep rate_limit`
- [ ] Validate Caddyfile parses: `docker run --rm caddy-test caddy validate --config /etc/caddy/Caddyfile`
- [ ] Deploy to staging and verify 429 after 300 rapid requests to `/trpc`
- [ ] Verify excluded routes (`/health`, `/webhooks/*`) never return 429
- [ ] Confirm image size stays under 70MB