### PR TITLE
feat(web): design system Step 2 — editorial split pane + ManuscriptRenderer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,11 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **Manuscript format**    | `docs/manuscript-format.md` (ProseMirror JSON schema, conversion pipeline)                 |
 | **Density provider**     | `apps/web/src/hooks/use-density.tsx` (DensityProvider + useDensity hook)                   |
 | **Layout shells**        | `apps/web/src/app/(dashboard)/{editor,slate,federation,webhooks,organizations}/layout.tsx` |
+| **Split pane**           | `apps/web/src/components/editor/editorial-split-pane.tsx` (triage/deep-read orchestrator)  |
+| **ManuscriptRenderer**   | `apps/web/src/components/manuscripts/manuscript-renderer.tsx` (genre-aware typography)     |
+| **Keyboard shortcuts**   | `apps/web/src/hooks/use-shortcuts.ts` (shell-scoped shortcut hook)                         |
+| **ProseMirror types**    | `apps/web/src/lib/manuscript.ts` (doc types + textToProseMirrorDoc converter)              |
+| **Literata font**        | `apps/web/src/lib/fonts.ts` (variable font with optical sizing)                            |
 | **QA log**               | `docs/qa-log.md`                                                                           |
 | **Release checklist**    | `docs/release-checklist.md`                                                                |
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -73,6 +73,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.72.0",
+    "react-resizable-panels": "^4.7.6",
     "recharts": "^3.8.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/apps/web/src/app/(dashboard)/editor/queue/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/queue/page.tsx
@@ -1,0 +1,10 @@
+import { EditorialSplitPane } from "@/components/editor/editorial-split-pane";
+
+export default async function EditorQueuePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ id?: string }>;
+}) {
+  const sp = await searchParams;
+  return <EditorialSplitPane initialId={sp.id ?? null} />;
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -111,6 +111,35 @@
   --density-line-height: 1.4;
 }
 
