### PR TITLE
feat: email invitation workflow for organization members

### DIFF
--- a/apps/api/src/rest/error-mapper.ts
+++ b/apps/api/src/rest/error-mapper.ts
@@ -82,6 +82,12 @@ import {
   ScoreOutOfRangeError,
 } from '../services/submission-vote.service.js';
 import { CSRImportError } from '../services/csr.service.js';
+import {
+  InvitationNotFoundError,
+  InvitationExpiredError,
+  InvitationAlreadyAcceptedError,
+  InvitationEmailMismatchError,
+} from '../services/invitation.service.js';
 
 type ORPCErrorCode = ConstructorParameters<typeof ORPCError>[0];
 
@@ -161,6 +167,11 @@ const errorCodeMap: [new (...args: never[]) => Error, ORPCErrorCode][] = [
   [CSRImportError, 'BAD_REQUEST'],
   // Precondition
   [FileNotCleanError, 'BAD_REQUEST'],
+  // Invitation errors
+  [InvitationNotFoundError, 'NOT_FOUND'],
+  [InvitationExpiredError, 'NOT_FOUND'],
+  [InvitationAlreadyAcceptedError, 'CONFLICT'],
+  [InvitationEmailMismatchError, 'FORBIDDEN'],
 ];
 
 /**

--- a/apps/api/src/rest/routers/organizations.spec.ts
+++ b/apps/api/src/rest/routers/organizations.spec.ts
@@ -14,6 +14,7 @@ vi.mock('../../services/organization.service.js', () => ({
     removeMember: vi.fn(),
     updateMemberRoles: vi.fn(),
     addMemberWithAudit: vi.fn(),
+    inviteOrAddMemberWithAudit: vi.fn(),
     removeMemberWithAudit: vi.fn(),
     updateMemberRolesWithAudit: vi.fn(),
     updateWithAudit: vi.fn(),
@@ -42,6 +43,13 @@ vi.mock('@colophony/db', () => ({
   eq: vi.fn(),
   and: vi.fn(),
   sql: vi.fn(),
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: () => ({
+    CORS_ORIGIN: 'http://localhost:3000',
+    SMTP_FROM: 'test@example.com',
+  }),
 }));
 
 import { organizationService } from '../../services/organization.service.js';
@@ -377,7 +385,7 @@ describe('organizations REST router', () => {
       ).rejects.toThrow('Admin role required');
     });
 
-    it('adds member via addMemberWithAudit', async () => {
+    it('adds member via inviteOrAddMemberWithAudit (fast path)', async () => {
       const member = {
         id: MEMBER_ID,
         organizationId: ORG_ID,
@@ -386,7 +394,10 @@ describe('organizations REST router', () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       };
-      mockService.addMemberWithAudit.mockResolvedValueOnce(member as never);
+      mockService.inviteOrAddMemberWithAudit.mockResolvedValueOnce({
+        type: 'member_added',
+        member,
+      } as never);
 
       const call = client(
         organizationsRouter.members.add,
@@ -397,27 +408,36 @@ describe('organizations REST router', () => {
         email: 'new@example.com',
         roles: ['READER'],
       });
-      expect(result).toEqual(member);
+      expect(result).toEqual({ type: 'member_added', member });
     });
 
-    it('maps UserNotFoundError to NOT_FOUND', async () => {
-      const { UserNotFoundError } =
-        await import('../../services/organization.service.js');
-      mockService.addMemberWithAudit.mockRejectedValueOnce(
-        new UserNotFoundError('nobody@example.com'),
-      );
+    it('sends invitation for unknown user', async () => {
+      const invitation = {
+        id: 'c0000000-0000-4000-a000-000000000001',
+        organizationId: ORG_ID,
+        email: 'nobody@example.com',
+        roles: ['READER'],
+        status: 'PENDING',
+        tokenPrefix: 'col_inv_',
+        invitedBy: USER_ID,
+        expiresAt: new Date('2026-04-03'),
+        createdAt: new Date(),
+      };
+      mockService.inviteOrAddMemberWithAudit.mockResolvedValueOnce({
+        type: 'invitation_sent',
+        invitation,
+      } as never);
 
       const call = client(
         organizationsRouter.members.add,
         orgContext(['ADMIN']),
       );
-      await expect(
-        call({
-          orgId: ORG_ID,
-          email: 'nobody@example.com',
-          roles: ['READER'],
-        }),
-      ).rejects.toThrow(ORPCError);
+      const result = await call({
+        orgId: ORG_ID,
+        email: 'nobody@example.com',
+        roles: ['READER'],
+      });
+      expect(result).toEqual({ type: 'invitation_sent', invitation });
     });
   });
 

--- a/apps/api/src/rest/routers/organizations.ts
+++ b/apps/api/src/rest/routers/organizations.ts
@@ -9,6 +9,7 @@ import {
   organizationMemberSchema,
   userOrganizationSchema,
   organizationMemberMutationResponseSchema,
+  inviteOrAddResultSchema,
   paginatedResponseSchema,
   successResponseSchema,
 } from '@colophony/types';
@@ -120,19 +121,21 @@ const membersAdd = adminProcedure
     method: 'POST',
     path: '/organizations/{orgId}/members',
     successStatus: 201,
-    summary: 'Add a member',
+    summary: 'Add or invite a member',
     description:
-      'Invite a user to the organization by email. The user must already have an account. Requires ADMIN role.',
+      'Add a user to the organization by email. If the user does not have an account, sends an invitation email. Requires ADMIN role.',
     operationId: 'addOrganizationMember',
     tags: ['Organizations'],
   })
   .input(orgIdParam.merge(inviteMemberSchema))
-  .output(organizationMemberMutationResponseSchema)
+  .output(inviteOrAddResultSchema)
   .handler(async ({ input, context }) => {
     assertOrgIdMatch(input.orgId, context.authContext.orgId);
+    const env = validateEnv();
     try {
-      return await organizationService.addMemberWithAudit(
+      return await organizationService.inviteOrAddMemberWithAudit(
         toServiceContext(context),
+        env,
         input.email,
         input.roles,
       );

--- a/apps/api/src/services/invitation.service.spec.ts
+++ b/apps/api/src/services/invitation.service.spec.ts
@@ -1,0 +1,399 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import crypto from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPoolQuery = vi.fn();
+
+vi.mock('@colophony/db', () => ({
+  organizationInvitations: {
+    id: 'oi.id',
+    organizationId: 'oi.organization_id',
+    email: 'oi.email',
+    roles: 'oi.roles',
+    tokenHash: 'oi.token_hash',
+    tokenPrefix: 'oi.token_prefix',
+    status: 'oi.status',
+    invitedBy: 'oi.invited_by',
+    acceptedBy: 'oi.accepted_by',
+    expiresAt: 'oi.expires_at',
+    acceptedAt: 'oi.accepted_at',
+    revokedAt: 'oi.revoked_at',
+    createdAt: 'oi.created_at',
+  },
+  organizations: { id: 'o.id', name: 'o.name' },
+  users: { id: 'u.id', email: 'u.email' },
+  pool: { query: (...args: unknown[]) => mockPoolQuery(...args) },
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+}));
+
+vi.mock('./email.service.js', () => ({
+  emailService: {
+    create: vi.fn().mockResolvedValue({ id: 'email-send-1' }),
+  },
+}));
+
+vi.mock('../queues/email.queue.js', () => ({
+  enqueueEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Chain builder for Drizzle ORM queries
+function createChain(result: unknown) {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn().mockReturnValue(chain);
+  chain.where = vi.fn().mockReturnValue(chain);
+  chain.set = vi.fn().mockReturnValue(chain);
+  chain.values = vi.fn().mockReturnValue(chain);
+  chain.leftJoin = vi.fn().mockReturnValue(chain);
+  chain.orderBy = vi.fn().mockReturnValue(chain);
+  chain.limit = vi.fn().mockReturnValue(chain);
+  chain.offset = vi.fn().mockReturnValue(chain);
+  chain.returning = vi
+    .fn()
+    .mockResolvedValue(Array.isArray(result) ? result : [result]);
+  // For queries that resolve directly (no .returning())
+  chain.then = vi
+    .fn()
+    .mockImplementation((resolve: (v: unknown) => void) =>
+      resolve(Array.isArray(result) ? result : [result]),
+    );
+  return chain;
+}
+
+function createMockTx() {
+  const insertChain = createChain({
+    id: 'inv-1',
+    organizationId: 'org-1',
+    email: 'test@example.com',
+    roles: ['READER'],
+    tokenHash: 'hash123',
+    tokenPrefix: 'col_inv_',
+    status: 'PENDING',
+    invitedBy: 'user-1',
+    expiresAt: new Date('2026-04-03'),
+    createdAt: new Date('2026-03-27'),
+  });
+
+  const updateChain = createChain({
+    id: 'inv-1',
+    status: 'REVOKED',
+    revokedAt: new Date(),
+  });
+
+  const selectChain = createChain([]);
+
+  return {
+    insert: vi.fn().mockReturnValue(insertChain),
+    update: vi.fn().mockReturnValue(updateChain),
+    select: vi.fn().mockReturnValue(selectChain),
+    _insertChain: insertChain,
+    _updateChain: updateChain,
+    _selectChain: selectChain,
+  };
+}
+
+// Import after mocks
+import {
+  invitationService,
+  InvitationNotFoundError,
+  InvitationExpiredError,
+  InvitationAlreadyAcceptedError,
+  InvitationEmailMismatchError,
+} from './invitation.service.js';
+
+describe('invitation.service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('token generation', () => {
+    it('generates tokens with col_inv_ prefix', async () => {
+      const tx = createMockTx();
+      const { plainTextToken } = await invitationService.create(
+        tx as never,
+        'org-1',
+        'test@example.com',
+        ['READER'],
+        'user-1',
+      );
+
+      expect(plainTextToken).toMatch(/^col_inv_[a-f0-9]{32}$/);
+    });
+
+    it('stores SHA-256 hash, not plaintext', async () => {
+      const tx = createMockTx();
+      const { plainTextToken } = await invitationService.create(
+        tx as never,
+        'org-1',
+        'test@example.com',
+        ['READER'],
+        'user-1',
+      );
+
+      // Verify the hash was computed correctly
+      const expectedHash = crypto
+        .createHash('sha256')
+        .update(plainTextToken)
+        .digest('hex');
+
+      const insertCall = tx.insert.mock.results[0]?.value;
+      const valuesCall = insertCall?.values;
+      expect(valuesCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tokenHash: expectedHash,
+          tokenPrefix: 'col_inv_',
+        }),
+      );
+    });
+  });
+
+  describe('verifyToken', () => {
+    it('returns invitation details for valid token', async () => {
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'inv-1',
+            organization_id: 'org-1',
+            email: 'test@example.com',
+            roles: ['EDITOR'],
+            status: 'PENDING',
+            invited_by: 'user-1',
+            expires_at: new Date('2026-04-03'),
+            created_at: new Date('2026-03-27'),
+            organization_name: 'Test Org',
+          },
+        ],
+      });
+
+      const result = await invitationService.verifyToken('col_inv_abc123');
+
+      expect(result).toEqual({
+        id: 'inv-1',
+        organizationId: 'org-1',
+        email: 'test@example.com',
+        roles: ['EDITOR'],
+        status: 'PENDING',
+        invitedBy: 'user-1',
+        expiresAt: expect.any(Date),
+        createdAt: expect.any(Date),
+        organizationName: 'Test Org',
+      });
+    });
+
+    it('returns null for non-existent token', async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+      const result = await invitationService.verifyToken('col_inv_nonexistent');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('acceptToken', () => {
+    it('returns result for valid token and matching email', async () => {
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            invitation_id: 'inv-1',
+            organization_id: 'org-1',
+            member_id: 'mem-1',
+            roles: ['EDITOR'],
+          },
+        ],
+      });
+
+      const result = await invitationService.acceptToken(
+        'col_inv_abc123',
+        'user-1',
+        'test@example.com',
+      );
+
+      expect(result).toEqual({
+        invitationId: 'inv-1',
+        organizationId: 'org-1',
+        memberId: 'mem-1',
+        roles: ['EDITOR'],
+      });
+
+      expect(mockPoolQuery).toHaveBeenCalledWith(
+        'SELECT * FROM accept_invitation($1, $2, $3)',
+        [expect.any(String), 'user-1', 'test@example.com'],
+      );
+    });
+
+    it('returns null when email does not match', async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+      const result = await invitationService.acceptToken(
+        'col_inv_abc123',
+        'user-1',
+        'wrong@example.com',
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for expired token', async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+      const result = await invitationService.acceptToken(
+        'col_inv_expired',
+        'user-1',
+        'test@example.com',
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('acceptWithAudit', () => {
+    it('throws InvitationNotFoundError for invalid token', async () => {
+      // acceptToken returns null
+      mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+      // verifyToken also returns null
+      mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+      const mockSvc = {
+        tx: createMockTx() as never,
+        userId: 'user-1',
+        audit: vi.fn(),
+      };
+
+      // Mock user lookup
+      const userChain = createChain([{ email: 'test@example.com' }]);
+      (mockSvc.tx as ReturnType<typeof createMockTx>).select = vi
+        .fn()
+        .mockReturnValue(userChain);
+
+      await expect(
+        invitationService.acceptWithAudit(mockSvc, 'col_inv_invalid'),
+      ).rejects.toThrow(InvitationNotFoundError);
+    });
+
+    it('throws InvitationAlreadyAcceptedError for accepted token', async () => {
+      // acceptToken returns null
+      mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+      // verifyToken returns accepted invitation
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'inv-1',
+            organization_id: 'org-1',
+            email: 'test@example.com',
+            roles: ['EDITOR'],
+            status: 'ACCEPTED',
+            invited_by: 'user-1',
+            expires_at: new Date('2026-04-03'),
+            created_at: new Date('2026-03-27'),
+            organization_name: 'Test Org',
+          },
+        ],
+      });
+
+      const mockSvc = {
+        tx: createMockTx() as never,
+        userId: 'user-1',
+        audit: vi.fn(),
+      };
+
+      const userChain = createChain([{ email: 'test@example.com' }]);
+      (mockSvc.tx as ReturnType<typeof createMockTx>).select = vi
+        .fn()
+        .mockReturnValue(userChain);
+
+      await expect(
+        invitationService.acceptWithAudit(mockSvc, 'col_inv_accepted'),
+      ).rejects.toThrow(InvitationAlreadyAcceptedError);
+    });
+
+    it('throws InvitationExpiredError for expired token', async () => {
+      // acceptToken returns null
+      mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+      // verifyToken returns expired invitation
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'inv-1',
+            organization_id: 'org-1',
+            email: 'test@example.com',
+            roles: ['EDITOR'],
+            status: 'PENDING',
+            invited_by: 'user-1',
+            expires_at: new Date('2020-01-01'), // expired
+            created_at: new Date('2019-12-25'),
+            organization_name: 'Test Org',
+          },
+        ],
+      });
+
+      const mockSvc = {
+        tx: createMockTx() as never,
+        userId: 'user-1',
+        audit: vi.fn(),
+      };
+
+      const userChain = createChain([{ email: 'test@example.com' }]);
+      (mockSvc.tx as ReturnType<typeof createMockTx>).select = vi
+        .fn()
+        .mockReturnValue(userChain);
+
+      await expect(
+        invitationService.acceptWithAudit(mockSvc, 'col_inv_expired'),
+      ).rejects.toThrow(InvitationExpiredError);
+    });
+
+    it('throws InvitationEmailMismatchError when emails differ', async () => {
+      // acceptToken returns null
+      mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+      // verifyToken returns invitation with different email
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'inv-1',
+            organization_id: 'org-1',
+            email: 'other@example.com',
+            roles: ['EDITOR'],
+            status: 'PENDING',
+            invited_by: 'user-1',
+            expires_at: new Date('2026-04-03'),
+            created_at: new Date('2026-03-27'),
+            organization_name: 'Test Org',
+          },
+        ],
+      });
+
+      const mockSvc = {
+        tx: createMockTx() as never,
+        userId: 'user-1',
+        audit: vi.fn(),
+      };
+
+      const userChain = createChain([{ email: 'test@example.com' }]);
+      (mockSvc.tx as ReturnType<typeof createMockTx>).select = vi
+        .fn()
+        .mockReturnValue(userChain);
+
+      await expect(
+        invitationService.acceptWithAudit(mockSvc, 'col_inv_mismatch'),
+      ).rejects.toThrow(InvitationEmailMismatchError);
+    });
+  });
+
+  describe('error classes', () => {
+    it('has correct names', () => {
+      expect(new InvitationNotFoundError().name).toBe(
+        'InvitationNotFoundError',
+      );
+      expect(new InvitationExpiredError().name).toBe('InvitationExpiredError');
+      expect(new InvitationAlreadyAcceptedError().name).toBe(
+        'InvitationAlreadyAcceptedError',
+      );
+      expect(new InvitationEmailMismatchError().name).toBe(
+        'InvitationEmailMismatchError',
+      );
+    });
+  });
+});

--- a/apps/api/src/services/invitation.service.ts
+++ b/apps/api/src/services/invitation.service.ts
@@ -1,0 +1,480 @@
+import crypto from 'node:crypto';
+import {
+  pool,
+  organizationInvitations,
+  organizations,
+  users,
+  eq,
+  and,
+  sql,
+  type DrizzleDb,
+} from '@colophony/db';
+import {
+  AuditActions,
+  AuditResources,
+  INVITATION_TOKEN_PREFIX,
+  ROLE_DISPLAY_DEFAULTS,
+  type Role,
+} from '@colophony/types';
+import type { ServiceContext, UserServiceContext } from './types.js';
+import { emailService } from './email.service.js';
+import { enqueueEmail } from '../queues/email.queue.js';
+import type { Env } from '../config/env.js';
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class InvitationNotFoundError extends Error {
+  override name = 'InvitationNotFoundError' as const;
+  constructor(message = 'Invitation not found') {
+    super(message);
+  }
+}
+
+export class InvitationExpiredError extends Error {
+  override name = 'InvitationExpiredError' as const;
+  constructor(message = 'Invitation has expired') {
+    super(message);
+  }
+}
+
+export class InvitationAlreadyAcceptedError extends Error {
+  override name = 'InvitationAlreadyAcceptedError' as const;
+  constructor(message = 'Invitation has already been accepted') {
+    super(message);
+  }
+}
+
+export class InvitationEmailMismatchError extends Error {
+  override name = 'InvitationEmailMismatchError' as const;
+  constructor(message = 'Your email does not match the invitation') {
+    super(message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Token helpers
+// ---------------------------------------------------------------------------
+
+function generateToken(): {
+  plainTextToken: string;
+  tokenHash: string;
+  tokenPrefix: string;
+} {
+  const randomPart = crypto.randomBytes(16).toString('hex');
+  const plainTextToken = `${INVITATION_TOKEN_PREFIX}${randomPart}`;
+  const tokenHash = crypto
+    .createHash('sha256')
+    .update(plainTextToken)
+    .digest('hex');
+  return { plainTextToken, tokenHash, tokenPrefix: INVITATION_TOKEN_PREFIX };
+}
+
+function hashToken(plainText: string): string {
+  return crypto.createHash('sha256').update(plainText).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface VerifiedInvitation {
+  id: string;
+  organizationId: string;
+  email: string;
+  roles: Role[];
+  status: string;
+  invitedBy: string;
+  expiresAt: Date;
+  createdAt: Date;
+  organizationName: string;
+}
+
+export interface AcceptResult {
+  invitationId: string;
+  organizationId: string;
+  memberId: string;
+  roles: Role[];
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const invitationService = {
+  // -------------------------------------------------------------------------
+  // Pure data methods (tx-scoped, RLS-filtered)
+  // -------------------------------------------------------------------------
+
+  async create(
+    tx: DrizzleDb,
+    orgId: string,
+    email: string,
+    roles: Role[],
+    invitedBy: string,
+    expiresInDays: number = 7,
+  ): Promise<{
+    invitation: typeof organizationInvitations.$inferSelect;
+    plainTextToken: string;
+  }> {
+    // Revoke any existing pending invitation for same org+email
+    await invitationService.revokeByEmail(tx, orgId, email);
+
+    const { plainTextToken, tokenHash, tokenPrefix } = generateToken();
+    const expiresAt = new Date(
+      Date.now() + expiresInDays * 24 * 60 * 60 * 1000,
+    );
+
+    const [invitation] = await tx
+      .insert(organizationInvitations)
+      .values({
+        organizationId: orgId,
+        email: email.toLowerCase(),
+        roles,
+        tokenHash,
+        tokenPrefix,
+        invitedBy,
+        expiresAt,
+      })
+      .returning();
+
+    return { invitation, plainTextToken };
+  },
+
+  async listPending(
+    tx: DrizzleDb,
+    orgId: string,
+    pagination: { page: number; limit: number } = { page: 1, limit: 50 },
+  ) {
+    const offset = (pagination.page - 1) * pagination.limit;
+
+    const items = await tx
+      .select({
+        id: organizationInvitations.id,
+        organizationId: organizationInvitations.organizationId,
+        email: organizationInvitations.email,
+        roles: sql<string[]>`${organizationInvitations.roles}::text[]`,
+        status: organizationInvitations.status,
+        tokenPrefix: organizationInvitations.tokenPrefix,
+        invitedBy: organizationInvitations.invitedBy,
+        expiresAt: organizationInvitations.expiresAt,
+        createdAt: organizationInvitations.createdAt,
+        inviterEmail: users.email,
+      })
+      .from(organizationInvitations)
+      .leftJoin(users, eq(users.id, organizationInvitations.invitedBy))
+      .where(
+        and(
+          eq(organizationInvitations.organizationId, orgId),
+          eq(organizationInvitations.status, 'PENDING'),
+        ),
+      )
+      .orderBy(sql`${organizationInvitations.createdAt} DESC`)
+      .limit(pagination.limit)
+      .offset(offset);
+
+    return items;
+  },
+
+  async revoke(tx: DrizzleDb, orgId: string, invitationId: string) {
+    const [updated] = await tx
+      .update(organizationInvitations)
+      .set({ status: 'REVOKED', revokedAt: new Date() })
+      .where(
+        and(
+          eq(organizationInvitations.id, invitationId),
+          eq(organizationInvitations.organizationId, orgId),
+          eq(organizationInvitations.status, 'PENDING'),
+        ),
+      )
+      .returning();
+
+    if (!updated) {
+      throw new InvitationNotFoundError();
+    }
+
+    return updated;
+  },
+
+  async revokeByEmail(tx: DrizzleDb, orgId: string, email: string) {
+    await tx
+      .update(organizationInvitations)
+      .set({ status: 'REVOKED', revokedAt: new Date() })
+      .where(
+        and(
+          eq(organizationInvitations.organizationId, orgId),
+          eq(organizationInvitations.email, email.toLowerCase()),
+          eq(organizationInvitations.status, 'PENDING'),
+        ),
+      );
+  },
+
+  async getById(tx: DrizzleDb, orgId: string, invitationId: string) {
+    const [invitation] = await tx
+      .select()
+      .from(organizationInvitations)
+      .where(
+        and(
+          eq(organizationInvitations.id, invitationId),
+          eq(organizationInvitations.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+
+    if (!invitation) {
+      throw new InvitationNotFoundError();
+    }
+    return invitation;
+  },
+
+  // -------------------------------------------------------------------------
+  // Cross-org methods (SECURITY DEFINER via pool)
+  // -------------------------------------------------------------------------
+
+  async verifyToken(
+    plainTextToken: string,
+  ): Promise<VerifiedInvitation | null> {
+    const tokenHash = hashToken(plainTextToken);
+    const result = await pool.query<{
+      id: string;
+      organization_id: string;
+      email: string;
+      roles: string[];
+      status: string;
+      invited_by: string;
+      expires_at: Date;
+      created_at: Date;
+      organization_name: string;
+    }>('SELECT * FROM verify_invitation_token($1)', [tokenHash]);
+
+    if (result.rows.length === 0) return null;
+
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      organizationId: row.organization_id,
+      email: row.email,
+      roles: row.roles as Role[],
+      status: row.status,
+      invitedBy: row.invited_by,
+      expiresAt: row.expires_at,
+      createdAt: row.created_at,
+      organizationName: row.organization_name,
+    };
+  },
+
+  async acceptToken(
+    plainTextToken: string,
+    userId: string,
+    userEmail: string,
+  ): Promise<AcceptResult | null> {
+    const tokenHash = hashToken(plainTextToken);
+    const result = await pool.query<{
+      invitation_id: string;
+      organization_id: string;
+      member_id: string;
+      roles: string[];
+    }>('SELECT * FROM accept_invitation($1, $2, $3)', [
+      tokenHash,
+      userId,
+      userEmail,
+    ]);
+
+    if (result.rows.length === 0) return null;
+
+    const row = result.rows[0];
+    return {
+      invitationId: row.invitation_id,
+      organizationId: row.organization_id,
+      memberId: row.member_id,
+      roles: row.roles as Role[],
+    };
+  },
+
+  // -------------------------------------------------------------------------
+  // Access-aware methods (ServiceContext)
+  // -------------------------------------------------------------------------
+
+  async createWithAudit(
+    svc: ServiceContext,
+    email: string,
+    roles: Role[],
+    expiresInDays?: number,
+  ) {
+    const result = await invitationService.create(
+      svc.tx,
+      svc.actor.orgId,
+      email,
+      roles,
+      svc.actor.userId,
+      expiresInDays,
+    );
+    await svc.audit({
+      action: AuditActions.INVITATION_CREATED,
+      resource: AuditResources.INVITATION,
+      resourceId: result.invitation.id,
+      newValue: { email, roles },
+    });
+    return result;
+  },
+
+  async revokeWithAudit(svc: ServiceContext, invitationId: string) {
+    const result = await invitationService.revoke(
+      svc.tx,
+      svc.actor.orgId,
+      invitationId,
+    );
+    await svc.audit({
+      action: AuditActions.INVITATION_REVOKED,
+      resource: AuditResources.INVITATION,
+      resourceId: invitationId,
+    });
+    return result;
+  },
+
+  async acceptWithAudit(
+    svc: UserServiceContext,
+    plainTextToken: string,
+  ): Promise<AcceptResult> {
+    // Look up the user email for verification
+    const [user] = await svc.tx
+      .select({ email: users.email })
+      .from(users)
+      .where(eq(users.id, svc.userId))
+      .limit(1);
+
+    if (!user) {
+      throw new InvitationNotFoundError('User not found');
+    }
+
+    const result = await invitationService.acceptToken(
+      plainTextToken,
+      svc.userId,
+      user.email,
+    );
+
+    if (!result) {
+      // Provide more specific error by checking the token
+      const verified = await invitationService.verifyToken(plainTextToken);
+      if (!verified) throw new InvitationNotFoundError();
+      if (verified.status === 'ACCEPTED')
+        throw new InvitationAlreadyAcceptedError();
+      if (verified.status === 'REVOKED')
+        throw new InvitationNotFoundError('Invitation has been revoked');
+      if (verified.expiresAt < new Date()) throw new InvitationExpiredError();
+      if (verified.email.toLowerCase() !== user.email.toLowerCase())
+        throw new InvitationEmailMismatchError();
+      throw new InvitationNotFoundError();
+    }
+
+    await svc.audit({
+      action: AuditActions.INVITATION_ACCEPTED,
+      resource: AuditResources.INVITATION,
+      resourceId: result.invitationId,
+      newValue: { organizationId: result.organizationId },
+    });
+
+    return result;
+  },
+
+  async resendWithAudit(svc: ServiceContext, invitationId: string, env: Env) {
+    // Get the existing invitation
+    const existing = await invitationService.getById(
+      svc.tx,
+      svc.actor.orgId,
+      invitationId,
+    );
+
+    if (existing.status !== 'PENDING') {
+      throw new InvitationNotFoundError('Invitation is not pending');
+    }
+
+    // Revoke the old one
+    await invitationService.revoke(svc.tx, svc.actor.orgId, invitationId);
+
+    // Create a new one with the same email and roles
+    const { invitation, plainTextToken } = await invitationService.create(
+      svc.tx,
+      svc.actor.orgId,
+      existing.email,
+      existing.roles,
+      svc.actor.userId,
+    );
+
+    await svc.audit({
+      action: AuditActions.INVITATION_RESENT,
+      resource: AuditResources.INVITATION,
+      resourceId: invitation.id,
+      newValue: { email: existing.email, previousInvitationId: invitationId },
+    });
+
+    // Send the invitation email
+    await invitationService.sendInvitationEmail(
+      svc,
+      env,
+      invitation,
+      plainTextToken,
+    );
+
+    return invitation;
+  },
+
+  // -------------------------------------------------------------------------
+  // Email helper
+  // -------------------------------------------------------------------------
+
+  async sendInvitationEmail(
+    svc: ServiceContext,
+    env: Env,
+    invitation: typeof organizationInvitations.$inferSelect,
+    plainTextToken: string,
+  ) {
+    // Resolve org name and inviter email
+    const [org] = await svc.tx
+      .select({ name: organizations.name })
+      .from(organizations)
+      .where(eq(organizations.id, svc.actor.orgId))
+      .limit(1);
+
+    const [inviter] = await svc.tx
+      .select({ email: users.email })
+      .from(users)
+      .where(eq(users.id, svc.actor.userId))
+      .limit(1);
+
+    const orgName = org?.name ?? 'an organization';
+    const inviterName = inviter?.email ?? 'An admin';
+    const inviteUrl = `${env.CORS_ORIGIN}/invite/accept/${plainTextToken}`;
+    const roleNames = invitation.roles
+      .map((r) => ROLE_DISPLAY_DEFAULTS[r] ?? r)
+      .join(', ');
+
+    const emailSend = await emailService.create(svc.tx, {
+      organizationId: svc.actor.orgId,
+      recipientEmail: invitation.email,
+      templateName: 'organization-invitation',
+      eventType: 'invitation.created',
+      subject: `You've been invited to join ${orgName}`,
+    });
+
+    await enqueueEmail(env, {
+      emailSendId: emailSend.id,
+      orgId: svc.actor.orgId,
+      to: invitation.email,
+      from: env.SMTP_FROM ?? env.SENDGRID_FROM ?? 'noreply@colophony.dev',
+      templateName: 'organization-invitation',
+      templateData: {
+        orgName,
+        inviterName,
+        inviteUrl,
+        roleName: roleNames,
+        expiresAt: invitation.expiresAt.toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        }),
+      },
+    });
+  },
+};

--- a/apps/api/src/services/invitation.service.ts
+++ b/apps/api/src/services/invitation.service.ts
@@ -445,7 +445,9 @@ export const invitationService = {
 
     const orgName = org?.name ?? 'an organization';
     const inviterName = inviter?.email ?? 'An admin';
-    const inviteUrl = `${env.CORS_ORIGIN}/invite/accept/${plainTextToken}`;
+    // CORS_ORIGIN may be comma-separated for multi-origin deployments; use the first origin
+    const webOrigin = env.CORS_ORIGIN.split(',')[0].trim();
+    const inviteUrl = `${webOrigin}/invite/accept/${plainTextToken}`;
     const roleNames = invitation.roles
       .map((r) => ROLE_DISPLAY_DEFAULTS[r] ?? r)
       .join(', ');

--- a/apps/api/src/services/organization.service.ts
+++ b/apps/api/src/services/organization.service.ts
@@ -14,10 +14,13 @@ import type {
   UpdateOrganizationInput,
   PaginationInput,
   Role,
+  InviteOrAddResult,
 } from '@colophony/types';
 import { AuditActions, AuditResources } from '@colophony/types';
 import type { ServiceContext, AuditFn } from './types.js';
 import { NotFoundError } from './errors.js';
+import { invitationService } from './invitation.service.js';
+import type { Env } from '../config/env.js';
 
 export class UserNotFoundError extends Error {
   constructor(email: string) {
@@ -321,6 +324,62 @@ export const organizationService = {
       newValue: { email, roles },
     });
     return member;
+  },
+
+  /**
+   * Try to add member directly (fast path). If user doesn't exist, create an
+   * invitation with a token and send an email. Returns a discriminated union.
+   */
+  async inviteOrAddMemberWithAudit(
+    svc: ServiceContext,
+    env: Env,
+    email: string,
+    roles: Role[],
+    expiresInDays?: number,
+  ): Promise<InviteOrAddResult> {
+    try {
+      const member = await organizationService.addMember(
+        svc.tx,
+        svc.actor.orgId,
+        email,
+        roles,
+      );
+      await svc.audit({
+        action: AuditActions.ORG_MEMBER_ADDED,
+        resource: AuditResources.ORGANIZATION,
+        resourceId: member.id,
+        newValue: { email, roles },
+      });
+      return { type: 'member_added', member };
+    } catch (e) {
+      if (!(e instanceof UserNotFoundError)) throw e;
+    }
+
+    // User doesn't exist — create invitation and send email
+    const { invitation, plainTextToken } =
+      await invitationService.createWithAudit(svc, email, roles, expiresInDays);
+
+    await invitationService.sendInvitationEmail(
+      svc,
+      env,
+      invitation,
+      plainTextToken,
+    );
+
+    return {
+      type: 'invitation_sent',
+      invitation: {
+        id: invitation.id,
+        organizationId: invitation.organizationId,
+        email: invitation.email,
+        roles: invitation.roles,
+        status: invitation.status,
+        tokenPrefix: invitation.tokenPrefix,
+        invitedBy: invitation.invitedBy,
+        expiresAt: invitation.expiresAt,
+        createdAt: invitation.createdAt,
+      },
+    };
   },
 
   /**

--- a/apps/api/src/templates/email/__tests__/render.spec.ts
+++ b/apps/api/src/templates/email/__tests__/render.spec.ts
@@ -68,6 +68,16 @@ describe('renderEmailTemplate', () => {
         orgName: 'Test Lit Mag',
       },
     },
+    {
+      name: 'organization-invitation',
+      data: {
+        orgName: 'Test Lit Mag',
+        inviterName: 'admin@example.com',
+        inviteUrl: 'https://example.com/invite/accept/col_inv_abc123',
+        roleName: 'Editor',
+        expiresAt: 'April 3, 2026',
+      },
+    },
   ];
 
   for (const { name, data } of templates) {

--- a/apps/api/src/templates/email/templates.ts
+++ b/apps/api/src/templates/email/templates.ts
@@ -9,6 +9,7 @@ import type {
   DiscussionCommentTemplateData,
   EmbedSubmissionConfirmationData,
   ResponseReminderTemplateData,
+  OrganizationInvitationData,
 } from './types.js';
 import { wrapInLayout } from './layout.js';
 
@@ -360,6 +361,33 @@ function submissionResponseReminder(
   };
 }
 
+function organizationInvitation(data: Record<string, unknown>): TemplateResult {
+  const d = data as unknown as OrganizationInvitationData;
+  return {
+    subject: `You've been invited to join ${d.orgName}`,
+    mjml: wrapInLayout(
+      `<mj-text>
+        <p>${escapeHtml(d.inviterName)} has invited you to join <strong>${escapeHtml(d.orgName)}</strong> as <strong>${escapeHtml(d.roleName)}</strong>.</p>
+      </mj-text>
+      <mj-button href="${escapeHtml(d.inviteUrl)}" background-color="#2563eb" color="#ffffff" font-size="14px" padding="16px 0">
+        Accept Invitation
+      </mj-button>
+      <mj-text font-size="12px" color="#6b7280">
+        <p>This invitation expires on ${escapeHtml(d.expiresAt)}.</p>
+        <p>Or copy this link: ${escapeHtml(d.inviteUrl)}</p>
+      </mj-text>`,
+      d.orgName,
+    ),
+    text: [
+      `${d.inviterName} has invited you to join ${d.orgName} as ${d.roleName}.`,
+      '',
+      `Accept the invitation: ${d.inviteUrl}`,
+      '',
+      `This invitation expires on ${d.expiresAt}.`,
+    ].join('\n'),
+  };
+}
+
 export const templates: Record<TemplateName, TemplateRenderer> = {
   'submission-received': submissionReceived,
   'submission-accepted': submissionAccepted,
@@ -373,6 +401,7 @@ export const templates: Record<TemplateName, TemplateRenderer> = {
   'discussion-comment': discussionComment,
   'embed-submission-confirmation': embedSubmissionConfirmation,
   'submission-response-reminder': submissionResponseReminder,
+  'organization-invitation': organizationInvitation,
 };
 
 function stripHtml(html: string): string {

--- a/apps/api/src/templates/email/types.ts
+++ b/apps/api/src/templates/email/types.ts
@@ -10,7 +10,8 @@ export type TemplateName =
   | 'reviewer-assigned'
   | 'discussion-comment'
   | 'embed-submission-confirmation'
-  | 'submission-response-reminder';
+  | 'submission-response-reminder'
+  | 'organization-invitation';
 
 export interface SubmissionTemplateData {
   submissionTitle: string;
@@ -77,6 +78,14 @@ export interface ResponseReminderTemplateData {
   queueUrl?: string;
 }
 
+export interface OrganizationInvitationData {
+  orgName: string;
+  inviterName: string;
+  inviteUrl: string;
+  roleName: string;
+  expiresAt: string;
+}
+
 export type TemplateData =
   | SubmissionTemplateData
   | ContractTemplateData
@@ -85,4 +94,5 @@ export type TemplateData =
   | ReviewerAssignedTemplateData
   | DiscussionCommentTemplateData
   | EmbedSubmissionConfirmationData
-  | ResponseReminderTemplateData;
+  | ResponseReminderTemplateData
+  | OrganizationInvitationData;

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -112,6 +112,12 @@ import {
   CollectionItemNotFoundError,
   SubmissionNotInOrgError,
 } from '../services/collection.service.js';
+import {
+  InvitationNotFoundError,
+  InvitationExpiredError,
+  InvitationAlreadyAcceptedError,
+  InvitationEmailMismatchError,
+} from '../services/invitation.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -215,6 +221,11 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [CollectionItemNotFoundError, 'NOT_FOUND'],
   [CollectionItemAlreadyExistsError, 'CONFLICT'],
   [SubmissionNotInOrgError, 'NOT_FOUND'],
+  // Invitation errors
+  [InvitationNotFoundError, 'NOT_FOUND'],
+  [InvitationExpiredError, 'NOT_FOUND'],
+  [InvitationAlreadyAcceptedError, 'CONFLICT'],
+  [InvitationEmailMismatchError, 'FORBIDDEN'],
 ];
 
 /**

--- a/apps/api/src/trpc/routers/organizations.spec.ts
+++ b/apps/api/src/trpc/routers/organizations.spec.ts
@@ -15,6 +15,7 @@ vi.mock('../../services/organization.service.js', () => ({
     updateMemberRoles: vi.fn(),
     // Access-aware methods (PR 2)
     addMemberWithAudit: vi.fn(),
+    inviteOrAddMemberWithAudit: vi.fn(),
     removeMemberWithAudit: vi.fn(),
     updateMemberRolesWithAudit: vi.fn(),
     updateWithAudit: vi.fn(),
@@ -44,6 +45,34 @@ vi.mock('@colophony/db', () => ({
   eq: vi.fn(),
   and: vi.fn(),
   sql: vi.fn(),
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: () => ({
+    CORS_ORIGIN: 'http://localhost:3000',
+    SMTP_FROM: 'test@example.com',
+  }),
+}));
+
+vi.mock('../../services/invitation.service.js', () => ({
+  invitationService: {
+    listPending: vi.fn().mockResolvedValue([]),
+    revokeWithAudit: vi.fn().mockResolvedValue({}),
+    resendWithAudit: vi.fn().mockResolvedValue({}),
+    acceptWithAudit: vi.fn().mockResolvedValue({}),
+  },
+  InvitationNotFoundError: class InvitationNotFoundError extends Error {
+    name = 'InvitationNotFoundError';
+  },
+  InvitationExpiredError: class InvitationExpiredError extends Error {
+    name = 'InvitationExpiredError';
+  },
+  InvitationAlreadyAcceptedError: class InvitationAlreadyAcceptedError extends Error {
+    name = 'InvitationAlreadyAcceptedError';
+  },
+  InvitationEmailMismatchError: class InvitationEmailMismatchError extends Error {
+    name = 'InvitationEmailMismatchError';
+  },
 }));
 
 import { organizationService } from '../../services/organization.service.js';
@@ -345,7 +374,7 @@ describe('organizations tRPC router', () => {
       ).rejects.toThrow('Admin role required');
     });
 
-    it('adds member via addMemberWithAudit', async () => {
+    it('adds member via inviteOrAddMemberWithAudit (fast path)', async () => {
       const member = {
         id: MEMBER_NEW_ID,
         organizationId: ORG_ID,
@@ -354,7 +383,10 @@ describe('organizations tRPC router', () => {
         createdAt: NOW,
         updatedAt: NOW,
       };
-      mockService.addMemberWithAudit.mockResolvedValueOnce(member as never);
+      mockService.inviteOrAddMemberWithAudit.mockResolvedValueOnce({
+        type: 'member_added',
+        member,
+      } as never);
 
       const ctx = orgContext(['ADMIN']);
       const caller = createCaller(ctx);
@@ -362,29 +394,38 @@ describe('organizations tRPC router', () => {
         email: 'new@example.com',
         roles: ['READER'],
       });
-      expect(result).toEqual(member);
+      expect(result).toEqual({ type: 'member_added', member });
     });
 
-    it('maps UserNotFoundError to NOT_FOUND', async () => {
-      const { UserNotFoundError } =
-        await import('../../services/organization.service.js');
-      mockService.addMemberWithAudit.mockRejectedValueOnce(
-        new UserNotFoundError('nobody@example.com'),
-      );
+    it('sends invitation for unknown user', async () => {
+      const invitation = {
+        id: 'c0000000-0000-4000-a000-000000000001',
+        organizationId: ORG_ID,
+        email: 'nobody@example.com',
+        roles: ['READER'],
+        status: 'PENDING',
+        tokenPrefix: 'col_inv_',
+        invitedBy: USER_ID,
+        expiresAt: new Date('2026-04-03'),
+        createdAt: NOW,
+      };
+      mockService.inviteOrAddMemberWithAudit.mockResolvedValueOnce({
+        type: 'invitation_sent',
+        invitation,
+      } as never);
 
       const caller = createCaller(orgContext(['ADMIN']));
-      await expect(
-        caller.organizations.members.add({
-          email: 'nobody@example.com',
-          roles: ['READER'],
-        }),
-      ).rejects.toThrow(TRPCError);
+      const result = await caller.organizations.members.add({
+        email: 'nobody@example.com',
+        roles: ['READER'],
+      });
+      expect(result).toEqual({ type: 'invitation_sent', invitation });
     });
 
     it('maps 23505 to CONFLICT', async () => {
       const pgError = new Error('duplicate key');
       (pgError as unknown as { code: string }).code = '23505';
-      mockService.addMemberWithAudit.mockRejectedValueOnce(pgError);
+      mockService.inviteOrAddMemberWithAudit.mockRejectedValueOnce(pgError);
 
       const caller = createCaller(orgContext(['ADMIN']));
       await expect(

--- a/apps/api/src/trpc/routers/organizations.ts
+++ b/apps/api/src/trpc/routers/organizations.ts
@@ -10,29 +10,39 @@ import {
   memberIdParamSchema,
   organizationSchema,
   organizationMemberSchema,
+  organizationInvitationSchema,
   userOrganizationSchema,
   slugAvailabilitySchema,
   createOrganizationResponseSchema,
+  inviteOrAddResultSchema,
+  acceptInvitationSchema,
+  acceptInvitationResultSchema,
   organizationMemberMutationResponseSchema,
   successResponseSchema,
   paginatedResponseSchema,
   type Organization,
   type CreateOrganizationResponse,
+  type Role,
 } from '@colophony/types';
 import {
   authedProcedure,
   orgProcedure,
   adminProcedure,
+  userProcedure,
   createRouter,
   requireScopes,
 } from '../init.js';
 import { organizationService } from '../../services/organization.service.js';
+import { invitationService } from '../../services/invitation.service.js';
 import {
   gdprService,
   OrgNotDeletableError,
 } from '../../services/gdpr.service.js';
 import { validateEnv } from '../../config/env.js';
-import { toServiceContext } from '../../services/context.js';
+import {
+  toServiceContext,
+  toUserServiceContext,
+} from '../../services/context.js';
 import { mapServiceError } from '../error-mapper.js';
 
 const membersRouter = createRouter({
@@ -47,11 +57,13 @@ const membersRouter = createRouter({
   add: adminProcedure
     .use(requireScopes('organizations:write'))
     .input(inviteMemberSchema)
-    .output(organizationMemberMutationResponseSchema)
+    .output(inviteOrAddResultSchema)
     .mutation(async ({ ctx, input }) => {
+      const env = validateEnv();
       try {
-        return await organizationService.addMemberWithAudit(
+        return await organizationService.inviteOrAddMemberWithAudit(
           toServiceContext(ctx),
+          env,
           input.email,
           input.roles,
         );
@@ -85,6 +97,71 @@ const membersRouter = createRouter({
           toServiceContext(ctx),
           input.memberId,
           input.roles,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+});
+
+const invitationsRouter = createRouter({
+  list: adminProcedure
+    .use(requireScopes('organizations:read'))
+    .output(z.array(organizationInvitationSchema))
+    .query(async ({ ctx }) => {
+      const items = await invitationService.listPending(
+        ctx.dbTx,
+        ctx.authContext.orgId,
+      );
+      // Strip inviterEmail (not in output schema) and cast roles
+      return items.map(({ inviterEmail: _, ...rest }) => ({
+        ...rest,
+        roles: rest.roles as typeof rest.roles & Role[],
+      }));
+    }),
+
+  revoke: adminProcedure
+    .use(requireScopes('organizations:write'))
+    .input(z.object({ invitationId: z.string().uuid() }))
+    .output(successResponseSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        await invitationService.revokeWithAudit(
+          toServiceContext(ctx),
+          input.invitationId,
+        );
+        return { success: true as const };
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  resend: adminProcedure
+    .use(requireScopes('organizations:write'))
+    .input(z.object({ invitationId: z.string().uuid() }))
+    .output(organizationInvitationSchema)
+    .mutation(async ({ ctx, input }) => {
+      const env = validateEnv();
+      try {
+        const invitation = await invitationService.resendWithAudit(
+          toServiceContext(ctx),
+          input.invitationId,
+          env,
+        );
+        return invitation;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  accept: userProcedure
+    .input(acceptInvitationSchema)
+    .output(acceptInvitationResultSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await invitationService.acceptWithAudit(
+          toUserServiceContext(ctx),
+          input.token,
         );
       } catch (e) {
         mapServiceError(e);
@@ -193,4 +270,5 @@ export const organizationsRouter = createRouter({
     }),
 
   members: membersRouter,
+  invitations: invitationsRouter,
 });

--- a/apps/web/src/app/invite/accept/[token]/page.tsx
+++ b/apps/web/src/app/invite/accept/[token]/page.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/hooks/use-auth";
+import { trpc } from "@/lib/trpc";
+import { setCurrentOrgId } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Loader2, CheckCircle2, XCircle } from "lucide-react";
+
+export default function AcceptInvitationPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = use(params);
+  const router = useRouter();
+  const { isAuthenticated, isLoading: authLoading, login } = useAuth();
+  const [attempted, setAttempted] = useState(false);
+
+  const acceptMutation = trpc.organizations.invitations.accept.useMutation({
+    onSuccess: (result) => {
+      setCurrentOrgId(result.organizationId);
+      // Brief delay so the user sees the success state
+      setTimeout(() => router.replace("/"), 1500);
+    },
+  });
+
+  useEffect(() => {
+    if (authLoading) return;
+
+    if (!isAuthenticated) {
+      login();
+      return;
+    }
+
+    if (!attempted) {
+      setAttempted(true);
+      acceptMutation.mutate({ token });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authLoading, isAuthenticated, attempted, token]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/30 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle>Organization Invitation</CardTitle>
+          <CardDescription>
+            {acceptMutation.isIdle || acceptMutation.isPending
+              ? "Processing your invitation..."
+              : acceptMutation.isSuccess
+                ? "You're in!"
+                : "Something went wrong"}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col items-center gap-4">
+          {(acceptMutation.isIdle ||
+            acceptMutation.isPending ||
+            authLoading) && (
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          )}
+
+          {acceptMutation.isSuccess && (
+            <>
+              <CheckCircle2 className="h-8 w-8 text-green-600" />
+              <p className="text-sm text-muted-foreground">
+                Redirecting to your new organization...
+              </p>
+            </>
+          )}
+
+          {acceptMutation.isError && (
+            <>
+              <XCircle className="h-8 w-8 text-destructive" />
+              <p className="text-sm text-destructive">
+                {acceptMutation.error.data?.code === "FORBIDDEN"
+                  ? "Your email address does not match this invitation."
+                  : acceptMutation.error.data?.code === "CONFLICT"
+                    ? "This invitation has already been accepted."
+                    : acceptMutation.error.data?.code === "NOT_FOUND"
+                      ? "This invitation is invalid or has expired."
+                      : acceptMutation.error.message}
+              </p>
+              <Button variant="outline" onClick={() => router.replace("/")}>
+                Go to Dashboard
+              </Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/invite/accept/[token]/page.tsx
+++ b/apps/web/src/app/invite/accept/[token]/page.tsx
@@ -24,10 +24,16 @@ export default function AcceptInvitationPage({
   const router = useRouter();
   const { isAuthenticated, isLoading: authLoading, login } = useAuth();
   const [attempted, setAttempted] = useState(false);
+  const utils = trpc.useUtils();
 
   const acceptMutation = trpc.organizations.invitations.accept.useMutation({
-    onSuccess: (result) => {
+    onSuccess: async (result) => {
       setCurrentOrgId(result.organizationId);
+      // Invalidate cached org list + user profile so dashboard sees the new org
+      await Promise.all([
+        utils.organizations.list.invalidate(),
+        utils.users.me.invalidate(),
+      ]);
       // Brief delay so the user sees the success state
       setTimeout(() => router.replace("/"), 1500);
     },

--- a/apps/web/src/components/organizations/invite-member-dialog.tsx
+++ b/apps/web/src/components/organizations/invite-member-dialog.tsx
@@ -56,16 +56,19 @@ export function InviteMemberDialog({
   });
 
   const addMutation = trpc.organizations.members.add.useMutation({
-    onSuccess: () => {
+    onSuccess: (result) => {
       utils.organizations.members.list.invalidate();
-      toast.success("Member added");
+      utils.organizations.invitations.list.invalidate();
+      if (result.type === "member_added") {
+        toast.success("Member added");
+      } else {
+        toast.success(`Invitation sent to ${form.getValues("email")}`);
+      }
       form.reset();
       onOpenChange(false);
     },
     onError: (err) => {
-      if (err.data?.code === "NOT_FOUND") {
-        toast.error("No user found with that email address");
-      } else if (err.data?.code === "CONFLICT") {
+      if (err.data?.code === "CONFLICT") {
         toast.error("This user is already a member");
       } else {
         toast.error(err.message);

--- a/apps/web/src/components/organizations/member-list.tsx
+++ b/apps/web/src/components/organizations/member-list.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { useOrganization } from "@/hooks/use-organization";
 import { InviteMemberDialog } from "./invite-member-dialog";
+import { PendingInvitations } from "./pending-invitations";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -241,6 +242,8 @@ export function MemberList() {
           </Button>
         </div>
       )}
+
+      {isAdmin && <PendingInvitations />}
 
       <InviteMemberDialog open={showInvite} onOpenChange={setShowInvite} />
 

--- a/apps/web/src/components/organizations/pending-invitations.tsx
+++ b/apps/web/src/components/organizations/pending-invitations.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { toast } from "sonner";
+import { Loader2, RotateCw, X } from "lucide-react";
+import { ROLE_DISPLAY_DEFAULTS, type Role } from "@colophony/types";
+import { formatDistanceToNow } from "date-fns";
+
+export function PendingInvitations() {
+  const utils = trpc.useUtils();
+
+  const { data: invitations, isLoading } =
+    trpc.organizations.invitations.list.useQuery();
+
+  const revokeMutation = trpc.organizations.invitations.revoke.useMutation({
+    onSuccess: () => {
+      utils.organizations.invitations.list.invalidate();
+      toast.success("Invitation revoked");
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const resendMutation = trpc.organizations.invitations.resend.useMutation({
+    onSuccess: () => {
+      utils.organizations.invitations.list.invalidate();
+      toast.success("Invitation resent");
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-4">
+        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!invitations?.length) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-medium text-muted-foreground">
+        Pending Invitations
+      </h3>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Email</TableHead>
+            <TableHead>Roles</TableHead>
+            <TableHead>Sent</TableHead>
+            <TableHead>Expires</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {invitations.map((invitation) => (
+            <TableRow key={invitation.id}>
+              <TableCell className="font-medium">{invitation.email}</TableCell>
+              <TableCell>
+                <div className="flex flex-wrap gap-1">
+                  {invitation.roles.map((role) => (
+                    <Badge key={role} variant="secondary" className="text-xs">
+                      {ROLE_DISPLAY_DEFAULTS[role as Role] ?? role}
+                    </Badge>
+                  ))}
+                </div>
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {formatDistanceToNow(new Date(invitation.createdAt), {
+                  addSuffix: true,
+                })}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {formatDistanceToNow(new Date(invitation.expiresAt), {
+                  addSuffix: true,
+                })}
+              </TableCell>
+              <TableCell className="text-right">
+                <div className="flex justify-end gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={resendMutation.isPending}
+                    onClick={() =>
+                      resendMutation.mutate({
+                        invitationId: invitation.id,
+                      })
+                    }
+                    title="Resend invitation"
+                  >
+                    <RotateCw className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={revokeMutation.isPending}
+                    onClick={() =>
+                      revokeMutation.mutate({
+                        invitationId: invitation.id,
+                      })
+                    }
+                    title="Revoke invitation"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -484,7 +484,7 @@
 - [ ] [P3] Additional CMS adapters — Substack, Contentful, or other targets based on early adopter needs — (codebase audit 2026-02-27)
 - [x] [P3] In-browser copyediting or diff view between manuscript versions — (persona gap analysis 2026-02-27; done 2026-03-26 PR pending)
 - [x] [P3] READER role enforcement — define what READER can and cannot do distinct from EDITOR; currently decorative — (persona gap analysis 2026-02-27; done 2026-03-03)
-- [ ] [P3] Email invitation workflow — invite by email link/token instead of requiring pre-existing Zitadel account — (persona gap analysis 2026-02-27)
+- [x] [P3] Email invitation workflow — invite by email link/token instead of requiring pre-existing Zitadel account — (persona gap analysis 2026-02-27; done 2026-03-27 PR pending)
 - [x] [P3] Custom org roles — expanded enum to 5 roles (ADMIN/EDITOR/READER/PRODUCTION/BUSINESS_OPS) with multi-role array, productionProcedure/editorProcedure middleware, role display names in org settings — (persona gap analysis 2026-02-27; done 2026-03-27 PR #369)
 - [x] [P1] Documenso webhook: defense-in-depth org filter — mutation phase uses `withRls()` on appPool + explicit `orgId` on `updateStatus`; Codex review caught `set_config` on superuser pool doesn't enforce RLS — (Codex review 2026-03-22; done 2026-03-22)
 - [x] [P2] Documenso webhook: Zod schema validation — `documensoWebhookPayloadSchema` validates payload structure before processing — (Codex review 2026-03-22; done 2026-03-22)

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,31 @@ Newest entries first.
 
 ---
 
+## 2026-03-27 — Email Invitation Workflow (Track 12)
+
+### Done
+
+- Token-based email invitations: admins can invite anyone by email, even users without Zitadel accounts
+- New `organization_invitations` table (migration 0061) with partial unique index, SECURITY DEFINER functions for cross-org token verification and atomic acceptance
+- Invitation service: create, verify, accept, revoke, resend with full audit logging
+- `inviteOrAddMemberWithAudit()`: tries direct add first, falls through to invitation if user not found
+- MJML email template (`organization-invitation`) with CTA button, custom org template override support
+- Frontend `/invite/accept/[token]` page: auth redirect flow via `useAuth().login()`, auto-claim on return
+- Pending invitations admin table with resend/revoke actions, integrated into member list (admin-only)
+- Updated invite dialog for discriminated union response (`member_added` | `invitation_sent`)
+- 12 new invitation service unit tests, updated tRPC + REST router tests for new response shape
+- Codex plan review: 4 Important findings addressed (userProcedure for accept, acceptWithAudit/resendWithAudit, defense-in-depth orgId, TEMPLATE_MERGE_FIELDS source of truth)
+- All tests passing: 1610 API + 707 web + 102 types
+
+### Decisions
+
+- Auth-required accept flow: invitation link redirects to Zitadel login/register if not authenticated, auto-claims after auth callback
+- Separate `organization_invitations` table (not inline on members): different lifecycle, different RLS rules, SECURITY DEFINER for public token verification
+- Direct email enqueue from service (not Inngest event): invitation is a direct admin action, not a domain event with multiple consumers
+- `accept_invitation()` SECURITY DEFINER function handles race conditions via FOR UPDATE lock + ON CONFLICT DO NOTHING
+
+---
+
 ## 2026-03-27 — Multi-Role Organization System (Track 12)
 
 ### Done

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -18,6 +18,7 @@ Newest entries first.
 - Updated invite dialog for discriminated union response (`member_added` | `invitation_sent`)
 - 12 new invitation service unit tests, updated tRPC + REST router tests for new response shape
 - Codex plan review: 4 Important findings addressed (userProcedure for accept, acceptWithAudit/resendWithAudit, defense-in-depth orgId, TEMPLATE_MERGE_FIELDS source of truth)
+- Codex branch review: 3 P1 findings addressed (stale org cache after accept, comma-separated CORS_ORIGIN in invite URL, invited_by NOT NULL + ON DELETE SET NULL conflict)
 - All tests passing: 1610 API + 707 web + 102 types
 
 ### Decisions

--- a/packages/db/migrations/0061_organization_invitations.sql
+++ b/packages/db/migrations/0061_organization_invitations.sql
@@ -13,7 +13,7 @@ CREATE TABLE "organization_invitations" (
   "token_hash" varchar(128) NOT NULL UNIQUE,
   "token_prefix" varchar(16) NOT NULL,
   "status" "InvitationStatus" NOT NULL DEFAULT 'PENDING',
-  "invited_by" uuid NOT NULL REFERENCES "users"("id") ON DELETE SET NULL,
+  "invited_by" uuid REFERENCES "users"("id") ON DELETE SET NULL,
   "accepted_by" uuid REFERENCES "users"("id") ON DELETE SET NULL,
   "expires_at" timestamptz NOT NULL,
   "accepted_at" timestamptz,

--- a/packages/db/migrations/0061_organization_invitations.sql
+++ b/packages/db/migrations/0061_organization_invitations.sql
@@ -1,0 +1,155 @@
+-- Organization invitations with token-based email invitation flow
+-- Allows admins to invite users by email even if they don't have an account yet
+
+--> statement-breakpoint
+CREATE TYPE "public"."InvitationStatus" AS ENUM('PENDING', 'ACCEPTED', 'REVOKED', 'EXPIRED');
+
+--> statement-breakpoint
+CREATE TABLE "organization_invitations" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "email" varchar(320) NOT NULL,
+  "roles" "Role"[] NOT NULL DEFAULT ARRAY['READER']::"Role"[],
+  "token_hash" varchar(128) NOT NULL UNIQUE,
+  "token_prefix" varchar(16) NOT NULL,
+  "status" "InvitationStatus" NOT NULL DEFAULT 'PENDING',
+  "invited_by" uuid NOT NULL REFERENCES "users"("id") ON DELETE SET NULL,
+  "accepted_by" uuid REFERENCES "users"("id") ON DELETE SET NULL,
+  "expires_at" timestamptz NOT NULL,
+  "accepted_at" timestamptz,
+  "revoked_at" timestamptz,
+  "created_at" timestamptz NOT NULL DEFAULT now()
+);
+
+--> statement-breakpoint
+CREATE UNIQUE INDEX "organization_invitations_org_email_pending_idx"
+  ON "organization_invitations" ("organization_id", "email")
+  WHERE status = 'PENDING';
+
+--> statement-breakpoint
+CREATE INDEX "organization_invitations_organization_id_idx"
+  ON "organization_invitations" ("organization_id");
+
+--> statement-breakpoint
+CREATE INDEX "organization_invitations_token_hash_idx"
+  ON "organization_invitations" ("token_hash");
+
+--> statement-breakpoint
+CREATE INDEX "organization_invitations_email_idx"
+  ON "organization_invitations" ("email");
+
+--> statement-breakpoint
+ALTER TABLE "organization_invitations" ENABLE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+ALTER TABLE "organization_invitations" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+CREATE POLICY "organization_invitations_org_isolation"
+  ON "organization_invitations"
+  FOR ALL
+  USING (organization_id = current_org_id())
+  WITH CHECK (organization_id = current_org_id());
+
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE ON "organization_invitations" TO app_user;
+
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION verify_invitation_token(p_token_hash varchar)
+RETURNS TABLE(
+  id uuid,
+  organization_id uuid,
+  email varchar,
+  roles text[],
+  status "InvitationStatus",
+  invited_by uuid,
+  expires_at timestamptz,
+  created_at timestamptz,
+  organization_name varchar
+)
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    oi.id,
+    oi.organization_id,
+    oi.email,
+    oi.roles::text[],
+    oi.status,
+    oi.invited_by,
+    oi.expires_at,
+    oi.created_at,
+    o.name AS organization_name
+  FROM public.organization_invitations oi
+  JOIN public.organizations o ON o.id = oi.organization_id
+  WHERE oi.token_hash = p_token_hash
+$$;
+
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION verify_invitation_token(varchar) FROM PUBLIC;
+
+--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION verify_invitation_token(varchar) TO app_user;
+
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION accept_invitation(
+  p_token_hash varchar,
+  p_user_id uuid,
+  p_user_email varchar
+)
+RETURNS TABLE(
+  invitation_id uuid,
+  organization_id uuid,
+  member_id uuid,
+  roles text[]
+)
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_inv RECORD;
+  v_member_id uuid;
+BEGIN
+  -- Lock and validate the invitation
+  SELECT * INTO v_inv
+  FROM public.organization_invitations
+  WHERE token_hash = p_token_hash
+    AND status = 'PENDING'
+    AND expires_at > now()
+    AND lower(email) = lower(p_user_email)
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  -- Mark as accepted
+  UPDATE public.organization_invitations
+  SET status = 'ACCEPTED',
+      accepted_by = p_user_id,
+      accepted_at = now()
+  WHERE id = v_inv.id;
+
+  -- Create membership (ON CONFLICT for idempotency)
+  INSERT INTO public.organization_members (organization_id, user_id, roles)
+  VALUES (v_inv.organization_id, p_user_id, v_inv.roles)
+  ON CONFLICT (organization_id, user_id) DO NOTHING
+  RETURNING id INTO v_member_id;
+
+  -- If member already existed, get the existing ID
+  IF v_member_id IS NULL THEN
+    SELECT om.id INTO v_member_id
+    FROM public.organization_members om
+    WHERE om.organization_id = v_inv.organization_id
+      AND om.user_id = p_user_id;
+  END IF;
+
+  RETURN QUERY SELECT v_inv.id, v_inv.organization_id, v_member_id, v_inv.roles::text[];
+END;
+$$;
+
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION accept_invitation(varchar, uuid, varchar) FROM PUBLIC;
+
+--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION accept_invitation(varchar, uuid, varchar) TO app_user;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1781200000000,
       "tag": "0060_multi_role_expansion",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1781400000000,
+      "tag": "0061_organization_invitations",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -298,3 +298,14 @@ export const collectionTypeHintEnum = pgEnum("CollectionTypeHint", [
   "issue_planning",
   "custom",
 ]);
+
+// ---------------------------------------------------------------------------
+// Organization — Invitations
+// ---------------------------------------------------------------------------
+
+export const invitationStatusEnum = pgEnum("InvitationStatus", [
+  "PENDING",
+  "ACCEPTED",
+  "REVOKED",
+  "EXPIRED",
+]);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -31,4 +31,5 @@ export * from "./writer-workspace";
 export * from "./email-templates";
 export * from "./saved-queue-presets";
 export * from "./workspace-collections";
+export * from "./invitations";
 export * from "./relations";

--- a/packages/db/src/schema/invitations.ts
+++ b/packages/db/src/schema/invitations.ts
@@ -27,9 +27,9 @@ export const organizationInvitations = pgTable(
     tokenHash: varchar("token_hash", { length: 128 }).notNull().unique(),
     tokenPrefix: varchar("token_prefix", { length: 16 }).notNull(),
     status: invitationStatusEnum("status").notNull().default("PENDING"),
-    invitedBy: uuid("invited_by")
-      .notNull()
-      .references(() => users.id, { onDelete: "set null" }),
+    invitedBy: uuid("invited_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
     acceptedBy: uuid("accepted_by").references(() => users.id, {
       onDelete: "set null",
     }),

--- a/packages/db/src/schema/invitations.ts
+++ b/packages/db/src/schema/invitations.ts
@@ -1,0 +1,58 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  timestamp,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { organizations } from "./organizations";
+import { users } from "./users";
+import { roleEnum, invitationStatusEnum } from "./enums";
+
+export const organizationInvitations = pgTable(
+  "organization_invitations",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    email: varchar("email", { length: 320 }).notNull(),
+    roles: roleEnum("roles")
+      .array()
+      .notNull()
+      .default(sql`ARRAY['READER']::"Role"[]`),
+    tokenHash: varchar("token_hash", { length: 128 }).notNull().unique(),
+    tokenPrefix: varchar("token_prefix", { length: 16 }).notNull(),
+    status: invitationStatusEnum("status").notNull().default("PENDING"),
+    invitedBy: uuid("invited_by")
+      .notNull()
+      .references(() => users.id, { onDelete: "set null" }),
+    acceptedBy: uuid("accepted_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    acceptedAt: timestamp("accepted_at", { withTimezone: true }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("organization_invitations_org_email_pending_idx")
+      .on(table.organizationId, table.email)
+      .where(sql`status = 'PENDING'`),
+    index("organization_invitations_organization_id_idx").on(
+      table.organizationId,
+    ),
+    index("organization_invitations_token_hash_idx").on(table.tokenHash),
+    index("organization_invitations_email_idx").on(table.email),
+    pgPolicy("organization_invitations_org_isolation", {
+      for: "all",
+      using: sql`organization_id = current_org_id()`,
+      withCheck: sql`organization_id = current_org_id()`,
+    }),
+  ],
+).enableRLS();

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -257,6 +257,12 @@ export const AuditActions = {
   // Audit access
   AUDIT_ACCESSED: "AUDIT_ACCESSED",
 
+  // Invitation lifecycle
+  INVITATION_CREATED: "INVITATION_CREATED",
+  INVITATION_REVOKED: "INVITATION_REVOKED",
+  INVITATION_ACCEPTED: "INVITATION_ACCEPTED",
+  INVITATION_RESENT: "INVITATION_RESENT",
+
   // Collection lifecycle
   COLLECTION_CREATED: "COLLECTION_CREATED",
   COLLECTION_UPDATED: "COLLECTION_UPDATED",
@@ -304,6 +310,7 @@ export const AuditResources = {
   CSR: "csr",
   AUDIT: "audit",
   COLLECTION: "collection",
+  INVITATION: "invitation",
 } as const;
 
 export type AuditResource =
@@ -680,6 +687,15 @@ export interface CollectionAuditParams extends BaseAuditParams {
     | typeof AuditActions.COLLECTION_ITEM_UPDATED;
 }
 
+export interface InvitationAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.INVITATION;
+  action:
+    | typeof AuditActions.INVITATION_CREATED
+    | typeof AuditActions.INVITATION_REVOKED
+    | typeof AuditActions.INVITATION_ACCEPTED
+    | typeof AuditActions.INVITATION_RESENT;
+}
+
 /** Union of all resource-specific param types. */
 export type AuditLogParams =
   | UserAuditParams
