### PR TITLE
feat(web): ops dashboard — health card grid (Step 7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,9 @@ Per-directory CLAUDE.md files contain domain-specific details:
 | **Metrics plugin**         | `apps/api/src/hooks/metrics.ts` (Fastify plugin — HTTP request instrumentation)             |
 | **Instrumented worker**    | `apps/api/src/config/instrumented-worker.ts` (BullMQ wrapper with metrics)                  |
 | **Webhook health**         | `apps/api/src/webhooks/webhook-health.route.ts`                                             |
+| **Ops tRPC router**        | `apps/api/src/trpc/routers/ops.ts` (queueHealth, webhookProviderHealth, submissionTrend)    |
+| **Ops dashboard**          | `apps/web/src/components/operations/ops-dashboard.tsx` (health card grid + quick links)     |
+| **Health card grid**       | `apps/web/src/components/operations/health-card-grid.tsx` (4-card status derivation)        |
 | **Alert rules**            | `docker/prometheus/alert-rules.yml`                                                         |
 | **AlertManager config**    | `docker/alertmanager/alertmanager.yml`                                                      |
 | **Loki config**            | `docker/loki/loki-config.yml` (dev), `loki-config.prod.yml` (prod)                          |

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -34,6 +34,7 @@ import { transferRouter } from './routers/transfer.js';
 import { migrationRouter } from './routers/migration.js';
 import { hubRouter } from './routers/hub.js';
 import { collectionsRouter } from './routers/collections.js';
+import { opsRouter } from './routers/ops.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -89,6 +90,7 @@ export const appRouter = t.router({
   migrations: migrationRouter,
   hub: hubRouter,
   collections: collectionsRouter,
+  ops: opsRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/ops.spec.ts
+++ b/apps/api/src/trpc/routers/ops.spec.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { TRPCContext } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — queue instances
+// ---------------------------------------------------------------------------
+
+const makeQueueMock = (counts: Record<string, number>) => ({
+  getJobCounts: vi.fn().mockResolvedValue(counts),
+});
+
+const { mockQueues } = vi.hoisted(() => {
+  const mockQueues = {
+    email: null as ReturnType<typeof makeQueueMock> | null,
+    webhook: null as ReturnType<typeof makeQueueMock> | null,
+    fileScan: null as ReturnType<typeof makeQueueMock> | null,
+    contentExtract: null as ReturnType<typeof makeQueueMock> | null,
+    s3Cleanup: null as ReturnType<typeof makeQueueMock> | null,
+    outboxPoller: null as ReturnType<typeof makeQueueMock> | null,
+    transferFetch: null as ReturnType<typeof makeQueueMock> | null,
+  };
+  return { mockQueues };
+});
+
+vi.mock('../../queues/index.js', () => ({
+  getEmailQueueInstance: () => mockQueues.email,
+  getWebhookQueueInstance: () => mockQueues.webhook,
+  getFileScanQueueInstance: () => mockQueues.fileScan,
+  getContentExtractQueueInstance: () => mockQueues.contentExtract,
+  getS3CleanupQueueInstance: () => mockQueues.s3Cleanup,
+  getOutboxPollerQueueInstance: () => mockQueues.outboxPoller,
+  getTransferFetchQueueInstance: () => mockQueues.transferFetch,
+  // Stubs required by other routers that import from queues
+  enqueueEmail: vi.fn(),
+  enqueueWebhook: vi.fn(),
+  enqueueFileScan: vi.fn(),
+  enqueueContentExtract: vi.fn(),
+  enqueueS3Cleanup: vi.fn(),
+  enqueueTransferFetch: vi.fn(),
+  startOutboxPoller: vi.fn(),
+  closeEmailQueue: vi.fn(),
+  closeWebhookQueue: vi.fn(),
+  closeFileScanQueue: vi.fn(),
+  closeContentExtractQueue: vi.fn(),
+  closeS3CleanupQueue: vi.fn(),
+  closeOutboxPollerQueue: vi.fn(),
+  closeTransferFetchQueue: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks — DB (webhook health + submission trend)
+// ---------------------------------------------------------------------------
+
+const mockDbExecute = vi.fn();
+
+vi.mock('@colophony/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@colophony/db')>();
+  return {
+    ...actual,
+    db: { execute: (...args: unknown[]) => mockDbExecute(...args) },
+  };
+});
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: () => ({
+    WEBHOOK_HEALTH_ZITADEL_STALE_SECONDS: 3600,
+    WEBHOOK_HEALTH_STRIPE_STALE_SECONDS: 86400,
+    WEBHOOK_HEALTH_DOCUMENSO_STALE_SECONDS: 86400,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import router after mocks
+// ---------------------------------------------------------------------------
+
+import { appRouter } from '../router.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides: Partial<TRPCContext> = {}): TRPCContext {
+  return {
+    authContext: null,
+    dbTx: null,
+    audit: vi.fn(),
+    ...overrides,
+  };
+}
+
+function adminContext(
+  dbTxOverride?: Partial<TRPCContext['dbTx']>,
+): TRPCContext {
+  const mockTx = {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockResolvedValue([{ value: 0 }]),
+    ...dbTxOverride,
+  } as never;
+  return makeContext({
+    authContext: {
+      userId: 'user-1',
+      zitadelUserId: 'zid-1',
+      email: 'admin@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+      orgId: 'org-1',
+      role: 'ADMIN',
+    },
+    dbTx: mockTx,
+    audit: vi.fn(),
+  });
+}
+
+function editorContext(): TRPCContext {
+  return makeContext({
+    authContext: {
+      userId: 'user-1',
+      zitadelUserId: 'zid-1',
+      email: 'editor@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+      orgId: 'org-1',
+      role: 'EDITOR',
+    },
+    dbTx: {} as never,
+    audit: vi.fn(),
+  });
+}
+
+const createCaller = (appRouter as any).createCaller as (
+  ctx: TRPCContext,
+) => any;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ops router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset all queue mocks to null
+    mockQueues.email = null;
+    mockQueues.webhook = null;
+    mockQueues.fileScan = null;
+    mockQueues.contentExtract = null;
+    mockQueues.s3Cleanup = null;
+    mockQueues.outboxPoller = null;
+    mockQueues.transferFetch = null;
+  });
+
+  describe('queueHealth', () => {
+    it('returns counts for all 7 queues', async () => {
+      const counts = { waiting: 5, active: 2, delayed: 1, failed: 0 };
+      mockQueues.email = makeQueueMock(counts);
+      mockQueues.webhook = makeQueueMock(counts);
+      mockQueues.fileScan = makeQueueMock(counts);
+      mockQueues.contentExtract = makeQueueMock(counts);
+      mockQueues.s3Cleanup = makeQueueMock(counts);
+      mockQueues.outboxPoller = makeQueueMock(counts);
+      mockQueues.transferFetch = makeQueueMock(counts);
+
+      const caller = createCaller(adminContext());
+      const result = await caller.ops.queueHealth();
+
+      expect(result.queues).toHaveLength(7);
+      for (const q of result.queues) {
+        expect(q).toMatchObject(counts);
+      }
+      expect(result.queues.map((q: { name: string }) => q.name)).toEqual([
+        'email',
+        'webhook',
+        'file-scan',
+        'content-extract',
+        's3-cleanup',
+        'outbox-poller',
+        'transfer-fetch',
+      ]);
+    });
+
+    it('returns zeros for null queue instances', async () => {
+      // All queues are null (default in beforeEach)
+      const caller = createCaller(adminContext());
+      const result = await caller.ops.queueHealth();
+
+      expect(result.queues).toHaveLength(7);
+      for (const q of result.queues) {
+        expect(q.waiting).toBe(0);
+        expect(q.active).toBe(0);
+        expect(q.delayed).toBe(0);
+        expect(q.failed).toBe(0);
+      }
+    });
+
+    it('returns zeros when Redis is unavailable', async () => {
+      mockQueues.email = {
+        getJobCounts: vi.fn().mockRejectedValue(new Error('Redis down')),
+      };
+
+      const caller = createCaller(adminContext());
+      const result = await caller.ops.queueHealth();
+
+      const emailQueue = result.queues.find(
+        (q: { name: string }) => q.name === 'email',
+      );
+      expect(emailQueue).toMatchObject({
+        waiting: 0,
+        active: 0,
+        delayed: 0,
+        failed: 0,
+      });
+    });
+  });
+
+  describe('webhookProviderHealth', () => {
+    it('returns provider statuses', async () => {
+      const now = new Date();
+      const recentTs = new Date(now.getTime() - 60_000).toISOString(); // 1 min ago
+      mockDbExecute.mockResolvedValueOnce({
+        rows: [
+          { provider: 'zitadel', last_received_at: recentTs },
+          { provider: 'stripe', last_received_at: recentTs },
+          { provider: 'documenso', last_received_at: null },
+        ],
+      });
+
+      const caller = createCaller(adminContext());
+      const result = await caller.ops.webhookProviderHealth();
+
+      expect(result.providers).toHaveLength(3);
+      expect(result.providers[0]).toMatchObject({
+        provider: 'zitadel',
+        status: 'healthy',
+      });
+      expect(result.providers[1]).toMatchObject({
+        provider: 'stripe',
+        status: 'healthy',
+      });
+      expect(result.providers[2]).toMatchObject({
+        provider: 'documenso',
+        status: 'unknown',
+        lastReceivedAt: null,
+      });
+      expect(result.timestamp).toBeDefined();
+    });
+
+    it('marks stale when over threshold', async () => {
+      const staleTs = new Date(
+        Date.now() - 7200_000, // 2 hours ago (> 3600s zitadel threshold)
+      ).toISOString();
+      mockDbExecute.mockResolvedValueOnce({
+        rows: [
+          { provider: 'zitadel', last_received_at: staleTs },
+          { provider: 'stripe', last_received_at: staleTs },
+          { provider: 'documenso', last_received_at: staleTs },
+        ],
+      });
+
+      const caller = createCaller(adminContext());
+      const result = await caller.ops.webhookProviderHealth();
+
+      expect(result.providers[0]).toMatchObject({
+        provider: 'zitadel',
+        status: 'stale',
+      });
+      // Stripe threshold is 86400s, so 2h ago is still healthy
+      expect(result.providers[1]).toMatchObject({
+        provider: 'stripe',
+        status: 'healthy',
+      });
+    });
+  });
+
+  describe('submissionTrend', () => {
+    it('returns this month vs last month counts', async () => {
+      const mockSelect = vi.fn().mockReturnThis();
+      const mockFrom = vi.fn().mockReturnThis();
+      const mockWhere = vi
+        .fn()
+        .mockResolvedValueOnce([{ value: 15 }]) // this month
+        .mockResolvedValueOnce([{ value: 10 }]); // last month
+
+      const ctx = adminContext({
+        select: mockSelect,
+        from: mockFrom,
+        where: mockWhere,
+      } as never);
+      const caller = createCaller(ctx);
+      const result = await caller.ops.submissionTrend();
+
+      expect(result).toEqual({
+        thisMonth: 15,
+        lastMonth: 10,
+        trend: 'up',
+      });
+    });
+
+    it('returns flat when counts equal', async () => {
+      const mockSelect = vi.fn().mockReturnThis();
+      const mockFrom = vi.fn().mockReturnThis();
+      const mockWhere = vi
+        .fn()
+        .mockResolvedValueOnce([{ value: 5 }])
+        .mockResolvedValueOnce([{ value: 5 }]);
+
+      const ctx = adminContext({
+        select: mockSelect,
+        from: mockFrom,
+        where: mockWhere,
+      } as never);
+      const caller = createCaller(ctx);
+      const result = await caller.ops.submissionTrend();
+
+      expect(result.trend).toBe('flat');
+    });
+
+    it('returns down when this month is lower', async () => {
+      const mockSelect = vi.fn().mockReturnThis();
+      const mockFrom = vi.fn().mockReturnThis();
+      const mockWhere = vi
+        .fn()
+        .mockResolvedValueOnce([{ value: 3 }])
+        .mockResolvedValueOnce([{ value: 10 }]);
+
+      const ctx = adminContext({
+        select: mockSelect,
+        from: mockFrom,
+        where: mockWhere,
+      } as never);
+      const caller = createCaller(ctx);
+      const result = await caller.ops.submissionTrend();
+
+      expect(result.trend).toBe('down');
+    });
+  });
+
+  describe('authorization', () => {
+    it('rejects non-admin users with FORBIDDEN', async () => {
+      const caller = createCaller(editorContext());
+
+      await expect(caller.ops.queueHealth()).rejects.toThrow(/admin/i);
+      await expect(caller.ops.webhookProviderHealth()).rejects.toThrow(
+        /admin/i,
+      );
+      await expect(caller.ops.submissionTrend()).rejects.toThrow(/admin/i);
+    });
+
+    it('rejects unauthenticated users', async () => {
+      const caller = createCaller(makeContext());
+
+      await expect(caller.ops.queueHealth()).rejects.toThrow(
+        /not authenticated/i,
+      );
+    });
+  });
+});

