### PR TITLE
feat(business-ops): rights agreement service with lifecycle management

### DIFF
--- a/apps/api/src/services/rights-agreement.service.spec.ts
+++ b/apps/api/src/services/rights-agreement.service.spec.ts
@@ -1,0 +1,610 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@colophony/db', () => ({
+  rightsAgreements: {
+    id: 'ra.id',
+    organizationId: 'ra.org_id',
+    contributorId: 'ra.contributor_id',
+    pipelineItemId: 'ra.pipeline_item_id',
+    rightsType: 'ra.rights_type',
+    customDescription: 'ra.custom_description',
+    status: 'ra.status',
+    grantedAt: 'ra.granted_at',
+    expiresAt: 'ra.expires_at',
+    revertedAt: 'ra.reverted_at',
+    notes: 'ra.notes',
+    createdAt: 'ra.created_at',
+    updatedAt: 'ra.updated_at',
+  },
+  contributors: {
+    id: 'c.id',
+    organizationId: 'c.org_id',
+    displayName: 'c.display_name',
+  },
+  pipelineItems: {
+    id: 'pi.id',
+    organizationId: 'pi.org_id',
+    submissionId: 'pi.submission_id',
+  },
+  submissions: {
+    id: 's.id',
+    title: 's.title',
+  },
+  eq: vi.fn(),
+  and: vi.fn(),
+  gte: vi.fn(),
+  lte: vi.fn(),
+  not: vi.fn(),
+  isNull: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  count: vi.fn(),
+}));
+
+vi.mock('./errors.js', () => ({
+  assertBusinessOpsOrAdmin: vi.fn(),
+  ForbiddenError: class ForbiddenError extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = 'ForbiddenError';
+    }
+  },
+}));
+
+vi.mock('./contributor.service.js', () => ({
+  PipelineItemNotInOrgError: class PipelineItemNotInOrgError extends Error {
+    constructor(id: string) {
+      super(`Pipeline item "${id}" does not belong to this organization`);
+      this.name = 'PipelineItemNotInOrgError';
+    }
+  },
+}));
+
+import {
+  rightsAgreementService,
+  RightsAgreementNotFoundError,
+  InvalidRightsStatusTransitionError,
+  ContributorNotInOrgError,
+} from './rights-agreement.service.js';
+import { PipelineItemNotInOrgError } from './contributor.service.js';
+import { assertBusinessOpsOrAdmin } from './errors.js';
+import type { ServiceContext } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ORG_ID = 'org-1';
+const USER_ID = 'user-1';
+const RIGHTS_ID = 'rights-1';
+const CONTRIBUTOR_ID = 'contributor-1';
+
+const fakeAgreement = {
+  id: RIGHTS_ID,
+  organizationId: ORG_ID,
+  contributorId: CONTRIBUTOR_ID,
+  pipelineItemId: null,
+  rightsType: 'first_north_american_serial' as const,
+  customDescription: null,
+  status: 'DRAFT' as const,
+  grantedAt: null,
+  expiresAt: null,
+  revertedAt: null,
+  notes: null,
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+};
+
+function makeChain() {
+  const c: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of [
+    'from',
+    'leftJoin',
+    'where',
+    'orderBy',
+    'limit',
+    'offset',
+    'values',
+    'set',
+    'returning',
+  ]) {
+    c[m] = vi.fn().mockReturnValue(c);
+  }
+  return c;
+}
+
+function makeMockTx() {
+  const chains: Array<Record<string, ReturnType<typeof vi.fn>>> = [];
+
+  function newChain() {
+    const c = makeChain();
+    chains.push(c);
+    return c;
+  }
+
+  return {
+    select: vi.fn(() => newChain()),
+    insert: vi.fn(() => newChain()),
+    update: vi.fn(() => newChain()),
+    delete: vi.fn(() => newChain()),
+    chain(n: number) {
+      return chains[n];
+    },
+    resetChains() {
+      chains.length = 0;
+    },
+  };
+}
+
+function makeServiceContext(tx: ReturnType<typeof makeMockTx>): ServiceContext {
+  return {
+    tx: tx as unknown as ServiceContext['tx'],
+    actor: { userId: USER_ID, orgId: ORG_ID, roles: ['BUSINESS_OPS'] },
+    audit: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('rightsAgreementService', () => {
+  let mockTx: ReturnType<typeof makeMockTx>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTx = makeMockTx();
+  });
+
+  // -----------------------------------------------------------------------
+  // getById
+  // -----------------------------------------------------------------------
+
+  describe('getById', () => {
+    it('returns agreement when found', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeAgreement]);
+        return c;
+      });
+
+      const result = await rightsAgreementService.getById(
+        mockTx as any,
+        RIGHTS_ID,
+        ORG_ID,
+      );
+      expect(result).toEqual(fakeAgreement);
+    });
+
+    it('returns null when not found', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([]);
+        return c;
+      });
+
+      const result = await rightsAgreementService.getById(
+        mockTx as any,
+        'nonexistent',
+        ORG_ID,
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getUpcomingReversions
+  // -----------------------------------------------------------------------
+
+  describe('getUpcomingReversions', () => {
+    it('returns active agreements expiring within window', async () => {
+      const expiring = {
+        ...fakeAgreement,
+        status: 'ACTIVE' as const,
+        expiresAt: new Date('2026-02-01'),
+      };
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.orderBy.mockResolvedValueOnce([expiring]);
+        return c;
+      });
+
+      const result = await rightsAgreementService.getUpcomingReversions(
+        mockTx as any,
+        ORG_ID,
+        30,
+      );
+      expect(result).toEqual([expiring]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // createWithAudit
+  // -----------------------------------------------------------------------
+
+  describe('createWithAudit', () => {
+    it('inserts agreement and emits audit event', async () => {
+      // contributor validation select + insert
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([{ id: CONTRIBUTOR_ID }]);
+        return c;
+      });
+      mockTx.insert = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([fakeAgreement]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await rightsAgreementService.createWithAudit(ctx, {
+        contributorId: CONTRIBUTOR_ID,
+        rightsType: 'first_north_american_serial',
+      });
+
+      expect(result).toEqual(fakeAgreement);
+      expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'RIGHTS_AGREEMENT_CREATED',
+          resource: 'rights_agreement',
+          resourceId: RIGHTS_ID,
+        }),
+      );
+    });
+
+    it('throws ContributorNotInOrgError for cross-org contributor', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        rightsAgreementService.createWithAudit(ctx, {
+          contributorId: 'other-org-contributor',
+          rightsType: 'electronic',
+        }),
+      ).rejects.toThrow(ContributorNotInOrgError);
+    });
+
+    it('validates pipeline item belongs to org when provided', async () => {
+      // First select: contributor found. Second select: pipeline item not found.
+      let selectCount = 0;
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        selectCount++;
+        if (selectCount === 1) {
+          c.limit.mockResolvedValueOnce([{ id: CONTRIBUTOR_ID }]);
+        } else {
+          c.limit.mockResolvedValueOnce([]);
+        }
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        rightsAgreementService.createWithAudit(ctx, {
+          contributorId: CONTRIBUTOR_ID,
+          pipelineItemId: 'bad-pi',
+          rightsType: 'electronic',
+        }),
+      ).rejects.toThrow(PipelineItemNotInOrgError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // updateWithAudit
+  // -----------------------------------------------------------------------
+
+  describe('updateWithAudit', () => {
+    it('updates fields and emits audit', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeAgreement]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...fakeAgreement, rightsType: 'electronic' },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await rightsAgreementService.updateWithAudit(ctx, {
+        id: RIGHTS_ID,
+        rightsType: 'electronic',
+      });
+
+      expect(result.rightsType).toBe('electronic');
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'RIGHTS_AGREEMENT_UPDATED',
+          resource: 'rights_agreement',
+        }),
+      );
+    });
+
+    it('throws RightsAgreementNotFoundError for missing ID', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        rightsAgreementService.updateWithAudit(ctx, {
+          id: 'nonexistent',
+          rightsType: 'electronic',
+        }),
+      ).rejects.toThrow(RightsAgreementNotFoundError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // transitionStatusWithAudit
+  // -----------------------------------------------------------------------
+
+  describe('transitionStatusWithAudit', () => {
+    it('transitions DRAFT to SENT and emits SENT audit', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeAgreement]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...fakeAgreement, status: 'SENT' },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await rightsAgreementService.transitionStatusWithAudit(
+        ctx,
+        { id: RIGHTS_ID, status: 'SENT' },
+      );
+
+      expect(result.status).toBe('SENT');
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'RIGHTS_AGREEMENT_SENT',
+          resource: 'rights_agreement',
+          newValue: { status: 'SENT' },
+        }),
+      );
+    });
+
+    it('transitions SIGNED to ACTIVE and sets grantedAt', async () => {
+      const signed = { ...fakeAgreement, status: 'SIGNED' as const };
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([signed]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...signed, status: 'ACTIVE', grantedAt: new Date() },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await rightsAgreementService.transitionStatusWithAudit(
+        ctx,
+        { id: RIGHTS_ID, status: 'ACTIVE' },
+      );
+
+      expect(result.status).toBe('ACTIVE');
+      expect(result.grantedAt).toBeTruthy();
+      // Verify update was called with grantedAt set
+      expect(mockTx.update).toHaveBeenCalled();
+    });
+
+    it('does not overwrite grantedAt if already set', async () => {
+      const alreadyGranted = {
+        ...fakeAgreement,
+        status: 'SIGNED' as const,
+        grantedAt: new Date('2026-01-15'),
+      };
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([alreadyGranted]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...alreadyGranted, status: 'ACTIVE' },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await rightsAgreementService.transitionStatusWithAudit(ctx, {
+        id: RIGHTS_ID,
+        status: 'ACTIVE',
+      });
+
+      // The update chain's set() should have been called with only status
+      // (no grantedAt override since it was already set)
+      const updateChain = mockTx.update.mock.results[0]?.value;
+      if (updateChain?.set?.mock?.calls?.[0]) {
+        const setArg = updateChain.set.mock.calls[0][0];
+        expect(setArg).not.toHaveProperty('grantedAt');
+      }
+    });
+
+    it('transitions ACTIVE to REVERTED and sets revertedAt', async () => {
+      const active = { ...fakeAgreement, status: 'ACTIVE' as const };
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([active]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...active, status: 'REVERTED', revertedAt: new Date() },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await rightsAgreementService.transitionStatusWithAudit(
+        ctx,
+        { id: RIGHTS_ID, status: 'REVERTED' },
+      );
+
+      expect(result.status).toBe('REVERTED');
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'RIGHTS_AGREEMENT_REVERTED',
+          resource: 'rights_agreement',
+        }),
+      );
+    });
+
+    it('throws InvalidRightsStatusTransitionError for invalid transition', async () => {
+      const reverted = { ...fakeAgreement, status: 'REVERTED' as const };
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([reverted]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        rightsAgreementService.transitionStatusWithAudit(ctx, {
+          id: RIGHTS_ID,
+          status: 'DRAFT',
+        }),
+      ).rejects.toThrow(InvalidRightsStatusTransitionError);
+    });
+
+    it('throws RightsAgreementNotFoundError for missing ID', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        rightsAgreementService.transitionStatusWithAudit(ctx, {
+          id: 'nonexistent',
+          status: 'SENT',
+        }),
+      ).rejects.toThrow(RightsAgreementNotFoundError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // deleteWithAudit
+  // -----------------------------------------------------------------------
+
+  describe('deleteWithAudit', () => {
+    it('deletes and emits audit', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeAgreement]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await rightsAgreementService.deleteWithAudit(ctx, RIGHTS_ID);
+
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'RIGHTS_AGREEMENT_DELETED',
+          resource: 'rights_agreement',
+          resourceId: RIGHTS_ID,
+        }),
+      );
+    });
+
+    it('throws RightsAgreementNotFoundError for missing ID', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        rightsAgreementService.deleteWithAudit(ctx, 'nonexistent'),
+      ).rejects.toThrow(RightsAgreementNotFoundError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Role guard
+  // -----------------------------------------------------------------------
+
+  describe('role guard', () => {
+    it('createWithAudit calls assertBusinessOpsOrAdmin', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([{ id: CONTRIBUTOR_ID }]);
+        return c;
+      });
+      mockTx.insert = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([fakeAgreement]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await rightsAgreementService.createWithAudit(ctx, {
+        contributorId: CONTRIBUTOR_ID,
+        rightsType: 'first_north_american_serial',
+      });
+      expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
+    });
+
+    it('transitionStatusWithAudit calls assertBusinessOpsOrAdmin', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeAgreement]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...fakeAgreement, status: 'SENT' },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await rightsAgreementService.transitionStatusWithAudit(ctx, {
+        id: RIGHTS_ID,
+        status: 'SENT',
+      });
+      expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
+    });
+
+    it('deleteWithAudit calls assertBusinessOpsOrAdmin', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeAgreement]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await rightsAgreementService.deleteWithAudit(ctx, RIGHTS_ID);
+      expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
+    });
+  });
+});

