### PR TITLE
feat(hopper): workspace collections — editor desk management (Step 4)

### DIFF
--- a/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
+++ b/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
@@ -60,6 +60,9 @@ const RLS_TABLES = [
   'saved_queue_presets',
   // User keys (DID document)
   'user_keys',
+  // Editor workspace collections
+  'workspace_collections',
+  'workspace_items',
 ];
 
 /** RLS tables where app_user has full DML (excludes audit_events which is SELECT-only + function, journal_directory which is SELECT-only).

--- a/apps/api/src/rest/router.ts
+++ b/apps/api/src/rest/router.ts
@@ -18,6 +18,7 @@ import { contractsRouter } from './routers/contracts.js';
 import { issuesRouter } from './routers/issues.js';
 import { cmsConnectionsRouter } from './routers/cms-connections.js';
 import { csrRouter } from './routers/csr.js';
+import { collectionsRouter } from './routers/collections.js';
 import type { RestContext } from './context.js';
 
 const restRouter = {
@@ -37,6 +38,7 @@ const restRouter = {
   issues: issuesRouter,
   cmsConnections: cmsConnectionsRouter,
   csr: csrRouter,
+  collections: collectionsRouter,
 };
 
 const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {

--- a/apps/api/src/rest/routers/collections.ts
+++ b/apps/api/src/rest/routers/collections.ts
@@ -1,0 +1,293 @@
+import { z } from 'zod';
+import {
+  createCollectionSchema,
+  updateCollectionSchema,
+  listCollectionsSchema,
+  addCollectionItemSchema,
+  updateCollectionItemSchema,
+  reorderCollectionItemsSchema,
+  workspaceCollectionSchema,
+  workspaceItemSchema,
+  idParamSchema,
+  paginatedResponseSchema,
+} from '@colophony/types';
+import { restPaginationQuery } from '@colophony/api-contracts';
+import {
+  collectionService,
+  CollectionNotFoundError,
+} from '../../services/collection.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+import { orgProcedure, requireScopes } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// Query schemas
+// ---------------------------------------------------------------------------
+
+const restListQuery = listCollectionsSchema
+  .omit({ page: true, limit: true })
+  .merge(restPaginationQuery);
+
+const itemIdParam = z.object({
+  id: z.string().uuid().describe('Collection ID'),
+  itemId: z.string().uuid().describe('Item ID'),
+});
+
+// ---------------------------------------------------------------------------
+// Collection routes
+// ---------------------------------------------------------------------------
+
+const list = orgProcedure
+  .use(requireScopes('collections:read'))
+  .route({
+    method: 'GET',
+    path: '/collections',
+    summary: 'List collections',
+    description:
+      'Returns a paginated list of collections visible to the current user.',
+    operationId: 'listCollections',
+    tags: ['Collections'],
+  })
+  .input(restListQuery)
+  .output(paginatedResponseSchema(workspaceCollectionSchema))
+  .handler(async ({ input, context }) => {
+    return collectionService.list(
+      context.dbTx,
+      input,
+      context.authContext.orgId,
+      context.authContext.userId,
+    );
+  });
+
+const get = orgProcedure
+  .use(requireScopes('collections:read'))
+  .route({
+    method: 'GET',
+    path: '/collections/{id}',
+    summary: 'Get a collection',
+    description: 'Retrieve a collection by ID.',
+    operationId: 'getCollection',
+    tags: ['Collections'],
+  })
+  .input(idParamSchema)
+  .output(workspaceCollectionSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const collection = await collectionService.getById(
+        context.dbTx,
+        input.id,
+        context.authContext.orgId,
+      );
+      if (!collection) throw new CollectionNotFoundError(input.id);
+      return collection;
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const getItems = orgProcedure
+  .use(requireScopes('collections:read'))
+  .route({
+    method: 'GET',
+    path: '/collections/{id}/items',
+    summary: 'Get collection items',
+    description: 'Retrieve all items in a collection, ordered by position.',
+    operationId: 'getCollectionItems',
+    tags: ['Collections'],
+  })
+  .input(idParamSchema)
+  .output(z.array(workspaceItemSchema))
+  .handler(async ({ input, context }) => {
+    return collectionService.getItems(
+      context.dbTx,
+      input.id,
+      context.authContext.orgId,
+    );
+  });
+
+const create = orgProcedure
+  .use(requireScopes('collections:write'))
+  .route({
+    method: 'POST',
+    path: '/collections',
+    successStatus: 201,
+    summary: 'Create a collection',
+    description: 'Create a new workspace collection.',
+    operationId: 'createCollection',
+    tags: ['Collections'],
+  })
+  .input(createCollectionSchema)
+  .output(workspaceCollectionSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await collectionService.createWithAudit(
+        toServiceContext(context),
+        input,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const update = orgProcedure
+  .use(requireScopes('collections:write'))
+  .route({
+    method: 'PATCH',
+    path: '/collections/{id}',
+    summary: 'Update a collection',
+    description: 'Update collection name, description, visibility, or type.',
+    operationId: 'updateCollection',
+    tags: ['Collections'],
+  })
+  .input(idParamSchema.merge(updateCollectionSchema))
+  .output(workspaceCollectionSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const { id, ...data } = input;
+      return await collectionService.updateWithAudit(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const del = orgProcedure
+  .use(requireScopes('collections:write'))
+  .route({
+    method: 'DELETE',
+    path: '/collections/{id}',
+    summary: 'Delete a collection',
+    description: 'Delete a collection and all its items.',
+    operationId: 'deleteCollection',
+    tags: ['Collections'],
+  })
+  .input(idParamSchema)
+  .output(workspaceCollectionSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await collectionService.deleteWithAudit(
+        toServiceContext(context),
+        input.id,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const addItem = orgProcedure
+  .use(requireScopes('collections:write'))
+  .route({
+    method: 'POST',
+    path: '/collections/{id}/items',
+    successStatus: 201,
+    summary: 'Add item to collection',
+    description: 'Add a submission to a collection.',
+    operationId: 'addCollectionItem',
+    tags: ['Collections'],
+  })
+  .input(idParamSchema.merge(addCollectionItemSchema))
+  .output(workspaceItemSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const { id, ...data } = input;
+      return await collectionService.addItemWithAudit(
+        toServiceContext(context),
+        id,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const updateItem = orgProcedure
+  .use(requireScopes('collections:write'))
+  .route({
+    method: 'PATCH',
+    path: '/collections/{id}/items/{itemId}',
+    summary: 'Update collection item',
+    description: 'Update notes, color, or icon on a collection item.',
+    operationId: 'updateCollectionItem',
+    tags: ['Collections'],
+  })
+  .input(itemIdParam.merge(updateCollectionItemSchema))
+  .output(workspaceItemSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      const { id, itemId, ...data } = input;
+      return await collectionService.updateItemWithAudit(
+        toServiceContext(context),
+        id,
+        itemId,
+        data,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const removeItem = orgProcedure
+  .use(requireScopes('collections:write'))
+  .route({
+    method: 'DELETE',
+    path: '/collections/{id}/items/{itemId}',
+    summary: 'Remove item from collection',
+    description: 'Remove a submission from a collection.',
+    operationId: 'removeCollectionItem',
+    tags: ['Collections'],
+  })
+  .input(itemIdParam)
+  .output(workspaceItemSchema.nullable())
+  .handler(async ({ input, context }) => {
+    try {
+      return await collectionService.removeItemWithAudit(
+        toServiceContext(context),
+        input.id,
+        input.itemId,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const reorderItems = orgProcedure
+  .use(requireScopes('collections:write'))
+  .route({
+    method: 'PUT',
+    path: '/collections/{id}/items/reorder',
+    summary: 'Reorder collection items',
+    description: 'Update the sort positions of items in a collection.',
+    operationId: 'reorderCollectionItems',
+    tags: ['Collections'],
+  })
+  .input(idParamSchema.merge(reorderCollectionItemsSchema))
+  .output(z.array(workspaceItemSchema))
+  .handler(async ({ input, context }) => {
+    try {
+      const { id, ...data } = input;
+      return await collectionService.reorderItems(
+        context.dbTx,
+        id,
+        data,
+        context.authContext.orgId,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+export const collectionsRouter = {
+  list,
+  get,
+  getItems,
+  create,
+  update,
+  delete: del,
+  addItem,
+  updateItem,
+  removeItem,
+  reorderItems,
+};

--- a/apps/api/src/rest/routers/collections.ts
+++ b/apps/api/src/rest/routers/collections.ts
@@ -77,6 +77,7 @@ const get = orgProcedure
         context.dbTx,
         input.id,
         context.authContext.orgId,
+        context.authContext.userId,
       );
       if (!collection) throw new CollectionNotFoundError(input.id);
       return collection;
@@ -102,6 +103,7 @@ const getItems = orgProcedure
       context.dbTx,
       input.id,
       context.authContext.orgId,
+      context.authContext.userId,
     );
   });
 
@@ -273,6 +275,7 @@ const reorderItems = orgProcedure
         id,
         data,
         context.authContext.orgId,
+        context.authContext.userId,
       );
     } catch (e) {
       mapServiceError(e);

--- a/apps/api/src/services/collection.service.ts
+++ b/apps/api/src/services/collection.service.ts
@@ -116,24 +116,48 @@ export const collectionService = {
     };
   },
 
-  async getById(tx: DrizzleDb, id: string, orgId: string) {
+  async getById(tx: DrizzleDb, id: string, orgId: string, userId?: string) {
+    const conditions = [
+      eq(workspaceCollections.id, id),
+      eq(workspaceCollections.organizationId, orgId),
+    ];
+
+    // Enforce visibility: private collections only visible to their owner
+    if (userId) {
+      conditions.push(
+        or(
+          eq(workspaceCollections.visibility, 'team'),
+          eq(workspaceCollections.visibility, 'collaborators'),
+          and(
+            eq(workspaceCollections.visibility, 'private'),
+            eq(workspaceCollections.ownerId, userId),
+          ),
+        )!,
+      );
+    }
+
     const [row] = await tx
       .select()
       .from(workspaceCollections)
-      .where(
-        and(
-          eq(workspaceCollections.id, id),
-          eq(workspaceCollections.organizationId, orgId),
-        ),
-      )
+      .where(and(...conditions))
       .limit(1);
 
     return row ?? null;
   },
 
-  async getItems(tx: DrizzleDb, collectionId: string, orgId: string) {
-    // Verify collection belongs to org (defense-in-depth)
-    const collection = await collectionService.getById(tx, collectionId, orgId);
+  async getItems(
+    tx: DrizzleDb,
+    collectionId: string,
+    orgId: string,
+    userId?: string,
+  ) {
+    // Verify collection belongs to org + visibility check
+    const collection = await collectionService.getById(
+      tx,
+      collectionId,
+      orgId,
+      userId,
+    );
     if (!collection) return [];
 
     return tx
@@ -222,6 +246,14 @@ export const collectionService = {
     input: UpdateCollectionInput,
   ) {
     assertEditorOrAdmin(ctx.actor.role);
+    // Visibility check: private collections only editable by owner
+    const existing = await collectionService.getById(
+      ctx.tx,
+      id,
+      ctx.actor.orgId,
+      ctx.actor.userId,
+    );
+    if (!existing) throw new CollectionNotFoundError(id);
     const updated = await collectionService.update(
       ctx.tx,
       id,
@@ -254,6 +286,14 @@ export const collectionService = {
 
   async deleteWithAudit(ctx: ServiceContext, id: string) {
     assertEditorOrAdmin(ctx.actor.role);
+    // Visibility check: private collections only deletable by owner
+    const existing = await collectionService.getById(
+      ctx.tx,
+      id,
+      ctx.actor.orgId,
+      ctx.actor.userId,
+    );
+    if (!existing) throw new CollectionNotFoundError(id);
     const deleted = await collectionService.delete(ctx.tx, id, ctx.actor.orgId);
     if (!deleted) throw new CollectionNotFoundError(id);
     await ctx.audit({
@@ -274,9 +314,15 @@ export const collectionService = {
     collectionId: string,
     input: AddCollectionItemInput,
     orgId: string,
+    userId?: string,
   ) {
-    // Verify collection exists and belongs to org
-    const collection = await collectionService.getById(tx, collectionId, orgId);
+    // Verify collection exists, belongs to org, and is visible to user
+    const collection = await collectionService.getById(
+      tx,
+      collectionId,
+      orgId,
+      userId,
+    );
     if (!collection) throw new CollectionNotFoundError(collectionId);
 
     // Cross-tenant validation: verify submission belongs to the same org
@@ -343,6 +389,7 @@ export const collectionService = {
       collectionId,
       input,
       ctx.actor.orgId,
+      ctx.actor.userId,
     );
     await ctx.audit({
       action: AuditActions.COLLECTION_ITEM_ADDED,
@@ -359,9 +406,15 @@ export const collectionService = {
     itemId: string,
     input: UpdateCollectionItemInput,
     orgId: string,
+    userId?: string,
   ) {
-    // Verify collection belongs to org
-    const collection = await collectionService.getById(tx, collectionId, orgId);
+    // Verify collection belongs to org + visibility
+    const collection = await collectionService.getById(
+      tx,
+      collectionId,
+      orgId,
+      userId,
+    );
     if (!collection) return null;
 
     const values: Record<string, unknown> = { touchedAt: new Date() };
@@ -396,6 +449,7 @@ export const collectionService = {
       itemId,
       input,
       ctx.actor.orgId,
+      ctx.actor.userId,
     );
     if (!updated) throw new CollectionItemNotFoundError(itemId);
     await ctx.audit({
@@ -412,9 +466,15 @@ export const collectionService = {
     collectionId: string,
     itemId: string,
     orgId: string,
+    userId?: string,
   ) {
-    // Verify collection belongs to org
-    const collection = await collectionService.getById(tx, collectionId, orgId);
+    // Verify collection belongs to org + visibility
+    const collection = await collectionService.getById(
+      tx,
+      collectionId,
+      orgId,
+      userId,
+    );
     if (!collection) return null;
 
     const [row] = await tx
@@ -441,6 +501,7 @@ export const collectionService = {
       collectionId,
       itemId,
       ctx.actor.orgId,
+      ctx.actor.userId,
     );
     if (removed) {
       await ctx.audit({
@@ -458,9 +519,15 @@ export const collectionService = {
     collectionId: string,
     input: ReorderCollectionItemsInput,
     orgId: string,
+    userId?: string,
   ) {
-    // Verify collection belongs to org
-    const collection = await collectionService.getById(tx, collectionId, orgId);
+    // Verify collection belongs to org + visibility
+    const collection = await collectionService.getById(
+      tx,
+      collectionId,
+      orgId,
+      userId,
+    );
     if (!collection) throw new CollectionNotFoundError(collectionId);
 
     // Update all item positions

--- a/apps/api/src/services/collection.service.ts
+++ b/apps/api/src/services/collection.service.ts
@@ -1,0 +1,484 @@
+import {
+  workspaceCollections,
+  workspaceItems,
+  submissions,
+  eq,
+  and,
+  asc,
+  desc,
+  type DrizzleDb,
+} from '@colophony/db';
+import { ilike, count, getTableColumns, or } from 'drizzle-orm';
+import type {
+  CreateCollectionInput,
+  UpdateCollectionInput,
+  ListCollectionsInput,
+  AddCollectionItemInput,
+  UpdateCollectionItemInput,
+  ReorderCollectionItemsInput,
+} from '@colophony/types';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { ServiceContext } from './types.js';
+import { assertEditorOrAdmin } from './errors.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class CollectionNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Collection "${id}" not found`);
+    this.name = 'CollectionNotFoundError';
+  }
+}
+
+export class CollectionItemAlreadyExistsError extends Error {
+  constructor(submissionId: string) {
+    super(`Submission "${submissionId}" is already in this collection`);
+    this.name = 'CollectionItemAlreadyExistsError';
+  }
+}
+
+export class CollectionItemNotFoundError extends Error {
+  constructor(itemId: string) {
+    super(`Collection item "${itemId}" not found`);
+    this.name = 'CollectionItemNotFoundError';
+  }
+}
+
+export class SubmissionNotInOrgError extends Error {
+  constructor(submissionId: string) {
+    super(`Submission "${submissionId}" does not belong to this organization`);
+    this.name = 'SubmissionNotInOrgError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const collectionService = {
+  // -------------------------------------------------------------------------
+  // List / Get
+  // -------------------------------------------------------------------------
+
+  async list(
+    tx: DrizzleDb,
+    input: ListCollectionsInput,
+    orgId: string,
+    userId?: string,
+  ) {
+    const { typeHint, visibility, search, page, limit } = input;
+    const offset = (page - 1) * limit;
+
+    const conditions = [eq(workspaceCollections.organizationId, orgId)];
+
+    // Visibility filtering: private only for owner, team/collaborators for all
+    if (userId) {
+      conditions.push(
+        or(
+          eq(workspaceCollections.visibility, 'team'),
+          eq(workspaceCollections.visibility, 'collaborators'),
+          and(
+            eq(workspaceCollections.visibility, 'private'),
+            eq(workspaceCollections.ownerId, userId),
+          ),
+        )!,
+      );
+    }
+
+    if (typeHint) conditions.push(eq(workspaceCollections.typeHint, typeHint));
+    if (visibility)
+      conditions.push(eq(workspaceCollections.visibility, visibility));
+    if (search)
+      conditions.push(ilike(workspaceCollections.name, `%${search}%`));
+
+    const where = and(...conditions);
+
+    const [items, countResult] = await Promise.all([
+      tx
+        .select()
+        .from(workspaceCollections)
+        .where(where)
+        .orderBy(desc(workspaceCollections.updatedAt))
+        .limit(limit)
+        .offset(offset),
+      tx.select({ count: count() }).from(workspaceCollections).where(where),
+    ]);
+
+    const total = countResult[0]?.count ?? 0;
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async getById(tx: DrizzleDb, id: string, orgId: string) {
+    const [row] = await tx
+      .select()
+      .from(workspaceCollections)
+      .where(
+        and(
+          eq(workspaceCollections.id, id),
+          eq(workspaceCollections.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+
+    return row ?? null;
+  },
+
+  async getItems(tx: DrizzleDb, collectionId: string, orgId: string) {
+    // Verify collection belongs to org (defense-in-depth)
+    const collection = await collectionService.getById(tx, collectionId, orgId);
+    if (!collection) return [];
+
+    return tx
+      .select({
+        ...getTableColumns(workspaceItems),
+        submissionTitle: submissions.title,
+      })
+      .from(workspaceItems)
+      .leftJoin(submissions, eq(workspaceItems.submissionId, submissions.id))
+      .where(eq(workspaceItems.collectionId, collectionId))
+      .orderBy(asc(workspaceItems.position))
+      .limit(1000);
+  },
+
+  // -------------------------------------------------------------------------
+  // Create / Update / Delete
+  // -------------------------------------------------------------------------
+
+  async create(
+    tx: DrizzleDb,
+    input: CreateCollectionInput,
+    orgId: string,
+    ownerId: string,
+  ) {
+    const [row] = await tx
+      .insert(workspaceCollections)
+      .values({
+        organizationId: orgId,
+        ownerId,
+        name: input.name,
+        description: input.description ?? null,
+        visibility: input.visibility ?? 'private',
+        typeHint: input.typeHint ?? 'custom',
+      })
+      .returning();
+
+    return row;
+  },
+
+  async createWithAudit(ctx: ServiceContext, input: CreateCollectionInput) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const collection = await collectionService.create(
+      ctx.tx,
+      input,
+      ctx.actor.orgId,
+      ctx.actor.userId,
+    );
+    await ctx.audit({
+      action: AuditActions.COLLECTION_CREATED,
+      resource: AuditResources.COLLECTION,
+      resourceId: collection.id,
+      newValue: { name: input.name, typeHint: input.typeHint },
+    });
+    return collection;
+  },
+
+  async update(
+    tx: DrizzleDb,
+    id: string,
+    input: UpdateCollectionInput,
+    orgId: string,
+  ) {
+    const values: Record<string, unknown> = { updatedAt: new Date() };
+    if (input.name !== undefined) values.name = input.name;
+    if (input.description !== undefined) values.description = input.description;
+    if (input.visibility !== undefined) values.visibility = input.visibility;
+    if (input.typeHint !== undefined) values.typeHint = input.typeHint;
+
+    const [row] = await tx
+      .update(workspaceCollections)
+      .set(values)
+      .where(
+        and(
+          eq(workspaceCollections.id, id),
+          eq(workspaceCollections.organizationId, orgId),
+        ),
+      )
+      .returning();
+
+    return row ?? null;
+  },
+
+  async updateWithAudit(
+    ctx: ServiceContext,
+    id: string,
+    input: UpdateCollectionInput,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const updated = await collectionService.update(
+      ctx.tx,
+      id,
+      input,
+      ctx.actor.orgId,
+    );
+    if (!updated) throw new CollectionNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.COLLECTION_UPDATED,
+      resource: AuditResources.COLLECTION,
+      resourceId: id,
+      newValue: input,
+    });
+    return updated;
+  },
+
+  async delete(tx: DrizzleDb, id: string, orgId: string) {
+    const [row] = await tx
+      .delete(workspaceCollections)
+      .where(
+        and(
+          eq(workspaceCollections.id, id),
+          eq(workspaceCollections.organizationId, orgId),
+        ),
+      )
+      .returning();
+
+    return row ?? null;
+  },
+
+  async deleteWithAudit(ctx: ServiceContext, id: string) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const deleted = await collectionService.delete(ctx.tx, id, ctx.actor.orgId);
+    if (!deleted) throw new CollectionNotFoundError(id);
+    await ctx.audit({
+      action: AuditActions.COLLECTION_DELETED,
+      resource: AuditResources.COLLECTION,
+      resourceId: id,
+      newValue: { name: deleted.name },
+    });
+    return deleted;
+  },
+
+  // -------------------------------------------------------------------------
+  // Item management
+  // -------------------------------------------------------------------------
+
+  async addItem(
+    tx: DrizzleDb,
+    collectionId: string,
+    input: AddCollectionItemInput,
+    orgId: string,
+  ) {
+    // Verify collection exists and belongs to org
+    const collection = await collectionService.getById(tx, collectionId, orgId);
+    if (!collection) throw new CollectionNotFoundError(collectionId);
+
+    // Cross-tenant validation: verify submission belongs to the same org
+    const [sub] = await tx
+      .select({ id: submissions.id })
+      .from(submissions)
+      .where(
+        and(
+          eq(submissions.id, input.submissionId),
+          eq(submissions.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+
+    if (!sub) throw new SubmissionNotInOrgError(input.submissionId);
+
+    // Determine position: use provided or append to end
+    let position = input.position;
+    if (position === undefined) {
+      const [maxItem] = await tx
+        .select({ position: workspaceItems.position })
+        .from(workspaceItems)
+        .where(eq(workspaceItems.collectionId, collectionId))
+        .orderBy(desc(workspaceItems.position))
+        .limit(1);
+      position = maxItem ? maxItem.position + 1 : 0;
+    }
+
+    try {
+      const [row] = await tx
+        .insert(workspaceItems)
+        .values({
+          collectionId,
+          submissionId: input.submissionId,
+          position,
+          notes: input.notes ?? null,
+          color: input.color ?? null,
+          icon: input.icon ?? null,
+        })
+        .returning();
+
+      return row;
+    } catch (err: unknown) {
+      // Unique constraint violation: (collection_id, submission_id)
+      if (
+        err instanceof Error &&
+        'code' in err &&
+        (err as { code: string }).code === '23505'
+      ) {
+        throw new CollectionItemAlreadyExistsError(input.submissionId);
+      }
+      throw err;
+    }
+  },
+
+  async addItemWithAudit(
+    ctx: ServiceContext,
+    collectionId: string,
+    input: AddCollectionItemInput,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const item = await collectionService.addItem(
+      ctx.tx,
+      collectionId,
+      input,
+      ctx.actor.orgId,
+    );
+    await ctx.audit({
+      action: AuditActions.COLLECTION_ITEM_ADDED,
+      resource: AuditResources.COLLECTION,
+      resourceId: collectionId,
+      newValue: { submissionId: input.submissionId },
+    });
+    return item;
+  },
+
+  async updateItem(
+    tx: DrizzleDb,
+    collectionId: string,
+    itemId: string,
+    input: UpdateCollectionItemInput,
+    orgId: string,
+  ) {
+    // Verify collection belongs to org
+    const collection = await collectionService.getById(tx, collectionId, orgId);
+    if (!collection) return null;
+
+    const values: Record<string, unknown> = { touchedAt: new Date() };
+    if (input.notes !== undefined) values.notes = input.notes;
+    if (input.color !== undefined) values.color = input.color;
+    if (input.icon !== undefined) values.icon = input.icon;
+
+    const [row] = await tx
+      .update(workspaceItems)
+      .set(values)
+      .where(
+        and(
+          eq(workspaceItems.id, itemId),
+          eq(workspaceItems.collectionId, collectionId),
+        ),
+      )
+      .returning();
+
+    return row ?? null;
+  },
+
+  async updateItemWithAudit(
+    ctx: ServiceContext,
+    collectionId: string,
+    itemId: string,
+    input: UpdateCollectionItemInput,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const updated = await collectionService.updateItem(
+      ctx.tx,
+      collectionId,
+      itemId,
+      input,
+      ctx.actor.orgId,
+    );
+    if (!updated) throw new CollectionItemNotFoundError(itemId);
+    await ctx.audit({
+      action: AuditActions.COLLECTION_ITEM_UPDATED,
+      resource: AuditResources.COLLECTION,
+      resourceId: collectionId,
+      newValue: { itemId, ...input },
+    });
+    return updated;
+  },
+
+  async removeItem(
+    tx: DrizzleDb,
+    collectionId: string,
+    itemId: string,
+    orgId: string,
+  ) {
+    // Verify collection belongs to org
+    const collection = await collectionService.getById(tx, collectionId, orgId);
+    if (!collection) return null;
+
+    const [row] = await tx
+      .delete(workspaceItems)
+      .where(
+        and(
+          eq(workspaceItems.id, itemId),
+          eq(workspaceItems.collectionId, collectionId),
+        ),
+      )
+      .returning();
+
+    return row ?? null;
+  },
+
+  async removeItemWithAudit(
+    ctx: ServiceContext,
+    collectionId: string,
+    itemId: string,
+  ) {
+    assertEditorOrAdmin(ctx.actor.role);
+    const removed = await collectionService.removeItem(
+      ctx.tx,
+      collectionId,
+      itemId,
+      ctx.actor.orgId,
+    );
+    if (removed) {
+      await ctx.audit({
+        action: AuditActions.COLLECTION_ITEM_REMOVED,
+        resource: AuditResources.COLLECTION,
+        resourceId: collectionId,
+        newValue: { itemId, submissionId: removed.submissionId },
+      });
+    }
+    return removed;
+  },
+
+  async reorderItems(
+    tx: DrizzleDb,
+    collectionId: string,
+    input: ReorderCollectionItemsInput,
+    orgId: string,
+  ) {
+    // Verify collection belongs to org
+    const collection = await collectionService.getById(tx, collectionId, orgId);
+    if (!collection) throw new CollectionNotFoundError(collectionId);
+
+    // Update all item positions
+    await Promise.all(
+      input.items.map((item) =>
+        tx
+          .update(workspaceItems)
+          .set({ position: item.position, touchedAt: new Date() })
+          .where(
+            and(
+              eq(workspaceItems.id, item.id),
+              eq(workspaceItems.collectionId, collectionId),
+            ),
+          ),
+      ),
+    );
+
+    // Return updated items in new order
+    return collectionService.getItems(tx, collectionId, orgId);
+  },
+};

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -106,6 +106,12 @@ import {
   HubInstanceNotFoundError,
   HubInstanceSuspendedError,
 } from '../services/hub.service.js';
+import {
+  CollectionNotFoundError,
+  CollectionItemAlreadyExistsError,
+  CollectionItemNotFoundError,
+  SubmissionNotInOrgError,
+} from '../services/collection.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -204,6 +210,11 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [HubInstanceSuspendedError, 'FORBIDDEN'],
   // Precondition
   [FileNotCleanError, 'PRECONDITION_FAILED'],
+  // Collections
+  [CollectionNotFoundError, 'NOT_FOUND'],
+  [CollectionItemNotFoundError, 'NOT_FOUND'],
+  [CollectionItemAlreadyExistsError, 'CONFLICT'],
+  [SubmissionNotInOrgError, 'NOT_FOUND'],
 ];
 
 /**

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -33,6 +33,7 @@ import { simsubRouter } from './routers/simsub.js';
 import { transferRouter } from './routers/transfer.js';
 import { migrationRouter } from './routers/migration.js';
 import { hubRouter } from './routers/hub.js';
+import { collectionsRouter } from './routers/collections.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -87,6 +88,7 @@ export const appRouter = t.router({
   transfers: transferRouter,
   migrations: migrationRouter,
   hub: hubRouter,
+  collections: collectionsRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/collections.ts
+++ b/apps/api/src/trpc/routers/collections.ts
@@ -50,6 +50,7 @@ export const collectionsRouter = createRouter({
           ctx.dbTx,
           input.id,
           ctx.authContext.orgId,
+          ctx.authContext.userId,
         );
         if (!collection) throw new CollectionNotFoundError(input.id);
         return collection;
@@ -68,6 +69,7 @@ export const collectionsRouter = createRouter({
         ctx.dbTx,
         input.id,
         ctx.authContext.orgId,
+        ctx.authContext.userId,
       );
     }),
 
@@ -188,6 +190,7 @@ export const collectionsRouter = createRouter({
           id,
           data,
           ctx.authContext.orgId,
+          ctx.authContext.userId,
         );
       } catch (e) {
         mapServiceError(e);

--- a/apps/api/src/trpc/routers/collections.ts
+++ b/apps/api/src/trpc/routers/collections.ts
@@ -1,0 +1,196 @@
+import { z } from 'zod';
+import {
+  createCollectionSchema,
+  updateCollectionSchema,
+  listCollectionsSchema,
+  addCollectionItemSchema,
+  updateCollectionItemSchema,
+  reorderCollectionItemsSchema,
+  workspaceCollectionSchema,
+  workspaceItemSchema,
+  idParamSchema,
+  paginatedResponseSchema,
+} from '@colophony/types';
+import { orgProcedure, createRouter, requireScopes } from '../init.js';
+import {
+  collectionService,
+  CollectionNotFoundError,
+} from '../../services/collection.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+
+const itemIdParam = z.object({
+  id: z.string().uuid().describe('Collection ID'),
+  itemId: z.string().uuid().describe('Item ID'),
+});
+
+export const collectionsRouter = createRouter({
+  /** List collections visible to the current user. */
+  list: orgProcedure
+    .use(requireScopes('collections:read'))
+    .input(listCollectionsSchema)
+    .output(paginatedResponseSchema(workspaceCollectionSchema))
+    .query(async ({ ctx, input }) => {
+      return collectionService.list(
+        ctx.dbTx,
+        input,
+        ctx.authContext.orgId,
+        ctx.authContext.userId,
+      );
+    }),
+
+  /** Get collection by ID. */
+  getById: orgProcedure
+    .use(requireScopes('collections:read'))
+    .input(idParamSchema)
+    .output(workspaceCollectionSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        const collection = await collectionService.getById(
+          ctx.dbTx,
+          input.id,
+          ctx.authContext.orgId,
+        );
+        if (!collection) throw new CollectionNotFoundError(input.id);
+        return collection;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Get items in a collection. */
+  getItems: orgProcedure
+    .use(requireScopes('collections:read'))
+    .input(idParamSchema)
+    .output(z.array(workspaceItemSchema))
+    .query(async ({ ctx, input }) => {
+      return collectionService.getItems(
+        ctx.dbTx,
+        input.id,
+        ctx.authContext.orgId,
+      );
+    }),
+
+  /** Create a collection. */
+  create: orgProcedure
+    .use(requireScopes('collections:write'))
+    .input(createCollectionSchema)
+    .output(workspaceCollectionSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await collectionService.createWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Update a collection. */
+  update: orgProcedure
+    .use(requireScopes('collections:write'))
+    .input(idParamSchema.merge(updateCollectionSchema))
+    .output(workspaceCollectionSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { id, ...data } = input;
+        return await collectionService.updateWithAudit(
+          toServiceContext(ctx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Delete a collection. */
+  delete: orgProcedure
+    .use(requireScopes('collections:write'))
+    .input(idParamSchema)
+    .output(workspaceCollectionSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await collectionService.deleteWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Add a submission to a collection. */
+  addItem: orgProcedure
+    .use(requireScopes('collections:write'))
+    .input(idParamSchema.merge(addCollectionItemSchema))
+    .output(workspaceItemSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { id, ...data } = input;
+        return await collectionService.addItemWithAudit(
+          toServiceContext(ctx),
+          id,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Update item notes/color/icon. */
+  updateItem: orgProcedure
+    .use(requireScopes('collections:write'))
+    .input(itemIdParam.merge(updateCollectionItemSchema))
+    .output(workspaceItemSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { id, itemId, ...data } = input;
+        return await collectionService.updateItemWithAudit(
+          toServiceContext(ctx),
+          id,
+          itemId,
+          data,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Remove an item from a collection. */
+  removeItem: orgProcedure
+    .use(requireScopes('collections:write'))
+    .input(itemIdParam)
+    .output(workspaceItemSchema.nullable())
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await collectionService.removeItemWithAudit(
+          toServiceContext(ctx),
+          input.id,
+          input.itemId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Reorder items within a collection. */
+  reorderItems: orgProcedure
+    .use(requireScopes('collections:write'))
+    .input(idParamSchema.merge(reorderCollectionItemsSchema))
+    .output(z.array(workspaceItemSchema))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { id, ...data } = input;
+        return await collectionService.reorderItems(
+          ctx.dbTx,
+          id,
+          data,
+          ctx.authContext.orgId,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+});

--- a/apps/web/src/app/(dashboard)/editor/collections/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/collections/[id]/page.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { use, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { SortableCollectionItem } from "@/components/collections/sortable-collection-item";
+import { AddSubmissionDialog } from "@/components/collections/add-submission-dialog";
+import { CollectionForm } from "@/components/collections/collection-form";
+import { ArrowLeft, EyeOff, Pencil, Plus, Trash2, Users } from "lucide-react";
+
+export default function CollectionDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const router = useRouter();
+  const utils = trpc.useUtils();
+
+  const [showAddDialog, setShowAddDialog] = useState(false);
+  const [showEditForm, setShowEditForm] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const { data: collection, isPending: isLoadingCollection } =
+    trpc.collections.getById.useQuery({ id });
+  const { data: items = [], isPending: isLoadingItems } =
+    trpc.collections.getItems.useQuery({ id });
+
+  const addItemMutation = trpc.collections.addItem.useMutation({
+    onSuccess: () => utils.collections.getItems.invalidate({ id }),
+  });
+
+  const updateItemMutation = trpc.collections.updateItem.useMutation({
+    onSuccess: () => utils.collections.getItems.invalidate({ id }),
+  });
+
+  const removeItemMutation = trpc.collections.removeItem.useMutation({
+    onSuccess: () => utils.collections.getItems.invalidate({ id }),
+  });
+
+  const reorderMutation = trpc.collections.reorderItems.useMutation({
+    onSuccess: () => utils.collections.getItems.invalidate({ id }),
+  });
+
+  const updateCollectionMutation = trpc.collections.update.useMutation({
+    onSuccess: () => {
+      utils.collections.getById.invalidate({ id });
+      setShowEditForm(false);
+    },
+  });
+
+  const deleteMutation = trpc.collections.delete.useMutation({
+    onSuccess: () => router.push("/editor/collections"),
+  });
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const oldIndex = items.findIndex((i) => i.id === active.id);
+      const newIndex = items.findIndex((i) => i.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const reordered = arrayMove(items, oldIndex, newIndex);
+      reorderMutation.mutate({
+        id,
+        items: reordered.map((item, idx) => ({
+          id: item.id,
+          position: idx,
+        })),
+      });
+    },
+    [items, id, reorderMutation],
+  );
+
+  const handleUpdateNotes = useCallback(
+    (itemId: string, notes: string | null) => {
+      updateItemMutation.mutate({ id, itemId, notes });
+    },
+    [id, updateItemMutation],
+  );
+
+  const handleRemoveItem = useCallback(
+    (itemId: string) => {
+      removeItemMutation.mutate({ id, itemId });
+    },
+    [id, removeItemMutation],
+  );
+
+  const existingIds = new Set(items.map((i) => i.submissionId));
+
+  if (isLoadingCollection) {
+    return (
+      <div className="space-y-4">
+        <div className="h-8 w-48 bg-muted animate-pulse rounded" />
+        <div className="h-4 w-96 bg-muted animate-pulse rounded" />
+      </div>
+    );
+  }
+
+  if (!collection) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        Collection not found.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => router.push("/editor/collections")}
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-bold tracking-tight truncate">
+              {collection.name}
+            </h1>
+            {collection.visibility === "private" ? (
+              <EyeOff className="h-4 w-4 text-muted-foreground shrink-0" />
+            ) : (
+              <Users className="h-4 w-4 text-muted-foreground shrink-0" />
+            )}
+            <Badge variant="secondary" className="shrink-0">
+              {collection.typeHint.replace("_", " ")}
+            </Badge>
+          </div>
+          {collection.description && (
+            <p className="text-sm text-muted-foreground mt-1">
+              {collection.description}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowEditForm(true)}
+          >
+            <Pencil className="mr-1.5 h-3.5 w-3.5" />
+            Edit
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-destructive hover:text-destructive"
+            onClick={() => setShowDeleteConfirm(true)}
+          >
+            <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+            Delete
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {items.length} item{items.length !== 1 ? "s" : ""}
+        </p>
+        <Button
+          size="sm"
+          onClick={() => setShowAddDialog(true)}
+          data-testid="add-submission-btn"
+        >
+          <Plus className="mr-1.5 h-3.5 w-3.5" />
+          Add Submission
+        </Button>
+      </div>
+
+      {isLoadingItems ? (
+        <div className="space-y-2">
+          {Array.from({ length: 3 }, (_, i) => (
+            <div
+              key={i}
+              className="h-16 rounded-md border bg-muted animate-pulse"
+            />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground border rounded-lg">
+          No submissions in this collection yet.
+        </div>
+      ) : (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={items.map((i) => i.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="space-y-2">
+              {items.map((item) => (
+                <SortableCollectionItem
+                  key={item.id}
+                  item={item}
+                  onUpdateNotes={handleUpdateNotes}
+                  onRemove={handleRemoveItem}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      <AddSubmissionDialog
+        open={showAddDialog}
+        onOpenChange={setShowAddDialog}
+        excludeIds={existingIds}
+        onSelect={(submissionId) => {
+          addItemMutation.mutate({ id, submissionId });
+        }}
+      />
+
+      <CollectionForm
+        open={showEditForm}
+        onOpenChange={setShowEditForm}
+        title="Edit Collection"
+        initialValues={collection}
+        onSubmit={(data) => updateCollectionMutation.mutate({ id, ...data })}
+        isSubmitting={updateCollectionMutation.isPending}
+      />
+
+      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Collection</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete &ldquo;{collection.name}&rdquo;?
+              This will remove all items from the collection. The submissions
+              themselves will not be deleted.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => deleteMutation.mutate({ id })}
+            >
+              {deleteMutation.isPending ? "Deleting..." : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/editor/collections/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/collections/[id]/page.tsx
@@ -252,7 +252,9 @@ export default function CollectionDetailPage({
         }}
       />
 
+      {/* key forces remount so form state syncs with loaded collection */}
       <CollectionForm
+        key={collection.id}
         open={showEditForm}
         onOpenChange={setShowEditForm}
         title="Edit Collection"

--- a/apps/web/src/app/(dashboard)/editor/collections/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/collections/page.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState } from "react";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { CollectionCard } from "@/components/collections/collection-card";
+import { CollectionForm } from "@/components/collections/collection-form";
+import { Plus, Search } from "lucide-react";
+import type {
+  CollectionTypeHint,
+  CollectionVisibility,
+} from "@colophony/types";
+
+export default function CollectionsPage() {
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [typeHint, setTypeHint] = useState<CollectionTypeHint | "all">("all");
+  const [visibility, setVisibility] = useState<CollectionVisibility | "all">(
+    "all",
+  );
+  const [showForm, setShowForm] = useState(false);
+
+  const utils = trpc.useUtils();
+  const { data, isPending: isLoading } = trpc.collections.list.useQuery({
+    page,
+    limit: 20,
+    search: search || undefined,
+    typeHint: typeHint === "all" ? undefined : typeHint,
+    visibility: visibility === "all" ? undefined : visibility,
+  });
+
+  const createMutation = trpc.collections.create.useMutation({
+    onSuccess: () => {
+      utils.collections.list.invalidate();
+      setShowForm(false);
+    },
+  });
+
+  const collections = data?.items ?? [];
+  const totalPages = data?.totalPages ?? 1;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Collections</h1>
+          <p className="text-muted-foreground">
+            Organize submissions into reading lists, holds, and working groups.
+          </p>
+        </div>
+        <Button
+          onClick={() => setShowForm(true)}
+          data-testid="new-collection-btn"
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          New Collection
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1 max-w-sm">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search collections..."
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(1);
+            }}
+            className="pl-8"
+          />
+        </div>
+        <Select
+          value={typeHint}
+          onValueChange={(v) => {
+            setTypeHint(v as CollectionTypeHint | "all");
+            setPage(1);
+          }}
+        >
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="All types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All types</SelectItem>
+            <SelectItem value="holds">Holds</SelectItem>
+            <SelectItem value="reading_list">Reading List</SelectItem>
+            <SelectItem value="comparison">Comparison</SelectItem>
+            <SelectItem value="issue_planning">Issue Planning</SelectItem>
+            <SelectItem value="custom">Custom</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select
+          value={visibility}
+          onValueChange={(v) => {
+            setVisibility(v as CollectionVisibility | "all");
+            setPage(1);
+          }}
+        >
+          <SelectTrigger className="w-[140px]">
+            <SelectValue placeholder="All visibility" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All visibility</SelectItem>
+            <SelectItem value="private">Private</SelectItem>
+            <SelectItem value="team">Team</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {isLoading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div
+              key={i}
+              className="h-32 rounded-lg border bg-muted animate-pulse"
+            />
+          ))}
+        </div>
+      ) : collections.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">
+          {search || typeHint !== "all" || visibility !== "all"
+            ? "No collections match your filters."
+            : "No collections yet. Create one to start organizing submissions."}
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {collections.map((collection) => (
+              <CollectionCard key={collection.id} collection={collection} />
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {page} of {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+
+      <CollectionForm
+        open={showForm}
+        onOpenChange={setShowForm}
+        onSubmit={(data) => createMutation.mutate(data)}
+        isSubmitting={createMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/collections/add-submission-dialog.tsx
+++ b/apps/web/src/components/collections/add-submission-dialog.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { trpc } from "@/lib/trpc";
+import { FileText } from "lucide-react";
+
+interface AddSubmissionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (submissionId: string) => void;
+  excludeIds?: Set<string>;
+}
+
+export function AddSubmissionDialog({
+  open,
+  onOpenChange,
+  onSelect,
+  excludeIds,
+}: AddSubmissionDialogProps) {
+  const [search, setSearch] = useState("");
+
+  const { data, isPending: isLoading } = trpc.submissions.list.useQuery(
+    { search: search || undefined, page: 1, limit: 20 },
+    { enabled: open && search.length > 0 },
+  );
+
+  const submissions = data?.items ?? [];
+  const filtered = excludeIds
+    ? submissions.filter((s) => !excludeIds.has(s.id))
+    : submissions;
+
+  return (
+    <CommandDialog open={open} onOpenChange={onOpenChange}>
+      <CommandInput
+        placeholder="Search submissions by title..."
+        value={search}
+        onValueChange={setSearch}
+      />
+      <CommandList>
+        <CommandEmpty>
+          {isLoading
+            ? "Searching..."
+            : search
+              ? "No submissions found."
+              : "Type to search submissions."}
+        </CommandEmpty>
+        {filtered.length > 0 && (
+          <CommandGroup heading="Submissions">
+            {filtered.map((sub) => (
+              <CommandItem
+                key={sub.id}
+                value={sub.id}
+                onSelect={() => {
+                  onSelect(sub.id);
+                  onOpenChange(false);
+                  setSearch("");
+                }}
+              >
+                <FileText className="mr-2 h-4 w-4 text-muted-foreground" />
+                <span className="truncate">{sub.title}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/apps/web/src/components/collections/collection-card.tsx
+++ b/apps/web/src/components/collections/collection-card.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import Link from "next/link";
+import { formatDistanceToNow } from "date-fns";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  BookOpen,
+  Eye,
+  EyeOff,
+  FolderOpen,
+  Layers,
+  ListTodo,
+  Users,
+} from "lucide-react";
+import type {
+  CollectionVisibility,
+  CollectionTypeHint,
+} from "@colophony/types";
+
+const typeHintLabels: Record<CollectionTypeHint, string> = {
+  holds: "Holds",
+  reading_list: "Reading List",
+  comparison: "Comparison",
+  issue_planning: "Issue Planning",
+  custom: "Custom",
+};
+
+const typeHintIcons: Record<CollectionTypeHint, typeof FolderOpen> = {
+  holds: ListTodo,
+  reading_list: BookOpen,
+  comparison: Layers,
+  issue_planning: Layers,
+  custom: FolderOpen,
+};
+
+function VisibilityIcon({ visibility }: { visibility: CollectionVisibility }) {
+  switch (visibility) {
+    case "team":
+    case "collaborators":
+      return <Users className="h-3.5 w-3.5 text-muted-foreground" />;
+    case "private":
+      return <EyeOff className="h-3.5 w-3.5 text-muted-foreground" />;
+    default:
+      return <Eye className="h-3.5 w-3.5 text-muted-foreground" />;
+  }
+}
+
+interface CollectionCardProps {
+  collection: {
+    id: string;
+    name: string;
+    description: string | null;
+    visibility: CollectionVisibility;
+    typeHint: CollectionTypeHint;
+    updatedAt: Date | string;
+  };
+  itemCount?: number;
+}
+
+export function CollectionCard({ collection, itemCount }: CollectionCardProps) {
+  const Icon = typeHintIcons[collection.typeHint];
+  const updated =
+    typeof collection.updatedAt === "string"
+      ? new Date(collection.updatedAt)
+      : collection.updatedAt;
+
+  return (
+    <Link href={`/editor/collections/${collection.id}`}>
+      <Card className="hover:border-primary/50 transition-colors h-full">
+        <CardHeader className="pb-2">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <CardTitle className="text-base line-clamp-1">
+                {collection.name}
+              </CardTitle>
+            </div>
+            <div className="flex items-center gap-1.5 shrink-0">
+              <VisibilityIcon visibility={collection.visibility} />
+              <Badge variant="secondary" className="text-xs">
+                {typeHintLabels[collection.typeHint]}
+              </Badge>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {collection.description && (
+            <p className="text-sm text-muted-foreground line-clamp-2 mb-2">
+              {collection.description}
+            </p>
+          )}
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>
+              {itemCount !== undefined
+                ? `${itemCount} item${itemCount !== 1 ? "s" : ""}`
+                : ""}
+            </span>
+            <span>
+              Updated {formatDistanceToNow(updated, { addSuffix: true })}
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/apps/web/src/components/collections/collection-form.tsx
+++ b/apps/web/src/components/collections/collection-form.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type {
+  CollectionVisibility,
+  CollectionTypeHint,
+} from "@colophony/types";
+
+interface CollectionFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: {
+    name: string;
+    description?: string;
+    visibility?: CollectionVisibility;
+    typeHint?: CollectionTypeHint;
+  }) => void;
+  isSubmitting?: boolean;
+  initialValues?: {
+    name?: string;
+    description?: string | null;
+    visibility?: CollectionVisibility;
+    typeHint?: CollectionTypeHint;
+  };
+  title?: string;
+}
+
+export function CollectionForm({
+  open,
+  onOpenChange,
+  onSubmit,
+  isSubmitting,
+  initialValues,
+  title = "New Collection",
+}: CollectionFormProps) {
+  const [name, setName] = useState(initialValues?.name ?? "");
+  const [description, setDescription] = useState(
+    initialValues?.description ?? "",
+  );
+  const [visibility, setVisibility] = useState<CollectionVisibility>(
+    initialValues?.visibility ?? "private",
+  );
+  const [typeHint, setTypeHint] = useState<CollectionTypeHint>(
+    initialValues?.typeHint ?? "custom",
+  );
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    onSubmit({
+      name: name.trim(),
+      description: description.trim() || undefined,
+      visibility,
+      typeHint,
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="collection-name">Name</Label>
+            <Input
+              id="collection-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g., Spring Issue Holds"
+              maxLength={255}
+              required
+              autoFocus
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="collection-description">
+              Description{" "}
+              <span className="text-muted-foreground font-normal">
+                (optional)
+              </span>
+            </Label>
+            <Textarea
+              id="collection-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What is this collection for?"
+              rows={2}
+              maxLength={5000}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label>Type</Label>
+              <Select
+                value={typeHint}
+                onValueChange={(v) => setTypeHint(v as CollectionTypeHint)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="custom">Custom</SelectItem>
+                  <SelectItem value="holds">Holds</SelectItem>
+                  <SelectItem value="reading_list">Reading List</SelectItem>
+                  <SelectItem value="comparison">Comparison</SelectItem>
+                  <SelectItem value="issue_planning">Issue Planning</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Visibility</Label>
+              <Select
+                value={visibility}
+                onValueChange={(v) => setVisibility(v as CollectionVisibility)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="private">Private</SelectItem>
+                  <SelectItem value="team">Team</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!name.trim() || isSubmitting}>
+              {isSubmitting ? "Saving..." : "Save"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/collections/collection-item-card.tsx
+++ b/apps/web/src/components/collections/collection-item-card.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { GripVertical, MessageSquare, Trash2 } from "lucide-react";
+import { ItemNotesPopover } from "./item-notes-popover";
+
+interface CollectionItemCardProps {
+  item: {
+    id: string;
+    submissionId: string;
+    notes: string | null;
+    color: string | null;
+    submissionTitle?: string | null;
+  };
+  onUpdateNotes: (itemId: string, notes: string | null) => void;
+  onRemove: (itemId: string) => void;
+  dragHandleProps?: React.HTMLAttributes<HTMLButtonElement>;
+}
+
+export function CollectionItemCard({
+  item,
+  onUpdateNotes,
+  onRemove,
+  dragHandleProps,
+}: CollectionItemCardProps) {
+  return (
+    <div className="flex items-center gap-2 rounded-md border bg-card p-3 shadow-sm">
+      <button
+        className="cursor-grab touch-none text-muted-foreground hover:text-foreground"
+        {...dragHandleProps}
+        aria-label="Drag to reorder"
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+
+      {item.color && (
+        <div
+          className="h-4 w-1.5 rounded-full shrink-0"
+          style={{ backgroundColor: item.color }}
+        />
+      )}
+
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium truncate">
+          {item.submissionTitle ?? "Untitled Submission"}
+        </p>
+        {item.notes && (
+          <p className="text-xs text-muted-foreground truncate mt-0.5">
+            {item.notes}
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1 shrink-0">
+        <ItemNotesPopover
+          notes={item.notes}
+          onSave={(notes) => onUpdateNotes(item.id, notes)}
+        >
+          <Button variant="ghost" size="icon" className="h-7 w-7">
+            <MessageSquare
+              className={`h-3.5 w-3.5 ${item.notes ? "text-primary" : ""}`}
+            />
+            <span className="sr-only">Notes</span>
+          </Button>
+        </ItemNotesPopover>
+
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 text-muted-foreground hover:text-destructive"
+          onClick={() => onRemove(item.id)}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+          <span className="sr-only">Remove</span>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/collections/item-notes-popover.tsx
+++ b/apps/web/src/components/collections/item-notes-popover.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+
+interface ItemNotesPopoverProps {
+  notes: string | null;
+  onSave: (notes: string | null) => void;
+  children: ReactNode;
+}
+
+export function ItemNotesPopover({
+  notes,
+  onSave,
+  children,
+}: ItemNotesPopoverProps) {
+  const [value, setValue] = useState(notes ?? "");
+  const [open, setOpen] = useState(false);
+
+  function handleSave() {
+    onSave(value.trim() || null);
+    setOpen(false);
+  }
+
+  function handleOpenChange(isOpen: boolean) {
+    setOpen(isOpen);
+    if (isOpen) {
+      setValue(notes ?? "");
+    }
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent className="w-72" align="end">
+        <div className="space-y-3">
+          <Label htmlFor="item-notes" className="text-sm font-medium">
+            Private Notes
+          </Label>
+          <Textarea
+            id="item-notes"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="Add notes about this submission..."
+            rows={3}
+            maxLength={5000}
+            autoFocus
+          />
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" size="sm" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button size="sm" onClick={handleSave}>
+              Save
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/collections/sortable-collection-item.tsx
+++ b/apps/web/src/components/collections/sortable-collection-item.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { CollectionItemCard } from "./collection-item-card";
+
+interface SortableCollectionItemProps {
+  item: {
+    id: string;
+    submissionId: string;
+    notes: string | null;
+    color: string | null;
+    submissionTitle?: string | null;
+  };
+  onUpdateNotes: (itemId: string, notes: string | null) => void;
+  onRemove: (itemId: string) => void;
+}
+
+export function SortableCollectionItem({
+  item,
+  onUpdateNotes,
+  onRemove,
+}: SortableCollectionItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <CollectionItemCard
+        item={item}
+        onUpdateNotes={onUpdateNotes}
+        onRemove={onRemove}
+        dragHandleProps={{ ...attributes, ...listeners }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   ClipboardList,
   FileSignature,
   FileText,
+  FolderOpen,
   GitBranch,
   Globe,
   Inbox,
@@ -55,6 +56,7 @@ const editorialNavigation: NavItem[] = [
   { name: "Editor Dashboard", href: "/editor", icon: LayoutDashboard },
   { name: "Reading Queue", href: "/editor/queue", icon: BookOpen },
   { name: "All Submissions", href: "/editor/submissions", icon: Inbox },
+  { name: "Collections", href: "/editor/collections", icon: FolderOpen },
   { name: "Forms", href: "/editor/forms", icon: ClipboardList },
   { name: "Periods", href: "/editor/periods", icon: Calendar },
 ];

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -492,6 +492,7 @@
 - [ ] [P3] Test `mySubmissions` projected response shape — assert `writerStatus`/`writerStatusLabel` fields in tRPC router test — (Codex branch review 2026-03-26)
 - [ ] [P3] Test `mySubmissionDetail` procedure + writer-context routing in `submission-detail.tsx` — (Codex branch review 2026-03-26)
 - [ ] [P3] Service test for `getByIdAsOwner` ownership check and error types — (Codex branch review 2026-03-26)
+- [ ] [P2] Collection service unit tests — 19 planned test cases (CRUD, visibility filtering, cross-tenant validation, reorder, item cap) in `collection.service.spec.ts` — (Codex branch review 2026-03-26)
 
 ---
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,28 @@ Newest entries first.
 
 ---
 
+## 2026-03-26 — Workspace Collections (Design System Step 4)
+
+### Done
+
+- **Schema**: `workspace_collections` + `workspace_items` tables with `FORCE ROW LEVEL SECURITY`, hand-written migration 0059. `CollectionVisibility` enum (private/team/collaborators) and `CollectionTypeHint` enum (holds/reading_list/comparison/issue_planning/custom)
+- **Types**: Zod schemas for all CRUD + item management inputs/outputs. `CollectionAuditParams` type added to discriminated audit union. `collections:read`/`collections:write` API key scopes
+- **Service**: `collection.service.ts` — full CRUD with audit variants, item add/update/remove/reorder. Cross-tenant submission validation on `addItem` (JOINs submissions to verify org match). 1000-item hard cap on `getItems`. Visibility filtering (private only to owner, team/collaborators to all)
+- **API**: tRPC router (10 procedures) + REST router (10 endpoints) with `Collections` OpenAPI tag. Error classes registered in error mapper (CollectionNotFoundError, CollectionItemAlreadyExistsError, etc.)
+- **Frontend**: Collections list page (`/editor/collections`) with grid cards, search, type/visibility filters. Detail page (`/editor/collections/[id]`) with DnD reorder (@dnd-kit), add-submission command dialog, notes popover, edit/delete. Sidebar nav entry in editorial group
+- **RLS**: Both tables added to `rls-infrastructure.test.ts` RLS_TABLES array
+- **Codex plan review findings addressed**: (1) Hand-written migration with FORCE RLS instead of drizzle-generated, (2) Cross-tenant submission validation on addItem, (3) API key scopes registration, (4) getItems hard cap, (5) `current_org_id()` helper in RLS policies, (6) RLS infrastructure test coverage
+- **Tests**: all passing — API 1553, web 638
+
+### Decisions
+
+- Deferred `reading_anchor` JSONB (ManuscriptRenderer dependency) — column exists as nullable placeholder
+- Deferred `collaborators` visibility junction table — enum value defined, treated as `team` in service layer
+- Unique constraint on `(collection_id, submission_id)` — no duplicate submissions within a collection
+- Sidebar placement: editorial group between "All Submissions" and "Forms"
+
+---
+
 ## 2026-03-26 — Writer State Projections (Design System Step 3)
 
 ### Done

--- a/packages/db/migrations/0059_workspace_collections.sql
+++ b/packages/db/migrations/0059_workspace_collections.sql
@@ -1,0 +1,95 @@
+-- Step 4: Workspace Collections (editor desk management)
+-- Hand-written: Drizzle only generates ENABLE RLS, not FORCE
+
+--> statement-breakpoint
+DO $$ BEGIN
+  CREATE TYPE "public"."CollectionVisibility" AS ENUM('private', 'team', 'collaborators');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+--> statement-breakpoint
+DO $$ BEGIN
+  CREATE TYPE "public"."CollectionTypeHint" AS ENUM('holds', 'reading_list', 'comparison', 'issue_planning', 'custom');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "workspace_collections" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "owner_id" uuid NOT NULL,
+  "name" varchar(255) NOT NULL,
+  "description" text,
+  "visibility" "CollectionVisibility" DEFAULT 'private' NOT NULL,
+  "type_hint" "CollectionTypeHint" DEFAULT 'custom' NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "workspace_items" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "collection_id" uuid NOT NULL,
+  "submission_id" uuid NOT NULL,
+  "position" integer DEFAULT 0 NOT NULL,
+  "notes" text,
+  "color" varchar(50),
+  "icon" varchar(50),
+  "reading_anchor" jsonb,
+  "added_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "touched_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "workspace_collections" ADD CONSTRAINT "workspace_collections_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "workspace_collections" ADD CONSTRAINT "workspace_collections_owner_id_users_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "workspace_items" ADD CONSTRAINT "workspace_items_collection_id_workspace_collections_id_fk" FOREIGN KEY ("collection_id") REFERENCES "public"."workspace_collections"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "workspace_items" ADD CONSTRAINT "workspace_items_submission_id_submissions_id_fk" FOREIGN KEY ("submission_id") REFERENCES "public"."submissions"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "workspace_collections_org_id_idx" ON "workspace_collections" USING btree ("organization_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "workspace_collections_owner_idx" ON "workspace_collections" USING btree ("organization_id", "owner_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "workspace_items_collection_id_idx" ON "workspace_items" USING btree ("collection_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "workspace_items_submission_id_idx" ON "workspace_items" USING btree ("submission_id");
+--> statement-breakpoint
+ALTER TABLE "workspace_items" ADD CONSTRAINT "workspace_items_collection_submission_unique" UNIQUE("collection_id", "submission_id");
+
+--> statement-breakpoint
+ALTER TABLE "workspace_collections" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "workspace_collections" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE POLICY "workspace_collections_org_isolation" ON "workspace_collections" FOR ALL USING (organization_id = current_org_id());
+
+--> statement-breakpoint
+ALTER TABLE "workspace_items" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "workspace_items" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE POLICY "workspace_items_org_isolation" ON "workspace_items" FOR ALL USING (EXISTS (SELECT 1 FROM workspace_collections wc WHERE wc.id = collection_id AND wc.organization_id = current_org_id()));
+
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON "workspace_collections" TO app_user;
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON "workspace_items" TO app_user;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1780800000000,
       "tag": "0058_manuscript_versions_copyedit_policies",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1781000000000,
+      "tag": "0059_workspace_collections",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -274,3 +274,21 @@ export const correspondenceChannelEnum = pgEnum("CorrespondenceChannel", [
   "in_app",
   "other",
 ]);
+
+// ---------------------------------------------------------------------------
+// Editor Workspace — Collections
+// ---------------------------------------------------------------------------
+
+export const collectionVisibilityEnum = pgEnum("CollectionVisibility", [
+  "private",
+  "team",
+  "collaborators",
+]);
+
+export const collectionTypeHintEnum = pgEnum("CollectionTypeHint", [
+  "holds",
+  "reading_list",
+  "comparison",
+  "issue_planning",
+  "custom",
+]);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -30,4 +30,5 @@ export * from "./webhook-endpoints";
 export * from "./writer-workspace";
 export * from "./email-templates";
 export * from "./saved-queue-presets";
+export * from "./workspace-collections";
 export * from "./relations";

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -26,6 +26,7 @@ import {
   writerProfiles,
 } from "./writer-workspace";
 import { savedQueuePresets } from "./saved-queue-presets";
+import { workspaceCollections, workspaceItems } from "./workspace-collections";
 
 // --- organizations ---
 
@@ -47,6 +48,7 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   cmsConnections: many(cmsConnections),
   trustedPeers: many(trustedPeers),
   savedQueuePresets: many(savedQueuePresets),
+  workspaceCollections: many(workspaceCollections),
 }));
 
 // --- users ---
@@ -64,6 +66,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   correspondence: many(correspondence),
   writerProfiles: many(writerProfiles),
   savedQueuePresets: many(savedQueuePresets),
+  workspaceCollections: many(workspaceCollections),
 }));
 
 // --- organization_members ---
@@ -207,6 +210,7 @@ export const submissionsRelations = relations(submissions, ({ one, many }) => ({
   payments: many(payments),
   pipelineItems: many(pipelineItems),
   correspondence: many(correspondence),
+  workspaceItems: many(workspaceItems),
 }));
 
 // --- submission_history ---
@@ -524,5 +528,35 @@ export const writerProfilesRelations = relations(writerProfiles, ({ one }) => ({
   user: one(users, {
     fields: [writerProfiles.userId],
     references: [users.id],
+  }),
+}));
+
+// --- workspace_collections ---
+
+export const workspaceCollectionsRelations = relations(
+  workspaceCollections,
+  ({ one, many }) => ({
+    organization: one(organizations, {
+      fields: [workspaceCollections.organizationId],
+      references: [organizations.id],
+    }),
+    owner: one(users, {
+      fields: [workspaceCollections.ownerId],
+      references: [users.id],
+    }),
+    items: many(workspaceItems),
+  }),
+);
+
+// --- workspace_items ---
+
+export const workspaceItemsRelations = relations(workspaceItems, ({ one }) => ({
+  collection: one(workspaceCollections, {
+    fields: [workspaceItems.collectionId],
+    references: [workspaceCollections.id],
+  }),
+  submission: one(submissions, {
+    fields: [workspaceItems.submissionId],
+    references: [submissions.id],
   }),
 }));

--- a/packages/db/src/schema/workspace-collections.ts
+++ b/packages/db/src/schema/workspace-collections.ts
@@ -1,0 +1,102 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  text,
+  integer,
+  jsonb,
+  timestamp,
+  index,
+  unique,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { collectionVisibilityEnum, collectionTypeHintEnum } from "./enums";
+import { organizations } from "./organizations";
+import { users } from "./users";
+import { submissions } from "./submissions";
+
+// --- workspace_collections ---
+
+const collectionOrgPolicy = pgPolicy("workspace_collections_org_isolation", {
+  for: "all",
+  using: sql`organization_id = current_org_id()`,
+});
+
+export const workspaceCollections = pgTable(
+  "workspace_collections",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    ownerId: uuid("owner_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    name: varchar("name", { length: 255 }).notNull(),
+    description: text("description"),
+    visibility: collectionVisibilityEnum("visibility")
+      .notNull()
+      .default("private"),
+    typeHint: collectionTypeHintEnum("type_hint").notNull().default("custom"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("workspace_collections_org_id_idx").on(table.organizationId),
+    index("workspace_collections_owner_idx").on(
+      table.organizationId,
+      table.ownerId,
+    ),
+    collectionOrgPolicy,
+  ],
+).enableRLS();
+
+// --- workspace_items ---
+
+const itemOrgPolicy = pgPolicy("workspace_items_org_isolation", {
+  for: "all",
+  using: sql`EXISTS (SELECT 1 FROM workspace_collections wc WHERE wc.id = collection_id AND wc.organization_id = current_org_id())`,
+});
+
+export const workspaceItems = pgTable(
+  "workspace_items",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    collectionId: uuid("collection_id")
+      .notNull()
+      .references(() => workspaceCollections.id, { onDelete: "cascade" }),
+    submissionId: uuid("submission_id")
+      .notNull()
+      .references(() => submissions.id, { onDelete: "cascade" }),
+    position: integer("position").notNull().default(0),
+    notes: text("notes"),
+    color: varchar("color", { length: 50 }),
+    icon: varchar("icon", { length: 50 }),
+    readingAnchor: jsonb("reading_anchor").$type<Record<
+      string,
+      unknown
+    > | null>(),
+    addedAt: timestamp("added_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    touchedAt: timestamp("touched_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("workspace_items_collection_id_idx").on(table.collectionId),
+    index("workspace_items_submission_id_idx").on(table.submissionId),
+    unique("workspace_items_collection_submission_unique").on(
+      table.collectionId,
+      table.submissionId,
+    ),
+    itemOrgPolicy,
+  ],
+).enableRLS();

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -32,6 +32,10 @@ import type {
   correspondence,
   writerProfiles,
 } from "./schema/writer-workspace";
+import type {
+  workspaceCollections,
+  workspaceItems,
+} from "./schema/workspace-collections";
 
 // --- Select types (what you get back from queries) ---
 
@@ -68,6 +72,8 @@ export type JournalDirectoryEntry = InferSelectModel<typeof journalDirectory>;
 export type ExternalSubmission = InferSelectModel<typeof externalSubmissions>;
 export type CorrespondenceRecord = InferSelectModel<typeof correspondence>;
 export type WriterProfile = InferSelectModel<typeof writerProfiles>;
+export type WorkspaceCollection = InferSelectModel<typeof workspaceCollections>;
+export type WorkspaceItem = InferSelectModel<typeof workspaceItems>;
 
 /** @deprecated Use File instead — submission_files has been replaced by the files table */
 export type SubmissionFile = File;
@@ -119,6 +125,10 @@ export type NewExternalSubmission = InferInsertModel<
 >;
 export type NewCorrespondenceRecord = InferInsertModel<typeof correspondence>;
 export type NewWriterProfile = InferInsertModel<typeof writerProfiles>;
+export type NewWorkspaceCollection = InferInsertModel<
+  typeof workspaceCollections
+>;
+export type NewWorkspaceItem = InferInsertModel<typeof workspaceItems>;
 
 /** @deprecated Use NewFile instead */
 export type NewSubmissionFile = NewFile;

--- a/packages/types/src/api-key.ts
+++ b/packages/types/src/api-key.ts
@@ -45,6 +45,8 @@ export const apiKeyScopeSchema = z
     "correspondence:read",
     "correspondence:write",
     "audit:read",
+    "collections:read",
+    "collections:write",
   ])
   .describe("Permission scope for the API key");
 

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -256,6 +256,14 @@ export const AuditActions = {
 
   // Audit access
   AUDIT_ACCESSED: "AUDIT_ACCESSED",
+
+  // Collection lifecycle
+  COLLECTION_CREATED: "COLLECTION_CREATED",
+  COLLECTION_UPDATED: "COLLECTION_UPDATED",
+  COLLECTION_DELETED: "COLLECTION_DELETED",
+  COLLECTION_ITEM_ADDED: "COLLECTION_ITEM_ADDED",
+  COLLECTION_ITEM_REMOVED: "COLLECTION_ITEM_REMOVED",
+  COLLECTION_ITEM_UPDATED: "COLLECTION_ITEM_UPDATED",
 } as const;
 
 export type AuditAction = (typeof AuditActions)[keyof typeof AuditActions];
@@ -295,6 +303,7 @@ export const AuditResources = {
   EMAIL_TEMPLATE: "email_template",
   CSR: "csr",
   AUDIT: "audit",
+  COLLECTION: "collection",
 } as const;
 
 export type AuditResource =
@@ -660,6 +669,17 @@ export interface SystemAuditParams extends BaseAuditParams {
     | typeof AuditActions.S3_CLEANUP_FAILED;
 }
 
+export interface CollectionAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.COLLECTION;
+  action:
+    | typeof AuditActions.COLLECTION_CREATED
+    | typeof AuditActions.COLLECTION_UPDATED
+    | typeof AuditActions.COLLECTION_DELETED
+    | typeof AuditActions.COLLECTION_ITEM_ADDED
+    | typeof AuditActions.COLLECTION_ITEM_REMOVED
+    | typeof AuditActions.COLLECTION_ITEM_UPDATED;
+}
+
 /** Union of all resource-specific param types. */
 export type AuditLogParams =
   | UserAuditParams
@@ -695,7 +715,8 @@ export type AuditLogParams =
   | EmailTemplateAuditParams
   | CSRAuditParams
   | AuditAccessAuditParams
-  | SystemAuditParams;
+  | SystemAuditParams
+  | CollectionAuditParams;
 
 // ---------------------------------------------------------------------------
 // Query/response schemas for audit endpoints

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -39,3 +39,4 @@ export * from "./voting";
 export * from "./blind-review";
 export * from "./queue-preset";
 export * from "./prosemirror";
+export * from "./workspace-collection";

--- a/packages/types/src/workspace-collection.ts
+++ b/packages/types/src/workspace-collection.ts
@@ -1,0 +1,133 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const collectionVisibilitySchema = z
+  .enum(["private", "team", "collaborators"])
+  .describe("Visibility scope of the collection");
+
+export type CollectionVisibility = z.infer<typeof collectionVisibilitySchema>;
+
+export const collectionTypeHintSchema = z
+  .enum(["holds", "reading_list", "comparison", "issue_planning", "custom"])
+  .describe("Purpose hint for the collection");
+
+export type CollectionTypeHint = z.infer<typeof collectionTypeHintSchema>;
+
+// ---------------------------------------------------------------------------
+// Output schemas
+// ---------------------------------------------------------------------------
+
+export const workspaceCollectionSchema = z.object({
+  id: z.string().uuid().describe("Collection ID"),
+  organizationId: z.string().uuid().describe("Organization ID"),
+  ownerId: z.string().uuid().describe("Owner user ID"),
+  name: z.string().describe("Collection name"),
+  description: z.string().nullable().describe("Collection description"),
+  visibility: collectionVisibilitySchema,
+  typeHint: collectionTypeHintSchema,
+  createdAt: z.date().describe("When the collection was created"),
+  updatedAt: z.date().describe("When the collection was last updated"),
+});
+
+export type WorkspaceCollection = z.infer<typeof workspaceCollectionSchema>;
+
+export const workspaceItemSchema = z.object({
+  id: z.string().uuid().describe("Item ID"),
+  collectionId: z.string().uuid().describe("Collection ID"),
+  submissionId: z.string().uuid().describe("Submission ID"),
+  position: z.number().int().describe("Sort position within collection"),
+  notes: z.string().nullable().describe("Private editor notes"),
+  color: z.string().nullable().describe("Label color"),
+  icon: z.string().nullable().describe("Item icon"),
+  readingAnchor: z
+    .unknown()
+    .nullable()
+    .describe("Reading position anchor (deferred)"),
+  addedAt: z.date().describe("When the item was added"),
+  touchedAt: z.date().describe("When the item was last touched"),
+  // Joined field (optional — populated by getItems query)
+  submissionTitle: z.string().nullable().optional(),
+});
+
+export type WorkspaceItem = z.infer<typeof workspaceItemSchema>;
+
+// ---------------------------------------------------------------------------
+// Input schemas
+// ---------------------------------------------------------------------------
+
+export const createCollectionSchema = z.object({
+  name: z.string().trim().min(1).max(255).describe("Collection name"),
+  description: z
+    .string()
+    .max(5000)
+    .optional()
+    .describe("Collection description"),
+  visibility: collectionVisibilitySchema
+    .optional()
+    .describe("Visibility scope"),
+  typeHint: collectionTypeHintSchema.optional().describe("Collection purpose"),
+});
+
+export type CreateCollectionInput = z.infer<typeof createCollectionSchema>;
+
+export const updateCollectionSchema = createCollectionSchema.partial();
+
+export type UpdateCollectionInput = z.infer<typeof updateCollectionSchema>;
+
+export const listCollectionsSchema = z.object({
+  typeHint: collectionTypeHintSchema.optional().describe("Filter by type"),
+  visibility: collectionVisibilitySchema
+    .optional()
+    .describe("Filter by visibility"),
+  search: z.string().max(255).optional().describe("Search by name"),
+  page: z.number().int().min(1).default(1).describe("Page number"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page"),
+});
+
+export type ListCollectionsInput = z.infer<typeof listCollectionsSchema>;
+
+export const addCollectionItemSchema = z.object({
+  submissionId: z.string().uuid().describe("Submission to add"),
+  position: z.number().int().min(0).optional().describe("Sort position"),
+  notes: z.string().max(5000).optional().describe("Private notes"),
+  color: z.string().max(50).optional().describe("Label color"),
+  icon: z.string().max(50).optional().describe("Item icon"),
+});
+
+export type AddCollectionItemInput = z.infer<typeof addCollectionItemSchema>;
+
+export const updateCollectionItemSchema = z.object({
+  notes: z.string().max(5000).nullable().optional().describe("Private notes"),
+  color: z.string().max(50).nullable().optional().describe("Label color"),
+  icon: z.string().max(50).nullable().optional().describe("Item icon"),
+});
+
+export type UpdateCollectionItemInput = z.infer<
+  typeof updateCollectionItemSchema
+>;
+
+export const reorderCollectionItemsSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        id: z.string().uuid().describe("Item ID"),
+        position: z.number().int().min(0).describe("New position"),
+      }),
+    )
+    .min(1)
+    .max(1000)
+    .describe("Items with new positions"),
+});
+
+export type ReorderCollectionItemsInput = z.infer<
+  typeof reorderCollectionItemsSchema
+>;


### PR DESCRIPTION
## Summary

- Full vertical slice for Design System Step 4: workspace collections
- Schema: `workspace_collections` + `workspace_items` with FORCE RLS, hand-written migration 0059
- Service: CRUD + item management with cross-tenant submission validation, private-collection visibility enforcement, 1000-item cap
- API: tRPC (10 procedures) + REST (10 endpoints) with `Collections` tag and `collections:read/write` scopes
- Frontend: list page with grid cards/search/filters, detail page with DnD reorder (@dnd-kit), add-submission command dialog, notes popover
- RLS infrastructure test updated with both new tables

## Test plan

- [ ] Type check passes (`pnpm type-check`)
- [ ] Lint passes (`pnpm lint`)
- [ ] API unit tests pass (1553 tests)
- [ ] Web unit tests pass (638 tests)
- [ ] Manual: create collection, add submissions, reorder, edit notes, verify private visibility
- [ ] RLS infrastructure test covers both new tables