### PR TITLE
test(e2e): invitation workflow E2E tests + bug fixes

### DIFF
--- a/.claude/plans/bright-nibbling-duckling.md
+++ b/.claude/plans/bright-nibbling-duckling.md
@@ -1,0 +1,203 @@
+# Plan: Accessibility Improvements — Cross-Cutting Pre-Launch
+
+## Context
+
+Four P2 accessibility backlog items address WCAG compliance gaps across the web frontend. All are scoped, concrete, and affect existing components. The app uses shadcn/ui (New York), lucide-react icons, and Tailwind CSS.
+
+---
+
+## 1. Status Badges — Add Icons Alongside Color
+
+**Problem:** 8 status badge components use color alone to convey meaning (WCAG 1.4.1 violation). Color-blind users cannot distinguish statuses.
+
+**Approach:** Add a lucide-react icon to each status in every badge config. Render `<Icon className="h-3 w-3" aria-hidden="true" />` before the label text inside each Badge. Icons are decorative (the text label is the accessible name), so `aria-hidden` is correct.
+
+**Icon assignments** (chosen for semantic meaning, not just decoration):
+
+### `status-badge.tsx` (SubmissionStatus — 8 statuses)
+
+| Status              | Icon          | Rationale          |
+| ------------------- | ------------- | ------------------ |
+| DRAFT               | `FileEdit`    | Editing/incomplete |
+| SUBMITTED           | `Send`        | Sent               |
+| UNDER_REVIEW        | `Eye`         | Being viewed       |
+| ACCEPTED            | `CheckCircle` | Success            |
+| REJECTED            | `XCircle`     | Declined           |
+| HOLD                | `Pause`       | Paused             |
+| REVISE_AND_RESUBMIT | `RotateCcw`   | Redo               |
+| WITHDRAWN           | `Undo2`       | Taken back         |
+
+### `pipeline-stage-badge.tsx` (PipelineStage — 7 stages)
+
+| Stage                | Icon          |
+| -------------------- | ------------- |
+| COPYEDIT_PENDING     | `Clock`       |
+| COPYEDIT_IN_PROGRESS | `Pencil`      |
+| AUTHOR_REVIEW        | `Eye`         |
+| PROOFREAD            | `ScanSearch`  |
+| READY_TO_PUBLISH     | `CheckCircle` |
+| PUBLISHED            | `BookOpen`    |
+| WITHDRAWN            | `XCircle`     |
+
+### `issue-status-badge.tsx` (IssueStatus — 5 statuses)
+
+| Status     | Icon          |
+| ---------- | ------------- |
+| PLANNING   | `Lightbulb`   |
+| ASSEMBLING | `Layers`      |
+| READY      | `CheckCircle` |
+| PUBLISHED  | `BookOpen`    |
+| ARCHIVED   | `Archive`     |
+
+### `publication-status-badge.tsx` (PublicationStatus — 2 statuses)
+
+| Status   | Icon          |
+| -------- | ------------- |
+| ACTIVE   | `CheckCircle` |
+| ARCHIVED | `Archive`     |
+
+### `form-status-badge.tsx` (FormStatus — 3 statuses)
+
+| Status    | Icon          |
+| --------- | ------------- |
+| DRAFT     | `FileEdit`    |
+| PUBLISHED | `CheckCircle` |
+| ARCHIVED  | `Archive`     |
+
+### `period-status-badge.tsx` (PeriodStatus — 3 statuses)
+
+| Status   | Icon        |
+| -------- | ----------- |
+| UPCOMING | `Clock`     |
+| OPEN     | `CircleDot` |
+| CLOSED   | `Lock`      |
+
+### `contract-status-badge.tsx` + `contract-utils.ts` (ContractStatus — 7 statuses)
+
+| Status        | Icon          |
+| ------------- | ------------- |
+| DRAFT         | `FileEdit`    |
+| SENT          | `Send`        |
+| VIEWED        | `Eye`         |
+| SIGNED        | `PenTool`     |
+| COUNTERSIGNED | `CheckCheck`  |
+| COMPLETED     | `CheckCircle` |
+| VOIDED        | `XCircle`     |
+
+### `csr-status-badge.tsx` (CSRStatus — 10 statuses)
+
+| Status      | Icon          |
+| ----------- | ------------- |
+| draft       | `FileEdit`    |
+| sent        | `Send`        |
+| in_review   | `Eye`         |
+| hold        | `Pause`       |
+| accepted    | `CheckCircle` |
+| rejected    | `XCircle`     |
+| withdrawn   | `Undo2`       |
+| no_response | `Clock`       |
+| revise      | `RotateCcw`   |
+| unknown     | `HelpCircle`  |
+
+**Pattern:** Each config record gains an `icon` field typed as `LucideIcon`. The render function adds `<Icon className="h-3 w-3" aria-hidden="true" />` in a `gap-1` flex container (Badge already uses `inline-flex`).
+
+### Files to modify
+
+- `apps/web/src/components/submissions/status-badge.tsx`
+- `apps/web/src/components/slate/pipeline-stage-badge.tsx`
+- `apps/web/src/components/slate/issue-status-badge.tsx`
+- `apps/web/src/components/slate/publication-status-badge.tsx`
+- `apps/web/src/components/slate/contract-status-badge.tsx`
+- `apps/web/src/lib/contract-utils.ts`
+- `apps/web/src/components/form-builder/form-status-badge.tsx`
+- `apps/web/src/components/periods/period-status-badge.tsx`
+- `apps/web/src/components/workspace/csr-status-badge.tsx`
+
+---
+
+## 2. File Drop Zones — Keyboard Focus & ARIA
+
+**Problem:** Drop zone `<div>`s are clickable but not keyboard-accessible. No `role`, `tabIndex`, or `onKeyDown`. Hidden `<input type="file">` is inaccessible without mouse.
+
+**Approach:** Add `role="button"`, `tabIndex={0}`, `onKeyDown` (Enter/Space triggers file input click), `aria-label`, and `aria-disabled` to both drop zone divs. Also add `aria-label="Remove file"` / `aria-label="Cancel upload"` to the X buttons.
+
+### `apps/web/src/components/submissions/file-upload.tsx`
+
+**Drop zone div (line 303):** Add:
+
+- `role="button"`
+- `tabIndex={canUpload ? 0 : -1}`
+- `aria-label={canUpload ? "Upload files" : "Upload limit reached"}`
+- `aria-disabled={!canUpload}`
+- `onKeyDown` handler: Enter/Space → `inputRef.current?.click()`
+
+**X buttons (lines 126–133, 165–172):** Add `aria-label`:
+
+- Uploading: `aria-label="Cancel upload"` or `aria-label="Remove file"` depending on `upload.status`
+- Existing: `aria-label="Delete file"`
+
+### `apps/web/src/components/embed/embed-upload-section.tsx`
+
+Same changes to the drop zone div (line 181) and X buttons (lines 246–257).
+
+---
+
+## 3. Scan Status — `aria-live` Region
+
+**Problem:** Scan status changes (PENDING → SCANNING → CLEAN/INFECTED) are not announced to screen readers.
+
+**Approach:** Wrap the `ScanStatusBadge` in both files with `<span role="status" aria-live="polite">`. This is the simplest approach — the badge re-renders with new text when status changes, and `aria-live="polite"` causes the screen reader to announce the new content.
+
+Also add `aria-hidden="true"` to the icon inside `ScanStatusBadge` (the text label is sufficient).
+
+### Files to modify
+
+- `apps/web/src/components/submissions/file-upload.tsx` — `ScanStatusBadge` component (line 73), usages at lines 118, 163
+- `apps/web/src/components/embed/embed-upload-section.tsx` — `ScanStatusBadge` component (line 78), usages at lines 241, 280
+
+**Implementation:** Modify `ScanStatusBadge` itself to include the `role="status"` wrapper, so all usages get it automatically:
+
+```tsx
+function ScanStatusBadge({ status }: { status: ScanStatus }) {
+  const config = scanStatusConfig[status];
+  const Icon = config.icon;
+  return (
+    <span role="status" aria-live="polite">
+      <Badge variant="secondary" className={cn("gap-1", config.className)}>
+        <Icon
+          className={cn("h-3 w-3", status === "SCANNING" && "animate-spin")}
+          aria-hidden="true"
+        />
+        {config.label}
+      </Badge>
+    </span>
+  );
+}
+```
+
+---
+
+## 4. Sidebar — `aria-label` on `<nav>`
+
+**Problem:** The `<nav>` element has no `aria-label`, making it indistinguishable from other nav landmarks.
+
+**Approach:** Add `aria-label="Main navigation"` to the `<nav>` element at line 113.
+
+### File to modify
+
+- `apps/web/src/components/layout/sidebar.tsx` — line 113
+
+---
+
+## Files NOT Changed
+
+- `apps/web/src/components/ui/badge.tsx` — base shadcn component, no changes needed (already `inline-flex`)
+
+## Verification
+
+1. `pnpm type-check` passes (lucide icon imports are correct)
+2. `pnpm lint` passes
+3. Visual check: badges show icons + text in all status badge locations
+4. Keyboard check: Tab to drop zone → Enter/Space opens file picker
+5. Screen reader check: scan status changes announced; sidebar nav identified by label
+6. Existing tests pass: `pnpm test` (unit) + verify no Playwright regressions

--- a/.claude/plans/deep-watching-crystal.md
+++ b/.claude/plans/deep-watching-crystal.md
@@ -1,0 +1,124 @@
+# Plan: READER Role Enforcement
+
+## Context
+
+The READER role exists in the org roles enum (ADMIN/EDITOR/READER) but is currently "decorative." READERs are blocked from mutations by `assertEditorOrAdmin()` on the backend, but the frontend doesn't distinguish them from EDITORs — they see all UI elements and only get 403 errors when attempting writes. The `isReader` flag in `useOrganization()` is broken (means "has any membership" instead of "has READER role").
+
+**Goal:** Make READER a proper read-only role: fix the semantic bug in `isReader`, add the one missing backend guard, and ensure the frontend hides write-action UI for READERs.
+
+## Design Decisions
+
+### Sidebar Navigation for READERs
+
+**Decision:** Keep Editor/Slate/Admin sections hidden for READERs (current behavior via `isEditor` guard is correct). READERs access submitter-facing pages only.
+
+### Pipeline Comments
+
+**Decision:** Add `assertEditorOrAdmin` to `addCommentWithAudit` — this is the only mutation missing a role check. READERs should not write pipeline comments.
+
+### Analytics Access
+
+**Decision:** Leave analytics endpoints gated behind `assertEditorOrAdmin` (current behavior). Writer personal analytics are already available without role checks.
+
+---
+
+## Changes
+
+### 1. Fix `isReader` semantics + add `canWrite` flag
+
+**File:** `apps/web/src/hooks/use-organization.ts` (line 101)
+
+- Change `isReader` from `!!currentOrg` to `currentOrg?.role === "READER"`
+- Add `canWrite` convenience flag: `!!currentOrg && currentOrg.role !== "READER"`
+- Add `canWrite` to the returned object
+
+### 2. Backend: Add missing pipeline comment guard
+
+**File:** `apps/api/src/services/pipeline.service.ts` (line 477, `addCommentWithAudit` method)
+
+- Add `assertEditorOrAdmin(ctx.actor.role)` as the first line of `addCommentWithAudit`
+- Import already exists at line 29: `import { assertEditorOrAdmin } from './errors.js'`
+- Add `.limit(1000)` to `listComments` (line 496) and `listHistory` (line 508) — unbounded query fix (Codex review finding)
+
+### 3. Update `useOrganization` hook tests
+
+**File:** `apps/web/src/hooks/__tests__/use-organization.spec.tsx`
+
+Update existing test assertions:
+
+- **"should detect ADMIN role"** (line 149): `isReader` → `false`, add `canWrite: true`
+- **"should detect EDITOR role"** (line 157): `isReader` → `false`, add `canWrite: true`
+- **"should detect READER role"** (line 165): `isReader` stays `true`, add `canWrite: false`
+- **"should recover to first org roles when stored org is stale"** (line 174): `isReader` → `false`, add `canWrite: true`
+
+### 4. Add sidebar READER test
+
+**File:** `apps/web/src/components/layout/__tests__/sidebar.spec.tsx`
+
+Add test case:
+
+- **"should hide Editor, Slate, and Admin sections for READER"**: Set `mockIsEditor = false`, `mockIsAdmin = false`, render `<Sidebar />`, assert Editor Dashboard / Slate Dashboard / Organization not in document, assert My Submissions is visible. (This mirrors existing tests but makes the READER-specific scenario explicit.)
+
+### 5. Add pipeline comment role guard test
+
+**File:** `apps/api/src/services/pipeline.service.spec.ts` (new or append to existing)
+
+Check if spec file exists. If not, create minimal spec with two test cases:
+
+- **"addCommentWithAudit rejects READER role"**: ctx with `actor.role = 'READER'`, assert throws ForbiddenError
+- **"addCommentWithAudit allows EDITOR role"**: ctx with `actor.role = 'EDITOR'`, mock getById returns item, assert no ForbiddenError
+
+### 6. E2E: READER role restrictions
+
+**File:** `apps/web/e2e/helpers/reader-fixtures.ts` (new)
+
+Create fixtures following `apps/web/e2e/helpers/workspace-fixtures.ts` pattern:
+
+- Use `writer@example.com` (READER role in quarterly-review org, already seeded)
+- API key scopes: read-only (`organizations:read`, `submissions:read`, `users:read`, `periods:read`)
+- `authedPage` fixture with READER auth state
+
+**File:** `apps/web/e2e/organization/reader-role.spec.ts` (new)
+
+Test cases:
+
+1. **"READER does not see editor navigation"**: navigate to `/submissions`, assert sidebar has no "Editor Dashboard", no "Slate Dashboard", no "Organization" heading. Assert "My Submissions" visible.
+2. **"READER sees org settings as read-only"**: navigate to `/organizations/settings`, assert page loads, assert no "Save" or "Update" button visible, assert no "Danger Zone" section.
+3. **"READER cannot see invite member button"**: navigate to `/organizations/settings`, click Members tab, assert member list loads, assert "Invite Member" button not visible.
+
+---
+
+## Files Changed
+
+| File                                                        | Type          | Description                                        |
+| ----------------------------------------------------------- | ------------- | -------------------------------------------------- |
+| `apps/web/src/hooks/use-organization.ts`                    | Modify        | Fix `isReader`, add `canWrite`                     |
+| `apps/web/src/hooks/__tests__/use-organization.spec.tsx`    | Modify        | Update assertions for `isReader`/`canWrite`        |
+| `apps/api/src/services/pipeline.service.ts`                 | Modify        | Add `assertEditorOrAdmin` to `addCommentWithAudit` |
+| `apps/web/src/components/layout/__tests__/sidebar.spec.tsx` | Modify        | Add READER navigation test                         |
+| `apps/api/src/services/pipeline.service.spec.ts`            | Create/Modify | Pipeline comment role guard tests                  |
+| `apps/web/e2e/helpers/reader-fixtures.ts`                   | Create        | E2E fixtures for READER tests                      |
+| `apps/web/e2e/organization/reader-role.spec.ts`             | Create        | E2E tests for READER restrictions                  |
+
+**Codex review findings addressed:**
+
+- E2E fixtures moved to `apps/web/e2e/helpers/` (project convention)
+- Pipeline `listComments`/`listHistory` unbounded queries capped with `.limit(1000)`
+- Pipeline defense-in-depth (orgId filters on query methods) — out of scope for this PR, noted for separate hardening pass
+
+## Files NOT Changed
+
+- `apps/api/src/services/errors.ts` — `assertEditorOrAdmin` already correct
+- `apps/api/src/trpc/init.ts` — no new procedure builder needed
+- `apps/api/src/services/submission-vote.service.ts` — READER reviewer exception already works
+- `apps/api/src/services/submission-discussion.service.ts` — READER reviewer exception already works
+- All Slate components — existing `isAdmin`/`isEditor` guards already hide write actions
+- All webhook/federation components — behind `isAdmin` sidebar gate
+- Sidebar component itself — already correctly gates with `isEditor`/`isAdmin`
+
+## Verification
+
+1. **Unit tests**: `pnpm --filter @colophony/api test -- pipeline.service` (new guard test)
+2. **Web tests**: `pnpm --filter @colophony/web test -- use-organization sidebar` (updated assertions)
+3. **E2E**: `pnpm --filter @colophony/web test:e2e -- reader-role` (new READER E2E)
+4. **Manual check**: Switch to a READER-role org in the UI, verify sidebar hides Editor/Slate/Admin, verify Settings shows read-only

--- a/.claude/plans/magical-finding-scone.md
+++ b/.claude/plans/magical-finding-scone.md
@@ -1,0 +1,210 @@
+# Testing Optimization Plan
+
+## Context
+
+Static review of testing infrastructure identified 6 CI/config improvements plus E2E brittleness issues. All development tracks are complete, making this a good time to harden the test foundation. The goal is to close gaps between what CI reports and what's actually tested, reduce config drift, and improve E2E selector resilience.
+
+## Scope & Phasing
+
+**This PR (chore/testing-optimization):** Items 1-6 (CI/config fixes). These are infrastructure changes with no feature code impact.
+
+**Separate PR (later):** E2E brittleness fixes — these touch component files (adding `data-testid`) and spec files. Keeping them separate isolates UI changes from CI plumbing. Noted in backlog.
+
+---
+
+## 1. Fix the CI contract around @colophony/db
+
+**Problem:** CI line 146 calls `pnpm --filter @colophony/db test` but `packages/db/package.json` has no `test` script. pnpm exits 0 silently — CI passes with zero assertions.
+
+**Fix:** Replace the `test` call with the existing verification scripts that actually validate something.
+
+**Files to modify:**
+
+- `packages/db/package.json` — Add `"test": "tsx --env-file=.env src/verify-migrations.ts --check"` script that runs the migration verification. This way the `pnpm test` turbo pipeline still works and actually asserts something.
+- `.github/workflows/ci.yml` line 146 — Change `pnpm --filter @colophony/db test` to `pnpm --filter @colophony/db verify && pnpm --filter @colophony/db validate-enums`. These scripts need a database connection, so they must move out of the `unit-tests` job (which has no Postgres service) into a dedicated step or existing Postgres-backed job.
+
+**Design decision:** The `unit-tests` job has no Postgres service. Options:
+
+- **A.** Move the db check to the `rls-tests` job (already has Postgres, low overhead to add a step) — recommended
+- **B.** Add a dedicated `db-tests` job with Postgres — more CI minutes, cleaner separation
+- **C.** Remove the `@colophony/db test` call from `unit-tests` entirely and add a note explaining it has no unit tests
+
+**Recommendation:** Option A — add a "Verify DB migrations" step at the top of `rls-tests` before the RLS tests run (migrations are already applied by the RLS test setup, so `verify` is a cheap sanity check). Remove `@colophony/db test` from the `unit-tests` job line.
+
+**Files:**
+
+- `.github/workflows/ci.yml` — Remove `pnpm --filter @colophony/db test &&` from unit-tests (line 146). Add step to rls-tests job after workspace build: `pnpm --filter @colophony/db verify` with `DATABASE_URL` env var.
+
+---
+
+## 2. Add a dedicated webhook CI job
+
+**Problem:** `test:webhooks` script exists and works locally but has no CI job. Webhook tests need Postgres (same as RLS, services, security tests).
+
+**Fix:** Add a `webhook-tests` job to CI with Postgres service, matching the pattern of `service-integration-tests` and `security-tests`.
+
+**Files:**
+
+- `.github/workflows/ci.yml` — Add `webhook-tests` job after `security-tests`. Copy the Postgres-only service pattern from `security-tests`. Run: `pnpm --filter @colophony/api test:webhooks` with same env vars (`DATABASE_TEST_URL`, `DATABASE_APP_URL`).
+
+**Also update:**
+
+- `CLAUDE.md` CI Pipeline table — add `webhook-tests` row
+
+---
+
+## 3. Include specialized suites in coverage
+
+**Problem:** Coverage job (lines 151-227) only runs `test:cov` which excludes RLS, webhooks, security, services, and queues directories. The reported coverage number understates the actual test surface.
+
+**Fix:** Run coverage variants for the specialized suites and merge their LCOV output into the combined report.
+
+**Approach:** Add `--coverage` flag to the specialized test commands and merge the resulting LCOV files. The specialized configs don't have coverage configured, so we need to add coverage settings to each.
+
+**Files:**
+
+- `apps/api/vitest.config.rls.ts` — Add `coverage` block (same provider/include/exclude/reporters as base config)
+- `apps/api/vitest.config.webhooks.ts` — Same
+- `apps/api/vitest.config.security.ts` — Same
+- `apps/api/vitest.config.services.ts` — Same
+- `apps/api/vitest.config.queues.ts` — Same
+- `.github/workflows/ci.yml` coverage job — After the main API coverage run, run each specialized suite with `--coverage` using a different `reportsDirectory` (e.g., `coverage-rls/`, `coverage-webhooks/`, etc.). Add all LCOV files to the merge step. This requires Postgres + Redis services on the coverage job.
+
+**Note:** This makes the coverage job heavier (needs Postgres + Redis, runs 6 test suites). An alternative is to publish separate coverage artifacts per specialized job and merge in a downstream job. The former is simpler; the latter is faster (parallel). Given these are relatively quick suites, running them sequentially in the coverage job is acceptable.
+
+**Files (coverage job additions):**
+
+- `.github/workflows/ci.yml` — Add Postgres + Redis services to coverage job. Add steps for each specialized suite with `--coverage`. Update LCOV_FILES array to include all reports. Update artifact upload paths.
+
+---
+
+## 4. Add Python SDK test enforcement
+
+**Problem:** Python SDK is generated from OpenAPI spec but has no tests and no CI enforcement. Generated code could have import errors or type issues that go undetected.
+
+**Fix:** Add pytest as a dev dependency, create a minimal smoke test, and add a CI job.
+
+**Files to create:**
+
+- `sdks/python/tests/__init__.py` — Empty
+- `sdks/python/tests/test_smoke.py` — Import smoke tests: verify the main client imports, models import without error, and a basic client instantiation works
+
+**Files to modify:**
+
+- `sdks/python/pyproject.toml` — Add `[tool.poetry.group.dev.dependencies]` with `pytest = "^8.0"`. Add `[tool.pytest.ini_options]` section.
+- `.github/workflows/ci.yml` — Add `python-sdk-tests` job: setup Python 3.12, `pip install poetry`, `cd sdks/python && poetry install && poetry run pytest`
+
+**Also update:**
+
+- `CLAUDE.md` CI Pipeline table — add `python-sdk-tests` row
+
+---
+
+## 5. Consolidate Vitest config
+
+**Problem:** 5 specialized configs (`rls`, `webhooks`, `security`, `services`, `queues`) duplicate the same settings (environment, globals, setupFiles, testTimeout, fileParallelism, pool, forks, env). Drift has already occurred — `webhooks` has `singleFork: true` at the wrong nesting level (`test.singleFork` instead of `test.poolOptions.forks.singleFork`), and `queues` uses `test.forks` instead of `test.poolOptions.forks`.
+
+**Fix:** Create a shared base config and use `mergeConfig` in each specialized config.
+
+**Files to create:**
+
+- `apps/api/vitest.config.integration-base.ts` — Shared base for all integration test configs:
+
+  ```typescript
+  import { defineConfig } from "vitest/config";
+
+  export const integrationBase = defineConfig({
+    test: {
+      environment: "node",
+      globals: false,
+      setupFiles: ["../../test/vitest-console-setup.ts"],
+      testTimeout: 30_000,
+      fileParallelism: false,
+      pool: "forks",
+      poolOptions: {
+        forks: {
+          singleFork: true,
+        },
+      },
+      env: {
+        DATABASE_URL:
+          process.env.DATABASE_APP_URL ??
+          "postgresql://app_user:app_password@localhost:5433/colophony_test",
+      },
+    },
+  });
+  ```
+
+**Files to modify:**
+
+- `apps/api/vitest.config.rls.ts` — Import base, `mergeConfig(integrationBase, { test: { include: [...] } })`
+- `apps/api/vitest.config.webhooks.ts` — Same, add `NODE_ENV: 'test'` env override. **Fix:** Remove incorrect `singleFork` at top level.
+- `apps/api/vitest.config.security.ts` — Same
+- `apps/api/vitest.config.services.ts` — Same
+- `apps/api/vitest.config.queues.ts` — Same, keep extra setupFiles and Redis env vars. **Fix:** Move `forks` into `poolOptions.forks`.
+
+**Note:** The base `vitest.config.ts` (unit tests) stays separate — it has different include/exclude patterns, runs in parallel, and has coverage thresholds. No value in merging it with the integration base.
+
+---
+
+## 6. Tighten determinism in web tests
+
+**Problem:** `apps/web/test/setup.ts:57` mocks `crypto.randomUUID` with `Math.random()`, producing non-deterministic UUIDs. Combined with Jest's `--randomize` flag, failures involving UUIDs are hard to reproduce.
+
+**Fix:** Replace `Math.random()` with a deterministic counter that produces predictable, unique UUIDs per test run.
+
+**Files to modify:**
+
+- `apps/web/test/setup.ts` lines 54-59 — Replace:
+  ```typescript
+  // Mock crypto.randomUUID with deterministic counter
+  let uuidCounter = 0;
+  Object.defineProperty(globalThis, "crypto", {
+    value: {
+      randomUUID: () => {
+        const count = (++uuidCounter).toString(16).padStart(12, "0");
+        return `00000000-0000-4000-8000-${count}`;
+      },
+    },
+  });
+  ```
+  Reset counter in `afterEach`:
+  ```typescript
+  uuidCounter = 0;
+  ```
+
+This produces valid UUID v4 format strings (`00000000-0000-4000-8000-000000000001`, `...002`, etc.) that are deterministic within each test and reset between tests.
+
+---
+
+## Files NOT changing
+
+- `apps/web/e2e/**` — E2E brittleness improvements are out of scope for this PR
+- `apps/web/src/components/**` — No `data-testid` additions in this PR
+- `apps/api/vitest.config.ts` — Base unit test config stays as-is
+- `apps/web/jest.config.ts` — Jest config stays as-is (Vitest migration is a separate P3 backlog item)
+
+---
+
+## Verification
+
+1. **Local checks:**
+   - `pnpm --filter @colophony/api test` — Unit tests still pass
+   - `pnpm --filter @colophony/api test:rls` — RLS tests pass with consolidated config
+   - `pnpm --filter @colophony/api test:webhooks` — Webhook tests pass
+   - `pnpm --filter @colophony/api test:security` — Security tests pass
+   - `pnpm --filter @colophony/api test:services` — Service tests pass
+   - `pnpm --filter @colophony/api test:queues` — Queue tests pass
+   - `pnpm --filter @colophony/web test` — Web unit tests pass with deterministic UUIDs
+   - `cd sdks/python && poetry install && poetry run pytest` — Python SDK smoke tests pass
+
+2. **CI validation:**
+   - Push branch, verify all existing jobs still pass
+   - Verify new `webhook-tests` job runs and passes
+   - Verify new `python-sdk-tests` job runs and passes
+   - Verify coverage job includes specialized suite LCOV data
+   - Verify `@colophony/db test` no longer silently passes in unit-tests
+
+3. **Config drift check:**
+   - Verify all 5 integration configs import from `vitest.config.integration-base.ts`
+   - Verify `poolOptions.forks.singleFork` is correctly nested in all configs