--- a/apps/api/src/trpc/routers/ops.ts
+++ b/apps/api/src/trpc/routers/ops.ts
@@ -1,0 +1,203 @@
+import { z } from 'zod';
+import { sql, eq, gte, lt, and, count } from 'drizzle-orm';
+import { db, submissions } from '@colophony/db';
+import { adminProcedure, createRouter } from '../init.js';
+import { validateEnv } from '../../config/env.js';
+import {
+  getEmailQueueInstance,
+  getWebhookQueueInstance,
+  getFileScanQueueInstance,
+  getContentExtractQueueInstance,
+  getS3CleanupQueueInstance,
+  getOutboxPollerQueueInstance,
+  getTransferFetchQueueInstance,
+} from '../../queues/index.js';
+
+// ---------------------------------------------------------------------------
+// Output schemas (ops-internal, not shared via @colophony/types)
+// ---------------------------------------------------------------------------
+
+const queueCountsSchema = z.object({
+  name: z.string(),
+  waiting: z.number(),
+  active: z.number(),
+  delayed: z.number(),
+  failed: z.number(),
+});
+
+const queueHealthOutputSchema = z.object({
+  queues: z.array(queueCountsSchema),
+});
+
+const webhookProviderSchema = z.object({
+  provider: z.string(),
+  status: z.enum(['healthy', 'stale', 'unknown']),
+  lastReceivedAt: z.string().nullable(),
+  freshnessSeconds: z.number().nullable(),
+});
+
+const webhookProviderHealthOutputSchema = z.object({
+  timestamp: z.string(),
+  providers: z.array(webhookProviderSchema),
+});
+
+const submissionTrendOutputSchema = z.object({
+  thisMonth: z.number(),
+  lastMonth: z.number(),
+  trend: z.enum(['up', 'down', 'flat']),
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const QUEUE_ACCESSORS = [
+  { name: 'email', get: getEmailQueueInstance },
+  { name: 'webhook', get: getWebhookQueueInstance },
+  { name: 'file-scan', get: getFileScanQueueInstance },
+  { name: 'content-extract', get: getContentExtractQueueInstance },
+  { name: 's3-cleanup', get: getS3CleanupQueueInstance },
+  { name: 'outbox-poller', get: getOutboxPollerQueueInstance },
+  { name: 'transfer-fetch', get: getTransferFetchQueueInstance },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+export const opsRouter = createRouter({
+  /**
+   * Queue health — job counts for all 7 BullMQ queues.
+   * Reads from Redis (not tenant-scoped), so no RLS needed.
+   */
+  queueHealth: adminProcedure
+    .output(queueHealthOutputSchema)
+    .query(async () => {
+      const queues = await Promise.all(
+        QUEUE_ACCESSORS.map(async ({ name, get }) => {
+          const instance = get();
+          if (!instance) {
+            return { name, waiting: 0, active: 0, delayed: 0, failed: 0 };
+          }
+          try {
+            const counts = await instance.getJobCounts(
+              'waiting',
+              'active',
+              'delayed',
+              'failed',
+            );
+            return {
+              name,
+              waiting: counts.waiting ?? 0,
+              active: counts.active ?? 0,
+              delayed: counts.delayed ?? 0,
+              failed: counts.failed ?? 0,
+            };
+          } catch {
+            // Redis unavailable — report zeros rather than fail the dashboard
+            return { name, waiting: 0, active: 0, delayed: 0, failed: 0 };
+          }
+        }),
+      );
+      return { queues };
+    }),
+
+  /**
+   * Webhook provider health — freshness status for Zitadel, Stripe, Documenso.
+   * Uses admin pool (system tables, no RLS).
+   */
+  webhookProviderHealth: adminProcedure
+    .output(webhookProviderHealthOutputSchema)
+    .query(async () => {
+      const env = validateEnv();
+      const thresholds: Record<string, number> = {
+        zitadel: env.WEBHOOK_HEALTH_ZITADEL_STALE_SECONDS,
+        stripe: env.WEBHOOK_HEALTH_STRIPE_STALE_SECONDS,
+        documenso: env.WEBHOOK_HEALTH_DOCUMENSO_STALE_SECONDS,
+      };
+
+      const result = await db.execute<{
+        provider: string;
+        last_received_at: string | null;
+      }>(sql`
+        SELECT 'zitadel' AS provider, MAX(received_at)::text AS last_received_at
+          FROM zitadel_webhook_events
+        UNION ALL
+        SELECT 'stripe' AS provider, MAX(received_at)::text AS last_received_at
+          FROM stripe_webhook_events
+        UNION ALL
+        SELECT 'documenso' AS provider, MAX(received_at)::text AS last_received_at
+          FROM documenso_webhook_events
+      `);
+
+      const now = new Date();
+      const providers = result.rows.map((row) => {
+        const lastReceivedAt = row.last_received_at;
+        if (!lastReceivedAt) {
+          return {
+            provider: row.provider,
+            status: 'unknown' as const,
+            lastReceivedAt: null,
+            freshnessSeconds: null,
+          };
+        }
+
+        const freshnessSeconds = Math.round(
+          (now.getTime() - new Date(lastReceivedAt).getTime()) / 1000,
+        );
+        const threshold = thresholds[row.provider] ?? 3600;
+        const status: 'healthy' | 'stale' =
+          freshnessSeconds > threshold ? 'stale' : 'healthy';
+
+        return {
+          provider: row.provider,
+          status,
+          lastReceivedAt,
+          freshnessSeconds,
+        };
+      });
+
+      return { timestamp: now.toISOString(), providers };
+    }),
+
+  /**
+   * Submission trend — this month vs last month, org-scoped.
+   * Uses ctx.dbTx (RLS) + explicit organizationId filter (defense-in-depth).
+   */
+  submissionTrend: adminProcedure
+    .output(submissionTrendOutputSchema)
+    .query(async ({ ctx }) => {
+      const now = new Date();
+      const thisMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+      const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+      const orgId = ctx.authContext.orgId;
+
+      const [thisMonthResult] = await ctx.dbTx
+        .select({ value: count() })
+        .from(submissions)
+        .where(
+          and(
+            eq(submissions.organizationId, orgId),
+            gte(submissions.createdAt, thisMonthStart),
+          ),
+        );
+
+      const [lastMonthResult] = await ctx.dbTx
+        .select({ value: count() })
+        .from(submissions)
+        .where(
+          and(
+            eq(submissions.organizationId, orgId),
+            gte(submissions.createdAt, lastMonthStart),
+            lt(submissions.createdAt, thisMonthStart),
+          ),
+        );
+
+      const thisMonth = thisMonthResult?.value ?? 0;
+      const lastMonth = lastMonthResult?.value ?? 0;
+      const trend: 'up' | 'down' | 'flat' =
+        thisMonth > lastMonth ? 'up' : thisMonth < lastMonth ? 'down' : 'flat';
+
+      return { thisMonth, lastMonth, trend };
+    }),
+});

--- a/apps/api/src/trpc/routers/ops.ts
+++ b/apps/api/src/trpc/routers/ops.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { sql, eq, gte, lt, and, count } from 'drizzle-orm';
+import { sql, eq, gte, lt, and, count, isNotNull } from 'drizzle-orm';
 import { db, submissions } from '@colophony/db';
 import { adminProcedure, createRouter } from '../init.js';
 import { validateEnv } from '../../config/env.js';
@@ -172,13 +172,16 @@ export const opsRouter = createRouter({
       const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
       const orgId = ctx.authContext.orgId;
 
+      // Use submittedAt (not createdAt) to exclude drafts and attribute
+      // submissions to the month they were actually submitted.
       const [thisMonthResult] = await ctx.dbTx
         .select({ value: count() })
         .from(submissions)
         .where(
           and(
             eq(submissions.organizationId, orgId),
-            gte(submissions.createdAt, thisMonthStart),
+            isNotNull(submissions.submittedAt),
+            gte(submissions.submittedAt, thisMonthStart),
           ),
         );
 
@@ -188,8 +191,9 @@ export const opsRouter = createRouter({
         .where(
           and(
             eq(submissions.organizationId, orgId),
-            gte(submissions.createdAt, lastMonthStart),
-            lt(submissions.createdAt, thisMonthStart),
+            isNotNull(submissions.submittedAt),
+            gte(submissions.submittedAt, lastMonthStart),
+            lt(submissions.submittedAt, thisMonthStart),
           ),
         );
 

--- a/apps/web/src/app/(dashboard)/operations/layout.tsx
+++ b/apps/web/src/app/(dashboard)/operations/layout.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { DensityProvider } from "@/hooks/use-density";
+
+export default function OpsLayout({ children }: { children: React.ReactNode }) {
+  return <DensityProvider density="compact">{children}</DensityProvider>;
+}

--- a/apps/web/src/app/(dashboard)/operations/page.tsx
+++ b/apps/web/src/app/(dashboard)/operations/page.tsx
@@ -1,0 +1,9 @@
+import { OpsDashboard } from "@/components/operations/ops-dashboard";
+
+export default function OperationsPage() {
+  return (
+    <div className="p-4">
+      <OpsDashboard />
+    </div>
+  );
+}

--- a/apps/web/src/components/operations/__tests__/health-card-grid.spec.tsx
+++ b/apps/web/src/components/operations/__tests__/health-card-grid.spec.tsx
@@ -1,0 +1,207 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mock tRPC
+// ---------------------------------------------------------------------------
+
+const mockListPeers = vi.fn();
+const mockQueueHealth = vi.fn();
+const mockWebhookHealth = vi.fn();
+const mockSubmissionTrend = vi.fn();
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    federation: {
+      listPeers: {
+        useQuery: (...args: unknown[]) => mockListPeers(...args),
+      },
+    },
+    ops: {
+      queueHealth: {
+        useQuery: (...args: unknown[]) => mockQueueHealth(...args),
+      },
+      webhookProviderHealth: {
+        useQuery: (...args: unknown[]) => mockWebhookHealth(...args),
+      },
+      submissionTrend: {
+        useQuery: (...args: unknown[]) => mockSubmissionTrend(...args),
+      },
+    },
+  },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+import { HealthCardGrid } from "../health-card-grid";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function loadingState() {
+  return { data: undefined, isPending: true, error: null };
+}
+
+function loaded<T>(data: T) {
+  return { data, isPending: false, error: null };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("HealthCardGrid", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders all four health cards", () => {
+    mockListPeers.mockReturnValue(
+      loaded([{ status: "active" }, { status: "active" }]),
+    );
+    mockQueueHealth.mockReturnValue(
+      loaded({
+        queues: [
+          { name: "email", waiting: 0, active: 0, delayed: 0, failed: 0 },
+        ],
+      }),
+    );
+    mockWebhookHealth.mockReturnValue(
+      loaded({
+        providers: [
+          {
+            provider: "zitadel",
+            status: "healthy",
+            lastReceivedAt: "2026-03-27T00:00:00Z",
+          },
+        ],
+      }),
+    );
+    mockSubmissionTrend.mockReturnValue(
+      loaded({ thisMonth: 5, lastMonth: 3, trend: "up" }),
+    );
+
+    render(<HealthCardGrid />);
+
+    expect(screen.getByText("Federation")).toBeInTheDocument();
+    expect(screen.getByText("Queues")).toBeInTheDocument();
+    expect(screen.getByText("Webhooks")).toBeInTheDocument();
+    expect(screen.getByText("Submissions")).toBeInTheDocument();
+  });
+
+  it("derives healthy federation status when all peers active", () => {
+    mockListPeers.mockReturnValue(
+      loaded([
+        { status: "active" },
+        { status: "active" },
+        { status: "active" },
+      ]),
+    );
+    mockQueueHealth.mockReturnValue(loadingState());
+    mockWebhookHealth.mockReturnValue(loadingState());
+    mockSubmissionTrend.mockReturnValue(loadingState());
+
+    render(<HealthCardGrid />);
+
+    expect(screen.getByText("3 active")).toBeInTheDocument();
+    // The metric should have green styling (healthy)
+    const metric = screen.getByText("3 active");
+    expect(metric.className).toContain("text-green-700");
+  });
+
+  it("derives degraded federation status when peers pending", () => {
+    mockListPeers.mockReturnValue(
+      loaded([{ status: "active" }, { status: "pending_inbound" }]),
+    );
+    mockQueueHealth.mockReturnValue(loadingState());
+    mockWebhookHealth.mockReturnValue(loadingState());
+    mockSubmissionTrend.mockReturnValue(loadingState());
+
+    render(<HealthCardGrid />);
+
+    expect(screen.getByText("1 active")).toBeInTheDocument();
+    expect(screen.getByText("1 pending")).toBeInTheDocument();
+    // Degraded = yellow
+    const metric = screen.getByText("1 active");
+    expect(metric.className).toContain("text-yellow-700");
+  });
+
+  it("derives correct queue status from job counts", () => {
+    mockListPeers.mockReturnValue(loadingState());
+    mockQueueHealth.mockReturnValue(
+      loaded({
+        queues: [
+          { name: "email", waiting: 10, active: 2, delayed: 0, failed: 3 },
+          { name: "webhook", waiting: 5, active: 0, delayed: 0, failed: 0 },
+        ],
+      }),
+    );
+    mockWebhookHealth.mockReturnValue(loadingState());
+    mockSubmissionTrend.mockReturnValue(loadingState());
+
+    render(<HealthCardGrid />);
+
+    expect(screen.getByText("15 waiting")).toBeInTheDocument();
+    expect(screen.getByText("3 failed")).toBeInTheDocument();
+    // failed > 0 = degraded = yellow
+    const metric = screen.getByText("15 waiting");
+    expect(metric.className).toContain("text-yellow-700");
+  });
+
+  it("derives correct webhook status from provider health", () => {
+    mockListPeers.mockReturnValue(loadingState());
+    mockQueueHealth.mockReturnValue(loadingState());
+    mockWebhookHealth.mockReturnValue(
+      loaded({
+        providers: [
+          {
+            provider: "zitadel",
+            status: "healthy",
+            lastReceivedAt: "2026-03-27T00:00:00Z",
+          },
+          {
+            provider: "stripe",
+            status: "stale",
+            lastReceivedAt: "2026-03-20T00:00:00Z",
+          },
+          {
+            provider: "documenso",
+            status: "healthy",
+            lastReceivedAt: "2026-03-27T00:00:00Z",
+          },
+        ],
+      }),
+    );
+    mockSubmissionTrend.mockReturnValue(loadingState());
+
+    render(<HealthCardGrid />);
+
+    expect(screen.getByText("2/3 healthy")).toBeInTheDocument();
+    expect(screen.getByText("Stale: stripe")).toBeInTheDocument();
+    // stale = degraded = yellow
+    const metric = screen.getByText("2/3 healthy");
+    expect(metric.className).toContain("text-yellow-700");
+  });
+
+  it("shows loading state while queries pending", () => {
+    mockListPeers.mockReturnValue(loadingState());
+    mockQueueHealth.mockReturnValue(loadingState());
+    mockWebhookHealth.mockReturnValue(loadingState());
+    mockSubmissionTrend.mockReturnValue(loadingState());
+
+    const { container } = render(<HealthCardGrid />);
+
+    // All cards should be in loading state (skeletons visible)
+    const skeletons = container.querySelectorAll('[class*="animate-pulse"]');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/components/operations/__tests__/health-card.spec.tsx
+++ b/apps/web/src/components/operations/__tests__/health-card.spec.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Network } from "lucide-react";
+import { HealthCard } from "../health-card";
+
+describe("HealthCard", () => {
+  it("renders title, metric, and subtitle", () => {
+    render(
+      <HealthCard
+        title="Federation"
+        status="healthy"
+        metric="12 active"
+        subtitle="2 pending"
+        icon={Network}
+      />,
+    );
+
+    expect(screen.getByText("Federation")).toBeInTheDocument();
+    expect(screen.getByText("12 active")).toBeInTheDocument();
+    expect(screen.getByText("2 pending")).toBeInTheDocument();
+  });
+
+  it("applies green styling for healthy status", () => {
+    render(
+      <HealthCard title="Test" status="healthy" metric="OK" icon={Network} />,
+    );
+
+    const metric = screen.getByText("OK");
+    expect(metric.className).toContain("text-green-700");
+  });
+
+  it("applies yellow styling for degraded status", () => {
+    render(
+      <HealthCard
+        title="Test"
+        status="degraded"
+        metric="3 stale"
+        icon={Network}
+      />,
+    );
+
+    const metric = screen.getByText("3 stale");
+    expect(metric.className).toContain("text-yellow-700");
+  });
+
+  it("applies red styling for unhealthy status", () => {
+    render(
+      <HealthCard
+        title="Test"
+        status="unhealthy"
+        metric="5 failed"
+        icon={Network}
+      />,
+    );
+
+    const metric = screen.getByText("5 failed");
+    expect(metric.className).toContain("text-red-700");
+  });
+
+  it("renders skeleton when status is loading", () => {
+    const { container } = render(
+      <HealthCard title="Test" status="loading" metric="" icon={Network} />,
+    );
+
+    expect(screen.queryByText("Test")).not.toBeInTheDocument();
+    const skeletons = container.querySelectorAll('[class*="animate-pulse"]');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("wraps in Link when href is provided", () => {
+    const { container } = render(
+      <HealthCard
+        title="Federation"
+        status="healthy"
+        metric="12 active"
+        icon={Network}
+        href="/federation"
+      />,
+    );
+
+    const link = container.querySelector("a");
+    expect(link).toBeInTheDocument();
+    expect(link?.getAttribute("href")).toBe("/federation");
+  });
+
+  it("calls onClick when clicked without href", () => {
+    const handleClick = vi.fn();
+    render(
+      <HealthCard
+        title="Queues"
+        status="healthy"
+        metric="0 waiting"
+        icon={Network}
+        onClick={handleClick}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("0 waiting"));
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/operations/__tests__/ops-dashboard.spec.tsx
+++ b/apps/web/src/components/operations/__tests__/ops-dashboard.spec.tsx
@@ -1,0 +1,171 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mock tRPC
+// ---------------------------------------------------------------------------
+
+const mockAuditList = vi.fn();
+const mockListPeers = vi.fn();
+const mockQueueHealth = vi.fn();
+const mockWebhookHealth = vi.fn();
+const mockSubmissionTrend = vi.fn();
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    audit: {
+      list: { useQuery: (...args: unknown[]) => mockAuditList(...args) },
+    },
+    federation: {
+      listPeers: {
+        useQuery: (...args: unknown[]) => mockListPeers(...args),
+      },
+    },
+    ops: {
+      queueHealth: {
+        useQuery: (...args: unknown[]) => mockQueueHealth(...args),
+      },
+      webhookProviderHealth: {
+        useQuery: (...args: unknown[]) => mockWebhookHealth(...args),
+      },
+      submissionTrend: {
+        useQuery: (...args: unknown[]) => mockSubmissionTrend(...args),
+      },
+    },
+  },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+import { OpsDashboard } from "../ops-dashboard";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function loadingState() {
+  return { data: undefined, isPending: true, error: null };
+}
+
+function setupDefaultMocks() {
+  mockListPeers.mockReturnValue({
+    data: [{ status: "active" }],
+    isPending: false,
+    error: null,
+  });
+  mockQueueHealth.mockReturnValue({
+    data: {
+      queues: [{ name: "email", waiting: 0, active: 0, delayed: 0, failed: 0 }],
+    },
+    isPending: false,
+    error: null,
+  });
+  mockWebhookHealth.mockReturnValue({
+    data: {
+      providers: [
+        {
+          provider: "zitadel",
+          status: "healthy",
+          lastReceivedAt: "2026-03-27T00:00:00Z",
+        },
+      ],
+    },
+    isPending: false,
+    error: null,
+  });
+  mockSubmissionTrend.mockReturnValue({
+    data: { thisMonth: 5, lastMonth: 3, trend: "up" },
+    isPending: false,
+    error: null,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("OpsDashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  it("renders header and health card grid", () => {
+    mockAuditList.mockReturnValue(loadingState());
+
+    render(<OpsDashboard />);
+
+    expect(screen.getByText("Operations")).toBeInTheDocument();
+    expect(screen.getByText("System health at a glance")).toBeInTheDocument();
+    // Health cards should be present (use getAllByText since labels repeat in quick links)
+    expect(screen.getByText("Queues")).toBeInTheDocument();
+    expect(screen.getByText("Submissions")).toBeInTheDocument();
+  });
+
+  it("renders quick links section", () => {
+    mockAuditList.mockReturnValue(loadingState());
+
+    render(<OpsDashboard />);
+
+    expect(screen.getByText("Quick Links")).toBeInTheDocument();
+    expect(screen.getByText("Organization")).toBeInTheDocument();
+
+    // Check links point to correct destinations
+    const orgLink = screen.getByText("Organization").closest("a");
+    expect(orgLink?.getAttribute("href")).toBe("/organizations/settings");
+
+    // Federation appears in both health card and quick link — verify quick link href
+    const fedLinks = screen.getAllByText("Federation");
+    const quickLinkFed = fedLinks
+      .map((el) => el.closest("a"))
+      .find((a) => a?.getAttribute("href") === "/federation");
+    expect(quickLinkFed).toBeTruthy();
+  });
+
+  it("renders recent audit events", () => {
+    mockAuditList.mockReturnValue({
+      data: {
+        items: [
+          {
+            id: "evt-1",
+            action: "USER_CREATED",
+            resource: "user",
+            resourceId: "u0000000-0000-4000-a000-000000000001",
+            createdAt: new Date("2026-03-27T10:30:00Z"),
+          },
+        ],
+        total: 1,
+        page: 1,
+        limit: 10,
+        totalPages: 1,
+      },
+      isPending: false,
+      error: null,
+    });
+
+    render(<OpsDashboard />);
+
+    expect(screen.getByText("Recent Activity")).toBeInTheDocument();
+    expect(screen.getByText("USER_CREATED")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no audit events", () => {
+    mockAuditList.mockReturnValue({
+      data: { items: [], total: 0, page: 1, limit: 10, totalPages: 0 },
+      isPending: false,
+      error: null,
+    });
+
+    render(<OpsDashboard />);
+
+    expect(screen.getByText("No recent activity.")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/operations/health-card-grid.tsx
+++ b/apps/web/src/components/operations/health-card-grid.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState } from "react";
+import { Network, ListTodo, Webhook, FileText } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { HealthCard, type HealthStatus } from "./health-card";
+import { QueueHealthDetail } from "./queue-health-detail";
+
+// ---------------------------------------------------------------------------
+// Status derivation helpers
+// ---------------------------------------------------------------------------
+
+function deriveFederationStatus(peers: Array<{ status: string }> | undefined): {
+  status: HealthStatus;
+  metric: string;
+  subtitle?: string;
+} {
+  if (!peers) return { status: "loading", metric: "" };
+
+  const active = peers.filter((p) => p.status === "active").length;
+  const pending = peers.filter(
+    (p) => p.status === "pending_inbound" || p.status === "pending_outbound",
+  ).length;
+  const troubled = peers.filter(
+    (p) => p.status === "rejected" || p.status === "revoked",
+  ).length;
+
+  let status: HealthStatus = "healthy";
+  if (troubled > 0) status = "unhealthy";
+  else if (pending > 0) status = "degraded";
+
+  return {
+    status,
+    metric: `${active} active`,
+    subtitle:
+      pending > 0
+        ? `${pending} pending`
+        : troubled > 0
+          ? `${troubled} revoked/rejected`
+          : undefined,
+  };
+}
+
+function deriveQueueStatus(
+  queues:
+    | Array<{
+        name: string;
+        waiting: number;
+        active: number;
+        delayed: number;
+        failed: number;
+      }>
+    | undefined,
+): { status: HealthStatus; metric: string; subtitle?: string } {
+  if (!queues) return { status: "loading", metric: "" };
+
+  const totalWaiting = queues.reduce((sum, q) => sum + q.waiting, 0);
+  const totalFailed = queues.reduce((sum, q) => sum + q.failed, 0);
+
+  let status: HealthStatus = "healthy";
+  if (totalFailed > 10) status = "unhealthy";
+  else if (totalFailed > 0 || totalWaiting >= 50) status = "degraded";
+
+  return {
+    status,
+    metric: `${totalWaiting} waiting`,
+    subtitle: totalFailed > 0 ? `${totalFailed} failed` : undefined,
+  };
+}
+
+function deriveWebhookStatus(
+  providers:
+    | Array<{ provider: string; status: string; lastReceivedAt: string | null }>
+    | undefined,
+): { status: HealthStatus; metric: string; subtitle?: string } {
+  if (!providers) return { status: "loading", metric: "" };
+
+  const healthy = providers.filter((p) => p.status === "healthy").length;
+  const stale = providers.filter((p) => p.status === "stale");
+  const unknown = providers.filter(
+    (p) => p.status === "unknown" && !p.lastReceivedAt,
+  );
+
+  let status: HealthStatus = "healthy";
+  if (unknown.length > 0) status = "unhealthy";
+  else if (stale.length > 0) status = "degraded";
+
+  const staleNames = stale.map((p) => p.provider).join(", ");
+
+  return {
+    status,
+    metric: `${healthy}/${providers.length} healthy`,
+    subtitle: staleNames ? `Stale: ${staleNames}` : undefined,
+  };
+}
+
+function deriveSubmissionStatus(
+  data: { thisMonth: number; lastMonth: number; trend: string } | undefined,
+): { status: HealthStatus; metric: string; subtitle?: string } {
+  if (!data) return { status: "loading", metric: "" };
+
+  let subtitle: string | undefined;
+  if (data.lastMonth > 0) {
+    const pct = Math.round(
+      ((data.thisMonth - data.lastMonth) / data.lastMonth) * 100,
+    );
+    const sign = pct >= 0 ? "+" : "";
+    subtitle = `${sign}${pct}% vs last month`;
+  } else if (data.thisMonth > 0) {
+    subtitle = "New this month";
+  }
+
+  return {
+    status: "healthy",
+    metric: `${data.thisMonth} this month`,
+    subtitle,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const REFETCH_INTERVAL = 60_000;
+
+export function HealthCardGrid() {
+  const [queueDialogOpen, setQueueDialogOpen] = useState(false);
+
+  const { data: peers, isPending: isPeersLoading } =
+    trpc.federation.listPeers.useQuery(undefined, {
+      refetchInterval: REFETCH_INTERVAL,
+    });
+
+  const { data: queueHealth, isPending: isQueuesLoading } =
+    trpc.ops.queueHealth.useQuery(undefined, {
+      refetchInterval: REFETCH_INTERVAL,
+    });
+
+  const { data: webhookHealth, isPending: isWebhooksLoading } =
+    trpc.ops.webhookProviderHealth.useQuery(undefined, {
+      refetchInterval: REFETCH_INTERVAL,
+    });
+
+  const { data: submissionTrend, isPending: isSubsLoading } =
+    trpc.ops.submissionTrend.useQuery(undefined, {
+      refetchInterval: REFETCH_INTERVAL,
+    });
+
+  const federation = deriveFederationStatus(isPeersLoading ? undefined : peers);
+  const queues = deriveQueueStatus(
+    isQueuesLoading ? undefined : queueHealth?.queues,
+  );
+  const webhooks = deriveWebhookStatus(
+    isWebhooksLoading ? undefined : webhookHealth?.providers,
+  );
+  const subs = deriveSubmissionStatus(
+    isSubsLoading ? undefined : submissionTrend,
+  );
+
+  return (
+    <>
+      <div className="grid gap-3 grid-cols-2 lg:grid-cols-4">
+        <HealthCard
+          title="Federation"
+          icon={Network}
+          href="/federation"
+          {...federation}
+        />
+        <HealthCard
+          title="Queues"
+          icon={ListTodo}
+          onClick={() => setQueueDialogOpen(true)}
+          {...queues}
+        />
+        <HealthCard
+          title="Webhooks"
+          icon={Webhook}
+          href="/webhooks"
+          {...webhooks}
+        />
+        <HealthCard
+          title="Submissions"
+          icon={FileText}
+          href="/editor/submissions"
+          {...subs}
+        />
+      </div>
+
+      {queueHealth?.queues && (
+        <QueueHealthDetail
+          open={queueDialogOpen}
+          onOpenChange={setQueueDialogOpen}
+          queues={queueHealth.queues}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/operations/health-card-grid.tsx
+++ b/apps/web/src/components/operations/health-card-grid.tsx
@@ -82,8 +82,10 @@ function deriveWebhookStatus(
   );
 
   let status: HealthStatus = "healthy";
-  if (unknown.length > 0) status = "unhealthy";
-  else if (stale.length > 0) status = "degraded";
+  if (stale.length > 0) status = "degraded";
+  // Never-seen providers are expected on fresh installs / optional integrations
+  if (unknown.length > 0 && healthy === 0 && stale.length === 0)
+    status = "unknown";
 
   const staleNames = stale.map((p) => p.provider).join(", ");
 

--- a/apps/web/src/components/operations/health-card.tsx
+++ b/apps/web/src/components/operations/health-card.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import Link from "next/link";
+import type { LucideIcon } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export type HealthStatus =
+  | "healthy"
+  | "degraded"
+  | "unhealthy"
+  | "unknown"
+  | "loading";
+
+export interface HealthCardProps {
+  title: string;
+  status: HealthStatus;
+  metric: string;
+  subtitle?: string;
+  icon: LucideIcon;
+  href?: string;
+  onClick?: () => void;
+}
+
+const STATUS_STYLES: Record<
+  Exclude<HealthStatus, "loading">,
+  { text: string; border: string }
+> = {
+  healthy: {
+    text: "text-green-700 dark:text-green-400",
+    border: "border-l-green-500",
+  },
+  degraded: {
+    text: "text-yellow-700 dark:text-yellow-400",
+    border: "border-l-yellow-500",
+  },
+  unhealthy: {
+    text: "text-red-700 dark:text-red-400",
+    border: "border-l-red-500",
+  },
+  unknown: {
+    text: "text-muted-foreground",
+    border: "border-l-muted-foreground/40",
+  },
+};
+
+export function HealthCard({
+  title,
+  status,
+  metric,
+  subtitle,
+  icon: Icon,
+  href,
+  onClick,
+}: HealthCardProps) {
+  if (status === "loading") {
+    return (
+      <Card className="border-l-4 border-l-muted">
+        <CardHeader className="py-2 px-3">
+          <Skeleton className="h-3 w-20" />
+        </CardHeader>
+        <CardContent className="py-1 px-3 pb-2">
+          <Skeleton className="h-7 w-16" />
+          <Skeleton className="mt-1 h-3 w-24" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const styles = STATUS_STYLES[status];
+
+  const card = (
+    <Card
+      className={`border-l-4 ${styles.border} transition-colors ${
+        href || onClick ? "cursor-pointer hover:bg-muted/50" : ""
+      }`}
+      onClick={!href ? onClick : undefined}
+    >
+      <CardHeader className="py-2 px-3">
+        <CardTitle className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <Icon className="h-3.5 w-3.5" />
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="py-1 px-3 pb-2">
+        <p className={`text-2xl font-bold ${styles.text}`}>{metric}</p>
+        {subtitle && (
+          <p className="mt-0.5 text-xs text-muted-foreground">{subtitle}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+
+  if (href) {
+    return <Link href={href}>{card}</Link>;
+  }
+
+  return card;
+}

--- a/apps/web/src/components/operations/ops-dashboard.tsx
+++ b/apps/web/src/components/operations/ops-dashboard.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import Link from "next/link";
+import { format } from "date-fns";
+import { Activity, Building2, Network, Webhook } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { HealthCardGrid } from "./health-card-grid";
+
+// ---------------------------------------------------------------------------
+// Quick links
+// ---------------------------------------------------------------------------
+
+const quickLinks = [
+  {
+    title: "Organization",
+    description: "Members, email templates, voting and writer status settings.",
+    href: "/organizations/settings",
+    icon: Building2,
+  },
+  {
+    title: "Webhooks",
+    description: "Outbound webhook endpoints, delivery history, and secrets.",
+    href: "/webhooks",
+    icon: Webhook,
+  },
+  {
+    title: "Federation",
+    description: "Peer trust, sim-sub checks, transfers, and migrations.",
+    href: "/federation",
+    icon: Network,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function OpsDashboard() {
+  const { data: auditData, isPending: isAuditLoading } =
+    trpc.audit.list.useQuery({ page: 1, limit: 10 });
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold">Operations</h1>
+        <p className="text-sm text-muted-foreground">
+          System health at a glance
+        </p>
+      </div>
+
+      {/* Health card grid */}
+      <HealthCardGrid />
+
+      {/* Quick links */}
+      <section>
+        <h2 className="mb-3 text-sm font-medium text-muted-foreground">
+          Quick Links
+        </h2>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {quickLinks.map((link) => (
+            <Card key={link.href} className="transition-colors hover:bg-accent">
+              <Link href={link.href} className="block">
+                <CardHeader className="pb-2">
+                  <div className="flex items-center gap-2">
+                    <link.icon className="h-4 w-4 text-muted-foreground" />
+                    <CardTitle className="text-sm">{link.title}</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-xs text-muted-foreground">
+                    {link.description}
+                  </p>
+                </CardContent>
+              </Link>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      {/* Recent activity */}
+      <section>
+        <h2 className="mb-3 flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
+          <Activity className="h-3.5 w-3.5" />
+          Recent Activity
+        </h2>
+        {isAuditLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-8 w-full" />
+            ))}
+          </div>
+        ) : auditData && auditData.items.length > 0 ? (
+          <Card>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Time</TableHead>
+                  <TableHead>Action</TableHead>
+                  <TableHead>Resource</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {auditData.items.map((event) => (
+                  <TableRow key={event.id}>
+                    <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                      {format(new Date(event.createdAt), "MMM d, HH:mm")}
+                    </TableCell>
+                    <TableCell className="text-xs font-medium">
+                      {event.action}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {event.resource}
+                      {event.resourceId
+                        ? ` (${event.resourceId.slice(0, 8)}...)`
+                        : ""}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Card>
+        ) : (
+          <p className="text-sm text-muted-foreground">No recent activity.</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/operations/queue-health-detail.tsx
+++ b/apps/web/src/components/operations/queue-health-detail.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface QueueCounts {
+  name: string;
+  waiting: number;
+  active: number;
+  delayed: number;
+  failed: number;
+}
+
+interface QueueHealthDetailProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  queues: QueueCounts[];
+}
+
+function statusColor(failed: number, waiting: number): string {
+  if (failed > 10) return "text-red-700 dark:text-red-400";
+  if (failed > 0 || waiting >= 50)
+    return "text-yellow-700 dark:text-yellow-400";
+  return "text-muted-foreground";
+}
+
+export function QueueHealthDetail({
+  open,
+  onOpenChange,
+  queues,
+}: QueueHealthDetailProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Queue Health</DialogTitle>
+        </DialogHeader>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Queue</TableHead>
+              <TableHead className="text-right">Waiting</TableHead>
+              <TableHead className="text-right">Active</TableHead>
+              <TableHead className="text-right">Delayed</TableHead>
+              <TableHead className="text-right">Failed</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {queues.map((q) => (
+              <TableRow key={q.name}>
+                <TableCell className="font-medium">{q.name}</TableCell>
+                <TableCell className="text-right">{q.waiting}</TableCell>
+                <TableCell className="text-right">{q.active}</TableCell>
+                <TableCell className="text-right">{q.delayed}</TableCell>
+                <TableCell
+                  className={`text-right font-medium ${statusColor(q.failed, q.waiting)}`}
+                >
+                  {q.failed}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -67,6 +67,11 @@ export const productionNavigation: NavItem[] = [
 
 export const operationsNavigation: NavItem[] = [
   {
+    name: "Dashboard",
+    href: "/operations",
+    icon: LayoutDashboard,
+  },
+  {
     name: "Organization",
     href: "/organizations/settings",
     icon: Building2,

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,32 @@ Newest entries first.
 
 ---
 
+## 2026-03-27 — Ops Dashboard (Design System Step 7)
+
+### Done
+
+- Built ops tRPC router (`ops.queueHealth`, `ops.webhookProviderHealth`, `ops.submissionTrend`) — 3 admin procedures
+- `queueHealth` reads all 7 BullMQ queues via `getJobCounts()` with graceful null/error handling
+- `webhookProviderHealth` reuses webhook health SQL (admin pool, not RLS) with per-provider stale thresholds
+- `submissionTrend` uses explicit `organizationId` WHERE clause (defense-in-depth per Codex plan review)
+- Built `HealthCard` component — green/yellow/red/gray status cards with optional `href` or `onClick` drill-down
+- Built `HealthCardGrid` — 4-card grid (Federation, Queues, Webhooks, Submissions) with status derivation and 60s auto-refresh
+- Built `QueueHealthDetail` dialog — per-queue breakdown table (7 rows)
+- Built `OpsDashboard` — health grid + quick links (Org, Webhooks, Federation) + recent audit activity
+- Created `/operations` route with compact density layout
+- Added "Dashboard" as first item in Operations sidebar navigation
+- 27 tests: 10 backend (queue health, webhook health, submission trend, auth) + 17 frontend (card, grid, dashboard)
+- Updated CLAUDE.md key file locations with ops dashboard entries
+
+### Decisions
+
+- New `/operations` route rather than replacing existing pages — keeps federation overview intact
+- Queue health via direct BullMQ `getJobCounts()` (not Prometheus metrics) — simpler, no extra dependency
+- Webhook health uses admin pool (system tables, no RLS) — consistent with existing REST endpoint
+- `HealthCard` supports both `href` and `onClick` — Queues card opens dialog, others navigate
+
+---
+
 ## 2026-03-26 — Production Dashboard (Design System Step 6)
 
 ### Done


### PR DESCRIPTION
## Summary

- New admin-only Operations dashboard at `/operations` with 4-card health grid (Federation peers, Queue depths, Webhook freshness, Submission trends), quick links, and recent audit activity
- Backend `ops` tRPC router with `queueHealth` (7 BullMQ queues), `webhookProviderHealth` (3 providers), and `submissionTrend` (defense-in-depth org filter, uses `submittedAt`)
- 27 tests (10 backend, 17 frontend)

## Test plan

- [ ] Unit tests pass: `pnpm --filter @colophony/api test -- ops.spec` (10 tests)
- [ ] Unit tests pass: `pnpm --filter @colophony/web test -- operations` (17 tests)
- [ ] Type check passes: `pnpm type-check`
- [ ] Navigate to `/operations` — 4 health cards visible with correct status colors
- [ ] Click Federation card → navigates to `/federation`
- [ ] Click Queues card → opens detail dialog with 7-row breakdown
- [ ] Click Webhooks card → navigates to `/webhooks`
- [ ] Quick links section shows Organization, Webhooks, Federation
- [ ] Recent Activity section shows last 10 audit events