### PR TITLE
feat(api): REST endpoint for invitation creation

### DIFF
--- a/apps/api/src/rest/routers/organizations.ts
+++ b/apps/api/src/rest/routers/organizations.ts
@@ -11,6 +11,7 @@ import {
   organizationMemberMutationResponseSchema,
   inviteOrAddResultSchema,
   organizationInvitationSchema,
+  createInvitationSchema,
   acceptInvitationSchema,
   acceptInvitationResultSchema,
   paginatedResponseSchema,
@@ -288,6 +289,47 @@ const invitationsResend = adminProcedure
     }
   });
 
+const invitationsCreate = adminProcedure
+  .use(requireScopes('organizations:write'))
+  .route({
+    method: 'POST',
+    path: '/organizations/{orgId}/invitations',
+    successStatus: 201,
+    summary: 'Create an invitation',
+    description:
+      'Create and send an email invitation to join the organization. Revokes any existing pending invitation for the same email. Requires ADMIN role.',
+    operationId: 'createOrganizationInvitation',
+    tags: ['Invitations'],
+  })
+  .input(orgIdParam.merge(createInvitationSchema))
+  .output(organizationInvitationSchema)
+  .handler(async ({ input, context }) => {
+    assertOrgIdMatch(input.orgId, context.authContext.orgId);
+    const env = validateEnv();
+    try {
+      const svc = toServiceContext(context);
+      const { invitation, plainTextToken } =
+        await invitationService.createWithAudit(
+          svc,
+          input.email,
+          input.roles,
+          input.expiresInDays,
+        );
+      await invitationService.sendInvitationEmail(
+        svc,
+        env,
+        invitation,
+        plainTextToken,
+      );
+      return {
+        ...invitation,
+        roles: invitation.roles,
+      };
+    } catch (e) {
+      mapServiceError(e);
+    }
+  });
+
 const invitationsAccept = userProcedure
   .route({
     method: 'POST',
@@ -483,6 +525,7 @@ export const organizationsRouter = {
   },
   invitations: {
     list: invitationsList,
+    create: invitationsCreate,
     revoke: invitationsRevoke,
     resend: invitationsResend,
     accept: invitationsAccept,

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -15,12 +15,14 @@ Newest entries first.
   - `POST /v1/invitations/accept` — accept via token (userProcedure, no org context)
 - Added `Invitations` OpenAPI tag to REST router spec
 - Type-check passes, no new files needed — extended existing organizations router
+- **Session 2:** Added `POST /v1/organizations/{orgId}/invitations` — create + send invitation (adminProcedure, 201). Completes the REST invitation CRUD. Uses `createWithAudit` + `sendInvitationEmail` (pure create, not the combo inviteOrAddMember pattern)
 
 ### Decisions
 
 - Nested invitations under `organizationsRouter` (same pattern as `members`) rather than a separate router file
 - No pagination on list endpoint — matches tRPC behavior, pending invitation list is small per-org
 - Accept endpoint at `/invitations/accept` (not nested under org) because user doesn't know org ID before accepting
+- Create endpoint is pure invitation (not inviteOrAddMember combo) — REST API should have explicit resource semantics
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `POST /v1/organizations/{orgId}/invitations` (HTTP 201) — creates and sends an email invitation
- Completes the REST invitation CRUD alongside list, revoke, resend, and accept from PR #372
- Uses `invitationService.createWithAudit()` + `sendInvitationEmail()` (pure create, not the combo `inviteOrAddMember` pattern)

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes (via turbo)
- [x] Unit tests pass (707 web + API suites)
- [ ] CI passes
- [ ] Manual curl: `POST /v1/organizations/{orgId}/invitations` with `{ "email": "...", "roles": ["EDITOR"] }` returns 201