--- a/apps/api/src/services/rights-agreement.service.spec.ts
+++ b/apps/api/src/services/rights-agreement.service.spec.ts
@@ -573,6 +573,28 @@ describe('rightsAgreementService', () => {
       expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
     });
 
+    it('updateWithAudit calls assertBusinessOpsOrAdmin', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeAgreement]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...fakeAgreement, rightsType: 'electronic' },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await rightsAgreementService.updateWithAudit(ctx, {
+        id: RIGHTS_ID,
+        rightsType: 'electronic',
+      });
+      expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
+    });
+
     it('transitionStatusWithAudit calls assertBusinessOpsOrAdmin', async () => {
       mockTx.select = vi.fn(() => {
         const c = makeChain();

--- a/apps/api/src/services/rights-agreement.service.ts
+++ b/apps/api/src/services/rights-agreement.service.ts
@@ -1,0 +1,389 @@
+import {
+  rightsAgreements,
+  contributors,
+  pipelineItems,
+  submissions,
+  eq,
+  and,
+  gte,
+  lte,
+  not,
+  isNull,
+  type DrizzleDb,
+} from '@colophony/db';
+import { count } from 'drizzle-orm';
+import type {
+  CreateRightsAgreementInput,
+  UpdateRightsAgreementInput,
+  ListRightsAgreementsInput,
+  TransitionRightsAgreementStatusInput,
+  RightsAgreementStatus,
+} from '@colophony/types';
+import {
+  AuditActions,
+  AuditResources,
+  VALID_RIGHTS_STATUS_TRANSITIONS,
+  type AuditAction,
+} from '@colophony/types';
+import type { ServiceContext } from './types.js';
+import { assertBusinessOpsOrAdmin } from './errors.js';
+import { PipelineItemNotInOrgError } from './contributor.service.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class RightsAgreementNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Rights agreement "${id}" not found`);
+    this.name = 'RightsAgreementNotFoundError';
+  }
+}
+
+export class InvalidRightsStatusTransitionError extends Error {
+  constructor(from: string, to: string) {
+    super(`Cannot transition rights agreement from "${from}" to "${to}"`);
+    this.name = 'InvalidRightsStatusTransitionError';
+  }
+}
+
+export class ContributorNotInOrgError extends Error {
+  constructor(contributorId: string) {
+    super(
+      `Contributor "${contributorId}" does not belong to this organization`,
+    );
+    this.name = 'ContributorNotInOrgError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Audit action map for status transitions
+// ---------------------------------------------------------------------------
+
+const STATUS_AUDIT_ACTION: Record<
+  Exclude<RightsAgreementStatus, 'DRAFT'>,
+  AuditAction
+> = {
+  SENT: AuditActions.RIGHTS_AGREEMENT_SENT,
+  SIGNED: AuditActions.RIGHTS_AGREEMENT_SIGNED,
+  ACTIVE: AuditActions.RIGHTS_AGREEMENT_ACTIVATED,
+  REVERTED: AuditActions.RIGHTS_AGREEMENT_REVERTED,
+};
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const rightsAgreementService = {
+  // -------------------------------------------------------------------------
+  // Pure data methods
+  // -------------------------------------------------------------------------
+
+  async list(tx: DrizzleDb, input: ListRightsAgreementsInput, orgId: string) {
+    const { page, limit } = input;
+    const offset = (page - 1) * limit;
+
+    const conditions = [eq(rightsAgreements.organizationId, orgId)];
+
+    if (input.contributorId) {
+      conditions.push(eq(rightsAgreements.contributorId, input.contributorId));
+    }
+    if (input.pipelineItemId) {
+      conditions.push(
+        eq(rightsAgreements.pipelineItemId, input.pipelineItemId),
+      );
+    }
+    if (input.status) {
+      conditions.push(eq(rightsAgreements.status, input.status));
+    }
+    if (input.rightsType) {
+      conditions.push(eq(rightsAgreements.rightsType, input.rightsType));
+    }
+
+    const where = and(...conditions);
+
+    const [items, [{ total }]] = await Promise.all([
+      tx
+        .select({
+          id: rightsAgreements.id,
+          organizationId: rightsAgreements.organizationId,
+          contributorId: rightsAgreements.contributorId,
+          pipelineItemId: rightsAgreements.pipelineItemId,
+          rightsType: rightsAgreements.rightsType,
+          customDescription: rightsAgreements.customDescription,
+          status: rightsAgreements.status,
+          grantedAt: rightsAgreements.grantedAt,
+          expiresAt: rightsAgreements.expiresAt,
+          revertedAt: rightsAgreements.revertedAt,
+          notes: rightsAgreements.notes,
+          createdAt: rightsAgreements.createdAt,
+          updatedAt: rightsAgreements.updatedAt,
+          contributorName: contributors.displayName,
+          pipelineItemTitle: submissions.title,
+        })
+        .from(rightsAgreements)
+        .innerJoin(
+          contributors,
+          eq(rightsAgreements.contributorId, contributors.id),
+        )
+        .leftJoin(
+          pipelineItems,
+          eq(rightsAgreements.pipelineItemId, pipelineItems.id),
+        )
+        .leftJoin(submissions, eq(pipelineItems.submissionId, submissions.id))
+        .where(where)
+        .orderBy(rightsAgreements.createdAt)
+        .limit(limit)
+        .offset(offset),
+      tx.select({ total: count() }).from(rightsAgreements).where(where),
+    ]);
+
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async getById(tx: DrizzleDb, id: string, orgId: string) {
+    const [row] = await tx
+      .select()
+      .from(rightsAgreements)
+      .where(
+        and(
+          eq(rightsAgreements.id, id),
+          eq(rightsAgreements.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  },
+
+  async getUpcomingReversions(
+    tx: DrizzleDb,
+    orgId: string,
+    withinDays: number,
+  ) {
+    const now = new Date();
+    const deadline = new Date(now.getTime() + withinDays * 86_400_000);
+
+    return tx
+      .select()
+      .from(rightsAgreements)
+      .where(
+        and(
+          eq(rightsAgreements.organizationId, orgId),
+          eq(rightsAgreements.status, 'ACTIVE'),
+          not(isNull(rightsAgreements.expiresAt)),
+          gte(rightsAgreements.expiresAt, now),
+          lte(rightsAgreements.expiresAt, deadline),
+        ),
+      )
+      .orderBy(rightsAgreements.expiresAt);
+  },
+
+  // -------------------------------------------------------------------------
+  // Audit-wrapped methods
+  // -------------------------------------------------------------------------
+
+  async createWithAudit(
+    ctx: ServiceContext,
+    input: CreateRightsAgreementInput,
+  ) {
+    assertBusinessOpsOrAdmin(ctx.actor.roles);
+
+    // Validate contributor belongs to org
+    const [contributor] = await ctx.tx
+      .select({ id: contributors.id })
+      .from(contributors)
+      .where(
+        and(
+          eq(contributors.id, input.contributorId),
+          eq(contributors.organizationId, ctx.actor.orgId),
+        ),
+      )
+      .limit(1);
+    if (!contributor) throw new ContributorNotInOrgError(input.contributorId);
+
+    // Validate pipeline item belongs to org (if provided)
+    if (input.pipelineItemId) {
+      const [item] = await ctx.tx
+        .select({ id: pipelineItems.id })
+        .from(pipelineItems)
+        .where(
+          and(
+            eq(pipelineItems.id, input.pipelineItemId),
+            eq(pipelineItems.organizationId, ctx.actor.orgId),
+          ),
+        )
+        .limit(1);
+      if (!item) throw new PipelineItemNotInOrgError(input.pipelineItemId);
+    }
+
+    const [agreement] = await ctx.tx
+      .insert(rightsAgreements)
+      .values({
+        organizationId: ctx.actor.orgId,
+        contributorId: input.contributorId,
+        pipelineItemId: input.pipelineItemId ?? null,
+        rightsType: input.rightsType,
+        customDescription: input.customDescription ?? null,
+        expiresAt: input.expiresAt ?? null,
+        notes: input.notes ?? null,
+      })
+      .returning();
+
+    await ctx.audit({
+      action: AuditActions.RIGHTS_AGREEMENT_CREATED,
+      resource: AuditResources.RIGHTS_AGREEMENT,
+      resourceId: agreement.id,
+      newValue: {
+        contributorId: agreement.contributorId,
+        rightsType: agreement.rightsType,
+        status: agreement.status,
+      },
+    });
+
+    return agreement;
+  },
+
+  async updateWithAudit(
+    ctx: ServiceContext,
+    input: UpdateRightsAgreementInput,
+  ) {
+    assertBusinessOpsOrAdmin(ctx.actor.roles);
+
+    const existing = await rightsAgreementService.getById(
+      ctx.tx,
+      input.id,
+      ctx.actor.orgId,
+    );
+    if (!existing) throw new RightsAgreementNotFoundError(input.id);
+
+    // Build update payload excluding id and undefined values
+    const updateData: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(input)) {
+      if (key !== 'id' && value !== undefined) {
+        updateData[key] = value;
+      }
+    }
+
+    const [updated] = await ctx.tx
+      .update(rightsAgreements)
+      .set(updateData)
+      .where(
+        and(
+          eq(rightsAgreements.id, input.id),
+          eq(rightsAgreements.organizationId, ctx.actor.orgId),
+        ),
+      )
+      .returning();
+
+    await ctx.audit({
+      action: AuditActions.RIGHTS_AGREEMENT_UPDATED,
+      resource: AuditResources.RIGHTS_AGREEMENT,
+      resourceId: input.id,
+      oldValue: {
+        rightsType: existing.rightsType,
+        expiresAt: existing.expiresAt,
+        notes: existing.notes,
+      },
+      newValue: {
+        rightsType: updated.rightsType,
+        expiresAt: updated.expiresAt,
+        notes: updated.notes,
+      },
+    });
+
+    return updated;
+  },
+
+  async transitionStatusWithAudit(
+    ctx: ServiceContext,
+    input: TransitionRightsAgreementStatusInput,
+  ) {
+    assertBusinessOpsOrAdmin(ctx.actor.roles);
+
+    const existing = await rightsAgreementService.getById(
+      ctx.tx,
+      input.id,
+      ctx.actor.orgId,
+    );
+    if (!existing) throw new RightsAgreementNotFoundError(input.id);
+
+    const allowed = VALID_RIGHTS_STATUS_TRANSITIONS[existing.status];
+    if (!allowed.includes(input.status)) {
+      throw new InvalidRightsStatusTransitionError(
+        existing.status,
+        input.status,
+      );
+    }
+
+    // Build update payload with timestamp side effects
+    const updateData: Record<string, unknown> = { status: input.status };
+
+    if (input.status === 'ACTIVE' && !existing.grantedAt) {
+      updateData.grantedAt = new Date();
+    }
+    if (input.status === 'REVERTED') {
+      updateData.revertedAt = new Date();
+    }
+
+    const [updated] = await ctx.tx
+      .update(rightsAgreements)
+      .set(updateData)
+      .where(
+        and(
+          eq(rightsAgreements.id, input.id),
+          eq(rightsAgreements.organizationId, ctx.actor.orgId),
+        ),
+      )
+      .returning();
+
+    await ctx.audit({
+      action:
+        STATUS_AUDIT_ACTION[
+          input.status as Exclude<RightsAgreementStatus, 'DRAFT'>
+        ],
+      resource: AuditResources.RIGHTS_AGREEMENT,
+      resourceId: input.id,
+      oldValue: { status: existing.status },
+      newValue: { status: input.status },
+    });
+
+    return updated;
+  },
+
+  async deleteWithAudit(ctx: ServiceContext, id: string) {
+    assertBusinessOpsOrAdmin(ctx.actor.roles);
+
+    const existing = await rightsAgreementService.getById(
+      ctx.tx,
+      id,
+      ctx.actor.orgId,
+    );
+    if (!existing) throw new RightsAgreementNotFoundError(id);
+
+    await ctx.tx
+      .delete(rightsAgreements)
+      .where(
+        and(
+          eq(rightsAgreements.id, id),
+          eq(rightsAgreements.organizationId, ctx.actor.orgId),
+        ),
+      );
+
+    await ctx.audit({
+      action: AuditActions.RIGHTS_AGREEMENT_DELETED,
+      resource: AuditResources.RIGHTS_AGREEMENT,
+      resourceId: id,
+      oldValue: {
+        contributorId: existing.contributorId,
+        rightsType: existing.rightsType,
+        status: existing.status,
+      },
+    });
+  },
+};

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -124,6 +124,11 @@ import {
   ContributorPublicationDuplicateError,
   PipelineItemNotInOrgError,
 } from '../services/contributor.service.js';
+import {
+  RightsAgreementNotFoundError,
+  InvalidRightsStatusTransitionError,
+  ContributorNotInOrgError,
+} from '../services/rights-agreement.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -237,6 +242,10 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [ContributorAlreadyLinkedError, 'CONFLICT'],
   [ContributorPublicationDuplicateError, 'CONFLICT'],
   [PipelineItemNotInOrgError, 'NOT_FOUND'],
+  // Rights agreement errors
+  [RightsAgreementNotFoundError, 'NOT_FOUND'],
+  [InvalidRightsStatusTransitionError, 'BAD_REQUEST'],
+  [ContributorNotInOrgError, 'NOT_FOUND'],
 ];
 
 /**

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -36,6 +36,7 @@ import { hubRouter } from './routers/hub.js';
 import { collectionsRouter } from './routers/collections.js';
 import { opsRouter } from './routers/ops.js';
 import { contributorsRouter } from './routers/contributors.js';
+import { rightsAgreementsRouter } from './routers/rights-agreements.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -94,6 +95,7 @@ export const appRouter = t.router({
   collections: collectionsRouter,
   ops: opsRouter,
   contributors: contributorsRouter,
+  rightsAgreements: rightsAgreementsRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/rights-agreements.ts
+++ b/apps/api/src/trpc/routers/rights-agreements.ts
@@ -1,0 +1,134 @@
+import { z } from 'zod';
+import {
+  rightsAgreementSchema,
+  rightsAgreementListItemSchema,
+  createRightsAgreementSchema,
+  updateRightsAgreementSchema,
+  listRightsAgreementsSchema,
+  transitionRightsAgreementStatusSchema,
+  idParamSchema,
+  paginatedResponseSchema,
+} from '@colophony/types';
+import { businessOpsProcedure, createRouter, requireScopes } from '../init.js';
+import { rightsAgreementService } from '../../services/rights-agreement.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+
+export const rightsAgreementsRouter = createRouter({
+  /** List rights agreements for the current org (with joined names). */
+  list: businessOpsProcedure
+    .use(requireScopes('rights:read'))
+    .input(listRightsAgreementsSchema)
+    .output(paginatedResponseSchema(rightsAgreementListItemSchema))
+    .query(async ({ ctx, input }) => {
+      return rightsAgreementService.list(
+        ctx.dbTx,
+        input,
+        ctx.authContext.orgId,
+      );
+    }),
+
+  /** Get a rights agreement by ID. */
+  getById: businessOpsProcedure
+    .use(requireScopes('rights:read'))
+    .input(idParamSchema)
+    .output(rightsAgreementSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        const agreement = await rightsAgreementService.getById(
+          ctx.dbTx,
+          input.id,
+          ctx.authContext.orgId,
+        );
+        if (!agreement) {
+          const { RightsAgreementNotFoundError } =
+            await import('../../services/rights-agreement.service.js');
+          throw new RightsAgreementNotFoundError(input.id);
+        }
+        return agreement;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Get active agreements with upcoming reversion dates. */
+  upcomingReversions: businessOpsProcedure
+    .use(requireScopes('rights:read'))
+    .input(
+      z.object({
+        withinDays: z.number().int().min(1).max(365).default(30),
+      }),
+    )
+    .output(z.array(rightsAgreementSchema))
+    .query(async ({ ctx, input }) => {
+      return rightsAgreementService.getUpcomingReversions(
+        ctx.dbTx,
+        ctx.authContext.orgId,
+        input.withinDays,
+      );
+    }),
+
+  /** Create a new rights agreement. */
+  create: businessOpsProcedure
+    .use(requireScopes('rights:write'))
+    .input(createRightsAgreementSchema)
+    .output(rightsAgreementSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await rightsAgreementService.createWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Update a rights agreement (metadata only, not status). */
+  update: businessOpsProcedure
+    .use(requireScopes('rights:write'))
+    .input(updateRightsAgreementSchema)
+    .output(rightsAgreementSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await rightsAgreementService.updateWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Transition a rights agreement to a new status. */
+  transitionStatus: businessOpsProcedure
+    .use(requireScopes('rights:write'))
+    .input(transitionRightsAgreementStatusSchema)
+    .output(rightsAgreementSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await rightsAgreementService.transitionStatusWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Delete a rights agreement. */
+  delete: businessOpsProcedure
+    .use(requireScopes('rights:write'))
+    .input(idParamSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        await rightsAgreementService.deleteWithAudit(
+          toServiceContext(ctx),
+          input.id,
+        );
+        return { success: true };
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+});

--- a/apps/web/src/app/(dashboard)/business/rights/page.tsx
+++ b/apps/web/src/app/(dashboard)/business/rights/page.tsx
@@ -1,11 +1,89 @@
+"use client";
+
+import { trpc } from "@/lib/trpc";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import type { BadgeProps } from "@/components/ui/badge";
+
+const STATUS_BADGE_VARIANT: Record<string, BadgeProps["variant"]> = {
+  DRAFT: "secondary",
+  SENT: "outline",
+  SIGNED: "default",
+  ACTIVE: "default",
+  REVERTED: "destructive",
+};
+
+function formatRightsType(type: string): string {
+  return type
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
 export default function RightsPage() {
+  const { data, isPending: isLoading } = trpc.rightsAgreements.list.useQuery({
+    page: 1,
+    limit: 20,
+  });
+
   return (
     <div className="p-6">
       <h1 className="text-2xl font-semibold mb-4">Rights Agreements</h1>
-      <p className="text-muted-foreground">
-        Track intellectual property rights, reversion dates, and agreement
-        status for published works.
-      </p>
+
+      {isLoading && <p className="text-muted-foreground">Loading...</p>}
+
+      {data && data.items.length === 0 && (
+        <p className="text-muted-foreground">
+          No rights agreements yet. Rights agreements track intellectual
+          property rights for published works.
+        </p>
+      )}
+
+      {data && data.items.length > 0 && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Rights Type</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Contributor</TableHead>
+              <TableHead>Work</TableHead>
+              <TableHead>Expires</TableHead>
+              <TableHead>Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.items.map((r) => (
+              <TableRow key={r.id}>
+                <TableCell className="font-medium">
+                  {formatRightsType(r.rightsType)}
+                </TableCell>
+                <TableCell>
+                  <Badge variant={STATUS_BADGE_VARIANT[r.status]}>
+                    {r.status}
+                  </Badge>
+                </TableCell>
+                <TableCell>{r.contributorName}</TableCell>
+                <TableCell>{r.pipelineItemTitle ?? "—"}</TableCell>
+                <TableCell>
+                  {r.expiresAt
+                    ? new Date(r.expiresAt).toLocaleDateString()
+                    : "—"}
+                </TableCell>
+                <TableCell>
+                  {new Date(r.createdAt).toLocaleDateString()}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
     </div>
   );
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -512,7 +512,7 @@
 - [x] [P1] `businessOpsProcedure` middleware — BUSINESS_OPS or ADMIN role check, following existing procedure pattern in `apps/api/src/trpc/init.ts` — (design system session 2026-03-28; done 2026-03-28)
 - [x] [P1] Business Ops nav group + sidebar rendering — new "Business" activity group visible to BUSINESS_OPS/ADMIN, command palette updated — (design system session 2026-03-28; done 2026-03-28)
 - [x] [P1] Contributor service + tRPC router — CRUD, link to submissions/users, publication add/remove, 8 procedures with audit + scope enforcement. Detail view deferred to next PR — (design system session 2026-03-28; done 2026-03-28)
-- [ ] [P1] Rights service — lifecycle management, reversion alerts ("3 rights agreements reverting in 30 days"), integration with production pipeline — (design system session 2026-03-28)
+- [x] [P1] Rights service — lifecycle management, reversion alerts ("3 rights agreements reverting in 30 days"), integration with production pipeline — (design system session 2026-03-28; done 2026-03-28)
 - [ ] [P1] Revenue service — submission fees (existing Stripe), contributor payments, contest prizes, revenue reporting — (design system session 2026-03-28)
 - [ ] [P2] Business Ops dashboard — health card grid pattern with contributor count, outstanding payments, upcoming reversions, revenue summary — (design system session 2026-03-28)
 - [ ] [P2] Editorial analytics dashboard — acceptance rate (overall + by genre/period), response time (avg/median/p90 + trend), pipeline health, genre distribution, contributor diversity, reader alignment — (design system session 2026-03-28)

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,27 @@ Newest entries first.
 
 ---
 
+## 2026-03-28 — Rights Agreement Service (Track 13)
+
+### Done
+
+- Rights agreement service: 7 methods — list (with inner join for contributor names, left join for submission titles), getById, getUpcomingReversions (expiring ACTIVE agreements within N days), createWithAudit, updateWithAudit, transitionStatusWithAudit, deleteWithAudit
+- Enforced status lifecycle: DRAFT → SENT → SIGNED → ACTIVE → REVERTED via `VALID_RIGHTS_STATUS_TRANSITIONS` map; timestamp side effects (grantedAt on ACTIVE, revertedAt on REVERTED)
+- tRPC router with 7 procedures (`list`, `getById`, `upcomingReversions`, `create`, `update`, `transitionStatus`, `delete`), all with `businessOpsProcedure` + `requireScopes`
+- 3 error classes (RightsAgreementNotFoundError, InvalidRightsStatusTransitionError, ContributorNotInOrgError) mapped in error-mapper.ts
+- 19 unit tests covering all methods, error paths, role guards, and transition edge cases
+- Frontend rights page: client list view with status badges (variant per status), contributor display names, submission titles via joined query
+- Extended `packages/types/src/rights-agreement.ts` with transition map, list/transition input schemas, `rightsAgreementListItemSchema` for joined responses
+
+### Decisions
+
+- Renamed `VALID_STATUS_TRANSITIONS` to `VALID_RIGHTS_STATUS_TRANSITIONS` to avoid name collision with submission module export
+- Inner join for contributors (contributorId is NOT NULL FK), left join for pipeline items → submissions for title
+- Single `transitionStatusWithAudit` method (not per-status methods) — switch for timestamp side effects keeps service lean
+- `grantedAt` only set on first ACTIVE transition (not overwritten if already set)
+
+---
+
 ## 2026-03-28 — Business Operations Foundation (Track 13)
 
 ### Done

--- a/packages/types/src/rights-agreement.ts
+++ b/packages/types/src/rights-agreement.ts
@@ -24,6 +24,22 @@ export const rightsAgreementStatusSchema = z
 export type RightsAgreementStatus = z.infer<typeof rightsAgreementStatusSchema>;
 
 // ---------------------------------------------------------------------------
+// Status transitions
+// ---------------------------------------------------------------------------
+
+/** Allowed status transitions for rights agreements. */
+export const VALID_RIGHTS_STATUS_TRANSITIONS: Record<
+  RightsAgreementStatus,
+  RightsAgreementStatus[]
+> = {
+  DRAFT: ["SENT", "SIGNED", "ACTIVE"],
+  SENT: ["SIGNED", "ACTIVE"],
+  SIGNED: ["ACTIVE"],
+  ACTIVE: ["REVERTED"],
+  REVERTED: [],
+};
+
+// ---------------------------------------------------------------------------
 // Response
 // ---------------------------------------------------------------------------
 
@@ -87,3 +103,52 @@ export const updateRightsAgreementSchema = z.object({
 export type UpdateRightsAgreementInput = z.infer<
   typeof updateRightsAgreementSchema
 >;
+
+// ---------------------------------------------------------------------------
+// Transition
+// ---------------------------------------------------------------------------
+
+export const transitionRightsAgreementStatusSchema = z.object({
+  id: z.string().uuid().describe("Rights agreement ID"),
+  status: rightsAgreementStatusSchema.describe("Target status"),
+});
+
+export type TransitionRightsAgreementStatusInput = z.infer<
+  typeof transitionRightsAgreementStatusSchema
+>;
+
+// ---------------------------------------------------------------------------
+// List (with joined names)
+// ---------------------------------------------------------------------------
+
+export const listRightsAgreementsSchema = z.object({
+  contributorId: z.string().uuid().optional().describe("Filter by contributor"),
+  pipelineItemId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Filter by pipeline item"),
+  status: rightsAgreementStatusSchema.optional().describe("Filter by status"),
+  rightsType: rightsTypeSchema.optional().describe("Filter by rights type"),
+  page: z.number().int().min(1).default(1).describe("Page number (1-based)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page"),
+});
+
+export type ListRightsAgreementsInput = z.infer<
+  typeof listRightsAgreementsSchema
+>;
+
+/** Extended response schema for list queries with joined display names. */
+export const rightsAgreementListItemSchema = rightsAgreementSchema.extend({
+  contributorName: z.string().describe("Contributor display name"),
+  pipelineItemTitle: z
+    .string()
+    .nullable()
+    .describe("Pipeline item title, if linked"),
+});

--- a/packages/types/src/rights-agreement.ts
+++ b/packages/types/src/rights-agreement.ts
@@ -92,13 +92,22 @@ export type CreateRightsAgreementInput = z.infer<
 // Update
 // ---------------------------------------------------------------------------
 
-export const updateRightsAgreementSchema = z.object({
-  id: z.string().uuid().describe("Rights agreement ID"),
-  rightsType: rightsTypeSchema.optional(),
-  customDescription: z.string().max(5000).nullable().optional(),
-  expiresAt: z.coerce.date().nullable().optional(),
-  notes: z.string().max(10000).nullable().optional(),
-});
+export const updateRightsAgreementSchema = z
+  .object({
+    id: z.string().uuid().describe("Rights agreement ID"),
+    rightsType: rightsTypeSchema.optional(),
+    customDescription: z.string().max(5000).nullable().optional(),
+    expiresAt: z.coerce.date().nullable().optional(),
+    notes: z.string().max(10000).nullable().optional(),
+  })
+  .refine(
+    (data) =>
+      data.rightsType !== undefined ||
+      data.customDescription !== undefined ||
+      data.expiresAt !== undefined ||
+      data.notes !== undefined,
+    { message: "At least one field to update is required" },
+  );
 
 export type UpdateRightsAgreementInput = z.infer<
   typeof updateRightsAgreementSchema


### PR DESCRIPTION
## Summary

- Rights agreement service with enforced status lifecycle (DRAFT→SENT→SIGNED→ACTIVE→REVERTED), reversion alerts, and full CRUD with audit logging
- tRPC router with 7 procedures (`list`, `getById`, `upcomingReversions`, `create`, `update`, `transitionStatus`, `delete`), all with `businessOpsProcedure` + `requireScopes`
- Frontend list page with joined contributor names, submission titles, and status badges

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `packages/types/src/rights-agreement.ts` | `VALID_STATUS_TRANSITIONS` | `VALID_RIGHTS_STATUS_TRANSITIONS` | Name collision with submission module's same-named export |
| `apps/api/src/services/rights-agreement.service.ts` | Left join for contributors | Inner join for contributors | `contributorId` is NOT NULL FK — inner join is correct; left join would introduce spurious nullable type |
| `apps/api/src/services/rights-agreement.service.ts` | `pipelineItems.title` for work title | `submissions.title` via `pipelineItems → submissions` join | `pipelineItems` has no `title` column; title lives on `submissions` |

## Test plan

- [x] 20 unit tests covering all service methods, error paths, role guards, and transition edge cases
- [x] Type-check passes across workspace (13/13 tasks)
- [x] Lint clean (API + web)
- [x] Existing contributor service tests pass (14/14 regression)
- [x] Existing RLS business ops tests unaffected
- [ ] CI pipeline