### PR TITLE
feat(business-ops): Business Ops dashboard with health card grid

### DIFF
--- a/apps/api/src/services/rights-agreement.service.spec.ts
+++ b/apps/api/src/services/rights-agreement.service.spec.ts
@@ -210,7 +210,7 @@ describe('rightsAgreementService', () => {
       };
       mockTx.select = vi.fn(() => {
         const c = makeChain();
-        c.orderBy.mockResolvedValueOnce([expiring]);
+        c.limit.mockResolvedValueOnce([expiring]);
         return c;
       });
 

--- a/apps/api/src/services/rights-agreement.service.ts
+++ b/apps/api/src/services/rights-agreement.service.ts
@@ -181,7 +181,8 @@ export const rightsAgreementService = {
           lte(rightsAgreements.expiresAt, deadline),
         ),
       )
-      .orderBy(rightsAgreements.expiresAt);
+      .orderBy(rightsAgreements.expiresAt)
+      .limit(100);
   },
 
   // -------------------------------------------------------------------------

--- a/apps/api/src/services/rights-agreement.service.ts
+++ b/apps/api/src/services/rights-agreement.service.ts
@@ -169,20 +169,27 @@ export const rightsAgreementService = {
     const now = new Date();
     const deadline = new Date(now.getTime() + withinDays * 86_400_000);
 
-    return tx
-      .select()
-      .from(rightsAgreements)
-      .where(
-        and(
-          eq(rightsAgreements.organizationId, orgId),
-          eq(rightsAgreements.status, 'ACTIVE'),
-          not(isNull(rightsAgreements.expiresAt)),
-          gte(rightsAgreements.expiresAt, now),
-          lte(rightsAgreements.expiresAt, deadline),
-        ),
-      )
-      .orderBy(rightsAgreements.expiresAt)
-      .limit(100);
+    return (
+      tx
+        .select()
+        .from(rightsAgreements)
+        .where(
+          and(
+            eq(rightsAgreements.organizationId, orgId),
+            eq(rightsAgreements.status, 'ACTIVE'),
+            not(isNull(rightsAgreements.expiresAt)),
+            gte(rightsAgreements.expiresAt, now),
+            lte(rightsAgreements.expiresAt, deadline),
+          ),
+        )
+        .orderBy(rightsAgreements.expiresAt)
+        // Cap at 250 rows — dashboard derives count from .length.
+        // 250 reverting within a single window is well beyond any
+        // realistic literary magazine workload; if exceeded, the
+        // dashboard will undercount (acceptable vs. adding a separate
+        // count endpoint for this edge case).
+        .limit(250)
+    );
   },
 
   // -------------------------------------------------------------------------

--- a/apps/web/src/app/(dashboard)/business/page.tsx
+++ b/apps/web/src/app/(dashboard)/business/page.tsx
@@ -1,10 +1,9 @@
+import { BusinessDashboard } from "@/components/business/business-dashboard";
+
 export default function BusinessDashboardPage() {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold mb-4">Business Operations</h1>
-      <p className="text-muted-foreground">
-        Contributor management, rights agreements, and payment tracking.
-      </p>
+    <div className="p-4">
+      <BusinessDashboard />
     </div>
   );
 }

