### PR TITLE
feat(business-ops): revenue service with payment transaction management

### DIFF
--- a/apps/api/src/services/revenue.service.spec.ts
+++ b/apps/api/src/services/revenue.service.spec.ts
@@ -1,0 +1,727 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@colophony/db', () => ({
+  paymentTransactions: {
+    id: 'pt.id',
+    organizationId: 'pt.org_id',
+    contributorId: 'pt.contributor_id',
+    submissionId: 'pt.submission_id',
+    paymentId: 'pt.payment_id',
+    type: 'pt.type',
+    direction: 'pt.direction',
+    amount: 'pt.amount',
+    currency: 'pt.currency',
+    status: 'pt.status',
+    description: 'pt.description',
+    metadata: 'pt.metadata',
+    processedAt: 'pt.processed_at',
+    createdAt: 'pt.created_at',
+    updatedAt: 'pt.updated_at',
+  },
+  contributors: {
+    id: 'c.id',
+    organizationId: 'c.org_id',
+    displayName: 'c.display_name',
+  },
+  eq: vi.fn(),
+  and: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  count: vi.fn(),
+  sql: vi.fn(),
+}));
+
+vi.mock('./errors.js', () => ({
+  assertBusinessOpsOrAdmin: vi.fn(),
+  ForbiddenError: class ForbiddenError extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = 'ForbiddenError';
+    }
+  },
+}));
+
+vi.mock('./rights-agreement.service.js', () => ({
+  ContributorNotInOrgError: class ContributorNotInOrgError extends Error {
+    constructor(id: string) {
+      super(`Contributor "${id}" does not belong to this organization`);
+      this.name = 'ContributorNotInOrgError';
+    }
+  },
+}));
+
+import {
+  revenueService,
+  PaymentTransactionNotFoundError,
+  InvalidPaymentStatusTransitionError,
+} from './revenue.service.js';
+import { ContributorNotInOrgError } from './rights-agreement.service.js';
+import { assertBusinessOpsOrAdmin } from './errors.js';
+import type { ServiceContext } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ORG_ID = 'org-1';
+const USER_ID = 'user-1';
+const TX_ID = 'tx-1';
+const CONTRIBUTOR_ID = 'contributor-1';
+
+const fakeTransaction = {
+  id: TX_ID,
+  organizationId: ORG_ID,
+  contributorId: CONTRIBUTOR_ID,
+  submissionId: null,
+  paymentId: null,
+  type: 'submission_fee' as const,
+  direction: 'inbound' as const,
+  amount: 1500,
+  currency: 'usd',
+  status: 'PENDING' as const,
+  description: null,
+  metadata: null,
+  processedAt: null,
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+};
+
+function makeChain() {
+  const c: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of [
+    'from',
+    'leftJoin',
+    'innerJoin',
+    'where',
+    'orderBy',
+    'limit',
+    'offset',
+    'values',
+    'set',
+    'returning',
+    'groupBy',
+  ]) {
+    c[m] = vi.fn().mockReturnValue(c);
+  }
+  return c;
+}
+
+function makeMockTx() {
+  const chains: Array<Record<string, ReturnType<typeof vi.fn>>> = [];
+
+  function newChain() {
+    const c = makeChain();
+    chains.push(c);
+    return c;
+  }
+
+  return {
+    select: vi.fn(() => newChain()),
+    insert: vi.fn(() => newChain()),
+    update: vi.fn(() => newChain()),
+    delete: vi.fn(() => newChain()),
+    chain(n: number) {
+      return chains[n];
+    },
+    resetChains() {
+      chains.length = 0;
+    },
+  };
+}
+
+function makeServiceContext(tx: ReturnType<typeof makeMockTx>): ServiceContext {
+  return {
+    tx: tx as unknown as ServiceContext['tx'],
+    actor: { userId: USER_ID, orgId: ORG_ID, roles: ['BUSINESS_OPS'] },
+    audit: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('revenueService', () => {
+  let mockTx: ReturnType<typeof makeMockTx>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTx = makeMockTx();
+  });
+
+  // -----------------------------------------------------------------------
+  // getById
+  // -----------------------------------------------------------------------
+
+  describe('getById', () => {
+    it('returns transaction when found', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeTransaction]);
+        return c;
+      });
+
+      const result = await revenueService.getById(mockTx as any, TX_ID, ORG_ID);
+      expect(result).toEqual(fakeTransaction);
+    });
+
+    it('returns null when not found', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([]);
+        return c;
+      });
+
+      const result = await revenueService.getById(
+        mockTx as any,
+        'nonexistent',
+        ORG_ID,
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // list
+  // -----------------------------------------------------------------------
+
+  describe('list', () => {
+    it('returns paginated results', async () => {
+      const listItem = { ...fakeTransaction, contributorName: 'Jane Doe' };
+      let selectCount = 0;
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        selectCount++;
+        if (selectCount === 1) {
+          c.offset.mockResolvedValueOnce([listItem]);
+        } else {
+          // count query
+          c.where.mockResolvedValueOnce([{ total: 1 }]);
+        }
+        return c;
+      });
+
+      const result = await revenueService.list(
+        mockTx as any,
+        { page: 1, limit: 20 },
+        ORG_ID,
+      );
+
+      expect(result.items).toEqual([listItem]);
+      expect(result.total).toBe(1);
+      expect(result.totalPages).toBe(1);
+    });
+
+    it('applies type filter', async () => {
+      let selectCount = 0;
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        selectCount++;
+        if (selectCount === 1) {
+          c.offset.mockResolvedValueOnce([]);
+        } else {
+          c.where.mockResolvedValueOnce([{ total: 0 }]);
+        }
+        return c;
+      });
+
+      await revenueService.list(
+        mockTx as any,
+        { page: 1, limit: 20, type: 'submission_fee' },
+        ORG_ID,
+      );
+
+      // Should have been called (we just verify it doesn't throw)
+      expect(mockTx.select).toHaveBeenCalledTimes(2);
+    });
+
+    it('applies status filter', async () => {
+      let selectCount = 0;
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        selectCount++;
+        if (selectCount === 1) {
+          c.offset.mockResolvedValueOnce([]);
+        } else {
+          c.where.mockResolvedValueOnce([{ total: 0 }]);
+        }
+        return c;
+      });
+
+      await revenueService.list(
+        mockTx as any,
+        { page: 1, limit: 20, status: 'SUCCEEDED' },
+        ORG_ID,
+      );
+
+      expect(mockTx.select).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getSummary
+  // -----------------------------------------------------------------------
+
+  describe('getSummary', () => {
+    it('returns aggregated revenue summary', async () => {
+      let selectCount = 0;
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        selectCount++;
+        if (selectCount === 1) {
+          // totals query
+          c.where.mockResolvedValueOnce([
+            { totalInbound: 5000, totalOutbound: 2000 },
+          ]);
+        } else if (selectCount === 2) {
+          // countByType
+          c.groupBy.mockResolvedValueOnce([
+            { type: 'submission_fee', count: 3 },
+            { type: 'contributor_payment', count: 1 },
+          ]);
+        } else {
+          // countByStatus
+          c.groupBy.mockResolvedValueOnce([
+            { status: 'SUCCEEDED', count: 3 },
+            { status: 'PENDING', count: 1 },
+          ]);
+        }
+        return c;
+      });
+
+      const result = await revenueService.getSummary(mockTx as any, ORG_ID);
+
+      expect(result.totalInbound).toBe(5000);
+      expect(result.totalOutbound).toBe(2000);
+      expect(result.net).toBe(3000);
+      expect(result.countByType).toEqual({
+        submission_fee: 3,
+        contributor_payment: 1,
+      });
+      expect(result.countByStatus).toEqual({
+        SUCCEEDED: 3,
+        PENDING: 1,
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // createWithAudit
+  // -----------------------------------------------------------------------
+
+  describe('createWithAudit', () => {
+    it('inserts transaction and emits audit event', async () => {
+      // contributor validation + insert
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([{ id: CONTRIBUTOR_ID }]);
+        return c;
+      });
+      mockTx.insert = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([fakeTransaction]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await revenueService.createWithAudit(ctx, {
+        contributorId: CONTRIBUTOR_ID,
+        type: 'submission_fee',
+        direction: 'inbound',
+        amount: 1500,
+        currency: 'usd',
+      });
+
+      expect(result).toEqual(fakeTransaction);
+      expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'PAYMENT_TRANSACTION_CREATED',
+          resource: 'payment_transaction',
+          resourceId: TX_ID,
+        }),
+      );
+    });
+
+    it('allows creation without contributorId', async () => {
+      mockTx.insert = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...fakeTransaction, contributorId: null },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await revenueService.createWithAudit(ctx, {
+        type: 'submission_fee',
+        direction: 'inbound',
+        amount: 1500,
+        currency: 'usd',
+      });
+
+      expect(result.contributorId).toBeNull();
+      // No contributor select should have happened
+      expect(mockTx.select).not.toHaveBeenCalled();
+    });
+
+    it('throws ContributorNotInOrgError for cross-org contributor', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        revenueService.createWithAudit(ctx, {
+          contributorId: 'other-org-contributor',
+          type: 'submission_fee',
+          direction: 'inbound',
+          amount: 1500,
+          currency: 'usd',
+        }),
+      ).rejects.toThrow(ContributorNotInOrgError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // updateWithAudit
+  // -----------------------------------------------------------------------
+
+  describe('updateWithAudit', () => {
+    it('updates fields and emits audit', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeTransaction]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...fakeTransaction, description: 'Updated desc' },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await revenueService.updateWithAudit(ctx, {
+        id: TX_ID,
+        description: 'Updated desc',
+      });
+
+      expect(result.description).toBe('Updated desc');
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'PAYMENT_TRANSACTION_UPDATED',
+          resource: 'payment_transaction',
+        }),
+      );
+    });
+
+    it('throws PaymentTransactionNotFoundError for missing ID', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        revenueService.updateWithAudit(ctx, {
+          id: 'nonexistent',
+          description: 'foo',
+        }),
+      ).rejects.toThrow(PaymentTransactionNotFoundError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // transitionStatusWithAudit
+  // -----------------------------------------------------------------------
+
+  describe('transitionStatusWithAudit', () => {
+    it('transitions PENDING to PROCESSING', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeTransaction]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...fakeTransaction, status: 'PROCESSING' },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await revenueService.transitionStatusWithAudit(ctx, {
+        id: TX_ID,
+        status: 'PROCESSING',
+      });
+
+      expect(result.status).toBe('PROCESSING');
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'PAYMENT_TRANSACTION_STATUS_CHANGED',
+          newValue: { status: 'PROCESSING' },
+        }),
+      );
+    });
+
+    it('transitions PROCESSING to SUCCEEDED and sets processedAt', async () => {
+      const processing = { ...fakeTransaction, status: 'PROCESSING' as const };
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([processing]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...processing, status: 'SUCCEEDED', processedAt: new Date() },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await revenueService.transitionStatusWithAudit(ctx, {
+        id: TX_ID,
+        status: 'SUCCEEDED',
+      });
+
+      expect(result.status).toBe('SUCCEEDED');
+      expect(result.processedAt).toBeTruthy();
+    });
+
+    it('transitions SUCCEEDED to REFUNDED and sets processedAt', async () => {
+      const succeeded = {
+        ...fakeTransaction,
+        status: 'SUCCEEDED' as const,
+        processedAt: new Date('2026-01-15'),
+      };
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([succeeded]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...succeeded, status: 'REFUNDED', processedAt: new Date() },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await revenueService.transitionStatusWithAudit(ctx, {
+        id: TX_ID,
+        status: 'REFUNDED',
+      });
+
+      expect(result.status).toBe('REFUNDED');
+    });
+
+    it('transitions FAILED to PENDING (retry) and resets processedAt', async () => {
+      const failed = {
+        ...fakeTransaction,
+        status: 'FAILED' as const,
+        processedAt: new Date('2026-01-15'),
+      };
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([failed]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...failed, status: 'PENDING', processedAt: null },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      const result = await revenueService.transitionStatusWithAudit(ctx, {
+        id: TX_ID,
+        status: 'PENDING',
+      });
+
+      expect(result.status).toBe('PENDING');
+      expect(result.processedAt).toBeNull();
+    });
+
+    it('throws InvalidPaymentStatusTransitionError for REFUNDED to any', async () => {
+      const refunded = { ...fakeTransaction, status: 'REFUNDED' as const };
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([refunded]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        revenueService.transitionStatusWithAudit(ctx, {
+          id: TX_ID,
+          status: 'PENDING',
+        }),
+      ).rejects.toThrow(InvalidPaymentStatusTransitionError);
+    });
+
+    it('throws InvalidPaymentStatusTransitionError for SUCCEEDED to PROCESSING', async () => {
+      const succeeded = { ...fakeTransaction, status: 'SUCCEEDED' as const };
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([succeeded]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        revenueService.transitionStatusWithAudit(ctx, {
+          id: TX_ID,
+          status: 'PROCESSING',
+        }),
+      ).rejects.toThrow(InvalidPaymentStatusTransitionError);
+    });
+
+    it('throws PaymentTransactionNotFoundError for missing ID', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        revenueService.transitionStatusWithAudit(ctx, {
+          id: 'nonexistent',
+          status: 'PROCESSING',
+        }),
+      ).rejects.toThrow(PaymentTransactionNotFoundError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // deleteWithAudit
+  // -----------------------------------------------------------------------
+
+  describe('deleteWithAudit', () => {
+    it('deletes and emits audit', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeTransaction]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await revenueService.deleteWithAudit(ctx, TX_ID);
+
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'PAYMENT_TRANSACTION_DELETED',
+          resource: 'payment_transaction',
+          resourceId: TX_ID,
+        }),
+      );
+    });
+
+    it('throws PaymentTransactionNotFoundError for missing ID', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await expect(
+        revenueService.deleteWithAudit(ctx, 'nonexistent'),
+      ).rejects.toThrow(PaymentTransactionNotFoundError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Role guard
+  // -----------------------------------------------------------------------
+
+  describe('role guard', () => {
+    it('createWithAudit calls assertBusinessOpsOrAdmin', async () => {
+      mockTx.insert = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([fakeTransaction]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await revenueService.createWithAudit(ctx, {
+        type: 'submission_fee',
+        direction: 'inbound',
+        amount: 1500,
+        currency: 'usd',
+      });
+      expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
+    });
+
+    it('updateWithAudit calls assertBusinessOpsOrAdmin', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeTransaction]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...fakeTransaction, description: 'x' },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await revenueService.updateWithAudit(ctx, {
+        id: TX_ID,
+        description: 'x',
+      });
+      expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
+    });
+
+    it('transitionStatusWithAudit calls assertBusinessOpsOrAdmin', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeTransaction]);
+        return c;
+      });
+      mockTx.update = vi.fn(() => {
+        const c = makeChain();
+        c.returning.mockResolvedValueOnce([
+          { ...fakeTransaction, status: 'PROCESSING' },
+        ]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await revenueService.transitionStatusWithAudit(ctx, {
+        id: TX_ID,
+        status: 'PROCESSING',
+      });
+      expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
+    });
+
+    it('deleteWithAudit calls assertBusinessOpsOrAdmin', async () => {
+      mockTx.select = vi.fn(() => {
+        const c = makeChain();
+        c.limit.mockResolvedValueOnce([fakeTransaction]);
+        return c;
+      });
+      const ctx = makeServiceContext(mockTx);
+
+      await revenueService.deleteWithAudit(ctx, TX_ID);
+      expect(assertBusinessOpsOrAdmin).toHaveBeenCalledWith(['BUSINESS_OPS']);
+    });
+  });
+});

