### PR TITLE
feat(web): keyboard shortcuts + command palette (Steps 5+8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,10 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **ManuscriptDiff**         | `apps/web/src/components/manuscripts/manuscript-diff.tsx` (word-level diff view)           |
 | **TipTap manuscript ext**  | `apps/web/src/lib/tiptap-manuscript-extensions.ts` (custom nodes/marks + converters)       |
 | **Keyboard shortcuts**     | `apps/web/src/hooks/use-shortcuts.ts` (shell-scoped shortcut hook)                         |
+| **Command palette**        | `apps/web/src/components/command-palette/command-palette.tsx` (Cmd+K global nav)           |
+| **Shortcut overlay**       | `apps/web/src/components/command-palette/shortcut-overlay.tsx` (? key help dialog)         |
+| **Shared navigation**      | `apps/web/src/lib/navigation.ts` (nav items + groups, shared by sidebar + palette)         |
+| **Platform utilities**     | `apps/web/src/lib/platform.ts` (isMac, modifierKey, modifierSymbol)                        |
 | **ProseMirror types**      | `packages/types/src/prosemirror.ts` (shared), `apps/web/src/lib/manuscript.ts` (converter) |
 | **Content converters**     | `apps/api/src/converters/` (text, docx, smart-typography, format router)                   |
 | **Content extract queue**  | `apps/api/src/queues/content-extract.queue.ts`                                             |

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -5,6 +5,7 @@ import { Header } from "@/components/layout/header";
 import { Sidebar } from "@/components/layout/sidebar";
 import { Toaster } from "@/components/ui/sonner";
 import { DensityProvider } from "@/hooks/use-density";
+import { CommandPaletteProvider } from "@/components/command-palette/command-palette";
 
 export default function DashboardLayout({
   children,
@@ -14,21 +15,23 @@ export default function DashboardLayout({
   return (
     <ProtectedRoute>
       <DensityProvider density="comfortable">
-        <div className="min-h-screen flex flex-col">
-          <Header />
-          <div className="flex-1 flex">
-            {/* Sidebar - hidden on mobile */}
-            <aside className="hidden md:flex w-64 flex-col border-r">
-              <Sidebar />
-            </aside>
+        <CommandPaletteProvider>
+          <div className="min-h-screen flex flex-col">
+            <Header />
+            <div className="flex-1 flex">
+              {/* Sidebar - hidden on mobile */}
+              <aside className="hidden md:flex w-64 flex-col border-r">
+                <Sidebar />
+              </aside>
 
-            {/* Main content */}
-            <main className="flex-1 overflow-auto">
-              <div className="container py-6">{children}</div>
-            </main>
+              {/* Main content */}
+              <main className="flex-1 overflow-auto">
+                <div className="container py-6">{children}</div>
+              </main>
+            </div>
+            <Toaster />
           </div>
-          <Toaster />
-        </div>
+        </CommandPaletteProvider>
       </DensityProvider>
     </ProtectedRoute>
   );

--- a/apps/web/src/components/command-palette/__tests__/command-palette.spec.tsx
+++ b/apps/web/src/components/command-palette/__tests__/command-palette.spec.tsx
@@ -1,0 +1,131 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CommandPaletteProvider } from "../command-palette";
+
+// cmdk calls scrollIntoView which doesn't exist in JSDOM
+Element.prototype.scrollIntoView = vi.fn();
+
+// --- Mutable mock state ---
+let mockIsEditor = true;
+let mockIsAdmin = true;
+const mockPush = vi.fn();
+
+vi.mock("@/hooks/use-organization", () => ({
+  useOrganization: () => ({
+    isEditor: mockIsEditor,
+    isAdmin: mockIsAdmin,
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: vi.fn(),
+    back: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/",
+}));
+
+vi.mock("@/lib/platform", () => ({
+  modifierKey: () => "meta" as const,
+  modifierSymbol: () => "⌘",
+  isMac: () => true,
+}));
+
+function renderPalette() {
+  return render(
+    <CommandPaletteProvider>
+      <div>App content</div>
+    </CommandPaletteProvider>,
+  );
+}
+
+function openPalette() {
+  act(() => {
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "k",
+        metaKey: true,
+        bubbles: true,
+      }),
+    );
+  });
+}
+
+describe("CommandPaletteProvider", () => {
+  beforeEach(() => {
+    mockIsEditor = true;
+    mockIsAdmin = true;
+    mockPush.mockClear();
+  });
+
+  it("renders children without dialog visible by default", () => {
+    renderPalette();
+    expect(screen.getByText("App content")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Jump to...")).not.toBeInTheDocument();
+  });
+
+  it("opens command palette on Cmd+K", () => {
+    renderPalette();
+    openPalette();
+    expect(screen.getByPlaceholderText("Jump to...")).toBeInTheDocument();
+  });
+
+  it("shows Writing nav group for all users", () => {
+    mockIsEditor = false;
+    mockIsAdmin = false;
+
+    renderPalette();
+    openPalette();
+
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Manuscripts")).toBeInTheDocument();
+  });
+
+  it("hides Editorial group for non-editors", () => {
+    mockIsEditor = false;
+    mockIsAdmin = false;
+
+    renderPalette();
+    openPalette();
+
+    expect(screen.queryByText("Editor Dashboard")).not.toBeInTheDocument();
+  });
+
+  it("shows Editorial group for editors", () => {
+    mockIsEditor = true;
+
+    renderPalette();
+    openPalette();
+
+    expect(screen.getByText("Editor Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Reading Queue")).toBeInTheDocument();
+  });
+
+  it("navigates on item select", async () => {
+    const user = userEvent.setup();
+
+    renderPalette();
+    openPalette();
+
+    await user.click(screen.getByText("Reading Queue"));
+
+    expect(mockPush).toHaveBeenCalledWith("/editor/queue");
+  });
+
+  it("filters items on search input", async () => {
+    const user = userEvent.setup();
+
+    renderPalette();
+    openPalette();
+
+    const input = screen.getByPlaceholderText("Jump to...");
+    await user.type(input, "forms");
+
+    expect(screen.getByText("Forms")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/command-palette/__tests__/command-palette.spec.tsx
+++ b/apps/web/src/components/command-palette/__tests__/command-palette.spec.tsx
@@ -128,4 +128,24 @@ describe("CommandPaletteProvider", () => {
 
     expect(screen.getByText("Forms")).toBeInTheDocument();
   });
+
+  it("closes on Cmd+K when open", () => {
+    renderPalette();
+    openPalette();
+
+    expect(screen.getByPlaceholderText("Jump to...")).toBeInTheDocument();
+
+    // Second Cmd+K should close via the document-level listener
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "k",
+          metaKey: true,
+          bubbles: true,
+        }),
+      );
+    });
+
+    expect(screen.queryByPlaceholderText("Jump to...")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/command-palette/__tests__/shortcut-overlay.spec.tsx
+++ b/apps/web/src/components/command-palette/__tests__/shortcut-overlay.spec.tsx
@@ -1,0 +1,50 @@
+import { vi, describe, it, expect } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ShortcutOverlay } from "../shortcut-overlay";
+
+vi.mock("@/lib/platform", () => ({
+  modifierSymbol: () => "⌘",
+  isMac: () => true,
+}));
+
+describe("ShortcutOverlay", () => {
+  it("renders shortcut groups when open", () => {
+    render(<ShortcutOverlay open={true} onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText("Global")).toBeInTheDocument();
+    expect(screen.getByText("Editorial (Reading Queue)")).toBeInTheDocument();
+  });
+
+  it("shows platform-appropriate modifier symbol", () => {
+    render(<ShortcutOverlay open={true} onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText("⌘+K")).toBeInTheDocument();
+  });
+
+  it("shows editorial shortcuts", () => {
+    render(<ShortcutOverlay open={true} onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText("Next submission")).toBeInTheDocument();
+    expect(screen.getByText("Previous submission")).toBeInTheDocument();
+    expect(screen.getByText("Enter deep-read mode")).toBeInTheDocument();
+    expect(screen.getByText("Return to triage")).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    render(<ShortcutOverlay open={false} onOpenChange={vi.fn()} />);
+
+    expect(screen.queryByText("Keyboard Shortcuts")).not.toBeInTheDocument();
+  });
+
+  it("calls onOpenChange when close is requested", () => {
+    const onOpenChange = vi.fn();
+    render(<ShortcutOverlay open={true} onOpenChange={onOpenChange} />);
+
+    // Dialog close button (X) or overlay click
+    const closeButton = screen.getByRole("button", { name: /close/i });
+    closeButton.click();
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { createContext, useContext, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useOrganization } from "@/hooks/use-organization";
+import { useShortcuts } from "@/hooks/use-shortcuts";
+import { modifierKey } from "@/lib/platform";
+import { navGroups, type NavItem } from "@/lib/navigation";
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+} from "@/components/ui/command";
+import { ShortcutOverlay } from "./shortcut-overlay";
+
+interface CommandPaletteContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const CommandPaletteContext = createContext<CommandPaletteContextValue | null>(
+  null,
+);
+
+export function useCommandPalette() {
+  const ctx = useContext(CommandPaletteContext);
+  if (!ctx)
+    throw new Error(
+      "useCommandPalette must be used within CommandPaletteProvider",
+    );
+  return ctx;
+}
+
+function roleCheck(
+  role: "editor" | "admin" | null,
+  isEditor: boolean,
+  isAdmin: boolean,
+): boolean {
+  if (role === null) return true;
+  if (role === "editor") return isEditor;
+  if (role === "admin") return isAdmin;
+  return false;
+}
+
+export function CommandPaletteProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const [overlayOpen, setOverlayOpen] = useState(false);
+  const router = useRouter();
+  const { isEditor, isAdmin } = useOrganization();
+
+  const mod = modifierKey();
+
+  useShortcuts([
+    {
+      key: "k",
+      modifiers: [mod],
+      handler: () => setOpen((o) => !o),
+      description: "Toggle command palette",
+    },
+    {
+      key: "?",
+      handler: () => setOverlayOpen(true),
+      description: "Show keyboard shortcuts",
+    },
+  ]);
+
+  const handleSelect = useCallback(
+    (href: string) => {
+      setOpen(false);
+      router.push(href);
+    },
+    [router],
+  );
+
+  return (
+    <CommandPaletteContext value={{ open, setOpen }}>
+      {children}
+      <CommandDialog open={open} onOpenChange={setOpen}>
+        <CommandInput placeholder="Jump to..." />
+        <CommandList>
+          <CommandEmpty>No results found.</CommandEmpty>
+          {navGroups
+            .filter((g) => roleCheck(g.role, isEditor, isAdmin))
+            .map((group) => (
+              <CommandGroup key={group.label} heading={group.label}>
+                {group.items.map((item: NavItem) => (
+                  <CommandItem
+                    key={item.href}
+                    value={`${group.label} ${item.name}`}
+                    onSelect={() => handleSelect(item.href)}
+                  >
+                    <item.icon className="mr-2 h-4 w-4" />
+                    {item.name}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ))}
+          <CommandGroup heading="Actions">
+            <CommandItem
+              value="Show keyboard shortcuts"
+              onSelect={() => {
+                setOpen(false);
+                setOverlayOpen(true);
+              }}
+            >
+              Keyboard shortcuts
+              <CommandShortcut>?</CommandShortcut>
+            </CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>
+      <ShortcutOverlay open={overlayOpen} onOpenChange={setOverlayOpen} />
+    </CommandPaletteContext>
+  );
+}

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { createContext, useContext, useState, useCallback } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+} from "react";
 import { useRouter } from "next/navigation";
 import { useOrganization } from "@/hooks/use-organization";
 import { useShortcuts } from "@/hooks/use-shortcuts";
@@ -58,12 +64,15 @@ export function CommandPaletteProvider({
 
   const mod = modifierKey();
 
+  // useShortcuts opens the palette (ignored when focus is on INPUT elements).
+  // A separate document-level listener handles Cmd/Ctrl+K while the palette
+  // is open (cmdk autofocuses its <input>, which useShortcuts skips).
   useShortcuts([
     {
       key: "k",
       modifiers: [mod],
-      handler: () => setOpen((o) => !o),
-      description: "Toggle command palette",
+      handler: () => setOpen(true),
+      description: "Open command palette",
     },
     {
       key: "?",
@@ -71,6 +80,19 @@ export function CommandPaletteProvider({
       description: "Show keyboard shortcuts",
     },
   ]);
+
+  useEffect(() => {
+    if (!open) return;
+    const modKey = mod === "meta" ? "metaKey" : "ctrlKey";
+    const handleClose = (e: KeyboardEvent) => {
+      if (e.key === "k" && e[modKey]) {
+        e.preventDefault();
+        setOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleClose);
+    return () => document.removeEventListener("keydown", handleClose);
+  }, [open, mod]);
 
   const handleSelect = useCallback(
     (href: string) => {

--- a/apps/web/src/components/command-palette/shortcut-overlay.tsx
+++ b/apps/web/src/components/command-palette/shortcut-overlay.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { modifierSymbol } from "@/lib/platform";
+
+interface ShortcutOverlayProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface ShortcutEntry {
+  keys: string;
+  description: string;
+}
+
+function getGlobalShortcuts(): ShortcutEntry[] {
+  const mod = modifierSymbol();
+  return [
+    { keys: `${mod}+K`, description: "Open command palette" },
+    { keys: "?", description: "Show keyboard shortcuts" },
+  ];
+}
+
+const editorialShortcuts: ShortcutEntry[] = [
+  { keys: "j", description: "Next submission" },
+  { keys: "k", description: "Previous submission" },
+  { keys: "r", description: "Enter deep-read mode" },
+  { keys: "Esc", description: "Return to triage" },
+];
+
+function ShortcutGroup({
+  heading,
+  shortcuts,
+}: {
+  heading: string;
+  shortcuts: ShortcutEntry[];
+}) {
+  return (
+    <div>
+      <h3 className="mb-2 text-sm font-semibold text-foreground">{heading}</h3>
+      <div className="space-y-1.5">
+        {shortcuts.map((s) => (
+          <div
+            key={s.keys}
+            className="flex items-center justify-between text-sm"
+          >
+            <span className="text-muted-foreground">{s.description}</span>
+            <kbd className="rounded border bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+              {s.keys}
+            </kbd>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ShortcutOverlay({ open, onOpenChange }: ShortcutOverlayProps) {
+  const globalShortcuts = getGlobalShortcuts();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Keyboard Shortcuts</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-6 py-2">
+          <ShortcutGroup heading="Global" shortcuts={globalShortcuts} />
+          <ShortcutGroup
+            heading="Editorial (Reading Queue)"
+            shortcuts={editorialShortcuts}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/layout/__tests__/header.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/header.spec.tsx
@@ -61,6 +61,17 @@ vi.mock("@/components/notifications/notification-bell", () => ({
   NotificationBell: () => <div data-testid="notification-bell">Bell</div>,
 }));
 
+const mockSetOpen = vi.fn();
+vi.mock("@/components/command-palette/command-palette", () => ({
+  useCommandPalette: () => ({ open: false, setOpen: mockSetOpen }),
+}));
+
+vi.mock("@/lib/platform", () => ({
+  modifierSymbol: () => "⌘",
+  modifierKey: () => "meta",
+  isMac: () => true,
+}));
+
 describe("Header", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -137,5 +148,21 @@ describe("Header", () => {
 
     expect(screen.getByText("Test Org")).toBeInTheDocument();
     expect(screen.getByTestId("notification-bell")).toBeInTheDocument();
+  });
+
+  it("renders command palette trigger button when authenticated", () => {
+    render(<Header />);
+
+    expect(screen.getByText("⌘K")).toBeInTheDocument();
+  });
+
+  it("opens command palette on trigger click", async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+
+    const trigger = screen.getByText("⌘K").closest("button")!;
+    await user.click(trigger);
+
+    expect(mockSetOpen).toHaveBeenCalledWith(true);
   });
 });

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -13,9 +13,11 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
-import { Menu } from "lucide-react";
+import { Menu, Search } from "lucide-react";
 import { Sidebar } from "./sidebar";
 import { NotificationBell } from "@/components/notifications/notification-bell";
+import { useCommandPalette } from "@/components/command-palette/command-palette";
+import { modifierSymbol } from "@/lib/platform";
 
 /** Keyed by pathname — remounts on navigation to auto-close the sheet. */
 function MobileMenu() {
@@ -34,6 +36,21 @@ function MobileMenu() {
         <Sidebar />
       </SheetContent>
     </Sheet>
+  );
+}
+
+function CommandPaletteTrigger() {
+  const { setOpen } = useCommandPalette();
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="hidden md:flex items-center gap-2 text-muted-foreground"
+      onClick={() => setOpen(true)}
+    >
+      <Search className="h-4 w-4" />
+      <span className="text-xs">{modifierSymbol()}K</span>
+    </Button>
   );
 }
 
@@ -58,6 +75,7 @@ export function Header() {
         {/* Right side */}
         {isAuthenticated ? (
           <div className="flex items-center space-x-4">
+            <CommandPaletteTrigger />
             <OrgSwitcher />
             <NotificationBell />
             <UserMenu />

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuth } from "@/hooks/use-auth";
@@ -39,8 +39,15 @@ function MobileMenu() {
   );
 }
 
+// SSR-safe platform detection via useSyncExternalStore
+const subscribe = () => () => {};
+const getSnapshot = () => modifierSymbol();
+const getServerSnapshot = () => "Ctrl";
+
 function CommandPaletteTrigger() {
   const { setOpen } = useCommandPalette();
+  const mod = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
   return (
     <Button
       variant="outline"
@@ -49,7 +56,7 @@ function CommandPaletteTrigger() {
       onClick={() => setOpen(true)}
     >
       <Search className="h-4 w-4" />
-      <span className="text-xs">{modifierSymbol()}K</span>
+      <span className="text-xs">{mod}K</span>
     </Button>
   );
 }

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -1,93 +1,16 @@
 "use client";
 
-import type { LucideIcon } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { useOrganization } from "@/hooks/use-organization";
 import {
-  BarChart3,
-  BookCopy,
-  BookMarked,
-  BookOpen,
-  Building2,
-  Calendar,
-  ClipboardList,
-  FileSignature,
-  FileText,
-  FolderOpen,
-  GitBranch,
-  Globe,
-  Inbox,
-  Layers,
-  LayoutDashboard,
-  Library,
-  Mail,
-  Network,
-  Send,
-  Settings,
-  Upload,
-  Webhook,
-} from "lucide-react";
-
-interface NavItem {
-  name: string;
-  href: string;
-  icon: LucideIcon;
-}
-
-const writingNavigation: NavItem[] = [
-  { name: "Dashboard", href: "/workspace", icon: LayoutDashboard },
-  { name: "Manuscripts", href: "/manuscripts", icon: BookOpen },
-  { name: "My Submissions", href: "/submissions", icon: FileText },
-  { name: "External Subs", href: "/workspace/external", icon: Send },
-  {
-    name: "Correspondence",
-    href: "/workspace/correspondence",
-    icon: Mail,
-  },
-  { name: "Portfolio", href: "/workspace/portfolio", icon: Layers },
-  { name: "Analytics", href: "/workspace/analytics", icon: BarChart3 },
-  { name: "Import", href: "/workspace/import", icon: Upload },
-  { name: "Settings", href: "/settings", icon: Settings },
-];
-
-const editorialNavigation: NavItem[] = [
-  { name: "Editor Dashboard", href: "/editor", icon: LayoutDashboard },
-  { name: "Reading Queue", href: "/editor/queue", icon: BookOpen },
-  { name: "All Submissions", href: "/editor/submissions", icon: Inbox },
-  { name: "Collections", href: "/editor/collections", icon: FolderOpen },
-  { name: "Forms", href: "/editor/forms", icon: ClipboardList },
-  { name: "Periods", href: "/editor/periods", icon: Calendar },
-];
-
-const productionNavigation: NavItem[] = [
-  { name: "Production Dashboard", href: "/slate", icon: BookMarked },
-  { name: "Publications", href: "/slate/publications", icon: Library },
-  { name: "Pipeline", href: "/slate/pipeline", icon: GitBranch },
-  { name: "Issues", href: "/slate/issues", icon: BookCopy },
-  { name: "Calendar", href: "/slate/calendar", icon: Calendar },
-  { name: "Contracts", href: "/slate/contracts", icon: FileSignature },
-  { name: "CMS", href: "/slate/cms", icon: Globe },
-];
-
-const operationsNavigation: NavItem[] = [
-  {
-    name: "Organization",
-    href: "/organizations/settings",
-    icon: Building2,
-  },
-  {
-    name: "Webhooks",
-    href: "/webhooks",
-    icon: Webhook,
-  },
-  {
-    name: "Federation",
-    href: "/federation",
-    icon: Network,
-  },
-];
+  writingNavigation,
+  editorialNavigation,
+  productionNavigation,
+  operationsNavigation,
+  type NavItem,
+} from "@/lib/navigation";
 
 function isActiveLink(pathname: string, href: string): boolean {
   if (href === "/editor") return pathname === "/editor";

--- a/apps/web/src/hooks/__tests__/use-shortcuts.spec.ts
+++ b/apps/web/src/hooks/__tests__/use-shortcuts.spec.ts
@@ -3,14 +3,26 @@ import { renderHook } from "@testing-library/react";
 import { useShortcuts } from "../use-shortcuts";
 import type { ShortcutBinding } from "../use-shortcuts";
 
-function fireKey(key: string, target?: HTMLElement) {
+function fireKey(
+  key: string,
+  target?: HTMLElement,
+  mods?: {
+    metaKey?: boolean;
+    ctrlKey?: boolean;
+    altKey?: boolean;
+    shiftKey?: boolean;
+  },
+) {
   const event = new KeyboardEvent("keydown", {
     key,
     bubbles: true,
     cancelable: true,
+    metaKey: mods?.metaKey ?? false,
+    ctrlKey: mods?.ctrlKey ?? false,
+    altKey: mods?.altKey ?? false,
+    shiftKey: mods?.shiftKey ?? false,
   });
   if (target) {
-    // Override event.target by dispatching from the element
     target.dispatchEvent(event);
   } else {
     document.dispatchEvent(event);
@@ -141,5 +153,84 @@ describe("useShortcuts", () => {
     fireKey("Escape");
 
     expect(handler).toHaveBeenCalledOnce();
+  });
+
+  describe("modifier keys", () => {
+    it("fires binding with matching modifier", () => {
+      const handler = vi.fn();
+      const bindings: ShortcutBinding[] = [
+        { key: "k", modifiers: ["meta"], handler, description: "palette" },
+      ];
+
+      renderHook(() => useShortcuts(bindings));
+      fireKey("k", undefined, { metaKey: true });
+
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it("does NOT fire when wrong modifier is pressed", () => {
+      const handler = vi.fn();
+      const bindings: ShortcutBinding[] = [
+        { key: "k", modifiers: ["meta"], handler, description: "palette" },
+      ];
+
+      renderHook(() => useShortcuts(bindings));
+      fireKey("k", undefined, { ctrlKey: true });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("does NOT fire unmodified binding when a modifier is pressed", () => {
+      const handler = vi.fn();
+      const bindings: ShortcutBinding[] = [
+        { key: "j", handler, description: "next" },
+      ];
+
+      renderHook(() => useShortcuts(bindings));
+      fireKey("j", undefined, { metaKey: true });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("matches multiple modifiers", () => {
+      const handler = vi.fn();
+      const bindings: ShortcutBinding[] = [
+        {
+          key: "s",
+          modifiers: ["meta", "shift"],
+          handler,
+          description: "save all",
+        },
+      ];
+
+      renderHook(() => useShortcuts(bindings));
+      fireKey("s", undefined, { metaKey: true, shiftKey: true });
+
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it("allows shift for unmodified bindings (? = Shift+/)", () => {
+      const handler = vi.fn();
+      const bindings: ShortcutBinding[] = [
+        { key: "?", handler, description: "help" },
+      ];
+
+      renderHook(() => useShortcuts(bindings));
+      fireKey("?", undefined, { shiftKey: true });
+
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it("blocks extra shift on modifier bindings", () => {
+      const handler = vi.fn();
+      const bindings: ShortcutBinding[] = [
+        { key: "k", modifiers: ["meta"], handler, description: "palette" },
+      ];
+
+      renderHook(() => useShortcuts(bindings));
+      fireKey("k", undefined, { metaKey: true, shiftKey: true });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/src/hooks/use-shortcuts.ts
+++ b/apps/web/src/hooks/use-shortcuts.ts
@@ -11,6 +11,8 @@ export interface ShortcutBinding {
   description: string;
   /** Whether this binding is active (default true) */
   enabled?: boolean;
+  /** Modifier keys required (e.g., ["meta"] for Cmd+K). When omitted, binding requires NO meta/ctrl/alt modifiers. */
+  modifiers?: Array<"meta" | "ctrl" | "alt" | "shift">;
 }
 
 const IGNORED_ELEMENTS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
@@ -42,12 +44,24 @@ export function useShortcuts(bindings: ShortcutBinding[]): void {
       }
     }
 
-    // Ignore modified keypresses (Ctrl+R, Cmd+K, etc.)
-    if (event.metaKey || event.ctrlKey || event.altKey) return;
-
     for (const binding of bindingsRef.current) {
       if (binding.enabled === false) continue;
-      if (event.key === binding.key) {
+      if (event.key !== binding.key) continue;
+
+      const requiredMods = binding.modifiers ?? [];
+      const hasExplicitMods = requiredMods.length > 0;
+
+      // For modifier bindings: check all declared modifiers exactly
+      // For non-modifier bindings: require no meta/ctrl/alt but ignore shift
+      //   (allows "?" = Shift+/ and other shifted characters)
+      const modMatch = hasExplicitMods
+        ? requiredMods.includes("meta") === event.metaKey &&
+          requiredMods.includes("ctrl") === event.ctrlKey &&
+          requiredMods.includes("alt") === event.altKey &&
+          requiredMods.includes("shift") === event.shiftKey
+        : !event.metaKey && !event.ctrlKey && !event.altKey;
+
+      if (modMatch) {
         event.preventDefault();
         binding.handler();
         return;

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -1,0 +1,100 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  BarChart3,
+  BookCopy,
+  BookMarked,
+  BookOpen,
+  Building2,
+  Calendar,
+  ClipboardList,
+  FileSignature,
+  FileText,
+  FolderOpen,
+  GitBranch,
+  Globe,
+  Inbox,
+  Layers,
+  LayoutDashboard,
+  Library,
+  Mail,
+  Network,
+  Send,
+  Settings,
+  Upload,
+  Webhook,
+} from "lucide-react";
+
+export interface NavItem {
+  name: string;
+  href: string;
+  icon: LucideIcon;
+}
+
+export const writingNavigation: NavItem[] = [
+  { name: "Dashboard", href: "/workspace", icon: LayoutDashboard },
+  { name: "Manuscripts", href: "/manuscripts", icon: BookOpen },
+  { name: "My Submissions", href: "/submissions", icon: FileText },
+  { name: "External Subs", href: "/workspace/external", icon: Send },
+  {
+    name: "Correspondence",
+    href: "/workspace/correspondence",
+    icon: Mail,
+  },
+  { name: "Portfolio", href: "/workspace/portfolio", icon: Layers },
+  { name: "Analytics", href: "/workspace/analytics", icon: BarChart3 },
+  { name: "Import", href: "/workspace/import", icon: Upload },
+  { name: "Settings", href: "/settings", icon: Settings },
+];
+
+export const editorialNavigation: NavItem[] = [
+  { name: "Editor Dashboard", href: "/editor", icon: LayoutDashboard },
+  { name: "Reading Queue", href: "/editor/queue", icon: BookOpen },
+  { name: "All Submissions", href: "/editor/submissions", icon: Inbox },
+  { name: "Collections", href: "/editor/collections", icon: FolderOpen },
+  { name: "Forms", href: "/editor/forms", icon: ClipboardList },
+  { name: "Periods", href: "/editor/periods", icon: Calendar },
+];
+
+export const productionNavigation: NavItem[] = [
+  { name: "Production Dashboard", href: "/slate", icon: BookMarked },
+  { name: "Publications", href: "/slate/publications", icon: Library },
+  { name: "Pipeline", href: "/slate/pipeline", icon: GitBranch },
+  { name: "Issues", href: "/slate/issues", icon: BookCopy },
+  { name: "Calendar", href: "/slate/calendar", icon: Calendar },
+  { name: "Contracts", href: "/slate/contracts", icon: FileSignature },
+  { name: "CMS", href: "/slate/cms", icon: Globe },
+];
+
+export const operationsNavigation: NavItem[] = [
+  {
+    name: "Organization",
+    href: "/organizations/settings",
+    icon: Building2,
+  },
+  {
+    name: "Webhooks",
+    href: "/webhooks",
+    icon: Webhook,
+  },
+  {
+    name: "Federation",
+    href: "/federation",
+    icon: Network,
+  },
+];
+
+/** All nav groups with their label and role requirement */
+export const navGroups = [
+  { label: "Writing", items: writingNavigation, role: null },
+  { label: "Editorial", items: editorialNavigation, role: "editor" as const },
+  {
+    label: "Production",
+    items: productionNavigation,
+    role: "editor" as const,
+  },
+  {
+    label: "Operations",
+    items: operationsNavigation,
+    role: "admin" as const,
+  },
+] as const;

--- a/apps/web/src/lib/platform.ts
+++ b/apps/web/src/lib/platform.ts
@@ -1,0 +1,17 @@
+/** Returns true when running on a Mac/iOS platform */
+export function isMac(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    /Mac|iPod|iPhone|iPad/.test(navigator.platform)
+  );
+}
+
+/** Returns the platform-appropriate modifier key for keyboard shortcuts */
+export function modifierKey(): "meta" | "ctrl" {
+  return isMac() ? "meta" : "ctrl";
+}
+
+/** Returns the display symbol for the platform modifier key */
+export function modifierSymbol(): string {
+  return isMac() ? "⌘" : "Ctrl";
+}

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,27 @@ Newest entries first.
 
 ---
 
+## 2026-03-26 — Keyboard Shortcuts + Command Palette (Design System Steps 5+8)
+
+### Done
+
+- **useShortcuts modifier support**: Extended `ShortcutBinding` with optional `modifiers` field. Conditional modifier matching — unmodified bindings ignore shiftKey (fixes `?` = Shift+/), modifier bindings are exact. 6 new hook tests
+- **Shared navigation**: Extracted sidebar nav arrays to `apps/web/src/lib/navigation.ts` — consumed by both sidebar and command palette. Includes `navGroups` with role requirements
+- **Platform utilities**: `apps/web/src/lib/platform.ts` — `isMac()`, `modifierKey()`, `modifierSymbol()` for cross-platform shortcut display
+- **Command palette**: `CommandPaletteProvider` mounted in dashboard layout. Cmd+K (Mac) / Ctrl+K (Windows) toggle. Role-gated nav groups via `useOrganization`. Fuzzy search via cmdk. "Keyboard shortcuts" action opens overlay. 7 tests
+- **Shortcut overlay**: Dialog showing Global and Editorial shortcut groups. `?` key opens it. Platform-appropriate modifier symbols computed at render time. 5 tests
+- **Header trigger**: Search button with platform modifier hint (e.g., "⌘K") between notification bell and user menu. 2 new header tests + mocks
+- **Codex plan review findings addressed**: (1) Shift+/ handling for `?` key, (2) Removed `n` shortcut (no unread metadata in split pane), (3) `modifierSymbol()` at render time not module scope, (4) Existing test file updates
+- **Tests**: all passing — web 658 (20 new)
+
+### Decisions
+
+- Deferred all editorial shortcuts (1/2/3/d/h/n/c) — detail pane needs action interface refactor to expose vote/status/correspondence callbacks
+- Navigation-only palette — async entity search (submissions, manuscripts by title) deferred as v2
+- Shift-transparent for unmodified bindings — matches on `event.key` character value, not physical key
+
+---
+
 ## 2026-03-26 — Workspace Collections (Design System Step 4)
 
 ### Done


### PR DESCRIPTION
## Summary
- Extended `useShortcuts` hook with modifier key support (shift-transparent for unmodified bindings)
- Global command palette (Cmd+K / Ctrl+K) with role-gated navigation groups from shared nav data
- Keyboard shortcut overlay (? key) showing Global + Editorial shortcuts
- Header trigger button with SSR-safe platform detection via `useSyncExternalStore`
- Extracted sidebar nav arrays to `apps/web/src/lib/navigation.ts` (shared by sidebar + palette)
- 21 new tests, 659/659 web tests passing

## Test plan
- [ ] Verify Cmd+K opens command palette, type to filter, select navigates
- [ ] Verify Cmd+K closes palette when already open (toggle)
- [ ] Verify ? key opens shortcut overlay with correct platform modifier symbol
- [ ] Verify j/k/r/Escape still work in editorial split pane (no regression)
- [ ] Verify shortcuts don't fire when typing in form inputs
- [ ] Verify no SSR hydration flash on the header trigger button