--- a/apps/web/src/components/business/__tests__/business-dashboard-cards.spec.tsx
+++ b/apps/web/src/components/business/__tests__/business-dashboard-cards.spec.tsx
@@ -1,0 +1,254 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mock tRPC
+// ---------------------------------------------------------------------------
+
+const mockContributorsList = vi.fn();
+const mockPaymentSummary = vi.fn();
+const mockUpcomingReversions = vi.fn();
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    contributors: {
+      list: {
+        useQuery: (...args: unknown[]) => mockContributorsList(...args),
+      },
+    },
+    paymentTransactions: {
+      summary: {
+        useQuery: (...args: unknown[]) => mockPaymentSummary(...args),
+      },
+    },
+    rightsAgreements: {
+      upcomingReversions: {
+        useQuery: (...args: unknown[]) => mockUpcomingReversions(...args),
+      },
+    },
+  },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+import { BusinessDashboardCards } from "../business-dashboard-cards";
+import {
+  deriveContributorStatus,
+  deriveOutstandingPaymentsStatus,
+  deriveReversionStatus,
+  deriveRevenueStatus,
+} from "../business-dashboard-cards";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function loadingState() {
+  return { data: undefined, isPending: true, isError: false, error: null };
+}
+
+function loaded<T>(data: T) {
+  return { data, isPending: false, isError: false, error: null };
+}
+
+function errored() {
+  return {
+    data: undefined,
+    isPending: false,
+    isError: true,
+    error: new Error("fail"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: status derivation helpers
+// ---------------------------------------------------------------------------
+
+describe("deriveContributorStatus", () => {
+  it("returns loading when undefined", () => {
+    expect(deriveContributorStatus(undefined).status).toBe("loading");
+  });
+
+  it("returns healthy with count", () => {
+    const result = deriveContributorStatus(42);
+    expect(result.status).toBe("healthy");
+    expect(result.metric).toBe("42");
+  });
+
+  it("returns healthy even when 0", () => {
+    expect(deriveContributorStatus(0).status).toBe("healthy");
+  });
+});
+
+describe("deriveOutstandingPaymentsStatus", () => {
+  it("returns loading when undefined", () => {
+    expect(deriveOutstandingPaymentsStatus(undefined).status).toBe("loading");
+  });
+
+  it("returns healthy when no outstanding", () => {
+    const result = deriveOutstandingPaymentsStatus({ SUCCEEDED: 10 });
+    expect(result.status).toBe("healthy");
+    expect(result.metric).toBe("0");
+    expect(result.subtitle).toBe("All settled");
+  });
+
+  it("returns degraded for 1-5 outstanding", () => {
+    const result = deriveOutstandingPaymentsStatus({
+      PENDING: 2,
+      PROCESSING: 1,
+    });
+    expect(result.status).toBe("degraded");
+    expect(result.metric).toBe("3");
+  });
+
+  it("returns unhealthy for >5 outstanding", () => {
+    const result = deriveOutstandingPaymentsStatus({
+      PENDING: 4,
+      PROCESSING: 3,
+    });
+    expect(result.status).toBe("unhealthy");
+    expect(result.metric).toBe("7");
+  });
+
+  it("handles missing PENDING/PROCESSING keys without NaN", () => {
+    const result = deriveOutstandingPaymentsStatus({});
+    expect(result.status).toBe("healthy");
+    expect(result.metric).toBe("0");
+  });
+});
+
+describe("deriveReversionStatus", () => {
+  it("returns loading when undefined", () => {
+    expect(deriveReversionStatus(undefined).status).toBe("loading");
+  });
+
+  it("returns healthy when 0", () => {
+    const result = deriveReversionStatus(0);
+    expect(result.status).toBe("healthy");
+    expect(result.subtitle).toBe("None due");
+  });
+
+  it("returns degraded for 1-3", () => {
+    expect(deriveReversionStatus(1).status).toBe("degraded");
+    expect(deriveReversionStatus(3).status).toBe("degraded");
+  });
+
+  it("returns unhealthy for >3", () => {
+    expect(deriveReversionStatus(4).status).toBe("unhealthy");
+  });
+});
+
+describe("deriveRevenueStatus", () => {
+  it("returns loading when undefined", () => {
+    expect(deriveRevenueStatus(undefined).status).toBe("loading");
+  });
+
+  it("returns healthy for positive net", () => {
+    const result = deriveRevenueStatus(150000);
+    expect(result.status).toBe("healthy");
+    expect(result.metric).toBe("$1,500.00");
+  });
+
+  it("returns healthy for zero net", () => {
+    expect(deriveRevenueStatus(0).status).toBe("healthy");
+  });
+
+  it("returns unhealthy for negative net", () => {
+    const result = deriveRevenueStatus(-5000);
+    expect(result.status).toBe("unhealthy");
+    expect(result.metric).toBe("-$50.00");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component tests
+// ---------------------------------------------------------------------------
+
+describe("BusinessDashboardCards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders all four health cards with loaded data", () => {
+    mockContributorsList.mockReturnValue(
+      loaded({ items: [], total: 12, page: 1, limit: 1, totalPages: 12 }),
+    );
+    mockPaymentSummary.mockReturnValue(
+      loaded({
+        totalInbound: 500000,
+        totalOutbound: 200000,
+        net: 300000,
+        countByType: { submission_fee: 10 },
+        countByStatus: { SUCCEEDED: 8, PENDING: 2 },
+      }),
+    );
+    mockUpcomingReversions.mockReturnValue(loaded([{ id: "1" }, { id: "2" }]));
+
+    render(<BusinessDashboardCards />);
+
+    expect(screen.getByText("Contributors")).toBeInTheDocument();
+    expect(screen.getByText("Outstanding Payments")).toBeInTheDocument();
+    expect(screen.getByText("Upcoming Reversions")).toBeInTheDocument();
+    expect(screen.getByText("Revenue")).toBeInTheDocument();
+
+    // Verify metrics
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("$3,000.00")).toBeInTheDocument();
+    expect(screen.getByText("Pending + processing")).toBeInTheDocument();
+    expect(screen.getByText("Within 30 days")).toBeInTheDocument();
+  });
+
+  it("shows loading state while queries pending", () => {
+    mockContributorsList.mockReturnValue(loadingState());
+    mockPaymentSummary.mockReturnValue(loadingState());
+    mockUpcomingReversions.mockReturnValue(loadingState());
+
+    const { container } = render(<BusinessDashboardCards />);
+
+    const skeletons = container.querySelectorAll('[class*="animate-pulse"]');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows error state when queries fail", () => {
+    mockContributorsList.mockReturnValue(errored());
+    mockPaymentSummary.mockReturnValue(errored());
+    mockUpcomingReversions.mockReturnValue(errored());
+
+    render(<BusinessDashboardCards />);
+
+    const failedMessages = screen.getAllByText("Failed to load");
+    expect(failedMessages).toHaveLength(4);
+  });
+
+  it("links cards to correct pages", () => {
+    mockContributorsList.mockReturnValue(
+      loaded({ items: [], total: 0, page: 1, limit: 1, totalPages: 0 }),
+    );
+    mockPaymentSummary.mockReturnValue(
+      loaded({
+        totalInbound: 0,
+        totalOutbound: 0,
+        net: 0,
+        countByType: {},
+        countByStatus: {},
+      }),
+    );
+    mockUpcomingReversions.mockReturnValue(loaded([]));
+
+    render(<BusinessDashboardCards />);
+
+    const links = screen.getAllByRole("link");
+    const hrefs = links.map((l) => l.getAttribute("href"));
+    expect(hrefs).toContain("/business/contributors");
+    expect(hrefs).toContain("/business/payments");
+    expect(hrefs).toContain("/business/rights");
+  });
+});

--- a/apps/web/src/components/business/business-dashboard-cards.tsx
+++ b/apps/web/src/components/business/business-dashboard-cards.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { Users, Clock, CalendarClock, DollarSign } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { HealthCard, type HealthStatus } from "../operations/health-card";
+
+// ---------------------------------------------------------------------------
+// Currency formatting
+// ---------------------------------------------------------------------------
+
+const usdFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+function formatCents(cents: number): string {
+  return usdFormatter.format(cents / 100);
+}
+
+// ---------------------------------------------------------------------------
+// Status derivation helpers
+// ---------------------------------------------------------------------------
+
+interface DerivedStatus {
+  status: HealthStatus;
+  metric: string;
+  subtitle?: string;
+}
+
+export function deriveContributorStatus(
+  total: number | undefined,
+): DerivedStatus {
+  if (total === undefined) return { status: "loading", metric: "" };
+  return {
+    status: "healthy",
+    metric: String(total),
+    subtitle: "Total in organization",
+  };
+}
+
+export function deriveOutstandingPaymentsStatus(
+  countByStatus: Record<string, number> | undefined,
+): DerivedStatus {
+  if (!countByStatus) return { status: "loading", metric: "" };
+
+  const outstanding =
+    (countByStatus.PENDING ?? 0) + (countByStatus.PROCESSING ?? 0);
+
+  let status: HealthStatus = "healthy";
+  if (outstanding > 5) status = "unhealthy";
+  else if (outstanding > 0) status = "degraded";
+
+  return {
+    status,
+    metric: String(outstanding),
+    subtitle: outstanding === 0 ? "All settled" : "Pending + processing",
+  };
+}
+
+export function deriveReversionStatus(
+  reversionCount: number | undefined,
+): DerivedStatus {
+  if (reversionCount === undefined) return { status: "loading", metric: "" };
+
+  let status: HealthStatus = "healthy";
+  if (reversionCount > 3) status = "unhealthy";
+  else if (reversionCount > 0) status = "degraded";
+
+  return {
+    status,
+    metric: String(reversionCount),
+    subtitle: reversionCount === 0 ? "None due" : "Within 30 days",
+  };
+}
+
+export function deriveRevenueStatus(net: number | undefined): DerivedStatus {
+  if (net === undefined) return { status: "loading", metric: "" };
+
+  return {
+    status: net >= 0 ? "healthy" : "unhealthy",
+    metric: formatCents(net),
+    subtitle: "Net (inbound \u2212 outbound)",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function BusinessDashboardCards() {
+  const {
+    data: contributorData,
+    isPending: isContributorsLoading,
+    isError: isContributorsError,
+  } = trpc.contributors.list.useQuery({ page: 1, limit: 1 });
+
+  const {
+    data: summaryData,
+    isPending: isSummaryLoading,
+    isError: isSummaryError,
+  } = trpc.paymentTransactions.summary.useQuery();
+
+  const {
+    data: reversions,
+    isPending: isReversionsLoading,
+    isError: isReversionsError,
+  } = trpc.rightsAgreements.upcomingReversions.useQuery({ withinDays: 30 });
+
+  const contributors = isContributorsError
+    ? { status: "unknown" as const, metric: "--", subtitle: "Failed to load" }
+    : deriveContributorStatus(
+        isContributorsLoading ? undefined : contributorData?.total,
+      );
+
+  const payments = isSummaryError
+    ? { status: "unknown" as const, metric: "--", subtitle: "Failed to load" }
+    : deriveOutstandingPaymentsStatus(
+        isSummaryLoading ? undefined : summaryData?.countByStatus,
+      );
+
+  const reversionStatus = isReversionsError
+    ? { status: "unknown" as const, metric: "--", subtitle: "Failed to load" }
+    : deriveReversionStatus(
+        isReversionsLoading ? undefined : reversions?.length,
+      );
+
+  const revenue = isSummaryError
+    ? { status: "unknown" as const, metric: "--", subtitle: "Failed to load" }
+    : deriveRevenueStatus(isSummaryLoading ? undefined : summaryData?.net);
+
+  return (
+    <div className="grid gap-3 grid-cols-2 lg:grid-cols-4">
+      <HealthCard
+        title="Contributors"
+        icon={Users}
+        href="/business/contributors"
+        {...contributors}
+      />
+      <HealthCard
+        title="Outstanding Payments"
+        icon={Clock}
+        href="/business/payments"
+        {...payments}
+      />
+      <HealthCard
+        title="Upcoming Reversions"
+        icon={CalendarClock}
+        href="/business/rights"
+        {...reversionStatus}
+      />
+      <HealthCard
+        title="Revenue"
+        icon={DollarSign}
+        href="/business/payments"
+        {...revenue}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/business/business-dashboard.tsx
+++ b/apps/web/src/components/business/business-dashboard.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Link from "next/link";
+import { Users, FileCheck, DollarSign } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { BusinessDashboardCards } from "./business-dashboard-cards";
+
+// ---------------------------------------------------------------------------
+// Quick links
+// ---------------------------------------------------------------------------
+
+const quickLinks = [
+  {
+    title: "Contributors",
+    description: "Manage authors, translators, and creative contributors.",
+    href: "/business/contributors",
+    icon: Users,
+  },
+  {
+    title: "Rights Agreements",
+    description: "Track IP rights, reversion dates, and agreement status.",
+    href: "/business/rights",
+    icon: FileCheck,
+  },
+  {
+    title: "Payments",
+    description: "View payment transactions, fees, and revenue.",
+    href: "/business/payments",
+    icon: DollarSign,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function BusinessDashboard() {
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold">Business Operations</h1>
+        <p className="text-sm text-muted-foreground">
+          Contributor management, rights agreements, and payment tracking.
+        </p>
+      </div>
+
+      {/* Health card grid */}
+      <BusinessDashboardCards />
+
+      {/* Quick links */}
+      <section>
+        <h2 className="mb-3 text-sm font-medium text-muted-foreground">
+          Quick Links
+        </h2>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {quickLinks.map((link) => (
+            <Card key={link.href} className="transition-colors hover:bg-accent">
+              <Link href={link.href} className="block">
+                <CardHeader className="pb-2">
+                  <div className="flex items-center gap-2">
+                    <link.icon className="h-4 w-4 text-muted-foreground" />
+                    <CardTitle className="text-sm">{link.title}</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-xs text-muted-foreground">
+                    {link.description}
+                  </p>
+                </CardContent>
+              </Link>
+            </Card>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -514,7 +514,7 @@
 - [x] [P1] Contributor service + tRPC router — CRUD, link to submissions/users, publication add/remove, 8 procedures with audit + scope enforcement. Detail view deferred to next PR — (design system session 2026-03-28; done 2026-03-28)
 - [x] [P1] Rights service — lifecycle management, reversion alerts ("3 rights agreements reverting in 30 days"), integration with production pipeline — (design system session 2026-03-28; done 2026-03-28)
 - [x] [P1] Revenue service — submission fees (existing Stripe), contributor payments, contest prizes, revenue reporting — (design system session 2026-03-28; done 2026-03-29)
-- [ ] [P2] Business Ops dashboard — health card grid pattern with contributor count, outstanding payments, upcoming reversions, revenue summary — (design system session 2026-03-28)
+- [x] [P2] Business Ops dashboard — health card grid pattern with contributor count, outstanding payments, upcoming reversions, revenue summary — (design system session 2026-03-28; done 2026-03-29)
 - [ ] [P2] Editorial analytics dashboard — acceptance rate (overall + by genre/period), response time (avg/median/p90 + trend), pipeline health, genre distribution, contributor diversity, reader alignment — (design system session 2026-03-28)
 - [ ] [P2] Contest management — contest-type submission periods with rounds (`contestGroupId` + `contestRound`), judge assignments, anonymous judging, prize disbursement. Period-scoped guest editor roles deferred — (design system session 2026-03-28)
 
@@ -605,6 +605,7 @@
 - [x] [P2] Evaluate MinIO replacement — MinIO repo archived Feb 2026; no future security patches. Evaluate alternatives (LocalStack, SeaweedFS, direct S3/R2) for dev/CI/self-hosted object storage. Not urgent while no CVEs exist, but blocked from upstream fixes if one surfaces — (2026-03-25, CI image pin session; done 2026-03-25 — migrated to Garage v2.2.0)
 - [x] [P2] Replace Overmind with hivemind or concurrently — Overmind solves signal handling but tmux dependency, `dev:clean` escape hatch, and WSL quirks are operational drag. hivemind (Go binary, no tmux, proper signal handling) preferred; concurrently as fallback. Test on macOS, Linux, WSL before standardizing. Keep `dev:clean` as escape hatch, not normal workflow. Turbo `--watch` only if shutdown behavior verified in this repo — (architecture review 2026-03-16; code changes done 2026-03-16; validated on WSL/Linux 2026-03-22, macOS deferred — not in team environment)
 - [x] [P3] Remove `packages/eslint-config` — unused v1 legacy configs (`base.js`, `nextjs.js`, `nestjs.js`), neither app imports from it. Moved `eslint` and `eslint-config-next` to direct app devDependencies — (architecture review 2026-03-16; done 2026-03-16)
+- [ ] [P1] Migrate project hooks from `.claude/hooks/hooks.json` to `.claude/settings.json` — hooks.json uses wrong schema (`event`+`script` keys) and wrong file location; Claude Code only reads hooks from settings.json files with `matcher`+`hooks[{type,command}]` format. ALL project hooks (pre-edit-validate, pre-payment-validate, pre-frontend-validate, pre-router-audit, pre-push-branch, pre-exit-plan-review, post-edit-lint, post-schema, post-email-template, post-migration-validate, post-commit-devlog, post-test-file) are affected. Requires Claude Code restart after fix — (diagnosed 2026-03-29, ExitPlanMode hook failed to block)
 
 ### Testing & CI
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,26 @@ Newest entries first.
 
 ---
 
+## 2026-03-29 — Business Ops Dashboard (Track 13)
+
+### Done
+
+- Business Ops dashboard page at `/business` with 4 health cards: contributor count, outstanding payments, upcoming reversions, net revenue
+- Reused `HealthCard` component from operations dashboard — no new component needed
+- 3 tRPC queries (contributors.list, paymentTransactions.summary, rightsAgreements.upcomingReversions) with loading/error states
+- Quick links section with cards to Contributors, Rights Agreements, Payments sub-pages
+- 20 unit tests: 16 for status derivation helpers (boundary values), 4 component tests
+- Fixed unbounded `getUpcomingReversions` query — added `.limit(100)` (Codex plan review finding)
+- Added `?? 0` fallbacks for `countByStatus` keys to prevent NaN (Codex plan review finding)
+- Diagnosed project hooks misconfiguration: `.claude/hooks/hooks.json` uses wrong schema (`event`+`script`) and wrong file location; Claude Code requires `matcher`+`hooks[{type,command}]` in `settings.json`. All 14 project hooks affected. Added P1 backlog item.
+
+### Decisions
+
+- USD-only currency formatting — Colophony doesn't support multi-currency payments
+- Status thresholds: payments 0/1-5/>5 (healthy/degraded/unhealthy), reversions 0/1-3/>3, revenue ≥0/<0
+
+---
+
 ## 2026-03-29 — Revenue Service (Track 13)
 
 ### Done


### PR DESCRIPTION
## Summary
- Add dashboard landing page at `/business` with 4 health cards: contributor count, outstanding payments, upcoming reversions (capped at 250), net revenue
- Reuse existing `HealthCard` component from operations dashboard
- Fix unbounded `getUpcomingReversions` query (add `.limit(250)` with documented assumption)
- 20 unit tests for status derivation helpers and component rendering
- Added P1 backlog item for hooks.json migration (all project hooks using wrong format)

## Codex Review
- **Plan review**: 2 Important findings addressed (unbounded query, `?? 0` fallbacks)
- **Branch review**: 1 P2 finding addressed (reversion count cap raised to 250 with comment)
- **Plan drift**: 5 MATCH, 1 minor DRIFT (test assertion style — functionally equivalent)

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes (api + web)
- [x] API unit tests pass (154 suites, 1681 tests)
- [x] Web unit tests pass (88 suites, 727 tests)
- [ ] CI passes
- [ ] Manual QA: navigate to `/business`, verify 4 cards load with real data