### PR TITLE
feat(business-ops): Track 13 foundation — contributors, rights, payments schema

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -87,15 +87,16 @@ GraphQL extracted to feature branch — re-merge when demand materializes. All s
 
 ## tRPC Procedure Builders (`src/trpc/init.ts`)
 
-| Builder               | Guarantees                                    |
-| --------------------- | --------------------------------------------- |
-| `publicProcedure`     | No auth                                       |
-| `authedProcedure`     | `ctx.authContext` non-null                    |
-| `orgProcedure`        | `orgId/roles` + `dbTx` set                    |
-| `userProcedure`       | `authContext` + `dbTx` (no org)               |
-| `editorProcedure`     | `orgProcedure` + EDITOR or ADMIN              |
-| `productionProcedure` | `orgProcedure` + PRODUCTION, EDITOR, or ADMIN |
-| `adminProcedure`      | `orgProcedure` + ADMIN                        |
+| Builder                | Guarantees                                    |
+| ---------------------- | --------------------------------------------- |
+| `publicProcedure`      | No auth                                       |
+| `authedProcedure`      | `ctx.authContext` non-null                    |
+| `orgProcedure`         | `orgId/roles` + `dbTx` set                    |
+| `userProcedure`        | `authContext` + `dbTx` (no org)               |
+| `editorProcedure`      | `orgProcedure` + EDITOR or ADMIN              |
+| `productionProcedure`  | `orgProcedure` + PRODUCTION, EDITOR, or ADMIN |
+| `businessOpsProcedure` | `orgProcedure` + BUSINESS_OPS or ADMIN        |
+| `adminProcedure`       | `orgProcedure` + ADMIN                        |
 
 ---
 