--- a/.claude/plans/parsed-jingling-petal.md
+++ b/.claude/plans/parsed-jingling-petal.md
@@ -1,0 +1,198 @@
+# Plan: CLI Tooling Scripts
+
+## Context
+
+The monitoring stack (Prometheus, Grafana, AlertManager, Loki, Promtail) shipped in PRs #324-#325. The last session's handoff identified CLI tooling scripts as the next deliverable — 6 bash scripts that give developers and operators quick access to monitoring data, logs, and deployment controls without navigating multiple UIs.
+
+## Design Decisions
+
+**Inline boilerplate (not shared lib):** Each script duplicates color constants and `usage()`. The project has 15+ scripts and none share a lib file. Consistency > DRY for 30 lines of boilerplate.
+
+**Pure bash for all scripts:** Even `zitadel-admin.sh` uses bash+curl+jq rather than TypeScript. The existing TS Zitadel scripts are for provisioning (write ops); these are read-only queries where jq suffices.
+
+**Container resolution:** `coolify-logs.sh` uses `docker compose ps --format` to resolve service names to container names (not hardcoded `colophony-` prefix). Coolify compose doesn't set `container_name`, so prefix assumption is unsound for remote/Coolify use. Fall back to `docker ps --filter` with service label matching.
+
+## Files to Create
+
+### 1. `scripts/webhook-health.sh` (~120 lines)
+
+Query `GET /webhooks/health` and display formatted provider status.
+
+**Flags:** `--url <base-url>` (default `http://localhost:4000`), `--json`, `--quiet`, `-h`
+
+**Output format:**
+
+```
+Provider     Status       Last Event            Freshness
+zitadel      ✓ healthy    2026-03-23 14:30      2m ago
+stripe       ⚠ stale      2026-03-22 01:00      1d 13h ago
+documenso    ❌ unknown    —                     —
+```
+
+**Exit code:** 1 if any provider is stale/unknown (CI-friendly).
+
+**Dependencies:** `curl`, `jq`
+
+### 2. `scripts/grafana-query.sh` (~180 lines)
+
+Query Loki for logs and AlertManager for firing alerts.
+
+**Subcommands:**
+
+- `logs --query '<LogQL>' --since 1h --limit 100 --loki-url <url>`
+- `alerts --alertmanager-url <url>` (default `http://localhost:9093`; Grafana and AlertManager are separate services on different ports)
+
+**Loki API:** `GET /loki/api/v1/query_range?query=<encoded>&start=<ns>&limit=N&direction=backward`
+
+- URL-encode query via `jq -sRr @uri`
+- Parse `.data.result[].values[]` (each is `[timestamp, line]`)
+- Colorize log level: red=error, yellow=warn, cyan=info
+
+**Alerts:** `GET http://localhost:9093/api/v2/alerts` → filter firing → format table.
+
+**Flags:** `--json` on both subcommands, `-h`
+
+**Dependencies:** `curl`, `jq`
+
+### 3. `scripts/coolify-logs.sh` (~160 lines)
+
+Tail and search Docker container logs, locally or via SSH.
+
+**Subcommands:**
+
+- `tail <service> [--lines N] [--follow] [--all] [--host <ssh-host>]`
+- `search <pattern> [--service <name>] [--since 1h] [--host <ssh-host>]`
+
+**Container resolution:** `resolve_container()` uses `docker compose ps --format '{{.Name}}' --filter service=<name>` to find the actual container name for a compose service. Falls back to `docker ps --filter name=<name>` for non-compose setups. Does not assume `colophony-` prefix (Coolify compose omits `container_name`).
+
+**Remote:** `run_cmd()` helper wraps commands in `ssh $HOST "..."` when `--host` is set.
+
+**Dependencies:** `docker` (local), `ssh` (remote)
+
+### 4. `scripts/sentry-issues.sh` (~130 lines)
+
+List recent Sentry issues via the Sentry API.
+
+**Flags:** `--limit N` (default 10), `--resolved`, `--json`, `--url <sentry-url>` (default `https://sentry.io`), `-h`
+
+**Env vars (required):** `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`
+
+**API:** `GET /api/0/projects/{org}/{project}/issues/?limit=N&query=is:unresolved`
+
+- Auth: `Authorization: Bearer $SENTRY_AUTH_TOKEN`
+- Format: level (colorized), title (truncated), count, last seen (relative), link
+
+**Dependencies:** `curl`, `jq`
+
+### 5. `scripts/zitadel-admin.sh` (~200 lines)
+
+Common Zitadel admin queries via the Management/Admin API.
+
+**Subcommands:** `status`, `users`, `orgs`, `sessions`
+
+**Flags:** `--authority <url>` (default `$ZITADEL_AUTHORITY`), `--token <token>` (default `$ZITADEL_SERVICE_TOKEN`, falls back to `.docker/zitadel/machinekey/admin.pat`), `--limit N` (default 20), `--json`, `-h`
+
+**API endpoints:**
+
+- `status`: `GET /debug/healthz`
+- `users`: `POST /v2/users` with `{"queries":[],"limit":N}` (matches `zitadel-helpers.ts` payload format)
+- `orgs`: `POST /admin/v1/orgs/_search` with `{"queries":[],"limit":N}`
+- `sessions`: `POST /v2/sessions/search` with `{"queries":[],"limit":N}`
+
+**Note:** Validate exact payload format against Zitadel v2 API docs during implementation — existing TS helpers use `queries` array, not `query` object.
+
+**Dependencies:** `curl`, `jq`
+
+### 6. `scripts/coolify-deploy.sh` (~140 lines)
+
+Trigger a Coolify deployment from CLI, mirroring the GitHub Actions pattern.
+
+**Flags:** `--no-wait`, `--yes`/`-y`, `--health-url <url>`, `--skip-smoke`, `-h`
+
+**Env vars (required):** `COOLIFY_WEBHOOK_URL`, `COOLIFY_API_TOKEN`
+
+**Logic (mirrors `deploy.yml` lines 121-152):**
+
+1. Confirm unless `--yes`
+2. `curl -X GET -H "Authorization: Bearer ${COOLIFY_API_TOKEN}" "${COOLIFY_WEBHOOK_URL}"` — check HTTP 200/201
+3. Sleep 30s
+4. Poll health endpoint (10 attempts × 15s)
+5. Run `smoke-test.sh` unless `--skip-smoke`
+
+**Dependencies:** `curl`
+
+## Files to Modify
+
+### `.env.example`
+
+Fold new vars into existing sections (not a new top-level block):
+
+- `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` → existing Monitoring/Sentry section
+- `COOLIFY_WEBHOOK_URL`, `COOLIFY_API_TOKEN` → existing Deployment section (or Monitoring if no deploy section)
+- `ZITADEL_SERVICE_TOKEN` → existing Zitadel/Auth section
+
+### `.env.prod.example`
+
+Same vars, same sections.
+
+### `.env.staging.example`
+
+Same vars, same sections.
+
+### `CLAUDE.md`
+
+Add to Key File Locations table:
+
+- `scripts/webhook-health.sh`, `scripts/grafana-query.sh`, `scripts/coolify-logs.sh`
+- `scripts/sentry-issues.sh`, `scripts/zitadel-admin.sh`, `scripts/coolify-deploy.sh`
+
+Add CLI usage examples to "Starting Development" section after monitoring block.
+
+## Files That Should NOT Change
+
+- `apps/api/src/webhooks/webhook-health.route.ts` — consumed, not modified
+- `apps/api/src/config/env.ts` — no new API-side env vars needed
+- `docker-compose.yml` / `docker-compose.prod.yml` — no Docker changes
+- `scripts/smoke-test.sh` — consumed by `coolify-deploy.sh`, not modified
+- `.github/workflows/deploy.yml` — scripts complement, not replace
+- `package.json` — no new npm dependencies
+
+## Implementation Sequence
+
+1. `webhook-health.sh` — simplest, validates boilerplate pattern
+2. `grafana-query.sh` — Loki API, log formatting
+3. `coolify-logs.sh` — Docker logs, SSH remote pattern
+4. `sentry-issues.sh` — external API with auth
+5. `zitadel-admin.sh` — most complex (4 subcommands)
+6. `coolify-deploy.sh` — depends on smoke-test.sh integration
+7. `.env.example` / `.env.prod.example` / `.env.staging.example` updates
+8. `CLAUDE.md` updates
+
+## Verification
+
+1. `bash -n scripts/<each>.sh` — syntax check all 6
+2. `bash scripts/<each>.sh --help` — exits 1 and prints usage (matches existing `usage()` convention in `rotate-secrets.sh`)
+3. `webhook-health.sh` — test against running dev API; test `--json`, `--quiet`; test with API down
+4. `grafana-query.sh logs` — test with `--profile monitoring` up
+5. `grafana-query.sh alerts` — test against AlertManager API
+6. `coolify-logs.sh tail api` — test against running dev containers
+7. `sentry-issues.sh` — test with valid `SENTRY_AUTH_TOKEN`; test without token (error msg)
+8. `zitadel-admin.sh status` — test against local Zitadel
+9. `coolify-deploy.sh` — test confirmation prompt with 'n'; test `--yes` flag
+
+## Codex Review (2026-03-23)
+
+**Verdict:** Issues found (0 critical, 3 important, 2 suggestions — all addressed above)
+
+- Renamed `--grafana-url` → `--alertmanager-url` on `alerts` subcommand (AlertManager is port 9093, not Grafana 3001)
+- Replaced `colophony-` prefix assumption with `docker compose ps` service name resolution (Coolify compose omits `container_name`)
+- Fixed Zitadel API payload to use `queries` array (matching `zitadel-helpers.ts` pattern)
+- Folded env vars into existing `.env.example` sections instead of new top-level block
+- Fixed `--help` exit code to 1 (matching existing `usage()` convention)
+
+## Reference Files
+
+- `scripts/rotate-secrets.sh` — primary bash pattern reference
+- `scripts/smoke-test.sh` — curl + health check pattern, consumed by coolify-deploy.sh
+- `.github/workflows/deploy.yml:121-152` — Coolify webhook trigger pattern
+- `apps/api/src/webhooks/webhook-health.route.ts` — response contract

--- a/.claude/plans/peppy-greeting-church.md
+++ b/.claude/plans/peppy-greeting-church.md
@@ -1,0 +1,167 @@
+# Plan: Migrate apps/web from Jest to Vitest
+
+## Context
+
+The monorepo has a test runner split: `apps/api` uses Vitest, `apps/web` uses Jest. This causes recurring gotchas (`vi.*` vs `jest.*` confusion, duplicate mock APIs, separate coverage configs). Migrating web to Vitest eliminates the split, unifies the test toolchain, and allows sharing patterns/setup across the monorepo.
+
+## Design Decisions
+
+1. **`globals: true`** — Unlike the API (`globals: false`), web tests will use implicit `describe/it/expect` globals. This avoids adding vitest imports to all ~72 files; only the ~59 files using `jest.*` APIs need `import { vi } from 'vitest'`. Can tighten later.
+2. **Keep `.spec.ts(x)` pattern** — All existing files use `.spec`, no reason to expand.
+3. **Convert local console-setup** rather than reuse root `test/vitest-console-setup.ts` — web has its own allowlist patterns (Radix UI DialogTitle/Description warnings).
+4. **`@testing-library/jest-dom/vitest`** — Switch import path for proper Vitest matcher types.
+
+## Implementation
+
+### Phase 1: Dependencies (`apps/web/package.json`)
+
+**Remove** from devDependencies:
+
+- `jest`, `ts-jest`, `jest-environment-jsdom`, `@types/jest`
+
+**Add** to devDependencies:
+
+- `vitest` (`^4.1.0` — matches API)
+- `@vitest/coverage-v8` (`^4.1.0`)
+- `jsdom` (Vitest peer dep for `environment: 'jsdom'`)
+
+**Update scripts:**
+
+- `"test"`: `"vitest run"`
+- `"test:watch"`: `"vitest"`
+- `"test:cov"`: `"vitest run --coverage"`
+
+E2E scripts unchanged (Playwright).
+
+### Phase 2: Vitest config (`apps/web/vitest.config.ts` — new)
+
+```typescript
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      { find: /^@\/(.*)$/, replacement: path.resolve(__dirname, "src/$1") },
+      {
+        find: "@colophony/api/trpc/client-types",
+        replacement: path.resolve(__dirname, "../api/src/trpc/client-types.ts"),
+      },
+      {
+        find: /^@colophony\/types$/,
+        replacement: path.resolve(
+          __dirname,
+          "../../packages/types/src/index.ts",
+        ),
+      },
+      {
+        find: /^@colophony\/types\/(.*)$/,
+        replacement: path.resolve(__dirname, "../../packages/types/src/$1"),
+      },
+    ],
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["src/**/*.spec.{ts,tsx}"],
+    exclude: [
+      ".next/**",
+      "node_modules/**",
+      "e2e/**",
+      "_v1/**",
+      "**/*.flaky.test.*",
+    ],
+    sequence: { shuffle: true },
+    setupFiles: ["./test/setup.ts"],
+    testTimeout: 15_000,
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: ["src/**/*.d.ts", "src/app/**/*", "src/components/ui/**/*"],
+      reporter: ["text", "text-summary", "json-summary", "lcov"],
+      reportsDirectory: "./coverage",
+      thresholds: { statements: 42, branches: 65, functions: 31, lines: 42 },
+    },
+  },
+});
+```
+
+Key: uses regex-based alias array to correctly handle both `@colophony/types` (exact) and `@colophony/types/csr` (subpath).
+
+### Phase 3: TypeScript config (`apps/web/tsconfig.json`)
+
+Add `"vitest/globals"` to `compilerOptions.types` so TS recognizes `describe`, `it`, `expect` as globals (previously provided by `@types/jest`).
+
+### Phase 4: Console setup (`apps/web/test/console-setup.ts`)
+
+Convert in place:
+
+- `jest.SpyInstance` → `MockInstance` (import from `vitest`)
+- `jest.spyOn` → `vi.spyOn`
+- Add `import { afterEach, beforeEach, vi, type MockInstance } from 'vitest'`
+- Keep all allowlist patterns and logic unchanged
+
+### Phase 5: Test setup (`apps/web/test/setup.ts`)
+
+Convert in place:
+
+- `import "@testing-library/jest-dom"` → `import "@testing-library/jest-dom/vitest"`
+- Remove `jest.setTimeout(15000)` (now in vitest config as `testTimeout`)
+- All `jest.fn()` → `vi.fn()`, `jest.mock()` → `vi.mock()`
+- Add `import { vi, afterEach } from 'vitest'`
+- Exported mocks (`mockPush`, `mockReplace`, `mockBack`, `mockRefresh`) keep same names
+
+### Phase 6: Mechanical replacement in ~59 test files
+
+For each file containing `jest.*` calls:
+
+1. Add `import { vi } from 'vitest'` at top (files using `Mock`/`MockedFunction` types add those too)
+2. Replace all Jest API calls and types:
+
+| Jest                             | Vitest                                                    |
+| -------------------------------- | --------------------------------------------------------- |
+| `jest.fn()`                      | `vi.fn()`                                                 |
+| `jest.mock(`                     | `vi.mock(`                                                |
+| `jest.spyOn(`                    | `vi.spyOn(`                                               |
+| `jest.clearAllMocks()`           | `vi.clearAllMocks()`                                      |
+| `jest.restoreAllMocks()`         | `vi.restoreAllMocks()`                                    |
+| `jest.useFakeTimers()`           | `vi.useFakeTimers()`                                      |
+| `jest.useRealTimers()`           | `vi.useRealTimers()`                                      |
+| `jest.advanceTimersByTime(`      | `vi.advanceTimersByTime(`                                 |
+| `jest.advanceTimersByTimeAsync(` | `vi.advanceTimersByTimeAsync(`                            |
+| `jest.requireActual(`            | `vi.importActual(` (NOTE: returns Promise — must `await`) |
+| `jest.Mock` (type)               | `Mock` (import from `vitest`)                             |
+| `jest.MockedFunction<T>` (type)  | `MockedFunction<T>` (import from `vitest`)                |
+| `jest.SpyInstance` (type)        | `MockInstance` (import from `vitest`)                     |
+
+~545 replacements total. Mutable mock pattern (let var + factory closure) works identically in Vitest.
+
+**`jest.requireActual` → `vi.importActual` migration note:** `vi.importActual` is async, so `jest.requireActual(...)` inside a `vi.mock` factory must become `await vi.importActual(...)` and the factory must be `async`. Affected file: `submission-form.spec.tsx:221`.
+
+### Phase 6b: Remove redundant setup imports from ~20 test files
+
+20 test files explicitly `import "../../../../test/setup"` (or import `mockPush` from it). Since Vitest runs `setupFiles` automatically, bare `import "../../../../test/setup"` lines cause double-execution of setup side effects. Fix:
+
+- Files that only do `import "../../../../test/setup"` (bare import, no named imports): **remove the import entirely**
+- Files that import named exports like `import { mockPush } from "../../../../test/setup"`: **keep the import** (needed for the mock reference)
+
+### Phase 7: Delete `apps/web/jest.config.ts`
+
+Remove after everything works.
+
+## Files That Should NOT Change
+
+- `apps/web/playwright.config.ts`, `apps/web/e2e/**` (Playwright, unrelated)
+- `apps/api/**` (already on Vitest)
+- `test/vitest-console-setup.ts` (root shared setup, stays as-is)
+- `.github/workflows/ci.yml` (script-name based, no changes needed)
+- Non-test source files in `apps/web/src/`
+
+## Verification
+
+1. `pnpm install` — resolve new deps
+2. `pnpm --filter @colophony/web exec vitest run src/hooks/__tests__/use-debounce.spec.ts` — smoke test (uses fake timers)
+3. `pnpm --filter @colophony/web test` — full suite (~72 files, shuffled)
+4. `pnpm --filter @colophony/web test:cov` — coverage thresholds pass
+5. `grep -rn "jest\.\|jest\.Mock\|jest\.SpyInstance\|jest\.MockedFunction" apps/web/src/ apps/web/test/ --include="*.spec.*" --include="*.ts"` — zero results (no stragglers)
+6. `pnpm --filter @colophony/web type-check` — verifies `vitest/globals` types work

--- a/.claude/plans/playful-tinkering-thimble.md
+++ b/.claude/plans/playful-tinkering-thimble.md
@@ -1,0 +1,93 @@
+# Plan: Automate Zitadel Actions v2 Executions Setup
+
+## Context
+
+The Zitadel webhook handler (`apps/api/src/webhooks/zitadel.webhook.ts`) already handles all 6 user lifecycle events. However, Zitadel-side configuration (creating **targets** and **executions** via the Zitadel Actions v2 API) is currently done manually through the Zitadel UI. Only `user.human.added` has an execution configured on staging.
+
+The remaining events need executions: `user.human.changed`, `user.human.deactivated`, `user.human.reactivated`, `user.human.removed`, `user.human.email.verified`.
+
+This should be automated in the existing `pnpm zitadel:setup` script so that local dev, E2E, and staging environments all get consistent webhook configuration.
+
+## Files to Modify
+
+### 1. `docker-compose.yml` — Add `extra_hosts` to Zitadel service
+
+The Zitadel container needs `host.docker.internal` to reach the host-network API (same pattern as tusd at line 151). Add:
+
+```yaml
+zitadel:
+  ...
+  extra_hosts:
+    - 'host.docker.internal:host-gateway'
+```
+
+### 2. `scripts/zitadel-helpers.ts` — Add target + execution helpers
+
+**`findOrCreateTarget(token, name, url, timeout?)`**
+
+- Search: `POST /v2/targets/search` with `targetNameQuery` (exact match)
+- If found: return `{ targetId, signingKey: null }` (Zitadel only returns signingKey on creation)
+- If not found: `POST /v2/targets` with `{ name, restWebhook: { interruptOnError: false }, endpoint: url, timeout: timeout || "10s" }`
+- Return `{ targetId, signingKey }` — signingKey is the HMAC secret for `ZITADEL-Signature` verification
+
+**`setExecution(token, eventType, targetId)`**
+
+- `PUT /v2/executions` with `{ condition: { request: { event: eventType } }, targets: [{ target: targetId }] }`
+- Idempotent — PUT replaces any existing execution for the same condition
+
+**`WEBHOOK_EVENT_TYPES` constant** — array of all 6 event types:
+
+```typescript
+export const WEBHOOK_EVENT_TYPES = [
+  "user.human.added",
+  "user.human.changed",
+  "user.human.deactivated",
+  "user.human.reactivated",
+  "user.human.removed",
+  "user.human.email.verified",
+] as const;
+```
+
+### 3. `scripts/setup-zitadel-dev.ts` — Wire webhook setup into dev provisioning
+
+Add after step 5 (OIDC app setup), before .env patching:
+
+```
+Step 6: Set up webhook target + executions
+```
+
+- Target name: `colophony-dev-webhook`
+- Target URL: `http://host.docker.internal:4000/webhooks/zitadel` (reaches host API from Docker)
+- Call `findOrCreateTarget()`, then `setExecution()` for all 6 event types
+- **Signing key handling:**
+  - If target was **created** (signingKey returned): patch `ZITADEL_WEBHOOK_SECRET` into `apps/api/.env`
+  - If target **already exists** (signingKey is null): check if `ZITADEL_WEBHOOK_SECRET` is already set in `apps/api/.env`. If missing, warn user and offer to delete+recreate: log `"Target already exists but ZITADEL_WEBHOOK_SECRET not found in .env. Delete the target in Zitadel UI and rerun, or set the secret manually."`
+
+### 4. `scripts/setup-zitadel-e2e.ts` — Wire webhook setup into E2E provisioning
+
+Same pattern but with E2E-specific values:
+
+- Target name: `colophony-e2e-webhook`
+- Target URL: `http://host.docker.internal:4010/webhooks/zitadel` (E2E API port per `playwright.config.ts:27`)
+- Write `ZITADEL_WEBHOOK_SECRET` to the E2E config JSON file (or to the API .env, same as dev — E2E loads from API .env via `dotenv`)
+
+### Files that should NOT change
+
+- `apps/api/src/webhooks/zitadel.webhook.ts` — handler is complete
+- `packages/auth-client/src/` — types and signature verification are complete
+- `apps/api/src/config/env.ts` — `ZITADEL_WEBHOOK_SECRET` already defined
+
+## Codex Review Notes
+
+- **Critical (addressed):** Target URL must use `host.docker.internal` not `localhost` — Zitadel runs in Docker. Also need `extra_hosts` mapping on the Zitadel service in `docker-compose.yml`.
+- **Important (addressed):** E2E uses port 4010, not 4000. Separate target with correct port.
+- **Important (addressed):** Existing target without signingKey needs explicit handling — warn + fail rather than silently skip.
+- **Suggestion (addressed):** Use `pnpm --filter @colophony/api test:webhooks` for verification.
+
+## Verification
+
+1. `docker compose --profile auth up -d` — start Zitadel (now with `extra_hosts`)
+2. `pnpm zitadel:setup` — should create target + 6 executions + patch `ZITADEL_WEBHOOK_SECRET`
+3. Verify via Zitadel UI (Actions > Targets, Actions > Executions) that all 6 events are configured
+4. Register a test user in Zitadel UI → confirm webhook fires and user appears in Colophony DB
+5. Run existing tests: `pnpm --filter @colophony/api test:webhooks`

