### PR TITLE
feat(api): oRPC REST endpoints for invitation management

### DIFF
--- a/apps/api/src/rest/router.ts
+++ b/apps/api/src/rest/router.ts
@@ -75,6 +75,11 @@ const openApiHandler = new OpenAPIHandler<RestContext>(restRouter, {
               'Manage organizations and their members. Organizations are the top-level tenant in Colophony.',
           },
           {
+            name: 'Invitations',
+            description:
+              'Manage organization membership invitations — list pending, revoke, resend, and accept.',
+          },
+          {
             name: 'Manuscripts',
             description:
               'Manage manuscripts — personal library of creative works with versioning.',

--- a/apps/api/src/rest/routers/organizations.ts
+++ b/apps/api/src/rest/routers/organizations.ts
@@ -10,22 +10,31 @@ import {
   userOrganizationSchema,
   organizationMemberMutationResponseSchema,
   inviteOrAddResultSchema,
+  organizationInvitationSchema,
+  acceptInvitationSchema,
+  acceptInvitationResultSchema,
   paginatedResponseSchema,
   successResponseSchema,
+  type Role,
 } from '@colophony/types';
 import { restPaginationQuery } from '@colophony/api-contracts';
 import { organizationService } from '../../services/organization.service.js';
+import { invitationService } from '../../services/invitation.service.js';
 import {
   gdprService,
   OrgNotDeletableError,
 } from '../../services/gdpr.service.js';
 import { validateEnv } from '../../config/env.js';
-import { toServiceContext } from '../../services/context.js';
+import {
+  toServiceContext,
+  toUserServiceContext,
+} from '../../services/context.js';
 import { mapServiceError } from '../error-mapper.js';
 import {
   authedProcedure,
   orgProcedure,
   adminProcedure,
+  userProcedure,
   requireScopes,
 } from '../context.js';
 
@@ -37,6 +46,10 @@ const orgIdParam = z.object({ orgId: z.string().uuid() });
 const memberIdParam = z.object({
   orgId: z.string().uuid(),
   memberId: z.string().uuid(),
+});
+const invitationIdParam = z.object({
+  orgId: z.string().uuid(),
+  invitationId: z.string().uuid(),
 });
 
 /**
@@ -188,6 +201,110 @@ const membersUpdateRoles = adminProcedure
         toServiceContext(context),
         input.memberId,
         input.roles,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Invitation routes
+// ---------------------------------------------------------------------------
+
+const invitationsList = adminProcedure
+  .use(requireScopes('organizations:read'))
+  .route({
+    method: 'GET',
+    path: '/organizations/{orgId}/invitations',
+    summary: 'List pending invitations',
+    description:
+      'Returns pending invitations for the specified organization. Requires ADMIN role.',
+    operationId: 'listOrganizationInvitations',
+    tags: ['Invitations'],
+  })
+  .input(orgIdParam)
+  .output(z.array(organizationInvitationSchema))
+  .handler(async ({ input, context }) => {
+    assertOrgIdMatch(input.orgId, context.authContext.orgId);
+    const items = await invitationService.listPending(
+      context.dbTx,
+      context.authContext.orgId,
+    );
+    return items.map(({ inviterEmail: _, ...rest }) => ({
+      ...rest,
+      roles: rest.roles as typeof rest.roles & Role[],
+    }));
+  });
+
+const invitationsRevoke = adminProcedure
+  .use(requireScopes('organizations:write'))
+  .route({
+    method: 'DELETE',
+    path: '/organizations/{orgId}/invitations/{invitationId}',
+    summary: 'Revoke an invitation',
+    description: 'Revoke a pending invitation. Requires ADMIN role.',
+    operationId: 'revokeOrganizationInvitation',
+    tags: ['Invitations'],
+  })
+  .input(invitationIdParam)
+  .output(successResponseSchema)
+  .handler(async ({ input, context }) => {
+    assertOrgIdMatch(input.orgId, context.authContext.orgId);
+    try {
+      await invitationService.revokeWithAudit(
+        toServiceContext(context),
+        input.invitationId,
+      );
+      return { success: true as const };
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const invitationsResend = adminProcedure
+  .use(requireScopes('organizations:write'))
+  .route({
+    method: 'POST',
+    path: '/organizations/{orgId}/invitations/{invitationId}/resend',
+    summary: 'Resend an invitation',
+    description:
+      'Revoke the existing invitation and send a new one with a fresh token and expiry. Requires ADMIN role.',
+    operationId: 'resendOrganizationInvitation',
+    tags: ['Invitations'],
+  })
+  .input(invitationIdParam)
+  .output(organizationInvitationSchema)
+  .handler(async ({ input, context }) => {
+    assertOrgIdMatch(input.orgId, context.authContext.orgId);
+    const env = validateEnv();
+    try {
+      return await invitationService.resendWithAudit(
+        toServiceContext(context),
+        input.invitationId,
+        env,
+      );
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
+const invitationsAccept = userProcedure
+  .route({
+    method: 'POST',
+    path: '/invitations/accept',
+    summary: 'Accept an invitation',
+    description:
+      'Accept a pending invitation using the token from the invitation email. Adds the authenticated user as a member of the inviting organization.',
+    operationId: 'acceptInvitation',
+    tags: ['Invitations'],
+  })
+  .input(acceptInvitationSchema)
+  .output(acceptInvitationResultSchema)
+  .handler(async ({ input, context }) => {
+    try {
+      return await invitationService.acceptWithAudit(
+        toUserServiceContext(context),
+        input.token,
       );
     } catch (e) {
       mapServiceError(e);
@@ -363,5 +480,11 @@ export const organizationsRouter = {
     add: membersAdd,
     remove: membersRemove,
     updateRoles: membersUpdateRoles,
+  },
+  invitations: {
+    list: invitationsList,
+    revoke: invitationsRevoke,
+    resend: invitationsResend,
+    accept: invitationsAccept,
   },
 };

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,26 @@ Newest entries first.
 
 ---
 
+## 2026-03-28 — oRPC REST Invitation Endpoints
+
+### Done
+
+- 4 oRPC REST endpoints for invitation management, mirroring existing tRPC procedures:
+  - `GET /v1/organizations/{orgId}/invitations` — list pending (adminProcedure)
+  - `DELETE /v1/organizations/{orgId}/invitations/{invitationId}` — revoke (adminProcedure)
+  - `POST /v1/organizations/{orgId}/invitations/{invitationId}/resend` — resend (adminProcedure)
+  - `POST /v1/invitations/accept` — accept via token (userProcedure, no org context)
+- Added `Invitations` OpenAPI tag to REST router spec
+- Type-check passes, no new files needed — extended existing organizations router
+
+### Decisions
+
+- Nested invitations under `organizationsRouter` (same pattern as `members`) rather than a separate router file
+- No pagination on list endpoint — matches tRPC behavior, pending invitation list is small per-org
+- Accept endpoint at `/invitations/accept` (not nested under org) because user doesn't know org ID before accepting
+
+---
+
 ## 2026-03-28 — Invitation E2E Tests + Bug Fixes
 
 ### Done


### PR DESCRIPTION
## Summary

- Add 4 oRPC REST endpoints mirroring existing tRPC invitation procedures:
  - `GET /v1/organizations/{orgId}/invitations` — list pending (adminProcedure)
  - `DELETE /v1/organizations/{orgId}/invitations/{invitationId}` — revoke
  - `POST /v1/organizations/{orgId}/invitations/{invitationId}/resend` — resend
  - `POST /v1/invitations/accept` — accept via token (userProcedure, no org context)
- Add `Invitations` OpenAPI tag to REST spec

## Test plan

- [x] Type-check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Unit tests pass (237 suites, 2317 tests)
- [x] branch review: LGTM, no findings
- [ ] CI pipeline