--- a/apps/api/src/__tests__/rls/rls-business-ops.test.ts
+++ b/apps/api/src/__tests__/rls/rls-business-ops.test.ts
@@ -6,7 +6,7 @@ import { withTestRls } from './helpers/rls-context';
 import {
   createOrganization,
   createUser,
-  createMember,
+  createOrgMember,
 } from './helpers/factories';
 import {
   contributors,
@@ -46,8 +46,8 @@ describe('RLS Business Operations Tables', () => {
     orgB = await createOrganization({ name: 'Org B' });
     userA = await createUser();
     userB = await createUser();
-    await createMember(orgA.id, userA.id);
-    await createMember(orgB.id, userB.id);
+    await createOrgMember(orgA.id, userA.id);
+    await createOrgMember(orgB.id, userB.id);
 
     // Create contributors in each org
     [contributorA] = await db

--- a/apps/api/src/__tests__/rls/rls-business-ops.test.ts
+++ b/apps/api/src/__tests__/rls/rls-business-ops.test.ts
@@ -69,7 +69,7 @@ describe('RLS Business Operations Tables', () => {
     // Create pipeline item prereqs for contributor_publications
     const [pubA] = await db
       .insert(publications)
-      .values({ organizationId: orgA.id, name: 'Pub A' })
+      .values({ organizationId: orgA.id, name: 'Pub A', slug: 'pub-a' })
       .returning();
 
     const [manuscript] = await db
@@ -88,6 +88,8 @@ describe('RLS Business Operations Tables', () => {
         organizationId: orgA.id,
         name: 'Period A',
         publicationId: pubA.id,
+        opensAt: new Date('2026-01-01'),
+        closesAt: new Date('2026-12-31'),
       })
       .returning();
 
@@ -108,7 +110,6 @@ describe('RLS Business Operations Tables', () => {
         organizationId: orgA.id,
         submissionId: submission.id,
         publicationId: pubA.id,
-        title: 'Pipeline Item A',
       })
       .returning();
 

--- a/apps/api/src/__tests__/rls/rls-business-ops.test.ts
+++ b/apps/api/src/__tests__/rls/rls-business-ops.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { globalSetup, getAdminPool } from './helpers/db-setup';
+import { truncateAllTables } from './helpers/cleanup';
+import { withTestRls } from './helpers/rls-context';
+import {
+  createOrganization,
+  createUser,
+  createMember,
+} from './helpers/factories';
+import {
+  contributors,
+  contributorPublications,
+  rightsAgreements,
+  paymentTransactions,
+  pipelineItems,
+  publications,
+  submissions,
+  submissionPeriods,
+  manuscripts,
+  manuscriptVersions,
+} from '@colophony/db';
+import { drizzle } from 'drizzle-orm/node-postgres';
+
+function adminDb(): any {
+  return drizzle(getAdminPool());
+}
+
+let orgA: { id: string };
+let orgB: { id: string };
+let userA: { id: string };
+let userB: { id: string };
+let contributorA: { id: string };
+let contributorB: { id: string };
+let pipelineItemA: { id: string };
+
+describe('RLS Business Operations Tables', () => {
+  beforeAll(async () => {
+    await globalSetup();
+    await truncateAllTables();
+
+    const db = adminDb();
+
+    // Create two orgs and users
+    orgA = await createOrganization({ name: 'Org A' });
+    orgB = await createOrganization({ name: 'Org B' });
+    userA = await createUser();
+    userB = await createUser();
+    await createMember(orgA.id, userA.id);
+    await createMember(orgB.id, userB.id);
+
+    // Create contributors in each org
+    [contributorA] = await db
+      .insert(contributors)
+      .values({
+        organizationId: orgA.id,
+        displayName: 'Contributor A',
+      })
+      .returning();
+
+    [contributorB] = await db
+      .insert(contributors)
+      .values({
+        organizationId: orgB.id,
+        displayName: 'Contributor B',
+      })
+      .returning();
+
+    // Create pipeline item prereqs for contributor_publications
+    const [pubA] = await db
+      .insert(publications)
+      .values({ organizationId: orgA.id, name: 'Pub A' })
+      .returning();
+
+    const [manuscript] = await db
+      .insert(manuscripts)
+      .values({ ownerId: userA.id, title: 'Test Manuscript' })
+      .returning();
+
+    const [version] = await db
+      .insert(manuscriptVersions)
+      .values({ manuscriptId: manuscript.id, versionNumber: 1 })
+      .returning();
+
+    const [period] = await db
+      .insert(submissionPeriods)
+      .values({
+        organizationId: orgA.id,
+        name: 'Period A',
+        publicationId: pubA.id,
+      })
+      .returning();
+
+    const [submission] = await db
+      .insert(submissions)
+      .values({
+        organizationId: orgA.id,
+        submitterId: userA.id,
+        submissionPeriodId: period.id,
+        manuscriptVersionId: version.id,
+        title: 'Test Submission',
+      })
+      .returning();
+
+    [pipelineItemA] = await db
+      .insert(pipelineItems)
+      .values({
+        organizationId: orgA.id,
+        submissionId: submission.id,
+        publicationId: pubA.id,
+        title: 'Pipeline Item A',
+      })
+      .returning();
+
+    // Create contributor_publications
+    await db.insert(contributorPublications).values({
+      contributorId: contributorA.id,
+      pipelineItemId: pipelineItemA.id,
+      role: 'author',
+    });
+
+    // Create rights_agreements in each org
+    await db.insert(rightsAgreements).values({
+      organizationId: orgA.id,
+      contributorId: contributorA.id,
+      rightsType: 'first_north_american_serial',
+    });
+
+    await db.insert(rightsAgreements).values({
+      organizationId: orgB.id,
+      contributorId: contributorB.id,
+      rightsType: 'electronic',
+    });
+
+    // Create payment_transactions in each org
+    await db.insert(paymentTransactions).values({
+      organizationId: orgA.id,
+      type: 'contributor_payment',
+      direction: 'outbound',
+      amount: 5000,
+    });
+
+    await db.insert(paymentTransactions).values({
+      organizationId: orgB.id,
+      type: 'submission_fee',
+      direction: 'inbound',
+      amount: 1500,
+    });
+  });
+
+  afterAll(async () => {
+    await truncateAllTables();
+  });
+
+  // -----------------------------------------------------------------------
+  // contributors (direct org isolation)
+  // -----------------------------------------------------------------------
+
+  describe('contributors', () => {
+    it('org A context sees only org A contributors', async () => {
+      const rows = await withTestRls(
+        { orgId: orgA.id, userId: userA.id },
+        (tx) => tx.select().from(contributors),
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].id).toBe(contributorA.id);
+    });
+
+    it('org B context sees only org B contributors', async () => {
+      const rows = await withTestRls(
+        { orgId: orgB.id, userId: userB.id },
+        (tx) => tx.select().from(contributors),
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].id).toBe(contributorB.id);
+    });
+
+    it('org A context cannot find org B contributor by ID', async () => {
+      const rows = await withTestRls(
+        { orgId: orgA.id, userId: userA.id },
+        (tx) =>
+          tx
+            .select()
+            .from(contributors)
+            .where(eq(contributors.id, contributorB.id)),
+      );
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // contributor_publications (parent-based isolation)
+  // -----------------------------------------------------------------------
+
+  describe('contributor_publications', () => {
+    it('org A context sees contributor publications', async () => {
+      const rows = await withTestRls(
+        { orgId: orgA.id, userId: userA.id },
+        (tx) => tx.select().from(contributorPublications),
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].contributorId).toBe(contributorA.id);
+    });
+
+    it('org B context sees no contributor publications (none seeded for org B)', async () => {
+      const rows = await withTestRls(
+        { orgId: orgB.id, userId: userB.id },
+        (tx) => tx.select().from(contributorPublications),
+      );
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // rights_agreements (direct org isolation)
+  // -----------------------------------------------------------------------
+
+  describe('rights_agreements', () => {
+    it('org A context sees only org A rights agreements', async () => {
+      const rows = await withTestRls(
+        { orgId: orgA.id, userId: userA.id },
+        (tx) => tx.select().from(rightsAgreements),
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].rightsType).toBe('first_north_american_serial');
+    });
+
+    it('org B context sees only org B rights agreements', async () => {
+      const rows = await withTestRls(
+        { orgId: orgB.id, userId: userB.id },
+        (tx) => tx.select().from(rightsAgreements),
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].rightsType).toBe('electronic');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // payment_transactions (direct org isolation)
+  // -----------------------------------------------------------------------
+
+  describe('payment_transactions', () => {
+    it('org A context sees only org A transactions', async () => {
+      const rows = await withTestRls(
+        { orgId: orgA.id, userId: userA.id },
+        (tx) => tx.select().from(paymentTransactions),
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].type).toBe('contributor_payment');
+      expect(rows[0].amount).toBe(5000);
+    });
+
+    it('org B context sees only org B transactions', async () => {
+      const rows = await withTestRls(
+        { orgId: orgB.id, userId: userB.id },
+        (tx) => tx.select().from(paymentTransactions),
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].type).toBe('submission_fee');
+      expect(rows[0].amount).toBe(1500);
+    });
+  });
+});

--- a/apps/api/src/services/contributor.service.spec.ts
+++ b/apps/api/src/services/contributor.service.spec.ts
@@ -27,6 +27,10 @@ vi.mock('@colophony/db', () => ({
     displayOrder: 'cp.display_order',
     createdAt: 'cp.created_at',
   },
+  pipelineItems: {
+    id: 'pi.id',
+    organizationId: 'pi.org_id',
+  },
   eq: vi.fn(),
   and: vi.fn(),
 }));
@@ -335,6 +339,12 @@ describe('contributorService', () => {
 
   describe('addPublicationWithAudit', () => {
     it('inserts publication link and emits audit', async () => {
+      // Pipeline item org validation
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([{ id: 'pi-1' }]);
+        return c;
+      });
       mockTx.insert = vi.fn(() => {
         const c = makeChain();
         c.returning.mockResolvedValueOnce([fakePub]);
@@ -359,6 +369,11 @@ describe('contributorService', () => {
     });
 
     it('throws ContributorPublicationDuplicateError on unique violation', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([{ id: 'pi-1' }]);
+        return c;
+      });
       mockTx.insert = vi.fn(() => {
         const c = makeChain();
         c.returning.mockRejectedValueOnce(
@@ -434,6 +449,11 @@ describe('contributorService', () => {
     });
 
     it('addPublicationWithAudit calls assertBusinessOpsOrAdmin', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([{ id: 'pi-1' }]);
+        return c;
+      });
       mockTx.insert = vi.fn(() => {
         const c = makeChain();
         c.returning.mockResolvedValueOnce([fakePub]);

--- a/apps/api/src/services/contributor.service.spec.ts
+++ b/apps/api/src/services/contributor.service.spec.ts
@@ -1,0 +1,453 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@colophony/db', () => ({
+  contributors: {
+    id: 'c.id',
+    organizationId: 'c.org_id',
+    userId: 'c.user_id',
+    displayName: 'c.display_name',
+    bio: 'c.bio',
+    pronouns: 'c.pronouns',
+    email: 'c.email',
+    website: 'c.website',
+    mailingAddress: 'c.mailing_address',
+    notes: 'c.notes',
+    createdAt: 'c.created_at',
+    updatedAt: 'c.updated_at',
+  },
+  contributorPublications: {
+    id: 'cp.id',
+    contributorId: 'cp.contributor_id',
+    pipelineItemId: 'cp.pipeline_item_id',
+    role: 'cp.role',
+    displayOrder: 'cp.display_order',
+    createdAt: 'cp.created_at',
+  },
+  eq: vi.fn(),
+  and: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  ilike: vi.fn(),
+  count: vi.fn(),
+}));
+
+vi.mock('./errors.js', () => ({
+  assertBusinessOpsOrAdmin: vi.fn(),
+  ForbiddenError: class ForbiddenError extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = 'ForbiddenError';
+    }
+  },
+}));
+
+import {
+  contributorService,
+  ContributorNotFoundError,
+  ContributorAlreadyLinkedError,
+  ContributorPublicationDuplicateError,
+} from './contributor.service.js';
+import { assertBusinessOpsOrAdmin } from './errors.js';
+import type { ServiceContext } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ORG_ID = 'org-1';
+const USER_ID = 'user-1';
+const CONTRIBUTOR_ID = 'contributor-1';
+
+const fakeContributor = {
+  id: CONTRIBUTOR_ID,
+  organizationId: ORG_ID,
+  userId: null,
+  displayName: 'Jane Poet',
+  bio: null,
+  pronouns: 'she/her',
+  email: 'jane@example.com',
+  website: null,
+  mailingAddress: null,
+  notes: null,
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+};
+
+const fakePub = {
+  id: 'pub-1',
+  contributorId: CONTRIBUTOR_ID,
+  pipelineItemId: 'pi-1',
+  role: 'author' as const,
+  displayOrder: 0,
+  createdAt: new Date('2026-01-01'),
+};
+
+/**
+ * Build a mock tx. Each call to select/insert/update/delete returns a fresh
+ * chain to avoid shared-state issues between sequential queries.
+ */
+function makeChain() {
+  const c: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of [
+    'from',
+    'where',
+    'orderBy',
+    'limit',
+    'offset',
+    'values',
+    'set',
+    'returning',
+  ]) {
+    c[m] = vi.fn().mockReturnValue(c);
+  }
+  return c;
+}
+
+function makeMockTx() {
+  // Track all chains so tests can set return values on the Nth chain.
+  const chains: Array<Record<string, ReturnType<typeof vi.fn>>> = [];
+
+  function newChain() {
+    const c = makeChain();
+    chains.push(c);
+    return c;
+  }
+
+  return {
+    select: vi.fn(() => newChain()),
+    insert: vi.fn(() => newChain()),
+    update: vi.fn(() => newChain()),
+    delete: vi.fn(() => newChain()),
+    /** Get the Nth chain (0-based) created during the test. */
+    chain(n: number) {
+      return chains[n];
+    },
+    /** Reset chains for next test. */
+    resetChains() {
+      chains.length = 0;
+    },
+  };
+}
+
+function makeServiceContext(tx: ReturnType<typeof makeMockTx>): ServiceContext {
+  return {
+    tx: tx as unknown as ServiceContext['tx'],
+    actor: { userId: USER_ID, orgId: ORG_ID, roles: ['BUSINESS_OPS'] },
+    audit: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('contributorService', () => {
+  let mockTx: ReturnType<typeof makeMockTx>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTx = makeMockTx();
+  });
+
+  // -----------------------------------------------------------------------
+  // getById
+  // -----------------------------------------------------------------------
+
+  describe('getById', () => {
+    it('returns contributor when found', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeContributor]);
+        return c;
+      });
+
+      const result = await contributorService.getById(
+        mockTx as any,
+        CONTRIBUTOR_ID,
+        ORG_ID,
+      );
+      expect(result).toEqual(fakeContributor);
+    });
+
+    it('returns null when not found', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([]);
+        return c;
+      });
+
+      const result = await contributorService.getById(
+        mockTx as any,
+        'nonexistent',
+        ORG_ID,
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // createWithAudit
+  // -----------------------------------------------------------------------
+
+  describe('createWithAudit', () => {
+    it('inserts contributor and emits audit event', async () => {
+      // insert chain: insert→values→returning
+      mockTx.insert = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([fakeContributor]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await contributorService.createWithAudit(ctx, {
+        displayName: 'Jane Poet',
+        pronouns: 'she/her',
+        email: 'jane@example.com',
+      });
+
+      expect(result).toEqual(fakeContributor);
+      expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'CONTRIBUTOR_CREATED',
+          resource: 'contributor',
+          resourceId: CONTRIBUTOR_ID,
+        }),
+      );
+    });
+
+    it('throws ContributorAlreadyLinkedError when userId already linked', async () => {
+      // getByUserId: select→from→where→limit resolves with existing
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeContributor]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        contributorService.createWithAudit(ctx, {
+          displayName: 'Another',
+          userId: USER_ID,
+        }),
+      ).rejects.toThrow(ContributorAlreadyLinkedError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // updateWithAudit
+  // -----------------------------------------------------------------------
+
+  describe('updateWithAudit', () => {
+    it('updates fields and emits audit', async () => {
+      // getById returns existing, then update returns updated
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeContributor]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...fakeContributor, displayName: 'Jane Updated' },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await contributorService.updateWithAudit(ctx, {
+        id: CONTRIBUTOR_ID,
+        displayName: 'Jane Updated',
+      });
+
+      expect(result.displayName).toBe('Jane Updated');
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'CONTRIBUTOR_UPDATED',
+          resource: 'contributor',
+        }),
+      );
+    });
+
+    it('throws ContributorNotFoundError for missing ID', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        contributorService.updateWithAudit(ctx, {
+          id: 'nonexistent',
+          displayName: 'X',
+        }),
+      ).rejects.toThrow(ContributorNotFoundError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // deleteWithAudit
+  // -----------------------------------------------------------------------
+
+  describe('deleteWithAudit', () => {
+    it('deletes and emits audit', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeContributor]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await contributorService.deleteWithAudit(ctx, CONTRIBUTOR_ID);
+
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'CONTRIBUTOR_DELETED',
+          resource: 'contributor',
+          resourceId: CONTRIBUTOR_ID,
+        }),
+      );
+    });
+
+    it('throws ContributorNotFoundError for missing ID', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        contributorService.deleteWithAudit(ctx, 'nonexistent'),
+      ).rejects.toThrow(ContributorNotFoundError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // addPublicationWithAudit
+  // -----------------------------------------------------------------------
+
+  describe('addPublicationWithAudit', () => {
+    it('inserts publication link and emits audit', async () => {
+      mockTx.insert = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([fakePub]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await contributorService.addPublicationWithAudit(ctx, {
+        contributorId: CONTRIBUTOR_ID,
+        pipelineItemId: 'pi-1',
+        role: 'author',
+        displayOrder: 0,
+      });
+
+      expect(result).toEqual(fakePub);
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'CONTRIBUTOR_PUBLICATION_ADDED',
+          resource: 'contributor',
+        }),
+      );
+    });
+
+    it('throws ContributorPublicationDuplicateError on unique violation', async () => {
+      mockTx.insert = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockRejectedValueOnce(
+          new Error(
+            'duplicate key value violates unique constraint "contributor_publications_contributor_item_role_idx"',
+          ),
+        );
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        contributorService.addPublicationWithAudit(ctx, {
+          contributorId: CONTRIBUTOR_ID,
+          pipelineItemId: 'pi-1',
+          role: 'author',
+          displayOrder: 0,
+        }),
+      ).rejects.toThrow(ContributorPublicationDuplicateError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // removePublicationWithAudit
+  // -----------------------------------------------------------------------
+
+  describe('removePublicationWithAudit', () => {
+    it('removes link and emits audit', async () => {
+      const ctx = makeServiceContext(mockTx);
+
+      await contributorService.removePublicationWithAudit(ctx, {
+        contributorId: CONTRIBUTOR_ID,
+        pipelineItemId: 'pi-1',
+        role: 'author',
+      });
+
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'CONTRIBUTOR_PUBLICATION_REMOVED',
+          resource: 'contributor',
+        }),
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Role guard
+  // -----------------------------------------------------------------------
+
+  describe('role guard', () => {
+    it('createWithAudit calls assertBusinessOpsOrAdmin', async () => {
+      mockTx.insert = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([fakeContributor]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await contributorService.createWithAudit(ctx, { displayName: 'Test' });
+      expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
+    });
+
+    it('deleteWithAudit calls assertBusinessOpsOrAdmin', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeContributor]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await contributorService.deleteWithAudit(ctx, CONTRIBUTOR_ID);
+      expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
+    });
+
+    it('addPublicationWithAudit calls assertBusinessOpsOrAdmin', async () => {
+      mockTx.insert = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([fakePub]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await contributorService.addPublicationWithAudit(ctx, {
+        contributorId: CONTRIBUTOR_ID,
+        pipelineItemId: 'pi-1',
+        role: 'author',
+        displayOrder: 0,
+      });
+      expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
+    });
+  });
+});

--- a/apps/api/src/services/contributor.service.ts
+++ b/apps/api/src/services/contributor.service.ts
@@ -1,6 +1,7 @@
 import {
   contributors,
   contributorPublications,
+  pipelineItems,
   eq,
   and,
   type DrizzleDb,
@@ -39,6 +40,15 @@ export class ContributorPublicationDuplicateError extends Error {
   constructor() {
     super('This contributor already has this role on this publication');
     this.name = 'ContributorPublicationDuplicateError';
+  }
+}
+
+export class PipelineItemNotInOrgError extends Error {
+  constructor(pipelineItemId: string) {
+    super(
+      `Pipeline item "${pipelineItemId}" does not belong to this organization`,
+    );
+    this.name = 'PipelineItemNotInOrgError';
   }
 }
 
@@ -269,6 +279,19 @@ export const contributorService = {
     input: AddContributorPublicationInput,
   ) {
     assertBusinessOpsOrAdmin(ctx.actor.roles);
+
+    // Defense-in-depth: verify pipeline item belongs to current org
+    const [item] = await ctx.tx
+      .select({ id: pipelineItems.id })
+      .from(pipelineItems)
+      .where(
+        and(
+          eq(pipelineItems.id, input.pipelineItemId),
+          eq(pipelineItems.organizationId, ctx.actor.orgId),
+        ),
+      )
+      .limit(1);
+    if (!item) throw new PipelineItemNotInOrgError(input.pipelineItemId);
 
     try {
       const [pub] = await ctx.tx

--- a/apps/api/src/services/contributor.service.ts
+++ b/apps/api/src/services/contributor.service.ts
@@ -1,0 +1,332 @@
+import {
+  contributors,
+  contributorPublications,
+  eq,
+  and,
+  type DrizzleDb,
+} from '@colophony/db';
+import { ilike, count } from 'drizzle-orm';
+import type {
+  CreateContributorInput,
+  UpdateContributorInput,
+  ListContributorsInput,
+  AddContributorPublicationInput,
+  RemoveContributorPublicationInput,
+} from '@colophony/types';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { ServiceContext } from './types.js';
+import { assertBusinessOpsOrAdmin } from './errors.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class ContributorNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Contributor "${id}" not found`);
+    this.name = 'ContributorNotFoundError';
+  }
+}
+
+export class ContributorAlreadyLinkedError extends Error {
+  constructor(userId: string) {
+    super(`A contributor is already linked to user "${userId}" in this org`);
+    this.name = 'ContributorAlreadyLinkedError';
+  }
+}
+
+export class ContributorPublicationDuplicateError extends Error {
+  constructor() {
+    super('This contributor already has this role on this publication');
+    this.name = 'ContributorPublicationDuplicateError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const contributorService = {
+  // -------------------------------------------------------------------------
+  // Pure data methods
+  // -------------------------------------------------------------------------
+
+  async list(tx: DrizzleDb, input: ListContributorsInput, orgId: string) {
+    const { search, page, limit } = input;
+    const offset = (page - 1) * limit;
+
+    const conditions = [eq(contributors.organizationId, orgId)];
+
+    if (search) {
+      conditions.push(ilike(contributors.displayName, `%${search}%`));
+    }
+
+    const where = and(...conditions);
+
+    const [items, [{ total }]] = await Promise.all([
+      tx
+        .select()
+        .from(contributors)
+        .where(where)
+        .orderBy(contributors.displayName)
+        .limit(limit)
+        .offset(offset),
+      tx.select({ total: count() }).from(contributors).where(where),
+    ]);
+
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async getById(tx: DrizzleDb, id: string, orgId: string) {
+    const [row] = await tx
+      .select()
+      .from(contributors)
+      .where(
+        and(eq(contributors.id, id), eq(contributors.organizationId, orgId)),
+      )
+      .limit(1);
+    return row ?? null;
+  },
+
+  async getByUserId(tx: DrizzleDb, userId: string, orgId: string) {
+    const [row] = await tx
+      .select()
+      .from(contributors)
+      .where(
+        and(
+          eq(contributors.userId, userId),
+          eq(contributors.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  },
+
+  async listPublications(tx: DrizzleDb, contributorId: string) {
+    return tx
+      .select()
+      .from(contributorPublications)
+      .where(eq(contributorPublications.contributorId, contributorId))
+      .orderBy(contributorPublications.displayOrder);
+  },
+
+  // -------------------------------------------------------------------------
+  // Audit-wrapped methods
+  // -------------------------------------------------------------------------
+
+  async createWithAudit(ctx: ServiceContext, input: CreateContributorInput) {
+    assertBusinessOpsOrAdmin(ctx.actor.roles);
+
+    // If linking to a user, check for existing link
+    if (input.userId) {
+      const existing = await contributorService.getByUserId(
+        ctx.tx,
+        input.userId,
+        ctx.actor.orgId,
+      );
+      if (existing) {
+        throw new ContributorAlreadyLinkedError(input.userId);
+      }
+    }
+
+    const [contributor] = await ctx.tx
+      .insert(contributors)
+      .values({
+        organizationId: ctx.actor.orgId,
+        displayName: input.displayName,
+        bio: input.bio ?? null,
+        pronouns: input.pronouns ?? null,
+        email: input.email ?? null,
+        website: input.website ?? null,
+        mailingAddress: input.mailingAddress ?? null,
+        notes: input.notes ?? null,
+        userId: input.userId ?? null,
+      })
+      .returning();
+
+    await ctx.audit({
+      action: AuditActions.CONTRIBUTOR_CREATED,
+      resource: AuditResources.CONTRIBUTOR,
+      resourceId: contributor.id,
+      newValue: {
+        displayName: contributor.displayName,
+        userId: contributor.userId,
+      },
+    });
+
+    return contributor;
+  },
+
+  async updateWithAudit(ctx: ServiceContext, input: UpdateContributorInput) {
+    assertBusinessOpsOrAdmin(ctx.actor.roles);
+
+    const existing = await contributorService.getById(
+      ctx.tx,
+      input.id,
+      ctx.actor.orgId,
+    );
+    if (!existing) throw new ContributorNotFoundError(input.id);
+
+    // Check userId link changes
+    const userIdChanging =
+      input.userId !== undefined && input.userId !== existing.userId;
+
+    if (userIdChanging && input.userId) {
+      const linkedToOther = await contributorService.getByUserId(
+        ctx.tx,
+        input.userId,
+        ctx.actor.orgId,
+      );
+      if (linkedToOther && linkedToOther.id !== existing.id) {
+        throw new ContributorAlreadyLinkedError(input.userId);
+      }
+    }
+
+    // Build update payload excluding id and undefined values
+    const updateData: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(input)) {
+      if (key !== 'id' && value !== undefined) {
+        updateData[key] = value;
+      }
+    }
+
+    const [updated] = await ctx.tx
+      .update(contributors)
+      .set(updateData)
+      .where(
+        and(
+          eq(contributors.id, input.id),
+          eq(contributors.organizationId, ctx.actor.orgId),
+        ),
+      )
+      .returning();
+
+    await ctx.audit({
+      action: AuditActions.CONTRIBUTOR_UPDATED,
+      resource: AuditResources.CONTRIBUTOR,
+      resourceId: input.id,
+      oldValue: { displayName: existing.displayName, userId: existing.userId },
+      newValue: { displayName: updated.displayName, userId: updated.userId },
+    });
+
+    // Audit link/unlink separately
+    if (userIdChanging) {
+      if (existing.userId && !input.userId) {
+        await ctx.audit({
+          action: AuditActions.CONTRIBUTOR_UNLINKED,
+          resource: AuditResources.CONTRIBUTOR,
+          resourceId: input.id,
+          oldValue: { userId: existing.userId },
+        });
+      } else if (input.userId) {
+        await ctx.audit({
+          action: AuditActions.CONTRIBUTOR_LINKED,
+          resource: AuditResources.CONTRIBUTOR,
+          resourceId: input.id,
+          newValue: { userId: input.userId },
+        });
+      }
+    }
+
+    return updated;
+  },
+
+  async deleteWithAudit(ctx: ServiceContext, id: string) {
+    assertBusinessOpsOrAdmin(ctx.actor.roles);
+
+    const existing = await contributorService.getById(
+      ctx.tx,
+      id,
+      ctx.actor.orgId,
+    );
+    if (!existing) throw new ContributorNotFoundError(id);
+
+    await ctx.tx
+      .delete(contributors)
+      .where(
+        and(
+          eq(contributors.id, id),
+          eq(contributors.organizationId, ctx.actor.orgId),
+        ),
+      );
+
+    await ctx.audit({
+      action: AuditActions.CONTRIBUTOR_DELETED,
+      resource: AuditResources.CONTRIBUTOR,
+      resourceId: id,
+      oldValue: { displayName: existing.displayName },
+    });
+  },
+
+  async addPublicationWithAudit(
+    ctx: ServiceContext,
+    input: AddContributorPublicationInput,
+  ) {
+    assertBusinessOpsOrAdmin(ctx.actor.roles);
+
+    try {
+      const [pub] = await ctx.tx
+        .insert(contributorPublications)
+        .values({
+          contributorId: input.contributorId,
+          pipelineItemId: input.pipelineItemId,
+          role: input.role,
+          displayOrder: input.displayOrder,
+        })
+        .returning();
+
+      await ctx.audit({
+        action: AuditActions.CONTRIBUTOR_PUBLICATION_ADDED,
+        resource: AuditResources.CONTRIBUTOR,
+        resourceId: input.contributorId,
+        newValue: {
+          pipelineItemId: input.pipelineItemId,
+          role: input.role,
+        },
+      });
+
+      return pub;
+    } catch (e: unknown) {
+      if (
+        e instanceof Error &&
+        e.message.includes('contributor_publications_contributor_item_role_idx')
+      ) {
+        throw new ContributorPublicationDuplicateError();
+      }
+      throw e;
+    }
+  },
+
+  async removePublicationWithAudit(
+    ctx: ServiceContext,
+    input: RemoveContributorPublicationInput,
+  ) {
+    assertBusinessOpsOrAdmin(ctx.actor.roles);
+
+    await ctx.tx
+      .delete(contributorPublications)
+      .where(
+        and(
+          eq(contributorPublications.contributorId, input.contributorId),
+          eq(contributorPublications.pipelineItemId, input.pipelineItemId),
+          eq(contributorPublications.role, input.role),
+        ),
+      );
+
+    await ctx.audit({
+      action: AuditActions.CONTRIBUTOR_PUBLICATION_REMOVED,
+      resource: AuditResources.CONTRIBUTOR,
+      resourceId: input.contributorId,
+      oldValue: {
+        pipelineItemId: input.pipelineItemId,
+        role: input.role,
+      },
+    });
+  },
+};

--- a/apps/api/src/services/errors.ts
+++ b/apps/api/src/services/errors.ts
@@ -64,3 +64,13 @@ export function assertEditorOrProductionOrAdmin(
     throw new ForbiddenError('Editor, production, or admin role required');
   }
 }
+
+/**
+ * Assert the caller has BUSINESS_OPS or ADMIN role.
+ * Throws {@link ForbiddenError} if the roles are insufficient.
+ */
+export function assertBusinessOpsOrAdmin(roles: readonly string[]): void {
+  if (!roles.some((r) => ['BUSINESS_OPS', 'ADMIN'].includes(r))) {
+    throw new ForbiddenError('Business Operations or admin role required');
+  }
+}

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -122,6 +122,7 @@ import {
   ContributorNotFoundError,
   ContributorAlreadyLinkedError,
   ContributorPublicationDuplicateError,
+  PipelineItemNotInOrgError,
 } from '../services/contributor.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
@@ -235,6 +236,7 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [ContributorNotFoundError, 'NOT_FOUND'],
   [ContributorAlreadyLinkedError, 'CONFLICT'],
   [ContributorPublicationDuplicateError, 'CONFLICT'],
+  [PipelineItemNotInOrgError, 'NOT_FOUND'],
 ];
 
 /**

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -118,6 +118,11 @@ import {
   InvitationAlreadyAcceptedError,
   InvitationEmailMismatchError,
 } from '../services/invitation.service.js';
+import {
+  ContributorNotFoundError,
+  ContributorAlreadyLinkedError,
+  ContributorPublicationDuplicateError,
+} from '../services/contributor.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -226,6 +231,10 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [InvitationExpiredError, 'NOT_FOUND'],
   [InvitationAlreadyAcceptedError, 'CONFLICT'],
   [InvitationEmailMismatchError, 'FORBIDDEN'],
+  // Contributor errors
+  [ContributorNotFoundError, 'NOT_FOUND'],
+  [ContributorAlreadyLinkedError, 'CONFLICT'],
+  [ContributorPublicationDuplicateError, 'CONFLICT'],
 ];
 
 /**

--- a/apps/api/src/trpc/init.ts
+++ b/apps/api/src/trpc/init.ts
@@ -168,6 +168,38 @@ const isProduction = t.middleware(({ ctx, next }) => {
   });
 });
 
+/** Requires BUSINESS_OPS or ADMIN role. */
+const isBusinessOps = t.middleware(({ ctx, next }) => {
+  if (!ctx.authContext) {
+    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
+  }
+  if (!ctx.authContext.orgId || !ctx.authContext.roles?.length) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'X-Organization-Id header is required',
+    });
+  }
+  if (!hasRole(ctx.authContext.roles, 'BUSINESS_OPS', 'ADMIN')) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Business Operations or Admin role required',
+    });
+  }
+  if (!ctx.dbTx) {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Database transaction not available',
+    });
+  }
+  return next({
+    ctx: {
+      ...ctx,
+      authContext: ctx.authContext as OrgAuthContext,
+      dbTx: ctx.dbTx,
+    },
+  });
+});
+
 /**
  * Factory: returns tRPC middleware that enforces API key scopes.
  * OIDC/test auth bypasses the check (scopes are API-key-only).
@@ -227,5 +259,6 @@ export const orgProcedure = t.procedure.use(hasOrgContext);
 export const editorProcedure = t.procedure.use(isEditor);
 export const productionProcedure = t.procedure.use(isProduction);
 export const adminProcedure = t.procedure.use(isAdmin);
+export const businessOpsProcedure = t.procedure.use(isBusinessOps);
 export const createRouter = t.router;
 export const mergeRouters = t.mergeRouters;

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -35,6 +35,7 @@ import { migrationRouter } from './routers/migration.js';
 import { hubRouter } from './routers/hub.js';
 import { collectionsRouter } from './routers/collections.js';
 import { opsRouter } from './routers/ops.js';
+import { contributorsRouter } from './routers/contributors.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -42,6 +43,7 @@ export {
   authedProcedure,
   orgProcedure,
   adminProcedure,
+  businessOpsProcedure,
   createRouter,
   mergeRouters,
 } from './init.js';
@@ -91,6 +93,7 @@ export const appRouter = t.router({
   hub: hubRouter,
   collections: collectionsRouter,
   ops: opsRouter,
+  contributors: contributorsRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/contributors.ts
+++ b/apps/api/src/trpc/routers/contributors.ts
@@ -1,0 +1,144 @@
+import { z } from 'zod';
+import {
+  contributorSchema,
+  contributorPublicationSchema,
+  createContributorSchema,
+  updateContributorSchema,
+  listContributorsSchema,
+  addContributorPublicationSchema,
+  removeContributorPublicationSchema,
+  idParamSchema,
+  paginatedResponseSchema,
+} from '@colophony/types';
+import {
+  orgProcedure,
+  businessOpsProcedure,
+  createRouter,
+  requireScopes,
+} from '../init.js';
+import { contributorService } from '../../services/contributor.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+
+export const contributorsRouter = createRouter({
+  /** List contributors for the current org. */
+  list: orgProcedure
+    .use(requireScopes('contributors:read'))
+    .input(listContributorsSchema)
+    .output(paginatedResponseSchema(contributorSchema))
+    .query(async ({ ctx, input }) => {
+      return contributorService.list(ctx.dbTx, input, ctx.authContext.orgId);
+    }),
+
+  /** Get a contributor by ID. */
+  getById: orgProcedure
+    .use(requireScopes('contributors:read'))
+    .input(idParamSchema)
+    .output(contributorSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        const contributor = await contributorService.getById(
+          ctx.dbTx,
+          input.id,
+          ctx.authContext.orgId,
+        );
+        if (!contributor) {
+          const { ContributorNotFoundError } =
+            await import('../../services/contributor.service.js');
+          throw new ContributorNotFoundError(input.id);
+        }
+        return contributor;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Create a new contributor. */
+  create: businessOpsProcedure
+    .use(requireScopes('contributors:write'))
+    .input(createContributorSchema)
+    .output(contributorSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await contributorService.createWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Update an existing contributor. */
+  update: businessOpsProcedure
+    .use(requireScopes('contributors:write'))
+    .input(updateContributorSchema)
+    .output(contributorSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await contributorService.updateWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Delete a contributor. */
+  delete: businessOpsProcedure
+    .use(requireScopes('contributors:write'))
+    .input(idParamSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        await contributorService.deleteWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
+        return { success: true };
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Add a publication credit for a contributor. */
+  addPublication: businessOpsProcedure
+    .use(requireScopes('contributors:write'))
+    .input(addContributorPublicationSchema)
+    .output(contributorPublicationSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await contributorService.addPublicationWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Remove a publication credit from a contributor. */
+  removePublication: businessOpsProcedure
+    .use(requireScopes('contributors:write'))
+    .input(removeContributorPublicationSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        await contributorService.removePublicationWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+        return { success: true };
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** List publication credits for a contributor. */
+  listPublications: orgProcedure
+    .use(requireScopes('contributors:read'))
+    .input(z.object({ contributorId: z.string().uuid() }))
+    .output(z.array(contributorPublicationSchema))
+    .query(async ({ ctx, input }) => {
+      return contributorService.listPublications(ctx.dbTx, input.contributorId);
+    }),
+});

--- a/apps/api/src/trpc/routers/contributors.ts
+++ b/apps/api/src/trpc/routers/contributors.ts
@@ -10,19 +10,14 @@ import {
   idParamSchema,
   paginatedResponseSchema,
 } from '@colophony/types';
-import {
-  orgProcedure,
-  businessOpsProcedure,
-  createRouter,
-  requireScopes,
-} from '../init.js';
+import { businessOpsProcedure, createRouter, requireScopes } from '../init.js';
 import { contributorService } from '../../services/contributor.service.js';
 import { toServiceContext } from '../../services/context.js';
 import { mapServiceError } from '../error-mapper.js';
 
 export const contributorsRouter = createRouter({
   /** List contributors for the current org. */
-  list: orgProcedure
+  list: businessOpsProcedure
     .use(requireScopes('contributors:read'))
     .input(listContributorsSchema)
     .output(paginatedResponseSchema(contributorSchema))
@@ -31,7 +26,7 @@ export const contributorsRouter = createRouter({
     }),
 
   /** Get a contributor by ID. */
-  getById: orgProcedure
+  getById: businessOpsProcedure
     .use(requireScopes('contributors:read'))
     .input(idParamSchema)
     .output(contributorSchema)
@@ -134,7 +129,7 @@ export const contributorsRouter = createRouter({
     }),
 
   /** List publication credits for a contributor. */
-  listPublications: orgProcedure
+  listPublications: businessOpsProcedure
     .use(requireScopes('contributors:read'))
     .input(z.object({ contributorId: z.string().uuid() }))
     .output(z.array(contributorPublicationSchema))

--- a/apps/web/src/app/(dashboard)/business/contributors/page.tsx
+++ b/apps/web/src/app/(dashboard)/business/contributors/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { trpc } from "@/lib/trpc";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export default function ContributorsPage() {
+  const { data, isPending: isLoading } = trpc.contributors.list.useQuery({
+    page: 1,
+    limit: 20,
+  });
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold mb-4">Contributors</h1>
+
+      {isLoading && <p className="text-muted-foreground">Loading...</p>}
+
+      {data && data.items.length === 0 && (
+        <p className="text-muted-foreground">
+          No contributors yet. Contributors link authors, translators, and other
+          creatives to their published works.
+        </p>
+      )}
+
+      {data && data.items.length > 0 && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Pronouns</TableHead>
+              <TableHead>Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.items.map((c) => (
+              <TableRow key={c.id}>
+                <TableCell className="font-medium">{c.displayName}</TableCell>
+                <TableCell>{c.email ?? "—"}</TableCell>
+                <TableCell>{c.pronouns ?? "—"}</TableCell>
+                <TableCell>
+                  {new Date(c.createdAt).toLocaleDateString()}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/business/page.tsx
+++ b/apps/web/src/app/(dashboard)/business/page.tsx
@@ -1,0 +1,10 @@
+export default function BusinessDashboardPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold mb-4">Business Operations</h1>
+      <p className="text-muted-foreground">
+        Contributor management, rights agreements, and payment tracking.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/business/payments/page.tsx
+++ b/apps/web/src/app/(dashboard)/business/payments/page.tsx
@@ -1,0 +1,11 @@
+export default function PaymentsPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold mb-4">Payments</h1>
+      <p className="text-muted-foreground">
+        Submission fees, contributor payments, and contest prizes — all
+        transaction types in one place.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/business/rights/page.tsx
+++ b/apps/web/src/app/(dashboard)/business/rights/page.tsx
@@ -1,0 +1,11 @@
+export default function RightsPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold mb-4">Rights Agreements</h1>
+      <p className="text-muted-foreground">
+        Track intellectual property rights, reversion dates, and agreement
+        status for published works.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -42,14 +42,16 @@ export function useCommandPalette() {
 }
 
 function roleCheck(
-  role: "editor" | "production" | "admin" | null,
+  role: "editor" | "production" | "business_ops" | "admin" | null,
   isEditor: boolean,
   isProduction: boolean,
+  isBusinessOps: boolean,
   isAdmin: boolean,
 ): boolean {
   if (role === null) return true;
   if (role === "editor") return isEditor;
   if (role === "production") return isProduction;
+  if (role === "business_ops") return isBusinessOps;
   if (role === "admin") return isAdmin;
   return false;
 }
@@ -62,7 +64,7 @@ export function CommandPaletteProvider({
   const [open, setOpen] = useState(false);
   const [overlayOpen, setOverlayOpen] = useState(false);
   const router = useRouter();
-  const { isEditor, isProduction, isAdmin } = useOrganization();
+  const { isEditor, isProduction, isBusinessOps, isAdmin } = useOrganization();
 
   const mod = modifierKey();
 
@@ -112,7 +114,9 @@ export function CommandPaletteProvider({
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
           {navGroups
-            .filter((g) => roleCheck(g.role, isEditor, isProduction, isAdmin))
+            .filter((g) =>
+              roleCheck(g.role, isEditor, isProduction, isBusinessOps, isAdmin),
+            )
             .map((group) => (
               <CommandGroup key={group.label} heading={group.label}>
                 {group.items.map((item: NavItem) => (

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   writingNavigation,
   editorialNavigation,
   productionNavigation,
+  businessNavigation,
   operationsNavigation,
   type NavItem,
 } from "@/lib/navigation";
@@ -73,7 +74,7 @@ function NavGroup({
 
 export function Sidebar() {
   const pathname = usePathname();
-  const { isEditor, isProduction, isAdmin } = useOrganization();
+  const { isEditor, isProduction, isBusinessOps, isAdmin } = useOrganization();
 
   return (
     <div className="flex flex-col h-full bg-background">
@@ -105,6 +106,14 @@ export function Sidebar() {
           <NavGroup
             label="Production"
             items={productionNavigation}
+            pathname={pathname}
+          />
+        )}
+
+        {isBusinessOps && (
+          <NavGroup
+            label="Business"
+            items={businessNavigation}
             pathname={pathname}
           />
         )}

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -7,6 +7,8 @@ import {
   Building2,
   Calendar,
   ClipboardList,
+  DollarSign,
+  FileCheck,
   FileSignature,
   FileText,
   FolderOpen,
@@ -21,6 +23,7 @@ import {
   Send,
   Settings,
   Upload,
+  Users,
   Webhook,
 } from "lucide-react";
 
@@ -65,6 +68,13 @@ export const productionNavigation: NavItem[] = [
   { name: "CMS", href: "/slate/cms", icon: Globe },
 ];
 
+export const businessNavigation: NavItem[] = [
+  { name: "Business Dashboard", href: "/business", icon: LayoutDashboard },
+  { name: "Contributors", href: "/business/contributors", icon: Users },
+  { name: "Rights", href: "/business/rights", icon: FileCheck },
+  { name: "Payments", href: "/business/payments", icon: DollarSign },
+];
+
 export const operationsNavigation: NavItem[] = [
   {
     name: "Dashboard",
@@ -96,6 +106,11 @@ export const navGroups = [
     label: "Production",
     items: productionNavigation,
     role: "production" as const,
+  },
+  {
+    label: "Business",
+    items: businessNavigation,
+    role: "business_ops" as const,
   },
   {
     label: "Operations",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -502,16 +502,16 @@
 
 ## Track 13 — Business Operations (Post-Launch)
 
-> **Status:** Planned. Contributor record is the foundational entity; all other items depend on it.
+> **Status:** Foundation shipped. Schema, middleware, contributor service, and sidebar in PR. Rights/revenue services next.
 
 ### Code
 
-- [ ] [P1] `contributors` + `contributor_publications` schema — org-scoped contributor entity linking submissions, publications, payments, rights. Columns: display_name, bio, pronouns, website, mailing_address (encrypted), notes — (design system session 2026-03-28)
-- [ ] [P1] `rights_agreements` schema — per-published-piece IP ownership lifecycle (first_north_american_serial, electronic, anthology, audio, translation, custom). Status: draft → sent → signed → active → reverted. Reversion date tracking. Separate from Documenso `contracts` table — (design system session 2026-03-28)
-- [ ] [P1] `payment_transactions` schema — unified payment table with type discriminator (submission_fee, contest_fee, contributor_payment). Extends beyond current submission-fee-only `payments` table — (design system session 2026-03-28)
-- [ ] [P1] `businessOpsProcedure` middleware — BUSINESS_OPS or ADMIN role check, following existing procedure pattern in `apps/api/src/trpc/init.ts` — (design system session 2026-03-28)
-- [ ] [P1] Business Ops nav group + sidebar rendering — new "Business" activity group visible to BUSINESS_OPS/ADMIN with compact density `BusinessLayout` — (design system session 2026-03-28)
-- [ ] [P1] Contributor service + tRPC router — CRUD, link to submissions/users, publication history, detail view with all submissions/publications/payments/rights/correspondence — (design system session 2026-03-28)
+- [x] [P1] `contributors` + `contributor_publications` schema — org-scoped contributor entity linking submissions, publications, payments, rights. Columns: display_name, bio, pronouns, website, mailing_address (plain text, app-level encryption deferred), notes — (design system session 2026-03-28; done 2026-03-28)
+- [x] [P1] `rights_agreements` schema — per-published-piece IP ownership lifecycle (first_north_american_serial, electronic, anthology, audio, translation, custom). Status: draft → sent → signed → active → reverted. Reversion date tracking. Separate from Documenso `contracts` table — (design system session 2026-03-28; done 2026-03-28)
+- [x] [P1] `payment_transactions` schema — unified payment table with type discriminator (submission_fee, contest_fee, contributor_payment). New table, not extending existing `payments` — (design system session 2026-03-28; done 2026-03-28)
+- [x] [P1] `businessOpsProcedure` middleware — BUSINESS_OPS or ADMIN role check, following existing procedure pattern in `apps/api/src/trpc/init.ts` — (design system session 2026-03-28; done 2026-03-28)
+- [x] [P1] Business Ops nav group + sidebar rendering — new "Business" activity group visible to BUSINESS_OPS/ADMIN, command palette updated — (design system session 2026-03-28; done 2026-03-28)
+- [x] [P1] Contributor service + tRPC router — CRUD, link to submissions/users, publication add/remove, 8 procedures with audit + scope enforcement. Detail view deferred to next PR — (design system session 2026-03-28; done 2026-03-28)
 - [ ] [P1] Rights service — lifecycle management, reversion alerts ("3 rights agreements reverting in 30 days"), integration with production pipeline — (design system session 2026-03-28)
 - [ ] [P1] Revenue service — submission fees (existing Stripe), contributor payments, contest prizes, revenue reporting — (design system session 2026-03-28)
 - [ ] [P2] Business Ops dashboard — health card grid pattern with contributor count, outstanding payments, upcoming reversions, revenue summary — (design system session 2026-03-28)

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,31 @@ Newest entries first.
 
 ---
 
+## 2026-03-28 — Business Operations Foundation (Track 13)
+
+### Done
+
+- Track 13 foundation PR: 4 new tables, 5 enums, migration 0063 with full RLS
+- Schema: `contributors` (org-scoped, optional user link), `contributor_publications` (join with role discriminator), `rights_agreements` (IP lifecycle with reversion dates), `payment_transactions` (unified type-discriminated table, separate from Stripe `payments`)
+- `businessOpsProcedure` middleware (BUSINESS_OPS or ADMIN role) in `apps/api/src/trpc/init.ts`
+- `contributorService` — full CRUD with audit logging, user link/unlink tracking, publication add/remove
+- `contributorsRouter` — 8 tRPC procedures with requireScopes enforcement
+- Business nav group in sidebar and command palette (role-gated to BUSINESS_OPS/ADMIN)
+- 4 placeholder pages: dashboard, contributors (with tRPC list query), rights, payments
+- 3 new Zod type files, 20 audit actions, 4 resources, 6 API key scopes
+- 14 unit tests for contributor service, RLS isolation test for all 4 new tables
+- Codex plan review: 2 Important findings addressed (command palette role filter, RLS test location)
+
+### Decisions
+
+- mailing_address stored as plain text — defer app-level encryption as cross-cutting concern (full-disk + RLS adequate)
+- payment_transactions as new table, not extending existing payments (Stripe webhook coupling)
+- contributor_publications join table with role enum (author/translator/illustrator/photographer/editor) + display order
+- Rights types as pgEnum: first_north_american_serial, electronic, anthology, audio, translation, custom
+- PR scope: foundation only; rights/revenue services, dashboard UI, editorial analytics deferred
+
+---
+
 ## 2026-03-28 — Copyedit Stage Manual Round-Trip
 
 ### Done

--- a/packages/db/migrations/0063_business_ops_foundation.sql
+++ b/packages/db/migrations/0063_business_ops_foundation.sql
@@ -1,0 +1,203 @@
+-- Business Operations Foundation
+-- New tables: contributors, contributor_publications, rights_agreements, payment_transactions
+
+--> statement-breakpoint
+CREATE TYPE "public"."ContributorPublicationRole" AS ENUM('author', 'translator', 'illustrator', 'photographer', 'editor');
+
+--> statement-breakpoint
+CREATE TYPE "public"."RightsType" AS ENUM('first_north_american_serial', 'electronic', 'anthology', 'audio', 'translation', 'custom');
+
+--> statement-breakpoint
+CREATE TYPE "public"."RightsAgreementStatus" AS ENUM('DRAFT', 'SENT', 'SIGNED', 'ACTIVE', 'REVERTED');
+
+--> statement-breakpoint
+CREATE TYPE "public"."PaymentTransactionType" AS ENUM('submission_fee', 'contest_fee', 'contributor_payment');
+
+--> statement-breakpoint
+CREATE TYPE "public"."PaymentTransactionDirection" AS ENUM('inbound', 'outbound');
+
+--> statement-breakpoint
+CREATE TABLE "contributors" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "user_id" uuid REFERENCES "users"("id") ON DELETE SET NULL,
+  "display_name" varchar(255) NOT NULL,
+  "bio" text,
+  "pronouns" varchar(100),
+  "email" varchar(320),
+  "website" varchar(2048),
+  "mailing_address" text,
+  "notes" text,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+--> statement-breakpoint
+CREATE TABLE "contributor_publications" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "contributor_id" uuid NOT NULL REFERENCES "contributors"("id") ON DELETE CASCADE,
+  "pipeline_item_id" uuid NOT NULL REFERENCES "pipeline_items"("id") ON DELETE CASCADE,
+  "role" "ContributorPublicationRole" NOT NULL DEFAULT 'author',
+  "display_order" integer NOT NULL DEFAULT 0,
+  "created_at" timestamptz NOT NULL DEFAULT now()
+);
+
+--> statement-breakpoint
+CREATE TABLE "rights_agreements" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "contributor_id" uuid NOT NULL REFERENCES "contributors"("id") ON DELETE RESTRICT,
+  "pipeline_item_id" uuid REFERENCES "pipeline_items"("id") ON DELETE SET NULL,
+  "rights_type" "RightsType" NOT NULL,
+  "custom_description" text,
+  "status" "RightsAgreementStatus" NOT NULL DEFAULT 'DRAFT',
+  "granted_at" timestamptz,
+  "expires_at" timestamptz,
+  "reverted_at" timestamptz,
+  "notes" text,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+--> statement-breakpoint
+CREATE TABLE "payment_transactions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "contributor_id" uuid REFERENCES "contributors"("id") ON DELETE SET NULL,
+  "submission_id" uuid REFERENCES "submissions"("id") ON DELETE SET NULL,
+  "payment_id" uuid REFERENCES "payments"("id") ON DELETE SET NULL,
+  "type" "PaymentTransactionType" NOT NULL,
+  "direction" "PaymentTransactionDirection" NOT NULL,
+  "amount" integer NOT NULL,
+  "currency" varchar(3) NOT NULL DEFAULT 'usd',
+  "status" "PaymentStatus" NOT NULL DEFAULT 'PENDING',
+  "description" text,
+  "metadata" jsonb DEFAULT '{}',
+  "processed_at" timestamptz,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+--> statement-breakpoint
+CREATE INDEX "contributors_organization_id_idx" ON "contributors" ("organization_id");
+
+--> statement-breakpoint
+CREATE INDEX "contributors_user_id_idx" ON "contributors" ("user_id");
+
+--> statement-breakpoint
+CREATE INDEX "contributors_org_name_idx" ON "contributors" ("organization_id", "display_name");
+
+--> statement-breakpoint
+CREATE INDEX "contributor_publications_contributor_id_idx" ON "contributor_publications" ("contributor_id");
+
+--> statement-breakpoint
+CREATE INDEX "contributor_publications_pipeline_item_id_idx" ON "contributor_publications" ("pipeline_item_id");
+
+--> statement-breakpoint
+CREATE UNIQUE INDEX "contributor_publications_contributor_item_role_idx" ON "contributor_publications" ("contributor_id", "pipeline_item_id", "role");
+
+--> statement-breakpoint
+CREATE INDEX "rights_agreements_organization_id_idx" ON "rights_agreements" ("organization_id");
+
+--> statement-breakpoint
+CREATE INDEX "rights_agreements_contributor_id_idx" ON "rights_agreements" ("contributor_id");
+
+--> statement-breakpoint
+CREATE INDEX "rights_agreements_pipeline_item_id_idx" ON "rights_agreements" ("pipeline_item_id");
+
+--> statement-breakpoint
+CREATE INDEX "rights_agreements_org_status_idx" ON "rights_agreements" ("organization_id", "status");
+
+--> statement-breakpoint
+CREATE INDEX "rights_agreements_org_expires_idx" ON "rights_agreements" ("organization_id", "expires_at");
+
+--> statement-breakpoint
+CREATE INDEX "payment_transactions_organization_id_idx" ON "payment_transactions" ("organization_id");
+
+--> statement-breakpoint
+CREATE INDEX "payment_transactions_contributor_id_idx" ON "payment_transactions" ("contributor_id");
+
+--> statement-breakpoint
+CREATE INDEX "payment_transactions_submission_id_idx" ON "payment_transactions" ("submission_id");
+
+--> statement-breakpoint
+CREATE INDEX "payment_transactions_payment_id_idx" ON "payment_transactions" ("payment_id");
+
+--> statement-breakpoint
+CREATE INDEX "payment_transactions_org_type_idx" ON "payment_transactions" ("organization_id", "type");
+
+--> statement-breakpoint
+CREATE INDEX "payment_transactions_org_status_idx" ON "payment_transactions" ("organization_id", "status");
+
+--> statement-breakpoint
+CREATE INDEX "payment_transactions_metadata_gin_idx" ON "payment_transactions" USING gin ("metadata" jsonb_path_ops);
+
+--> statement-breakpoint
+ALTER TABLE "contributors" ENABLE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+ALTER TABLE "contributors" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+ALTER TABLE "contributor_publications" ENABLE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+ALTER TABLE "contributor_publications" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+ALTER TABLE "rights_agreements" ENABLE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+ALTER TABLE "rights_agreements" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+ALTER TABLE "payment_transactions" ENABLE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+ALTER TABLE "payment_transactions" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+CREATE POLICY "contributors_org_isolation"
+  ON "contributors"
+  FOR ALL
+  USING (organization_id = current_org_id())
+  WITH CHECK (organization_id = current_org_id());
+
+--> statement-breakpoint
+CREATE POLICY "contributor_publications_org_isolation"
+  ON "contributor_publications"
+  FOR ALL
+  USING (contributor_id IN (
+    SELECT id FROM contributors
+    WHERE organization_id = current_org_id()
+  ))
+  WITH CHECK (contributor_id IN (
+    SELECT id FROM contributors
+    WHERE organization_id = current_org_id()
+  ));
+
+--> statement-breakpoint
+CREATE POLICY "rights_agreements_org_isolation"
+  ON "rights_agreements"
+  FOR ALL
+  USING (organization_id = current_org_id())
+  WITH CHECK (organization_id = current_org_id());
+
+--> statement-breakpoint
+CREATE POLICY "payment_transactions_org_isolation"
+  ON "payment_transactions"
+  FOR ALL
+  USING (organization_id = current_org_id())
+  WITH CHECK (organization_id = current_org_id());
+
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON "contributors" TO app_user;
+
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON "contributor_publications" TO app_user;
+
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON "rights_agreements" TO app_user;
+
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON "payment_transactions" TO app_user;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1781600000000,
       "tag": "0062_fix_accept_invitation_ambiguous_column",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1781800000000,
+      "tag": "0063_business_ops_foundation",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/business-ops.ts
+++ b/packages/db/src/schema/business-ops.ts
@@ -1,0 +1,213 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  text,
+  integer,
+  jsonb,
+  timestamp,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import {
+  contributorPublicationRoleEnum,
+  rightsTypeEnum,
+  rightsAgreementStatusEnum,
+  paymentTransactionTypeEnum,
+  paymentTransactionDirectionEnum,
+  paymentStatusEnum,
+} from "./enums";
+import { organizations } from "./organizations";
+import { users } from "./users";
+import { pipelineItems } from "./pipeline";
+import { submissions } from "./submissions";
+import { payments } from "./payments";
+
+const orgIsolationPolicy = pgPolicy("org_isolation", {
+  for: "all",
+  using: sql`organization_id = current_org_id()`,
+});
+
+// --- contributors ---
+
+export const contributors = pgTable(
+  "contributors",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    userId: uuid("user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    displayName: varchar("display_name", { length: 255 }).notNull(),
+    bio: text("bio"),
+    pronouns: varchar("pronouns", { length: 100 }),
+    email: varchar("email", { length: 320 }),
+    website: varchar("website", { length: 2048 }),
+    // Sensitive field — full-disk encryption + RLS provides baseline protection.
+    // Application-level column encryption deferred as a cross-cutting concern.
+    mailingAddress: text("mailing_address"),
+    notes: text("notes"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("contributors_organization_id_idx").on(table.organizationId),
+    index("contributors_user_id_idx").on(table.userId),
+    index("contributors_org_name_idx").on(
+      table.organizationId,
+      table.displayName,
+    ),
+    orgIsolationPolicy,
+  ],
+).enableRLS();
+
+// --- contributor_publications ---
+
+export const contributorPublications = pgTable(
+  "contributor_publications",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    contributorId: uuid("contributor_id")
+      .notNull()
+      .references(() => contributors.id, { onDelete: "cascade" }),
+    pipelineItemId: uuid("pipeline_item_id")
+      .notNull()
+      .references(() => pipelineItems.id, { onDelete: "cascade" }),
+    role: contributorPublicationRoleEnum("role").notNull().default("author"),
+    displayOrder: integer("display_order").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("contributor_publications_contributor_id_idx").on(
+      table.contributorId,
+    ),
+    index("contributor_publications_pipeline_item_id_idx").on(
+      table.pipelineItemId,
+    ),
+    uniqueIndex("contributor_publications_contributor_item_role_idx").on(
+      table.contributorId,
+      table.pipelineItemId,
+      table.role,
+    ),
+    pgPolicy("contributor_publications_org_isolation", {
+      for: "all",
+      using: sql`contributor_id IN (
+        SELECT id FROM contributors
+        WHERE organization_id = current_org_id()
+      )`,
+    }),
+  ],
+).enableRLS();
+
+// --- rights_agreements ---
+
+export const rightsAgreements = pgTable(
+  "rights_agreements",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    contributorId: uuid("contributor_id")
+      .notNull()
+      .references(() => contributors.id, { onDelete: "restrict" }),
+    pipelineItemId: uuid("pipeline_item_id").references(
+      () => pipelineItems.id,
+      { onDelete: "set null" },
+    ),
+    rightsType: rightsTypeEnum("rights_type").notNull(),
+    customDescription: text("custom_description"),
+    status: rightsAgreementStatusEnum("status").notNull().default("DRAFT"),
+    grantedAt: timestamp("granted_at", { withTimezone: true }),
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+    revertedAt: timestamp("reverted_at", { withTimezone: true }),
+    notes: text("notes"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("rights_agreements_organization_id_idx").on(table.organizationId),
+    index("rights_agreements_contributor_id_idx").on(table.contributorId),
+    index("rights_agreements_pipeline_item_id_idx").on(table.pipelineItemId),
+    index("rights_agreements_org_status_idx").on(
+      table.organizationId,
+      table.status,
+    ),
+    index("rights_agreements_org_expires_idx").on(
+      table.organizationId,
+      table.expiresAt,
+    ),
+    orgIsolationPolicy,
+  ],
+).enableRLS();
+
+// --- payment_transactions ---
+
+export const paymentTransactions = pgTable(
+  "payment_transactions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    contributorId: uuid("contributor_id").references(() => contributors.id, {
+      onDelete: "set null",
+    }),
+    submissionId: uuid("submission_id").references(() => submissions.id, {
+      onDelete: "set null",
+    }),
+    paymentId: uuid("payment_id").references(() => payments.id, {
+      onDelete: "set null",
+    }),
+    type: paymentTransactionTypeEnum("type").notNull(),
+    direction: paymentTransactionDirectionEnum("direction").notNull(),
+    amount: integer("amount").notNull(),
+    currency: varchar("currency", { length: 3 }).notNull().default("usd"),
+    status: paymentStatusEnum("status").notNull().default("PENDING"),
+    description: text("description"),
+    metadata: jsonb("metadata").default({}),
+    processedAt: timestamp("processed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("payment_transactions_organization_id_idx").on(table.organizationId),
+    index("payment_transactions_contributor_id_idx").on(table.contributorId),
+    index("payment_transactions_submission_id_idx").on(table.submissionId),
+    index("payment_transactions_payment_id_idx").on(table.paymentId),
+    index("payment_transactions_org_type_idx").on(
+      table.organizationId,
+      table.type,
+    ),
+    index("payment_transactions_org_status_idx").on(
+      table.organizationId,
+      table.status,
+    ),
+    index("payment_transactions_metadata_gin_idx").using(
+      "gin",
+      sql`${table.metadata} jsonb_path_ops`,
+    ),
+    orgIsolationPolicy,
+  ],
+).enableRLS();

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -309,3 +309,40 @@ export const invitationStatusEnum = pgEnum("InvitationStatus", [
   "REVOKED",
   "EXPIRED",
 ]);
+
+// ---------------------------------------------------------------------------
+// Business Operations
+// ---------------------------------------------------------------------------
+
+export const contributorPublicationRoleEnum = pgEnum(
+  "ContributorPublicationRole",
+  ["author", "translator", "illustrator", "photographer", "editor"],
+);
+
+export const rightsTypeEnum = pgEnum("RightsType", [
+  "first_north_american_serial",
+  "electronic",
+  "anthology",
+  "audio",
+  "translation",
+  "custom",
+]);
+
+export const rightsAgreementStatusEnum = pgEnum("RightsAgreementStatus", [
+  "DRAFT",
+  "SENT",
+  "SIGNED",
+  "ACTIVE",
+  "REVERTED",
+]);
+
+export const paymentTransactionTypeEnum = pgEnum("PaymentTransactionType", [
+  "submission_fee",
+  "contest_fee",
+  "contributor_payment",
+]);
+
+export const paymentTransactionDirectionEnum = pgEnum(
+  "PaymentTransactionDirection",
+  ["inbound", "outbound"],
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -32,4 +32,5 @@ export * from "./email-templates";
 export * from "./saved-queue-presets";
 export * from "./workspace-collections";
 export * from "./invitations";
+export * from "./business-ops";
 export * from "./relations";

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -27,6 +27,12 @@ import {
 } from "./writer-workspace";
 import { savedQueuePresets } from "./saved-queue-presets";
 import { workspaceCollections, workspaceItems } from "./workspace-collections";
+import {
+  contributors,
+  contributorPublications,
+  rightsAgreements,
+  paymentTransactions,
+} from "./business-ops";
 
 // --- organizations ---
 
@@ -49,6 +55,9 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   trustedPeers: many(trustedPeers),
   savedQueuePresets: many(savedQueuePresets),
   workspaceCollections: many(workspaceCollections),
+  contributors: many(contributors),
+  rightsAgreements: many(rightsAgreements),
+  paymentTransactions: many(paymentTransactions),
 }));
 
 // --- users ---
@@ -560,3 +569,82 @@ export const workspaceItemsRelations = relations(workspaceItems, ({ one }) => ({
     references: [submissions.id],
   }),
 }));
+
+// --- contributors ---
+
+export const contributorsRelations = relations(
+  contributors,
+  ({ one, many }) => ({
+    organization: one(organizations, {
+      fields: [contributors.organizationId],
+      references: [organizations.id],
+    }),
+    user: one(users, {
+      fields: [contributors.userId],
+      references: [users.id],
+    }),
+    publications: many(contributorPublications),
+    rightsAgreements: many(rightsAgreements),
+    paymentTransactions: many(paymentTransactions),
+  }),
+);
+
+// --- contributor_publications ---
+
+export const contributorPublicationsRelations = relations(
+  contributorPublications,
+  ({ one }) => ({
+    contributor: one(contributors, {
+      fields: [contributorPublications.contributorId],
+      references: [contributors.id],
+    }),
+    pipelineItem: one(pipelineItems, {
+      fields: [contributorPublications.pipelineItemId],
+      references: [pipelineItems.id],
+    }),
+  }),
+);
+
+// --- rights_agreements ---
+
+export const rightsAgreementsRelations = relations(
+  rightsAgreements,
+  ({ one }) => ({
+    organization: one(organizations, {
+      fields: [rightsAgreements.organizationId],
+      references: [organizations.id],
+    }),
+    contributor: one(contributors, {
+      fields: [rightsAgreements.contributorId],
+      references: [contributors.id],
+    }),
+    pipelineItem: one(pipelineItems, {
+      fields: [rightsAgreements.pipelineItemId],
+      references: [pipelineItems.id],
+    }),
+  }),
+);
+
+// --- payment_transactions ---
+
+export const paymentTransactionsRelations = relations(
+  paymentTransactions,
+  ({ one }) => ({
+    organization: one(organizations, {
+      fields: [paymentTransactions.organizationId],
+      references: [organizations.id],
+    }),
+    contributor: one(contributors, {
+      fields: [paymentTransactions.contributorId],
+      references: [contributors.id],
+    }),
+    submission: one(submissions, {
+      fields: [paymentTransactions.submissionId],
+      references: [submissions.id],
+    }),
+    payment: one(payments, {
+      fields: [paymentTransactions.paymentId],
+      references: [payments.id],
+    }),
+  }),
+);

--- a/packages/types/src/api-key.ts
+++ b/packages/types/src/api-key.ts
@@ -47,6 +47,12 @@ export const apiKeyScopeSchema = z
     "audit:read",
     "collections:read",
     "collections:write",
+    "contributors:read",
+    "contributors:write",
+    "rights:read",
+    "rights:write",
+    "payment-transactions:read",
+    "payment-transactions:write",
   ])
   .describe("Permission scope for the API key");
 

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -272,6 +272,29 @@ export const AuditActions = {
   COLLECTION_ITEM_ADDED: "COLLECTION_ITEM_ADDED",
   COLLECTION_ITEM_REMOVED: "COLLECTION_ITEM_REMOVED",
   COLLECTION_ITEM_UPDATED: "COLLECTION_ITEM_UPDATED",
+
+  // Contributor lifecycle
+  CONTRIBUTOR_CREATED: "CONTRIBUTOR_CREATED",
+  CONTRIBUTOR_UPDATED: "CONTRIBUTOR_UPDATED",
+  CONTRIBUTOR_DELETED: "CONTRIBUTOR_DELETED",
+  CONTRIBUTOR_LINKED: "CONTRIBUTOR_LINKED",
+  CONTRIBUTOR_UNLINKED: "CONTRIBUTOR_UNLINKED",
+  CONTRIBUTOR_PUBLICATION_ADDED: "CONTRIBUTOR_PUBLICATION_ADDED",
+  CONTRIBUTOR_PUBLICATION_REMOVED: "CONTRIBUTOR_PUBLICATION_REMOVED",
+
+  // Rights agreement lifecycle
+  RIGHTS_AGREEMENT_CREATED: "RIGHTS_AGREEMENT_CREATED",
+  RIGHTS_AGREEMENT_UPDATED: "RIGHTS_AGREEMENT_UPDATED",
+  RIGHTS_AGREEMENT_SENT: "RIGHTS_AGREEMENT_SENT",
+  RIGHTS_AGREEMENT_SIGNED: "RIGHTS_AGREEMENT_SIGNED",
+  RIGHTS_AGREEMENT_ACTIVATED: "RIGHTS_AGREEMENT_ACTIVATED",
+  RIGHTS_AGREEMENT_REVERTED: "RIGHTS_AGREEMENT_REVERTED",
+  RIGHTS_AGREEMENT_DELETED: "RIGHTS_AGREEMENT_DELETED",
+
+  // Payment transaction lifecycle
+  PAYMENT_TRANSACTION_CREATED: "PAYMENT_TRANSACTION_CREATED",
+  PAYMENT_TRANSACTION_UPDATED: "PAYMENT_TRANSACTION_UPDATED",
+  PAYMENT_TRANSACTION_STATUS_CHANGED: "PAYMENT_TRANSACTION_STATUS_CHANGED",
 } as const;
 
 export type AuditAction = (typeof AuditActions)[keyof typeof AuditActions];
@@ -313,6 +336,10 @@ export const AuditResources = {
   AUDIT: "audit",
   COLLECTION: "collection",
   INVITATION: "invitation",
+  CONTRIBUTOR: "contributor",
+  CONTRIBUTOR_PUBLICATION: "contributor_publication",
+  RIGHTS_AGREEMENT: "rights_agreement",
+  PAYMENT_TRANSACTION: "payment_transaction",
 } as const;
 
 export type AuditResource =
@@ -700,6 +727,38 @@ export interface InvitationAuditParams extends BaseAuditParams {
     | typeof AuditActions.INVITATION_RESENT;
 }
 
+export interface ContributorAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.CONTRIBUTOR;
+  action:
+    | typeof AuditActions.CONTRIBUTOR_CREATED
+    | typeof AuditActions.CONTRIBUTOR_UPDATED
+    | typeof AuditActions.CONTRIBUTOR_DELETED
+    | typeof AuditActions.CONTRIBUTOR_LINKED
+    | typeof AuditActions.CONTRIBUTOR_UNLINKED
+    | typeof AuditActions.CONTRIBUTOR_PUBLICATION_ADDED
+    | typeof AuditActions.CONTRIBUTOR_PUBLICATION_REMOVED;
+}
+
+export interface RightsAgreementAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.RIGHTS_AGREEMENT;
+  action:
+    | typeof AuditActions.RIGHTS_AGREEMENT_CREATED
+    | typeof AuditActions.RIGHTS_AGREEMENT_UPDATED
+    | typeof AuditActions.RIGHTS_AGREEMENT_SENT
+    | typeof AuditActions.RIGHTS_AGREEMENT_SIGNED
+    | typeof AuditActions.RIGHTS_AGREEMENT_ACTIVATED
+    | typeof AuditActions.RIGHTS_AGREEMENT_REVERTED
+    | typeof AuditActions.RIGHTS_AGREEMENT_DELETED;
+}
+
+export interface PaymentTransactionAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.PAYMENT_TRANSACTION;
+  action:
+    | typeof AuditActions.PAYMENT_TRANSACTION_CREATED
+    | typeof AuditActions.PAYMENT_TRANSACTION_UPDATED
+    | typeof AuditActions.PAYMENT_TRANSACTION_STATUS_CHANGED;
+}
+
 /** Union of all resource-specific param types. */
 export type AuditLogParams =
   | UserAuditParams
@@ -737,7 +796,10 @@ export type AuditLogParams =
   | AuditAccessAuditParams
   | SystemAuditParams
   | CollectionAuditParams
-  | InvitationAuditParams;
+  | InvitationAuditParams
+  | ContributorAuditParams
+  | RightsAgreementAuditParams
+  | PaymentTransactionAuditParams;
 
 // ---------------------------------------------------------------------------
 // Query/response schemas for audit endpoints

--- a/packages/types/src/contributor.ts
+++ b/packages/types/src/contributor.ts
@@ -1,0 +1,164 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const contributorPublicationRoleSchema = z
+  .enum(["author", "translator", "illustrator", "photographer", "editor"])
+  .describe("Contributor's role in a publication");
+
+export type ContributorPublicationRole = z.infer<
+  typeof contributorPublicationRoleSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Contributor response
+// ---------------------------------------------------------------------------
+
+export const contributorSchema = z.object({
+  id: z.string().uuid().describe("Contributor ID"),
+  organizationId: z.string().uuid().describe("Organization ID"),
+  userId: z.string().uuid().nullable().describe("Linked Colophony user ID"),
+  displayName: z.string().describe("Display name"),
+  bio: z.string().nullable().describe("Biography"),
+  pronouns: z.string().nullable().describe("Pronouns"),
+  email: z.string().nullable().describe("Contact email"),
+  website: z.string().nullable().describe("Website URL"),
+  mailingAddress: z.string().nullable().describe("Mailing address (sensitive)"),
+  notes: z.string().nullable().describe("Internal notes"),
+  createdAt: z.date().describe("When the contributor was created"),
+  updatedAt: z.date().describe("When the contributor was last updated"),
+});
+
+export type Contributor = z.infer<typeof contributorSchema>;
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+export const createContributorSchema = z.object({
+  displayName: z.string().trim().min(1).max(255).describe("Display name"),
+  bio: z.string().max(5000).optional().describe("Biography"),
+  pronouns: z.string().max(100).optional().describe("Pronouns"),
+  email: z.string().email().max(320).optional().describe("Contact email"),
+  website: z.string().url().max(2048).optional().describe("Website URL"),
+  mailingAddress: z.string().max(2000).optional().describe("Mailing address"),
+  notes: z.string().max(10000).optional().describe("Internal notes"),
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Link to existing Colophony user"),
+});
+
+export type CreateContributorInput = z.infer<typeof createContributorSchema>;
+
+// ---------------------------------------------------------------------------
+// Update
+// ---------------------------------------------------------------------------
+
+export const updateContributorSchema = z.object({
+  id: z.string().uuid().describe("Contributor ID to update"),
+  displayName: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .optional()
+    .describe("Display name"),
+  bio: z.string().max(5000).nullable().optional().describe("Biography"),
+  pronouns: z.string().max(100).nullable().optional().describe("Pronouns"),
+  email: z
+    .string()
+    .email()
+    .max(320)
+    .nullable()
+    .optional()
+    .describe("Contact email"),
+  website: z
+    .string()
+    .url()
+    .max(2048)
+    .nullable()
+    .optional()
+    .describe("Website URL"),
+  mailingAddress: z
+    .string()
+    .max(2000)
+    .nullable()
+    .optional()
+    .describe("Mailing address"),
+  notes: z.string().max(10000).nullable().optional().describe("Internal notes"),
+  userId: z
+    .string()
+    .uuid()
+    .nullable()
+    .optional()
+    .describe("Link/unlink Colophony user"),
+});
+
+export type UpdateContributorInput = z.infer<typeof updateContributorSchema>;
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+export const listContributorsSchema = z.object({
+  search: z
+    .string()
+    .trim()
+    .max(200)
+    .optional()
+    .describe("Search by display name"),
+  page: z.number().int().min(1).default(1).describe("Page number (1-based)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page"),
+});
+
+export type ListContributorsInput = z.infer<typeof listContributorsSchema>;
+
+// ---------------------------------------------------------------------------
+// Contributor publication link
+// ---------------------------------------------------------------------------
+
+export const contributorPublicationSchema = z.object({
+  id: z.string().uuid().describe("Contributor publication link ID"),
+  contributorId: z.string().uuid().describe("Contributor ID"),
+  pipelineItemId: z.string().uuid().describe("Pipeline item ID"),
+  role: contributorPublicationRoleSchema,
+  displayOrder: z.number().int().describe("Display order"),
+  createdAt: z.date().describe("When the link was created"),
+});
+
+export type ContributorPublication = z.infer<
+  typeof contributorPublicationSchema
+>;
+
+export const addContributorPublicationSchema = z.object({
+  contributorId: z.string().uuid().describe("Contributor ID"),
+  pipelineItemId: z.string().uuid().describe("Pipeline item ID"),
+  role: contributorPublicationRoleSchema
+    .default("author")
+    .describe("Role in publication"),
+  displayOrder: z.number().int().min(0).default(0).describe("Display order"),
+});
+
+export type AddContributorPublicationInput = z.infer<
+  typeof addContributorPublicationSchema
+>;
+
+export const removeContributorPublicationSchema = z.object({
+  contributorId: z.string().uuid().describe("Contributor ID"),
+  pipelineItemId: z.string().uuid().describe("Pipeline item ID"),
+  role: contributorPublicationRoleSchema.describe("Role to remove"),
+});
+
+export type RemoveContributorPublicationInput = z.infer<
+  typeof removeContributorPublicationSchema
+>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -40,3 +40,6 @@ export * from "./blind-review";
 export * from "./queue-preset";
 export * from "./prosemirror";
 export * from "./workspace-collection";
+export * from "./contributor";
+export * from "./rights-agreement";
+export * from "./payment-transaction";

--- a/packages/types/src/payment-transaction.ts
+++ b/packages/types/src/payment-transaction.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const paymentTransactionTypeSchema = z
+  .enum(["submission_fee", "contest_fee", "contributor_payment"])
+  .describe("Type of payment transaction");
+
+export type PaymentTransactionType = z.infer<
+  typeof paymentTransactionTypeSchema
+>;
+
+export const paymentTransactionDirectionSchema = z
+  .enum(["inbound", "outbound"])
+  .describe("Direction: inbound (received) or outbound (paid)");
+
+export type PaymentTransactionDirection = z.infer<
+  typeof paymentTransactionDirectionSchema
+>;
+
+export const paymentTransactionStatusSchema = z
+  .enum(["PENDING", "PROCESSING", "SUCCEEDED", "FAILED", "REFUNDED"])
+  .describe("Payment status");
+
+export type PaymentTransactionStatus = z.infer<
+  typeof paymentTransactionStatusSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Response
+// ---------------------------------------------------------------------------
+
+export const paymentTransactionSchema = z.object({
+  id: z.string().uuid().describe("Transaction ID"),
+  organizationId: z.string().uuid().describe("Organization ID"),
+  contributorId: z.string().uuid().nullable().describe("Contributor ID"),
+  submissionId: z.string().uuid().nullable().describe("Submission ID"),
+  paymentId: z.string().uuid().nullable().describe("Linked Stripe payment ID"),
+  type: paymentTransactionTypeSchema,
+  direction: paymentTransactionDirectionSchema,
+  amount: z.number().int().describe("Amount in cents"),
+  currency: z.string().max(3).describe("ISO 4217 currency code"),
+  status: paymentTransactionStatusSchema,
+  description: z.string().nullable().describe("Human-readable description"),
+  metadata: z
+    .record(z.string(), z.unknown())
+    .nullable()
+    .describe("Additional metadata"),
+  processedAt: z
+    .date()
+    .nullable()
+    .describe("When the transaction was processed"),
+  createdAt: z.date().describe("Record creation timestamp"),
+  updatedAt: z.date().describe("Record update timestamp"),
+});
+
+export type PaymentTransaction = z.infer<typeof paymentTransactionSchema>;
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+export const createPaymentTransactionSchema = z.object({
+  contributorId: z.string().uuid().optional().describe("Contributor ID"),
+  submissionId: z.string().uuid().optional().describe("Submission ID"),
+  paymentId: z.string().uuid().optional().describe("Linked Stripe payment ID"),
+  type: paymentTransactionTypeSchema,
+  direction: paymentTransactionDirectionSchema,
+  amount: z.number().int().min(0).describe("Amount in cents"),
+  currency: z
+    .string()
+    .length(3, "Currency code must be 3 characters")
+    .default("usd")
+    .describe("ISO 4217 currency code"),
+  description: z.string().max(1000).optional().describe("Description"),
+  metadata: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe("Additional metadata"),
+});
+
+export type CreatePaymentTransactionInput = z.infer<
+  typeof createPaymentTransactionSchema
+>;
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+export const listPaymentTransactionsSchema = z.object({
+  type: paymentTransactionTypeSchema.optional().describe("Filter by type"),
+  direction: paymentTransactionDirectionSchema
+    .optional()
+    .describe("Filter by direction"),
+  contributorId: z.string().uuid().optional().describe("Filter by contributor"),
+  status: paymentTransactionStatusSchema.optional(),
+  page: z.number().int().min(1).default(1).describe("Page number"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page"),
+});
+
+export type ListPaymentTransactionsInput = z.infer<
+  typeof listPaymentTransactionsSchema
+>;

--- a/packages/types/src/rights-agreement.ts
+++ b/packages/types/src/rights-agreement.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const rightsTypeSchema = z
+  .enum([
+    "first_north_american_serial",
+    "electronic",
+    "anthology",
+    "audio",
+    "translation",
+    "custom",
+  ])
+  .describe("Type of rights granted");
+
+export type RightsType = z.infer<typeof rightsTypeSchema>;
+
+export const rightsAgreementStatusSchema = z
+  .enum(["DRAFT", "SENT", "SIGNED", "ACTIVE", "REVERTED"])
+  .describe("Current status of the rights agreement");
+
+export type RightsAgreementStatus = z.infer<typeof rightsAgreementStatusSchema>;
+
+// ---------------------------------------------------------------------------
+// Response
+// ---------------------------------------------------------------------------
+
+export const rightsAgreementSchema = z.object({
+  id: z.string().uuid().describe("Rights agreement ID"),
+  organizationId: z.string().uuid().describe("Organization ID"),
+  contributorId: z.string().uuid().describe("Contributor ID"),
+  pipelineItemId: z.string().uuid().nullable().describe("Pipeline item ID"),
+  rightsType: rightsTypeSchema,
+  customDescription: z
+    .string()
+    .nullable()
+    .describe("Description when type is custom"),
+  status: rightsAgreementStatusSchema,
+  grantedAt: z.date().nullable().describe("When rights were granted"),
+  expiresAt: z.date().nullable().describe("When rights revert"),
+  revertedAt: z
+    .date()
+    .nullable()
+    .describe("When rights were actually reverted"),
+  notes: z.string().nullable().describe("Internal notes"),
+  createdAt: z.date().describe("Record creation timestamp"),
+  updatedAt: z.date().describe("Record update timestamp"),
+});
+
+export type RightsAgreement = z.infer<typeof rightsAgreementSchema>;
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+export const createRightsAgreementSchema = z.object({
+  contributorId: z.string().uuid().describe("Contributor ID"),
+  pipelineItemId: z.string().uuid().optional().describe("Pipeline item ID"),
+  rightsType: rightsTypeSchema,
+  customDescription: z
+    .string()
+    .max(5000)
+    .optional()
+    .describe("Description when type is custom"),
+  expiresAt: z.coerce.date().optional().describe("Reversion date"),
+  notes: z.string().max(10000).optional().describe("Internal notes"),
+});
+
+export type CreateRightsAgreementInput = z.infer<
+  typeof createRightsAgreementSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Update
+// ---------------------------------------------------------------------------
+
+export const updateRightsAgreementSchema = z.object({
+  id: z.string().uuid().describe("Rights agreement ID"),
+  rightsType: rightsTypeSchema.optional(),
+  customDescription: z.string().max(5000).nullable().optional(),
+  expiresAt: z.coerce.date().nullable().optional(),
+  notes: z.string().max(10000).nullable().optional(),
+});
+
+export type UpdateRightsAgreementInput = z.infer<
+  typeof updateRightsAgreementSchema
+>;


### PR DESCRIPTION
## Summary

- 4 new tables (`contributors`, `contributor_publications`, `rights_agreements`, `payment_transactions`) with full RLS, 5 new pgEnums, migration 0063
- `businessOpsProcedure` middleware (BUSINESS_OPS or ADMIN role)
- Contributor service with CRUD + audit logging, 8 tRPC procedures with scope enforcement
- Business nav group in sidebar + command palette (role-gated)
- 3 Zod type files, 20 audit actions, 4 resources, 6 API key scopes
- 14 unit tests, RLS isolation test for all 4 tables

## Design Decisions

- `mailingAddress` stored as plain text (app-level encryption deferred as cross-cutting concern)
- `payment_transactions` is a **new table**, not extending existing `payments` (Stripe webhook coupling)
- All contributor procedures use `businessOpsProcedure` (including reads — sensitive fields like `mailingAddress`)
- `addPublicationWithAudit` validates pipeline item org ownership (defense-in-depth)

## Test plan

- [x] `pnpm type-check` — passes
- [x] `pnpm lint` — passes
- [x] 1637 API unit tests + 707 web unit tests — all pass
- [x] 14 new contributor service tests pass
- [ ] RLS isolation test (requires running DB — CI `rls-tests` job)
- [ ] Manual: log in as BUSINESS_OPS user, verify sidebar shows Business group

## Plan Overrides

| File | Planned | Actual | Rationale |
|---|---|---|---|
| `contributors.ts` router | `list`/`getById`/`listPublications` on `orgProcedure` | All procedures on `businessOpsProcedure` | code review: prevent READER access to sensitive fields |
| `contributor.service.ts` | No pipeline item org validation | Added `PipelineItemNotInOrgError` + org check | code review: prevent cross-org FK links |