+/* Manuscript typography — reading-quality rendering for literary content */
+.manuscript-prose {
+  max-width: 65ch;
+  line-height: 1.65;
+  font-size: 1.0625rem;
+  text-align: left;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.manuscript-prose p + p {
+  text-indent: 1.5em;
+}
+
+.manuscript-prose > p:first-child {
+  text-indent: 0;
+}
+
+.manuscript-poetry {
+  max-width: 50ch;
+  line-height: 1.55;
+  font-size: 1.0625rem;
+  text-align: left;
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 @layer base {
   * {
     @apply border-border;

--- a/apps/web/src/components/editor/__tests__/editorial-split-pane.spec.tsx
+++ b/apps/web/src/components/editor/__tests__/editorial-split-pane.spec.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { EditorialSplitPane } from "../editorial-split-pane";
+
+// Mock resizable panels
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: React.PropsWithChildren) => (
+    <div data-testid="panel-group">{children}</div>
+  ),
+  ResizablePanel: ({ children }: React.PropsWithChildren) => (
+    <div data-testid="panel">{children}</div>
+  ),
+  ResizableHandle: () => <div data-testid="panel-handle" />,
+}));
+
+// Mock child components to avoid deep tRPC dependency trees
+vi.mock("../triage-list", () => ({
+  TriageList: ({
+    selectedId,
+    onSelect,
+    onItemsChange,
+  }: {
+    selectedId: string | null;
+    onSelect: (id: string) => void;
+    onItemsChange?: (ids: string[]) => void;
+  }) => {
+    // Simulate items being available via useEffect equivalent
+    if (onItemsChange) {
+      // Call synchronously (simulates the effect)
+      setTimeout(() => onItemsChange(["sub-1", "sub-2", "sub-3"]), 0);
+    }
+    return (
+      <div data-testid="triage-list">
+        <button
+          data-testid="item-sub-1"
+          aria-selected={selectedId === "sub-1"}
+          role="option"
+          onClick={() => onSelect("sub-1")}
+        >
+          The River House
+        </button>
+        <button
+          data-testid="item-sub-2"
+          aria-selected={selectedId === "sub-2"}
+          role="option"
+          onClick={() => onSelect("sub-2")}
+        >
+          Memory Palace
+        </button>
+        <button
+          data-testid="item-sub-3"
+          aria-selected={selectedId === "sub-3"}
+          role="option"
+          onClick={() => onSelect("sub-3")}
+        >
+          After the Rain
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock("../detail-pane", () => ({
+  DetailPane: ({
+    submissionId,
+    mode,
+  }: {
+    submissionId: string | null;
+    mode: string;
+  }) => (
+    <div
+      data-testid="detail-pane"
+      data-mode={mode}
+      data-submission={submissionId}
+    >
+      {submissionId
+        ? `Detail: ${submissionId} (${mode})`
+        : "No submission selected"}
+    </div>
+  ),
+}));
+
+vi.mock("../queue-rail", () => ({
+  QueueRail: ({
+    currentIndex,
+    totalCount,
+    onExpand,
+  }: {
+    currentIndex: number;
+    totalCount: number;
+    onExpand: () => void;
+  }) => (
+    <div data-testid="queue-rail" onClick={onExpand}>
+      {currentIndex + 1} of {totalCount}
+    </div>
+  ),
+}));
+
+// Mock window.history.replaceState
+const replaceStateSpy = vi.spyOn(window.history, "replaceState");
+
+describe("EditorialSplitPane", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders triage mode by default with list and detail panels", () => {
+    render(<EditorialSplitPane />);
+
+    expect(screen.getByTestId("triage-list")).toBeTruthy();
+    expect(screen.getByTestId("detail-pane")).toBeTruthy();
+    expect(screen.getByText("No submission selected")).toBeTruthy();
+  });
+
+  it("selecting a submission updates the detail pane and URL", () => {
+    render(<EditorialSplitPane />);
+
+    fireEvent.click(screen.getByTestId("item-sub-1"));
+
+    expect(screen.getByText("Detail: sub-1 (triage)")).toBeTruthy();
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      null,
+      "",
+      "/editor/queue?id=sub-1",
+    );
+  });
+
+  it("pressing r switches to deep-read mode when a submission is selected", () => {
+    render(<EditorialSplitPane initialId="sub-1" />);
+
+    // Let the onItemsChange callback fire
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    fireEvent.keyDown(document, { key: "r" });
+
+    // Should see rail and deep-read detail
+    expect(screen.getByTestId("queue-rail")).toBeTruthy();
+    expect(screen.getByText("Detail: sub-1 (deep-read)")).toBeTruthy();
+  });
+
+  it("pressing Escape returns to triage mode from deep-read", () => {
+    render(<EditorialSplitPane initialId="sub-1" />);
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    // Enter deep-read
+    fireEvent.keyDown(document, { key: "r" });
+    expect(screen.getByTestId("queue-rail")).toBeTruthy();
+
+    // Return to triage
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.getByTestId("triage-list")).toBeTruthy();
+    expect(screen.queryByTestId("queue-rail")).toBeNull();
+  });
+
+  it("j/k moves selection through list items", () => {
+    render(<EditorialSplitPane />);
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    // j selects first item
+    fireEvent.keyDown(document, { key: "j" });
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      null,
+      "",
+      "/editor/queue?id=sub-1",
+    );
+
+    // j again selects second
+    fireEvent.keyDown(document, { key: "j" });
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      null,
+      "",
+      "/editor/queue?id=sub-2",
+    );
+
+    // k goes back to first
+    fireEvent.keyDown(document, { key: "k" });
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      null,
+      "",
+      "/editor/queue?id=sub-1",
+    );
+  });
+
+  it("r does not activate deep-read when no submission is selected", () => {
+    render(<EditorialSplitPane />);
+
+    fireEvent.keyDown(document, { key: "r" });
+
+    // Should still be in triage mode
+    expect(screen.getByTestId("triage-list")).toBeTruthy();
+    expect(screen.queryByTestId("queue-rail")).toBeNull();
+  });
+
+  it("pre-selects submission from initialId prop", () => {
+    render(<EditorialSplitPane initialId="sub-2" />);
+
+    expect(screen.getByText("Detail: sub-2 (triage)")).toBeTruthy();
+  });
+
+  it("clicking rail expand button returns to triage", () => {
+    render(<EditorialSplitPane initialId="sub-1" />);
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    // Enter deep-read
+    fireEvent.keyDown(document, { key: "r" });
+    expect(screen.getByTestId("queue-rail")).toBeTruthy();
+
+    // Click rail to expand
+    fireEvent.click(screen.getByTestId("queue-rail"));
+    expect(screen.getByTestId("triage-list")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/editor/detail-pane.tsx
+++ b/apps/web/src/components/editor/detail-pane.tsx
@@ -82,6 +82,10 @@ function DeepReadView({ submissionId }: { submissionId: string }) {
     ? textToProseMirrorDoc(submission.content)
     : null;
 
+  // Only show "As submitted" toggle when the doc has smart_text marks
+  // (not present in the plain text fallback — toggle would be a no-op)
+  const hasSmartTextMarks = content?.attrs?.smart_typography_applied === true;
+
   return (
     <DensityProvider density="comfortable">
       <div className="h-full overflow-y-auto">
@@ -98,7 +102,7 @@ function DeepReadView({ submissionId }: { submissionId: string }) {
                 </p>
               )}
             </div>
-            {content && (
+            {hasSmartTextMarks && (
               <div className="flex items-center gap-2">
                 <Switch
                   id="show-as-submitted"

--- a/apps/web/src/components/editor/detail-pane.tsx
+++ b/apps/web/src/components/editor/detail-pane.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { trpc } from "@/lib/trpc";
+import { DensityProvider } from "@/hooks/use-density";
+import { SubmissionDetail } from "@/components/submissions/submission-detail";
+import { ManuscriptRenderer } from "@/components/manuscripts/manuscript-renderer";
+import { textToProseMirrorDoc } from "@/lib/manuscript";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { BookOpen } from "lucide-react";
+import { useState } from "react";
+
+interface DetailPaneProps {
+  submissionId: string | null;
+  mode: "triage" | "deep-read";
+}
+
+/**
+ * Right pane wrapper that renders submission detail (triage)
+ * or ManuscriptRenderer (deep-read) based on mode.
+ */
+export function DetailPane({ submissionId, mode }: DetailPaneProps) {
+  if (!submissionId) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        <div className="text-center">
+          <BookOpen className="h-12 w-12 mx-auto mb-3 opacity-40" />
+          <p className="text-sm">Select a submission to begin reading</p>
+          <p className="text-xs mt-1">
+            Use{" "}
+            <kbd className="px-1 py-0.5 rounded border bg-muted text-xs">j</kbd>
+            /
+            <kbd className="px-1 py-0.5 rounded border bg-muted text-xs">k</kbd>{" "}
+            to navigate
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (mode === "triage") {
+    return (
+      <div className="h-full overflow-y-auto p-4">
+        <SubmissionDetail submissionId={submissionId} embedded />
+      </div>
+    );
+  }
+
+  return <DeepReadView submissionId={submissionId} />;
+}
+
+function DeepReadView({ submissionId }: { submissionId: string }) {
+  const [showAsSubmitted, setShowAsSubmitted] = useState(false);
+
+  const { data: submission, isPending } = trpc.submissions.getById.useQuery({
+    id: submissionId,
+  });
+
+  if (isPending) {
+    return (
+      <div className="p-8 max-w-[65ch] mx-auto space-y-4">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/4" />
+      </div>
+    );
+  }
+
+  if (!submission) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        Submission not found
+      </div>
+    );
+  }
+
+  // Convert plain text content to ProseMirror doc (fallback path —
+  // the only path until the backend content extraction pipeline ships)
+  const content = submission.content
+    ? textToProseMirrorDoc(submission.content)
+    : null;
+
+  return (
+    <DensityProvider density="comfortable">
+      <div className="h-full overflow-y-auto">
+        <div className="mx-auto max-w-[65ch] px-6 py-8">
+          {/* Header */}
+          <div className="flex items-start justify-between mb-8">
+            <div>
+              <h2 className="text-lg font-medium text-muted-foreground">
+                {submission.title ?? "Untitled"}
+              </h2>
+              {submission.submitterEmail && (
+                <p className="text-sm text-muted-foreground/70 mt-0.5">
+                  {submission.submitterEmail}
+                </p>
+              )}
+            </div>
+            {content && (
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="show-as-submitted"
+                  checked={showAsSubmitted}
+                  onCheckedChange={setShowAsSubmitted}
+                />
+                <Label
+                  htmlFor="show-as-submitted"
+                  className="text-xs text-muted-foreground"
+                >
+                  As submitted
+                </Label>
+              </div>
+            )}
+          </div>
+
+          {/* Manuscript content */}
+          {content ? (
+            <ManuscriptRenderer
+              content={content}
+              showAsSubmitted={showAsSubmitted}
+            />
+          ) : (
+            <p className="text-muted-foreground text-sm">
+              No text content available for this submission.
+            </p>
+          )}
+
+          {/* Cover letter */}
+          {submission.coverLetter && (
+            <div className="mt-12 pt-8 border-t">
+              <h3 className="text-sm font-medium text-muted-foreground mb-4">
+                Cover Letter
+              </h3>
+              <div className="text-sm leading-relaxed whitespace-pre-wrap">
+                {submission.coverLetter}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </DensityProvider>
+  );
+}

--- a/apps/web/src/components/editor/editorial-split-pane.tsx
+++ b/apps/web/src/components/editor/editorial-split-pane.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  ResizablePanelGroup,
+  ResizablePanel,
+  ResizableHandle,
+} from "@/components/ui/resizable";
+import { TriageList } from "./triage-list";
+import { DetailPane } from "./detail-pane";
+import { QueueRail } from "./queue-rail";
+import { useShortcuts } from "@/hooks/use-shortcuts";
+
+interface EditorialSplitPaneProps {
+  initialId?: string | null;
+}
+
+/**
+ * Main split pane orchestrator for the editorial reading queue.
+ *
+ * Two modes:
+ * - Triage: 30% list + 70% detail, keyboard j/k navigation
+ * - Deep-read: rail + manuscript at comfortable density
+ */
+export function EditorialSplitPane({ initialId }: EditorialSplitPaneProps) {
+  const [mode, setMode] = useState<"triage" | "deep-read">("triage");
+  const [selectedId, setSelectedId] = useState<string | null>(
+    initialId ?? null,
+  );
+  const [itemIds, setItemIds] = useState<string[]>([]);
+
+  const handleItemsChange = useCallback((ids: string[]) => {
+    setItemIds(ids);
+  }, []);
+
+  const handleSelect = useCallback((id: string) => {
+    setSelectedId(id);
+    // Update URL without triggering Next.js re-render
+    window.history.replaceState(null, "", `/editor/queue?id=${id}`);
+  }, []);
+
+  const selectNext = useCallback(() => {
+    if (itemIds.length === 0) return;
+    const currentIdx = selectedId ? itemIds.indexOf(selectedId) : -1;
+    const nextIdx = Math.min(currentIdx + 1, itemIds.length - 1);
+    handleSelect(itemIds[nextIdx]);
+  }, [selectedId, handleSelect, itemIds]);
+
+  const selectPrev = useCallback(() => {
+    if (itemIds.length === 0) return;
+    const currentIdx = selectedId
+      ? itemIds.indexOf(selectedId)
+      : itemIds.length;
+    const prevIdx = Math.max(currentIdx - 1, 0);
+    handleSelect(itemIds[prevIdx]);
+  }, [selectedId, handleSelect, itemIds]);
+
+  const currentIndex = selectedId ? itemIds.indexOf(selectedId) : -1;
+  const totalCount = itemIds.length;
+
+  useShortcuts([
+    {
+      key: "r",
+      handler: () => {
+        if (mode === "triage" && selectedId) {
+          setMode("deep-read");
+        }
+      },
+      description: "Enter deep-read mode",
+      enabled: mode === "triage" && selectedId !== null,
+    },
+    {
+      key: "Escape",
+      handler: () => setMode("triage"),
+      description: "Return to triage mode",
+      enabled: mode === "deep-read",
+    },
+    {
+      key: "j",
+      handler: selectNext,
+      description: "Select next submission",
+    },
+    {
+      key: "k",
+      handler: selectPrev,
+      description: "Select previous submission",
+    },
+  ]);
+
+  if (mode === "deep-read") {
+    return (
+      <div className="h-[calc(100vh-4rem)]">
+        <ResizablePanelGroup orientation="horizontal">
+          <ResizablePanel defaultSize={5} minSize={3} maxSize={12}>
+            <QueueRail
+              currentIndex={currentIndex >= 0 ? currentIndex : 0}
+              totalCount={totalCount}
+              onExpand={() => setMode("triage")}
+            />
+          </ResizablePanel>
+          <ResizableHandle />
+          <ResizablePanel defaultSize={95}>
+            <DetailPane submissionId={selectedId} mode="deep-read" />
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-[calc(100vh-4rem)]">
+      <ResizablePanelGroup orientation="horizontal">
+        <ResizablePanel defaultSize={30} minSize={20} maxSize={45}>
+          <TriageList
+            selectedId={selectedId}
+            onSelect={handleSelect}
+            onItemsChange={handleItemsChange}
+          />
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel defaultSize={70}>
+          <DetailPane submissionId={selectedId} mode="triage" />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  );
+}

--- a/apps/web/src/components/editor/queue-rail.tsx
+++ b/apps/web/src/components/editor/queue-rail.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { ChevronRight } from "lucide-react";
+
+interface QueueRailProps {
+  currentIndex: number;
+  totalCount: number;
+  onExpand: () => void;
+}
+
+/**
+ * Collapsed rail shown in deep-read mode.
+ * Displays position indicator and expand button.
+ */
+export function QueueRail({
+  currentIndex,
+  totalCount,
+  onExpand,
+}: QueueRailProps) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 px-2 border-r bg-muted/30">
+      <div className="text-center">
+        <div className="text-sm font-medium tabular-nums">
+          {currentIndex + 1}
+        </div>
+        <div className="text-xs text-muted-foreground">of {totalCount}</div>
+      </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onExpand}
+        aria-label="Expand queue list"
+        className="h-7 w-7"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/editor/triage-list.tsx
+++ b/apps/web/src/components/editor/triage-list.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useState, useEffect, useRef, useMemo } from "react";
+import { differenceInDays } from "date-fns";
+import { trpc } from "@/lib/trpc";
+import { StatusBadge } from "@/components/submissions/status-badge";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Inbox } from "lucide-react";
+import type {
+  SubmissionStatus,
+  SubmissionSortBy,
+  SortOrder,
+} from "@colophony/types";
+
+const STATUS_TABS: Array<{ value: SubmissionStatus | "ALL"; label: string }> = [
+  { value: "ALL", label: "All" },
+  { value: "SUBMITTED", label: "New" },
+  { value: "UNDER_REVIEW", label: "Review" },
+  { value: "HOLD", label: "Hold" },
+];
+
+const TERMINAL_STATUSES = new Set(["ACCEPTED", "REJECTED", "WITHDRAWN"]);
+
+interface TriageListProps {
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  /** Expose current item IDs for keyboard navigation from parent */
+  onItemsChange?: (ids: string[]) => void;
+}
+
+/**
+ * Compact submission list for the split pane left panel.
+ * Shows title, submitter, content preview, status, and age.
+ */
+export function TriageList({
+  selectedId,
+  onSelect,
+  onItemsChange,
+}: TriageListProps) {
+  const [statusFilter, setStatusFilter] = useState<SubmissionStatus | "ALL">(
+    "ALL",
+  );
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const selectedRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const { data, isPending } = trpc.submissions.list.useQuery({
+    status: statusFilter === "ALL" ? undefined : statusFilter,
+    search: debouncedSearch || undefined,
+    sortBy: "createdAt" as SubmissionSortBy,
+    sortOrder: "desc" as SortOrder,
+    page: 1,
+    limit: 50,
+  });
+
+  const items = useMemo(() => data?.items ?? [], [data?.items]);
+  const itemIds = useMemo(() => items.map((item) => item.id), [items]);
+
+  // Notify parent of available IDs for keyboard navigation
+  useEffect(() => {
+    onItemsChange?.(itemIds);
+  }, [itemIds, onItemsChange]);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: "nearest" });
+  }, [selectedId]);
+
+  return (
+    <div className="flex h-full flex-col border-r">
+      {/* Search */}
+      <div className="p-2 border-b">
+        <Input
+          placeholder="Search submissions..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="h-8 text-sm"
+        />
+      </div>
+
+      {/* Status tabs */}
+      <div className="px-2 py-1 border-b">
+        <Tabs
+          value={statusFilter}
+          onValueChange={(v) => setStatusFilter(v as SubmissionStatus | "ALL")}
+        >
+          <TabsList className="h-7 w-full">
+            {STATUS_TABS.map((tab) => (
+              <TabsTrigger
+                key={tab.value}
+                value={tab.value}
+                className="text-xs px-2 py-0.5"
+              >
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
+
+      {/* Item list */}
+      <div className="flex-1 overflow-y-auto">
+        {isPending ? (
+          <div className="space-y-2 p-2">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full" />
+            ))}
+          </div>
+        ) : items.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+            <Inbox className="h-8 w-8 mb-2" />
+            <p className="text-sm">No submissions found</p>
+          </div>
+        ) : (
+          <div className="divide-y">
+            {items.map((item) => (
+              <TriageItem
+                key={item.id}
+                ref={item.id === selectedId ? selectedRef : undefined}
+                item={item}
+                isSelected={item.id === selectedId}
+                onSelect={() => onSelect(item.id)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Count footer */}
+      {data && (
+        <div className="px-3 py-1.5 border-t text-xs text-muted-foreground">
+          {data.total} submission{data.total !== 1 ? "s" : ""}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- Triage item ---
+
+interface TriageItemProps {
+  item: {
+    id: string;
+    title: string | null;
+    status: string;
+    content: string | null;
+    submitterEmail: string | null;
+    submittedAt: string | null;
+  };
+  isSelected: boolean;
+  onSelect: () => void;
+}
+
+const TriageItem = ({
+  ref,
+  item,
+  isSelected,
+  onSelect,
+}: TriageItemProps & { ref?: React.Ref<HTMLButtonElement> }) => {
+  return (
+    <button
+      ref={ref}
+      onClick={onSelect}
+      className={`w-full text-left px-3 py-2 transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+        isSelected ? "bg-accent" : ""
+      }`}
+      aria-selected={isSelected}
+      role="option"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <StatusBadge status={item.status as SubmissionStatus} />
+            <span className="text-sm font-medium truncate">
+              {item.title ?? "(Untitled)"}
+            </span>
+          </div>
+          <p className="text-xs text-muted-foreground truncate mt-0.5">
+            {item.submitterEmail ?? "[Anonymous]"}
+          </p>
+          {item.content && (
+            <p className="text-xs text-muted-foreground/70 line-clamp-2 mt-1 leading-relaxed">
+              {item.content}
+            </p>
+          )}
+        </div>
+        <AgeBadge submittedAt={item.submittedAt} status={item.status} />
+      </div>
+    </button>
+  );
+};
+
+function AgeBadge({
+  submittedAt,
+  status,
+}: {
+  submittedAt: string | null;
+  status: string;
+}) {
+  if (TERMINAL_STATUSES.has(status) || !submittedAt) return null;
+
+  const days = differenceInDays(new Date(), new Date(submittedAt));
+  let colorClass =
+    "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300";
+  if (days > 30) {
+    colorClass = "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300";
+  } else if (days >= 14) {
+    colorClass =
+      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300";
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium flex-shrink-0 ${colorClass}`}
+    >
+      {days}d
+    </span>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -53,7 +53,8 @@ const writingNavigation: NavItem[] = [
 
 const editorialNavigation: NavItem[] = [
   { name: "Editor Dashboard", href: "/editor", icon: LayoutDashboard },
-  { name: "Submissions", href: "/editor/submissions", icon: Inbox },
+  { name: "Reading Queue", href: "/editor/queue", icon: BookOpen },
+  { name: "All Submissions", href: "/editor/submissions", icon: Inbox },
   { name: "Forms", href: "/editor/forms", icon: ClipboardList },
   { name: "Periods", href: "/editor/periods", icon: Calendar },
 ];

--- a/apps/web/src/components/manuscripts/__tests__/manuscript-renderer.spec.tsx
+++ b/apps/web/src/components/manuscripts/__tests__/manuscript-renderer.spec.tsx
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ManuscriptRenderer } from "../manuscript-renderer";
+import type { ProseMirrorDoc } from "@/lib/manuscript";
+
+// Mock the font to avoid next/font/google in test environment
+vi.mock("@/lib/fonts", () => ({
+  literata: { className: "literata-mock" },
+}));
+
+function makeDoc(overrides: Partial<ProseMirrorDoc> = {}): ProseMirrorDoc {
+  return {
+    type: "doc",
+    content: [],
+    ...overrides,
+  };
+}
+
+describe("ManuscriptRenderer", () => {
+  it("renders prose paragraphs with Literata font class", () => {
+    const doc = makeDoc({
+      attrs: { genre_hint: "prose" },
+      content: [
+        {
+          type: "paragraph",
+          attrs: { indent: false },
+          text: "First paragraph.",
+        },
+        {
+          type: "paragraph",
+          attrs: { indent: true },
+          text: "Second paragraph.",
+        },
+      ],
+    });
+
+    const { container } = render(<ManuscriptRenderer content={doc} />);
+
+    expect(container.querySelector(".literata-mock")).toBeTruthy();
+    expect(screen.getByText("First paragraph.")).toBeTruthy();
+    expect(screen.getByText("Second paragraph.")).toBeTruthy();
+
+    // Both should be <p> elements
+    const paragraphs = container.querySelectorAll("p");
+    expect(paragraphs).toHaveLength(2);
+  });
+
+  it("renders section breaks as structural whitespace", () => {
+    const doc = makeDoc({
+      content: [
+        { type: "paragraph", text: "Before." },
+        { type: "section_break" },
+        { type: "paragraph", text: "After." },
+      ],
+    });
+
+    const { container } = render(<ManuscriptRenderer content={doc} />);
+
+    // Section break is a div with my-8 class
+    const sectionBreak = container.querySelector('[aria-hidden="true"]');
+    expect(sectionBreak).toBeTruthy();
+    expect(sectionBreak?.className).toContain("my-8");
+  });
+
+  it("renders poetry lines without wrapping", () => {
+    const doc = makeDoc({
+      attrs: { genre_hint: "poetry" },
+      content: [
+        { type: "poem_line", text: "Shall I compare thee to a summer's day?" },
+        { type: "poem_line", text: "Thou art more lovely and more temperate." },
+      ],
+    });
+
+    const { container } = render(<ManuscriptRenderer content={doc} />);
+
+    const lines = container.querySelectorAll(".whitespace-pre");
+    expect(lines).toHaveLength(2);
+    expect(lines[0].textContent).toBe(
+      "Shall I compare thee to a summer's day?",
+    );
+  });
+
+  it("renders stanza breaks in poetry", () => {
+    const doc = makeDoc({
+      attrs: { genre_hint: "poetry" },
+      content: [
+        { type: "poem_line", text: "Line one." },
+        { type: "stanza_break" },
+        { type: "poem_line", text: "Line two." },
+      ],
+    });
+
+    const { container } = render(<ManuscriptRenderer content={doc} />);
+
+    const stanzaBreak = container.querySelector('[aria-hidden="true"]');
+    expect(stanzaBreak).toBeTruthy();
+    expect(stanzaBreak?.className).toContain("my-6");
+  });
+
+  it("renders preserved_indent with depth-based padding", () => {
+    const doc = makeDoc({
+      attrs: { genre_hint: "poetry" },
+      content: [
+        {
+          type: "preserved_indent",
+          attrs: { depth: 3 },
+          text: "Indented line",
+        },
+      ],
+    });
+
+    const { container } = render(<ManuscriptRenderer content={doc} />);
+
+    const indented = container.querySelector(".whitespace-pre");
+    expect(indented).toBeTruthy();
+    expect((indented as HTMLElement).style.paddingLeft).toBe("6em");
+  });
+
+  it("uses smart_text mark original when showAsSubmitted is true", () => {
+    const doc = makeDoc({
+      content: [
+        {
+          type: "paragraph",
+          text: "\u201CHello,\u201D she said.",
+          marks: [
+            {
+              type: "smart_text",
+              attrs: { original: '"Hello," she said.' },
+            },
+          ],
+        },
+      ],
+    });
+
+    // Default: shows normalized text
+    const { rerender } = render(<ManuscriptRenderer content={doc} />);
+    expect(screen.getByText("\u201CHello,\u201D she said.")).toBeTruthy();
+
+    // showAsSubmitted: shows original
+    rerender(<ManuscriptRenderer content={doc} showAsSubmitted />);
+    expect(screen.getByText('"Hello," she said.')).toBeTruthy();
+  });
+
+  it("renders normalized text when no smart_text mark present", () => {
+    const doc = makeDoc({
+      content: [{ type: "paragraph", text: "Plain text without marks." }],
+    });
+
+    render(<ManuscriptRenderer content={doc} />);
+    expect(screen.getByText("Plain text without marks.")).toBeTruthy();
+  });
+
+  it("switches to PoetryRenderer for poetry genre hint", () => {
+    const doc = makeDoc({
+      attrs: { genre_hint: "poetry" },
+      content: [{ type: "poem_line", text: "A line of verse." }],
+    });
+
+    const { container } = render(<ManuscriptRenderer content={doc} />);
+
+    // Poetry uses manuscript-poetry class, not manuscript-prose
+    expect(container.querySelector(".manuscript-poetry")).toBeTruthy();
+    expect(container.querySelector(".manuscript-prose")).toBeNull();
+  });
+
+  it("uses ProseRenderer for creative_nonfiction genre", () => {
+    const doc = makeDoc({
+      attrs: { genre_hint: "creative_nonfiction" },
+      content: [{ type: "paragraph", text: "An essay paragraph." }],
+    });
+
+    const { container } = render(<ManuscriptRenderer content={doc} />);
+
+    expect(container.querySelector(".manuscript-prose")).toBeTruthy();
+  });
+
+  it("defaults to prose when no genre hint", () => {
+    const doc = makeDoc({
+      content: [{ type: "paragraph", text: "Default prose." }],
+    });
+
+    const { container } = render(<ManuscriptRenderer content={doc} />);
+
+    expect(container.querySelector(".manuscript-prose")).toBeTruthy();
+  });
+
+  it("renders emphasis marks", () => {
+    const doc = makeDoc({
+      content: [
+        {
+          type: "paragraph",
+          text: "emphasized text",
+          marks: [{ type: "emphasis" }],
+        },
+      ],
+    });
+
+    const { container } = render(<ManuscriptRenderer content={doc} />);
+
+    const em = container.querySelector("em");
+    expect(em).toBeTruthy();
+    expect(em?.textContent).toBe("emphasized text");
+  });
+
+  it("renders strong marks", () => {
+    const doc = makeDoc({
+      content: [
+        {
+          type: "paragraph",
+          text: "bold text",
+          marks: [{ type: "strong" }],
+        },
+      ],
+    });
+
+    const { container } = render(<ManuscriptRenderer content={doc} />);
+
+    const strong = container.querySelector("strong");
+    expect(strong).toBeTruthy();
+    expect(strong?.textContent).toBe("bold text");
+  });
+
+  it("renders block quotes", () => {
+    const doc = makeDoc({
+      content: [
+        {
+          type: "block_quote",
+          content: [{ type: "paragraph", text: "Quoted text." }],
+        },
+      ],
+    });
+
+    const { container } = render(<ManuscriptRenderer content={doc} />);
+
+    const blockquote = container.querySelector("blockquote");
+    expect(blockquote).toBeTruthy();
+    expect(blockquote?.textContent).toBe("Quoted text.");
+  });
+});

--- a/apps/web/src/components/manuscripts/manuscript-renderer.tsx
+++ b/apps/web/src/components/manuscripts/manuscript-renderer.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { literata } from "@/lib/fonts";
+import { cn } from "@/lib/utils";
+import type {
+  ProseMirrorDoc,
+  ProseMirrorNode,
+  ProseMirrorMark,
+} from "@/lib/manuscript";
+
+interface ManuscriptRendererProps {
+  content: ProseMirrorDoc;
+  showAsSubmitted?: boolean;
+  className?: string;
+}
+
+/**
+ * Genre-aware manuscript renderer with literary typography.
+ *
+ * Always renders at reading-quality regardless of density context.
+ * Uses Literata variable font with optical sizing.
+ */
+export function ManuscriptRenderer({
+  content,
+  showAsSubmitted = false,
+  className,
+}: ManuscriptRendererProps) {
+  const genre = content.attrs?.genre_hint ?? "prose";
+
+  return (
+    <div className={cn(literata.className, "text-foreground", className)}>
+      {genre === "poetry" ? (
+        <PoetryRenderer
+          nodes={content.content}
+          showAsSubmitted={showAsSubmitted}
+        />
+      ) : (
+        <ProseRenderer
+          nodes={content.content}
+          showAsSubmitted={showAsSubmitted}
+        />
+      )}
+    </div>
+  );
+}
+
+// --- Internal renderers ---
+
+function ProseRenderer({
+  nodes,
+  showAsSubmitted,
+}: {
+  nodes: ProseMirrorNode[];
+  showAsSubmitted: boolean;
+}) {
+  return (
+    <div className="manuscript-prose">
+      {nodes.map((node, i) => (
+        <ProseNode key={i} node={node} showAsSubmitted={showAsSubmitted} />
+      ))}
+    </div>
+  );
+}
+
+function ProseNode({
+  node,
+  showAsSubmitted,
+}: {
+  node: ProseMirrorNode;
+  showAsSubmitted: boolean;
+}) {
+  switch (node.type) {
+    case "paragraph":
+      return <p>{renderTextWithMarks(node, showAsSubmitted)}</p>;
+    case "section_break":
+      return <div className="my-8" aria-hidden="true" />;
+    case "block_quote":
+      return (
+        <blockquote className="border-l-2 border-muted-foreground/30 pl-4 italic">
+          {node.content?.map((child, i) => (
+            <ProseNode key={i} node={child} showAsSubmitted={showAsSubmitted} />
+          ))}
+        </blockquote>
+      );
+    default:
+      // Render unknown nodes as plain text fallback
+      return node.text ? <p>{node.text}</p> : null;
+  }
+}
+
+function PoetryRenderer({
+  nodes,
+  showAsSubmitted,
+}: {
+  nodes: ProseMirrorNode[];
+  showAsSubmitted: boolean;
+}) {
+  return (
+    <div className="manuscript-poetry">
+      {nodes.map((node, i) => (
+        <PoetryNode key={i} node={node} showAsSubmitted={showAsSubmitted} />
+      ))}
+    </div>
+  );
+}
+
+function PoetryNode({
+  node,
+  showAsSubmitted,
+}: {
+  node: ProseMirrorNode;
+  showAsSubmitted: boolean;
+}) {
+  switch (node.type) {
+    case "poem_line":
+      return (
+        <div className="whitespace-pre">
+          {renderTextWithMarks(node, showAsSubmitted)}
+        </div>
+      );
+    case "stanza_break":
+      return <div className="my-6" aria-hidden="true" />;
+    case "preserved_indent": {
+      const depth = (node.attrs?.depth as number) ?? 1;
+      return (
+        <div
+          className="whitespace-pre"
+          style={{ paddingLeft: `${depth * 2}em` }}
+        >
+          {renderTextWithMarks(node, showAsSubmitted)}
+        </div>
+      );
+    }
+    case "caesura": {
+      const width = (node.attrs?.width as number) ?? 2;
+      return <span style={{ display: "inline-block", width: `${width}em` }} />;
+    }
+    default:
+      return node.text ? (
+        <div className="whitespace-pre">{node.text}</div>
+      ) : null;
+  }
+}
+
+// --- Text rendering with smart typography marks ---
+
+function renderTextWithMarks(
+  node: ProseMirrorNode,
+  showAsSubmitted: boolean,
+): React.ReactNode {
+  const text = node.text ?? "";
+  if (!node.marks || node.marks.length === 0) {
+    return text;
+  }
+
+  return wrapWithMarks(text, node.marks, showAsSubmitted);
+}
+
+function wrapWithMarks(
+  text: string,
+  marks: ProseMirrorMark[],
+  showAsSubmitted: boolean,
+): React.ReactNode {
+  let content: React.ReactNode = text;
+
+  for (const mark of marks) {
+    switch (mark.type) {
+      case "smart_text":
+        // Show original text when "show as submitted" is toggled
+        if (showAsSubmitted && mark.attrs?.original) {
+          content = mark.attrs.original;
+        }
+        break;
+      case "emphasis":
+        content = <em>{content}</em>;
+        break;
+      case "strong":
+        content = <strong>{content}</strong>;
+        break;
+      case "small_caps":
+        content = <span className="font-variant-small-caps">{content}</span>;
+        break;
+    }
+  }
+
+  return content;
+}

--- a/apps/web/src/components/submissions/submission-detail.tsx
+++ b/apps/web/src/components/submissions/submission-detail.tsx
@@ -63,6 +63,8 @@ interface SubmissionDetailProps {
   backHref?: string;
   queueIds?: string[];
   queueIdx?: number;
+  /** When true, hides back link, queue nav, and reading mode toggle (split pane manages those) */
+  embedded?: boolean;
 }
 
 const scanStatusIcons: Record<
@@ -95,6 +97,7 @@ export function SubmissionDetail({
   backHref = "/submissions",
   queueIds,
   queueIdx,
+  embedded = false,
 }: SubmissionDetailProps) {
   const router = useRouter();
   const { user, isEditor, isAdmin } = useOrganization();
@@ -203,14 +206,18 @@ export function SubmissionDetail({
       {/* Header */}
       <div className="flex items-start justify-between">
         <div className="space-y-1">
-          <Link
-            href={backHref}
-            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
-          >
-            <ArrowLeft className="mr-1 h-4 w-4" />
-            Back to submissions
-          </Link>
-          <h1 className="text-2xl font-bold">{submission.title}</h1>
+          {!embedded && (
+            <Link
+              href={backHref}
+              className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+            >
+              <ArrowLeft className="mr-1 h-4 w-4" />
+              Back to submissions
+            </Link>
+          )}
+          <h1 className={embedded ? "text-lg font-bold" : "text-2xl font-bold"}>
+            {submission.title}
+          </h1>
           <div className="flex items-center gap-2">
             <StatusBadge status={submission.status as SubmissionStatus} />
             <span className="text-sm text-muted-foreground">
@@ -223,7 +230,7 @@ export function SubmissionDetail({
         </div>
 
         <div className="flex gap-2">
-          {(isEditor || isAdmin) && (
+          {!embedded && (isEditor || isAdmin) && (
             <Button
               variant={isReadingMode ? "default" : "outline"}
               size="icon"
@@ -276,8 +283,8 @@ export function SubmissionDetail({
         />
       )}
 
-      {/* Queue navigation */}
-      {queueIds && queueIds.length > 0 && queueIdx != null && (
+      {/* Queue navigation — hidden when embedded in split pane */}
+      {!embedded && queueIds && queueIds.length > 0 && queueIdx != null && (
         <div className="flex items-center justify-between rounded-lg border p-2">
           <Button
             variant="ghost"
@@ -424,13 +431,21 @@ export function SubmissionDetail({
       {/* Content */}
       <div
         className={
-          isReadingMode
+          !embedded && isReadingMode
             ? "max-w-3xl mx-auto space-y-6"
-            : "grid gap-6 md:grid-cols-3"
+            : embedded
+              ? "space-y-6"
+              : "grid gap-6 md:grid-cols-3"
         }
       >
         <div
-          className={isReadingMode ? "space-y-6" : "md:col-span-2 space-y-6"}
+          className={
+            !embedded && isReadingMode
+              ? "space-y-6"
+              : embedded
+                ? "space-y-6"
+                : "md:col-span-2 space-y-6"
+          }
         >
           {/* Main content */}
           <Card>
@@ -573,8 +588,8 @@ export function SubmissionDetail({
           )}
         </div>
 
-        {/* Sidebar — hidden in reading mode */}
-        {!isReadingMode && (
+        {/* Sidebar — hidden in reading mode and embedded mode */}
+        {!embedded && !isReadingMode && (
           <div className="space-y-6">
             {/* History */}
             <Card>

--- a/apps/web/src/components/ui/resizable.tsx
+++ b/apps/web/src/components/ui/resizable.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { GripVertical } from "lucide-react";
+import { Group, Panel, Separator } from "react-resizable-panels";
+
+import { cn } from "@/lib/utils";
+
+const ResizablePanelGroup = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof Group>) => (
+  <Group
+    className={cn(
+      "flex h-full w-full data-[orientation=vertical]:flex-col",
+      className,
+    )}
+    {...props}
+  />
+);
+
+const ResizablePanel = Panel;
+
+const ResizableHandle = ({
+  withHandle,
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator> & {
+  withHandle?: boolean;
+}) => (
+  <Separator
+    className={cn(
+      "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[orientation=vertical]:h-px data-[orientation=vertical]:w-full data-[orientation=vertical]:after:left-0 data-[orientation=vertical]:after:h-1 data-[orientation=vertical]:after:w-full data-[orientation=vertical]:after:-translate-y-1/2 data-[orientation=vertical]:after:translate-x-0 [&[data-orientation=vertical]>div]:rotate-90",
+      className,
+    )}
+    {...props}
+  >
+    {withHandle && (
+      <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-border">
+        <GripVertical className="h-2.5 w-2.5" />
+      </div>
+    )}
+  </Separator>
+);
+
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle };

--- a/apps/web/src/hooks/__tests__/use-shortcuts.spec.ts
+++ b/apps/web/src/hooks/__tests__/use-shortcuts.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useShortcuts } from "../use-shortcuts";
+import type { ShortcutBinding } from "../use-shortcuts";
+
+function fireKey(key: string, target?: HTMLElement) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+  });
+  if (target) {
+    // Override event.target by dispatching from the element
+    target.dispatchEvent(event);
+  } else {
+    document.dispatchEvent(event);
+  }
+}
+
+describe("useShortcuts", () => {
+  it("fires handler on matching key press", () => {
+    const handler = vi.fn();
+    const bindings: ShortcutBinding[] = [
+      { key: "r", handler, description: "test" },
+    ];
+
+    renderHook(() => useShortcuts(bindings));
+    fireKey("r");
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("does not fire handler for non-matching key", () => {
+    const handler = vi.fn();
+    const bindings: ShortcutBinding[] = [
+      { key: "r", handler, description: "test" },
+    ];
+
+    renderHook(() => useShortcuts(bindings));
+    fireKey("j");
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire when target is an input element", () => {
+    const handler = vi.fn();
+    const bindings: ShortcutBinding[] = [
+      { key: "r", handler, description: "test" },
+    ];
+
+    renderHook(() => useShortcuts(bindings));
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    fireKey("r", input);
+    document.body.removeChild(input);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire when target is a textarea element", () => {
+    const handler = vi.fn();
+    const bindings: ShortcutBinding[] = [
+      { key: "r", handler, description: "test" },
+    ];
+
+    renderHook(() => useShortcuts(bindings));
+
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    fireKey("r", textarea);
+    document.body.removeChild(textarea);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire when target is contenteditable", () => {
+    const handler = vi.fn();
+    const bindings: ShortcutBinding[] = [
+      { key: "r", handler, description: "test" },
+    ];
+
+    renderHook(() => useShortcuts(bindings));
+
+    const div = document.createElement("div");
+    div.contentEditable = "true";
+    document.body.appendChild(div);
+    fireKey("r", div);
+    document.body.removeChild(div);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("cleans up listeners on unmount", () => {
+    const handler = vi.fn();
+    const bindings: ShortcutBinding[] = [
+      { key: "r", handler, description: "test" },
+    ];
+
+    const { unmount } = renderHook(() => useShortcuts(bindings));
+    unmount();
+
+    fireKey("r");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("respects enabled: false on individual bindings", () => {
+    const handler = vi.fn();
+    const bindings: ShortcutBinding[] = [
+      { key: "r", handler, description: "test", enabled: false },
+    ];
+
+    renderHook(() => useShortcuts(bindings));
+    fireKey("r");
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("handles multiple bindings, only fires matching one", () => {
+    const handlerR = vi.fn();
+    const handlerJ = vi.fn();
+    const bindings: ShortcutBinding[] = [
+      { key: "r", handler: handlerR, description: "read" },
+      { key: "j", handler: handlerJ, description: "next" },
+    ];
+
+    renderHook(() => useShortcuts(bindings));
+    fireKey("j");
+
+    expect(handlerR).not.toHaveBeenCalled();
+    expect(handlerJ).toHaveBeenCalledOnce();
+  });
+
+  it("handles Escape key", () => {
+    const handler = vi.fn();
+    const bindings: ShortcutBinding[] = [
+      { key: "Escape", handler, description: "exit" },
+    ];
+
+    renderHook(() => useShortcuts(bindings));
+    fireKey("Escape");
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/hooks/use-shortcuts.ts
+++ b/apps/web/src/hooks/use-shortcuts.ts
@@ -42,6 +42,9 @@ export function useShortcuts(bindings: ShortcutBinding[]): void {
       }
     }
 
+    // Ignore modified keypresses (Ctrl+R, Cmd+K, etc.)
+    if (event.metaKey || event.ctrlKey || event.altKey) return;
+
     for (const binding of bindingsRef.current) {
       if (binding.enabled === false) continue;
       if (event.key === binding.key) {

--- a/apps/web/src/hooks/use-shortcuts.ts
+++ b/apps/web/src/hooks/use-shortcuts.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+
+export interface ShortcutBinding {
+  /** Key value to match against event.key (e.g. "r", "Escape", "j") */
+  key: string;
+  /** Handler called when the shortcut fires */
+  handler: () => void;
+  /** Human-readable description for future shortcut overlay */
+  description: string;
+  /** Whether this binding is active (default true) */
+  enabled?: boolean;
+}
+
+const IGNORED_ELEMENTS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
+
+/**
+ * Shell-scoped keyboard shortcut hook.
+ *
+ * Registers document-level keydown listeners for the provided bindings.
+ * Ignores events when focus is on input/textarea/select/contenteditable elements.
+ * Bindings are stored in a ref to avoid re-registering on every render.
+ */
+export function useShortcuts(bindings: ShortcutBinding[]): void {
+  const bindingsRef = useRef(bindings);
+
+  useEffect(() => {
+    bindingsRef.current = bindings;
+  });
+
+  const handleKeyDown = useCallback((event: KeyboardEvent) => {
+    // Skip when typing in form elements
+    const target = event.target;
+    if (target instanceof HTMLElement) {
+      if (
+        IGNORED_ELEMENTS.has(target.tagName) ||
+        target.isContentEditable ||
+        target.contentEditable === "true"
+      ) {
+        return;
+      }
+    }
+
+    for (const binding of bindingsRef.current) {
+      if (binding.enabled === false) continue;
+      if (event.key === binding.key) {
+        event.preventDefault();
+        binding.handler();
+        return;
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+}

--- a/apps/web/src/lib/__tests__/manuscript.spec.ts
+++ b/apps/web/src/lib/__tests__/manuscript.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { textToProseMirrorDoc } from "../manuscript";
+
+describe("textToProseMirrorDoc", () => {
+  describe("prose mode (default)", () => {
+    it("converts double newlines to paragraph nodes", () => {
+      const doc = textToProseMirrorDoc("First paragraph.\n\nSecond paragraph.");
+      expect(doc.type).toBe("doc");
+      expect(doc.attrs?.genre_hint).toBe("prose");
+      expect(doc.content).toHaveLength(2);
+      expect(doc.content[0]).toEqual({
+        type: "paragraph",
+        attrs: { indent: false },
+        text: "First paragraph.",
+      });
+      expect(doc.content[1]).toEqual({
+        type: "paragraph",
+        attrs: { indent: true },
+        text: "Second paragraph.",
+      });
+    });
+
+    it("sets indent false on first paragraph, true on subsequent", () => {
+      const doc = textToProseMirrorDoc("One.\n\nTwo.\n\nThree.");
+      expect(doc.content[0].attrs?.indent).toBe(false);
+      expect(doc.content[1].attrs?.indent).toBe(true);
+      expect(doc.content[2].attrs?.indent).toBe(true);
+    });
+
+    it("inserts section_break for triple+ newlines", () => {
+      const doc = textToProseMirrorDoc("Part one.\n\n\nPart two.");
+      expect(doc.content).toHaveLength(3);
+      expect(doc.content[0].type).toBe("paragraph");
+      expect(doc.content[1].type).toBe("section_break");
+      expect(doc.content[2].type).toBe("paragraph");
+    });
+
+    it("handles quadruple newlines as section break", () => {
+      const doc = textToProseMirrorDoc("A.\n\n\n\nB.");
+      const types = doc.content.map((n) => n.type);
+      expect(types).toEqual(["paragraph", "section_break", "paragraph"]);
+    });
+
+    it("returns empty content array for empty string", () => {
+      const doc = textToProseMirrorDoc("");
+      expect(doc.content).toEqual([]);
+    });
+
+    it("returns empty content array for whitespace-only string", () => {
+      const doc = textToProseMirrorDoc("   \n\n   ");
+      expect(doc.content).toEqual([]);
+    });
+
+    it("handles single paragraph (no double newlines)", () => {
+      const doc = textToProseMirrorDoc("Just one paragraph.");
+      expect(doc.content).toHaveLength(1);
+      expect(doc.content[0].attrs?.indent).toBe(false);
+    });
+
+    it("trims whitespace from paragraph text", () => {
+      const doc = textToProseMirrorDoc("  Hello world.  \n\n  Goodbye.  ");
+      expect(doc.content[0].text).toBe("Hello world.");
+      expect(doc.content[1].text).toBe("Goodbye.");
+    });
+  });
+
+  describe("poetry mode", () => {
+    it("converts single newlines to poem_line nodes", () => {
+      const doc = textToProseMirrorDoc(
+        "First line\nSecond line\nThird line",
+        "poetry",
+      );
+      expect(doc.attrs?.genre_hint).toBe("poetry");
+      expect(doc.content).toHaveLength(3);
+      expect(doc.content.every((n) => n.type === "poem_line")).toBe(true);
+    });
+
+    it("inserts stanza_break on double newlines", () => {
+      const doc = textToProseMirrorDoc(
+        "Line one\nLine two\n\nLine three\nLine four",
+        "poetry",
+      );
+      const types = doc.content.map((n) => n.type);
+      expect(types).toEqual([
+        "poem_line",
+        "poem_line",
+        "stanza_break",
+        "poem_line",
+        "poem_line",
+      ]);
+    });
+
+    it("converts leading whitespace to preserved_indent with depth", () => {
+      const doc = textToProseMirrorDoc(
+        "Normal line\n    Indented line",
+        "poetry",
+      );
+      expect(doc.content[0]).toEqual({
+        type: "poem_line",
+        text: "Normal line",
+      });
+      expect(doc.content[1]).toEqual({
+        type: "preserved_indent",
+        attrs: { depth: 2 },
+        text: "Indented line",
+      });
+    });
+
+    it("returns empty content for empty string", () => {
+      const doc = textToProseMirrorDoc("", "poetry");
+      expect(doc.content).toEqual([]);
+    });
+  });
+
+  describe("genre hint passthrough", () => {
+    it("defaults to prose when no hint provided", () => {
+      const doc = textToProseMirrorDoc("Hello.");
+      expect(doc.attrs?.genre_hint).toBe("prose");
+    });
+
+    it("passes through creative_nonfiction as prose rendering", () => {
+      const doc = textToProseMirrorDoc(
+        "First.\n\nSecond.",
+        "creative_nonfiction",
+      );
+      expect(doc.attrs?.genre_hint).toBe("creative_nonfiction");
+      // creative_nonfiction uses prose converter
+      expect(doc.content[0].type).toBe("paragraph");
+    });
+
+    it("passes through hybrid as prose rendering", () => {
+      const doc = textToProseMirrorDoc("First.\n\nSecond.", "hybrid");
+      expect(doc.attrs?.genre_hint).toBe("hybrid");
+      expect(doc.content[0].type).toBe("paragraph");
+    });
+  });
+});

--- a/apps/web/src/lib/fonts.ts
+++ b/apps/web/src/lib/fonts.ts
@@ -1,0 +1,8 @@
+import { Literata } from "next/font/google";
+
+export const literata = Literata({
+  subsets: ["latin"],
+  axes: ["opsz"],
+  display: "swap",
+  variable: "--font-literata",
+});

--- a/apps/web/src/lib/manuscript.ts
+++ b/apps/web/src/lib/manuscript.ts
@@ -1,0 +1,152 @@
+// ProseMirror document types aligned with docs/manuscript-format.md spec
+// and a plain-text-to-ProseMirror converter for immediate use before
+// the backend content extraction pipeline ships.
+
+// --- Types ---
+
+export type GenreHint = "prose" | "poetry" | "hybrid" | "creative_nonfiction";
+
+export interface ProseMirrorMark {
+  type: "emphasis" | "strong" | "small_caps" | "smart_text";
+  attrs?: { original?: string };
+}
+
+export type ProseMirrorNodeType =
+  | "paragraph"
+  | "section_break"
+  | "block_quote"
+  | "poem_line"
+  | "stanza_break"
+  | "preserved_indent"
+  | "caesura"
+  | "preserved_whitespace";
+
+export interface ProseMirrorNode {
+  type: ProseMirrorNodeType;
+  attrs?: Record<string, unknown>;
+  content?: ProseMirrorNode[];
+  text?: string;
+  marks?: ProseMirrorMark[];
+}
+
+export interface SubmissionMetadata {
+  original_filename: string;
+  original_format: string;
+  converted_at: string; // ISO 8601
+  converter_version: string;
+}
+
+export interface ProseMirrorDoc {
+  type: "doc";
+  attrs?: {
+    genre_hint?: GenreHint;
+    submission_metadata?: SubmissionMetadata;
+    smart_typography_applied?: boolean;
+  };
+  content: ProseMirrorNode[];
+}
+
+export interface ReadingAnchor {
+  nodeIndex: number;
+  charOffset: number;
+}
+
+// --- Converter ---
+
+/**
+ * Convert plain text to a basic ProseMirrorDoc.
+ *
+ * Prose mode (default):
+ *   - Double newlines (\n\n) → paragraph breaks
+ *   - Triple+ newlines (\n\n\n+) → section_break between paragraphs
+ *   - First paragraph: indent false; subsequent: indent true
+ *
+ * Poetry mode:
+ *   - Single newlines → poem_line nodes
+ *   - Double+ newlines → stanza_break nodes
+ */
+export function textToProseMirrorDoc(
+  text: string,
+  genreHint?: GenreHint,
+): ProseMirrorDoc {
+  const hint = genreHint ?? "prose";
+  const content: ProseMirrorNode[] =
+    hint === "poetry" ? convertPoetry(text) : convertProse(text);
+
+  return {
+    type: "doc",
+    attrs: { genre_hint: hint },
+    content,
+  };
+}
+
+function convertProse(text: string): ProseMirrorNode[] {
+  if (!text.trim()) return [];
+
+  const nodes: ProseMirrorNode[] = [];
+  // Split on 2+ newlines, keeping the delimiter to detect section breaks (3+)
+  const parts = text.split(/(\n{2,})/);
+  let paragraphIndex = 0;
+
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (!trimmed) {
+      // This is a delimiter — check if it's a section break (3+ newlines)
+      if (part.length >= 3 && /\n{3,}/.test(part)) {
+        nodes.push({ type: "section_break" });
+      }
+      continue;
+    }
+
+    nodes.push({
+      type: "paragraph",
+      attrs: { indent: paragraphIndex > 0 },
+      text: trimmed,
+    });
+    paragraphIndex++;
+  }
+
+  return nodes;
+}
+
+function convertPoetry(text: string): ProseMirrorNode[] {
+  if (!text.trim()) return [];
+
+  const nodes: ProseMirrorNode[] = [];
+  // Split into stanzas on double+ newlines
+  const stanzas = text.split(/\n{2,}/);
+
+  for (let i = 0; i < stanzas.length; i++) {
+    if (i > 0) {
+      nodes.push({ type: "stanza_break" });
+    }
+
+    const stanza = stanzas[i];
+    if (!stanza.trim()) continue;
+
+    const lines = stanza.split("\n");
+    for (const line of lines) {
+      // Preserve leading whitespace as preserved_indent
+      const leadingSpaces = line.match(/^(\s*)/)?.[1] ?? "";
+      const depth = Math.ceil(leadingSpaces.length / 2); // 2 spaces = 1 depth
+      const trimmedLine = line.trimStart();
+
+      if (!trimmedLine && !leadingSpaces) continue;
+
+      if (depth > 0) {
+        nodes.push({
+          type: "preserved_indent",
+          attrs: { depth },
+          text: trimmedLine,
+        });
+      } else {
+        nodes.push({
+          type: "poem_line",
+          text: trimmedLine || " ", // preserve intentional blank lines within stanza
+        });
+      }
+    }
+  }
+
+  return nodes;
+}

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,45 @@ Newest entries first.
 
 ---
 
+## 2026-03-25 — Design System Step 2 PR1: Editorial Split Pane + ManuscriptRenderer
+
+### Done
+
+- **Built editorial split pane** at `/editor/queue` with triage/deep-read modes:
+  - Triage mode: 30% submission list + 70% detail, resizable via react-resizable-panels v4
+  - Deep-read mode: collapsed rail ("14 of 237") + near-full-width ManuscriptRenderer at comfortable density
+  - Core keyboard shortcuts: `r` enter deep-read, `Esc` return to triage, `j`/`k` navigate queue
+- **Created ManuscriptRenderer** with genre-aware literary typography:
+  - Prose: paragraph indentation (first-para no indent), max 65ch measure, 1.65 line height
+  - Poetry: preserved line breaks, stanza breaks, depth-based indentation
+  - Smart typography mark support: `showAsSubmitted` toggle reads original text from marks
+  - Literata variable font with optical sizing axis via `next/font/google`
+- **Created ProseMirror document types** (`apps/web/src/lib/manuscript.ts`):
+  - Types aligned with `docs/manuscript-format.md` spec (all node types including caesura, preserved_whitespace)
+  - `textToProseMirrorDoc()` converter for immediate use on plain text content
+  - Poetry mode: single newlines → poem_line, double → stanza_break, leading whitespace → preserved_indent
+- **Created `useShortcuts` hook** for shell-scoped keyboard shortcuts:
+  - Document-level keydown listener, ignores input/textarea/contenteditable
+  - Bindings via ref to avoid re-registration; individual `enabled` flag
+- **Refactored `submission-detail.tsx`** with `embedded` prop:
+  - When embedded: hides back link, queue navigation, reading mode toggle
+  - Split pane manages mode and navigation instead
+- **Updated sidebar**: "Reading Queue" added as primary editorial link above "All Submissions"
+- **Adapted shadcn/ui Resizable** for react-resizable-panels v4 API (Group/Panel/Separator)
+- Codex plan review: 4 important findings addressed (route assumption, triage data gap, deep-read fallback clarity, ProseMirror types drift)
+- 45 new tests across 4 test files. 619/619 total tests pass, 0 type errors, 0 lint errors.
+
+### Decisions
+
+- UI-first PR strategy: split pane + renderer ship before backend content extraction pipeline
+- Core keyboard shortcuts (r/Esc/j/k) included in Step 2; scoring shortcuts (1/2/3/d/h) deferred to Step 5
+- Literata variable font chosen over Source Serif/Lora — designed for long-form screen reading with optical sizing
+- `/editor/queue` as new combined route with `?id=xxx` query param; old `/editor/[id]` route stays unchanged
+- Plain text fallback is the only code path until backend pipeline PR — every submission uses `textToProseMirrorDoc()`
+- Triage list uses available API fields only (title, email, content preview, age); genre/word count deferred to API expansion
+
+---
+
 ## 2026-03-25 — Design System Step 1: Layout Shells + Sidebar
 
 ### Done

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,9 @@ importers:
       react-hook-form:
         specifier: ^7.72.0
         version: 7.72.0(react@19.2.4)
+      react-resizable-panels:
+        specifier: ^4.7.6
+        version: 4.7.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       recharts:
         specifier: ^3.8.0
         version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
@@ -6936,6 +6939,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-resizable-panels@4.7.6:
+    resolution: {integrity: sha512-w3gbmUihfvH2Ho0iV1ULS2c/E/7HW/6g0GihogsIHjZf+JmmyVnKhryB3+I4JSxO8++uD3cKsSpOVTJV+GWEuA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -13079,7 +13088,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.1
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -13106,7 +13115,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -13121,13 +13130,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -13142,7 +13151,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15264,6 +15273,11 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
+
+  react-resizable-panels@4.7.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary
- Editorial split pane at `/editor/queue` with triage (30% list + 70% detail) and deep-read (rail + full-width manuscript) modes
- Genre-aware ManuscriptRenderer with Literata variable font, prose/poetry rendering, and smart typography mark support
- Core keyboard shortcuts: `r` deep-read, `Esc` triage, `j`/`k` navigate queue
- ProseMirror document types aligned with `docs/manuscript-format.md` spec + `textToProseMirrorDoc()` plain text fallback converter

## Test plan
- [ ] 45 new unit tests pass (manuscript converter, shortcuts hook, ManuscriptRenderer, split pane orchestrator)
- [ ] 619/619 total web unit tests pass
- [ ] Type-check clean (0 errors)
- [ ] Lint clean (0 warnings)
- [ ] Manual QA: verify Literata font loads, paragraph indentation, split pane resize, deep-read mode transition
- [ ] Manual QA: verify `Ctrl+R`/`Cmd+R` browser refresh works (not captured by shortcuts)

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `apps/web/e2e/editor-queue/split-pane.spec.ts` | E2E test file | Not created | Requires dev servers; deferred to follow-up |
| `apps/web/src/components/editor/__tests__/triage-list.spec.tsx` | Triage list unit tests | Not created | Split pane orchestrator tests cover integration; triage list is thin wrapper over tRPC query |
| `resizable.tsx` | shadcn/ui default (PanelGroup API) | Adapted for react-resizable-panels v4 (Group/Panel/Separator) | v4 renamed exports; shadcn template was outdated |