### PR TITLE
fix(db): org-scoped SELECT policies for manuscripts + Garage shell fix

### DIFF
--- a/.claude/skills/end-session/SKILL.md
+++ b/.claude/skills/end-session/SKILL.md
@@ -181,6 +181,24 @@ Read `docs/backlog.md` and update it:
 
 Search the codebase for any `TODO(CLAUDE.md)` comments added during this session using the Grep tool (not bash) to search for `TODO(CLAUDE.md)` in `*.ts`, `*.tsx`, and `*.js` files.
 
+**Check for unresolved RTK bypass entries:**
+
+```bash
+grep '^# UNRESOLVED' ~/.claude/hooks/rtk-bypass.conf 2>/dev/null
+```
+
+If any `# UNRESOLVED` entries exist, present them to the user:
+
+```
+RTK bypass: N unresolved failure(s) logged this session:
+1. [command summary] — [timestamp]
+
+For each: investigate the root cause (new format flag? RTK bug? transient error?)
+and either add a bypass pattern or remove the comment if it was a one-off.
+```
+
+After the user decides, clean up the resolved `# UNRESOLVED` and `# Command:` comment lines from `~/.claude/hooks/rtk-bypass.conf`.
+
 Also review the session for any new patterns, quirks, or constraints discovered. Check whether any of these CLAUDE.md files need updates:
 
 - `CLAUDE.md` (root) — Known Quirks, Security Status checklist, Version Pins, Key File Locations

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -308,7 +308,8 @@ services:
 
   # Garage S3-compatible object storage
   garage:
-    image: dxflrs/garage:v2.2.0
+    build: ./docker/garage
+    image: colophony-garage:local
     container_name: colophony-garage
     expose:
       - "3900"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,8 @@ services:
 
   # Garage S3-compatible object storage
   garage:
-    image: dxflrs/garage:v2.2.0
+    build: ./docker/garage
+    image: colophony-garage:local
     container_name: colophony-garage
     ports:
       - '3900:3900'

--- a/docker/garage/Dockerfile
+++ b/docker/garage/Dockerfile
@@ -1,0 +1,7 @@
+# Garage images are FROM scratch (single static binary, Nix-built) — no shell.
+# We need /bin/sh for start-garage.sh (layout assignment via CLI) and curl
+# for the healthcheck. Copy the binary into Alpine to get both.
+FROM dxflrs/garage:v2.2.0 AS garage
+FROM alpine:3.21
+RUN apk add --no-cache curl
+COPY --from=garage /garage /garage

--- a/docker/garage/start-garage.sh
+++ b/docker/garage/start-garage.sh
@@ -17,11 +17,12 @@ until /garage status > /dev/null 2>&1; do
 done
 echo "Garage RPC ready."
 
-# Check if layout needs to be applied
-LAYOUT_VER=$(/garage layout show 2>/dev/null | grep -c "NO ROLE ASSIGNED" || true)
-if [ "$LAYOUT_VER" -gt 0 ]; then
+# Check if layout needs to be applied (version 0 = never applied)
+LAYOUT_VER=$(/garage layout show 2>/dev/null | sed -n 's/.*layout version: \([0-9]*\)/\1/p' | head -1)
+LAYOUT_VER=${LAYOUT_VER:-0}
+if [ "$LAYOUT_VER" -eq 0 ]; then
   echo "Applying initial layout..."
-  NODE_ID=$(/garage status 2>/dev/null | grep -oP '^\s*\K[0-9a-f]{16}' | head -1)
+  NODE_ID=$(/garage status 2>/dev/null | awk '/^[[:space:]]*[0-9a-f]{16}/ { print $1; exit }')
   /garage layout assign -z dc1 -c "${GARAGE_CAPACITY:-1G}" "$NODE_ID" 2>/dev/null
   /garage layout apply --version 1 2>/dev/null
   echo "Layout applied."

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,26 @@ Newest entries first.
 
 ---
 
