### PR TITLE
feat(web): wire backend-extracted content to editorial deep-read

### DIFF
--- a/apps/api/src/services/submission.service.ts
+++ b/apps/api/src/services/submission.service.ts
@@ -557,6 +557,9 @@ export const submissionService = {
               manuscriptId: manuscripts.id,
               manuscriptTitle: manuscripts.title,
               versionNumber: manuscriptVersions.versionNumber,
+              extractedContent: manuscriptVersions.content,
+              contentExtractionStatus:
+                manuscriptVersions.contentExtractionStatus,
             })
             .from(manuscriptVersions)
             .innerJoin(
@@ -573,7 +576,18 @@ export const submissionService = {
       ...submission,
       files: versionFiles,
       submitterEmail: submitter?.email ?? null,
-      manuscript: manuscriptInfo,
+      manuscript: manuscriptInfo
+        ? {
+            ...manuscriptInfo,
+            // Drizzle jsonb() returns `unknown`; tRPC .output() validates at
+            // runtime via proseMirrorDocSchema — cast is safe here.
+            extractedContent: manuscriptInfo.extractedContent as {
+              type: 'doc';
+              content: unknown[];
+              attrs?: Record<string, unknown>;
+            } | null,
+          }
+        : null,
     };
   },
 

--- a/apps/api/src/trpc/routers/submissions.spec.ts
+++ b/apps/api/src/trpc/routers/submissions.spec.ts
@@ -433,6 +433,51 @@ describe('submissions tRPC router', () => {
         caller.submissions.getById({ id: SUBMISSION_ID }),
       ).rejects.toThrow('not found');
     });