--- a/.claude/plans/replicated-yawning-kite.md
+++ b/.claude/plans/replicated-yawning-kite.md
@@ -1,0 +1,403 @@
+# Content Extraction Pipeline
+
+## Context
+
+The ManuscriptRenderer (frontend) already renders ProseMirror JSON with genre-aware typography. Currently it only works with the client-side `textToProseMirrorDoc` fallback. This plan adds the **backend pipeline** that converts uploaded files to ProseMirror JSON after virus scanning, enabling real content display in the editorial split pane.
+
+Pipeline: file upload → tusd → ClamAV scan → CLEAN → **content-extract BullMQ job** → ProseMirror JSON → store in DB.
+
+---
+
+## Step 1: Shared ProseMirror Types
+
+Move ProseMirror type definitions from the frontend to the shared types package so both backend converters and frontend renderer use the same types.
+
+**Create** `packages/types/src/prosemirror.ts`:
+
+- Export: `GenreHint`, `ProseMirrorMark`, `ProseMirrorNodeType`, `ProseMirrorNode`, `SubmissionMetadata`, `ProseMirrorDoc`, `ReadingAnchor`
+- Identical to current definitions in `apps/web/src/lib/manuscript.ts` lines 7-52
+
+**Modify** `packages/types/src/index.ts`:
+
+- Add `export * from "./prosemirror.js";`
+
+**Modify** `apps/web/src/lib/manuscript.ts`:
+
+- Replace inline type definitions with re-exports from `@colophony/types`
+- Keep `textToProseMirrorDoc` and its helpers (frontend-only runtime code)
+
+---
+
+## Step 2: Schema Migration
+
+**Modify** `packages/db/src/schema/enums.ts`:
+
+- Add after `scanStatusEnum` (line 22):
+
+```typescript
+export const contentExtractionStatusEnum = pgEnum("ContentExtractionStatus", [
+  "PENDING",
+  "EXTRACTING",
+  "COMPLETE",
+  "FAILED",
+  "UNSUPPORTED",
+]);
+```
+
+**Modify** `packages/db/src/schema/manuscripts.ts`:
+
+- Import `contentExtractionStatusEnum`
+- Add 3 columns to `manuscriptVersions`:
+  - `content: jsonb("content")` — nullable, ProseMirror JSON
+  - `contentFormat: varchar("content_format", { length: 50 })` — nullable, initially `'prosemirror_v1'`
+  - `contentExtractionStatus: contentExtractionStatusEnum("content_extraction_status").notNull().default("PENDING")`
+
+**Generate migration** via `pnpm db:generate` (or write manually if TUI blocks):
+
+```sql
+CREATE TYPE "ContentExtractionStatus" AS ENUM ('PENDING', 'EXTRACTING', 'COMPLETE', 'FAILED', 'UNSUPPORTED');
+--> statement-breakpoint
+ALTER TABLE "manuscript_versions" ADD COLUMN "content" jsonb;
+--> statement-breakpoint
+ALTER TABLE "manuscript_versions" ADD COLUMN "content_format" varchar(50);
+--> statement-breakpoint
+ALTER TABLE "manuscript_versions" ADD COLUMN "content_extraction_status" "ContentExtractionStatus" DEFAULT 'PENDING' NOT NULL;
+```
+
+No RLS changes — new columns inherit existing row-level policies.
+
+---
+
+## Step 3: Audit Constants
+
+**Modify** `packages/types/src/audit.ts`:
+
+- Add actions after `MANUSCRIPT_VERSION_CREATED` (line 84):
+
+```typescript
+CONTENT_EXTRACT_COMPLETE: "CONTENT_EXTRACT_COMPLETE",
+CONTENT_EXTRACT_FAILED: "CONTENT_EXTRACT_FAILED",
+CONTENT_EXTRACT_UNSUPPORTED: "CONTENT_EXTRACT_UNSUPPORTED",
+```
+
+- Add to `ManuscriptAuditParams` union (line 374, uses existing `MANUSCRIPT` resource):
+
+```typescript
+| typeof AuditActions.CONTENT_EXTRACT_COMPLETE
+| typeof AuditActions.CONTENT_EXTRACT_FAILED
+| typeof AuditActions.CONTENT_EXTRACT_UNSUPPORTED;
+```
+
+---
+
+## Step 4: Converters
+
+### `apps/api/src/converters/text-converter.ts` (NEW)
+
+Server-side port of frontend `textToProseMirrorDoc`. Identical logic to `apps/web/src/lib/manuscript.ts:68-152` but imports types from `@colophony/types`.
+
+```typescript
+export function convertTextToProseMirror(
+  text: string,
+  genreHint?: GenreHint,
+): ProseMirrorDoc;
+```
+
+- Internal: `convertProse(text)`, `convertPoetry(text)` — same algorithms as frontend
+
+### `apps/api/src/converters/docx-converter.ts` (NEW)
+
+Uses mammoth.js → HTML, then maps HTML to ProseMirror nodes via htmlparser2.
+
+```typescript
+export async function convertDocxToProseMirror(
+  buffer: Buffer,
+  genreHint?: GenreHint,
+): Promise<ProseMirrorDoc>;
+```
+
+- mammoth style map: `<w:smallCaps/>` → `small_caps` mark
+- HTML→ProseMirror mapping:
+  - `<p>` → `paragraph` (prose) or `poem_line` (poetry)
+  - `<em>`/`<i>` → `emphasis` mark
+  - `<strong>`/`<b>` → `strong` mark
+  - `<blockquote>` → `block_quote`
+  - Empty `<p>` → `section_break` (prose) or `stanza_break` (poetry)
+- Poetry mode: detect leading whitespace → `preserved_indent` with `depth`
+
+### `apps/api/src/converters/smart-typography.ts` (NEW)
+
+```typescript
+export function applySmartTypography(doc: ProseMirrorDoc): ProseMirrorDoc;
+export function smartifyText(text: string): { text: string; changed: boolean };
+```
+
+- Rules: `"` → `""`/`""`, `'` → `''`/`''` (context-sensitive), `--`/`---` → `—`, `...` → `…` (excluding `Mr.`, `Mrs.`, `Dr.`, `vs.`, `etc.`, `i.e.`, `e.g.`)
+- Walks all nodes. For each text node where `smartifyText` returns `changed: true`: set `smart_text` mark with `attrs.original` = original text
+- Sets `doc.attrs.smart_typography_applied = true`
+
+### `apps/api/src/converters/index.ts` (NEW)
+
+Format router + barrel:
+
+```typescript
+export type ConversionResult =
+  | { status: "success"; doc: ProseMirrorDoc }
+  | { status: "unsupported"; mimeType: string };
+
+export async function convertFile(
+  buffer: Buffer,
+  mimeType: string,
+  filename: string,
+  genreHint?: GenreHint,
+): Promise<ConversionResult>;
+```
+
+- `text/plain` → text converter
+- `application/vnd.openxmlformats-officedocument.wordprocessingml.document` → docx converter
+- Anything else → `{ status: 'unsupported' }`
+- After format conversion: apply `applySmartTypography`, set `submission_metadata` attrs
+
+### Dependencies
+
+**Modify** `apps/api/package.json` — add:
+
+- `mammoth: ^1.8.0` (.docx conversion)
+- `htmlparser2: ^9.1.0` (server-side HTML parsing)
+
+---
+
+## Step 5: Content Extraction Service
+
+**Create** `apps/api/src/services/content-extraction.service.ts`
+
+```typescript
+export const contentExtractionService = {
+  async getStatus(tx: DrizzleDb, manuscriptVersionId: string): Promise<string | null>;
+  async updateStatus(tx: DrizzleDb, manuscriptVersionId: string, status: string): Promise<void>;
+  async storeContent(tx: DrizzleDb, manuscriptVersionId: string, content: ProseMirrorDoc, contentFormat?: string): Promise<void>;
+  async getGenreHintForVersion(tx: DrizzleDb, manuscriptVersionId: string): Promise<GenreHint | null>;
+};
+```
+
+- `getStatus`: SELECT `content_extraction_status` WHERE id = versionId
+- `updateStatus`: UPDATE `content_extraction_status` WHERE id = versionId
+- `storeContent`: UPDATE `content`, `content_format` (default `'prosemirror_v1'`), `content_extraction_status` = `'COMPLETE'`
+- `getGenreHintForVersion`: JOIN `manuscript_versions` → `manuscripts` to get `genre.primary`, map to `GenreHint`
+
+---
+
+## Step 6: Queue Definition
+
+**Create** `apps/api/src/queues/content-extract.queue.ts`
+
+```typescript
+export interface ContentExtractJobData {
+  fileId: string;
+  storageKey: string;
+  manuscriptVersionId: string;
+  userId: string;
+  organizationId?: string;
+  mimeType: string;
+  filename: string;
+}
+```
+
+- Queue name: `content-extract`
+- Job options: `attempts: 3`, exponential backoff 30s, removeOnComplete 24h, removeOnFail 7d
+- Idempotency: `jobId: data.fileId`
+- Exports: `enqueueContentExtract()`, `getContentExtractQueueInstance()`, `closeContentExtractQueue()`
+
+**Modify** `apps/api/src/queues/index.ts` — add barrel exports
+
+---
+
+## Step 7: Worker
+
+**Create** `apps/api/src/workers/content-extract.worker.ts`
+
+```typescript
+export function startContentExtractWorker(
+  env: Env,
+  registry: AdapterRegistry,
+): Worker<ContentExtractJobData>;
+export async function stopContentExtractWorker(): Promise<void>;
+```
+
+Processor phases:
+
+1. **Idempotency + EXTRACTING**: `withRls({ userId })` → check status, skip if COMPLETE, set EXTRACTING
+2. **Download**: `storage.downloadFromBucket(defaultBucket, storageKey)` → collect to Buffer (outside withRls). Size guard: skip files > 50MB → UNSUPPORTED.
+3. **Convert**: `convertFile(buffer, mimeType, filename, genreHint)` — genreHint fetched from DB in phase 1
+4. **Store/Audit**: `withRls({ userId })` →
+   - If `success`: `storeContent()` + audit `CONTENT_EXTRACT_COMPLETE` (with `{ filename, mimeType, contentFormat, nodeCount }`)
+   - If `unsupported`: `updateStatus('UNSUPPORTED')` + audit `CONTENT_EXTRACT_UNSUPPORTED`
+5. **Error catch**: `updateStatus('FAILED')` + audit `CONTENT_EXTRACT_FAILED` + re-throw for retry
+
+Concurrency: 3. RLS context: `{ userId }` (user-scoped, no orgId in audit — same pattern as file-scan worker).
+
+**Modify** `apps/api/src/workers/index.ts` — add barrel exports
+
+---
+
+## Step 8: Chaining — File-Scan Worker
+
+**Modify** `apps/api/src/workers/file-scan.worker.ts`:
+
+Add import: `import { enqueueContentExtract } from '../queues/content-extract.queue.js';`
+
+After the CLEAN `withRls` block (after line 133, inside `if (!isInfected)` branch):
+
+```typescript
+// Chain: enqueue content extraction for the clean file
+const file = await withRls(rlsCtx, async (tx) =>
+  fileService.getById(tx, fileId),
+);
+if (file) {
+  await enqueueContentExtract(env, {
+    fileId: file.id,
+    storageKey,
+    manuscriptVersionId: file.manuscriptVersionId,
+    userId: job.data.userId,
+    organizationId: job.data.organizationId,
+    mimeType: file.mimeType,
+    filename: file.filename,
+  });
+}
+```
+
+---
+
+## Step 9: Chaining — tusd Webhook (scan disabled)
+
+**Modify** `apps/api/src/webhooks/tusd.webhook.ts`:
+
+Add import: `import { enqueueContentExtract } from '../queues/content-extract.queue.js';`
+
+After the S3 bucket move (line 643, inside the `!VIRUS_SCAN_ENABLED` block), enqueue content-extract:
+
+```typescript
+// Chain: enqueue content extraction when scan is skipped
+await enqueueContentExtract(env, {
+  fileId: fileIdToScan,
+  storageKey,
+  manuscriptVersionId,
+  userId,
+  ...(orgId ? { organizationId: orgId } : {}),
+  mimeType,
+  filename,
+});
+```
+
+`manuscriptVersionId`, `mimeType`, and `filename` are already in scope from the webhook handler.
+
+---
+
+## Step 10: Worker Registration
+
+**Modify** `apps/api/src/main.ts`:
+
+- **Imports**: Add `startContentExtractWorker`, `stopContentExtractWorker`, `closeContentExtractQueue`, `getContentExtractQueueInstance`
+- **Worker start** (after file-scan, ~line 380): `startContentExtractWorker(env, registry);` — always active (not feature-gated)
+- **Queue depth polling** (~line 407): Add `{ name: 'content-extract', queue: getContentExtractQueueInstance() }`
+- **Shutdown**: Add `await stopContentExtractWorker();` and `await closeContentExtractQueue();` in proper order (workers before queues)
+
+---
+
+## Step 11: Tests
+
+### Unit: Text Converter
+
+**`apps/api/src/__tests__/converters/text-converter.test.ts`** (NEW)
+
+| Test              | Input                          | Assert                              |
+| ----------------- | ------------------------------ | ----------------------------------- |
+| prose paragraphs  | `"First\n\nSecond"`, prose     | 2 paragraphs, indent false/true     |
+| section breaks    | `"Para\n\n\nPara"`, prose      | paragraph, section_break, paragraph |
+| poetry lines      | `"Line one\nLine two"`, poetry | 2 poem_line nodes                   |
+| stanza breaks     | `"L1\n\nL2"`, poetry           | poem_line, stanza_break, poem_line  |
+| preserved indent  | `"    Indented"`, poetry       | preserved_indent with depth=2       |
+| empty text        | `""`                           | empty content array                 |
+| defaults to prose | no hint                        | paragraph nodes                     |
+
+### Unit: Smart Typography
+
+**`apps/api/src/__tests__/converters/smart-typography.test.ts`** (NEW)
+
+| Test                         | Input                         | Assert                              |
+| ---------------------------- | ----------------------------- | ----------------------------------- |
+| double quotes                | `'She said "hello"'`          | curly doubles                       |
+| single quotes / contractions | `"it's fine"`                 | curly apostrophe                    |
+| double hyphen → em dash      | `"word -- word"`              | `\u2014`                            |
+| triple hyphen → em dash      | `"word --- word"`             | `\u2014`                            |
+| three dots → ellipsis        | `"wait..."`                   | `\u2026`                            |
+| preserves Mr.                | `"Mr. Smith"`                 | unchanged                           |
+| preserves etc.               | `"etc."`                      | unchanged                           |
+| smart_text mark added        | doc with straight quotes      | mark with original attr             |
+| unchanged nodes skipped      | doc with no convertible chars | no marks                            |
+| doc flag set                 | any doc                       | `smart_typography_applied === true` |
+| nested quotes                | `"She said 'hello'"`          | correct curling                     |
+
+### Unit: Docx Converter
+
+**`apps/api/src/__tests__/converters/docx-converter.test.ts`** (NEW)
+
+| Test               | Input                     | Assert            |
+| ------------------ | ------------------------- | ----------------- |
+| basic paragraphs   | 2-paragraph .docx fixture | 2 paragraph nodes |
+| emphasis preserved | .docx with italic         | emphasis mark     |
+| strong preserved   | .docx with bold           | strong mark       |
+| empty docx         | empty .docx               | empty content     |
+
+Fixtures: `apps/api/src/__tests__/converters/fixtures/` — small .docx files (can be generated programmatically in test setup using mammoth's own test utilities or committed as binary).
+
+### Integration: Content Extract Queue
+
+**`apps/api/src/__tests__/queues/content-extract.queue.test.ts`** (NEW)
+
+Follow pattern of existing queue tests (`email.queue.test.ts`). Uses `globalSetup`, `truncateAllTables`, Redis db 1, mock S3 adapter.
+
+| Test                            | Setup                                    | Assert                                                                       |
+| ------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| PENDING → EXTRACTING → COMPLETE | .txt file (CLEAN), mock S3 returns text  | status COMPLETE, content is ProseMirrorDoc, contentFormat = 'prosemirror_v1' |
+| UNSUPPORTED for unknown mime    | image/png file, mock S3 returns buffer   | status UNSUPPORTED, content null                                             |
+| FAILED on conversion error      | .docx file, mock S3 returns corrupt data | status FAILED                                                                |
+| idempotency skip                | status already COMPLETE                  | S3 download not called                                                       |
+| smart typography applied        | .txt with straight quotes                | content has smart_text marks                                                 |
+
+---
+
+## Files That Should NOT Change
+
+- `apps/web/src/components/manuscripts/manuscript-renderer.tsx` (already consumes ProseMirrorDoc)
+- `apps/api/src/services/audit.service.ts` (used as-is)
+- `apps/api/src/config/instrumented-worker.ts` (used as-is)
+- `packages/db/src/context.ts` (used as-is)
+
+---
+
+## Implementation Sequence
+
+1. Shared types (packages/types) + frontend re-export refactor
+2. Schema (enums + manuscripts) + generate migration
+3. Audit constants
+4. Converters (text, docx, smart-typography, barrel) + unit tests
+5. Content extraction service
+6. Queue definition + barrel export
+7. Worker + barrel export
+8. File-scan worker chaining
+9. tusd webhook chaining (scan-disabled path)
+10. main.ts registration
+11. Queue integration test
+12. Build + type-check + lint
+
+---
+
+## Verification
+
+1. `pnpm db:reset` — migration applies cleanly
+2. `pnpm test` — all unit tests pass (converters + smart typography)
+3. `pnpm type-check` — no type errors across workspace
+4. `pnpm lint` — no lint warnings
+5. Queue integration test — `pnpm vitest run apps/api/src/__tests__/queues/content-extract.queue.test.ts`
+6. Manual: upload a .txt file through the submission form, verify `manuscript_versions.content` populates as ProseMirror JSON (requires Docker infra running)

--- a/.claude/plans/shimmering-puzzling-pnueli.md
+++ b/.claude/plans/shimmering-puzzling-pnueli.md
@@ -1,0 +1,103 @@
+# Production Hardening: enableRLS, SSRF, Unbounded Queries
+
+## Context
+
+Three P2/P3 production hardening items remain from Codex reviews (2026-03-19). All are defense-in-depth fixes — RLS is active in the migration but the schema definition is inconsistent, SSRF validation is partially applied, and three queries lack safety limits. Closing these before Coolify deployment.
+
+## Fix 1: userKeys missing `.enableRLS()`
+
+**Problem:** `userKeys` table has 3 `pgPolicy` definitions but no `.enableRLS()` call. The migration (0024) correctly has `ENABLE ROW LEVEL SECURITY` + `FORCE ROW LEVEL SECURITY`, so production is protected — but the Drizzle schema is inconsistent, and future `drizzle-kit generate` could produce a migration that drops RLS.
+
+**File:** `packages/db/src/schema/user-keys.ts`
+
+**Change:** Add `.enableRLS()` after line 63's closing `]` → `]).enableRLS();`
+
+**Migration:** Generate migration via `pnpm db:generate`. The migration should add `ALTER TABLE "user_keys" ENABLE ROW LEVEL SECURITY` + `FORCE ROW LEVEL SECURITY` (idempotent — already present from 0024, Postgres ignores duplicate ENABLE).
+
+## Fix 2: SSRF validation in hub-client.service.ts
+
+**Problem:** 4 `fetch()` calls, only 1 has `validateOutboundUrl()` (line 199). The other 3 (lines 38, 104, 141) skip validation. All use `env.HUB_DOMAIN` (admin-configured env var, not user input), but defense-in-depth requires validation — a misconfigured env var pointing to a private IP could enable SSRF.
+
+**File:** `apps/api/src/services/hub-client.service.ts`
+
+**Changes (3 locations):**
+
+1. **`registerWithHub()` (before line 38):** Add URL construction + validation:
+
+   ```typescript
+   const url = `https://${env.HUB_DOMAIN}/federation/v1/hub/register`;
+   const devMode = env.NODE_ENV === "development" || env.NODE_ENV === "test";
+   await validateOutboundUrl(url, { devMode });
+   ```
+
+   Then use `url` in the fetch call.
+
+2. **`pushFingerprint()` (before line 104):** Add after existing URL construction (line 94):
+
+   ```typescript
+   const devMode = env.NODE_ENV === "development" || env.NODE_ENV === "test";
+   await validateOutboundUrl(url, { devMode });
+   ```
+
+3. **`queryHubFingerprints()` (before line 141):** Add after existing URL construction (line 130):
+   ```typescript
+   const devMode = env.NODE_ENV === "development" || env.NODE_ENV === "test";
+   await validateOutboundUrl(url, { devMode });
+   ```
+
+**Pattern:** Matches `initiateHubAttestedTrust()` at line 199 (same file) and `trust.service.ts:90-104`.
+
+**Not changed:** Line 199 (`initiateHubAttestedTrust`) — already protected.
+
+**DRY consideration:** Extract `devMode` to a module-level helper or constant to avoid repeating `env.NODE_ENV === 'development' || env.NODE_ENV === 'test'` in 4 places. Check if `initiateHubAttestedTrust` already computes it the same way.
+
+## Fix 3: Unbounded queries — add safety LIMIT
+
+**Problem:** Three queries return all matching rows with no LIMIT. While practical row counts are small (correspondence per submission, history per submission, files per manuscript version), defense-in-depth requires a cap.
+
+**Approach:** Add a hard safety LIMIT (not full pagination) since these are internal/detail-view methods where callers expect all results. Use a reasonable cap constant.
+
+### 3a. `correspondence.service.ts:70` — `listBySubmission()`
+
+**File:** `apps/api/src/services/correspondence.service.ts`
+
+**Change:** Add `.limit(500)` to the query chain (after `.orderBy()`). 500 is generous — submissions rarely have more than ~50 messages.
+
+### 3b. `submission.service.ts:730` — `getHistory()`
+
+**File:** `apps/api/src/services/submission.service.ts`
+
+**Change:** Add `.limit(1000)` to the query chain. History is append-only status transitions — even busy submissions won't exceed hundreds.
+
+### 3c. `file.service.ts:80` — `listByManuscriptVersion()`
+
+**File:** `apps/api/src/services/file.service.ts`
+
+**Change:** Add `.limit(100)` to the query chain. Manuscript versions have practical file limits (main document + supplementary materials).
+
+## Files Modified
+
+| File                                              | Change                                     |
+| ------------------------------------------------- | ------------------------------------------ |
+| `packages/db/src/schema/user-keys.ts`             | Add `.enableRLS()`                         |
+| `packages/db/migrations/NNNN_*.sql`               | Generated migration (enableRLS idempotent) |
+| `apps/api/src/services/hub-client.service.ts`     | Add 3x `validateOutboundUrl()` calls       |
+| `apps/api/src/services/correspondence.service.ts` | Add `.limit(500)`                          |
+| `apps/api/src/services/submission.service.ts`     | Add `.limit(1000)`                         |
+| `apps/api/src/services/file.service.ts`           | Add `.limit(100)`                          |
+
+## Files NOT Modified
+
+- `apps/api/src/lib/url-validation.ts` — no changes needed
+- `packages/db/migrations/0024_user_keys.sql` — already correct
+- Any test files — these are defense-in-depth hardening, existing tests cover functionality
+
+## Verification
+
+1. `pnpm db:generate` — verify migration is generated for enableRLS
+2. `pnpm db:migrate` — apply migration (should be idempotent)
+3. `pnpm type-check` — no type errors
+4. `pnpm test` — all unit tests pass
+5. `pnpm lint` — no lint errors
+6. Grep for `fetch(` in `hub-client.service.ts` — every call preceded by `validateOutboundUrl`
+7. Grep for `.from(correspondence)`, `.from(submissionHistory)`, `.from(files)` — verify LIMIT present on the three targeted queries

--- a/.claude/plans/spicy-baking-rivest.md
+++ b/.claude/plans/spicy-baking-rivest.md
@@ -1,0 +1,164 @@
+# Accessibility P2 Improvements
+
+## Context
+
+All 10 development tracks are complete. Four P2 accessibility items remain in the backlog (from persona gap analysis 2026-02-27). These improve usability for color-blind users and screen reader users. The `ScanStatusBadge` in `file-upload.tsx` already demonstrates the icon+color pattern we'll follow for status badges.
+
+---
+
+## 1. Status Badges: Add Icons Alongside Color
+
+**Goal:** Color-blind users can distinguish statuses without relying on color alone.
+
+**Approach:** Add a Lucide icon to each status config entry (following the existing `ScanStatusBadge` pattern in `file-upload.tsx:32-85`). Render `<Icon className="h-3 w-3" />` before the label text, with `gap-1` on the Badge.
+
+### Files to modify
+
+**`apps/web/src/components/submissions/status-badge.tsx`** — SubmissionStatus (8 statuses)
+
+- Extend `statusConfig` type to include `icon: React.ComponentType<{ className?: string }>`
+- Icon mapping:
+  - DRAFT → `FileEdit` (gray)
+  - SUBMITTED → `Send` (blue)
+  - UNDER_REVIEW → `Eye` (yellow)
+  - ACCEPTED → `CheckCircle` (green)
+  - REJECTED → `XCircle` (red)
+  - HOLD → `Pause` (orange)
+  - REVISE_AND_RESUBMIT → `RotateCcw` (amber)
+  - WITHDRAWN → `Ban` (purple)
+- Render: `<Badge ...><Icon className="h-3 w-3" />{config.label}</Badge>` with `gap-1`
+
+**`apps/web/src/components/workspace/csr-status-badge.tsx`** — CSRStatus (10 statuses)
+
+- Extend `statusConfig` type to include `icon`
+- Icon mapping:
+  - draft → `FileEdit`
+  - sent → `Send`
+  - in_review → `Eye`
+  - hold → `Pause`
+  - accepted → `CheckCircle`
+  - rejected → `XCircle`
+  - withdrawn → `Ban`
+  - no_response → `Clock`
+  - revise → `RotateCcw`
+  - unknown → `HelpCircle`
+- Render: same pattern as above
+
+**`apps/web/src/components/slate/issue-status-badge.tsx`** — IssueStatus (5 statuses)
+
+- PLANNING → `Pencil`, ASSEMBLING → `Layers`, READY → `CheckCircle`, PUBLISHED → `Globe`, ARCHIVED → `Archive`
+
+**`apps/web/src/components/slate/publication-status-badge.tsx`** — PublicationStatus (2 statuses)
+
+- ACTIVE → `CheckCircle`, ARCHIVED → `Archive`
+
+**`apps/web/src/components/slate/contract-status-badge.tsx`** + **`apps/web/src/lib/contract-utils.ts`**
+
+- Add `icon` to `contractStatusConfig`
+- DRAFT → `FileEdit`, SENT → `Send`, VIEWED → `Eye`, SIGNED → `PenLine`, COUNTERSIGNED → `CheckCheck`, COMPLETED → `CheckCircle`, VOIDED → `XCircle`
+
+**`apps/web/src/components/slate/pipeline-stage-badge.tsx`** — PipelineStage (7 statuses)
+
+- COPYEDIT_PENDING → `Clock`, COPYEDIT_IN_PROGRESS → `Pencil`, AUTHOR_REVIEW → `Eye`, PROOFREAD → `BookOpen`, READY_TO_PUBLISH → `CheckCircle`, PUBLISHED → `Globe`, WITHDRAWN → `Ban`
+
+**`apps/web/src/components/periods/period-status-badge.tsx`** — PeriodStatus (3 statuses)
+
+- UPCOMING → `Clock`, OPEN → `CheckCircle`, CLOSED → `Lock`
+
+**`apps/web/src/components/form-builder/form-status-badge.tsx`** — FormStatus (3 statuses)
+
+- DRAFT → `FileEdit`, PUBLISHED → `CheckCircle`, ARCHIVED → `Archive`
+
+### Files that should NOT change
+
+- `apps/web/src/components/slate/calendar-issue-badge.tsx` — uses border-left color only, not a status badge; too compact for icons
+- `apps/web/src/components/submissions/file-upload.tsx` `ScanStatusBadge` — already has icons
+- `apps/web/src/components/manuscripts/manuscript-version-files.tsx` `ScanStatusBadge` — already has icons; read-only display (no dynamic scan updates, so no `aria-live` needed)
+
+---
+
+## 2. File Drop Zones: Keyboard Accessibility
+
+**Goal:** Drop zones are focusable and operable via keyboard.
+
+### Files to modify
+
+**`apps/web/src/components/submissions/file-upload.tsx`** (lines 303-333)
+
+- Add to drop zone `<div>`:
+  - `role="button"`
+  - `tabIndex={canUpload ? 0 : -1}`
+  - `aria-label={canUpload ? "Drop files here or click to upload" : "Upload limit reached"}`
+  - `aria-disabled={!canUpload}`
+  - `onKeyDown` handler: trigger `inputRef.current?.click()` on Enter or Space (prevent default for Space to avoid scroll)
+
+**`apps/web/src/components/embed/embed-upload-section.tsx`** (lines 181-207)
+
+- Same changes as above
+
+---
+
+## 3. Scan Status: `aria-live` Regions
+
+**Goal:** Screen readers announce scan status changes dynamically.
+
+### Files to modify
+
+**`apps/web/src/components/submissions/file-upload.tsx`**
+
+- Wrap the scan warning messages (lines 365-381) in a `<div aria-live="polite">` container
+- This covers both the "pending scan" and "infected" warnings
+
+**`apps/web/src/components/embed/embed-upload-section.tsx`**
+
+- Same: wrap scan warning messages in `<div aria-live="polite">`
+
+---
+
+## 4. Sidebar: `aria-label` on `<nav>`
+
+**Goal:** Screen readers announce the sidebar navigation's purpose.
+
+### Files to modify
+
+**`apps/web/src/components/layout/sidebar.tsx`** (line 113)
+
+- Add `aria-label="Main navigation"` to the `<nav>` element
+
+---
+
+## Tests
+
+### New test file: `apps/web/src/components/submissions/__tests__/status-badge.spec.tsx`
+
+- Test: each status renders an icon (check for SVG element within badge)
+- Test: each status renders correct label text
+
+### New test file: `apps/web/src/components/workspace/__tests__/csr-status-badge.spec.tsx`
+
+- Test: each CSR status renders an icon
+- Test: each CSR status renders correct label text
+
+### Update: `apps/web/src/components/layout/__tests__/sidebar.spec.tsx`
+
+- Test: nav element has `aria-label="Main navigation"`
+
+### Update: `apps/web/src/components/submissions/__tests__/file-upload.spec.tsx`
+
+- Test: drop zone has `role="button"` and `tabIndex`
+- Test: drop zone has `aria-label`
+- Test: scan warnings are in `aria-live` region
+
+### Update: `apps/web/src/components/embed/__tests__/embed-upload-section.spec.tsx`
+
+- Test: drop zone has `role="button"` and `tabIndex`
+- Test: scan warnings are in `aria-live` region
+
+---
+
+## Verification
+
+1. `pnpm --filter @colophony/web test` — all Jest tests pass
+2. `pnpm type-check` — no type errors
+3. `pnpm lint` — no lint errors
+4. Visual check: badges render with icons in dev (not required for merge but nice to confirm)

--- a/.claude/skills/end-session/SKILL.md
+++ b/.claude/skills/end-session/SKILL.md
@@ -222,6 +222,14 @@ If updates are warranted, propose them:
 
 Ask the user if they want to apply the suggestions before proceeding.
 
+### Step 5.5: Pre-flight validation
+
+Run `/pre-pr` to catch type errors, lint violations, and test failures before the PR. This runs type-check, lint, and unit tests, fixing any issues found.
+
+- If `/pre-pr` applies fixes, those fixes become part of the doc commit (Step 6) or get their own commit if they touch code files.
+- If `/pre-pr` reports blocking issues that can't be auto-fixed, stop and ask the user before proceeding.
+- **Skip this step** if the session had no code changes (doc-only update) or the user explicitly says to skip validation.
+
 ### Step 6: Commit doc updates
 
 This is the **final commit** on the branch. Stage all doc changes:

--- a/.claude/skills/pre-pr/SKILL.md
+++ b/.claude/skills/pre-pr/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: pre-pr
+description: Pre-flight validation before PR creation — type-check, lint, and test suite.
+---
+
+# /pre-pr
+
+Run the full validation suite before creating a PR. Catches CI failures locally.
+
+## What this skill does
+
+1. Runs type-check (`pnpm type-check`)
+2. Runs lint (`pnpm lint`)
+3. Runs unit tests (`pnpm test`)
+4. Reports results and fixes any failures before proceeding
+
+## Usage
+
+```
+/pre-pr
+```
+
+Typically run before `/end-session` or as part of it (end-session chains this automatically before pushing).
+
+## Instructions for Claude
+
+When the user invokes `/pre-pr`, run the following validation sequence. Each step must pass before proceeding to the next. If any step fails, fix the issue and re-run that step before continuing.
+
+### Step 1: Check for uncommitted changes
+
+```bash
+git status --short
+```
+
+If there are unstaged changes, warn the user — validation runs against the current file state, not the staged state. This is informational, not blocking.
+
+### Step 2: Type-check
+
+```bash
+pnpm type-check
+```
+
+If type errors are found:
+
+1. Read the error output carefully — identify the root cause (not just the symptom)
+2. Fix the errors using the Edit tool
+3. Re-run `pnpm type-check` to verify the fix
+4. Repeat until clean
+
+### Step 3: Lint
+
+```bash
+pnpm lint
+```
+
+If lint errors are found:
+
+1. Fix the errors (the post-edit-lint hook should have caught most, but cross-file issues can slip through)
+2. Re-run `pnpm lint` to verify
+3. Repeat until clean
+
+### Step 4: Unit tests
+
+```bash
+pnpm test
+```
+
+If tests fail:
+
+1. Read the failure output — distinguish between:
+   - **Test fixture issues** (invalid UUIDs, wrong enum values, missing fields) — fix the fixture
+   - **Actual bugs** in the implementation — fix the code
+   - **Stale mocks** (mock doesn't match current interface) — update the mock
+   - **Flaky tests** (passes on re-run) — note it but don't block
+2. Fix and re-run until green
+3. If a test is genuinely flaky (passes on second run with no changes), note it in the session summary but proceed
+
+### Step 5: Report
+
+Print a summary:
+
+```
+## Pre-PR Validation
+
+- Type-check: PASS
+- Lint: PASS
+- Tests: PASS (N suites, M tests)
+
+[If any fixes were made:]
+### Fixes Applied
+- [file:line] — [what was fixed and why]
+
+Ready for PR.
+```
+
+If any step could not be resolved after 3 attempts, stop and report the blocking issue to the user rather than looping indefinitely.
+
+## Important notes
+
+- This skill does NOT commit changes. Fixes are applied to the working tree — the caller (user or `/end-session`) handles committing.
+- This skill does NOT run E2E/Playwright tests — those require dev servers and are validated by CI. The goal here is to catch the failures that most commonly slip through: type errors, lint violations, and unit test regressions.
+- Max 3 fix-and-retry cycles per step. If still failing after 3 rounds, report and let the user decide.
+- If `pnpm test` takes longer than 5 minutes, it may be hanging — check for stuck workers or missing test teardown.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ API layer and plugin system use the `@colophony/` prefix directly.
 
 ---
 
-## Quick Reference: Key File Locations
+## Key File Locations
 
 Per-directory CLAUDE.md files contain domain-specific details:
 
@@ -28,110 +28,7 @@ Per-directory CLAUDE.md files contain domain-specific details:
 - **`apps/api/CLAUDE.md`** — Hook registration, tRPC procedures, auth, webhooks
 - **`apps/web/CLAUDE.md`** — tRPC client, providers, auth utilities, conventions
 
-| What                       | Path                                                                                        |
-| -------------------------- | ------------------------------------------------------------------------------------------- |
-| **Drizzle schema**         | `packages/db/src/schema/` (one file per table group)                                        |
-| **Drizzle migrations**     | `packages/db/migrations/`                                                                   |
-| **Drizzle client**         | `packages/db/src/client.ts`                                                                 |
-| **RLS context**            | `packages/db/src/context.ts` (`withRls()`)                                                  |
-| **Shared Zod schemas**     | `packages/types/src/`                                                                       |
-| **Zitadel auth client**    | `packages/auth-client/src/`                                                                 |
-| **Fastify app entry**      | `apps/api/src/main.ts`                                                                      |
-| **Fastify hooks**          | `apps/api/src/hooks/` (auth, rate-limit, org-context, db-context, audit)                    |
-| **Service layer**          | `apps/api/src/services/`                                                                    |
-| **tRPC (internal)**        | `apps/api/src/trpc/`                                                                        |
-| **Zitadel webhook**        | `apps/api/src/webhooks/zitadel.webhook.ts`                                                  |
-| **Stripe webhook**         | `apps/api/src/webhooks/stripe.webhook.ts`                                                   |
-| **Documenso webhook**      | `apps/api/src/webhooks/documenso.webhook.ts`                                                |
-| **Inngest functions**      | `apps/api/src/inngest/`                                                                     |
-| **Adapter registry**       | `apps/api/src/adapters/registry-accessor.ts` (module-level singleton)                       |
-| **Config builder**         | `apps/api/src/colophony.config.ts` (maps env → adapter init)                                |
-| **SDK adapters**           | `apps/api/src/adapters/{email,storage,payment}/` (SDK-compatible)                           |
-| **CMS adapters**           | `apps/api/src/adapters/cms/`                                                                |
-| **Federation discovery**   | `apps/api/src/federation/discovery.routes.ts`                                               |
-| **Federation DID**         | `apps/api/src/federation/did.routes.ts`                                                     |
-| **Federation service**     | `apps/api/src/services/federation.service.ts`                                               |
-| **Federation trust**       | `apps/api/src/federation/trust.routes.ts` (S2S), `trust-admin.routes.ts`                    |
-| **Trust service**          | `apps/api/src/services/trust.service.ts`                                                    |
-| **HTTP signatures**        | `apps/api/src/federation/http-signatures.ts`                                                |
-| **Federation auth**        | `apps/api/src/federation/federation-auth.ts` (S2S signature middleware)                     |
-| **Sim-sub (BSAP)**         | `apps/api/src/federation/simsub.routes.ts` (S2S), `simsub-admin.routes.ts`                  |
-| **Sim-sub service**        | `apps/api/src/services/simsub.service.ts`                                                   |
-| **Fingerprint service**    | `apps/api/src/services/fingerprint.service.ts`                                              |
-| **Transfer routes**        | `apps/api/src/federation/transfer.routes.ts` (S2S), `transfer-admin.routes.ts`              |
-| **Transfer service**       | `apps/api/src/services/transfer.service.ts`                                                 |
-| **Migration routes**       | `apps/api/src/federation/migration.routes.ts` (S2S), `migration-admin.routes.ts`            |
-| **Migration service**      | `apps/api/src/services/migration.service.ts`, `migration-bundle.service.ts`                 |
-| **Hub routes**             | `apps/api/src/federation/hub.routes.ts` (S2S), `hub-admin.routes.ts`                        |
-| **Hub auth**               | `apps/api/src/federation/hub-auth.ts` (S2S hub auth middleware)                             |
-| **Hub service**            | `apps/api/src/services/hub.service.ts`                                                      |
-| **Hub client service**     | `apps/api/src/services/hub-client.service.ts`                                               |
-| **Analytics service**      | `apps/api/src/services/submission-analytics.service.ts`                                     |
-| **Analytics components**   | `apps/web/src/components/analytics/` (charts, filters, dashboard page)                      |
-| **Portfolio service**      | `apps/api/src/services/portfolio.service.ts` (cross-org UNION ALL, status maps)             |
-| **Writer analytics svc**   | `apps/api/src/services/writer-analytics.service.ts` (personal stats/charts)                 |
-| **Writer analytics UI**    | `apps/web/src/components/workspace/writer-*` (analytics page + chart components)            |
-| **Next.js frontend**       | `apps/web/`                                                                                 |
-| **tRPC client**            | `apps/web/src/lib/trpc.ts`                                                                  |
-| **Env config (Zod)**       | `apps/api/src/config/env.ts`                                                                |
-| **Plugin SDK**             | `packages/plugin-sdk/src/` (adapters, hooks, config, plugin-base, testing)                  |
-| **OpenAPI spec**           | `sdks/openapi.json` (exported from running API, 67 paths, 15 tag groups)                    |
-| **TypeScript SDK**         | `sdks/typescript/` (`@colophony/sdk` — openapi-fetch + generated types)                     |
-| **Python SDK**             | `sdks/python/` (`colophony` — openapi-python-client generated)                              |
-| **SDK generation**         | `scripts/generate-sdks.ts` (regenerate both SDKs from committed spec)                       |
-| **SSRF validation**        | `apps/api/src/lib/url-validation.ts` (validateOutboundUrl, isPrivateIPv4/v6)                |
-| **Sentry config**          | `apps/api/src/config/sentry.ts` (init, captureException, isSentryEnabled)                   |
-| **Metrics registry**       | `apps/api/src/config/metrics.ts` (Prometheus counters, histograms, gauges)                  |
-| **Metrics plugin**         | `apps/api/src/hooks/metrics.ts` (Fastify plugin — HTTP request instrumentation)             |
-| **Instrumented worker**    | `apps/api/src/config/instrumented-worker.ts` (BullMQ wrapper with metrics)                  |
-| **Webhook health**         | `apps/api/src/webhooks/webhook-health.route.ts`                                             |
-| **Ops tRPC router**        | `apps/api/src/trpc/routers/ops.ts` (queueHealth, webhookProviderHealth, submissionTrend)    |
-| **Ops dashboard**          | `apps/web/src/components/operations/ops-dashboard.tsx` (health card grid + quick links)     |
-| **Health card grid**       | `apps/web/src/components/operations/health-card-grid.tsx` (4-card status derivation)        |
-| **Alert rules**            | `docker/prometheus/alert-rules.yml`                                                         |
-| **AlertManager config**    | `docker/alertmanager/alertmanager.yml`                                                      |
-| **Loki config**            | `docker/loki/loki-config.yml` (dev), `loki-config.prod.yml` (prod)                          |
-| **Promtail config**        | `docker/promtail/promtail-config.yml`                                                       |
-| **Grafana dashboards**     | `docker/grafana/dashboards/` (API metrics + logs exploration)                               |
-| **CLI: webhook health**    | `scripts/webhook-health.sh` (query `/webhooks/health`, formatted status)                    |
-| **CLI: log query**         | `scripts/grafana-query.sh` (Loki logs + AlertManager alerts)                                |
-| **CLI: container logs**    | `scripts/server-logs.sh` (tail/search Docker logs, local or SSH)                            |
-| **CLI: Sentry issues**     | `scripts/sentry-issues.sh` (list Sentry issues via API)                                     |
-| **CLI: Zitadel admin**     | `scripts/zitadel-admin.sh` (users, orgs, sessions, health)                                  |
-| **Gateway config**         | `gateway/Caddyfile` (Caddy reverse proxy — routing, security headers, maintenance page)     |
-| **Gateway Dockerfile**     | `gateway/Dockerfile`                                                                        |
-| **Uptime workflow**        | `.github/workflows/uptime.yml` (cron health checks, issue-based alerting)                   |
-| **Writer workspace**       | `packages/db/src/schema/writer-workspace.ts`                                                |
-| **CSR types**              | `packages/types/src/csr.ts`                                                                 |
-| **CSR service**            | `apps/api/src/services/csr.service.ts` (export/import for data portability)                 |
-| **CSR format spec**        | `docs/csr-format.md`                                                                        |
-| **Backlog**                | `docs/backlog.md` (track-organized, drives session focus)                                   |
-| **Design system**          | `docs/DESIGN_SYSTEM.md` (roles, density, navigation, typography, migration path)            |
-| **Manuscript format**      | `docs/manuscript-format.md` (ProseMirror JSON schema, conversion pipeline)                  |
-| **Density provider**       | `apps/web/src/hooks/use-density.tsx` (DensityProvider + useDensity hook)                    |
-| **Layout shells**          | `apps/web/src/app/(dashboard)/{editor,slate,federation,webhooks,organizations}/layout.tsx`  |
-| **Split pane**             | `apps/web/src/components/editor/editorial-split-pane.tsx` (triage/deep-read orchestrator)   |
-| **ManuscriptRenderer**     | `apps/web/src/components/manuscripts/manuscript-renderer.tsx` (genre-aware typography)      |
-| **ManuscriptEditor**       | `apps/web/src/components/manuscripts/manuscript-editor.tsx` (TipTap copyedit editor)        |
-| **ManuscriptDiff**         | `apps/web/src/components/manuscripts/manuscript-diff.tsx` (word-level diff view)            |
-| **TipTap manuscript ext**  | `apps/web/src/lib/tiptap-manuscript-extensions.ts` (custom nodes/marks + converters)        |
-| **Production dashboard**   | `apps/web/src/components/slate/production-dashboard.tsx` (issue-centric pipeline overview)  |
-| **Production aging**       | `apps/web/src/components/slate/production-aging.ts` (aging status, deadline, handoff utils) |
-| **Keyboard shortcuts**     | `apps/web/src/hooks/use-shortcuts.ts` (shell-scoped shortcut hook)                          |
-| **Command palette**        | `apps/web/src/components/command-palette/command-palette.tsx` (Cmd+K global nav)            |
-| **Shortcut overlay**       | `apps/web/src/components/command-palette/shortcut-overlay.tsx` (? key help dialog)          |
-| **Shared navigation**      | `apps/web/src/lib/navigation.ts` (nav items + groups, shared by sidebar + palette)          |
-| **Platform utilities**     | `apps/web/src/lib/platform.ts` (isMac, modifierKey, modifierSymbol)                         |
-| **ProseMirror types**      | `packages/types/src/prosemirror.ts` (shared), `apps/web/src/lib/manuscript.ts` (converter)  |
-| **Content converters**     | `apps/api/src/converters/` (text, docx, smart-typography, format router)                    |
-| **Content extract queue**  | `apps/api/src/queues/content-extract.queue.ts`                                              |
-| **Content extract worker** | `apps/api/src/workers/content-extract.worker.ts` (4-phase extraction)                       |
-| **Content extract svc**    | `apps/api/src/services/content-extraction.service.ts`                                       |
-| **Literata font**          | `apps/web/src/lib/fonts.ts` (variable font with optical sizing)                             |
-| **QA log**                 | `docs/qa-log.md`                                                                            |
-| **Release checklist**      | `docs/release-checklist.md`                                                                 |
-
-Full project structure: [docs/architecture.md](docs/architecture.md)
+Full file index: [docs/file-index.md](docs/file-index.md) | Project structure: [docs/architecture.md](docs/architecture.md)
 
 ---
 
@@ -165,15 +62,13 @@ Summary: Zitadel handles all authentication. API validates tokens via Fastify `o
 
 ### 3. File Uploads (tusd)
 
-Client → tusd sidecar (chunked, resumable) → pre-create hook validates → post-finish hook creates record → BullMQ → ClamAV scan → clean/quarantine.
-
-Unchanged from v1. Uses tus-js-client on frontend, tusd sidecar in Docker Compose.
+Client → tusd sidecar (chunked, resumable) → pre-create hook validates → post-finish hook creates record → BullMQ → ClamAV scan → clean/quarantine. Uses tus-js-client on frontend, tusd sidecar in Docker Compose.
 
 ### 4. Payments (Stripe Checkout)
 
 **See `apps/api/CLAUDE.md`** for PCI NEVER list and webhook idempotency patterns.
 
-Summary: Stripe Checkout only (zero PCI scope). Webhook handler built with two-step idempotency (INSERT event, check `processed` status). PCI guardrails enforced: never log card numbers or store card data.
+Summary: Stripe Checkout only (zero PCI scope). Two-step idempotency (INSERT event, check `processed` status). Never log card numbers or store card data.
 
 ### 5. Frontend
 
@@ -185,41 +80,31 @@ Summary: Stripe Checkout only (zero PCI scope). Webhook handler built with two-s
 
 Domain-specific quirks are in per-directory CLAUDE.md files. Cross-cutting quirks below:
 
-| Quirk                                                 | Details                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Docker Compose env_file**                           | `env_file:` sets container env only. For YAML `${VAR}` substitution, use `--env-file .env` on CLI                                                                                                                                                                                                                                                                                                                                 |
-| **PostgreSQL init-db.sh**                             | Only runs on first DB creation. Must `docker compose down -v` to re-run after changes                                                                                                                                                                                                                                                                                                                                             |
-| **PgBouncer: migrations must bypass**                 | `drizzle-kit` and `pnpm db:migrate` use `DATABASE_URL` (direct port 5432). Only `DATABASE_APP_URL` routes through PgBouncer (port 6432). `SET LOCAL` is required (not `SET`) — transaction pooling reuses server connections                                                                                                                                                                                                      |
-| **WSL husky hooks need nvm PATH**                     | Husky v9 runs hooks under `sh`/`dash`; `nvm.sh` can't be sourced. Hooks add nvm node bin to PATH directly. `lint-staged` called without `npx`                                                                                                                                                                                                                                                                                     |
-| **CI: workspace deps need build before Vitest**       | Vitest resolves workspace packages via `exports` field (pointing to `dist/`). CI must build deps before running tests                                                                                                                                                                                                                                                                                                             |
-| **`drizzle-kit generate` TUI blocks automation**      | Interactive prompts (rename vs create) use a TUI that ignores piped stdin. Write manual migrations in non-interactive shells; snapshot files may need regeneration interactively                                                                                                                                                                                                                                                  |
-| **Playwright `webServer.env` replaces `process.env`** | `webServer.env` **replaces** (not merges) the child process environment. Must load `.env` files via `dotenv` and spread `...process.env` to ensure `DATABASE_URL` etc. reach dev servers                                                                                                                                                                                                                                          |
-| **Zitadel issuer ± trailing slash**                   | Zitadel v4.10.1 omits trailing slash in JWT `iss` claim. JWKS verifier uses array issuer `[base, base + "/"]` to match both. Don't normalize to one form                                                                                                                                                                                                                                                                          |
-| **hivemind for dev servers**                          | `pnpm dev` uses hivemind (single Go binary, no tmux). Install `hivemind`. Turbo stays for builds; hivemind replaces it for persistent dev servers only. Use `pnpm dev:clean` to kill orphans if hivemind crashes. No per-process `connect`/`restart` — use Ctrl+C to stop all, rely on hot-reload for changes. hivemind always injects a PORT env var (base 5000); `Procfile.dev` sets `PORT=` explicitly per process to override |
-| **Caddy `DOMAIN` env var controls TLS**               | Caddy auto-provisions HTTPS (LetsEncrypt) when `DOMAIN` is a real domain. When `DOMAIN=localhost` (or unset), Caddy uses self-signed certs. Set `DOMAIN` in `.env.staging`/`.env.prod`                                                                                                                                                                                                                                            |
-| **Zitadel Actions v2 payload format**                 | Zitadel sends `event_type` (not `eventType`), `created_at` (not `creationDate`), `aggregateID:sequence` for idempotency (no `eventId`), and user data in `event_payload` (not `user`). Signature header is `ZITADEL-Signature` with format `t=<ts>,v1=<hmac>` where HMAC is over `<ts>.<body>`. Handler maps `user.human.*` event names to internal `user.*` names via alias table                                                |
-| **GitHub: secrets don't trim whitespace**             | GitHub Actions secret values are stored verbatim — leading/trailing spaces are not trimmed. A pasted secret with a leading space will silently cause auth failures. GitHub masks the value in logs, making this invisible. Verify with `echo "Length: ${#VAR} chars"` in the workflow                                                                                                                                             |
-| **Garage admin API `UpdateClusterLayout` broken**     | Garage v2.2.0's admin API `POST /v2/UpdateClusterLayout` silently accepts requests but doesn't stage changes. Use CLI (`/garage layout assign`) via RPC instead. `start-garage.sh` handles this. Admin API works correctly for `ImportKey`, `CreateBucket`, `AllowBucketKey`. Key IDs must be `GK` + 24 hex chars                                                                                                                 |
+| Quirk                                                 | Details                                                                                                                                                                              |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Docker Compose env_file**                           | `env_file:` sets container env only. For YAML `${VAR}` substitution, use `--env-file .env` on CLI                                                                                    |
+| **PostgreSQL init-db.sh**                             | Only runs on first DB creation. `docker compose down -v` to re-run                                                                                                                   |
+| **PgBouncer: migrations must bypass**                 | `DATABASE_URL` (port 5432) for migrations. `DATABASE_APP_URL` (port 6432) through PgBouncer. Use `SET LOCAL` (not `SET`) — transaction pooling reuses connections                    |
+| **WSL husky hooks need nvm PATH**                     | Husky v9 runs under `sh`/`dash`; hooks add nvm node bin to PATH directly                                                                                                             |
+| **CI: workspace deps need build before Vitest**       | Vitest resolves workspace packages via `exports` → `dist/`. CI must build deps first                                                                                                 |
+| **`drizzle-kit generate` TUI blocks automation**      | Write manual migrations in non-interactive shells; snapshot files may need regeneration interactively                                                                                |
+| **Playwright `webServer.env` replaces `process.env`** | Must spread `...process.env` in `webServer.env` to ensure env vars reach dev servers                                                                                                 |
+| **Zitadel issuer ± trailing slash**                   | JWKS verifier uses array issuer `[base, base + "/"]` to match both. Don't normalize                                                                                                  |
+| **hivemind for dev servers**                          | `pnpm dev` uses hivemind. Use `pnpm dev:clean` to kill orphans. `Procfile.dev` sets `PORT=` explicitly per process to override hivemind's default                                    |
+| **Caddy `DOMAIN` env var controls TLS**               | Real domain → LetsEncrypt. `localhost` → self-signed. Set in `.env.staging`/`.env.prod`                                                                                              |
+| **Zitadel Actions v2 payload format**                 | `event_type`/`created_at`/`event_payload` (not camelCase). `ZITADEL-Signature` header: `t=<ts>,v1=<hmac>` over `<ts>.<body>`. Handler maps `user.human.*` → `user.*` via alias table |
+| **GitHub: secrets don't trim whitespace**             | Verify with `echo "Length: ${#VAR} chars"` in workflow                                                                                                                               |
+| **Garage admin API `UpdateClusterLayout` broken**     | Use CLI (`/garage layout assign`) via RPC. `start-garage.sh` handles this                                                                                                            |
+| **Test fixtures must match DB constraints**           | Valid UUIDs, valid enum values, all non-nullable fields. Invalid fixtures pass type-check but fail at runtime                                                                        |
+| **PostgreSQL migration behaviors**                    | `CREATE OR REPLACE FUNCTION` silently overwrites. RLS policies can cause infinite recursion across tables — test with `SET app.current_org_id` in psql                               |
 
-**Version pin (cross-cutting):**
-
-| Package     | Pinned        | Notes                                        |
-| ----------- | ------------- | -------------------------------------------- |
-| Drizzle ORM | latest stable | Schema API evolving; pin after initial setup |
-
-All other version pins are in their respective per-directory CLAUDE.md files.
+**Version pin:** Drizzle ORM latest stable (schema API evolving). Other pins in per-directory CLAUDE.md files.
 
 ---
 
 ## Security Status
 
-Application security controls (rate limiting, auth, RLS, audit, input validation, webhook verification, etc.) are all in place. See `docs/release-checklist.md` for the full checklist.
-
-**Remaining production TODOs:**
-
-- [x] Backups (WAL-G to S3) — `docker/postgres/` (WAL-G image), `scripts/backup-db.sh`, `scripts/verify-backup.sh`, `scripts/restore-backup.sh`
-- [x] Rotate credentials quarterly — `scripts/rotate-secrets.sh` + `docs/credential-rotation.md`
-- [x] Verify RLS in production — `scripts/verify-rls.sh` (structural + behavioral, integrated into deploy via `init-prod.sh`)
+All security controls in place (rate limiting, auth, RLS, audit, input validation, webhook verification). All production TODOs complete (backups, credential rotation, RLS verification). See `docs/release-checklist.md`.
 
 ---
 
@@ -228,78 +113,26 @@ Application security controls (rate limiting, auth, RLS, audit, input validation
 **NEVER push directly to `main`.** Protected branch — requires PR + CI + senior dev review. The `pre-push-branch.js` hook blocks direct pushes.
 
 - **Branching:** `feat/<topic>`, `fix/<topic>`, `chore/<topic>` from `main`. Squash merge.
-- **Commits:** [Conventional Commits](https://www.conventionalcommits.org/) — scope with component name when specific (e.g., `feat(hopper): ...`).
+- **Commits:** [Conventional Commits](https://www.conventionalcommits.org/) — scope with component name (e.g., `feat(hopper): ...`).
 - **Commit cadence:** At stable checkpoints. Always before risky ops, ending a session, or switching context.
 - **Push cadence:** When you have a reviewable unit, are stepping away, or want CI feedback. Don't push broken states.
-- **Release tags:** semver `v{major}.{minor}.{patch}`. v1 MVP tagged `v1.0.0-mvp`.
 
 ### Git Hooks (husky)
 
-| Hook           | Checks                                                                                                                                                                                                                                                           |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Pre-commit** | Secret scanning (`scripts/check-secrets.sh`), lint-staged (Prettier on `.ts`/`.tsx`/`.json`/`.md`, ESLint `--max-warnings 0` on `.ts`/`.tsx` via `scripts/lint-staged-eslint.sh`)                                                                                |
-| **Pre-push**   | `pnpm type-check` (tsc --noEmit, scoped to `db` + `api` packages), `pnpm lint` (ESLint), Docker Compose validation (if compose files changed), shell syntax check (if `.sh` changed), garage.toml validation (if changed). Full workspace type-check runs in CI. |
+| Hook           | Checks                                                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **Pre-commit** | Secret scanning (`scripts/check-secrets.sh`), lint-staged (Prettier + ESLint `--max-warnings 0`)                                     |
+| **Pre-push**   | `pnpm type-check` (tsc --noEmit, `db` + `api`), `pnpm lint`, Docker Compose validation (if changed), shell syntax check (if changed) |
 
 ### CI Pipeline (GitHub Actions)
 
-| Job                           | Checks                                                      |
-| ----------------------------- | ----------------------------------------------------------- |
-| **quality**                   | `format:check`, `lint`, `type-check`, `pnpm audit`          |
-| **unit-tests**                | `pnpm test`                                                 |
-| **rls-tests**                 | RLS tenant isolation integration tests                      |
-| **queue-tests**               | Queue/worker integration tests (19 tests, Redis + Postgres) |
-| **service-integration-tests** | Service integration tests (Postgres)                        |
-| **security-tests**            | Security tests (Postgres)                                   |
-| **webhook-tests**             | Webhook integration tests (Postgres)                        |
-| **python-sdk-tests**          | Python SDK smoke tests                                      |
-| **playwright-tests**          | Playwright E2E submissions project (20 tests)               |
-| **playwright-uploads**        | Playwright E2E uploads project (6 tests)                    |
-| **playwright-oidc**           | Playwright E2E OIDC project (6 tests)                       |
-| **playwright-embed**          | Playwright E2E embed project (10 tests)                     |
-| **playwright-slate**          | Playwright E2E Slate pipeline project (30 tests)            |
-| **playwright-workspace**      | Playwright E2E Writer Workspace project (21 tests)          |
-| **playwright-forms**          | Playwright E2E Form Builder project (16 tests)              |
-| **playwright-organization**   | Playwright E2E Organization & Settings project (14 tests)   |
-| **playwright-analytics**      | Playwright E2E Submission Analytics project (6 tests)       |
-| **playwright-federation**     | Playwright E2E Federation Admin project (16 tests)          |
-| **build**                     | `pnpm build` (API + Web production build)                   |
+Jobs: quality, unit-tests, rls-tests, queue-tests, service-integration-tests, security-tests, webhook-tests, python-sdk-tests, 9 Playwright suites, build. See `.github/workflows/ci.yml`.
 
-**Path filtering:** Playwright suites run selectively on PRs based on changed files (`.github/scripts/detect-changes.sh`). Shared paths (packages, API, shared hooks/lib/ui) trigger all suites. Suite-specific paths (e.g., `apps/web/e2e/slate/`, `apps/web/src/components/slate/`) trigger only that suite. Unknown paths fail-open (all suites run). Push to `main` always runs everything. Fast jobs (quality, unit-tests, rls-tests, queue-tests, service-integration-tests, security-tests, build) are unaffected — they always run on non-docs PRs.
+**Path filtering:** Playwright suites run selectively based on changed files (`.github/scripts/detect-changes.sh`). Shared paths trigger all suites. Push to `main` runs everything. Fast jobs always run on non-docs PRs.
 
 ---
 
 ## Development Workflow
-
-### Claude Code Skills
-
-```
-# Backend
-/db-reset             # Reset database and apply Drizzle migrations + RLS
-/db-reset --test      # Reset test database
-/new-route <name>     # Scaffold ts-rest route with Fastify handler + tests
-/new-service <name>   # Scaffold service class with Drizzle queries + tests
-/new-processor <name> # Scaffold BullMQ job processor
-/new-migration <name> # Add Drizzle schema + generate migration + RLS policy
-/stripe-webhook <evt> # Add Stripe webhook handler with idempotency
-/test-rls             # Run RLS integration tests
-
-# Infrastructure
-/smoke-test           # Validate infra locally (compose, Garage S3, shell scripts)
-/smoke-test compose   # Fast: compose + config only (no Docker daemon needed)
-/smoke-test garage    # Garage S3 round-trip only (requires Docker)
-
-# Frontend
-/new-page <name>      # Scaffold Next.js page (auth, dashboard, or public)
-/new-component <name> # Scaffold React component (form, list, dialog, or basic)
-/new-hook <name>      # Scaffold React hook (query, mutation, or state)
-/new-e2e <feature>    # Scaffold Playwright E2E test with helpers
-
-# Session
-/start-session        # Session briefing (DEVLOG context, git state, PRs, infra)
-/end-session          # End-of-session housekeeping (DEVLOG, git, PR, summary)
-/codex-review [type]  # Run Codex code review (plan, diff, branch; default: branch)
-/opencode-review [type] # Run OpenCode code review (plan, diff, branch; default: branch)
-```
 
 ### Claude Code Hooks (run automatically)
 
@@ -309,141 +142,57 @@ Application security controls (rate limiting, auth, RLS, audit, input validation
 
 ### Code Review Integration
 
-Two review tools available — use either:
-
-- `/codex-review [plan|diff|branch]` — Codex CLI review. Branch: `codex review --base origin/main`. Diff: `--uncommitted`. Plan: `codex exec -s read-only`.
-- `/opencode-review [plan|diff|branch]` — OpenCode CLI review. All modes use `opencode run` with a review prompt and `-f` to attach diffs/plans.
+- `/codex-review [plan|diff|branch]` — Codex CLI review
+- `/opencode-review [plan|diff|branch]` — OpenCode CLI review
 
 For interactive Codex in tmux: source nvm, `nvm use v22.22.0`, then `codex`. Use `codex resume` or `codex fork --last` for follow-up.
 
 ### Decision Surfacing in Plan Mode
 
-After exploring the codebase but **before writing the implementation plan**, enumerate any architectural gray areas discovered during exploration. Present each as a decision point:
-
-```
-## Design Decisions
-
-### [Decision Title]
-**Context:** [What was found during exploration that creates ambiguity]
-**Options:**
-  A. [Option] — [pro/con]
-  B. [Option] — [pro/con]
-**Recommendation:** [A or B] — [rationale]
-```
-
-Wait for user confirmation or redirection on each decision before proceeding to write the plan. This prevents wasted planning effort on an approach the user would reject.
-
-**Skip this step when:**
-
-- The task has no meaningful design choices (pure mechanical refactoring, typo fixes)
-- All decisions were already made in the requirements (backlog item specifies the approach)
-- The user explicitly says "just do it" or "use your judgment"
+Before writing the implementation plan, enumerate architectural gray areas as decision points with options and recommendations. Wait for user confirmation before proceeding. Skip for mechanical refactoring, fully-specified backlog items, or when user says "just do it."
 
 ### Plan Review: Codex Integration
 
-<!-- To switch to OpenCode: replace /codex-review with /opencode-review below -->
+Every non-trivial plan must be reviewed before presenting to the user:
 
-Every non-trivial plan **must be reviewed before presenting to the user for approval**. The workflow is:
+1. Write the plan → 2. Run `/codex-review plan` automatically → 3. Adjust for critical issues → 4. Present to user
 
-1. **Write the plan** (after decision surfacing, per above)
-2. **Run `/codex-review plan`** automatically — do not ask the user, just run it
-3. **Evaluate review findings** — adjust the plan for any critical or important issues; for dismissed suggestions, add a brief note (e.g., "Review suggested X; dismissed because Y")
-4. **Present the reviewed plan** to the user for approval
-
-The user sees a plan that has already been through one round of review. This replaces the previous pattern of creating blocking task list entries for review.
-
-**When to skip:** Trivial plans (typo fix, single config change, doc-only update). If in doubt, run the review.
+Skip for trivial plans (typo fix, single config change, doc-only update).
 
 ### Plan Specificity Standard
 
-Plans must be concrete enough to mechanically verify after implementation. Every non-trivial plan should include:
-
-- **Exact file paths** for all files to create or modify (absolute from repo root)
-- **Concrete type/interface names** for new exports (e.g., "export `FormFieldValidator` type from `form-validation.service.ts`")
-- **Function/method signatures** with parameter and return types
-- **Named test cases** with setup conditions and expected assertions (e.g., "Test 'rejects invalid email': setup field with `fieldType: 'email'`, pass value `'not-an-email'`, assert error message contains 'valid email'")
-- **Import changes** when moving code between files
-- **Files that should NOT change** when relevant (confirms scope boundaries)
-
-The goal: another developer (or Codex) could diff the implementation against the plan and flag unintentional divergences. When a plan item is too exploratory to specify concretely, mark it as `[exploratory]` and note what will be determined during implementation.
+Plans must include: exact file paths, concrete type/interface names, function signatures with types, named test cases with assertions, import changes, and files that should NOT change. Goal: another developer could diff implementation against the plan. Mark exploratory items as `[exploratory]`.
 
 ### Plan Override Log
 
-During implementation, when discoveries require deliberate divergence from the approved plan, log overrides immediately. Do not wait until the end.
+Log deliberate divergences from approved plans in a `## Plan Overrides` section of the PR description:
 
-**Where to log:** Add a `## Plan Overrides` section to the PR description body (created by `/end-session` or `gh pr create`). Use this table format:
+| File | Planned | Actual | Rationale |
 
-| File              | Planned               | Actual                                    | Rationale                                       |
-| ----------------- | --------------------- | ----------------------------------------- | ----------------------------------------------- |
-| `path/to/file.ts` | Export `FooValidator` | Export `validateFoo` (function, not type) | Function is simpler; no consumers need the type |
-
-**When to log:**
-
-- A file was created/modified that was not in the plan
-- A planned file was not created (scope reduced)
-- An export name, type, or signature differs from the plan
-- A test case was added, removed, or substantially changed
-
-**When NOT to log:**
-
-- Trivial formatting differences (import order, whitespace)
-- Bug fixes discovered during implementation that are clearly in-scope
-- Additional test cases that strengthen coverage beyond the plan
-
-Drift detection (in `/opencode-review branch` or `/codex-review branch`) reads this section and excludes acknowledged overrides from its findings.
+Log when: files added/removed vs plan, exports differ, test cases changed substantially. Skip for: formatting, in-scope bug fixes, additional test cases.
 
 ### File Size Guideline
 
-Soft limit of 500 lines per source file. Files exceeding 500 lines should be flagged during code review (`/opencode-review` or `/codex-review`) for potential extraction. This is a review trigger, not a hard gate — some files (e.g., schema definitions, test suites) naturally exceed this. When flagged, evaluate whether there is a natural seam for extraction (pure logic vs DB-dependent, CRUD vs validation, etc.).
+Soft limit of 500 lines per source file. Review trigger, not a hard gate.
 
-### MCP Servers (restart Claude Code to activate)
+### MCP Servers
 
-- **postgres**: Direct DB queries (`@modelcontextprotocol/server-postgres`)
-- **redis**: Job/session inspection (`@modelcontextprotocol/server-redis`)
-- **context7**: Library docs (`@upstash/context7-mcp`)
-- **stripe**: Stripe API/docs (`@stripe/mcp`)
-- **playwright**: E2E automation (`@anthropic/mcp-playwright`)
-- **docker**: Container inspection — logs, health, stats (`@modelcontextprotocol/server-docker`)
-
-Config template: `.claude/mcp-servers.example.json`
+postgres, redis, context7, stripe, playwright, docker. Config: `.claude/mcp-servers.example.json`.
 
 ### Starting Development
 
 ```bash
 pnpm docker:up                # Core infra + Zitadel (or --full for ClamAV, --core to skip Zitadel)
-pnpm install
-pnpm db:migrate               # Run Drizzle migrations
-pnpm db:seed                  # Seed dev data (orgs, submissions, Slate pipeline)
-pnpm db:seed:staging          # Rich staging/demo data (80 subs, forms, editorial, federation, etc.)
-pnpm zitadel:setup            # Provision Zitadel + patch .env files (after volume wipe)
-pnpm dev                      # hivemind: builds packages, then API: 4000, Web: 3000
+pnpm install && pnpm db:migrate && pnpm db:seed
+pnpm zitadel:setup            # After volume wipe
+pnpm dev                      # hivemind: API:4000, Web:3000
 ```
 
-**Optional monitoring stack** (Prometheus + Grafana + AlertManager + Loki):
+**Other commands:** `pnpm db:generate`, `pnpm db:reset`, `pnpm db:seed:staging`, `pnpm db:validate-migrations`, `pnpm db:add-migration <name>`, `pnpm sdk:export-spec`, `pnpm sdk:generate`
 
-```bash
-docker compose --profile monitoring up -d  # Prometheus:9090, Grafana:3001, AlertManager:9093, Loki:3100
-```
+**Monitoring:** `docker compose --profile monitoring up -d` (Prometheus:9090, Grafana:3001, AlertManager:9093, Loki:3100)
 
-**CLI tooling** (all scripts self-document with `--help`):
-
-```bash
-bash scripts/webhook-health.sh                                           # Check webhook provider freshness
-bash scripts/grafana-query.sh logs --query '{service="api"} |= "error"'  # Search Loki logs
-bash scripts/grafana-query.sh alerts                                     # List firing alerts
-bash scripts/server-logs.sh tail api -f                                  # Follow API container logs
-bash scripts/sentry-issues.sh                                            # Recent unresolved Sentry issues
-bash scripts/zitadel-admin.sh status                                     # Zitadel health check
-```
-
-**hivemind controls** (while `pnpm dev` is running):
-
-```bash
-Ctrl+C                         # Stop all dev servers (hivemind forwards signals)
-pnpm dev:clean                 # Kill orphaned processes + stale files (fallback)
-```
-
-Note: hivemind does not support per-process attach/restart. Both apps have hot-reload, so file changes trigger automatic restarts. Use `pnpm dev:clean && pnpm dev` for a full restart.
+**CLI scripts** (all self-document with `--help`): `scripts/webhook-health.sh`, `scripts/grafana-query.sh`, `scripts/server-logs.sh`, `scripts/sentry-issues.sh`, `scripts/zitadel-admin.sh`
 
 ### Running Tests
 
@@ -455,31 +204,12 @@ pnpm --filter @colophony/web test:e2e  # Playwright (needs dev servers)
 
 Full testing guide: [docs/testing.md](docs/testing.md)
 
-### Database Management
-
-```bash
-pnpm db:migrate               # Validate journal + run Drizzle migrations
-pnpm db:generate              # Generate migration from schema changes
-pnpm db:seed                  # Seed test data
-pnpm db:seed:staging          # Seed rich staging/demo data (all feature areas)
-pnpm db:reset                 # Drop and recreate with migrations + RLS
-pnpm db:validate-migrations   # Check SQL files ↔ journal consistency
-pnpm db:add-migration <name>  # Add journal entry for a manual migration
-```
-
-### SDK Management
-
-```bash
-pnpm sdk:export-spec          # Export OpenAPI spec from running dev server → sdks/openapi.json
-pnpm sdk:generate             # Regenerate TypeScript + Python SDKs from committed spec
-```
-
 ### Environment Variables
 
-Canonical definition with Zod validation: `apps/api/src/config/env.ts` (66 variables, all defaults and descriptions inline). Read that file for the full reference.
+Canonical definition with Zod validation: `apps/api/src/config/env.ts` (66 variables, all defaults and descriptions inline).
 
 ---
 
 ## Development Tracks
 
-All 10 tracks complete. Track 6 (Plugins) extracted to feature branch. See [docs/architecture.md Section 6](docs/architecture.md) for details.
+All 10 tracks complete. Track 6 (Plugins) extracted to feature branch. See [docs/architecture.md Section 6](docs/architecture.md).

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -2,78 +2,28 @@
 
 ## Key Paths
 
-| What               | Path                                                           |
-| ------------------ | -------------------------------------------------------------- |
-| App entry          | `src/main.ts`                                                  |
-| Env config (Zod)   | `src/config/env.ts`                                            |
-| Fastify hooks      | `src/hooks/`                                                   |
-| Service layer      | `src/services/`                                                |
-| Manuscript svc     | `src/services/manuscript.service.ts`                           |
-| tRPC router        | `src/trpc/router.ts`                                           |
-| tRPC client types  | `src/trpc/client-types.ts`                                     |
-| tRPC init          | `src/trpc/init.ts`                                             |
-| tRPC context       | `src/trpc/context.ts`                                          |
-| REST router        | `src/rest/router.ts`                                           |
-| REST context       | `src/rest/context.ts`                                          |
-| REST error mapper  | `src/rest/error-mapper.ts`                                     |
-| REST org handlers  | `src/rest/routers/organizations.ts`                            |
-| Form service       | `src/services/form.service.ts`                                 |
-| Form validation    | `src/services/form-validation.service.ts`                      |
-| GDPR service       | `src/services/gdpr.service.ts`                                 |
-| Embed routes       | `src/routes/embed.routes.ts`                                   |
-| Embed token svc    | `src/services/embed-token.service.ts`                          |
-| Embed submit svc   | `src/services/embed-submission.service.ts`                     |
-| tusd webhook       | `src/webhooks/tusd.webhook.ts`                                 |
-| Zitadel webhook    | `src/webhooks/zitadel.webhook.ts`                              |
-| Stripe webhook     | `src/webhooks/stripe.webhook.ts`                               |
-| Documenso webhook  | `src/webhooks/documenso.webhook.ts`                            |
-| Inngest client     | `src/inngest/client.ts`                                        |
-| Inngest functions  | `src/inngest/functions/`                                       |
-| Inngest serve      | `src/inngest/serve.ts`                                         |
-| Email adapters     | `src/adapters/email/` (SmtpEmailAdapter, SendGridEmailAdapter) |
-| Storage adapter    | `src/adapters/storage/` (S3StorageAdapter)                     |
-| Payment adapter    | `src/adapters/payment/` (StripePaymentAdapter)                 |
-| Registry accessor  | `src/adapters/registry-accessor.ts`                            |
-| Config builder     | `src/colophony.config.ts`                                      |
-| Email templates    | `src/templates/email/` (MJML)                                  |
-| Content converters | `src/converters/` (text, docx, smart-typography, barrel)       |
-| Content queue      | `src/queues/content-extract.queue.ts`                          |
-| Content worker     | `src/workers/content-extract.worker.ts`                        |
-| Content svc        | `src/services/content-extraction.service.ts`                   |
-| Email queue        | `src/queues/email.queue.ts`                                    |
-| Email worker       | `src/workers/email.worker.ts`                                  |
-| Email service      | `src/services/email.service.ts`                                |
-| Notif pref svc     | `src/services/notification-preference.service.ts`              |
-| Webhook queue      | `src/queues/webhook.queue.ts`                                  |
-| Webhook worker     | `src/workers/webhook.worker.ts`                                |
-| Webhook service    | `src/services/webhook.service.ts`                              |
-| CMS adapters       | `src/adapters/cms/`                                            |
-| Documenso adapter  | `src/adapters/documenso.adapter.ts`                            |
-| Outbox poller      | `src/workers/outbox-poller.worker.ts`                          |
-| SSE notif stream   | `src/sse/notification-stream.ts` (hijacked, manual CORS)       |
-| Redis pub/sub      | `src/sse/redis-pubsub.ts`                                      |
-| Federation trust   | `src/federation/trust.routes.ts` (S2S)                         |
-| Trust admin        | `src/federation/trust-admin.routes.ts`                         |
-| Key admin          | `src/federation/key-admin.routes.ts`                           |
-| Trust service      | `src/services/trust.service.ts`                                |
-| HTTP signatures    | `src/federation/http-signatures.ts`                            |
-| Federation auth    | `src/federation/federation-auth.ts`                            |
-| Sim-sub routes     | `src/federation/simsub.routes.ts` (S2S)                        |
-| Sim-sub admin      | `src/federation/simsub-admin.routes.ts`                        |
-| Sim-sub service    | `src/services/simsub.service.ts`                               |
-| Fingerprint svc    | `src/services/fingerprint.service.ts`                          |
-| Transfer routes    | `src/federation/transfer.routes.ts` (S2S)                      |
-| Transfer admin     | `src/federation/transfer-admin.routes.ts`                      |
-| Transfer service   | `src/services/transfer.service.ts`                             |
-| Migration routes   | `src/federation/migration.routes.ts` (S2S)                     |
-| Migration admin    | `src/federation/migration-admin.routes.ts`                     |
-| Migration service  | `src/services/migration.service.ts`                            |
-| Migration bundle   | `src/services/migration-bundle.service.ts`                     |
-| Hub routes         | `src/federation/hub.routes.ts` (S2S)                           |
-| Hub admin          | `src/federation/hub-admin.routes.ts`                           |
-| Hub auth           | `src/federation/hub-auth.ts`                                   |
-| Hub service        | `src/services/hub.service.ts`                                  |
-| Hub client svc     | `src/services/hub-client.service.ts`                           |
+| What               | Path                                                                                                  |
+| ------------------ | ----------------------------------------------------------------------------------------------------- |
+| App entry          | `src/main.ts`                                                                                         |
+| Env config (Zod)   | `src/config/env.ts`                                                                                   |
+| Fastify hooks      | `src/hooks/`                                                                                          |
+| Service layer      | `src/services/`                                                                                       |
+| tRPC               | `src/trpc/` (router, init, context, client-types)                                                     |
+| REST (oRPC)        | `src/rest/` (router, context, error-mapper, routers/)                                                 |
+| Webhooks           | `src/webhooks/` (zitadel, stripe, tusd, documenso)                                                    |
+| Inngest            | `src/inngest/` (client, serve, functions/)                                                            |
+| Adapters           | `src/adapters/` (email/, storage/, payment/, cms/, registry-accessor, documenso)                      |
+| Config builder     | `src/colophony.config.ts`                                                                             |
+| Email templates    | `src/templates/email/` (MJML)                                                                         |
+| Content converters | `src/converters/` (text, docx, smart-typography)                                                      |
+| Queues             | `src/queues/` (email, webhook, file-scan, content-extract, s3-cleanup, outbox-poller, transfer-fetch) |
+| Workers            | `src/workers/` (matching queue names)                                                                 |
+| SSE notifications  | `src/sse/` (notification-stream, redis-pubsub)                                                        |
+| Federation         | `src/federation/` (trust, simsub, transfer, migration, hub — each has S2S routes + admin routes)      |
+| Embed routes       | `src/routes/embed.routes.ts`                                                                          |
+| SSRF validation    | `src/lib/url-validation.ts`                                                                           |
+
+Full file index: [docs/file-index.md](../../docs/file-index.md)
 
 ### Service Method Naming
 
@@ -83,7 +33,7 @@
 | `AsOwner`    | Checks ownership (submitterId === actor.userId) + audits |
 | `WithAudit`  | Wraps a mutation with audit logging                      |
 
-Pure data methods keep `(tx, ...)` signatures for worker/internal use. Access-aware methods accept `ServiceContext` and throw `ForbiddenError`/`NotFoundError` — callers use `mapServiceError()` to translate to surface-specific errors.
+Pure data methods keep `(tx, ...)` signatures for worker/internal use. Access-aware methods accept `ServiceContext` and throw `ForbiddenError`/`NotFoundError` — callers use `mapServiceError()` to translate.
 
 ---
 
@@ -93,16 +43,14 @@ Pure data methods keep `(tx, ...)` signatures for worker/internal use. Access-aw
 rateLimit (IP) → auth → rateLimitAuth (user) → orgContext → dbContext → audit
 ```
 
-Each hook decorates the Fastify request:
-
-| Hook                  | Decorates                        | Purpose                                                                 |
-| --------------------- | -------------------------------- | ----------------------------------------------------------------------- |
-| `rateLimitPlugin`     | `app.rateLimitRedis`             | IP-based rate limiting (DEFAULT_MAX, runs before auth — DoS shield)     |
-| `rateLimitAuthPlugin` | —                                | User-based rate limiting (AUTH_MAX, runs after auth, overrides headers) |
-| `authPlugin`          | `request.authContext`            | Validates OIDC token or X-Api-Key, extracts user identity               |
-| `orgContextPlugin`    | `request.authContext.orgId/role` | Resolves `X-Organization-Id` header, checks membership                  |
-| `dbContextPlugin`     | `request.dbTx`                   | Opens RLS transaction via `SET LOCAL` with org/user context             |
-| `auditPlugin`         | `request.audit`                  | Provides `audit(action, details)` helper for logging                    |
+| Hook                  | Decorates                        | Purpose                                           |
+| --------------------- | -------------------------------- | ------------------------------------------------- |
+| `rateLimitPlugin`     | `app.rateLimitRedis`             | IP-based rate limiting (before auth — DoS shield) |
+| `rateLimitAuthPlugin` | —                                | User-based rate limiting (after auth)             |
+| `authPlugin`          | `request.authContext`            | Validates OIDC token or X-Api-Key                 |
+| `orgContextPlugin`    | `request.authContext.orgId/role` | Resolves `X-Organization-Id`, checks membership   |
+| `dbContextPlugin`     | `request.dbTx`                   | Opens RLS transaction via `SET LOCAL`             |
+| `auditPlugin`         | `request.audit`                  | Provides `audit(action, details)` helper          |
 
 **RLS runtime contract:** `dbContext` hook calls `SET LOCAL` to set `app.current_org` and `app.user_id` inside a per-request transaction. RLS policy definitions are in `packages/db/CLAUDE.md`.
 
@@ -112,268 +60,145 @@ Each hook decorates the Fastify request:
 
 Dual auth: Zitadel OIDC tokens for interactive users, API keys for programmatic access.
 
-**Default-deny model:** The auth hook rejects all requests to non-public routes that lack a valid `Authorization` header or `X-Api-Key` header (returns 401). Public routes are explicitly allowlisted in `auth.ts` via `PUBLIC_EXACT` and `PUBLIC_PREFIXES`. This provides defense-in-depth — even if a tRPC procedure accidentally uses `publicProcedure`, the hook layer still requires auth unless the route is explicitly allowlisted.
+**Default-deny:** Auth hook rejects all requests to non-public routes without valid `Authorization` or `X-Api-Key` (401). Public routes allowlisted in `auth.ts` via `PUBLIC_EXACT`/`PUBLIC_PREFIXES`. Defense-in-depth — even `publicProcedure` requires explicit allowlisting at hook layer.
 
-**Auth precedence:** Bearer token (OIDC) is checked first. `X-Api-Key` is the fallback when no `Authorization` header is present. When both are present, Bearer wins.
-
-- **Interactive users:** Zitadel OIDC tokens (access + refresh) — sets `authMethod: 'oidc'`
-- **API consumers:** API keys via `X-Api-Key` header — sets `authMethod: 'apikey'`
-- **Dev bypass:** Set `DEV_AUTH_BYPASS=true` to allow unauthenticated requests in development when `ZITADEL_AUTHORITY` is not configured. Never effective in production.
+**Precedence:** Bearer (OIDC) checked first, `X-Api-Key` fallback. Dev bypass: `DEV_AUTH_BYPASS=true` (never in production).
 
 ### API Key Authentication
 
-- **Key format:** `col_live_<32 hex chars>` (41 chars total, 128 bits of entropy)
-- **Storage:** SHA-256 hash stored in `api_keys` table. Plain text shown once on creation, never stored.
-- **Org-scoped:** Each key belongs to an organization. `createdBy` tracks the creating user.
-- **Auth context:** Uses the creator's `userId` for audit trail and RLS. Pre-sets `orgId` from the key.
-- **Scopes:** Stored in `scopes` JSONB column. Enforced by `requireScopes` middleware on REST + tRPC surfaces. OIDC/test auth bypasses scope checks.
-- **Lookup:** `verify_api_key()` SECURITY DEFINER function bypasses RLS for cross-org hash lookup.
-- **`lastUsedAt`:** Updated fire-and-forget via `touch_api_key_last_used()` SECURITY DEFINER function.
-- **CRUD:** tRPC router at `apiKeys.*`. Only ADMIN can create/revoke/delete. All org members can list.
-- **Fail closed:** If the key creator is no longer an org member, the org-context hook rejects with 403.
-
-User lifecycle events are synced from Zitadel to the local DB via webhooks.
+- **Format:** `col_live_<32 hex chars>` — SHA-256 hash stored, plain text shown once
+- **Org-scoped:** Uses creator's `userId` for audit/RLS, pre-sets `orgId`
+- **Scopes:** JSONB column, enforced by `requireScopes` middleware (OIDC bypasses)
+- **Lookup:** `verify_api_key()` SECURITY DEFINER bypasses RLS for cross-org hash lookup
+- **CRUD:** tRPC `apiKeys.*`. ADMIN only for create/revoke/delete. Fail closed if creator leaves org.
 
 ---
 
 ## API Surfaces
 
-| Surface  | Audience              | Status                                       | Auth               |
-| -------- | --------------------- | -------------------------------------------- | ------------------ |
-| **tRPC** | Internal web frontend | **Built**                                    | Zitadel OIDC token |
-| **REST** | Public API, Zapier    | **Built** (oRPC + OpenAPI 3.1 at `/v1/docs`) | API key or OIDC    |
+| Surface  | Audience                                              | Auth               |
+| -------- | ----------------------------------------------------- | ------------------ |
+| **tRPC** | Internal web frontend                                 | Zitadel OIDC token |
+| **REST** | Public API, Zapier (oRPC + OpenAPI 3.1 at `/v1/docs`) | API key or OIDC    |
 
-GraphQL (Pothos + Yoga) was built but extracted to feature branch `chore/extract-graphql-to-feature-branch` — re-merge when demand materializes.
-
-All surfaces share the same service layer and Zod schemas from `@colophony/types`.
+GraphQL extracted to feature branch — re-merge when demand materializes. All surfaces share service layer and `@colophony/types` Zod schemas.
 
 ---
 
 ## tRPC Procedure Builders (`src/trpc/init.ts`)
 
-| Builder               | Middleware chain | Guarantees                                                   |
-| --------------------- | ---------------- | ------------------------------------------------------------ |
-| `publicProcedure`     | none             | No auth required                                             |
-| `authedProcedure`     | `isAuthed`       | `ctx.authContext` is non-null                                |
-| `orgProcedure`        | `hasOrgContext`  | `ctx.authContext.orgId/roles` + `ctx.dbTx` set               |
-| `userProcedure`       | `hasUserContext` | `ctx.authContext` + `ctx.dbTx` (no org)                      |
-| `editorProcedure`     | `isEditor`       | `orgProcedure` + roles includes EDITOR or ADMIN              |
-| `productionProcedure` | `isProduction`   | `orgProcedure` + roles includes PRODUCTION, EDITOR, or ADMIN |
-| `adminProcedure`      | `isAdmin`        | `orgProcedure` + roles includes ADMIN                        |
-
-Also exported: `createRouter`, `mergeRouters`.
+| Builder               | Guarantees                                    |
+| --------------------- | --------------------------------------------- |
+| `publicProcedure`     | No auth                                       |
+| `authedProcedure`     | `ctx.authContext` non-null                    |
+| `orgProcedure`        | `orgId/roles` + `dbTx` set                    |
+| `userProcedure`       | `authContext` + `dbTx` (no org)               |
+| `editorProcedure`     | `orgProcedure` + EDITOR or ADMIN              |
+| `productionProcedure` | `orgProcedure` + PRODUCTION, EDITOR, or ADMIN |
+| `adminProcedure`      | `orgProcedure` + ADMIN                        |
 
 ---
 
 ## Payments (Stripe Checkout)
 
-Stripe Checkout only (zero PCI scope). Webhook handler built at `src/webhooks/stripe.webhook.ts`.
+Stripe Checkout only (zero PCI scope). Handler: `src/webhooks/stripe.webhook.ts`.
 
-**NEVER:**
-
-- Log card numbers or CVV
-- Store card data in database
-- Process a webhook without idempotency check
-- Skip transaction wrapping for webhook processing
+**NEVER:** Log card numbers/CVV, store card data, skip idempotency check, skip transaction wrapping.
 
 ---
 
 ## Webhook Idempotency
 
-### Zitadel (built)
+All webhook handlers use two-step idempotency: INSERT event → check `processed` status → skip if true, (re)process if false.
 
-`src/webhooks/zitadel.webhook.ts` — verifies `ZITADEL-Signature` header (timestamp-prefixed HMAC: `t=<ts>,v1=<hmac>`), registered in an isolated Fastify scope with `fastify-raw-body`. Uses Zitadel Actions v2 payload format (`event_type`, `created_at`, `aggregateID:sequence` for idempotency, `event_payload` for user data). Two-step idempotency: INSERT event into `zitadel_webhook_events`, then SELECT `processed` status. If `processed = true`, skip. If `processed = false` (crash recovery or new event), reprocess. Event type aliases map `user.human.*` to internal `user.*` names. Timestamp freshness check rejects events older than `WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS` or >60s in the future. Out-of-order guard via `setWhere`/`WHERE` on `lastEventAt`. Webhook-specific rate limiting via Redis Lua script (key prefix `:wh:zitadel:`).
-
-### tusd (built)
-
-`src/webhooks/tusd.webhook.ts` — pre-create validates auth/submission/limits, post-finish creates file record idempotently (checks `storageKey` exists before insert). Registered in isolated Fastify scope at `/webhooks/tusd`. Auth: validates forwarded `Authorization` header via JWKS, resolves Zitadel `sub` → local user UUID via `resolveLocalUserId()`. Fails closed when auth cannot be verified.
-
-### Stripe (built)
-
-`src/webhooks/stripe.webhook.ts` — verifies `stripe-signature` header via `constructEvent()` (with configurable timestamp tolerance), registered in an isolated Fastify scope with `fastify-raw-body`. Two-step idempotency: INSERT event into `stripe_webhook_events`, then SELECT `processed` status. If `processed = true`, skip. If `processed = false` (crash recovery), reprocess. RLS org context set via `set_config('app.current_org', ...)` from Stripe session metadata (Zod-validated).
+- **Zitadel:** Verifies `ZITADEL-Signature` (`t=<ts>,v1=<hmac>` over `<ts>.<body>`). Actions v2 format: `event_type`/`created_at`/`event_payload`. Idempotency key: `aggregateID:sequence`. Timestamp freshness + out-of-order guard. Rate limited via Redis Lua.
+- **tusd:** Pre-create validates auth/submission/limits. Post-finish creates file record idempotently (checks `storageKey`). Auth via forwarded Bearer → JWKS → `resolveLocalUserId()`.
+- **Stripe:** Verifies `stripe-signature` via `constructEvent()`. Org context from session metadata. Idempotency via `stripe_webhook_events` table.
 
 ---
 
 ## SSRF Protection
 
-Outbound HTTP calls to user-controlled URLs must validate against private IP ranges.
+`src/lib/url-validation.ts` — `validateOutboundUrl(url, { devMode })`. Enforced at webhook endpoint CRUD, delivery, and federation metadata fetch. Dev mode allows HTTP/private IPs.
 
-**Utility:** `src/lib/url-validation.ts` — `validateOutboundUrl(url, { devMode })`.
-
-**Enforced at:** webhook endpoint creation/update, webhook delivery, federation metadata fetch.
-
-**Dev mode:** `NODE_ENV === 'development' || 'test'` allows HTTP and private IPs.
-
-**NEVER:**
-
-- Call `fetch()` on a user-provided URL without SSRF validation
-- Skip HTTPS enforcement in production
-- Allow redirects to bypass SSRF checks
+**NEVER:** `fetch()` user URL without SSRF validation, skip HTTPS in production, allow redirects to bypass checks.
 
 ---
 
 ## BullMQ Workers
 
-### Queue/Worker Pattern
+### Pattern
 
-- **Queues**: `src/queues/<name>.queue.ts` — singleton queue, `enqueue*()` helper, `close*()` for shutdown
-- **Workers**: `src/workers/<name>.worker.ts` — `start*Worker(env)` / `stop*Worker()` lifecycle functions
-- **Barrel exports**: `src/queues/index.ts` and `src/workers/index.ts`
+- **Queues**: `src/queues/<name>.queue.ts` — singleton, `enqueue*()` helper, `close*()` for shutdown
+- **Workers**: `src/workers/<name>.worker.ts` — `start*Worker(env)` / `stop*Worker()` lifecycle
+- **Shutdown**: Close workers before queues (in `main.ts` graceful shutdown)
 
 ### RLS in Workers
 
-Workers have no HTTP context. Use `withRls({ orgId })` for all DB operations on tenant tables. Each logical phase (status update, audit log) should be wrapped in its own `withRls()` call. S3 operations happen outside `withRls` since they don't touch the DB.
+Workers have no HTTP context. Use `withRls({ orgId })` per logical phase. S3 ops happen outside `withRls`.
 
 ```typescript
-// Phase 1: update status
 await withRls({ orgId: job.data.organizationId }, async (tx) => {
   await fileService.updateScanStatus(tx, fileId, 'SCANNING');
 });
-// Phase 2: S3/external ops (no RLS needed)
-// Phase 3: update status + audit
+// S3/external ops (no RLS needed)
 await withRls({ orgId: job.data.organizationId }, async (tx) => {
   await fileService.updateScanStatus(tx, fileId, 'CLEAN');
   await auditService.log(tx, { ... });
 });
 ```
 
-### Shutdown
+### Worker Inventory
 
-Workers and queues are started in `main.ts` and closed during graceful shutdown. Always close workers before queues.
+| Worker          | Queue             | Idempotency                    | Flow                                   | Retries            | Concurrency | Gate                 |
+| --------------- | ----------------- | ------------------------------ | -------------------------------------- | ------------------ | ----------- | -------------------- |
+| File scan       | `file-scan`       | `jobId: fileId`                | PENDING→SCANNING→CLEAN/INFECTED/FAILED | 3, exp backoff     | —           | `VIRUS_SCAN_ENABLED` |
+| Content extract | `content-extract` | `jobId: fileId` + status check | PENDING→EXTRACTING→COMPLETE/FAILED     | 3, exp 30s         | 3           | always               |
+| Email           | `email`           | `jobId: emailSendId`           | QUEUED→SENDING→SENT/FAILED             | 5, exp 30s         | 5           | `EMAIL_PROVIDER`     |
+| S3 cleanup      | `s3-cleanup`      | —                              | iterate keys → delete → audit          | 5, exp 60s         | —           | always               |
+| Webhook         | `webhook`         | `jobId: deliveryId`            | QUEUED→DELIVERING→DELIVERED/FAILED     | 8, custom [1s..1h] | 10          | always               |
+| Outbox poller   | `outbox-poller`   | —                              | poll `domain_events` → Inngest         | repeatable cron    | —           | always               |
+| Transfer fetch  | `transfer-fetch`  | —                              | HTTP download from remote              | —                  | —           | always               |
 
-### File Scan Worker
-
-- **Queue**: `file-scan` — jobs enqueued from tusd post-finish webhook _after_ DB commit
-- **Job idempotency**: `jobId: fileId` prevents duplicate scans from duplicate webhook calls
-- **Flow**: PENDING → SCANNING → CLEAN/INFECTED/FAILED
-- **Fail closed**: ClamAV errors → FAILED status → downloads blocked → BullMQ retries (3 attempts, exponential backoff)
-- **Feature flag**: `VIRUS_SCAN_ENABLED` (default `true`). When `false`, files are marked CLEAN immediately in the tusd webhook
-- **Chaining**: On CLEAN, enqueues `content-extract` job for supported MIME types (text/plain, docx)
-
-### Content Extract Worker
-
-- **Queue**: `content-extract` — jobs enqueued from file-scan worker (CLEAN) or tusd webhook (scan disabled)
-- **Job idempotency**: `jobId: fileId` prevents duplicate extractions; also skips if version status is COMPLETE or EXTRACTING
-- **Flow**: PENDING → EXTRACTING → COMPLETE/FAILED/UNSUPPORTED
-- **Processing**: Download from S3 → format-specific converter (.txt or .docx) → smart typography pass → store ProseMirror JSON in `manuscript_versions.content`
-- **Canonical source**: Only supported MIME types enqueued; first file to start extraction wins (multi-file race protection)
-- **Defense-in-depth**: All service methods verify manuscript ownership via explicit JOIN
-- **Retries**: 3 attempts, exponential backoff from 30s
-- **Concurrency**: 3
-- **Always active**: Not feature-gated
-
-### Email Worker
-
-- **Queue**: `email` — jobs enqueued from Inngest notification functions via `enqueueEmail()`
-- **Job idempotency**: `jobId: emailSendId` prevents duplicate sends from duplicate events
-- **Flow**: QUEUED → SENDING → SENT/FAILED (tracked in `email_sends` table)
-- **Processing**: Render MJML template → send via adapter (SMTP/SendGrid) → update status + audit
-- **Retries**: 5 attempts, exponential backoff from 30s
-- **Concurrency**: 5
-- **Feature flag**: `EMAIL_PROVIDER` (default `'none'`). Worker only starts when provider is configured (`smtp` or `sendgrid`)
-
-### S3 Cleanup Worker
-
-- **Queue**: `s3-cleanup` — jobs enqueued from `gdprService.deleteUser()` after transaction commit
-- **Flow**: Iterates storage keys, deletes from clean or quarantine bucket, logs audit event
-- **Retries**: 5 attempts, exponential backoff from 60s, 30-day fail retention
-- **Always active**: Not gated on `VIRUS_SCAN_ENABLED` — runs whenever GDPR deletion occurs
-
-### Webhook Worker
-
-- **Queue**: `webhook` — jobs enqueued from `webhookDelivery` Inngest function via `enqueueWebhook()`
-- **Job idempotency**: `jobId: deliveryId` prevents duplicate deliveries
-- **Flow**: QUEUED → DELIVERING → DELIVERED/FAILED (tracked in `webhook_deliveries` table)
-- **Processing**: Compute HMAC-SHA256 signature → HTTP POST with headers (`X-Webhook-Signature`, `X-Webhook-Id`, `User-Agent`) → update status + audit
-- **Retries**: 8 attempts, custom backoff [1s, 5s, 30s, 2m, 10m, 1h, 1h, 1h]
-- **Concurrency**: 10 (I/O-bound HTTP calls)
-- **Timeout**: 30s per delivery (AbortController)
-- **Auto-disable**: After 5 consecutive final failures for an endpoint, sets endpoint status to DISABLED
-- **Always active**: No feature flag — harmless when no endpoints registered
+File scan chains to content-extract on CLEAN. Webhook auto-disables endpoint after 5 consecutive failures.
 
 ---
 
 ## BullMQ / Inngest Boundary
 
-**Ownership rule:** Inngest owns orchestration + notification logic. BullMQ owns final-mile delivery (I/O-bound side effects).
+**Rule:** Inngest owns orchestration + notification logic. BullMQ owns final-mile delivery (I/O-bound side effects).
 
-### Decision Criteria
+- **Inngest:** Multi-step workflows, notification fan-out (3 workflow + 11 notification + 1 bridge = 15 functions)
+- **BullMQ:** Email send, webhook delivery, file scan, S3 cleanup, outbox polling, transfer fetch (7 queues)
+- **Glue:** Inngest calls `enqueue*()` helpers. Fire-and-forget.
+- **Outbox:** Service writes to `domain_events` in same DB tx → poller → Inngest. Exception: Documenso webhook uses direct `inngest.send()` (already external).
 
-| Job type             | System  | Why                                                          |
-| -------------------- | ------- | ------------------------------------------------------------ |
-| Multi-step workflows | Inngest | Built-in step functions, retries per step, DAG visualization |
-| Notification fan-out | Inngest | Event-driven: one domain event → multiple notification types |
-| Email send           | BullMQ  | Final-mile I/O, adapter-specific retries, concurrency limit  |
-| Webhook delivery     | BullMQ  | Final-mile HTTP, custom backoff schedule, auto-disable logic |
-| File virus scan      | BullMQ  | Final-mile I/O (ClamAV TCP), job-level idempotency by fileId |
-| S3 cleanup (GDPR)    | BullMQ  | Final-mile S3 ops, long retention on failure                 |
-| Outbox polling       | BullMQ  | Repeatable cron job, bridges transactional events → Inngest  |
-| Transfer file fetch  | BullMQ  | Final-mile HTTP download from remote instance                |
-
-### Inventory
-
-- **BullMQ queues (7):** `email`, `webhook`, `file-scan`, `content-extract`, `s3-cleanup`, `outbox-poller`, `transfer-fetch`
-- **Inngest functions (15):** 3 workflow (submission, pipeline, contract), 11 notification (per event type), 1 bridge (Documenso webhook → domain events)
-
-### Glue Pattern
-
-Inngest functions call `enqueue*()` helpers (e.g., `enqueueEmail()`, `enqueueWebhook()`) to dispatch BullMQ jobs. Fire-and-forget — Inngest does not wait for BullMQ job completion.
-
-### Outbox Pattern
-
-The outbox poller (`outbox-poller` BullMQ worker) is the default bridge for transactional domain events: service writes event to `domain_events` table inside the same DB transaction → poller picks up unprocessed events → sends to Inngest. **Exception:** Documenso webhook handler uses direct `inngest.send()` because the event source is already external (non-transactional, acceptable).
-
-### NEVER
-
-- Use BullMQ for multi-step workflows (no step-level retry, no DAG visibility)
-- Use Inngest for final-mile I/O delivery (email, HTTP, S3, ClamAV) — Inngest steps are for orchestration logic, not adapter-specific I/O with custom concurrency/backoff
-- Skip the outbox for domain events emitted inside DB transactions — direct `inngest.send()` outside a transaction risks event loss on crash
-
-### Env Vars
-
-| Variable                    | Default       | Purpose                                     |
-| --------------------------- | ------------- | ------------------------------------------- |
-| `CLAMAV_HOST`               | `localhost`   | ClamAV daemon TCP host                      |
-| `CLAMAV_PORT`               | `3310`        | ClamAV daemon TCP port                      |
-| `VIRUS_SCAN_ENABLED`        | `true`        | Enable/disable virus scans                  |
-| `DEV_AUTH_BYPASS`           | `false`       | Allow unauthed requests in dev (no Zitadel) |
-| `EMAIL_PROVIDER`            | `none`        | Email provider: `smtp`, `sendgrid`, `none`  |
-| `SMTP_HOST`                 | —             | SMTP server hostname                        |
-| `SMTP_PORT`                 | `587`         | SMTP server port                            |
-| `SMTP_FROM`                 | —             | SMTP sender address                         |
-| `SENDGRID_API_KEY`          | —             | SendGrid API key                            |
-| `SENDGRID_FROM`             | —             | SendGrid sender address                     |
-| `SENTRY_DSN`                | —             | Sentry DSN (enables error tracking)         |
-| `SENTRY_ENVIRONMENT`        | `development` | Sentry environment label                    |
-| `SENTRY_TRACES_SAMPLE_RATE` | `0`           | Sentry tracing sample rate (0-1)            |
-| `SENTRY_RELEASE`            | —             | Sentry release tag                          |
-| `METRICS_ENABLED`           | `false`       | Enable Prometheus `/metrics` endpoint       |
+**NEVER:** BullMQ for multi-step workflows. Inngest for final-mile I/O. Direct `inngest.send()` inside DB transactions.
 
 ---
 
 ## Quirks
 
-| Quirk                                            | Details                                                                                                                                                                                                                                                                                                                                                                                                         |
-| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Zitadel webhook signatures**                   | Verify `ZITADEL-Signature` header (lowercased to `zitadel-signature` by Node.js) on all webhook payloads. Handler also accepts legacy `x-zitadel-signature` as fallback. Signing key is auto-generated when creating a Target via Zitadel API                                                                                                                                                                   |
-| **BullMQ Redis password**                        | Uses `REDIS_HOST`/`REDIS_PORT`/`REDIS_PASSWORD` (not `REDIS_URL`). Pass password in worker/queue config                                                                                                                                                                                                                                                                                                         |
-| **tRPC TS2742 under NodeNext**                   | Resolved in tRPC v11. `declaration: true` now works in API tsconfig. Web app still resolves `AppRouter` via source path alias pointing to `src/trpc/client-types.ts` (bundler resolution). All web-facing type exports go through `client-types.ts`                                                                                                                                                             |
-| **`@fastify/raw-body` doesn't exist**            | Official `@fastify/` scoped package not published on npm. Use `fastify-raw-body` (community package, v5.0.0 for Fastify 5)                                                                                                                                                                                                                                                                                      |
-| **tusd v2 webhook payload format**               | tusd v2.8.0 sends `{ Type: "pre-create"\|"post-finish", Event: { Upload, HTTPRequest } }` instead of v1's `Hook-Name` header + `{ Upload, HTTPRequest }` body. Our handler supports both formats. The `Event` envelope is unwrapped before dispatch.                                                                                                                                                            |
-| **Fastify 5 preHandler short-circuit**           | To stop request processing in a `preHandler` hook, you MUST `return reply.status(N).send(...)`. Using `void reply.send(); return;` does NOT work — Fastify still runs the handler, causing `ERR_HTTP_HEADERS_SENT` crash. This bit us in webhook rate limiters.                                                                                                                                                 |
-| **oRPC OpenAPI needs Zod 4 converter**           | `OpenAPIReferencePlugin` requires explicit `schemaConverters: [new ZodToJsonSchemaConverter()]` from `@orpc/zod/zod4`. Without it, all schemas become `{}` and routes with path params throw 500. The default `@orpc/zod` export is Zod 3 only.                                                                                                                                                                 |
-| **tRPC v11 no superjson**                        | `httpBatchLink` uses plain JSON — `Date` objects become ISO strings over the wire. Input schemas must use `z.coerce.date()` (not `z.date()`) for date fields sent from the client. Output schemas are unaffected since Drizzle returns real Date objects server-side.                                                                                                                                           |
-| **`validateEnv()` must be lazy**                 | Call `validateEnv()` inside handler functions, NOT at module level. Module-level calls execute at import time, breaking any test that imports the router tree (9 test files failed when GDPR router used module-level `validateEnv()`). See `files.ts` for correct pattern.                                                                                                                                     |
-| **tusd `-cors-allow-headers` replaces defaults** | When passing custom headers to tusd's `-cors-allow-headers` flag, you MUST include all standard tus protocol headers (`Authorization`, `Origin`, `Content-Type`, `Upload-Length`, `Upload-Offset`, `Tus-Resumable`, `Upload-Metadata`, `Upload-Defer-Length`) because the flag **replaces** the built-in defaults rather than appending. Missing tus headers causes CORS preflight failures for the tus client. |
-| **Fastify `maxParamLength` and tRPC batching**   | Fastify defaults `maxParamLength` to 100 characters. tRPC's `httpBatchLink` encodes comma-separated procedure names in the URL path (e.g., `/trpc/a.b,c.d,e.f`). Pages that batch many queries (like the analytics dashboard with ~8 procedures) produce paths exceeding 100 chars, causing Fastify to silently return 404. Set `maxParamLength: 500` in the Fastify constructor to accommodate large batches.  |
-| **`reply.hijack()` bypasses `@fastify/cors`**    | `reply.hijack()` takes ownership of the raw Node.js response, preventing all Fastify hooks (including `@fastify/cors` `onSend` hook) from running. Any hijacked route (e.g., SSE streams) must manually include CORS headers in its `writeHead()` call. See `src/sse/notification-stream.ts` for the `buildCorsHeaders()` pattern.                                                                              |
-| **Zitadel Actions v2 signature format**          | Zitadel v2 sends `ZITADEL-Signature: t=<timestamp>,v1=<hex-hmac>` where HMAC is computed over `<timestamp>.<body>` (not just body). Handler accepts both this format and legacy simple HMAC. Event types use `user.human.*` naming (mapped to internal `user.*` via alias table in `zitadel.webhook.ts`).                                                                                                       |
+| Quirk                                            | Details                                                                                              |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| **Zitadel webhook signatures**                   | Header lowercased to `zitadel-signature` by Node.js. Also accepts legacy `x-zitadel-signature`       |
+| **BullMQ Redis password**                        | Uses `REDIS_HOST`/`REDIS_PORT`/`REDIS_PASSWORD` (not `REDIS_URL`)                                    |
+| **tRPC TS2742**                                  | Resolved in v11. Web resolves `AppRouter` via source path alias → `client-types.ts`                  |
+| **`@fastify/raw-body` doesn't exist**            | Use `fastify-raw-body` (community, v5.0.0 for Fastify 5)                                             |
+| **tusd v2 webhook format**                       | Sends `{ Type, Event: { Upload, HTTPRequest } }`. Handler supports both v1/v2                        |
+| **Fastify 5 preHandler short-circuit**           | MUST `return reply.status(N).send(...)`. `void reply.send(); return;` causes `ERR_HTTP_HEADERS_SENT` |
+| **oRPC needs Zod 4 converter**                   | `OpenAPIReferencePlugin` requires `ZodToJsonSchemaConverter` from `@orpc/zod/zod4`                   |
+| **tRPC v11 no superjson**                        | Dates become ISO strings. Use `z.coerce.date()` for input schemas                                    |
+| **`validateEnv()` must be lazy**                 | Call inside handlers, not at module level (breaks test imports)                                      |
+| **tusd `-cors-allow-headers` replaces defaults** | Must include all standard tus protocol headers (flag replaces, not appends)                          |
+| **Fastify `maxParamLength` + tRPC batching**     | Default 100 chars too short for batched tRPC paths. Set `maxParamLength: 500`                        |
+| **`reply.hijack()` bypasses `@fastify/cors`**    | Hijacked routes must manually set CORS headers. See `notification-stream.ts`                         |
 
 ## Version Pins
 
-| Package | Pinned | Notes                                               |
-| ------- | ------ | --------------------------------------------------- |
-| Fastify | 5.x    | Major version; check plugin compat before upgrading |
-| tRPC    | 11.x   | Internal only; upgraded from v10 with Zod 4         |
-| Stripe  | 20.4   | —                                                   |
-| BullMQ  | 5      | —                                                   |
+| Package | Pinned | Notes                                       |
+| ------- | ------ | ------------------------------------------- |
+| Fastify | 5.x    | Check plugin compat before upgrading        |
+| tRPC    | 11.x   | Internal only; upgraded from v10 with Zod 4 |
+| Stripe  | 20.4   | —                                           |
+| BullMQ  | 5      | —                                           |

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -229,6 +229,29 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
 ];
 
 /**
+ * Extract a PostgreSQL error from a raw PG error or a Drizzle-wrapped error.
+ * Drizzle ORM wraps PG errors in a plain Error with the original in `.cause`.
+ */
+function extractPgError(
+  error: unknown,
+): { code: string; detail?: string } | null {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as { code: unknown }).code === 'string'
+  ) {
+    const e = error as { code: string; detail?: string };
+    if (/^\d{5}$/.test(e.code)) return e;
+  }
+  // Drizzle wraps PG errors in .cause
+  if (error instanceof Error && error.cause) {
+    return extractPgError(error.cause);
+  }
+  return null;
+}
+
+/**
  * Map a domain error thrown by a service method to a {@link TRPCError}.
  *
  * - Known domain errors → appropriate tRPC code with the original message.
@@ -269,18 +292,12 @@ export function mapServiceError(error: unknown): never {
     }
   }
 
-  // PostgreSQL unique violation
-  if (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    (error as { code: string }).code === '23505'
-  ) {
+  // PostgreSQL unique violation (direct PG error or Drizzle-wrapped)
+  const pgError = extractPgError(error);
+  if (pgError?.code === '23505') {
     throw new TRPCError({
       code: 'CONFLICT',
-      message:
-        (error as { detail?: string }).detail ??
-        'A record with this value already exists',
+      message: pgError.detail ?? 'A record with this value already exists',
     });
   }
 

--- a/apps/web/e2e/helpers/organization-db.ts
+++ b/apps/web/e2e/helpers/organization-db.ts
@@ -4,8 +4,14 @@
  * Uses the admin pool from db.ts to bypass RLS.
  */
 
+import { randomBytes, createHash } from "crypto";
 import { eq, and } from "drizzle-orm";
-import { organizationMembers, users } from "@colophony/db";
+import {
+  organizationMembers,
+  organizationInvitations,
+  users,
+} from "@colophony/db";
+import { INVITATION_TOKEN_PREFIX } from "@colophony/types";
 import { getDb } from "./db";
 
 /**
@@ -70,4 +76,141 @@ export async function getMembers(
     .from(organizationMembers)
     .innerJoin(users, eq(users.id, organizationMembers.userId))
     .where(eq(organizationMembers.organizationId, orgId));
+}
+
+// ---------------------------------------------------------------------------
+// Invitation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an invitation directly in the DB, returning the plaintext token.
+ * Bypasses RLS via admin pool — used for E2E test setup.
+ */
+export async function createInvitation(data: {
+  orgId: string;
+  email: string;
+  roles?: Array<"ADMIN" | "EDITOR" | "READER" | "PRODUCTION" | "BUSINESS_OPS">;
+  invitedBy: string;
+  status?: "PENDING" | "ACCEPTED" | "REVOKED" | "EXPIRED";
+  expiresAt?: Date;
+}): Promise<{ id: string; plainToken: string }> {
+  const db = getDb();
+  const plainToken = `${INVITATION_TOKEN_PREFIX}${randomBytes(16).toString("hex")}`;
+  const tokenHash = createHash("sha256").update(plainToken).digest("hex");
+
+  const expiresAt =
+    data.expiresAt ?? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+  const [row] = await db
+    .insert(organizationInvitations)
+    .values({
+      organizationId: data.orgId,
+      email: data.email.toLowerCase(),
+      roles: data.roles ?? ["READER"],
+      tokenHash,
+      tokenPrefix: INVITATION_TOKEN_PREFIX,
+      status: data.status ?? "PENDING",
+      invitedBy: data.invitedBy,
+      expiresAt,
+    })
+    .returning({ id: organizationInvitations.id });
+
+  return { id: row.id, plainToken };
+}
+
+/**
+ * Create an expired invitation (expiresAt = 1 hour ago).
+ */
+export async function createExpiredInvitation(
+  data: Omit<Parameters<typeof createInvitation>[0], "expiresAt" | "status">,
+): Promise<{ id: string; plainToken: string }> {
+  return createInvitation({
+    ...data,
+    expiresAt: new Date(Date.now() - 60 * 60 * 1000),
+  });
+}
+
+/**
+ * Delete an invitation by ID. Swallows errors if already deleted.
+ */
+export async function deleteInvitation(id: string): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(organizationInvitations)
+    .where(eq(organizationInvitations.id, id))
+    .catch(() => {
+      // Ignore if already deleted
+    });
+}
+
+/**
+ * Delete all invitations for an org+email pair.
+ */
+export async function deleteInvitationsByEmail(
+  orgId: string,
+  email: string,
+): Promise<void> {
+  const db = getDb();
+  await db
+    .delete(organizationInvitations)
+    .where(
+      and(
+        eq(organizationInvitations.organizationId, orgId),
+        eq(organizationInvitations.email, email.toLowerCase()),
+      ),
+    )
+    .catch(() => {});
+}
+
+/**
+ * Query an invitation by org+email for assertions.
+ */
+export async function getInvitationByEmail(
+  orgId: string,
+  email: string,
+): Promise<{
+  id: string;
+  status: string;
+  roles: string[];
+  email: string;
+  expiresAt: Date;
+  createdAt: Date;
+} | null> {
+  const db = getDb();
+  const [row] = await db
+    .select({
+      id: organizationInvitations.id,
+      status: organizationInvitations.status,
+      roles: organizationInvitations.roles,
+      email: organizationInvitations.email,
+      expiresAt: organizationInvitations.expiresAt,
+      createdAt: organizationInvitations.createdAt,
+    })
+    .from(organizationInvitations)
+    .where(
+      and(
+        eq(organizationInvitations.organizationId, orgId),
+        eq(organizationInvitations.email, email.toLowerCase()),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Mark an invitation as ACCEPTED. For "already accepted" test setup.
+ */
+export async function markInvitationAccepted(
+  id: string,
+  userId: string,
+): Promise<void> {
+  const db = getDb();
+  await db
+    .update(organizationInvitations)
+    .set({
+      status: "ACCEPTED",
+      acceptedBy: userId,
+      acceptedAt: new Date(),
+    })
+    .where(eq(organizationInvitations.id, id));
 }

--- a/apps/web/e2e/helpers/organization-fixtures.ts
+++ b/apps/web/e2e/helpers/organization-fixtures.ts
@@ -17,6 +17,9 @@ import {
   deleteApiKey,
   createUser,
   deleteUser,
+  createOrg,
+  deleteOrg,
+  addMember,
 } from "./db";
 
 /** Admin user profile (ADMIN role in quarterly-review org) */
@@ -60,6 +63,8 @@ export const test = base.extend<{
   testApiKey: TestApiKey;
   authedPage: Page;
   inviteTarget: InviteTarget;
+  inviteeOrg: SeedOrg;
+  inviteePage: Page;
 }>({
   seedOrg: async ({}, use) => {
     const org = await getOrgBySlug("quarterly-review");
@@ -126,6 +131,57 @@ export const test = base.extend<{
     await use({ id: user.id, email: user.email });
 
     await deleteUser(user.id);
+  },
+
+  /**
+   * Separate org for invitee API key auth.
+   *
+   * The org-context hook requires the API key creator to be a member of
+   * the key's org. The invitee isn't a member of the seed org, so we
+   * create a dedicated org where the invitee IS a member. The accept
+   * endpoint uses SECURITY DEFINER functions that operate cross-org.
+   */
+  inviteeOrg: async ({ inviteTarget }, use) => {
+    const org = await createOrg({
+      name: "Invitee Auth Org",
+      slug: `invitee-auth-${Date.now().toString(36)}`,
+    });
+    await addMember(org.id, inviteTarget.id, "READER");
+    await use(org);
+    await deleteOrg(org.id);
+  },
+
+  /**
+   * Playwright page authenticated as the inviteTarget user.
+   * Used for accept-side invitation tests.
+   */
+  inviteePage: async ({ browser, inviteeOrg, inviteTarget, baseURL }, use) => {
+    const apiKey = await createApiKey({
+      orgId: inviteeOrg.id,
+      userId: inviteTarget.id,
+      scopes: ["organizations:read", "users:read"],
+      name: `e2e-invitee-${Date.now()}`,
+    });
+
+    const inviteeProfile = {
+      sub: `e2e-zitadel-invite-${inviteTarget.id}`,
+      email: inviteTarget.email,
+      name: "Test Invitee",
+    };
+
+    const context = await browser.newContext({
+      ...devices["Desktop Chrome"],
+      baseURL: baseURL ?? undefined,
+      storageState: buildStorageState(inviteeOrg.id, inviteeProfile),
+    });
+
+    const page = await context.newPage();
+    await setupPageAuth(page, inviteeOrg.id, apiKey.plainKey, inviteeProfile);
+
+    await use(page);
+
+    await context.close();
+    await deleteApiKey(apiKey.id);
   },
 });
 

--- a/apps/web/e2e/organization/invitations.spec.ts
+++ b/apps/web/e2e/organization/invitations.spec.ts
@@ -1,0 +1,344 @@
+import { test, expect } from "../helpers/organization-fixtures";
+import { addMember } from "../helpers/db";
+import {
+  createInvitation,
+  createExpiredInvitation,
+  deleteInvitation,
+  deleteInvitationsByEmail,
+  getInvitationByEmail,
+  markInvitationAccepted,
+  getMemberByEmail,
+  removeMember,
+} from "../helpers/organization-db";
+
+// ---------------------------------------------------------------------------
+// Admin-side tests (org settings → Members tab)
+// ---------------------------------------------------------------------------
+
+test.describe("Email Invitations — Admin Side", () => {
+  test("invite non-existing user shows 'Invitation sent' toast", async ({
+    authedPage,
+    seedOrg,
+    seedAdmin,
+  }) => {
+    const email = `nobody-${Date.now()}@test.example.com`;
+
+    await authedPage.goto("/organizations/settings");
+    await authedPage.getByRole("tab", { name: "Members" }).click();
+    await authedPage.getByRole("button", { name: "Invite Member" }).click();
+
+    const dialog = authedPage.getByRole("dialog");
+    await dialog.getByLabel("Email").fill(email);
+
+    // Select Editor role
+    await dialog.getByLabel("Role").click();
+    await authedPage.getByRole("option", { name: "Editor" }).click();
+
+    await authedPage.getByRole("button", { name: "Add Member" }).click();
+
+    await expect(
+      authedPage.getByText(`Invitation sent to ${email}`),
+    ).toBeVisible();
+
+    // Pending invitations section should appear
+    await expect(
+      authedPage.getByRole("heading", { name: "Pending Invitations" }),
+    ).toBeVisible();
+
+    // Email should be in the pending table
+    await expect(authedPage.getByRole("cell", { name: email })).toBeVisible();
+
+    // Cleanup
+    await deleteInvitationsByEmail(seedOrg.id, email);
+  });
+
+  test("pending invitations table shows correct data", async ({
+    authedPage,
+    seedOrg,
+    seedAdmin,
+  }) => {
+    const email = `pending-display-${Date.now()}@test.example.com`;
+    const { id: invitationId } = await createInvitation({
+      orgId: seedOrg.id,
+      email,
+      roles: ["EDITOR"],
+      invitedBy: seedAdmin.id,
+    });
+
+    await authedPage.goto("/organizations/settings");
+    await authedPage.getByRole("tab", { name: "Members" }).click();
+
+    await expect(
+      authedPage.getByRole("heading", { name: "Pending Invitations" }),
+    ).toBeVisible();
+
+    // Check column headers
+    const pendingSection = authedPage.locator("section").filter({
+      has: authedPage.getByRole("heading", { name: "Pending Invitations" }),
+    });
+
+    // Verify the row data
+    const row = authedPage.getByRole("row").filter({ hasText: email });
+    await expect(row).toBeVisible();
+    await expect(row.getByText("Editor")).toBeVisible();
+
+    // Cleanup
+    await deleteInvitation(invitationId);
+  });
+
+  test("revoke invitation removes it from pending table", async ({
+    authedPage,
+    seedOrg,
+    seedAdmin,
+  }) => {
+    const email = `revoke-target-${Date.now()}@test.example.com`;
+    const { id: invitationId } = await createInvitation({
+      orgId: seedOrg.id,
+      email,
+      roles: ["READER"],
+      invitedBy: seedAdmin.id,
+    });
+
+    await authedPage.goto("/organizations/settings");
+    await authedPage.getByRole("tab", { name: "Members" }).click();
+
+    const row = authedPage.getByRole("row").filter({ hasText: email });
+    await expect(row).toBeVisible();
+
+    await row.getByRole("button", { name: "Revoke invitation" }).click();
+
+    await expect(authedPage.getByText("Invitation revoked")).toBeVisible();
+
+    // Row should disappear
+    await expect(row).not.toBeVisible();
+
+    // Verify DB state
+    const inv = await getInvitationByEmail(seedOrg.id, email);
+    expect(inv?.status).toBe("REVOKED");
+
+    // Cleanup
+    await deleteInvitation(invitationId);
+  });
+
+  test("resend invitation shows confirmation toast", async ({
+    authedPage,
+    seedOrg,
+    seedAdmin,
+  }) => {
+    const email = `resend-target-${Date.now()}@test.example.com`;
+    const { id: invitationId } = await createInvitation({
+      orgId: seedOrg.id,
+      email,
+      roles: ["READER"],
+      invitedBy: seedAdmin.id,
+    });
+
+    await authedPage.goto("/organizations/settings");
+    await authedPage.getByRole("tab", { name: "Members" }).click();
+
+    const row = authedPage.getByRole("row").filter({ hasText: email });
+    await expect(row).toBeVisible();
+
+    await row.getByRole("button", { name: "Resend invitation" }).click();
+
+    await expect(authedPage.getByText("Invitation resent")).toBeVisible();
+
+    // Row should still be present (new invitation replaces old)
+    await expect(row).toBeVisible();
+
+    // Cleanup (resend revokes old + creates new, so clean by email)
+    await deleteInvitationsByEmail(seedOrg.id, email);
+  });
+
+  test("re-invite same email replaces old invitation with new role", async ({
+    authedPage,
+    seedOrg,
+    seedAdmin,
+  }) => {
+    const email = `reinvite-target-${Date.now()}@test.example.com`;
+    const { id: invitationId } = await createInvitation({
+      orgId: seedOrg.id,
+      email,
+      roles: ["READER"],
+      invitedBy: seedAdmin.id,
+    });
+
+    await authedPage.goto("/organizations/settings");
+    await authedPage.getByRole("tab", { name: "Members" }).click();
+
+    // Verify initial invitation row
+    const row = authedPage.getByRole("row").filter({ hasText: email });
+    await expect(row).toBeVisible();
+
+    // Invite same email with different role via dialog
+    await authedPage.getByRole("button", { name: "Invite Member" }).click();
+    const dialog = authedPage.getByRole("dialog");
+    await dialog.getByLabel("Email").fill(email);
+    await dialog.getByLabel("Role").click();
+    await authedPage.getByRole("option", { name: "Admin" }).click();
+    await authedPage.getByRole("button", { name: "Add Member" }).click();
+
+    await expect(
+      authedPage.getByText(`Invitation sent to ${email}`),
+    ).toBeVisible();
+
+    // Should only be ONE row for that email
+    const rows = authedPage.getByRole("row").filter({ hasText: email });
+    await expect(rows).toHaveCount(1);
+
+    // The role badge should show the new role
+    await expect(rows.getByText("Admin")).toBeVisible();
+
+    // Cleanup
+    await deleteInvitationsByEmail(seedOrg.id, email);
+  });
+
+  test("invite existing member shows 'already a member' error", async ({
+    authedPage,
+    seedOrg,
+    inviteTarget,
+  }) => {
+    // Add inviteTarget as a member first
+    await addMember(seedOrg.id, inviteTarget.id, "READER");
+
+    await authedPage.goto("/organizations/settings");
+    await authedPage.getByRole("tab", { name: "Members" }).click();
+
+    await authedPage.getByRole("button", { name: "Invite Member" }).click();
+    const dialog = authedPage.getByRole("dialog");
+    await dialog.getByLabel("Email").fill(inviteTarget.email);
+
+    await dialog.getByRole("button", { name: "Add Member" }).click();
+
+    await expect(
+      authedPage.getByText("This user is already a member"),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Cleanup
+    const member = await getMemberByEmail(seedOrg.id, inviteTarget.email);
+    if (member) {
+      await removeMember(member.id);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Accept-side tests (accept page)
+// ---------------------------------------------------------------------------
+
+test.describe("Email Invitations — Accept Side", () => {
+  test("accept valid invitation shows success", async ({
+    inviteePage,
+    seedOrg,
+    seedAdmin,
+    inviteTarget,
+  }) => {
+    const { id: invitationId, plainToken } = await createInvitation({
+      orgId: seedOrg.id,
+      email: inviteTarget.email,
+      roles: ["READER"],
+      invitedBy: seedAdmin.id,
+    });
+
+    await inviteePage.goto(`/invite/accept/${plainToken}`);
+
+    await expect(inviteePage.getByText("You're in!")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      inviteePage.getByText("Redirecting to your new organization..."),
+    ).toBeVisible();
+
+    // Cleanup: remove member created by accept + delete invitation
+    const member = await getMemberByEmail(seedOrg.id, inviteTarget.email);
+    if (member) {
+      await removeMember(member.id);
+    }
+    await deleteInvitation(invitationId);
+  });
+
+  test("accept with wrong email shows mismatch error", async ({
+    inviteePage,
+    seedOrg,
+    seedAdmin,
+  }) => {
+    const { id: invitationId, plainToken } = await createInvitation({
+      orgId: seedOrg.id,
+      email: "wrong@example.com",
+      roles: ["READER"],
+      invitedBy: seedAdmin.id,
+    });
+
+    await inviteePage.goto(`/invite/accept/${plainToken}`);
+
+    await expect(
+      inviteePage.getByText(
+        "Your email address does not match this invitation.",
+      ),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await expect(
+      inviteePage.getByRole("button", { name: "Go to Dashboard" }),
+    ).toBeVisible();
+
+    // Cleanup
+    await deleteInvitation(invitationId);
+  });
+
+  test("accept expired invitation shows expired error", async ({
+    inviteePage,
+    seedOrg,
+    seedAdmin,
+    inviteTarget,
+  }) => {
+    const { id: invitationId, plainToken } = await createExpiredInvitation({
+      orgId: seedOrg.id,
+      email: inviteTarget.email,
+      roles: ["READER"],
+      invitedBy: seedAdmin.id,
+    });
+
+    await inviteePage.goto(`/invite/accept/${plainToken}`);
+
+    await expect(
+      inviteePage.getByText("This invitation is invalid or has expired."),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Cleanup
+    await deleteInvitation(invitationId);
+  });
+
+  test("accept already-accepted invitation shows conflict error", async ({
+    inviteePage,
+    seedOrg,
+    seedAdmin,
+    inviteTarget,
+  }) => {
+    const { id: invitationId, plainToken } = await createInvitation({
+      orgId: seedOrg.id,
+      email: inviteTarget.email,
+      roles: ["READER"],
+      invitedBy: seedAdmin.id,
+    });
+    await markInvitationAccepted(invitationId, inviteTarget.id);
+
+    await inviteePage.goto(`/invite/accept/${plainToken}`);
+
+    await expect(
+      inviteePage.getByText("This invitation has already been accepted."),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Cleanup
+    await deleteInvitation(invitationId);
+  });
+
+  test("accept with invalid token shows not-found error", async ({
+    inviteePage,
+  }) => {
+    await inviteePage.goto("/invite/accept/col_inv_0000000000000000");
+
+    await expect(
+      inviteePage.getByText("This invitation is invalid or has expired."),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/apps/web/e2e/organization/invitations.spec.ts
+++ b/apps/web/e2e/organization/invitations.spec.ts
@@ -19,7 +19,6 @@ test.describe("Email Invitations — Admin Side", () => {
   test("invite non-existing user shows 'Invitation sent' toast", async ({
     authedPage,
     seedOrg,
-    seedAdmin,
   }) => {
     const email = `nobody-${Date.now()}@test.example.com`;
 
@@ -72,11 +71,6 @@ test.describe("Email Invitations — Admin Side", () => {
       authedPage.getByRole("heading", { name: "Pending Invitations" }),
     ).toBeVisible();
 
-    // Check column headers
-    const pendingSection = authedPage.locator("section").filter({
-      has: authedPage.getByRole("heading", { name: "Pending Invitations" }),
-    });
-
     // Verify the row data
     const row = authedPage.getByRole("row").filter({ hasText: email });
     await expect(row).toBeVisible();
@@ -126,7 +120,7 @@ test.describe("Email Invitations — Admin Side", () => {
     seedAdmin,
   }) => {
     const email = `resend-target-${Date.now()}@test.example.com`;
-    const { id: invitationId } = await createInvitation({
+    await createInvitation({
       orgId: seedOrg.id,
       email,
       roles: ["READER"],
@@ -156,7 +150,7 @@ test.describe("Email Invitations — Admin Side", () => {
     seedAdmin,
   }) => {
     const email = `reinvite-target-${Date.now()}@test.example.com`;
-    const { id: invitationId } = await createInvitation({
+    await createInvitation({
       orgId: seedOrg.id,
       email,
       roles: ["READER"],

--- a/apps/web/src/components/organizations/pending-invitations.tsx
+++ b/apps/web/src/components/organizations/pending-invitations.tsx
@@ -103,6 +103,7 @@ export function PendingInvitations() {
                         invitationId: invitation.id,
                       })
                     }
+                    aria-label="Resend invitation"
                     title="Resend invitation"
                   >
                     <RotateCw className="h-4 w-4" />
@@ -116,6 +117,7 @@ export function PendingInvitations() {
                         invitationId: invitation.id,
                       })
                     }
+                    aria-label="Revoke invitation"
                     title="Revoke invitation"
                   >
                     <X className="h-4 w-4" />

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,27 @@ Newest entries first.
 
 ---
 
+## 2026-03-28 — Invitation E2E Tests + Bug Fixes
+
+### Done
+
+- 11 Playwright E2E tests for email invitation workflow: 6 admin-side (invite, list, revoke, resend, re-invite, already-member) + 5 accept-side (success, wrong email, expired, already accepted, invalid token)
+- New E2E fixtures: `inviteeOrg` (separate auth org) + `inviteePage` (second browser context for invitee)
+- 6 invitation DB helpers for test setup/cleanup in `organization-db.ts`
+- Added `aria-label` to Resend/Revoke icon buttons in pending invitations table (accessibility + reliable locators)
+- Bug fix: `accept_invitation()` SQL function had ambiguous `organization_id` column reference between `RETURNS TABLE` output parameter and `organization_members` table — added `#variable_conflict use_column` (migration 0062)
+- Bug fix: `mapServiceError()` didn't unwrap Drizzle-wrapped PG errors — unique violation (23505) returned 500 instead of CONFLICT. Added `extractPgError()` helper that recursively unwraps `.cause`
+- Codex plan review: 1 Critical finding addressed (invitee API key auth requires org membership — used separate "invitee auth org" pattern)
+- All 32 organization E2E tests passing, no regressions
+
+### Decisions
+
+- Invitee auth in E2E uses a separate "invitee auth org" where the invitee IS a member — the org-context hook requires API key creators to be members, but the `accept` endpoint uses SECURITY DEFINER functions that operate cross-org
+- Fixed real bugs found by E2E tests in production code rather than mocking around them
+- Used unique-per-run test emails (`${Date.now()}@test.example.com`) to prevent stale data conflicts across runs
+
+---
+
 ## 2026-03-27 — Email Invitation Workflow (Track 12)
 
 ### Done

--- a/docs/file-index.md
+++ b/docs/file-index.md
@@ -1,0 +1,133 @@
+# Key File Locations
+
+Quick-reference index of important files across the codebase. See also per-directory `CLAUDE.md` files for domain-specific details.
+
+## Core Packages
+
+| What                    | Path                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------ |
+| **Drizzle schema**      | `packages/db/src/schema/` (one file per table group)                                       |
+| **Drizzle migrations**  | `packages/db/migrations/`                                                                  |
+| **Drizzle client**      | `packages/db/src/client.ts`                                                                |
+| **RLS context**         | `packages/db/src/context.ts` (`withRls()`)                                                 |
+| **Shared Zod schemas**  | `packages/types/src/`                                                                      |
+| **Zitadel auth client** | `packages/auth-client/src/`                                                                |
+| **Plugin SDK**          | `packages/plugin-sdk/src/` (adapters, hooks, config, plugin-base, testing)                 |
+| **Writer workspace**    | `packages/db/src/schema/writer-workspace.ts`                                               |
+| **CSR types**           | `packages/types/src/csr.ts`                                                                |
+| **ProseMirror types**   | `packages/types/src/prosemirror.ts` (shared), `apps/web/src/lib/manuscript.ts` (converter) |
+
+## API (`apps/api/`)
+
+| What                       | Path                                                                                     |
+| -------------------------- | ---------------------------------------------------------------------------------------- |
+| **Fastify app entry**      | `apps/api/src/main.ts`                                                                   |
+| **Fastify hooks**          | `apps/api/src/hooks/` (auth, rate-limit, org-context, db-context, audit)                 |
+| **Service layer**          | `apps/api/src/services/`                                                                 |
+| **tRPC (internal)**        | `apps/api/src/trpc/`                                                                     |
+| **Zitadel webhook**        | `apps/api/src/webhooks/zitadel.webhook.ts`                                               |
+| **Stripe webhook**         | `apps/api/src/webhooks/stripe.webhook.ts`                                                |
+| **Documenso webhook**      | `apps/api/src/webhooks/documenso.webhook.ts`                                             |
+| **Inngest functions**      | `apps/api/src/inngest/`                                                                  |
+| **Adapter registry**       | `apps/api/src/adapters/registry-accessor.ts` (module-level singleton)                    |
+| **Config builder**         | `apps/api/src/colophony.config.ts` (maps env → adapter init)                             |
+| **SDK adapters**           | `apps/api/src/adapters/{email,storage,payment}/` (SDK-compatible)                        |
+| **CMS adapters**           | `apps/api/src/adapters/cms/`                                                             |
+| **Env config (Zod)**       | `apps/api/src/config/env.ts`                                                             |
+| **SSRF validation**        | `apps/api/src/lib/url-validation.ts` (validateOutboundUrl, isPrivateIPv4/v6)             |
+| **Sentry config**          | `apps/api/src/config/sentry.ts` (init, captureException, isSentryEnabled)                |
+| **Metrics registry**       | `apps/api/src/config/metrics.ts` (Prometheus counters, histograms, gauges)               |
+| **Metrics plugin**         | `apps/api/src/hooks/metrics.ts` (Fastify plugin — HTTP request instrumentation)          |
+| **Instrumented worker**    | `apps/api/src/config/instrumented-worker.ts` (BullMQ wrapper with metrics)               |
+| **Webhook health**         | `apps/api/src/webhooks/webhook-health.route.ts`                                          |
+| **Ops tRPC router**        | `apps/api/src/trpc/routers/ops.ts` (queueHealth, webhookProviderHealth, submissionTrend) |
+| **Content converters**     | `apps/api/src/converters/` (text, docx, smart-typography, format router)                 |
+| **Content extract queue**  | `apps/api/src/queues/content-extract.queue.ts`                                           |
+| **Content extract worker** | `apps/api/src/workers/content-extract.worker.ts` (4-phase extraction)                    |
+| **Content extract svc**    | `apps/api/src/services/content-extraction.service.ts`                                    |
+| **CSR service**            | `apps/api/src/services/csr.service.ts` (export/import for data portability)              |
+| **Analytics service**      | `apps/api/src/services/submission-analytics.service.ts`                                  |
+| **Portfolio service**      | `apps/api/src/services/portfolio.service.ts` (cross-org UNION ALL, status maps)          |
+| **Writer analytics svc**   | `apps/api/src/services/writer-analytics.service.ts` (personal stats/charts)              |
+
+## Federation (`apps/api/src/federation/`)
+
+| What                    | Path                                                                             |
+| ----------------------- | -------------------------------------------------------------------------------- |
+| **Discovery**           | `apps/api/src/federation/discovery.routes.ts`                                    |
+| **DID**                 | `apps/api/src/federation/did.routes.ts`                                          |
+| **Federation service**  | `apps/api/src/services/federation.service.ts`                                    |
+| **Trust**               | `apps/api/src/federation/trust.routes.ts` (S2S), `trust-admin.routes.ts`         |
+| **Trust service**       | `apps/api/src/services/trust.service.ts`                                         |
+| **HTTP signatures**     | `apps/api/src/federation/http-signatures.ts`                                     |
+| **Federation auth**     | `apps/api/src/federation/federation-auth.ts` (S2S signature middleware)          |
+| **Sim-sub (BSAP)**      | `apps/api/src/federation/simsub.routes.ts` (S2S), `simsub-admin.routes.ts`       |
+| **Sim-sub service**     | `apps/api/src/services/simsub.service.ts`                                        |
+| **Fingerprint service** | `apps/api/src/services/fingerprint.service.ts`                                   |
+| **Transfer routes**     | `apps/api/src/federation/transfer.routes.ts` (S2S), `transfer-admin.routes.ts`   |
+| **Transfer service**    | `apps/api/src/services/transfer.service.ts`                                      |
+| **Migration routes**    | `apps/api/src/federation/migration.routes.ts` (S2S), `migration-admin.routes.ts` |
+| **Migration service**   | `apps/api/src/services/migration.service.ts`, `migration-bundle.service.ts`      |
+| **Hub routes**          | `apps/api/src/federation/hub.routes.ts` (S2S), `hub-admin.routes.ts`             |
+| **Hub auth**            | `apps/api/src/federation/hub-auth.ts` (S2S hub auth middleware)                  |
+| **Hub service**         | `apps/api/src/services/hub.service.ts`                                           |
+| **Hub client service**  | `apps/api/src/services/hub-client.service.ts`                                    |
+
+## Frontend (`apps/web/`)
+
+| What                      | Path                                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------------------- |
+| **Next.js frontend**      | `apps/web/`                                                                                 |
+| **tRPC client**           | `apps/web/src/lib/trpc.ts`                                                                  |
+| **Analytics components**  | `apps/web/src/components/analytics/` (charts, filters, dashboard page)                      |
+| **Writer analytics UI**   | `apps/web/src/components/workspace/writer-*` (analytics page + chart components)            |
+| **Ops dashboard**         | `apps/web/src/components/operations/ops-dashboard.tsx` (health card grid + quick links)     |
+| **Health card grid**      | `apps/web/src/components/operations/health-card-grid.tsx` (4-card status derivation)        |
+| **Density provider**      | `apps/web/src/hooks/use-density.tsx` (DensityProvider + useDensity hook)                    |
+| **Layout shells**         | `apps/web/src/app/(dashboard)/{editor,slate,federation,webhooks,organizations}/layout.tsx`  |
+| **Split pane**            | `apps/web/src/components/editor/editorial-split-pane.tsx` (triage/deep-read orchestrator)   |
+| **ManuscriptRenderer**    | `apps/web/src/components/manuscripts/manuscript-renderer.tsx` (genre-aware typography)      |
+| **ManuscriptEditor**      | `apps/web/src/components/manuscripts/manuscript-editor.tsx` (TipTap copyedit editor)        |
+| **ManuscriptDiff**        | `apps/web/src/components/manuscripts/manuscript-diff.tsx` (word-level diff view)            |
+| **TipTap manuscript ext** | `apps/web/src/lib/tiptap-manuscript-extensions.ts` (custom nodes/marks + converters)        |
+| **Production dashboard**  | `apps/web/src/components/slate/production-dashboard.tsx` (issue-centric pipeline overview)  |
+| **Production aging**      | `apps/web/src/components/slate/production-aging.ts` (aging status, deadline, handoff utils) |
+| **Keyboard shortcuts**    | `apps/web/src/hooks/use-shortcuts.ts` (shell-scoped shortcut hook)                          |
+| **Command palette**       | `apps/web/src/components/command-palette/command-palette.tsx` (Cmd+K global nav)            |
+| **Shortcut overlay**      | `apps/web/src/components/command-palette/shortcut-overlay.tsx` (? key help dialog)          |
+| **Shared navigation**     | `apps/web/src/lib/navigation.ts` (nav items + groups, shared by sidebar + palette)          |
+| **Platform utilities**    | `apps/web/src/lib/platform.ts` (isMac, modifierKey, modifierSymbol)                         |
+| **Literata font**         | `apps/web/src/lib/fonts.ts` (variable font with optical sizing)                             |
+
+## SDKs & Scripts
+
+| What               | Path                                                                     |
+| ------------------ | ------------------------------------------------------------------------ |
+| **OpenAPI spec**   | `sdks/openapi.json` (exported from running API, 67 paths, 15 tag groups) |
+| **TypeScript SDK** | `sdks/typescript/` (`@colophony/sdk` — openapi-fetch + generated types)  |
+| **Python SDK**     | `sdks/python/` (`colophony` — openapi-python-client generated)           |
+| **SDK generation** | `scripts/generate-sdks.ts` (regenerate both SDKs from committed spec)    |
+
+## Infrastructure & Ops
+
+| What                    | Path                                                                                    |
+| ----------------------- | --------------------------------------------------------------------------------------- |
+| **Alert rules**         | `docker/prometheus/alert-rules.yml`                                                     |
+| **AlertManager config** | `docker/alertmanager/alertmanager.yml`                                                  |
+| **Loki config**         | `docker/loki/loki-config.yml` (dev), `loki-config.prod.yml` (prod)                      |
+| **Promtail config**     | `docker/promtail/promtail-config.yml`                                                   |
+| **Grafana dashboards**  | `docker/grafana/dashboards/` (API metrics + logs exploration)                           |
+| **Gateway config**      | `gateway/Caddyfile` (Caddy reverse proxy — routing, security headers, maintenance page) |
+| **Gateway Dockerfile**  | `gateway/Dockerfile`                                                                    |
+| **Uptime workflow**     | `.github/workflows/uptime.yml` (cron health checks, issue-based alerting)               |
+
+## Documentation
+
+| What                  | Path                                                                             |
+| --------------------- | -------------------------------------------------------------------------------- |
+| **Backlog**           | `docs/backlog.md` (track-organized, drives session focus)                        |
+| **Design system**     | `docs/DESIGN_SYSTEM.md` (roles, density, navigation, typography, migration path) |
+| **Manuscript format** | `docs/manuscript-format.md` (ProseMirror JSON schema, conversion pipeline)       |
+| **CSR format spec**   | `docs/csr-format.md`                                                             |
+| **QA log**            | `docs/qa-log.md`                                                                 |
+| **Release checklist** | `docs/release-checklist.md`                                                      |

--- a/packages/db/migrations/0062_fix_accept_invitation_ambiguous_column.sql
+++ b/packages/db/migrations/0062_fix_accept_invitation_ambiguous_column.sql
@@ -1,0 +1,62 @@
+-- Fix: "column reference organization_id is ambiguous" in accept_invitation()
+--
+-- The RETURNS TABLE(organization_id uuid, ...) creates OUT parameters that
+-- shadow the organization_members.organization_id column in PL/pgSQL.
+-- Adding #variable_conflict use_column tells PL/pgSQL to prefer column names.
+
+CREATE OR REPLACE FUNCTION accept_invitation(
+  p_token_hash varchar,
+  p_user_id uuid,
+  p_user_email varchar
+)
+RETURNS TABLE(
+  invitation_id uuid,
+  organization_id uuid,
+  member_id uuid,
+  roles text[]
+)
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+#variable_conflict use_column
+DECLARE
+  v_inv RECORD;
+  v_member_id uuid;
+BEGIN
+  -- Lock and validate the invitation
+  SELECT * INTO v_inv
+  FROM public.organization_invitations
+  WHERE token_hash = p_token_hash
+    AND status = 'PENDING'
+    AND expires_at > now()
+    AND lower(email) = lower(p_user_email)
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  -- Mark as accepted
+  UPDATE public.organization_invitations
+  SET status = 'ACCEPTED',
+      accepted_by = p_user_id,
+      accepted_at = now()
+  WHERE id = v_inv.id;
+
+  -- Create membership (ON CONFLICT for idempotency)
+  INSERT INTO public.organization_members (organization_id, user_id, roles)
+  VALUES (v_inv.organization_id, p_user_id, v_inv.roles)
+  ON CONFLICT (organization_id, user_id) DO NOTHING
+  RETURNING id INTO v_member_id;
+
+  -- If member already existed, get the existing ID
+  IF v_member_id IS NULL THEN
+    SELECT om.id INTO v_member_id
+    FROM public.organization_members om
+    WHERE om.organization_id = v_inv.organization_id
+      AND om.user_id = p_user_id;
+  END IF;
+
+  RETURN QUERY SELECT v_inv.id, v_inv.organization_id, v_member_id, v_inv.roles::text[];
+END;
+$$;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -435,6 +435,13 @@
       "when": 1781400000000,
       "tag": "0061_organization_invitations",
       "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1781600000000,
+      "tag": "0062_fix_accept_invitation_ambiguous_column",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- 11 Playwright E2E tests for email invitation workflow (6 admin-side, 5 accept-side)
- Fixed `accept_invitation` SQL function: ambiguous `organization_id` column between `RETURNS TABLE` output parameter and table column (migration 0062, `#variable_conflict use_column`)
- Fixed `mapServiceError`: Drizzle ORM wraps PG errors in `.cause`, so unique violation (23505) was returning 500 instead of CONFLICT. Added `extractPgError()` helper for recursive unwrapping
- Added `aria-label` to Resend/Revoke icon-only buttons in pending invitations (accessibility + reliable E2E locators)
- New E2E fixtures: `inviteeOrg` (separate auth org) + `inviteePage` (second browser context) for accept-side tests

## Test plan

- [ ] All 11 invitation E2E tests pass (`pnpm test:e2e:organization`)
- [ ] Full organization E2E suite passes (32 tests, no regressions)
- [ ] Unit tests pass (1610 API + 707 web)
- [ ] Type-check clean across all packages
- [ ] branch review: LGTM, no findings