+## 2026-03-26 — Manual QA + RLS Bug Fix + Garage Infrastructure
+
+### Done
+
+- **Manual QA of content extraction frontend** via Chrome DevTools MCP: verified ManuscriptRenderer renders all ProseMirror node types (paragraph, section_break, block_quote), smart typography (em dashes, curly quotes, ellipsis), and "As submitted" toggle correctly swaps to original text
+- **Found and fixed critical RLS bug**: editors could not see extracted content in deep-read mode because `manuscripts` and `manuscript_versions` tables had user-scoped RLS only (`owner_id`). The `INNER JOIN manuscripts` in `submission.service.ts` `getById()` returned null for submissions from other users
+- **Added org-scoped SELECT policies** (`manuscripts_org_read`, `manuscript_versions_org_read`) mirroring the existing `files_org_read` pattern — editors can read manuscript metadata and extracted content for non-DRAFT submissions in their org
+- **Broke RLS recursion** with `manuscript_ids_for_org()` SECURITY DEFINER function: `manuscript_versions` RLS references `manuscripts`, and the new `manuscripts_org_read` needs `manuscript_versions` — SECURITY DEFINER bypasses RLS on the intermediate lookup
+- **Fixed Garage S3 Docker image**: Garage images (`dxflrs/garage`) have always been `FROM scratch` (single static binary, Nix-built) — no shell. Added `docker/garage/Dockerfile` multi-stage build (copies `/garage` into Alpine for shell + curl). Also fixed `start-garage.sh` layout version detection (was grepping wrong text) and replaced GNU `grep -oP` with POSIX `awk`
+- Migration 0057: `manuscript_org_read_policies` (function + 2 policies)
+- 122 RLS tests + 37 submission tests passing
+
+### Decisions
+
+- SECURITY DEFINER to break policy recursion rather than restructuring the ownership chain — minimal blast radius, mirrors existing patterns (`verify_api_key()`, `touch_api_key_last_used()`)
+- Org SELECT only (not all DML) for manuscript cross-user reads — editors should read, not modify others' manuscripts
+- Garage Dockerfile approach over upstream alternatives — Garage has always been scratch-based, not a regression
+
+---
+
 ## 2026-03-26 — Content Extraction Pipeline (Step 2 PR2)
 
 ### Done

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -73,7 +73,9 @@ Acquires a dedicated connection, sets `app.current_org` and/or `app.user_id` via
 
 ### User-Scoped RLS (Manuscripts)
 
-Manuscripts use `owner_id = current_user_id()` instead of org-scoped isolation. The `current_user_id()` SQL function (migration 0000) returns `app.user_id`. Files use dual RLS: owner CRUD via manuscript ownership chain (`files → manuscript_versions → manuscripts WHERE owner_id = current_user_id()`) + org SELECT for editors on submitted manuscripts (`files → manuscript_versions → submissions WHERE organization_id = current_org_id()`). This is a new pattern — all other tables use org-scoped isolation only.
+Manuscripts use `owner_id = current_user_id()` instead of org-scoped isolation. The `current_user_id()` SQL function (migration 0000) returns `app.user_id`. All three manuscript-related tables use dual RLS: owner CRUD via manuscript ownership chain + org SELECT for editors on submitted (non-DRAFT) manuscripts. The org SELECT policies allow editors to see manuscript metadata and extracted content in the reading queue without owning the manuscript.
+
+**RLS recursion caveat:** `manuscript_versions` RLS references `manuscripts`; `manuscripts` org_read needs `manuscript_versions` to resolve `manuscript_id`. To break this cycle, `manuscripts_org_read` uses `manuscript_ids_for_org()` — a SECURITY DEFINER function that bypasses RLS on `manuscript_versions` for the lookup. `manuscript_versions_org_read` and `files_org_read` go through `submissions` only (no recursion risk).
 
 ### NEVER
 