--- a/apps/api/src/services/revenue.service.ts
+++ b/apps/api/src/services/revenue.service.ts
@@ -1,0 +1,359 @@
+import {
+  paymentTransactions,
+  contributors,
+  eq,
+  and,
+  type DrizzleDb,
+} from '@colophony/db';
+import { count, sql } from 'drizzle-orm';
+import type {
+  CreatePaymentTransactionInput,
+  UpdatePaymentTransactionInput,
+  ListPaymentTransactionsInput,
+  TransitionPaymentTransactionStatusInput,
+} from '@colophony/types';
+import {
+  AuditActions,
+  AuditResources,
+  VALID_PAYMENT_STATUS_TRANSITIONS,
+} from '@colophony/types';
+import type { ServiceContext } from './types.js';
+import { assertBusinessOpsOrAdmin } from './errors.js';
+import { ContributorNotInOrgError } from './rights-agreement.service.js';
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class PaymentTransactionNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Payment transaction "${id}" not found`);
+    this.name = 'PaymentTransactionNotFoundError';
+  }
+}
+
+export class InvalidPaymentStatusTransitionError extends Error {
+  constructor(from: string, to: string) {
+    super(`Cannot transition payment from "${from}" to "${to}"`);
+    this.name = 'InvalidPaymentStatusTransitionError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const revenueService = {
+  // -------------------------------------------------------------------------
+  // Pure data methods
+  // -------------------------------------------------------------------------
+
+  async list(
+    tx: DrizzleDb,
+    input: ListPaymentTransactionsInput,
+    orgId: string,
+  ) {
+    const { page, limit } = input;
+    const offset = (page - 1) * limit;
+
+    const conditions = [eq(paymentTransactions.organizationId, orgId)];
+
+    if (input.type) {
+      conditions.push(eq(paymentTransactions.type, input.type));
+    }
+    if (input.direction) {
+      conditions.push(eq(paymentTransactions.direction, input.direction));
+    }
+    if (input.contributorId) {
+      conditions.push(
+        eq(paymentTransactions.contributorId, input.contributorId),
+      );
+    }
+    if (input.status) {
+      conditions.push(eq(paymentTransactions.status, input.status));
+    }
+
+    const where = and(...conditions);
+
+    const [items, [{ total }]] = await Promise.all([
+      tx
+        .select({
+          id: paymentTransactions.id,
+          organizationId: paymentTransactions.organizationId,
+          contributorId: paymentTransactions.contributorId,
+          submissionId: paymentTransactions.submissionId,
+          paymentId: paymentTransactions.paymentId,
+          type: paymentTransactions.type,
+          direction: paymentTransactions.direction,
+          amount: paymentTransactions.amount,
+          currency: paymentTransactions.currency,
+          status: paymentTransactions.status,
+          description: paymentTransactions.description,
+          metadata: paymentTransactions.metadata,
+          processedAt: paymentTransactions.processedAt,
+          createdAt: paymentTransactions.createdAt,
+          updatedAt: paymentTransactions.updatedAt,
+          contributorName: contributors.displayName,
+        })
+        .from(paymentTransactions)
+        .leftJoin(
+          contributors,
+          eq(paymentTransactions.contributorId, contributors.id),
+        )
+        .where(where)
+        .orderBy(paymentTransactions.createdAt)
+        .limit(limit)
+        .offset(offset),
+      tx.select({ total: count() }).from(paymentTransactions).where(where),
+    ]);
+
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async getById(tx: DrizzleDb, id: string, orgId: string) {
+    const [row] = await tx
+      .select()
+      .from(paymentTransactions)
+      .where(
+        and(
+          eq(paymentTransactions.id, id),
+          eq(paymentTransactions.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  },
+
+  async getSummary(tx: DrizzleDb, orgId: string) {
+    const orgCondition = eq(paymentTransactions.organizationId, orgId);
+
+    const [[totals], typeCounts, statusCounts] = await Promise.all([
+      tx
+        .select({
+          totalInbound: sql<number>`COALESCE(SUM(CASE WHEN ${paymentTransactions.direction} = 'inbound' AND ${paymentTransactions.status} = 'SUCCEEDED' THEN ${paymentTransactions.amount} ELSE 0 END), 0)::int`,
+          totalOutbound: sql<number>`COALESCE(SUM(CASE WHEN ${paymentTransactions.direction} = 'outbound' AND ${paymentTransactions.status} = 'SUCCEEDED' THEN ${paymentTransactions.amount} ELSE 0 END), 0)::int`,
+        })
+        .from(paymentTransactions)
+        .where(orgCondition),
+      tx
+        .select({
+          type: paymentTransactions.type,
+          count: count(),
+        })
+        .from(paymentTransactions)
+        .where(orgCondition)
+        .groupBy(paymentTransactions.type),
+      tx
+        .select({
+          status: paymentTransactions.status,
+          count: count(),
+        })
+        .from(paymentTransactions)
+        .where(orgCondition)
+        .groupBy(paymentTransactions.status),
+    ]);
+
+    return {
+      totalInbound: totals.totalInbound,
+      totalOutbound: totals.totalOutbound,
+      net: totals.totalInbound - totals.totalOutbound,
+      countByType: Object.fromEntries(typeCounts.map((r) => [r.type, r.count])),
+      countByStatus: Object.fromEntries(
+        statusCounts.map((r) => [r.status, r.count]),
+      ),
+    };
+  },
+
+  // -------------------------------------------------------------------------
+  // Audit-wrapped methods
+  // -------------------------------------------------------------------------
+
+  async createWithAudit(
+    ctx: ServiceContext,
+    input: CreatePaymentTransactionInput,
+  ) {
+    assertBusinessOpsOrAdmin(ctx.actor.roles);
+
+    // Validate contributor belongs to org (if provided)
+    if (input.contributorId) {
+      const [contributor] = await ctx.tx
+        .select({ id: contributors.id })
+        .from(contributors)
+        .where(
+          and(
+            eq(contributors.id, input.contributorId),
+            eq(contributors.organizationId, ctx.actor.orgId),
+          ),
+        )
+        .limit(1);
+      if (!contributor) throw new ContributorNotInOrgError(input.contributorId);
+    }
+
+    const [transaction] = await ctx.tx
+      .insert(paymentTransactions)
+      .values({
+        organizationId: ctx.actor.orgId,
+        contributorId: input.contributorId ?? null,
+        submissionId: input.submissionId ?? null,
+        paymentId: input.paymentId ?? null,
+        type: input.type,
+        direction: input.direction,
+        amount: input.amount,
+        currency: input.currency ?? 'usd',
+        description: input.description ?? null,
+        metadata: input.metadata ?? null,
+      })
+      .returning();
+
+    await ctx.audit({
+      action: AuditActions.PAYMENT_TRANSACTION_CREATED,
+      resource: AuditResources.PAYMENT_TRANSACTION,
+      resourceId: transaction.id,
+      newValue: {
+        type: transaction.type,
+        direction: transaction.direction,
+        amount: transaction.amount,
+        status: transaction.status,
+      },
+    });
+
+    return transaction;
+  },
+
+  async updateWithAudit(
+    ctx: ServiceContext,
+    input: UpdatePaymentTransactionInput,
+  ) {
+    assertBusinessOpsOrAdmin(ctx.actor.roles);
+
+    const existing = await revenueService.getById(
+      ctx.tx,
+      input.id,
+      ctx.actor.orgId,
+    );
+    if (!existing) throw new PaymentTransactionNotFoundError(input.id);
+
+    // Build update payload excluding id and undefined values
+    const updateData: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(input)) {
+      if (key !== 'id' && value !== undefined) {
+        updateData[key] = value;
+      }
+    }
+
+    const [updated] = await ctx.tx
+      .update(paymentTransactions)
+      .set(updateData)
+      .where(
+        and(
+          eq(paymentTransactions.id, input.id),
+          eq(paymentTransactions.organizationId, ctx.actor.orgId),
+        ),
+      )
+      .returning();
+
+    await ctx.audit({
+      action: AuditActions.PAYMENT_TRANSACTION_UPDATED,
+      resource: AuditResources.PAYMENT_TRANSACTION,
+      resourceId: input.id,
+      oldValue: {
+        description: existing.description,
+        metadata: existing.metadata,
+      },
+      newValue: {
+        description: updated.description,
+        metadata: updated.metadata,
+      },
+    });
+
+    return updated;
+  },
+
+  async transitionStatusWithAudit(
+    ctx: ServiceContext,
+    input: TransitionPaymentTransactionStatusInput,
+  ) {
+    assertBusinessOpsOrAdmin(ctx.actor.roles);
+
+    const existing = await revenueService.getById(
+      ctx.tx,
+      input.id,
+      ctx.actor.orgId,
+    );
+    if (!existing) throw new PaymentTransactionNotFoundError(input.id);
+
+    const allowed = VALID_PAYMENT_STATUS_TRANSITIONS[existing.status];
+    if (!allowed.includes(input.status)) {
+      throw new InvalidPaymentStatusTransitionError(
+        existing.status,
+        input.status,
+      );
+    }
+
+    // Build update with timestamp side effects
+    const updateData: Record<string, unknown> = { status: input.status };
+
+    if (['SUCCEEDED', 'FAILED', 'REFUNDED'].includes(input.status)) {
+      updateData.processedAt = new Date();
+    }
+    // Reset processedAt on retry (FAILED → PENDING)
+    if (input.status === 'PENDING') {
+      updateData.processedAt = null;
+    }
+
+    const [updated] = await ctx.tx
+      .update(paymentTransactions)
+      .set(updateData)
+      .where(
+        and(
+          eq(paymentTransactions.id, input.id),
+          eq(paymentTransactions.organizationId, ctx.actor.orgId),
+        ),
+      )
+      .returning();
+
+    await ctx.audit({
+      action: AuditActions.PAYMENT_TRANSACTION_STATUS_CHANGED,
+      resource: AuditResources.PAYMENT_TRANSACTION,
+      resourceId: input.id,
+      oldValue: { status: existing.status },
+      newValue: { status: input.status },
+    });
+
+    return updated;
+  },
+
+  async deleteWithAudit(ctx: ServiceContext, id: string) {
+    assertBusinessOpsOrAdmin(ctx.actor.roles);
+
+    const existing = await revenueService.getById(ctx.tx, id, ctx.actor.orgId);
+    if (!existing) throw new PaymentTransactionNotFoundError(id);
+
+    await ctx.tx
+      .delete(paymentTransactions)
+      .where(
+        and(
+          eq(paymentTransactions.id, id),
+          eq(paymentTransactions.organizationId, ctx.actor.orgId),
+        ),
+      );
+
+    await ctx.audit({
+      action: AuditActions.PAYMENT_TRANSACTION_DELETED,
+      resource: AuditResources.PAYMENT_TRANSACTION,
+      resourceId: id,
+      oldValue: {
+        type: existing.type,
+        direction: existing.direction,
+        amount: existing.amount,
+        status: existing.status,
+      },
+    });
+  },
+};

--- a/apps/api/src/services/revenue.service.ts
+++ b/apps/api/src/services/revenue.service.ts
@@ -136,8 +136,8 @@ export const revenueService = {
     const [[totals], typeCounts, statusCounts] = await Promise.all([
       tx
         .select({
-          totalInbound: sql<number>`COALESCE(SUM(CASE WHEN ${paymentTransactions.direction} = 'inbound' AND ${paymentTransactions.status} = 'SUCCEEDED' THEN ${paymentTransactions.amount} ELSE 0 END), 0)::int`,
-          totalOutbound: sql<number>`COALESCE(SUM(CASE WHEN ${paymentTransactions.direction} = 'outbound' AND ${paymentTransactions.status} = 'SUCCEEDED' THEN ${paymentTransactions.amount} ELSE 0 END), 0)::int`,
+          totalInbound: sql<string>`COALESCE(SUM(CASE WHEN ${paymentTransactions.direction} = 'inbound' AND ${paymentTransactions.status} = 'SUCCEEDED' THEN ${paymentTransactions.amount} ELSE 0 END), 0)`,
+          totalOutbound: sql<string>`COALESCE(SUM(CASE WHEN ${paymentTransactions.direction} = 'outbound' AND ${paymentTransactions.status} = 'SUCCEEDED' THEN ${paymentTransactions.amount} ELSE 0 END), 0)`,
         })
         .from(paymentTransactions)
         .where(orgCondition),
@@ -159,10 +159,14 @@ export const revenueService = {
         .groupBy(paymentTransactions.status),
     ]);
 
+    // SUM(integer) returns bigint in PostgreSQL; parse safely to avoid ::int overflow
+    const totalInbound = Number(totals.totalInbound);
+    const totalOutbound = Number(totals.totalOutbound);
+
     return {
-      totalInbound: totals.totalInbound,
-      totalOutbound: totals.totalOutbound,
-      net: totals.totalInbound - totals.totalOutbound,
+      totalInbound,
+      totalOutbound,
+      net: totalInbound - totalOutbound,
       countByType: Object.fromEntries(typeCounts.map((r) => [r.type, r.count])),
       countByStatus: Object.fromEntries(
         statusCounts.map((r) => [r.status, r.count]),

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -129,6 +129,10 @@ import {
   InvalidRightsStatusTransitionError,
   ContributorNotInOrgError,
 } from '../services/rights-agreement.service.js';
+import {
+  PaymentTransactionNotFoundError,
+  InvalidPaymentStatusTransitionError,
+} from '../services/revenue.service.js';
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 
@@ -246,6 +250,9 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [RightsAgreementNotFoundError, 'NOT_FOUND'],
   [InvalidRightsStatusTransitionError, 'BAD_REQUEST'],
   [ContributorNotInOrgError, 'NOT_FOUND'],
+  // Payment transaction errors
+  [PaymentTransactionNotFoundError, 'NOT_FOUND'],
+  [InvalidPaymentStatusTransitionError, 'BAD_REQUEST'],
 ];
 
 /**

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -37,6 +37,7 @@ import { collectionsRouter } from './routers/collections.js';
 import { opsRouter } from './routers/ops.js';
 import { contributorsRouter } from './routers/contributors.js';
 import { rightsAgreementsRouter } from './routers/rights-agreements.js';
+import { paymentTransactionsRouter } from './routers/payment-transactions.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -96,6 +97,7 @@ export const appRouter = t.router({
   ops: opsRouter,
   contributors: contributorsRouter,
   rightsAgreements: rightsAgreementsRouter,
+  paymentTransactions: paymentTransactionsRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/payment-transactions.ts
+++ b/apps/api/src/trpc/routers/payment-transactions.ts
@@ -1,0 +1,118 @@
+import {
+  paymentTransactionSchema,
+  paymentTransactionListItemSchema,
+  createPaymentTransactionSchema,
+  updatePaymentTransactionSchema,
+  listPaymentTransactionsSchema,
+  transitionPaymentTransactionStatusSchema,
+  revenueSummarySchema,
+  idParamSchema,
+  paginatedResponseSchema,
+} from '@colophony/types';
+import { businessOpsProcedure, createRouter, requireScopes } from '../init.js';
+import { revenueService } from '../../services/revenue.service.js';
+import { toServiceContext } from '../../services/context.js';
+import { mapServiceError } from '../error-mapper.js';
+
+export const paymentTransactionsRouter = createRouter({
+  /** List payment transactions for the current org (with contributor names). */
+  list: businessOpsProcedure
+    .use(requireScopes('payment-transactions:read'))
+    .input(listPaymentTransactionsSchema)
+    .output(paginatedResponseSchema(paymentTransactionListItemSchema))
+    .query(async ({ ctx, input }) => {
+      return revenueService.list(ctx.dbTx, input, ctx.authContext.orgId);
+    }),
+
+  /** Get a payment transaction by ID. */
+  getById: businessOpsProcedure
+    .use(requireScopes('payment-transactions:read'))
+    .input(idParamSchema)
+    .output(paymentTransactionSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        const transaction = await revenueService.getById(
+          ctx.dbTx,
+          input.id,
+          ctx.authContext.orgId,
+        );
+        if (!transaction) {
+          const { PaymentTransactionNotFoundError } =
+            await import('../../services/revenue.service.js');
+          throw new PaymentTransactionNotFoundError(input.id);
+        }
+        return transaction;
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Get revenue summary for the current org. */
+  summary: businessOpsProcedure
+    .use(requireScopes('payment-transactions:read'))
+    .output(revenueSummarySchema)
+    .query(async ({ ctx }) => {
+      return revenueService.getSummary(ctx.dbTx, ctx.authContext.orgId);
+    }),
+
+  /** Create a new payment transaction. */
+  create: businessOpsProcedure
+    .use(requireScopes('payment-transactions:write'))
+    .input(createPaymentTransactionSchema)
+    .output(paymentTransactionSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await revenueService.createWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Update a payment transaction (description/metadata only). */
+  update: businessOpsProcedure
+    .use(requireScopes('payment-transactions:write'))
+    .input(updatePaymentTransactionSchema)
+    .output(paymentTransactionSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await revenueService.updateWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Transition a payment transaction to a new status. */
+  transitionStatus: businessOpsProcedure
+    .use(requireScopes('payment-transactions:write'))
+    .input(transitionPaymentTransactionStatusSchema)
+    .output(paymentTransactionSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await revenueService.transitionStatusWithAudit(
+          toServiceContext(ctx),
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Delete a payment transaction. */
+  delete: businessOpsProcedure
+    .use(requireScopes('payment-transactions:write'))
+    .input(idParamSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        await revenueService.deleteWithAudit(toServiceContext(ctx), input.id);
+        return { success: true as const };
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+});

--- a/apps/web/src/app/(dashboard)/business/payments/page.tsx
+++ b/apps/web/src/app/(dashboard)/business/payments/page.tsx
@@ -1,11 +1,109 @@
+"use client";
+
+import { trpc } from "@/lib/trpc";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import type { BadgeProps } from "@/components/ui/badge";
+
+const STATUS_BADGE_VARIANT: Record<string, BadgeProps["variant"]> = {
+  PENDING: "secondary",
+  PROCESSING: "outline",
+  SUCCEEDED: "default",
+  FAILED: "destructive",
+  REFUNDED: "secondary",
+};
+
+const DIRECTION_BADGE_VARIANT: Record<string, BadgeProps["variant"]> = {
+  inbound: "default",
+  outbound: "outline",
+};
+
+function formatCents(amount: number, currency: string): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: currency.toUpperCase(),
+  }).format(amount / 100);
+}
+
+function formatType(type: string): string {
+  return type
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
 export default function PaymentsPage() {
+  const { data, isPending: isLoading } = trpc.paymentTransactions.list.useQuery(
+    {
+      page: 1,
+      limit: 20,
+    },
+  );
+
   return (
     <div className="p-6">
       <h1 className="text-2xl font-semibold mb-4">Payments</h1>
-      <p className="text-muted-foreground">
-        Submission fees, contributor payments, and contest prizes — all
-        transaction types in one place.
-      </p>
+
+      {isLoading && <p className="text-muted-foreground">Loading...</p>}
+
+      {data && data.items.length === 0 && (
+        <p className="text-muted-foreground">
+          No payment transactions yet. Submission fees, contributor payments,
+          and contest prizes will appear here.
+        </p>
+      )}
+
+      {data && data.items.length > 0 && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Type</TableHead>
+              <TableHead>Direction</TableHead>
+              <TableHead className="text-right">Amount</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Contributor</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead>Date</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.items.map((tx) => (
+              <TableRow key={tx.id}>
+                <TableCell className="font-medium">
+                  {formatType(tx.type)}
+                </TableCell>
+                <TableCell>
+                  <Badge variant={DIRECTION_BADGE_VARIANT[tx.direction]}>
+                    {tx.direction}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-right">
+                  {formatCents(tx.amount, tx.currency)}
+                </TableCell>
+                <TableCell>
+                  <Badge variant={STATUS_BADGE_VARIANT[tx.status]}>
+                    {tx.status}
+                  </Badge>
+                </TableCell>
+                <TableCell>{tx.contributorName ?? "—"}</TableCell>
+                <TableCell className="max-w-[200px] truncate">
+                  {tx.description ?? "—"}
+                </TableCell>
+                <TableCell>
+                  {new Date(tx.createdAt).toLocaleDateString()}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
     </div>
   );
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -502,7 +502,7 @@
 
 ## Track 13 — Business Operations (Post-Launch)
 
-> **Status:** Foundation shipped. Schema, middleware, contributor service, and sidebar in PR. Rights/revenue services next.
+> **Status:** All P1 items complete. P2 items (dashboards, contest management) remain.
 
 ### Code
 
@@ -513,7 +513,7 @@
 - [x] [P1] Business Ops nav group + sidebar rendering — new "Business" activity group visible to BUSINESS_OPS/ADMIN, command palette updated — (design system session 2026-03-28; done 2026-03-28)
 - [x] [P1] Contributor service + tRPC router — CRUD, link to submissions/users, publication add/remove, 8 procedures with audit + scope enforcement. Detail view deferred to next PR — (design system session 2026-03-28; done 2026-03-28)
 - [x] [P1] Rights service — lifecycle management, reversion alerts ("3 rights agreements reverting in 30 days"), integration with production pipeline — (design system session 2026-03-28; done 2026-03-28)
-- [ ] [P1] Revenue service — submission fees (existing Stripe), contributor payments, contest prizes, revenue reporting — (design system session 2026-03-28)
+- [x] [P1] Revenue service — submission fees (existing Stripe), contributor payments, contest prizes, revenue reporting — (design system session 2026-03-28; done 2026-03-29)
 - [ ] [P2] Business Ops dashboard — health card grid pattern with contributor count, outstanding payments, upcoming reversions, revenue summary — (design system session 2026-03-28)
 - [ ] [P2] Editorial analytics dashboard — acceptance rate (overall + by genre/period), response time (avg/median/p90 + trend), pipeline health, genre distribution, contributor diversity, reader alignment — (design system session 2026-03-28)
 - [ ] [P2] Contest management — contest-type submission periods with rounds (`contestGroupId` + `contestRound`), judge assignments, anonymous judging, prize disbursement. Period-scoped guest editor roles deferred — (design system session 2026-03-28)

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,29 @@ Newest entries first.
 
 ---
 
+## 2026-03-29 — Revenue Service (Track 13)
+
+### Done
+
+- Revenue service: 7 methods — list (with left join for contributor names), getById, getSummary (SQL conditional aggregation for inbound/outbound totals + counts by type/status), createWithAudit, updateWithAudit, transitionStatusWithAudit, deleteWithAudit
+- Status lifecycle: PENDING → PROCESSING → SUCCEEDED → REFUNDED (terminal), FAILED → PENDING (retry); processedAt set on SUCCEEDED/FAILED/REFUNDED, reset to null on retry
+- tRPC router with 7 procedures (`list`, `getById`, `summary`, `create`, `update`, `transitionStatus`, `delete`), all with `businessOpsProcedure` + `requireScopes('payment-transactions:read/write')`
+- 2 error classes (PaymentTransactionNotFoundError, InvalidPaymentStatusTransitionError) mapped in error-mapper.ts; reuses ContributorNotInOrgError from rights agreement service
+- 24 unit tests covering all methods, error paths, role guards, transition edge cases, and summary aggregation
+- Frontend payments page: client list view with currency formatting (Intl.NumberFormat), status badges, direction badges, contributor names
+- Extended `packages/types/src/payment-transaction.ts` with VALID_PAYMENT_STATUS_TRANSITIONS, update/transition schemas, paymentTransactionListItemSchema, revenueSummarySchema
+- Added PAYMENT_TRANSACTION_DELETED audit action to audit.ts
+- Fixed JSONB metadata column type on payment_transactions schema (added .$type<> — type-only, no migration)
+
+### Decisions
+
+- Refund flow: manual recording only — transitionStatus to REFUNDED records the accounting fact, actual Stripe refunds happen via Stripe dashboard
+- Reused ContributorNotInOrgError from rights-agreement.service.ts (already mapped in error-mapper) rather than re-declaring
+- getSummary aggregation: SQL-level SUM with conditional CASE (SUCCEEDED only for totals), separate GROUP BY queries for countByType/countByStatus
+- processedAt reset to null on FAILED → PENDING retry to reflect re-opened processing
+
+---
+
 ## 2026-03-28 — Rights Agreement Service (Track 13)
 
 ### Done

--- a/packages/db/src/schema/business-ops.ts
+++ b/packages/db/src/schema/business-ops.ts
@@ -181,7 +181,9 @@ export const paymentTransactions = pgTable(
     currency: varchar("currency", { length: 3 }).notNull().default("usd"),
     status: paymentStatusEnum("status").notNull().default("PENDING"),
     description: text("description"),
-    metadata: jsonb("metadata").default({}),
+    metadata: jsonb("metadata")
+      .$type<Record<string, unknown> | null>()
+      .default({}),
     processedAt: timestamp("processed_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -295,6 +295,7 @@ export const AuditActions = {
   PAYMENT_TRANSACTION_CREATED: "PAYMENT_TRANSACTION_CREATED",
   PAYMENT_TRANSACTION_UPDATED: "PAYMENT_TRANSACTION_UPDATED",
   PAYMENT_TRANSACTION_STATUS_CHANGED: "PAYMENT_TRANSACTION_STATUS_CHANGED",
+  PAYMENT_TRANSACTION_DELETED: "PAYMENT_TRANSACTION_DELETED",
 } as const;
 
 export type AuditAction = (typeof AuditActions)[keyof typeof AuditActions];
@@ -756,7 +757,8 @@ export interface PaymentTransactionAuditParams extends BaseAuditParams {
   action:
     | typeof AuditActions.PAYMENT_TRANSACTION_CREATED
     | typeof AuditActions.PAYMENT_TRANSACTION_UPDATED
-    | typeof AuditActions.PAYMENT_TRANSACTION_STATUS_CHANGED;
+    | typeof AuditActions.PAYMENT_TRANSACTION_STATUS_CHANGED
+    | typeof AuditActions.PAYMENT_TRANSACTION_DELETED;
 }
 
 /** Union of all resource-specific param types. */

--- a/packages/types/src/payment-transaction.ts
+++ b/packages/types/src/payment-transaction.ts
@@ -109,3 +109,66 @@ export const listPaymentTransactionsSchema = z.object({
 export type ListPaymentTransactionsInput = z.infer<
   typeof listPaymentTransactionsSchema
 >;
+
+// ---------------------------------------------------------------------------
+// Status transitions
+// ---------------------------------------------------------------------------
+
+export const VALID_PAYMENT_STATUS_TRANSITIONS: Record<
+  PaymentTransactionStatus,
+  PaymentTransactionStatus[]
+> = {
+  PENDING: ["PROCESSING", "SUCCEEDED", "FAILED"],
+  PROCESSING: ["SUCCEEDED", "FAILED"],
+  SUCCEEDED: ["REFUNDED"],
+  FAILED: ["PENDING"], // retry
+  REFUNDED: [], // terminal
+};
+
+// ---------------------------------------------------------------------------
+// Update & transition schemas
+// ---------------------------------------------------------------------------
+
+export const updatePaymentTransactionSchema = z
+  .object({
+    id: z.string().uuid(),
+    description: z.string().max(1000).nullable().optional(),
+    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+  })
+  .refine(
+    (data) => data.description !== undefined || data.metadata !== undefined,
+    { message: "At least one field to update is required" },
+  );
+
+export type UpdatePaymentTransactionInput = z.infer<
+  typeof updatePaymentTransactionSchema
+>;
+
+export const transitionPaymentTransactionStatusSchema = z.object({
+  id: z.string().uuid(),
+  status: paymentTransactionStatusSchema,
+});
+
+export type TransitionPaymentTransactionStatusInput = z.infer<
+  typeof transitionPaymentTransactionStatusSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+export const paymentTransactionListItemSchema = paymentTransactionSchema.extend(
+  {
+    contributorName: z.string().nullable(),
+  },
+);
+
+export const revenueSummarySchema = z.object({
+  totalInbound: z.number().int(),
+  totalOutbound: z.number().int(),
+  net: z.number().int(),
+  countByType: z.record(z.string(), z.number().int()),
+  countByStatus: z.record(z.string(), z.number().int()),
+});
+
+export type RevenueSummary = z.infer<typeof revenueSummarySchema>;


### PR DESCRIPTION
## Summary

- Revenue service completing Track 13 P1 items: 7 service methods (list, getById, getSummary, create, update, transitionStatus, delete), tRPC router with 7 procedures, 24 unit tests, and frontend payments page
- Status transitions: PENDING→PROCESSING→SUCCEEDED→REFUNDED (terminal), FAILED→PENDING (retry). processedAt set on terminal states, reset on retry
- Summary endpoint aggregates inbound/outbound totals (SUCCEEDED only) and counts by type/status using SQL conditional aggregation

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `packages/db/src/schema/business-ops.ts` | Not changed | Added `.$type<>()` for JSONB metadata | Type-only fix — Drizzle JSONB infers as `unknown`, causing tRPC output schema type mismatch |

## Test plan

- [x] 24 unit tests covering all service methods, error paths, role guards, and transition edge cases
- [x] Type-check passes (13/13 packages)
- [x] Lint clean
- [x] branch review: 1 finding (bigint overflow in summary) addressed