### PR TITLE
feat: design system updates + collection reading anchor

### DIFF
--- a/apps/api/src/services/collection.service.ts
+++ b/apps/api/src/services/collection.service.ts
@@ -166,7 +166,13 @@ export const collectionService = {
         submissionTitle: submissions.title,
       })
       .from(workspaceItems)
-      .leftJoin(submissions, eq(workspaceItems.submissionId, submissions.id))
+      .leftJoin(
+        submissions,
+        and(
+          eq(workspaceItems.submissionId, submissions.id),
+          eq(submissions.organizationId, orgId),
+        ),
+      )
       .where(eq(workspaceItems.collectionId, collectionId))
       .orderBy(asc(workspaceItems.position))
       .limit(1000);
@@ -421,6 +427,8 @@ export const collectionService = {
     if (input.notes !== undefined) values.notes = input.notes;
     if (input.color !== undefined) values.color = input.color;
     if (input.icon !== undefined) values.icon = input.icon;
+    if (input.readingAnchor !== undefined)
+      values.readingAnchor = input.readingAnchor;
 
     const [row] = await tx
       .update(workspaceItems)

--- a/apps/web/src/app/(dashboard)/editor/collections/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/collections/[id]/page.tsx
@@ -33,7 +33,20 @@ import {
 import { SortableCollectionItem } from "@/components/collections/sortable-collection-item";
 import { AddSubmissionDialog } from "@/components/collections/add-submission-dialog";
 import { CollectionForm } from "@/components/collections/collection-form";
-import { ArrowLeft, EyeOff, Pencil, Plus, Trash2, Users } from "lucide-react";
+import {
+  DetailPane,
+  type WorkspaceContext,
+} from "@/components/editor/detail-pane";
+import {
+  ArrowLeft,
+  BookOpen,
+  EyeOff,
+  List,
+  Pencil,
+  Plus,
+  Trash2,
+  Users,
+} from "lucide-react";
 
 export default function CollectionDetailPage({
   params,
@@ -47,6 +60,7 @@ export default function CollectionDetailPage({
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [showEditForm, setShowEditForm] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
 
   const { data: collection, isPending: isLoadingCollection } =
     trpc.collections.getById.useQuery({ id });
@@ -118,9 +132,28 @@ export default function CollectionDetailPage({
   const handleRemoveItem = useCallback(
     (itemId: string) => {
       removeItemMutation.mutate({ id, itemId });
+      if (selectedItemId === itemId) setSelectedItemId(null);
     },
-    [id, removeItemMutation],
+    [id, removeItemMutation, selectedItemId],
   );
+
+  const handleItemClick = useCallback((itemId: string) => {
+    setSelectedItemId((prev) => (prev === itemId ? null : itemId));
+  }, []);
+
+  const selectedItem = items.find((i) => i.id === selectedItemId);
+  const isReadingMode = selectedItem != null;
+
+  const workspaceContext: WorkspaceContext | undefined = selectedItem
+    ? {
+        collectionId: id,
+        itemId: selectedItem.id,
+        readingAnchor: selectedItem.readingAnchor as {
+          nodeIndex: number;
+          charOffset: number;
+        } | null,
+      }
+    : undefined;
 
   const existingIds = new Set(items.map((i) => i.submissionId));
 
@@ -142,105 +175,159 @@ export default function CollectionDetailPage({
   }
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => router.push("/editor/collections")}
-        >
-          <ArrowLeft className="h-4 w-4" />
-        </Button>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <h1 className="text-2xl font-bold tracking-tight truncate">
-              {collection.name}
-            </h1>
-            {collection.visibility === "private" ? (
-              <EyeOff className="h-4 w-4 text-muted-foreground shrink-0" />
-            ) : (
-              <Users className="h-4 w-4 text-muted-foreground shrink-0" />
+    <div className="h-full flex flex-col">
+      {/* Header */}
+      <div className="shrink-0 space-y-4 pb-4">
+        <div className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => router.push("/editor/collections")}
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-bold tracking-tight truncate">
+                {collection.name}
+              </h1>
+              {collection.visibility === "private" ? (
+                <EyeOff className="h-4 w-4 text-muted-foreground shrink-0" />
+              ) : (
+                <Users className="h-4 w-4 text-muted-foreground shrink-0" />
+              )}
+              <Badge variant="secondary" className="shrink-0">
+                {collection.typeHint.replace("_", " ")}
+              </Badge>
+            </div>
+            {collection.description && (
+              <p className="text-sm text-muted-foreground mt-1">
+                {collection.description}
+              </p>
             )}
-            <Badge variant="secondary" className="shrink-0">
-              {collection.typeHint.replace("_", " ")}
-            </Badge>
           </div>
-          {collection.description && (
-            <p className="text-sm text-muted-foreground mt-1">
-              {collection.description}
-            </p>
-          )}
-        </div>
-        <div className="flex items-center gap-2 shrink-0">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setShowEditForm(true)}
-          >
-            <Pencil className="mr-1.5 h-3.5 w-3.5" />
-            Edit
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="text-destructive hover:text-destructive"
-            onClick={() => setShowDeleteConfirm(true)}
-          >
-            <Trash2 className="mr-1.5 h-3.5 w-3.5" />
-            Delete
-          </Button>
+          <div className="flex items-center gap-2 shrink-0">
+            {isReadingMode && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setSelectedItemId(null)}
+              >
+                <List className="mr-1.5 h-3.5 w-3.5" />
+                Manage
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowEditForm(true)}
+            >
+              <Pencil className="mr-1.5 h-3.5 w-3.5" />
+              Edit
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-destructive hover:text-destructive"
+              onClick={() => setShowDeleteConfirm(true)}
+            >
+              <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+              Delete
+            </Button>
+          </div>
         </div>
       </div>
 
-      <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground">
-          {items.length} item{items.length !== 1 ? "s" : ""}
-        </p>
-        <Button
-          size="sm"
-          onClick={() => setShowAddDialog(true)}
-          data-testid="add-submission-btn"
-        >
-          <Plus className="mr-1.5 h-3.5 w-3.5" />
-          Add Submission
-        </Button>
-      </div>
+      {/* Content area: management mode or reading mode */}
+      {isReadingMode && selectedItem ? (
+        <div className="flex-1 flex gap-4 min-h-0">
+          {/* Item rail */}
+          <div className="w-64 shrink-0 overflow-y-auto border rounded-lg p-2 space-y-1">
+            {items.map((item) => (
+              <button
+                key={item.id}
+                onClick={() => handleItemClick(item.id)}
+                className={`w-full text-left px-3 py-2 rounded-md text-sm truncate transition-colors ${
+                  item.id === selectedItemId
+                    ? "bg-primary/10 text-primary font-medium"
+                    : "text-muted-foreground hover:bg-muted"
+                }`}
+              >
+                {item.readingAnchor ? (
+                  <BookOpen className="inline h-3 w-3 mr-1.5 opacity-60" />
+                ) : null}
+                {item.submissionTitle ?? "Untitled"}
+              </button>
+            ))}
+          </div>
 
-      {isLoadingItems ? (
-        <div className="space-y-2">
-          {Array.from({ length: 3 }, (_, i) => (
-            <div
-              key={i}
-              className="h-16 rounded-md border bg-muted animate-pulse"
+          {/* Reading pane */}
+          <div className="flex-1 min-w-0 border rounded-lg overflow-hidden">
+            <DetailPane
+              submissionId={selectedItem.submissionId}
+              mode="deep-read"
+              workspaceContext={workspaceContext}
             />
-          ))}
-        </div>
-      ) : items.length === 0 ? (
-        <div className="text-center py-12 text-muted-foreground border rounded-lg">
-          No submissions in this collection yet.
+          </div>
         </div>
       ) : (
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragEnd={handleDragEnd}
-        >
-          <SortableContext
-            items={items.map((i) => i.id)}
-            strategy={verticalListSortingStrategy}
-          >
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">
+              {items.length} item{items.length !== 1 ? "s" : ""}
+            </p>
+            <Button
+              size="sm"
+              onClick={() => setShowAddDialog(true)}
+              data-testid="add-submission-btn"
+            >
+              <Plus className="mr-1.5 h-3.5 w-3.5" />
+              Add Submission
+            </Button>
+          </div>
+
+          {isLoadingItems ? (
             <div className="space-y-2">
-              {items.map((item) => (
-                <SortableCollectionItem
-                  key={item.id}
-                  item={item}
-                  onUpdateNotes={handleUpdateNotes}
-                  onRemove={handleRemoveItem}
+              {Array.from({ length: 3 }, (_, i) => (
+                <div
+                  key={i}
+                  className="h-16 rounded-md border bg-muted animate-pulse"
                 />
               ))}
             </div>
-          </SortableContext>
-        </DndContext>
+          ) : items.length === 0 ? (
+            <div className="text-center py-12 text-muted-foreground border rounded-lg">
+              No submissions in this collection yet.
+            </div>
+          ) : (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={items.map((i) => i.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="space-y-2">
+                  {items.map((item) => (
+                    <div
+                      key={item.id}
+                      onClick={() => handleItemClick(item.id)}
+                      className="cursor-pointer"
+                    >
+                      <SortableCollectionItem
+                        item={item}
+                        onUpdateNotes={handleUpdateNotes}
+                        onRemove={handleRemoveItem}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
+          )}
+        </div>
       )}
 
       <AddSubmissionDialog

--- a/apps/web/src/app/(dashboard)/editor/collections/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/collections/[id]/page.tsx
@@ -313,7 +313,17 @@ export default function CollectionDetailPage({
                   {items.map((item) => (
                     <div
                       key={item.id}
-                      onClick={() => handleItemClick(item.id)}
+                      onClick={(e) => {
+                        // Only enter reading mode if clicking the card body,
+                        // not action buttons (notes, remove, drag handle)
+                        if (
+                          (e.target as HTMLElement).closest(
+                            "button, [role='button']",
+                          )
+                        )
+                          return;
+                        handleItemClick(item.id);
+                      }}
                       className="cursor-pointer"
                     >
                       <SortableCollectionItem

--- a/apps/web/src/components/editor/detail-pane.tsx
+++ b/apps/web/src/components/editor/detail-pane.tsx
@@ -81,7 +81,15 @@ function DeepReadView({
     id: submissionId,
   });
 
-  const updateItemMutation = trpc.collections.updateItem.useMutation();
+  const utils = trpc.useUtils();
+  const updateItemMutation = trpc.collections.updateItem.useMutation({
+    onSuccess: (_data, variables) => {
+      // Only invalidate when anchor was updated, so Manage view shows fresh data
+      if (variables.readingAnchor !== undefined) {
+        utils.collections.getItems.invalidate({ id: variables.id });
+      }
+    },
+  });
 
   const handleAnchorChange = useCallback(
     (anchor: { nodeIndex: number }) => {

--- a/apps/web/src/components/editor/detail-pane.tsx
+++ b/apps/web/src/components/editor/detail-pane.tsx
@@ -10,18 +10,30 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { BookOpen, Loader2, AlertCircle } from "lucide-react";
 import type { ProseMirrorDoc } from "@colophony/types";
-import { useState } from "react";
+import { useCallback, useState } from "react";
+
+export interface WorkspaceContext {
+  collectionId: string;
+  itemId: string;
+  readingAnchor?: { nodeIndex: number; charOffset: number } | null;
+}
 
 interface DetailPaneProps {
   submissionId: string | null;
   mode: "triage" | "deep-read";
+  /** When set, reading anchor persistence is active (collection context). */
+  workspaceContext?: WorkspaceContext;
 }
 
 /**
  * Right pane wrapper that renders submission detail (triage)
  * or ManuscriptRenderer (deep-read) based on mode.
  */
-export function DetailPane({ submissionId, mode }: DetailPaneProps) {
+export function DetailPane({
+  submissionId,
+  mode,
+  workspaceContext,
+}: DetailPaneProps) {
   if (!submissionId) {
     return (
       <div className="flex h-full items-center justify-center text-muted-foreground">
@@ -48,15 +60,40 @@ export function DetailPane({ submissionId, mode }: DetailPaneProps) {
     );
   }
 
-  return <DeepReadView submissionId={submissionId} />;
+  return (
+    <DeepReadView
+      submissionId={submissionId}
+      workspaceContext={workspaceContext}
+    />
+  );
 }
 
-function DeepReadView({ submissionId }: { submissionId: string }) {
+function DeepReadView({
+  submissionId,
+  workspaceContext,
+}: {
+  submissionId: string;
+  workspaceContext?: WorkspaceContext;
+}) {
   const [showAsSubmitted, setShowAsSubmitted] = useState(false);
 
   const { data: submission, isPending } = trpc.submissions.getById.useQuery({
     id: submissionId,
   });
+
+  const updateItemMutation = trpc.collections.updateItem.useMutation();
+
+  const handleAnchorChange = useCallback(
+    (anchor: { nodeIndex: number }) => {
+      if (!workspaceContext) return;
+      updateItemMutation.mutate({
+        id: workspaceContext.collectionId,
+        itemId: workspaceContext.itemId,
+        readingAnchor: { nodeIndex: anchor.nodeIndex, charOffset: 0 },
+      });
+    },
+    [workspaceContext, updateItemMutation],
+  );
 
   if (isPending) {
     return (
@@ -141,6 +178,12 @@ function DeepReadView({ submissionId }: { submissionId: string }) {
             <ManuscriptRenderer
               content={content}
               showAsSubmitted={showAsSubmitted}
+              onAnchorChange={workspaceContext ? handleAnchorChange : undefined}
+              initialAnchor={
+                workspaceContext?.readingAnchor
+                  ? { nodeIndex: workspaceContext.readingAnchor.nodeIndex }
+                  : undefined
+              }
             />
           ) : (
             <p className="text-muted-foreground text-sm">

--- a/apps/web/src/components/manuscripts/manuscript-renderer.tsx
+++ b/apps/web/src/components/manuscripts/manuscript-renderer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { literata } from "@/lib/fonts";
 import { cn } from "@/lib/utils";
 import type {
@@ -8,10 +9,18 @@ import type {
   ProseMirrorMark,
 } from "@/lib/manuscript";
 
+interface ReadingAnchorPosition {
+  nodeIndex: number;
+}
+
 interface ManuscriptRendererProps {
   content: ProseMirrorDoc;
   showAsSubmitted?: boolean;
   className?: string;
+  /** Called when the topmost visible node changes (debounced). Collection context only. */
+  onAnchorChange?: (anchor: ReadingAnchorPosition) => void;
+  /** Restore scroll to this node on mount. Collection context only. */
+  initialAnchor?: ReadingAnchorPosition | null;
 }
 
 /**
@@ -24,11 +33,79 @@ export function ManuscriptRenderer({
   content,
   showAsSubmitted = false,
   className,
+  onAnchorChange,
+  initialAnchor,
 }: ManuscriptRendererProps) {
   const genre = content.attrs?.genre_hint ?? "prose";
+  const containerRef = useRef<HTMLDivElement>(null);
+  const anchorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastReportedIndex = useRef<number>(-1);
+  const restoredRef = useRef(false);
+
+  // Restore scroll position on mount when initialAnchor is provided
+  useEffect(() => {
+    if (!initialAnchor || restoredRef.current) return;
+    restoredRef.current = true;
+    // Defer to next frame so DOM nodes are rendered
+    requestAnimationFrame(() => {
+      const el = containerRef.current?.querySelector(
+        `[data-node-index="${initialAnchor.nodeIndex}"]`,
+      );
+      el?.scrollIntoView({ block: "start" });
+    });
+  }, [initialAnchor]);
+
+  // Track topmost visible node via IntersectionObserver
+  useEffect(() => {
+    if (!onAnchorChange || !containerRef.current) return;
+
+    const nodes = containerRef.current.querySelectorAll("[data-node-index]");
+    if (nodes.length === 0) return;
+
+    const visibleIndices = new Set<number>();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const idx = Number((entry.target as HTMLElement).dataset.nodeIndex);
+          if (entry.isIntersecting) {
+            visibleIndices.add(idx);
+          } else {
+            visibleIndices.delete(idx);
+          }
+        }
+
+        // Find the smallest visible node index (topmost)
+        if (visibleIndices.size === 0) return;
+        const topIndex = Math.min(...visibleIndices);
+        if (topIndex === lastReportedIndex.current) return;
+
+        // Debounce: wait 2s after last change before reporting
+        if (anchorTimerRef.current) clearTimeout(anchorTimerRef.current);
+        anchorTimerRef.current = setTimeout(() => {
+          lastReportedIndex.current = topIndex;
+          onAnchorChange({ nodeIndex: topIndex });
+        }, 2000);
+      },
+      {
+        root: null,
+        threshold: 0,
+      },
+    );
+
+    nodes.forEach((node) => observer.observe(node));
+
+    return () => {
+      observer.disconnect();
+      if (anchorTimerRef.current) clearTimeout(anchorTimerRef.current);
+    };
+  }, [onAnchorChange, content]);
 
   return (
-    <div className={cn(literata.className, "text-foreground", className)}>
+    <div
+      ref={containerRef}
+      className={cn(literata.className, "text-foreground", className)}
+    >
       {genre === "poetry" ? (
         <PoetryRenderer
           nodes={content.content}
@@ -56,7 +133,9 @@ function ProseRenderer({
   return (
     <div className="manuscript-prose">
       {nodes.map((node, i) => (
-        <ProseNode key={i} node={node} showAsSubmitted={showAsSubmitted} />
+        <div key={i} data-node-index={i}>
+          <ProseNode node={node} showAsSubmitted={showAsSubmitted} />
+        </div>
       ))}
     </div>
   );
@@ -98,7 +177,9 @@ function PoetryRenderer({
   return (
     <div className="manuscript-poetry">
       {nodes.map((node, i) => (
-        <PoetryNode key={i} node={node} showAsSubmitted={showAsSubmitted} />
+        <div key={i} data-node-index={i}>
+          <PoetryNode node={node} showAsSubmitted={showAsSubmitted} />
+        </div>
       ))}
     </div>
   );

--- a/apps/web/src/components/manuscripts/manuscript-renderer.tsx
+++ b/apps/web/src/components/manuscripts/manuscript-renderer.tsx
@@ -40,12 +40,10 @@ export function ManuscriptRenderer({
   const containerRef = useRef<HTMLDivElement>(null);
   const anchorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastReportedIndex = useRef<number>(-1);
-  const restoredRef = useRef(false);
 
-  // Restore scroll position on mount when initialAnchor is provided
+  // Restore scroll position when initialAnchor changes (including on item switch)
   useEffect(() => {
-    if (!initialAnchor || restoredRef.current) return;
-    restoredRef.current = true;
+    if (!initialAnchor) return;
     // Defer to next frame so DOM nodes are rendered
     requestAnimationFrame(() => {
       const el = containerRef.current?.querySelector(
@@ -53,7 +51,8 @@ export function ManuscriptRenderer({
       );
       el?.scrollIntoView({ block: "start" });
     });
-  }, [initialAnchor]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally depend on nodeIndex only, not the full object reference
+  }, [initialAnchor?.nodeIndex]);
 
   // Track topmost visible node via IntersectionObserver
   useEffect(() => {

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -41,15 +41,15 @@ Five roles, defined by activity rather than permission level. A single user may 
 
 ### Role-to-permission mapping
 
-Roles map to the existing permission model but reframe the UI:
+Roles map to the five-role permission model (`ADMIN`, `EDITOR`, `READER`, `PRODUCTION`, `BUSINESS_OPS`) with dedicated procedure middleware:
 
-| Role              | Current permission gate         | Notes                               |
-| ----------------- | ------------------------------- | ----------------------------------- |
-| Writer            | Always (any authenticated user) | Absorbs current "Submitter" section |
-| Manuscript Reader | `isEditor` or `isReader`        | First readers / slush readers       |
-| Text Editor       | `isEditor`                      | Full editorial authority            |
-| Production Editor | `isEditor`                      | Slate pipeline access               |
-| Operations Editor | `isAdmin`                       | Org settings, federation, webhooks  |
+| Role              | Permission gate                    | Procedure builder     | Notes                               |
+| ----------------- | ---------------------------------- | --------------------- | ----------------------------------- |
+| Writer            | Always (any authenticated user)    | `authedProcedure`     | Absorbs current "Submitter" section |
+| Manuscript Reader | `EDITOR`, `READER`, or `ADMIN`     | `editorProcedure`     | First readers / slush readers       |
+| Text Editor       | `EDITOR` or `ADMIN`                | `editorProcedure`     | Full editorial authority            |
+| Production Editor | `PRODUCTION`, `EDITOR`, or `ADMIN` | `productionProcedure` | Slate pipeline access               |
+| Operations Editor | `ADMIN`                            | `adminProcedure`      | Org settings, federation, webhooks  |
 
 ### Information architecture per role
 
@@ -123,43 +123,48 @@ The `ManuscriptRenderer` component **ignores density context entirely.** It alwa
 The sidebar is a single, coherent navigation organized by activity group. Groups appear based on the user's role assignments. Clicking a nav item implicitly loads the appropriate layout shell — no explicit mode switching.
 
 ```
-[Recents / Cmd+K jump-to]
-─────────────────────────
+[Cmd+K command palette / jump-to]
+──────────────────────────────────
 
-Writing                          (Writer)
+Writing                          (any authenticated user)
+  Dashboard
+  Manuscripts
   My Submissions
-  Drafts
+  External Subs
   Correspondence
-
-Reading                          (Manuscript Reader)
-  Queue
-  My Reviews
-  Statistics
-
-Editing                          (Text Editor)
-  Desk
-  Recommendations
-  Decisions
-  Correspondence
-
-Production                       (Production Editor)
-  Current Issue
-  Pipeline
-  Assets
-  Author Proofs
-
-Operations                       (Operations Editor)
-  System Health
-  Federation
-  Users & Roles
+  Portfolio
+  Analytics
+  Import
   Settings
-  Logs
+
+Editorial                        (EDITOR / READER / ADMIN)
+  Editor Dashboard
+  Reading Queue
+  All Submissions
+  Collections
+  Forms
+  Periods
+
+Production                       (PRODUCTION / EDITOR / ADMIN)
+  Production Dashboard
+  Publications
+  Pipeline
+  Issues
+  Calendar
+  Contracts
+  CMS
+
+Operations                       (ADMIN)
+  Dashboard
+  Organization
+  Webhooks
+  Federation
 ```
 
 ### Navigation principles
 
 - **Groups are chapters, not applications.** Visual distinction between groups uses subtle spacing and muted labels — not heavy separators. The sidebar should read as one coherent navigation.
-- **Self-configuring.** A writer who is not an editor sees only Writing. An editor who also submits sees Writing + Reading + Editing. No configuration required.
+- **Self-configuring.** A writer who is not an editor sees only Writing. An editor who also submits sees Writing + Editorial. No configuration required. Groups appear based on the user's role assignments (`navGroups` in `navigation.ts`).
 - **URL-driven.** Each nav item is a route. Browser back/forward works naturally. Bookmarkable. Linkable.
 - **Implicit shell transition.** Navigating from a Writing page to a Reading page changes the layout shell (and therefore density context) via the route's layout component — a Next.js layout boundary, not a mode toggle.
 
@@ -357,7 +362,7 @@ Render manuscripts like literature. Editors at literary magazines have strong op
 
 | Property        | Prose                                                  | Poetry                                          | Creative Nonfiction               |
 | --------------- | ------------------------------------------------------ | ----------------------------------------------- | --------------------------------- |
-| **Typeface**    | High-quality serif (Literata, Source Serif, or Lora)   | Same serif family                               | Same serif family                 |
+| **Typeface**    | Literata                                               | Literata                                        | Literata                          |
 | **Line height** | 1.6-1.7                                                | 1.5-1.6                                         | 1.6-1.7                           |
 | **Measure**     | Max 65ch                                               | Tighter (poems rarely reach 65ch)               | Max 65ch                          |
 | **Margins**     | Optical margins, generous                              | Extra breathing room around the poem            | Optical margins                   |
@@ -401,15 +406,32 @@ Editors cannot adjust:
 
 The reading experience should have a strong house opinion. If every editor configures a completely different environment, the platform loses its identity and creates a support surface where rendering bugs entangle with personal configuration.
 
-### Manuscript intermediate format
+### Manuscript intermediate format: ProseMirror JSON with custom nodes
 
-Writers submit in various formats (.doc, .docx, .pdf, .rtf, plain text). The conversion pipeline must:
+TipTap/ProseMirror is already in the stack. Rather than inventing a new format, the intermediate representation is ProseMirror JSON extended with custom node types that encode literary semantics.
+
+**Nodes:**
+
+- `paragraph` (with indent behavior), `section_break`, `block_quote` — prose structure
+- `poem_line`, `stanza_break`, `preserved_indent` (with indent depth attribute), `caesura` — poetry structure
+
+**Marks:**
+
+- `emphasis`, `strong`, `small_caps` — inline formatting
+- `smart_text` (with `original` attribute, enabling the "show as submitted" toggle)
+
+**Document-level attributes:**
+
+- `genre_hint` — prose, poetry, hybrid, or creative_nonfiction
+- `submission_metadata` — carries original filename and format
+
+The conversion pipeline (.docx, .rtf, .pdf, plain text) targets this schema. The `ManuscriptRenderer` only ever consumes ProseMirror JSON — it has no plain-text code path. The client-side `textToProseMirrorDoc()` shim converts legacy plain-text content into basic ProseMirror structure so existing submissions get typography improvements immediately.
+
+Writers submit in various formats. The conversion pipeline must:
 
 1. Preserve authorial intent (especially for poetry — tab-based and space-based indentation must produce identical output)
-2. Normalize into a **structured intermediate format** (constrained HTML subset or custom AST)
+2. Normalize into ProseMirror JSON using the node and mark types above
 3. Give the renderer a stable input regardless of source format
-
-This intermediate format is one of the hardest technical problems in the platform and should be designed carefully before implementation.
 
 ---
 
@@ -464,6 +486,24 @@ Current Issue: [Issue name] — [Publication date] — [N pieces, M on track, K 
 | Memory Palace   | Copyedit           |             2 | Mar 30    | ON TRACK  |          |
 | After the Rain  | Layout             |             0 | Apr 2     | BLOCKED   | Art      |
 ```
+
+### Copyedit stage protocol
+
+**Colophony owns the manuscript lifecycle but doesn't mandate the tools used at every stage.**
+
+The copyedit phase is defined as a **protocol, not an implementation:**
+
+- **Entry point:** Export from ProseMirror JSON to the editorial team's preferred format (.docx is the expected default). The export must preserve structural semantics — especially poetry line breaks, indentation, and section breaks.
+- **Exit point:** Import back from the edited document to ProseMirror JSON. The import must handle track-changes artifacts gracefully (accept all changes on import, or preserve change history as annotations — decide during implementation).
+- **The middle is the editorial team's choice.** The platform tracks the copyedit stage status (assigned, in progress, awaiting author review, complete) and who the document was sent to, but does not prescribe the editing tool.
+
+**Implementation tiers (build in order):**
+
+1. **Manual round-trip (build now):** Editor clicks "Send to copyedit." Platform exports .docx, editor shares it however they want (email, Google Drive, etc.), then uploads the final version back. Platform tracks stage status and elapsed time.
+2. **Google Docs integration (future, optional connector):** Platform creates a Google Doc from the export, shares it with the author, monitors for completion, imports the final version back automatically.
+3. **Built-in TipTap editor (future, optional):** For magazines that want the fully integrated experience. Collaborative editing via ProseMirror's collaboration framework. Only build if demonstrated demand.
+
+**Architectural constraint:** ProseMirror JSON is the canonical format at every stage. External tools borrow the content for editing; the platform always holds the source of truth.
 
 ---
 
@@ -596,43 +636,46 @@ Visual emphasis on elapsed time. Color-coding:
 
 ---
 
-## 13. Migration Path from Current Architecture
+## 13. Implementation Status
 
-### Current state -> Target state
+All design system features have been implemented. This section tracks what was built and where it lives.
 
-| Current                                                                       | Target                                                                | Migration                                                       |
-| ----------------------------------------------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------- |
-| 5 sidebar sections (My Writing, Submissions & Settings, Editor, Slate, Admin) | 5 activity groups (Writing, Reading, Editing, Production, Operations) | Reorganize sidebar; merge Submissions into Writing              |
-| `isEditor` / `isAdmin` binary gates                                           | Same permission gates, reframed as role-hat membership                | No backend changes needed initially                             |
-| Single page layout for all views                                              | Per-group layout shells with DensityProvider                          | Introduce layout shell components; wrap existing pages          |
-| Monolithic editor queue                                                       | Split pane with triage/deep-read modes                                | Major refactor of `editor-submission-queue.tsx`                 |
-| Status badges with full internal state                                        | Role-filtered projections                                             | Add projection layer; backend API returns role-appropriate data |
-| Table-based Slate pipeline                                                    | Issue-centric production dashboard                                    | New dashboard design (prototype first)                          |
-| Basic admin pages                                                             | Ops dashboard with health indicators                                  | New dashboard design                                            |
-| No editor workspace                                                           | Collections primitive (workspace_collections + workspace_items)       | New schema + service + UI                                       |
-| No manuscript rendering strategy                                              | Genre-aware ManuscriptRenderer with intermediate format               | New component + conversion pipeline                             |
-| No keyboard shortcuts                                                         | Shell-scoped shortcut system                                          | New keyboard hook + per-shell bindings                          |
-| No density system                                                             | DensityProvider + useDensity() + component variants                   | New context + incremental component updates                     |
+| Feature                                                                 | Status | Key files                                                                                                |
+| ----------------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------- |
+| Sidebar: 4 activity groups (Writing, Editorial, Production, Operations) | Done   | `src/lib/navigation.ts`, `src/components/layout/sidebar.tsx`                                             |
+| 5-role permission model (ADMIN/EDITOR/READER/PRODUCTION/BUSINESS_OPS)   | Done   | `packages/types/src/organization.ts`, `apps/api/src/trpc/init.ts`                                        |
+| DensityProvider + useDensity()                                          | Done   | `src/hooks/use-density.tsx`                                                                              |
+| Per-group layout shells with density                                    | Done   | `src/app/(dashboard)/*/layout.tsx`                                                                       |
+| Editorial split pane (triage + deep-read)                               | Done   | `src/components/editor/editorial-split-pane.tsx`, `triage-list.tsx`, `queue-rail.tsx`, `detail-pane.tsx` |
+| ManuscriptRenderer (genre-aware, Literata font)                         | Done   | `src/components/manuscripts/manuscript-renderer.tsx`                                                     |
+| Smart typography pipeline (curly quotes, em dashes, ellipses)           | Done   | `apps/api/src/converters/smart-typography.ts`                                                            |
+| Content conversion (DOCX/text to ProseMirror JSON)                      | Done   | `apps/api/src/converters/`                                                                               |
+| Writer state projection + org-configurable labels                       | Done   | `packages/types/src/writer-status.ts`                                                                    |
+| Editor/writer status badges (density-responsive)                        | Done   | `src/components/submissions/status-badge.tsx`, `writer-status-badge.tsx`                                 |
+| Collections primitive (workspace_collections + items)                   | Done   | `packages/db/src/schema/workspace-collections.ts`, `src/components/editor/collections/`                  |
+| Keyboard shortcuts (shell-scoped, j/k/r/Esc)                            | Done   | `src/hooks/use-shortcuts.ts`                                                                             |
+| Command palette (Cmd+K) + shortcut overlay (?)                          | Done   | `src/components/command-palette/`                                                                        |
+| Issue-centric production dashboard                                      | Done   | `src/app/(dashboard)/slate/`                                                                             |
+| Ops dashboard (health card grid)                                        | Done   | `src/app/(dashboard)/operations/`                                                                        |
+| Manuscript diff (word-level version comparison)                         | Done   | `src/components/manuscripts/manuscript-diff.tsx`                                                         |
+| Mobile navigation (hamburger menu for writer views)                     | Done   | `src/components/layout/`                                                                                 |
 
-### Suggested implementation order
+| Content-anchored reading position (`reading_anchor`) | Done | `workspace_items.readingAnchor`, `ManuscriptRenderer` IntersectionObserver, collection detail reading mode |
+| Collection reading mode | Done | `/editor/collections/[id]` click-to-read with item rail + detail pane |
 
-**Step 0 (parallel foundations):**
+### Planned features
 
-- **0a. DensityProvider + useDensity()** — UI foundation. No visible change, but enables everything else.
-- **0b. Manuscript intermediate format design** — Data foundation. Design the structured format (constrained HTML or AST), prototype the conversion pipeline for at least .docx and plain text. This is a prerequisite for the editorial split pane (step 2) — if you build the split pane first with raw manuscript display, you'll retrofit the renderer later and touch every integration point twice.
-
-These are independent workstreams that can happen in parallel.
-
-**Sequential steps:**
-
-1. **Layout shells** — Wrap existing pages in role-appropriate shells. Sidebar reorganization.
-2. **Editorial split pane + ManuscriptRenderer** — Triage/deep-read modes. Genre-aware typography. Depends on both 0a (density) and 0b (intermediate format).
-3. **State projections** — Role-filtered status display. Org-configurable writer names.
-4. **Collections primitive** — Editor workspace/desk. Schema + service + UI.
-5. **Keyboard shortcuts** — Shell-scoped bindings.
-6. **Production data model + dashboard** — Schema design first, then issue-centric view. Prototype before committing to a layout.
-7. **Ops dashboard** — Health card grid. Federation views.
-8. **Command palette** — Cmd+K jump-to across all sections.
+| Feature                                         | Status  | Notes                                                                  |
+| ----------------------------------------------- | ------- | ---------------------------------------------------------------------- |
+| Business Ops sidebar group + contributor record | Planned | BUSINESS_OPS role exists; contributor, rights, revenue tables + UI     |
+| Copyedit stage protocol (manual round-trip)     | Planned | .docx export/import, stage status tracking                             |
+| Contest and special issue management            | Planned | Contest-type submission periods with rounds, anonymous judging, prizes |
+| Editorial analytics dashboard                   | Planned | Acceptance rate, response time, pipeline health, genre distribution    |
+| Writer sim-sub management                       | Planned | Sim-sub groups, auto-withdraw on acceptance                            |
+| Reader feedback on rejection (opt-in)           | Planned | Org-configurable tags, forwardable comments                            |
+| Publication portfolio entries table             | Planned | `colophony_verified`, `federation_verified`, `external` types          |
+| Response time transparency                      | Planned | Aggregation queries, public display, `source` field for federation     |
+| Federation-native writer data sync              | Planned | Three-source model documented in Section 15                            |
 
 ---
 
@@ -661,19 +704,61 @@ However, **writers absolutely check submission status on mobile.** The writer ex
 
 ---
 
+## 15. Federation-Native Writer Data
+
+Writer-facing features — submission tracking, publication portfolio, response time transparency — are not designed around any specific external integration. They are **federation-native**, built on Colophony's existing federation architecture.
+
+### Three-source model
+
+All writer-facing data has three first-class sources:
+
+| Source                  | Origin                          | Provenance                                                                         | Example                                             |
+| ----------------------- | ------------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------- |
+| **Local**               | Writer's own Colophony instance | Auto-tracked from submissions and publications                                     | Submission to Magazine A (native Colophony org)     |
+| **Federation-reported** | Federated peer instances        | Carries `federation_source_instance` + `federation_entry_id` for dedup/attribution | Publication credit reported by a federated peer hub |
+| **Manual**              | Entered by the writer           | No provenance metadata                                                             | External submission logged by the writer            |
+
+### Hub architecture
+
+Any managed Colophony instance can serve as a **hub** — an instance that aggregates data from federated peers. The first hub will be the managed Colophony-as-a-service offering. External directories (e.g., Chill Subs) would connect as federated hub peers, bringing their existing magazine directory and response time data into the network as a peer, not as a privileged integration.
+
+**There is no special external API.** When an external directory connects, it's a federated peer that happens to have a large magazine directory. Data flows through the same federation protocol as any other peer. Any hub can aggregate. Multiple hubs can coexist.
+
+### Forward declarations in schema
+
+To avoid migrations when federation sync arrives, the following are present in the schema before the federation sync protocol is implemented:
+
+- **Portfolio entries:** `federation_verified` type alongside `colophony_verified` and `external`. The `federation_source_instance` and `federation_entry_id` columns exist but no code writes to them yet.
+- **Response time data:** API response shapes include a `source` field (local vs federated) so the frontend can distinguish data origins when federation data arrives.
+- **Submission tracker:** The `external_submissions` table is for manual entries only. Federation-reported submissions will arrive through a separate federation sync path with provenance metadata that manual entries don't carry.
+
+### Impact on writer features
+
+| Feature                   | Local                                                        | Manual                        | Federation (future)                                         |
+| ------------------------- | ------------------------------------------------------------ | ----------------------------- | ----------------------------------------------------------- |
+| **Submission tracker**    | Auto-tracked from native submissions                         | `external_submissions` table  | Federation sync (separate path, not `external_submissions`) |
+| **Publication portfolio** | `colophony_verified` entries from `contributor_publications` | `external` entries (no badge) | `federation_verified` entries (federated badge)             |
+| **Response time**         | Aggregation query over local submission records              | N/A                           | Peer-reported stats with `source: "federated"`              |
+
+### Design principle
+
+> There is no Chill Subs-specific code path — there is federation, and Chill Subs is a participant.
+
+---
+
 ## Appendix A: Design Decision Log
 
 | Decision               | Choice                                                      | Rationale                                                                                                                                                                           |
 | ---------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Density mechanism      | Layout shells with DensityProvider context                  | Shell -> context -> component gets dependency direction right. Role determines density, not per-component props.                                                                    |
-| Navigation model       | Unified sidebar grouped by activity                         | Roles are hats worn simultaneously, not modes. Avoids ceremony of mode-switching. Route-driven shell transitions.                                                                   |
+| Navigation model       | Unified sidebar with 4 activity groups                      | Reading + Editing merged into "Editorial" — split wasn't justified by distinct nav items. Route-driven shell transitions.                                                           |
 | Editor UX model        | Split pane with collapsible list + deep-read mode           | Editors read literature, not emails. The reading pane needs room to breathe. Triage and deep-read are different cognitive modes.                                                    |
 | State visibility       | Role-filtered projections                                   | Writers must not see internal editorial states. Each role sees only states relevant to their decision authority.                                                                    |
 | Writer-facing statuses | Org-configurable names                                      | Different magazines have different transparency cultures. Editorial voice decision, not software decision.                                                                          |
 | Editor workspace       | Generic collection primitive                                | One primitive (named, ordered, annotated collection) replaces holds, bookmarks, comparison sets, reading lists. Let editorial culture determine usage.                              |
 | Typography             | Genre-aware with strong house opinion                       | Render literature like literature. Constrained editor preferences (size, theme, line-height) around exceptional defaults.                                                           |
 | Production view        | Issue-centric with time-visible pipeline                    | Production thinks in issues and deadlines, not submissions. Time pressure must be visible. Prototype multiple approaches.                                                           |
-| Manuscript storage     | Structured intermediate format (constrained HTML or AST)    | Decouple rendering from source format (.docx, .pdf). Preserve authorial intent. Hardest technical problem — design carefully.                                                       |
+| Manuscript storage     | ProseMirror JSON with custom literary nodes and marks       | Decouple rendering from source format (.docx, .pdf). Preserve authorial intent. TipTap/ProseMirror already in the stack — extend rather than invent.                                |
 | Private notes          | Always invisible to writers, no toggle                      | An editor's desk reasoning is never submitter-facing. Making it configurable invites mistakes.                                                                                      |
 | Reading position       | Content-anchored (paragraph/char offset), not scroll offset | Scroll offsets break on any layout change (font size, resize, browser update). Content anchors are stable across rendering contexts.                                                |
 | Smart typography       | On by default, bypass per submission, store both forms      | Some writers use straight quotes or double hyphens intentionally. Storing both normalized and original in the intermediate format makes normalization reversible without data loss. |

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -326,6 +326,7 @@
 - [x] [P3] Flakiness and determinism CI checks — run unit tests with retries disabled and `--sequence.shuffle` on at least one CI lane; add quarantine convention (`.flaky.test.ts` suffix or skip marker) and fail PRs that introduce new flaky markers — (Codex feedback 2026-03-03; done 2026-03-04)
 - [x] [P3] Risk-based test matrix — audit coverage per domain (pipeline, federation, workspace, forms) and document minimum test layers per domain (unit + service integration + API route + E2E happy path) in `docs/testing.md`; identify high-risk low-coverage hotspots — (Codex feedback 2026-03-03; done 2026-03-04)
 - [ ] [P3] ESLint 9 → 10 upgrade — blocked by `eslint-plugin-react`, `eslint-plugin-react-hooks`, `eslint-plugin-jsx-a11y` (transitive via `eslint-config-next`); Dependabot canary will signal when unblocked; tracking issue #273 — (2026-03-16); canary verified 2026-03-22 (Dependabot PR #269 failed CI as expected, still blocked by eslint-plugin-react)
+- [ ] [P2] Diagnostic: Codex plan review step dropped from workflow — `/codex-review plan` was not triggered automatically before presenting plan for approval. Likely regressed during CLAUDE.md file consolidation sessions (~2026-03-25). Investigate whether the "Plan Review: Codex Integration" instruction in root CLAUDE.md is still being followed by the model; verify skill/instruction wording hasn't drifted — (2026-03-28, user-reported)
 - [x] [P3] Skill update: /codex-review should auto-add actionable out-of-scope findings to backlog — during both plan review and branch/diff review, any Important+ findings outside the current task scope should be appended to docs/backlog.md automatically — (workflow improvement 2026-03-03; done 2026-03-22 — enhanced /end-session Step 4b with systematic review finding extraction)
 - [x] [P4] Ephemeral DB/queue per test worker — standardize `TestContext` factory for isolated schemas per worker; replace ad-hoc Redis db 1 patching in `vitest-setup.ts`; add explicit contract tests around external boundaries (webhooks, auth, adapters) with fixture replay — (Codex feedback 2026-03-03; closed 2026-03-22 — current isolation via truncateAllTables, Redis db 1, singleFork is adequate)
 - [x] [P4] Manual QA tracking — establish lightweight QA log (structured markdown or checklist) for pre-release smoke tests, exploratory testing sessions, and regression checks; track what was tested, time spent, and issues found — (Codex feedback 2026-03-03; done 2026-03-03)
@@ -483,6 +484,7 @@
 - [x] [P2] CMS external ID tracking — store `externalId`/`externalUrl` returned from CMS publish back on the issue/items — (codebase audit 2026-02-27; done 2026-03-03)
 - [ ] [P3] Additional CMS adapters — Substack, Contentful, or other targets based on early adopter needs — (codebase audit 2026-02-27)
 - [x] [P3] In-browser copyediting or diff view between manuscript versions — (persona gap analysis 2026-02-27; done 2026-03-26 PR pending)
+- [ ] [P2] Copyedit stage manual round-trip — .docx export from ProseMirror JSON, editor shares externally, upload final version back, track stage status + elapsed time. Protocol defined in DESIGN_SYSTEM.md Section 9 — (design system session 2026-03-28)
 - [x] [P3] READER role enforcement — define what READER can and cannot do distinct from EDITOR; currently decorative — (persona gap analysis 2026-02-27; done 2026-03-03)
 - [x] [P3] Email invitation workflow — invite by email link/token instead of requiring pre-existing Zitadel account — (persona gap analysis 2026-02-27; done 2026-03-27 PR pending)
 - [x] [P3] Custom org roles — expanded enum to 5 roles (ADMIN/EDITOR/READER/PRODUCTION/BUSINESS_OPS) with multi-role array, productionProcedure/editorProcedure middleware, role display names in org settings — (persona gap analysis 2026-02-27; done 2026-03-27 PR #369)
@@ -493,6 +495,43 @@
 - [x] [P3] Test `mySubmissionDetail` procedure + writer-context routing in `submission-detail.tsx` — (Codex branch review 2026-03-26; done 2026-03-27)
 - [x] [P3] Service test for `getByIdAsOwner` ownership check and error types — (Codex branch review 2026-03-26; done 2026-03-27)
 - [x] [P2] Collection service unit tests — 24 tests (CRUD, visibility filtering, cross-tenant validation, audit logging, reorder) in `collection.service.spec.ts` — (Codex branch review 2026-03-26; done 2026-03-27)
+- [x] [P2] Reading anchor wiring — ManuscriptRenderer IntersectionObserver tracking, collection detail reading mode, updateCollectionItemSchema + service whitelist, defense-in-depth fix for getItems() submissions join — (design system session 2026-03-28; done 2026-03-28)
+
+---
+
+## Track 13 — Business Operations (Post-Launch)
+
+> **Status:** Planned. Contributor record is the foundational entity; all other items depend on it.
+
+### Code
+
+- [ ] [P1] `contributors` + `contributor_publications` schema — org-scoped contributor entity linking submissions, publications, payments, rights. Columns: display_name, bio, pronouns, website, mailing_address (encrypted), notes — (design system session 2026-03-28)
+- [ ] [P1] `rights_agreements` schema — per-published-piece IP ownership lifecycle (first_north_american_serial, electronic, anthology, audio, translation, custom). Status: draft → sent → signed → active → reverted. Reversion date tracking. Separate from Documenso `contracts` table — (design system session 2026-03-28)
+- [ ] [P1] `payment_transactions` schema — unified payment table with type discriminator (submission_fee, contest_fee, contributor_payment). Extends beyond current submission-fee-only `payments` table — (design system session 2026-03-28)
+- [ ] [P1] `businessOpsProcedure` middleware — BUSINESS_OPS or ADMIN role check, following existing procedure pattern in `apps/api/src/trpc/init.ts` — (design system session 2026-03-28)
+- [ ] [P1] Business Ops nav group + sidebar rendering — new "Business" activity group visible to BUSINESS_OPS/ADMIN with compact density `BusinessLayout` — (design system session 2026-03-28)
+- [ ] [P1] Contributor service + tRPC router — CRUD, link to submissions/users, publication history, detail view with all submissions/publications/payments/rights/correspondence — (design system session 2026-03-28)
+- [ ] [P1] Rights service — lifecycle management, reversion alerts ("3 rights agreements reverting in 30 days"), integration with production pipeline — (design system session 2026-03-28)
+- [ ] [P1] Revenue service — submission fees (existing Stripe), contributor payments, contest prizes, revenue reporting — (design system session 2026-03-28)
+- [ ] [P2] Business Ops dashboard — health card grid pattern with contributor count, outstanding payments, upcoming reversions, revenue summary — (design system session 2026-03-28)
+- [ ] [P2] Editorial analytics dashboard — acceptance rate (overall + by genre/period), response time (avg/median/p90 + trend), pipeline health, genre distribution, contributor diversity, reader alignment — (design system session 2026-03-28)
+- [ ] [P2] Contest management — contest-type submission periods with rounds (`contestGroupId` + `contestRound`), judge assignments, anonymous judging, prize disbursement. Period-scoped guest editor roles deferred — (design system session 2026-03-28)
+
+---
+
+## Track 14 — Writer Platform Enhancements (Post-Launch)
+
+> **Status:** Planned. Some features depend on Track 13 contributor infrastructure (portfolio entries link to `contributor_publications`).
+
+### Code
+
+- [ ] [P1] `simultaneous_submission_groups` schema — user-scoped sim-sub groupings linking native + external submissions of same work. Auto-withdraw prompt on acceptance — (design system session 2026-03-28)
+- [ ] [P1] `portfolio_entries` schema — three types: `colophony_verified` (from contributor_publications), `federation_verified` (future federation sync), `external` (manual). Forward-declares `federation_source_instance` + `federation_entry_id` columns — (design system session 2026-03-28)
+- [ ] [P1] `reader_feedback` schema — org-configurable tags (JSONB), short comment (280 chars), forwardable boolean. Opt-in per org. Anonymous reader identity on forwarded feedback — (design system session 2026-03-28)
+- [ ] [P2] Sim-sub management UI — group creation, linked submission view, auto-withdraw on acceptance at any Colophony magazine, manual withdraw reminder for external submissions — (design system session 2026-03-28)
+- [ ] [P2] Response time transparency — aggregation query over local submission records, displayed on magazine public profile + submission form. `source` field (local vs federated) for future federation data. Org opt-out available — (design system session 2026-03-28)
+- [ ] [P2] Feedback on rejection flow — reader tags/comments during scoring, editor inclusion of anonymized feedback in rejection notice, org-level feature toggle (default off) — (design system session 2026-03-28)
+- [ ] [P3] Writer sidebar updates — Sim-Sub Groups nav item, Portfolio badges (verified/federated/external), Analytics personal response time stats — (design system session 2026-03-28)
 
 ---
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -496,6 +496,7 @@
 - [x] [P3] Service test for `getByIdAsOwner` ownership check and error types — (Codex branch review 2026-03-26; done 2026-03-27)
 - [x] [P2] Collection service unit tests — 24 tests (CRUD, visibility filtering, cross-tenant validation, audit logging, reorder) in `collection.service.spec.ts` — (Codex branch review 2026-03-26; done 2026-03-27)
 - [x] [P2] Reading anchor wiring — ManuscriptRenderer IntersectionObserver tracking, collection detail reading mode, updateCollectionItemSchema + service whitelist, defense-in-depth fix for getItems() submissions join — (design system session 2026-03-28; done 2026-03-28)
+- [ ] [P3] Reading anchor test coverage — unit tests for: readingAnchor persistence in updateItem, org-scoped join predicate in getItems, ManuscriptRenderer anchor restore/callback, collection reading mode UI, scope guard (queue context = no anchor) — (Codex branch review drift 2026-03-28)
 
 ---
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,28 @@ Newest entries first.
 
 ---
 
+## 2026-03-28 — Design System Updates + Reading Anchor
+
+### Done
+
+- DESIGN_SYSTEM.md doc corrections: Section 8 updated with ProseMirror JSON decision (nodes, marks, document attrs), Literata as chosen typeface, Appendix A manuscript storage row
+- New section: Copyedit Stage Protocol (Section 9 subsection) — protocol-not-implementation approach with 3 implementation tiers
+- New section: Federation-Native Writer Data (Section 15) — three-source model (local, federation-reported, manual), hub architecture, replaces Chill Subs integration framing
+- Reading anchor implementation: `readingAnchorSchema` in types, `updateItem()` whitelist in collection service, ManuscriptRenderer IntersectionObserver tracking with debounced callback, collection detail page click-to-read mode with item rail + reading pane
+- Defense-in-depth fix: added `organizationId` predicate on `getItems()` submissions join (Codex plan review finding)
+- Section 13 implementation status updated: reading anchor Done, planned features table added
+- Backlog updated: Track 13 (Business Operations, 11 items), Track 14 (Writer Platform Enhancements, 7 items), copyedit manual round-trip item, diagnostic item for missed Codex plan review
+- Codex plan review: 3 Important findings + 1 Suggestion, all addressed before implementation
+
+### Decisions
+
+- v1 reading anchor uses nodeIndex only; charOffset=0 for forward compat with ReadingAnchor type
+- rights_agreements will be a new table separate from Documenso contracts (Session 2)
+- Session ordering: business ops before writer platform (contributors are foundational)
+- Federation-native framing: "There is no Chill Subs-specific code path — there is federation, and Chill Subs is a participant"
+
+---
+
 ## 2026-03-28 — oRPC REST Invitation Endpoints
 
 ### Done

--- a/packages/types/src/workspace-collection.ts
+++ b/packages/types/src/workspace-collection.ts
@@ -105,10 +105,21 @@ export const addCollectionItemSchema = z.object({
 
 export type AddCollectionItemInput = z.infer<typeof addCollectionItemSchema>;
 
+export const readingAnchorSchema = z
+  .object({
+    nodeIndex: z.number().int().min(0),
+    charOffset: z.number().int().min(0),
+  })
+  .describe("Content-anchored reading position in ProseMirror document");
+
 export const updateCollectionItemSchema = z.object({
   notes: z.string().max(5000).nullable().optional().describe("Private notes"),
   color: z.string().max(50).nullable().optional().describe("Label color"),
   icon: z.string().max(50).nullable().optional().describe("Item icon"),
+  readingAnchor: readingAnchorSchema
+    .nullable()
+    .optional()
+    .describe("Reading position anchor — persisted only in collection context"),
 });
 
 export type UpdateCollectionItemInput = z.infer<


### PR DESCRIPTION
## Summary

- **DESIGN_SYSTEM.md doc corrections:** Section 8 updated with ProseMirror JSON decision (nodes, marks, document-level attrs), Literata as chosen typeface, Appendix A manuscript storage row updated
- **Copyedit Stage Protocol:** New subsection in Section 9 — protocol-not-implementation with 3 tiers (manual round-trip, Google Docs, built-in TipTap)
- **Federation-Native Writer Data:** New Section 15 replacing Chill Subs framing — three-source model (local, federation-reported, manual), hub architecture, forward declarations in schema
- **Reading Anchor:** `readingAnchorSchema` + `updateCollectionItemSchema` extension, collection service whitelist + defense-in-depth fix on `getItems()` submissions join, ManuscriptRenderer IntersectionObserver tracking with debounced callback, collection detail page click-to-read mode with item rail + reading pane
- **Backlog:** Track 13 (Business Operations, 11 items), Track 14 (Writer Platform Enhancements, 7 items), copyedit manual round-trip, diagnostic item for missed plan review

## Test plan

- [x] `pnpm type-check` — 13/13 clean
- [x] `pnpm --filter @colophony/api test` — 150 suites, 1610 tests
- [x] `pnpm --filter @colophony/web test` — 87 suites, 707 tests
- [x] Manual QA via Chrome DevTools: collection management → reading mode → item switching → manage return
- [ ] CI pipeline

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `collection-reading-pane.tsx` | New dedicated component | Folded into existing `detail-pane.tsx` + `page.tsx` | Simpler — avoided unnecessary abstraction for what amounts to prop plumbing |