+
+    it('returns extracted content when manuscript has completed extraction', async () => {
+      const sub = {
+        ...makeDraftSubmission(),
+        manuscript: {
+          manuscriptId: 'd4444444-4444-4444-a444-444444444499',
+          manuscriptTitle: 'Test Manuscript',
+          versionNumber: 1,
+          extractedContent: {
+            type: 'doc' as const,
+            attrs: { genre_hint: 'prose', smart_typography_applied: true },
+            content: [{ type: 'paragraph', text: 'Hello world' }],
+          },
+          contentExtractionStatus: 'COMPLETE' as const,
+        },
+      };
+      mockService.getByIdWithAccess.mockResolvedValueOnce(sub as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.submissions.getById({ id: SUBMISSION_ID });
+      expect(result.manuscript).not.toBeNull();
+      expect(result.manuscript!.extractedContent).toEqual(
+        sub.manuscript.extractedContent,
+      );
+      expect(result.manuscript!.contentExtractionStatus).toBe('COMPLETE');
+    });
+
+    it('returns null extractedContent when extraction is pending', async () => {
+      const sub = {
+        ...makeDraftSubmission(),
+        manuscript: {
+          manuscriptId: 'd4444444-4444-4444-a444-444444444499',
+          manuscriptTitle: 'Test Manuscript',
+          versionNumber: 1,
+          extractedContent: null,
+          contentExtractionStatus: 'PENDING' as const,
+        },
+      };
+      mockService.getByIdWithAccess.mockResolvedValueOnce(sub as never);
+
+      const caller = createCaller(orgContext());
+      const result = await caller.submissions.getById({ id: SUBMISSION_ID });
+      expect(result.manuscript!.extractedContent).toBeNull();
+      expect(result.manuscript!.contentExtractionStatus).toBe('PENDING');
+    });
   });
 
   describe('getHistory', () => {

--- a/apps/web/src/components/editor/detail-pane.tsx
+++ b/apps/web/src/components/editor/detail-pane.tsx
@@ -8,7 +8,8 @@ import { textToProseMirrorDoc } from "@/lib/manuscript";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
-import { BookOpen } from "lucide-react";
+import { BookOpen, Loader2, AlertCircle } from "lucide-react";
+import type { ProseMirrorDoc } from "@colophony/types";
 import { useState } from "react";
 
 interface DetailPaneProps {
@@ -76,14 +77,16 @@ function DeepReadView({ submissionId }: { submissionId: string }) {
     );
   }
 
-  // Convert plain text content to ProseMirror doc (fallback path —
-  // the only path until the backend content extraction pipeline ships)
-  const content = submission.content
-    ? textToProseMirrorDoc(submission.content)
-    : null;
+  // Prefer backend-extracted ProseMirror content; fall back to client-side
+  // plain text conversion when extraction has not completed.
+  const extractionStatus = submission.manuscript?.contentExtractionStatus;
+  const content: ProseMirrorDoc | null =
+    submission.manuscript?.extractedContent && extractionStatus === "COMPLETE"
+      ? (submission.manuscript.extractedContent as ProseMirrorDoc)
+      : submission.content
+        ? textToProseMirrorDoc(submission.content)
+        : null;
 
-  // Only show "As submitted" toggle when the doc has smart_text marks
-  // (not present in the plain text fallback — toggle would be a no-op)
   const hasSmartTextMarks = content?.attrs?.smart_typography_applied === true;
 
   return (
@@ -118,6 +121,20 @@ function DeepReadView({ submissionId }: { submissionId: string }) {
               </div>
             )}
           </div>
+
+          {/* Extraction status (transient states only) */}
+          {extractionStatus === "PENDING" ||
+          extractionStatus === "EXTRACTING" ? (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground mb-4">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Content extraction in progress...
+            </div>
+          ) : extractionStatus === "FAILED" ? (
+            <div className="flex items-center gap-2 text-xs text-destructive mb-4">
+              <AlertCircle className="h-3 w-3" />
+              Content extraction failed — showing plain text fallback
+            </div>
+          ) : null}
 
           {/* Manuscript content */}
           {content ? (

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -33,6 +33,24 @@ Newest entries first.
 
 ---
 
+## 2026-03-26 — Content Extraction Frontend Wiring
+
+### Done
+
+- **Wired backend-extracted ProseMirror content to editorial deep-read view**: detail-pane.tsx now prefers `manuscript.extractedContent` (backend JSON with smart typography) over client-side `textToProseMirrorDoc()` fallback
+- **Added Zod schemas** for tRPC output validation: `proseMirrorDocSchema` (lightweight envelope check with `.passthrough()`) and `contentExtractionStatusSchema`
+- **Extended `submissionDetailSchema.manuscript`** with `extractedContent` (ProseMirrorDoc | null) and `contentExtractionStatus` fields
+- **Extraction status indicators** in deep-read view: spinner for PENDING/EXTRACTING, error message for FAILED
+- 2 new tests. 1551 API + 619 Web = 2170 total passing.
+
+### Decisions
+
+- Lightweight Zod envelope check for ProseMirrorDoc (`.passthrough()`) — full node validation left to backend converters
+- No polling for extraction status (MVP — user refreshes; polling is follow-up work)
+- RTK `--jq` flag conflict identified — `gh run list --jq` and `gh pr list --jq` fail through rtk proxy
+
+---
+
 ## 2026-03-25 — Design System Step 2 PR1: Editorial Split Pane + ManuscriptRenderer
 
 ### Done

--- a/packages/types/src/prosemirror.ts
+++ b/packages/types/src/prosemirror.ts
@@ -2,6 +2,8 @@
 // Shared between the backend content extraction pipeline and the frontend
 // ManuscriptRenderer component.
 
+import { z } from "zod";
+
 // --- Genre ---
 
 export type GenreHint = "prose" | "poetry" | "hybrid" | "creative_nonfiction";
@@ -67,3 +69,27 @@ export type ContentExtractionStatus =
   | "COMPLETE"
   | "FAILED"
   | "UNSUPPORTED";
+
+// --- Zod Schemas (for tRPC output validation) ---
+
+export const contentExtractionStatusSchema = z.enum([
+  "PENDING",
+  "EXTRACTING",
+  "COMPLETE",
+  "FAILED",
+  "UNSUPPORTED",
+]);
+
+/**
+ * Lightweight structural check for ProseMirror JSON.
+ * Validates the document envelope (type + content array) without
+ * recursively validating every node — full node structure is
+ * guaranteed by the backend converters.
+ */
+export const proseMirrorDocSchema = z
+  .object({
+    type: z.literal("doc"),
+    attrs: z.record(z.string(), z.unknown()).optional(),
+    content: z.array(z.unknown()),
+  })
+  .passthrough();

--- a/packages/types/src/submission.ts
+++ b/packages/types/src/submission.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { scanStatusSchema, fileSchema } from "./file";
 import { simSubPolicySchema } from "./sim-sub-policy";
+import {
+  proseMirrorDocSchema,
+  contentExtractionStatusSchema,
+} from "./prosemirror";
 
 export const submissionStatusSchema = z
   .enum([
@@ -185,6 +189,14 @@ export const submissionDetailSchema = submissionSchema.extend({
       manuscriptId: z.string().uuid(),
       manuscriptTitle: z.string(),
       versionNumber: z.number().int(),
+      extractedContent: proseMirrorDocSchema
+        .nullable()
+        .describe(
+          "ProseMirror JSON from backend extraction (null if not yet extracted)",
+        ),
+      contentExtractionStatus: contentExtractionStatusSchema.describe(
+        "Backend content extraction status",
+      ),
     })
     .nullable()
     .describe("Linked manuscript info (null if no manuscript attached)"),


### PR DESCRIPTION
## Summary

- Expose `manuscript_versions.content` and `contentExtractionStatus` through the submission detail API response
- Editorial deep-read view now prefers backend-extracted ProseMirror JSON (with smart typography) over client-side `textToProseMirrorDoc()` fallback
- Add extraction status indicators: spinner for PENDING/EXTRACTING, error for FAILED

## Plan Overrides

| File | Planned | Actual | Rationale |
|---|---|---|---|
| `apps/api/src/services/submission.service.ts` | "No other service changes" beyond SELECT columns | Added type cast block for `extractedContent` return | Drizzle `jsonb()` returns `unknown`; tRPC `.output()` needs the Zod-inferred shape at compile time |

## Test plan

- [ ] `pnpm type-check` passes (all 13 packages)
- [ ] `pnpm --filter @colophony/api test` passes (1551 tests, 2 new)
- [ ] `pnpm --filter @colophony/web test` passes (619 tests)
- [ ] Manual: open editorial split pane → deep-read on submission with uploaded .txt/.docx → renders with smart typography + "As submitted" toggle active
- [ ] Manual: submission with form text only (no file) → renders via client-side fallback (no toggle)