@@ -716,7 +732,8 @@ export type AuditLogParams =
   | CSRAuditParams
   | AuditAccessAuditParams
   | SystemAuditParams
-  | CollectionAuditParams;
+  | CollectionAuditParams
+  | InvitationAuditParams;
 
 // ---------------------------------------------------------------------------
 // Query/response schemas for audit endpoints

--- a/packages/types/src/email-templates.ts
+++ b/packages/types/src/email-templates.ts
@@ -12,6 +12,7 @@ export const templateNameValues = [
   "contract-ready",
   "copyeditor-assigned",
   "editor-message",
+  "organization-invitation",
 ] as const;
 
 export const templateNameSchema = z.enum(templateNameValues);
@@ -65,6 +66,13 @@ export const TEMPLATE_MERGE_FIELDS: Record<
     "editorName",
     "messageSubject",
     "messageBody",
+  ],
+  "organization-invitation": [
+    "orgName",
+    "inviterName",
+    "inviteUrl",
+    "roleName",
+    "expiresAt",
   ],
 };
 
@@ -124,6 +132,13 @@ export const TEMPLATE_SAMPLE_DATA: Record<
     messageSubject: "A note about your submission",
     messageBody: "<p>We have a few questions about your piece.</p>",
   },
+  "organization-invitation": {
+    orgName: "The Paris Review",
+    inviterName: "George Plimpton",
+    inviteUrl: "https://example.com/invite/accept/col_inv_abc123",
+    roleName: "Editor",
+    expiresAt: "April 3, 2026",
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -162,6 +177,11 @@ export const TEMPLATE_LABELS: Record<
   "editor-message": {
     label: "Editor Message",
     description: "Wrapper for personalized messages from editors to writers.",
+  },
+  "organization-invitation": {
+    label: "Organization Invitation",
+    description:
+      "Sent to an invitee when an admin invites them to join the organization.",
   },
 };
 

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -170,6 +170,77 @@ export const updateMemberRolesSchema = z.object({
 
 export type UpdateMemberRolesInput = z.infer<typeof updateMemberRolesSchema>;
 
+// ---------------------------------------------------------------------------
+// Invitations
+// ---------------------------------------------------------------------------
+
+export const INVITATION_TOKEN_PREFIX = "col_inv_";
+
+export const invitationStatusSchema = z
+  .enum(["PENDING", "ACCEPTED", "REVOKED", "EXPIRED"])
+  .describe("Lifecycle status of an organization invitation");
+export type InvitationStatus = z.infer<typeof invitationStatusSchema>;
+
+export const organizationInvitationSchema = z.object({
+  id: z.string().uuid().describe("Invitation record ID"),
+  organizationId: z.string().uuid().describe("ID of the organization"),
+  email: z.string().email().describe("Invitee email address"),
+  roles: rolesSchema,
+  status: invitationStatusSchema,
+  tokenPrefix: z.string().describe("Token prefix for identification"),
+  invitedBy: z.string().uuid().describe("ID of the user who sent the invite"),
+  expiresAt: z.date().describe("When the invitation expires"),
+  createdAt: z.date().describe("When the invitation was created"),
+});
+export type OrganizationInvitation = z.infer<
+  typeof organizationInvitationSchema
+>;
+
+export const createInvitationSchema = z.object({
+  email: z.string().email().describe("Email address to invite"),
+  roles: rolesSchema.describe("Roles to assign on acceptance"),
+  expiresInDays: z
+    .number()
+    .int()
+    .min(1)
+    .max(30)
+    .default(7)
+    .optional()
+    .describe("Days until invitation expires (1-30, default 7)"),
+});
+export type CreateInvitationInput = z.infer<typeof createInvitationSchema>;
+
+export const acceptInvitationSchema = z.object({
+  token: z.string().min(1).describe("Plain-text invitation token"),
+});
+export type AcceptInvitationInput = z.infer<typeof acceptInvitationSchema>;
+
+export const acceptInvitationResultSchema = z.object({
+  invitationId: z.string().uuid(),
+  organizationId: z.string().uuid(),
+  memberId: z.string().uuid(),
+  roles: rolesSchema,
+});
+export type AcceptInvitationResult = z.infer<
+  typeof acceptInvitationResultSchema
+>;
+
+export const inviteOrAddResultSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("member_added"),
+    member: organizationMemberMutationResponseSchema,
+  }),
+  z.object({
+    type: z.literal("invitation_sent"),
+    invitation: organizationInvitationSchema,
+  }),
+]);
+export type InviteOrAddResult = z.infer<typeof inviteOrAddResultSchema>;
+
+// ---------------------------------------------------------------------------
+// Org Settings
+// ---------------------------------------------------------------------------
+
 export const orgSettingsSchema = z.object({
   responseReminderEnabled: z.boolean().default(false),
   responseReminderDays: z.number().int().min(1).max(365).default(30),

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -188,7 +188,13 @@ export const organizationInvitationSchema = z.object({
   roles: rolesSchema,
   status: invitationStatusSchema,
   tokenPrefix: z.string().describe("Token prefix for identification"),
-  invitedBy: z.string().uuid().describe("ID of the user who sent the invite"),
+  invitedBy: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe(
+      "ID of the user who sent the invite (null if inviter was deleted)",
+    ),
   expiresAt: z.date().describe("When the invitation expires"),
   createdAt: z.date().describe("When the invitation was created"),
 });


### PR DESCRIPTION
## Summary

- Token-based email invitations so admins can invite anyone by email, even users without Zitadel accounts
- Auth-required accept flow: invitation link → Zitadel login/register → auto-join org
- Fast path preserved: existing users are added directly without invitation

## Changes

- New `organization_invitations` table with RLS, SECURITY DEFINER functions for cross-org token verification and atomic acceptance (migration 0061)
- Invitation service with full CRUD, token verification, audit logging
- `inviteOrAddMemberWithAudit()` — tries direct add, falls through to invitation
- MJML email template with "Accept Invitation" CTA and custom org template override support
- tRPC invitation endpoints: list, revoke, resend, accept (via `userProcedure`)
- Frontend accept page at `/invite/accept/[token]` with auth redirect
- Pending invitations admin table with resend/revoke actions
- Updated invite dialog for discriminated union response

## Plan Drift

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| REST invitation routes | GET/revoke/resend endpoints | Not implemented | tRPC covers all current consumers; REST can be added when API key consumers need it |
| Router tests | 8 invitation-specific tests | Not added | Service-level tests cover the logic; router tests for invitation CRUD are lower priority |

## Code Review

- **Plan review (Codex):** 4 Important findings, all addressed before implementation
- **Branch review (Codex):** 3 P1 findings, all addressed:
  - Invalidate org list cache after accepting invitation
  - Handle comma-separated CORS_ORIGIN in invite URLs
  - Make `invited_by` nullable for GDPR user deletion compatibility

## Test plan

- [ ] `pnpm type-check` — all packages pass
- [ ] `pnpm lint` — 0 errors
- [ ] API unit tests — 1610 pass (150 files), including 12 new invitation service tests
- [ ] Web unit tests — 707 pass
- [ ] Types tests — 102 pass
- [ ] Manual: invite existing user → fast-path add
- [ ] Manual: invite unknown email → invitation email with accept link
- [ ] Manual: click link while logged out → Zitadel → accept → org dashboard
- [ ] Manual: admin revoke/resend from member settings