--- a/packages/db/migrations/0057_manuscript_org_read_policies.sql
+++ b/packages/db/migrations/0057_manuscript_org_read_policies.sql
@@ -1,0 +1,32 @@
+-- Add org-scoped SELECT policies to manuscripts and manuscript_versions.
+-- Editors can read manuscript metadata and extracted content for non-draft
+-- submissions in their org. Mirrors the existing files_org_read pattern.
+--
+-- The manuscripts policy needs manuscript_id from manuscript_versions, but
+-- querying manuscript_versions triggers its RLS (which recurses back to
+-- manuscripts). We use a SECURITY DEFINER function to break the cycle.
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION manuscript_ids_for_org(org uuid)
+RETURNS SETOF uuid
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT mv.manuscript_id
+  FROM manuscript_versions mv
+  JOIN submissions s ON s.manuscript_version_id = mv.id
+  WHERE s.organization_id = org
+  AND s.status != 'DRAFT';
+$$;
+--> statement-breakpoint
+CREATE POLICY "manuscripts_org_read" ON "manuscripts" AS PERMISSIVE FOR SELECT TO "app_user"
+USING (id IN (SELECT manuscript_ids_for_org(current_org_id())));
+--> statement-breakpoint
+CREATE POLICY "manuscript_versions_org_read" ON "manuscript_versions" AS PERMISSIVE FOR SELECT TO "app_user"
+USING (id IN (
+  SELECT s.manuscript_version_id FROM submissions s
+  WHERE s.organization_id = current_org_id()
+  AND s.manuscript_version_id IS NOT NULL
+  AND s.status != 'DRAFT'
+));

--- a/packages/db/migrations/0057_manuscript_org_read_policies.sql
+++ b/packages/db/migrations/0057_manuscript_org_read_policies.sql
@@ -20,6 +20,10 @@ AS $$
   AND s.status != 'DRAFT';
 $$;
 --> statement-breakpoint
+REVOKE ALL ON FUNCTION manuscript_ids_for_org(uuid) FROM PUBLIC;
+--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION manuscript_ids_for_org(uuid) TO app_user;
+--> statement-breakpoint
 CREATE POLICY "manuscripts_org_read" ON "manuscripts" AS PERMISSIVE FOR SELECT TO "app_user"
 USING (id IN (SELECT manuscript_ids_for_org(current_org_id())));
 --> statement-breakpoint

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1780400000000,
       "tag": "0056_content_extraction",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1780600000000,
+      "tag": "0057_manuscript_org_read_policies",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/manuscripts.ts
+++ b/packages/db/src/schema/manuscripts.ts
@@ -47,6 +47,13 @@ export const manuscripts = pgTable(
       for: "all",
       using: sql`owner_id = current_user_id()`,
     }),
+    // Org read: editors can see manuscript metadata for non-draft submissions in their org.
+    // Uses SECURITY DEFINER function to avoid infinite recursion — manuscript_versions RLS
+    // references manuscripts, so a direct subquery on manuscript_versions would recurse.
+    pgPolicy("manuscripts_org_read", {
+      for: "select",
+      using: sql`id IN (SELECT manuscript_ids_for_org(current_org_id()))`,
+    }),
   ],
 ).enableRLS();
 
@@ -89,6 +96,16 @@ export const manuscriptVersions = pgTable(
     pgPolicy("manuscript_versions_owner", {
       for: "all",
       using: sql`manuscript_id IN (SELECT id FROM manuscripts WHERE owner_id = current_user_id())`,
+    }),
+    // Org read: editors can see version content for non-draft submissions in their org
+    pgPolicy("manuscript_versions_org_read", {
+      for: "select",
+      using: sql`id IN (
+        SELECT s.manuscript_version_id FROM submissions s
+        WHERE s.organization_id = current_org_id()
+        AND s.manuscript_version_id IS NOT NULL
+        AND s.status != 'DRAFT'
+      )`,
     }),
   ],
 ).enableRLS();


### PR DESCRIPTION
## Summary

- **Org-scoped SELECT policies for manuscripts/manuscript_versions** — editors can now see extracted content and manuscript metadata for submitted (non-DRAFT) submissions in their org. Fixes a bug where the content extraction deep-read view was empty for editors because manuscripts RLS was user-scoped only.
- **Garage Docker image fix** — Garage images (`dxflrs/garage`) have always been `FROM scratch` (no shell). Added multi-stage Dockerfile (Alpine + binary copy). Fixed layout detection and POSIX compatibility in `start-garage.sh`.
- **code review finding addressed** — `REVOKE ALL ... FROM PUBLIC` + `GRANT EXECUTE ... TO app_user` on `manuscript_ids_for_org()` SECURITY DEFINER function.

## Test plan

- [x] 122 RLS integration tests pass
- [x] 37 submission router tests pass
- [x] Manual QA via Chrome DevTools MCP: deep-read mode renders extracted content with smart typography, "As submitted" toggle works
- [ ] CI passes (quality, unit, rls, build)
- [ ] Verify Garage starts cleanly on fresh `docker compose up`