### PR TITLE
feat(hopper): editorial analytics dashboard

### DIFF
--- a/apps/api/src/services/editorial-analytics.service.spec.ts
+++ b/apps/api/src/services/editorial-analytics.service.spec.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Drizzle mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  submissions: {},
+  submissionHistory: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => {
+  const sqlTag = (_strings: TemplateStringsArray, ..._values: unknown[]) =>
+    'sql-fragment';
+  sqlTag.raw = (s: string) => s;
+  sqlTag.join = (parts: unknown[], _sep: unknown) =>
+    parts.length > 0 ? 'joined-where' : '';
+  return {
+    eq: vi.fn(),
+    and: vi.fn(),
+    sql: sqlTag,
+    desc: vi.fn(),
+    count: vi.fn(),
+  };
+});
+
+import { editorialAnalyticsService } from './editorial-analytics.service.js';
+import type { DrizzleDb } from '@colophony/db';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ORG_ID = '00000000-0000-0000-0000-000000000001';
+
+function mockTx(rows: Record<string, unknown>[]) {
+  return {
+    execute: vi.fn().mockResolvedValue({ rows }),
+  } as unknown as DrizzleDb;
+}
+
+function mockTxMulti(...rowSets: Record<string, unknown>[][]) {
+  const execute = vi.fn();
+  for (const rows of rowSets) {
+    execute.mockResolvedValueOnce({ rows });
+  }
+  return { execute } as unknown as DrizzleDb;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('editorialAnalyticsService', () => {
+  describe('getAcceptanceByGenre', () => {
+    it('returns genre breakdown with rates', async () => {
+      const tx = mockTx([
+        { genre: 'poetry', total: 20, accepted: 5, rejected: 10, rate: 33.3 },
+        { genre: 'fiction', total: 30, accepted: 15, rejected: 10, rate: 60.0 },
+      ]);
+
+      const result = await editorialAnalyticsService.getAcceptanceByGenre(
+        tx,
+        ORG_ID,
+        {},
+      );
+
+      expect(result.genres).toHaveLength(2);
+      expect(result.genres[0]).toEqual({
+        genre: 'poetry',
+        total: 20,
+        accepted: 5,
+        rejected: 10,
+        rate: 33.3,
+      });
+    });
+
+    it('handles empty results', async () => {
+      const tx = mockTx([]);
+
+      const result = await editorialAnalyticsService.getAcceptanceByGenre(
+        tx,
+        ORG_ID,
+        {},
+      );
+
+      expect(result.genres).toEqual([]);
+    });
+  });
+
+  describe('getAcceptanceByPeriod', () => {
+    it('returns period breakdown', async () => {
+      const tx = mockTx([
+        {
+          periodId: '11111111-1111-1111-1111-111111111111',
+          periodName: 'Spring 2026',
+          total: 40,
+          accepted: 10,
+          rejected: 20,
+          rate: 33.3,
+        },
+      ]);
+
+      const result = await editorialAnalyticsService.getAcceptanceByPeriod(
+        tx,
+        ORG_ID,
+        {},
+      );
+
+      expect(result.periods).toHaveLength(1);
+      expect(result.periods[0].periodName).toBe('Spring 2026');
+      expect(result.periods[0].rate).toBe(33.3);
+    });
+  });
+
+  describe('getResponseTimeStats', () => {
+    it('returns avg, median, p90 and trend', async () => {
+      const tx = mockTxMulti(
+        [{ avgDays: 15.2, medianDays: 12.0, p90Days: 35.5 }],
+        [
+          { month: '2026-01-01', medianDays: 10.0 },
+          { month: '2026-02-01', medianDays: 14.0 },
+        ],
+      );
+
+      const result = await editorialAnalyticsService.getResponseTimeStats(
+        tx,
+        ORG_ID,
+        {},
+      );
+
+      expect(result.avgDays).toBe(15.2);
+      expect(result.medianDays).toBe(12.0);
+      expect(result.p90Days).toBe(35.5);
+      expect(result.trend).toHaveLength(2);
+      expect(result.trend[0].month).toBe('2026-01');
+    });
+
+    it('handles null stats', async () => {
+      const tx = mockTxMulti(
+        [{ avgDays: null, medianDays: null, p90Days: null }],
+        [],
+      );
+
+      const result = await editorialAnalyticsService.getResponseTimeStats(
+        tx,
+        ORG_ID,
+        {},
+      );
+
+      expect(result.avgDays).toBeNull();
+      expect(result.medianDays).toBeNull();
+      expect(result.p90Days).toBeNull();
+      expect(result.trend).toEqual([]);
+    });
+  });
+
+  describe('getPipelineHealth', () => {
+    it('returns stage counts with stuck detection', async () => {
+      const tx = mockTx([
+        {
+          stage: 'COPYEDIT_PENDING',
+          count: 5,
+          avgDaysInStage: 8.3,
+          stuckCount: 2,
+        },
+        {
+          stage: 'AUTHOR_REVIEW',
+          count: 3,
+          avgDaysInStage: 4.1,
+          stuckCount: 0,
+        },
+      ]);
+
+      const result = await editorialAnalyticsService.getPipelineHealth(
+        tx,
+        ORG_ID,
+        {},
+      );
+
+      expect(result.stages).toHaveLength(2);
+      expect(result.stages[0].stuckCount).toBe(2);
+      expect(result.stages[1].stuckCount).toBe(0);
+    });
+
+    it('handles empty pipeline', async () => {
+      const tx = mockTx([]);
+
+      const result = await editorialAnalyticsService.getPipelineHealth(
+        tx,
+        ORG_ID,
+        {},
+      );
+
+      expect(result.stages).toEqual([]);
+    });
+  });
+
+  describe('getGenreDistribution', () => {
+    it('returns genre counts', async () => {
+      const tx = mockTx([
+        { genre: 'poetry', count: 45 },
+        { genre: 'fiction', count: 30 },
+        { genre: 'unknown', count: 5 },
+      ]);
+
+      const result = await editorialAnalyticsService.getGenreDistribution(
+        tx,
+        ORG_ID,
+        {},
+      );
+
+      expect(result.distribution).toHaveLength(3);
+      expect(result.distribution[0].genre).toBe('poetry');
+      expect(result.distribution[0].count).toBe(45);
+    });
+  });
+
+  describe('getContributorDiversity', () => {
+    it('returns new vs returning and genre spread', async () => {
+      const tx = mockTxMulti(
+        [
+          { periodName: 'Fall 2025', newCount: 12, returningCount: 8 },
+          { periodName: 'Spring 2026', newCount: 15, returningCount: 20 },
+        ],
+        [
+          { genre: 'poetry', count: 10 },
+          { genre: 'fiction', count: 7 },
+        ],
+      );
+
+      const result = await editorialAnalyticsService.getContributorDiversity(
+        tx,
+        ORG_ID,
+        {},
+      );
+
+      expect(result.newVsReturning).toHaveLength(2);
+      expect(result.newVsReturning[0].newCount).toBe(12);
+      expect(result.genreSpread).toHaveLength(2);
+      expect(result.genreSpread[0].genre).toBe('poetry');
+    });
+  });
+
+  describe('getReaderAlignment', () => {
+    it('computes consensus rate and breakdown', async () => {
+      const tx = mockTxMulti(
+        [
+          {
+            submissionId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            title: 'Poem A',
+            finalStatus: 'ACCEPTED',
+            majorityVote: 'ACCEPT',
+            voteCount: 3,
+            matched: true,
+          },
+          {
+            submissionId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+            title: 'Story B',
+            finalStatus: 'REJECTED',
+            majorityVote: 'ACCEPT',
+            voteCount: 2,
+            matched: false,
+          },
+        ],
+        [{ count: 10 }],
+      );
+
+      const result = await editorialAnalyticsService.getReaderAlignment(
+        tx,
+        ORG_ID,
+        {},
+      );
+
+      expect(result.totalDecided).toBe(10);
+      expect(result.totalWithVotes).toBe(2);
+      expect(result.consensusMatches).toBe(1);
+      expect(result.consensusRate).toBe(50);
+      expect(result.breakdown).toHaveLength(2);
+      expect(result.breakdown[0].matched).toBe(true);
+      expect(result.breakdown[1].matched).toBe(false);
+    });
+
+    it('handles no voted submissions', async () => {
+      const tx = mockTxMulti([], [{ count: 5 }]);
+
+      const result = await editorialAnalyticsService.getReaderAlignment(
+        tx,
+        ORG_ID,
+        {},
+      );
+
+      expect(result.totalDecided).toBe(5);
+      expect(result.totalWithVotes).toBe(0);
+      expect(result.consensusMatches).toBe(0);
+      expect(result.consensusRate).toBe(0);
+      expect(result.breakdown).toEqual([]);
+    });
+  });
+});

--- a/apps/api/src/services/editorial-analytics.service.ts
+++ b/apps/api/src/services/editorial-analytics.service.ts
@@ -40,21 +40,26 @@ function buildEditorialWhere(
       sql`${sql.raw(`${alias}.submission_period_id`)} = ${filter.submissionPeriodId}::uuid`,
     );
   }
-  if (filter.genre) {
-    parts.push(sql`${sql.raw(`${alias}.manuscript_version_id`)} IS NOT NULL`);
-  }
-
   return sql.join(parts, sql.raw(' AND '));
 }
 
 /**
+ * Build genre filter SQL fragment. When genre is set, requires a genre JOIN
+ * and filters by the specific genre value.
+ */
+function genreFilterSql(filter: EditorialAnalyticsFilter): SQL {
+  if (!filter.genre) return sql``;
+  return sql` AND m.genre->>'primary' = ${filter.genre}`;
+}
+
+/**
  * Genre JOIN fragment: submissions → manuscript_versions → manuscripts.
- * Returns the genre->>'primary' expression and required JOINs.
+ * Uses LEFT JOIN so submissions without manuscripts appear as "unknown" genre.
  */
 function genreJoin(alias = 's'): SQL {
   return sql.raw(
-    `JOIN manuscript_versions mv ON mv.id = ${alias}.manuscript_version_id ` +
-      `JOIN manuscripts m ON m.id = mv.manuscript_id`,
+    `LEFT JOIN manuscript_versions mv ON mv.id = ${alias}.manuscript_version_id ` +
+      `LEFT JOIN manuscripts m ON m.id = mv.manuscript_id`,
   );
 }
 
@@ -73,10 +78,6 @@ export const editorialAnalyticsService = {
   ): Promise<AcceptanceByGenre> {
     const where = buildEditorialWhere(organizationId, filter);
 
-    const genreFilter = filter.genre
-      ? sql` AND m.genre->>'primary' = ${filter.genre}`
-      : sql``;
-
     const result = await tx.execute(sql`
       SELECT
         COALESCE(m.genre->>'primary', 'unknown') AS genre,
@@ -92,7 +93,7 @@ export const editorialAnalyticsService = {
         )::float AS rate
       FROM submissions s
       ${genreJoin()}
-      WHERE ${where}${genreFilter}
+      WHERE ${where}${genreFilterSql(filter)}
       GROUP BY m.genre->>'primary'
       ORDER BY total DESC
       LIMIT 50
@@ -119,6 +120,8 @@ export const editorialAnalyticsService = {
   ): Promise<AcceptanceByPeriod> {
     const where = buildEditorialWhere(organizationId, filter);
 
+    const gJoin = filter.genre ? genreJoin() : sql``;
+
     const result = await tx.execute(sql`
       SELECT
         sp.id AS "periodId",
@@ -135,7 +138,8 @@ export const editorialAnalyticsService = {
         )::float AS rate
       FROM submissions s
       JOIN submission_periods sp ON sp.id = s.submission_period_id
-      WHERE ${where}
+      ${gJoin}
+      WHERE ${where}${genreFilterSql(filter)}
       GROUP BY sp.id, sp.name
       ORDER BY sp.closes_at DESC NULLS LAST
       LIMIT 50
@@ -190,6 +194,8 @@ export const editorialAnalyticsService = {
     const now = new Date();
     const sixMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 6, 1);
 
+    const trendWhere = buildEditorialWhere(organizationId, filter);
+
     const trendResult = await tx.execute(sql`
       WITH response_times AS (
         SELECT
@@ -202,8 +208,7 @@ export const editorialAnalyticsService = {
           WHERE sh.submission_id = s.id
             AND sh.to_status IN ('ACCEPTED', 'REJECTED')
         ) h ON h.changed_at IS NOT NULL
-        WHERE s.organization_id = ${organizationId}::uuid
-          AND s.status != 'DRAFT'
+        WHERE ${trendWhere}
           AND h.changed_at >= ${sixMonthsAgo}
       )
       SELECT
@@ -286,7 +291,7 @@ export const editorialAnalyticsService = {
         COUNT(*)::int AS count
       FROM submissions s
       ${genreJoin()}
-      WHERE ${where}
+      WHERE ${where}${genreFilterSql(filter)}
       GROUP BY m.genre->>'primary'
       ORDER BY count DESC
       LIMIT 50
@@ -309,10 +314,13 @@ export const editorialAnalyticsService = {
     organizationId: string,
     filter: EditorialAnalyticsFilter,
   ): Promise<ContributorDiversity> {
-    // Build optional date filter fragments
-    const dateFilter = [
+    // Build optional filter fragments
+    const extraFilters = [
       filter.startDate ? sql`AND s.submitted_at >= ${filter.startDate}` : sql``,
       filter.endDate ? sql`AND s.submitted_at <= ${filter.endDate}` : sql``,
+      filter.submissionPeriodId
+        ? sql`AND s.submission_period_id = ${filter.submissionPeriodId}::uuid`
+        : sql``,
     ];
 
     // New vs returning submitters per period
@@ -341,8 +349,9 @@ export const editorialAnalyticsService = {
         WHERE s.organization_id = ${organizationId}::uuid
           AND s.status != 'DRAFT'
           AND s.submitted_at IS NOT NULL
-          ${dateFilter[0]}
-          ${dateFilter[1]}
+          ${extraFilters[0]}
+          ${extraFilters[1]}
+          ${extraFilters[2]}
       )
       SELECT
         sp.name AS "periodName",
@@ -364,8 +373,10 @@ export const editorialAnalyticsService = {
       ${genreJoin()}
       WHERE s.organization_id = ${organizationId}::uuid
         AND s.status = 'ACCEPTED'
-        ${dateFilter[0]}
-        ${dateFilter[1]}
+        ${extraFilters[0]}
+        ${extraFilters[1]}
+        ${extraFilters[2]}
+        ${genreFilterSql(filter)}
       GROUP BY m.genre->>'primary'
       ORDER BY count DESC
       LIMIT 50
@@ -452,13 +463,12 @@ export const editorialAnalyticsService = {
     const totalWithVotes = rows.length;
     const consensusMatches = rows.filter((r) => r.matched).length;
 
-    // Get total decided count for context
+    // Get total decided count for context (using same filters)
     const decidedResult = await tx.execute(sql`
       SELECT COUNT(*)::int AS count
       FROM submissions s
-      WHERE s.organization_id = ${organizationId}::uuid
+      WHERE ${where}
         AND s.status IN ('ACCEPTED', 'REJECTED')
-        AND s.status != 'DRAFT'
     `);
 
     return {

--- a/apps/api/src/services/editorial-analytics.service.ts
+++ b/apps/api/src/services/editorial-analytics.service.ts
@@ -1,0 +1,482 @@
+import { sql, type SQL } from 'drizzle-orm';
+import type { DrizzleDb } from '@colophony/db';
+import type {
+  EditorialAnalyticsFilter,
+  AcceptanceByGenre,
+  AcceptanceByPeriod,
+  ResponseTimeStats,
+  PipelineHealth,
+  GenreDistribution,
+  ContributorDiversity,
+  ReaderAlignment,
+} from '@colophony/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build WHERE conditions for editorial analytics queries.
+ * Defense-in-depth: always includes explicit organization_id filter.
+ */
+function buildEditorialWhere(
+  organizationId: string,
+  filter: EditorialAnalyticsFilter,
+  alias = 's',
+): SQL {
+  const parts: SQL[] = [
+    sql`${sql.raw(`${alias}.organization_id`)} = ${organizationId}::uuid`,
+    sql.raw(`${alias}.status != 'DRAFT'`),
+  ];
+
+  if (filter.startDate) {
+    parts.push(sql`${sql.raw(`${alias}.submitted_at`)} >= ${filter.startDate}`);
+  }
+  if (filter.endDate) {
+    parts.push(sql`${sql.raw(`${alias}.submitted_at`)} <= ${filter.endDate}`);
+  }
+  if (filter.submissionPeriodId) {
+    parts.push(
+      sql`${sql.raw(`${alias}.submission_period_id`)} = ${filter.submissionPeriodId}::uuid`,
+    );
+  }
+  if (filter.genre) {
+    parts.push(sql`${sql.raw(`${alias}.manuscript_version_id`)} IS NOT NULL`);
+  }
+
+  return sql.join(parts, sql.raw(' AND '));
+}
+
+/**
+ * Genre JOIN fragment: submissions → manuscript_versions → manuscripts.
+ * Returns the genre->>'primary' expression and required JOINs.
+ */
+function genreJoin(alias = 's'): SQL {
+  return sql.raw(
+    `JOIN manuscript_versions mv ON mv.id = ${alias}.manuscript_version_id ` +
+      `JOIN manuscripts m ON m.id = mv.manuscript_id`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const editorialAnalyticsService = {
+  /**
+   * Acceptance rate broken down by primary genre.
+   */
+  async getAcceptanceByGenre(
+    tx: DrizzleDb,
+    organizationId: string,
+    filter: EditorialAnalyticsFilter,
+  ): Promise<AcceptanceByGenre> {
+    const where = buildEditorialWhere(organizationId, filter);
+
+    const genreFilter = filter.genre
+      ? sql` AND m.genre->>'primary' = ${filter.genre}`
+      : sql``;
+
+    const result = await tx.execute(sql`
+      SELECT
+        COALESCE(m.genre->>'primary', 'unknown') AS genre,
+        COUNT(*)::int AS total,
+        COUNT(*) FILTER (WHERE s.status = 'ACCEPTED')::int AS accepted,
+        COUNT(*) FILTER (WHERE s.status = 'REJECTED')::int AS rejected,
+        COALESCE(
+          ROUND(
+            COUNT(*) FILTER (WHERE s.status = 'ACCEPTED')::numeric
+            / NULLIF(COUNT(*) FILTER (WHERE s.status IN ('ACCEPTED', 'REJECTED'))::numeric, 0)
+            * 100, 1
+          ), 0
+        )::float AS rate
+      FROM submissions s
+      ${genreJoin()}
+      WHERE ${where}${genreFilter}
+      GROUP BY m.genre->>'primary'
+      ORDER BY total DESC
+      LIMIT 50
+    `);
+
+    return {
+      genres: result.rows.map((row) => ({
+        genre: row.genre as string,
+        total: row.total as number,
+        accepted: row.accepted as number,
+        rejected: row.rejected as number,
+        rate: row.rate as number,
+      })),
+    };
+  },
+
+  /**
+   * Acceptance rate broken down by submission period.
+   */
+  async getAcceptanceByPeriod(
+    tx: DrizzleDb,
+    organizationId: string,
+    filter: EditorialAnalyticsFilter,
+  ): Promise<AcceptanceByPeriod> {
+    const where = buildEditorialWhere(organizationId, filter);
+
+    const result = await tx.execute(sql`
+      SELECT
+        sp.id AS "periodId",
+        sp.name AS "periodName",
+        COUNT(*)::int AS total,
+        COUNT(*) FILTER (WHERE s.status = 'ACCEPTED')::int AS accepted,
+        COUNT(*) FILTER (WHERE s.status = 'REJECTED')::int AS rejected,
+        COALESCE(
+          ROUND(
+            COUNT(*) FILTER (WHERE s.status = 'ACCEPTED')::numeric
+            / NULLIF(COUNT(*) FILTER (WHERE s.status IN ('ACCEPTED', 'REJECTED'))::numeric, 0)
+            * 100, 1
+          ), 0
+        )::float AS rate
+      FROM submissions s
+      JOIN submission_periods sp ON sp.id = s.submission_period_id
+      WHERE ${where}
+      GROUP BY sp.id, sp.name
+      ORDER BY sp.closes_at DESC NULLS LAST
+      LIMIT 50
+    `);
+
+    return {
+      periods: result.rows.map((row) => ({
+        periodId: row.periodId as string,
+        periodName: row.periodName as string,
+        total: row.total as number,
+        accepted: row.accepted as number,
+        rejected: row.rejected as number,
+        rate: row.rate as number,
+      })),
+    };
+  },
+
+  /**
+   * Response time statistics: avg, median, p90, and monthly trend.
+   */
+  async getResponseTimeStats(
+    tx: DrizzleDb,
+    organizationId: string,
+    filter: EditorialAnalyticsFilter,
+  ): Promise<ResponseTimeStats> {
+    const where = buildEditorialWhere(organizationId, filter);
+
+    // Overall stats
+    const statsResult = await tx.execute(sql`
+      WITH response_times AS (
+        SELECT
+          EXTRACT(EPOCH FROM (h.changed_at - s.submitted_at)) / 86400 AS response_days
+        FROM submissions s
+        JOIN LATERAL (
+          SELECT MIN(changed_at) AS changed_at
+          FROM submission_history sh
+          WHERE sh.submission_id = s.id
+            AND sh.to_status IN ('ACCEPTED', 'REJECTED')
+        ) h ON h.changed_at IS NOT NULL
+        WHERE ${where}
+      )
+      SELECT
+        ROUND(AVG(response_days), 1)::float AS "avgDays",
+        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY response_days)::float AS "medianDays",
+        PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY response_days)::float AS "p90Days"
+      FROM response_times
+    `);
+
+    const statsRow = statsResult.rows[0];
+
+    // Monthly trend (last 6 months)
+    const now = new Date();
+    const sixMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 6, 1);
+
+    const trendResult = await tx.execute(sql`
+      WITH response_times AS (
+        SELECT
+          date_trunc('month', h.changed_at)::date::text AS month,
+          EXTRACT(EPOCH FROM (h.changed_at - s.submitted_at)) / 86400 AS response_days
+        FROM submissions s
+        JOIN LATERAL (
+          SELECT MIN(changed_at) AS changed_at
+          FROM submission_history sh
+          WHERE sh.submission_id = s.id
+            AND sh.to_status IN ('ACCEPTED', 'REJECTED')
+        ) h ON h.changed_at IS NOT NULL
+        WHERE s.organization_id = ${organizationId}::uuid
+          AND s.status != 'DRAFT'
+          AND h.changed_at >= ${sixMonthsAgo}
+      )
+      SELECT
+        month,
+        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY response_days)::float AS "medianDays"
+      FROM response_times
+      GROUP BY month
+      ORDER BY month ASC
+    `);
+
+    return {
+      avgDays: (statsRow.avgDays as number) ?? null,
+      medianDays: (statsRow.medianDays as number) ?? null,
+      p90Days: (statsRow.p90Days as number) ?? null,
+      trend: trendResult.rows.map((row) => ({
+        month: (row.month as string).substring(0, 7),
+        medianDays: (row.medianDays as number) ?? null,
+      })),
+    };
+  },
+
+  /**
+   * Pipeline health: items per stage, avg days, stuck count.
+   */
+  async getPipelineHealth(
+    tx: DrizzleDb,
+    organizationId: string,
+    filter: EditorialAnalyticsFilter,
+  ): Promise<PipelineHealth> {
+    // Pipeline items don't have submitted_at, so date filters apply to created_at
+    const dateParts: SQL[] = [
+      sql`pi.organization_id = ${organizationId}::uuid`,
+    ];
+    if (filter.startDate) {
+      dateParts.push(sql`pi.created_at >= ${filter.startDate}`);
+    }
+    if (filter.endDate) {
+      dateParts.push(sql`pi.created_at <= ${filter.endDate}`);
+    }
+    const pipelineWhere = sql.join(dateParts, sql.raw(' AND '));
+
+    const result = await tx.execute(sql`
+      SELECT
+        pi.stage,
+        COUNT(*)::int AS count,
+        ROUND(AVG(EXTRACT(EPOCH FROM (NOW() - pi.updated_at)) / 86400), 1)::float AS "avgDaysInStage",
+        COUNT(*) FILTER (
+          WHERE EXTRACT(EPOCH FROM (NOW() - pi.updated_at)) / 86400 > 14
+        )::int AS "stuckCount"
+      FROM pipeline_items pi
+      WHERE ${pipelineWhere}
+        AND pi.stage NOT IN ('PUBLISHED', 'WITHDRAWN')
+      GROUP BY pi.stage
+      ORDER BY count DESC
+    `);
+
+    return {
+      stages: result.rows.map((row) => ({
+        stage: row.stage as string,
+        count: row.count as number,
+        avgDaysInStage: (row.avgDaysInStage as number) ?? null,
+        stuckCount: row.stuckCount as number,
+      })),
+    };
+  },
+
+  /**
+   * Genre distribution of non-draft submissions.
+   */
+  async getGenreDistribution(
+    tx: DrizzleDb,
+    organizationId: string,
+    filter: EditorialAnalyticsFilter,
+  ): Promise<GenreDistribution> {
+    const where = buildEditorialWhere(organizationId, filter);
+
+    const result = await tx.execute(sql`
+      SELECT
+        COALESCE(m.genre->>'primary', 'unknown') AS genre,
+        COUNT(*)::int AS count
+      FROM submissions s
+      ${genreJoin()}
+      WHERE ${where}
+      GROUP BY m.genre->>'primary'
+      ORDER BY count DESC
+      LIMIT 50
+    `);
+
+    return {
+      distribution: result.rows.map((row) => ({
+        genre: row.genre as string,
+        count: row.count as number,
+      })),
+    };
+  },
+
+  /**
+   * Contributor diversity: new vs returning submitters per period,
+   * and genre spread of accepted submitters.
+   */
+  async getContributorDiversity(
+    tx: DrizzleDb,
+    organizationId: string,
+    filter: EditorialAnalyticsFilter,
+  ): Promise<ContributorDiversity> {
+    // Build optional date filter fragments
+    const dateFilter = [
+      filter.startDate ? sql`AND s.submitted_at >= ${filter.startDate}` : sql``,
+      filter.endDate ? sql`AND s.submitted_at <= ${filter.endDate}` : sql``,
+    ];
+
+    // New vs returning submitters per period
+    const newReturningResult = await tx.execute(sql`
+      WITH first_submissions AS (
+        SELECT
+          submitter_id,
+          MIN(submitted_at) AS first_submitted_at
+        FROM submissions
+        WHERE organization_id = ${organizationId}::uuid
+          AND status != 'DRAFT'
+          AND submitted_at IS NOT NULL
+        GROUP BY submitter_id
+      ),
+      period_submitters AS (
+        SELECT DISTINCT
+          s.submission_period_id,
+          s.submitter_id,
+          CASE
+            WHEN fs.first_submitted_at >= sp.opens_at THEN 'new'
+            ELSE 'returning'
+          END AS submitter_type
+        FROM submissions s
+        JOIN submission_periods sp ON sp.id = s.submission_period_id
+        JOIN first_submissions fs ON fs.submitter_id = s.submitter_id
+        WHERE s.organization_id = ${organizationId}::uuid
+          AND s.status != 'DRAFT'
+          AND s.submitted_at IS NOT NULL
+          ${dateFilter[0]}
+          ${dateFilter[1]}
+      )
+      SELECT
+        sp.name AS "periodName",
+        COUNT(*) FILTER (WHERE ps.submitter_type = 'new')::int AS "newCount",
+        COUNT(*) FILTER (WHERE ps.submitter_type = 'returning')::int AS "returningCount"
+      FROM period_submitters ps
+      JOIN submission_periods sp ON sp.id = ps.submission_period_id
+      GROUP BY sp.name, sp.closes_at
+      ORDER BY sp.closes_at DESC NULLS LAST
+      LIMIT 20
+    `);
+
+    // Genre spread of accepted submitters
+    const genreSpreadResult = await tx.execute(sql`
+      SELECT
+        COALESCE(m.genre->>'primary', 'unknown') AS genre,
+        COUNT(DISTINCT s.submitter_id)::int AS count
+      FROM submissions s
+      ${genreJoin()}
+      WHERE s.organization_id = ${organizationId}::uuid
+        AND s.status = 'ACCEPTED'
+        ${dateFilter[0]}
+        ${dateFilter[1]}
+      GROUP BY m.genre->>'primary'
+      ORDER BY count DESC
+      LIMIT 50
+    `);
+
+    return {
+      newVsReturning: newReturningResult.rows.map((row) => ({
+        periodName: row.periodName as string,
+        newCount: row.newCount as number,
+        returningCount: row.returningCount as number,
+      })),
+      genreSpread: genreSpreadResult.rows.map((row) => ({
+        genre: row.genre as string,
+        count: row.count as number,
+      })),
+    };
+  },
+
+  /**
+   * Reader alignment: vote consensus rate vs final decisions.
+   * For decided submissions with votes, checks if majority vote
+   * matched the final status.
+   */
+  async getReaderAlignment(
+    tx: DrizzleDb,
+    organizationId: string,
+    filter: EditorialAnalyticsFilter,
+  ): Promise<ReaderAlignment> {
+    const where = buildEditorialWhere(organizationId, filter);
+
+    const result = await tx.execute(sql`
+      WITH decided_with_votes AS (
+        SELECT
+          s.id AS submission_id,
+          s.title,
+          s.status AS final_status,
+          (
+            SELECT sv.decision
+            FROM submission_votes sv
+            WHERE sv.submission_id = s.id
+              AND sv.decision != 'MAYBE'
+            GROUP BY sv.decision
+            ORDER BY COUNT(*) DESC
+            LIMIT 1
+          ) AS majority_vote,
+          (
+            SELECT COUNT(*)::int
+            FROM submission_votes sv
+            WHERE sv.submission_id = s.id
+          ) AS vote_count
+        FROM submissions s
+        WHERE ${where}
+          AND s.status IN ('ACCEPTED', 'REJECTED')
+          AND EXISTS (
+            SELECT 1 FROM submission_votes sv WHERE sv.submission_id = s.id
+          )
+      )
+      SELECT
+        submission_id AS "submissionId",
+        title,
+        final_status AS "finalStatus",
+        majority_vote AS "majorityVote",
+        vote_count AS "voteCount",
+        CASE
+          WHEN final_status = 'ACCEPTED' AND majority_vote = 'ACCEPT' THEN true
+          WHEN final_status = 'REJECTED' AND majority_vote = 'REJECT' THEN true
+          ELSE false
+        END AS matched
+      FROM decided_with_votes
+      WHERE majority_vote IS NOT NULL
+      ORDER BY vote_count DESC
+      LIMIT 50
+    `);
+
+    const rows = result.rows as Array<{
+      submissionId: string;
+      title: string | null;
+      finalStatus: string;
+      majorityVote: string;
+      voteCount: number;
+      matched: boolean;
+    }>;
+
+    const totalWithVotes = rows.length;
+    const consensusMatches = rows.filter((r) => r.matched).length;
+
+    // Get total decided count for context
+    const decidedResult = await tx.execute(sql`
+      SELECT COUNT(*)::int AS count
+      FROM submissions s
+      WHERE s.organization_id = ${organizationId}::uuid
+        AND s.status IN ('ACCEPTED', 'REJECTED')
+        AND s.status != 'DRAFT'
+    `);
+
+    return {
+      totalDecided: (decidedResult.rows[0].count as number) ?? 0,
+      totalWithVotes,
+      consensusMatches,
+      consensusRate:
+        totalWithVotes > 0
+          ? Math.round((consensusMatches / totalWithVotes) * 1000) / 10
+          : 0,
+      breakdown: rows.map((row) => ({
+        submissionId: row.submissionId,
+        title: row.title,
+        finalStatus: row.finalStatus,
+        majorityVote: row.majorityVote,
+        matched: row.matched,
+        voteCount: row.voteCount,
+      })),
+    };
+  },
+};

--- a/apps/api/src/trpc/router.ts
+++ b/apps/api/src/trpc/router.ts
@@ -38,6 +38,7 @@ import { opsRouter } from './routers/ops.js';
 import { contributorsRouter } from './routers/contributors.js';
 import { rightsAgreementsRouter } from './routers/rights-agreements.js';
 import { paymentTransactionsRouter } from './routers/payment-transactions.js';
+import { editorialAnalyticsRouter } from './routers/editorial-analytics.js';
 
 // Re-export procedure builders for convenience
 export {
@@ -98,6 +99,7 @@ export const appRouter = t.router({
   contributors: contributorsRouter,
   rightsAgreements: rightsAgreementsRouter,
   paymentTransactions: paymentTransactionsRouter,
+  editorialAnalytics: editorialAnalyticsRouter,
   retention: t.router({}),
 });
 

--- a/apps/api/src/trpc/routers/editorial-analytics.ts
+++ b/apps/api/src/trpc/routers/editorial-analytics.ts
@@ -1,0 +1,134 @@
+import {
+  editorialAnalyticsFilterSchema,
+  acceptanceByGenreSchema,
+  acceptanceByPeriodSchema,
+  responseTimeStatsSchema,
+  pipelineHealthSchema,
+  genreDistributionSchema,
+  contributorDiversitySchema,
+  readerAlignmentSchema,
+} from '@colophony/types';
+import { editorProcedure, createRouter, requireScopes } from '../init.js';
+import { editorialAnalyticsService } from '../../services/editorial-analytics.service.js';
+import { mapServiceError } from '../error-mapper.js';
+
+export const editorialAnalyticsRouter = createRouter({
+  /** Acceptance rate broken down by primary genre. */
+  acceptanceByGenre: editorProcedure
+    .use(requireScopes('submissions:read'))
+    .input(editorialAnalyticsFilterSchema)
+    .output(acceptanceByGenreSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await editorialAnalyticsService.getAcceptanceByGenre(
+          ctx.dbTx,
+          ctx.authContext.orgId,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Acceptance rate broken down by submission period. */
+  acceptanceByPeriod: editorProcedure
+    .use(requireScopes('submissions:read'))
+    .input(editorialAnalyticsFilterSchema)
+    .output(acceptanceByPeriodSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await editorialAnalyticsService.getAcceptanceByPeriod(
+          ctx.dbTx,
+          ctx.authContext.orgId,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Response time stats: avg, median, p90, monthly trend. */
+  responseTimeStats: editorProcedure
+    .use(requireScopes('submissions:read'))
+    .input(editorialAnalyticsFilterSchema)
+    .output(responseTimeStatsSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await editorialAnalyticsService.getResponseTimeStats(
+          ctx.dbTx,
+          ctx.authContext.orgId,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Pipeline health: items per stage, avg days, stuck count. */
+  pipelineHealth: editorProcedure
+    .use(requireScopes('submissions:read'))
+    .input(editorialAnalyticsFilterSchema)
+    .output(pipelineHealthSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await editorialAnalyticsService.getPipelineHealth(
+          ctx.dbTx,
+          ctx.authContext.orgId,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Genre distribution of non-draft submissions. */
+  genreDistribution: editorProcedure
+    .use(requireScopes('submissions:read'))
+    .input(editorialAnalyticsFilterSchema)
+    .output(genreDistributionSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await editorialAnalyticsService.getGenreDistribution(
+          ctx.dbTx,
+          ctx.authContext.orgId,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** New vs returning submitters per period + genre spread. */
+  contributorDiversity: editorProcedure
+    .use(requireScopes('submissions:read'))
+    .input(editorialAnalyticsFilterSchema)
+    .output(contributorDiversitySchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await editorialAnalyticsService.getContributorDiversity(
+          ctx.dbTx,
+          ctx.authContext.orgId,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+
+  /** Reader alignment: vote consensus rate vs final decisions. */
+  readerAlignment: editorProcedure
+    .use(requireScopes('submissions:read'))
+    .input(editorialAnalyticsFilterSchema)
+    .output(readerAlignmentSchema)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await editorialAnalyticsService.getReaderAlignment(
+          ctx.dbTx,
+          ctx.authContext.orgId,
+          input,
+        );
+      } catch (e) {
+        mapServiceError(e);
+      }
+    }),
+});

--- a/apps/web/src/app/(dashboard)/editor/editorial-analytics/page.tsx
+++ b/apps/web/src/app/(dashboard)/editor/editorial-analytics/page.tsx
@@ -1,0 +1,9 @@
+import { EditorialAnalyticsPage } from "@/components/analytics/editorial/editorial-analytics-page";
+
+export default function EditorialAnalyticsDashboardPage() {
+  return (
+    <div className="p-6">
+      <EditorialAnalyticsPage />
+    </div>
+  );
+}

--- a/apps/web/src/components/analytics/chart-colors.ts
+++ b/apps/web/src/components/analytics/chart-colors.ts
@@ -33,3 +33,17 @@ export const CHART_COLORS = [
   "#A855F7",
   "#6B7280",
 ] as const;
+
+/** Hex color map for primary genre values */
+export const GENRE_COLORS: Record<string, string> = {
+  poetry: "#8B5CF6", // violet-500
+  fiction: "#3B82F6", // blue-500
+  creative_nonfiction: "#10B981", // emerald-500
+  nonfiction: "#6366F1", // indigo-500
+  drama: "#F59E0B", // amber-500
+  translation: "#EC4899", // pink-500
+  visual_art: "#14B8A6", // teal-500
+  comics: "#F97316", // orange-500
+  audio: "#06B6D4", // cyan-500
+  other: "#6B7280", // gray-500
+};

--- a/apps/web/src/components/analytics/editorial/acceptance-by-genre-chart.tsx
+++ b/apps/web/src/components/analytics/editorial/acceptance-by-genre-chart.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import { GENRE_COLORS } from "../chart-colors";
+import type { EditorialAnalyticsFilter } from "@colophony/types";
+
+interface AcceptanceByGenreChartProps {
+  filter: EditorialAnalyticsFilter;
+}
+
+function formatGenre(genre: string): string {
+  return genre.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function AcceptanceByGenreChart({
+  filter,
+}: AcceptanceByGenreChartProps) {
+  const { data, isPending: isLoading } =
+    trpc.editorialAnalytics.acceptanceByGenre.useQuery(filter);
+
+  const chartData = (data?.genres ?? []).map((g) => ({
+    ...g,
+    label: formatGenre(g.genre),
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Acceptance Rate by Genre</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : chartData.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-8 text-center">
+            No genre data available
+          </p>
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <BarChart data={chartData} layout="vertical" margin={{ left: 100 }}>
+              <XAxis
+                type="number"
+                domain={[0, 100]}
+                tickFormatter={(v) => `${v}%`}
+              />
+              <YAxis type="category" dataKey="label" width={90} />
+              <Tooltip formatter={(value) => [`${value}%`, "Rate"]} />
+              <Bar dataKey="rate" name="Acceptance Rate">
+                {chartData.map((entry) => (
+                  <Cell
+                    key={entry.genre}
+                    fill={GENRE_COLORS[entry.genre] ?? "#6B7280"}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/analytics/editorial/acceptance-by-period-chart.tsx
+++ b/apps/web/src/components/analytics/editorial/acceptance-by-period-chart.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import type { EditorialAnalyticsFilter } from "@colophony/types";
+
+interface AcceptanceByPeriodChartProps {
+  filter: EditorialAnalyticsFilter;
+}
+
+export function AcceptanceByPeriodChart({
+  filter,
+}: AcceptanceByPeriodChartProps) {
+  const { data, isPending: isLoading } =
+    trpc.editorialAnalytics.acceptanceByPeriod.useQuery(filter);
+
+  const chartData = (data?.periods ?? []).map((p) => ({
+    name: p.periodName,
+    rate: p.rate,
+    total: p.total,
+    accepted: p.accepted,
+    rejected: p.rejected,
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Acceptance Rate by Period</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : chartData.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-8 text-center">
+            No period data available
+          </p>
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <BarChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                dataKey="name"
+                tick={{ fontSize: 12 }}
+                interval={0}
+                angle={-30}
+                textAnchor="end"
+                height={60}
+              />
+              <YAxis domain={[0, 100]} tickFormatter={(v) => `${v}%`} />
+              <Tooltip
+                formatter={(value, name) => {
+                  if (name === "rate") return [`${value}%`, "Acceptance Rate"];
+                  return [value, name];
+                }}
+              />
+              <Bar dataKey="rate" fill="#3B82F6" name="rate" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/analytics/editorial/contributor-diversity-chart.tsx
+++ b/apps/web/src/components/analytics/editorial/contributor-diversity-chart.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Legend,
+  PieChart,
+  Pie,
+  Cell,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import { GENRE_COLORS } from "../chart-colors";
+import type { EditorialAnalyticsFilter } from "@colophony/types";
+
+interface ContributorDiversityChartProps {
+  filter: EditorialAnalyticsFilter;
+}
+
+function formatGenre(genre: string): string {
+  return genre.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function ContributorDiversityChart({
+  filter,
+}: ContributorDiversityChartProps) {
+  const { data, isPending: isLoading } =
+    trpc.editorialAnalytics.contributorDiversity.useQuery(filter);
+
+  const barData = data?.newVsReturning ?? [];
+  const pieData = (data?.genreSpread ?? []).map((g) => ({
+    ...g,
+    name: formatGenre(g.genre),
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Submitter Diversity</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-80 w-full" />
+        ) : barData.length === 0 && pieData.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-8 text-center">
+            No diversity data available
+          </p>
+        ) : (
+          <div className="space-y-6">
+            {barData.length > 0 && (
+              <div>
+                <p className="text-xs text-muted-foreground mb-2">
+                  New vs Returning Submitters by Period
+                </p>
+                <ResponsiveContainer width="100%" height={200}>
+                  <BarChart data={barData}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="periodName"
+                      tick={{ fontSize: 11 }}
+                      interval={0}
+                      angle={-20}
+                      textAnchor="end"
+                      height={50}
+                    />
+                    <YAxis />
+                    <Tooltip />
+                    <Legend />
+                    <Bar
+                      dataKey="newCount"
+                      name="New"
+                      fill="#3B82F6"
+                      stackId="submitters"
+                    />
+                    <Bar
+                      dataKey="returningCount"
+                      name="Returning"
+                      fill="#22C55E"
+                      stackId="submitters"
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+
+            {pieData.length > 0 && (
+              <div>
+                <p className="text-xs text-muted-foreground mb-2">
+                  Genre Spread of Accepted Submitters
+                </p>
+                <ResponsiveContainer width="100%" height={200}>
+                  <PieChart>
+                    <Pie
+                      data={pieData}
+                      dataKey="count"
+                      nameKey="name"
+                      cx="50%"
+                      cy="50%"
+                      outerRadius={75}
+                      label={({ name, value }) => `${name ?? ""}: ${value}`}
+                    >
+                      {pieData.map((entry) => (
+                        <Cell
+                          key={entry.genre}
+                          fill={GENRE_COLORS[entry.genre] ?? "#6B7280"}
+                        />
+                      ))}
+                    </Pie>
+                    <Tooltip />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/analytics/editorial/editorial-analytics-filters.tsx
+++ b/apps/web/src/components/analytics/editorial/editorial-analytics-filters.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { trpc } from "@/lib/trpc";
+
+const GENRES = [
+  { value: "poetry", label: "Poetry" },
+  { value: "fiction", label: "Fiction" },
+  { value: "creative_nonfiction", label: "Creative Nonfiction" },
+  { value: "nonfiction", label: "Nonfiction" },
+  { value: "drama", label: "Drama" },
+  { value: "translation", label: "Translation" },
+  { value: "visual_art", label: "Visual Art" },
+  { value: "comics", label: "Comics" },
+  { value: "audio", label: "Audio" },
+  { value: "other", label: "Other" },
+] as const;
+
+interface EditorialAnalyticsFiltersProps {
+  startDate: string;
+  endDate: string;
+  submissionPeriodId: string;
+  genre: string;
+  onStartDateChange: (val: string) => void;
+  onEndDateChange: (val: string) => void;
+  onPeriodChange: (val: string) => void;
+  onGenreChange: (val: string) => void;
+}
+
+export function EditorialAnalyticsFilters({
+  startDate,
+  endDate,
+  submissionPeriodId,
+  genre,
+  onStartDateChange,
+  onEndDateChange,
+  onPeriodChange,
+  onGenreChange,
+}: EditorialAnalyticsFiltersProps) {
+  const { data: periods } = trpc.periods.list.useQuery({});
+
+  return (
+    <div className="flex flex-wrap items-end gap-4">
+      <div className="space-y-1">
+        <Label htmlFor="start-date" className="text-xs">
+          Start Date
+        </Label>
+        <Input
+          id="start-date"
+          type="date"
+          value={startDate}
+          onChange={(e) => onStartDateChange(e.target.value)}
+          className="w-40"
+        />
+      </div>
+
+      <div className="space-y-1">
+        <Label htmlFor="end-date" className="text-xs">
+          End Date
+        </Label>
+        <Input
+          id="end-date"
+          type="date"
+          value={endDate}
+          onChange={(e) => onEndDateChange(e.target.value)}
+          className="w-40"
+        />
+      </div>
+
+      <div className="space-y-1">
+        <Label htmlFor="period" className="text-xs">
+          Period
+        </Label>
+        <Select value={submissionPeriodId} onValueChange={onPeriodChange}>
+          <SelectTrigger id="period" className="w-48">
+            <SelectValue placeholder="All Periods" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Periods</SelectItem>
+            {periods?.items?.map((p: { id: string; name: string | null }) => (
+              <SelectItem key={p.id} value={p.id}>
+                {p.name ?? "Unnamed Period"}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-1">
+        <Label htmlFor="genre" className="text-xs">
+          Genre
+        </Label>
+        <Select value={genre} onValueChange={onGenreChange}>
+          <SelectTrigger id="genre" className="w-44">
+            <SelectValue placeholder="All Genres" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Genres</SelectItem>
+            {GENRES.map((g) => (
+              <SelectItem key={g.value} value={g.value}>
+                {g.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/analytics/editorial/editorial-analytics-page.tsx
+++ b/apps/web/src/components/analytics/editorial/editorial-analytics-page.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import type { EditorialAnalyticsFilter } from "@colophony/types";
+import { EditorialAnalyticsFilters } from "./editorial-analytics-filters";
+import { EditorialOverviewCards } from "./editorial-overview-cards";
+import { AcceptanceByGenreChart } from "./acceptance-by-genre-chart";
+import { AcceptanceByPeriodChart } from "./acceptance-by-period-chart";
+import { ResponseTimeTrendChart } from "./response-time-trend-chart";
+import { PipelineHealthChart } from "./pipeline-health-chart";
+import { GenreDistributionChart } from "./genre-distribution-chart";
+import { ContributorDiversityChart } from "./contributor-diversity-chart";
+import { ReaderAlignmentTable } from "./reader-alignment-table";
+
+export function EditorialAnalyticsPage() {
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [submissionPeriodId, setSubmissionPeriodId] = useState("all");
+  const [genre, setGenre] = useState("all");
+
+  const filter: EditorialAnalyticsFilter = useMemo(() => {
+    const f: EditorialAnalyticsFilter = {};
+    if (startDate) f.startDate = new Date(startDate);
+    if (endDate) f.endDate = new Date(endDate);
+    if (submissionPeriodId && submissionPeriodId !== "all")
+      f.submissionPeriodId = submissionPeriodId;
+    if (genre && genre !== "all") f.genre = genre;
+    return f;
+  }, [startDate, endDate, submissionPeriodId, genre]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Editorial Analytics</h1>
+        <p className="text-muted-foreground mt-1">
+          Editorial performance insights: acceptance rates, response times,
+          pipeline health, and reader alignment.
+        </p>
+      </div>
+
+      <EditorialAnalyticsFilters
+        startDate={startDate}
+        endDate={endDate}
+        submissionPeriodId={submissionPeriodId}
+        genre={genre}
+        onStartDateChange={setStartDate}
+        onEndDateChange={setEndDate}
+        onPeriodChange={setSubmissionPeriodId}
+        onGenreChange={setGenre}
+      />
+
+      <EditorialOverviewCards filter={filter} />
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <AcceptanceByGenreChart filter={filter} />
+        <GenreDistributionChart filter={filter} />
+      </div>
+
+      <AcceptanceByPeriodChart filter={filter} />
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <ResponseTimeTrendChart filter={filter} />
+        <PipelineHealthChart filter={filter} />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <ContributorDiversityChart filter={filter} />
+        <ReaderAlignmentTable filter={filter} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/analytics/editorial/editorial-overview-cards.tsx
+++ b/apps/web/src/components/analytics/editorial/editorial-overview-cards.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { Percent, Clock, GitBranch, Users } from "lucide-react";
+import {
+  HealthCard,
+  type HealthStatus,
+} from "@/components/operations/health-card";
+import type { EditorialAnalyticsFilter } from "@colophony/types";
+import { trpc } from "@/lib/trpc";
+
+interface EditorialOverviewCardsProps {
+  filter: EditorialAnalyticsFilter;
+}
+
+export function EditorialOverviewCards({
+  filter,
+}: EditorialOverviewCardsProps) {
+  const { data: genreData, isPending: genreLoading } =
+    trpc.editorialAnalytics.acceptanceByGenre.useQuery(filter);
+  const { data: responseData, isPending: responseLoading } =
+    trpc.editorialAnalytics.responseTimeStats.useQuery(filter);
+  const { data: pipelineData, isPending: pipelineLoading } =
+    trpc.editorialAnalytics.pipelineHealth.useQuery(filter);
+  const { data: alignmentData, isPending: alignmentLoading } =
+    trpc.editorialAnalytics.readerAlignment.useQuery(filter);
+
+  // Derive acceptance rate from genre aggregates
+  const totalAccepted =
+    genreData?.genres.reduce((sum, g) => sum + g.accepted, 0) ?? 0;
+  const totalDecisions =
+    genreData?.genres.reduce((sum, g) => sum + g.accepted + g.rejected, 0) ?? 0;
+  const overallRate =
+    totalDecisions > 0
+      ? Math.round((totalAccepted / totalDecisions) * 1000) / 10
+      : 0;
+
+  // Derive pipeline total and stuck
+  const pipelineTotal =
+    pipelineData?.stages.reduce((sum, s) => sum + s.count, 0) ?? 0;
+  const pipelineStuck =
+    pipelineData?.stages.reduce((sum, s) => sum + s.stuckCount, 0) ?? 0;
+
+  function deriveAcceptanceStatus(): HealthStatus {
+    if (genreLoading) return "loading";
+    if (totalDecisions === 0) return "unknown";
+    return "healthy";
+  }
+
+  function deriveResponseStatus(): HealthStatus {
+    if (responseLoading) return "loading";
+    if (responseData?.medianDays == null) return "unknown";
+    if (responseData.medianDays > 60) return "unhealthy";
+    if (responseData.medianDays > 30) return "degraded";
+    return "healthy";
+  }
+
+  function derivePipelineStatus(): HealthStatus {
+    if (pipelineLoading) return "loading";
+    if (pipelineTotal === 0) return "unknown";
+    if (pipelineStuck > 5) return "unhealthy";
+    if (pipelineStuck > 0) return "degraded";
+    return "healthy";
+  }
+
+  function deriveAlignmentStatus(): HealthStatus {
+    if (alignmentLoading) return "loading";
+    if ((alignmentData?.totalWithVotes ?? 0) === 0) return "unknown";
+    if ((alignmentData?.consensusRate ?? 0) < 50) return "degraded";
+    return "healthy";
+  }
+
+  return (
+    <div className="grid gap-3 grid-cols-2 lg:grid-cols-4">
+      <HealthCard
+        title="Acceptance Rate"
+        status={deriveAcceptanceStatus()}
+        metric={`${overallRate}%`}
+        subtitle={`${totalDecisions} decisions`}
+        icon={Percent}
+      />
+      <HealthCard
+        title="Median Response"
+        status={deriveResponseStatus()}
+        metric={
+          responseData?.medianDays != null
+            ? `${Math.round(responseData.medianDays)}d`
+            : "—"
+        }
+        subtitle={
+          responseData?.p90Days != null
+            ? `p90: ${Math.round(responseData.p90Days)}d`
+            : undefined
+        }
+        icon={Clock}
+      />
+      <HealthCard
+        title="Pipeline Items"
+        status={derivePipelineStatus()}
+        metric={`${pipelineTotal}`}
+        subtitle={pipelineStuck > 0 ? `${pipelineStuck} stuck` : "All moving"}
+        icon={GitBranch}
+      />
+      <HealthCard
+        title="Vote Consensus"
+        status={deriveAlignmentStatus()}
+        metric={
+          alignmentData?.totalWithVotes
+            ? `${alignmentData.consensusRate}%`
+            : "—"
+        }
+        subtitle={
+          alignmentData?.totalWithVotes
+            ? `${alignmentData.totalWithVotes} voted`
+            : undefined
+        }
+        icon={Users}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/analytics/editorial/genre-distribution-chart.tsx
+++ b/apps/web/src/components/analytics/editorial/genre-distribution-chart.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import { GENRE_COLORS } from "../chart-colors";
+import type { EditorialAnalyticsFilter } from "@colophony/types";
+
+interface GenreDistributionChartProps {
+  filter: EditorialAnalyticsFilter;
+}
+
+function formatGenre(genre: string): string {
+  return genre.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function GenreDistributionChart({
+  filter,
+}: GenreDistributionChartProps) {
+  const { data, isPending: isLoading } =
+    trpc.editorialAnalytics.genreDistribution.useQuery(filter);
+
+  const chartData = (data?.distribution ?? []).map((d) => ({
+    ...d,
+    name: formatGenre(d.genre),
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Genre Distribution</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : chartData.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-8 text-center">
+            No genre data available
+          </p>
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <PieChart>
+              <Pie
+                data={chartData}
+                dataKey="count"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                outerRadius={100}
+                label={({ name, value }) => `${name ?? ""}: ${value}`}
+              >
+                {chartData.map((entry) => (
+                  <Cell
+                    key={entry.genre}
+                    fill={GENRE_COLORS[entry.genre] ?? "#6B7280"}
+                  />
+                ))}
+              </Pie>
+              <Tooltip />
+              <Legend />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/analytics/editorial/pipeline-health-chart.tsx
+++ b/apps/web/src/components/analytics/editorial/pipeline-health-chart.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Cell,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import type { EditorialAnalyticsFilter } from "@colophony/types";
+
+interface PipelineHealthChartProps {
+  filter: EditorialAnalyticsFilter;
+}
+
+const STAGE_COLORS: Record<string, string> = {
+  COPYEDIT_PENDING: "#3B82F6",
+  COPYEDIT_IN_PROGRESS: "#6366F1",
+  AUTHOR_REVIEW: "#F59E0B",
+  PROOFREAD: "#10B981",
+  READY_TO_PUBLISH: "#22C55E",
+};
+
+function formatStage(stage: string): string {
+  return stage
+    .replace(/_/g, " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function PipelineHealthChart({ filter }: PipelineHealthChartProps) {
+  const { data, isPending: isLoading } =
+    trpc.editorialAnalytics.pipelineHealth.useQuery(filter);
+
+  const chartData = (data?.stages ?? []).map((s) => ({
+    ...s,
+    label: formatStage(s.stage),
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Pipeline Health</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : chartData.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-8 text-center">
+            No pipeline items
+          </p>
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <BarChart data={chartData} layout="vertical" margin={{ left: 120 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis type="number" />
+              <YAxis
+                type="category"
+                dataKey="label"
+                width={110}
+                tick={{ fontSize: 12 }}
+              />
+              <Tooltip
+                content={({ active, payload }) => {
+                  if (!active || !payload?.[0]) return null;
+                  const d = payload[0].payload;
+                  return (
+                    <div className="rounded border bg-background p-2 text-xs shadow-sm">
+                      <p className="font-medium">{d.label}</p>
+                      <p>Count: {d.count}</p>
+                      <p>
+                        Avg days:{" "}
+                        {d.avgDaysInStage != null
+                          ? Math.round(d.avgDaysInStage)
+                          : "—"}
+                      </p>
+                      <p
+                        className={
+                          d.stuckCount > 0 ? "text-red-500 font-medium" : ""
+                        }
+                      >
+                        Stuck (&gt;14d): {d.stuckCount}
+                      </p>
+                    </div>
+                  );
+                }}
+              />
+              <Bar dataKey="count" name="Items">
+                {chartData.map((entry) => (
+                  <Cell
+                    key={entry.stage}
+                    fill={
+                      entry.stuckCount > 0
+                        ? "#EF4444"
+                        : (STAGE_COLORS[entry.stage] ?? "#6B7280")
+                    }
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/analytics/editorial/reader-alignment-table.tsx
+++ b/apps/web/src/components/analytics/editorial/reader-alignment-table.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import type { EditorialAnalyticsFilter } from "@colophony/types";
+
+interface ReaderAlignmentTableProps {
+  filter: EditorialAnalyticsFilter;
+}
+
+function statusBadgeVariant(
+  status: string,
+): "default" | "secondary" | "destructive" | "outline" {
+  if (status === "ACCEPTED" || status === "ACCEPT") return "default";
+  if (status === "REJECTED" || status === "REJECT") return "destructive";
+  return "secondary";
+}
+
+export function ReaderAlignmentTable({ filter }: ReaderAlignmentTableProps) {
+  const { data, isPending: isLoading } =
+    trpc.editorialAnalytics.readerAlignment.useQuery(filter);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Reader Alignment</CardTitle>
+        <CardDescription>
+          {data
+            ? `${data.consensusRate}% consensus — ${data.consensusMatches}/${data.totalWithVotes} voted submissions matched final decision (${data.totalDecided} total decided)`
+            : "Vote consensus vs final decisions"}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : !data || data.breakdown.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-8 text-center">
+            No voted submissions with decisions yet
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-muted-foreground">
+                  <th className="py-2 pr-4 font-medium">Title</th>
+                  <th className="py-2 pr-4 font-medium">Majority Vote</th>
+                  <th className="py-2 pr-4 font-medium">Final</th>
+                  <th className="py-2 pr-4 font-medium text-right">Votes</th>
+                  <th className="py-2 font-medium text-center">Match</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.breakdown.map((row) => (
+                  <tr key={row.submissionId} className="border-b last:border-0">
+                    <td className="py-2 pr-4 max-w-[200px] truncate">
+                      {row.title ?? "Untitled"}
+                    </td>
+                    <td className="py-2 pr-4">
+                      <Badge variant={statusBadgeVariant(row.majorityVote)}>
+                        {row.majorityVote}
+                      </Badge>
+                    </td>
+                    <td className="py-2 pr-4">
+                      <Badge variant={statusBadgeVariant(row.finalStatus)}>
+                        {row.finalStatus}
+                      </Badge>
+                    </td>
+                    <td className="py-2 pr-4 text-right">{row.voteCount}</td>
+                    <td className="py-2 text-center">
+                      {row.matched ? (
+                        <span className="text-green-600">Yes</span>
+                      ) : (
+                        <span className="text-red-500">No</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/analytics/editorial/response-time-trend-chart.tsx
+++ b/apps/web/src/components/analytics/editorial/response-time-trend-chart.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  ReferenceLine,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { trpc } from "@/lib/trpc";
+import type { EditorialAnalyticsFilter } from "@colophony/types";
+
+interface ResponseTimeTrendChartProps {
+  filter: EditorialAnalyticsFilter;
+}
+
+export function ResponseTimeTrendChart({
+  filter,
+}: ResponseTimeTrendChartProps) {
+  const { data, isPending: isLoading } =
+    trpc.editorialAnalytics.responseTimeStats.useQuery(filter);
+
+  const chartData = (data?.trend ?? []).map((t) => ({
+    month: t.month,
+    median: t.medianDays != null ? Math.round(t.medianDays * 10) / 10 : null,
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Response Time Trend</CardTitle>
+        <CardDescription>
+          {data?.avgDays != null &&
+            `Avg: ${Math.round(data.avgDays)}d | Median: ${data.medianDays != null ? Math.round(data.medianDays) : "—"}d | p90: ${data.p90Days != null ? Math.round(data.p90Days) : "—"}d`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : chartData.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-8 text-center">
+            No response time data available
+          </p>
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <LineChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="month" tick={{ fontSize: 12 }} />
+              <YAxis
+                tickFormatter={(v) => `${v}d`}
+                label={{
+                  value: "Days",
+                  angle: -90,
+                  position: "insideLeft",
+                }}
+              />
+              <Tooltip formatter={(value) => [`${value} days`, "Median"]} />
+              {data?.p90Days != null && (
+                <ReferenceLine
+                  y={Math.round(data.p90Days)}
+                  stroke="#EF4444"
+                  strokeDasharray="5 5"
+                  label={{ value: "p90", fill: "#EF4444", fontSize: 11 }}
+                />
+              )}
+              <Line
+                type="monotone"
+                dataKey="median"
+                stroke="#3B82F6"
+                strokeWidth={2}
+                dot={{ r: 4 }}
+                connectNulls
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -22,6 +22,7 @@ import {
   Network,
   Send,
   Settings,
+  TrendingUp,
   Upload,
   Users,
   Webhook,
@@ -56,6 +57,12 @@ export const editorialNavigation: NavItem[] = [
   { name: "Collections", href: "/editor/collections", icon: FolderOpen },
   { name: "Forms", href: "/editor/forms", icon: ClipboardList },
   { name: "Periods", href: "/editor/periods", icon: Calendar },
+  { name: "Submission Analytics", href: "/editor/analytics", icon: BarChart3 },
+  {
+    name: "Editorial Analytics",
+    href: "/editor/editorial-analytics",
+    icon: TrendingUp,
+  },
 ];
 
 export const productionNavigation: NavItem[] = [

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -502,7 +502,7 @@
 
 ## Track 13 — Business Operations (Post-Launch)
 
-> **Status:** All P1 items complete. P2 items (dashboards, contest management) remain.
+> **Status:** All P1 items and dashboards complete. One P2 item remains: contest management.
 
 ### Code
 
@@ -515,7 +515,7 @@
 - [x] [P1] Rights service — lifecycle management, reversion alerts ("3 rights agreements reverting in 30 days"), integration with production pipeline — (design system session 2026-03-28; done 2026-03-28)
 - [x] [P1] Revenue service — submission fees (existing Stripe), contributor payments, contest prizes, revenue reporting — (design system session 2026-03-28; done 2026-03-29)
 - [x] [P2] Business Ops dashboard — health card grid pattern with contributor count, outstanding payments, upcoming reversions, revenue summary — (design system session 2026-03-28; done 2026-03-29)
-- [ ] [P2] Editorial analytics dashboard — acceptance rate (overall + by genre/period), response time (avg/median/p90 + trend), pipeline health, genre distribution, contributor diversity, reader alignment — (design system session 2026-03-28)
+- [x] [P2] Editorial analytics dashboard — acceptance rate (overall + by genre/period), response time (avg/median/p90 + trend), pipeline health, genre distribution, contributor diversity, reader alignment — (design system session 2026-03-28; done 2026-03-29)
 - [ ] [P2] Contest management — contest-type submission periods with rounds (`contestGroupId` + `contestRound`), judge assignments, anonymous judging, prize disbursement. Period-scoped guest editor roles deferred — (design system session 2026-03-28)
 
 ---

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,37 @@ Newest entries first.
 
 ---
 
+## 2026-03-29 — Editorial Analytics Dashboard (Track 13 P2)
+
+### Done
+
+- Editorial analytics dashboard page at `/editor/editorial-analytics` with 7 metric sections
+- Backend: `editorial-analytics.service.ts` with 7 query methods, all with defense-in-depth `organizationId` filter
+- Acceptance rate by genre (horizontal bar chart, genre JOIN through manuscript_versions → manuscripts)
+- Acceptance rate by period (bar chart, JOIN submission_periods)
+- Response time stats: avg/median/p90 + 6-month monthly trend (line chart with p90 reference line)
+- Pipeline health by stage with stuck detection (>14 days, bar chart with red highlighting)
+- Genre distribution (pie chart with GENRE_COLORS map)
+- Submitter diversity: new vs returning per period (stacked bar) + genre spread of accepted submitters (pie)
+- Reader alignment: vote consensus rate vs final decisions (summary card + breakdown table)
+- 8 new Zod schemas in `@colophony/types` (filter + 7 responses)
+- New `editorialAnalyticsRouter` tRPC router (7 `editorProcedure` queries with `requireScopes`)
+- 10 frontend components under `components/analytics/editorial/`
+- `EditorialAnalyticsFilters` with genre dropdown (separate from existing submission analytics filters)
+- 4 `HealthCard` overview cards (acceptance rate, median response, pipeline items, vote consensus)
+- Added "Submission Analytics" and "Editorial Analytics" to editorial sidebar navigation
+- 11 unit tests for service layer (all passing)
+
+### Decisions
+
+- Separate page from existing `/editor/analytics` — different mental model (volume/flow vs performance/quality)
+- Genre via JOIN (no schema change) — denormalization deferred unless performance requires it
+- Reader alignment = vote consensus rate (majority vote vs final status), per-reader accuracy deferred
+- Contributor diversity uses submitters (not business-ops contributors table) — accepted submitters ≠ published contributors
+- New tRPC router to avoid bloating submissions router (~757 lines already)
+
+---
+
 ## 2026-03-29 — Hooks Migration (Dev Tooling P1)
 
 ### Done

--- a/packages/types/src/analytics.ts
+++ b/packages/types/src/analytics.ts
@@ -105,3 +105,115 @@ export const agingSubmissionsSchema = z.object({
   totalAging: z.number().int(),
 });
 export type AgingSubmissions = z.infer<typeof agingSubmissionsSchema>;
+
+// ---------------------------------------------------------------------------
+// Editorial analytics — filter
+// ---------------------------------------------------------------------------
+
+export const editorialAnalyticsFilterSchema = analyticsFilterSchema.extend({
+  genre: z.string().optional(),
+});
+export type EditorialAnalyticsFilter = z.infer<
+  typeof editorialAnalyticsFilterSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Editorial analytics — response schemas
+// ---------------------------------------------------------------------------
+
+export const acceptanceByGenreSchema = z.object({
+  genres: z.array(
+    z.object({
+      genre: z.string(),
+      total: z.number().int(),
+      accepted: z.number().int(),
+      rejected: z.number().int(),
+      rate: z.number().min(0).max(100),
+    }),
+  ),
+});
+export type AcceptanceByGenre = z.infer<typeof acceptanceByGenreSchema>;
+
+export const acceptanceByPeriodSchema = z.object({
+  periods: z.array(
+    z.object({
+      periodId: z.string().uuid(),
+      periodName: z.string(),
+      total: z.number().int(),
+      accepted: z.number().int(),
+      rejected: z.number().int(),
+      rate: z.number().min(0).max(100),
+    }),
+  ),
+});
+export type AcceptanceByPeriod = z.infer<typeof acceptanceByPeriodSchema>;
+
+export const responseTimeStatsSchema = z.object({
+  avgDays: z.number().nullable(),
+  medianDays: z.number().nullable(),
+  p90Days: z.number().nullable(),
+  trend: z.array(
+    z.object({
+      month: z.string(),
+      medianDays: z.number().nullable(),
+    }),
+  ),
+});
+export type ResponseTimeStats = z.infer<typeof responseTimeStatsSchema>;
+
+export const pipelineHealthSchema = z.object({
+  stages: z.array(
+    z.object({
+      stage: z.string(),
+      count: z.number().int(),
+      avgDaysInStage: z.number().nullable(),
+      stuckCount: z.number().int(),
+    }),
+  ),
+});
+export type PipelineHealth = z.infer<typeof pipelineHealthSchema>;
+
+export const genreDistributionSchema = z.object({
+  distribution: z.array(
+    z.object({
+      genre: z.string(),
+      count: z.number().int(),
+    }),
+  ),
+});
+export type GenreDistribution = z.infer<typeof genreDistributionSchema>;
+
+export const contributorDiversitySchema = z.object({
+  newVsReturning: z.array(
+    z.object({
+      periodName: z.string(),
+      newCount: z.number().int(),
+      returningCount: z.number().int(),
+    }),
+  ),
+  genreSpread: z.array(
+    z.object({
+      genre: z.string(),
+      count: z.number().int(),
+    }),
+  ),
+});
+export type ContributorDiversity = z.infer<typeof contributorDiversitySchema>;
+
+export const readerAlignmentSchema = z.object({
+  totalDecided: z.number().int(),
+  totalWithVotes: z.number().int(),
+  consensusMatches: z.number().int(),
+  consensusRate: z.number().min(0).max(100),
+  breakdown: z.array(
+    z.object({
+      submissionId: z.string().uuid(),
+      title: z.string().nullable(),
+      finalStatus: z.string(),
+      majorityVote: z.string(),
+      matched: z.boolean(),
+      voteCount: z.number().int(),
+    }),
+  ),
+});
+export type ReaderAlignment = z.infer<typeof readerAlignmentSchema>;


### PR DESCRIPTION
## Summary
- New editorial analytics page at `/editor/editorial-analytics` with 7 metric sections
- Backend: `editorial-analytics.service.ts` with 7 query methods, defense-in-depth `organizationId` filter on all queries
- Frontend: 10 components (page, filters, 4 health cards, 6 chart/table sections)
- Filters: date range, submission period, genre — applied consistently across all metrics
- Added "Submission Analytics" and "Editorial Analytics" to editorial sidebar navigation

### Metrics
1. **Acceptance rate by genre** — horizontal bar chart with GENRE_COLORS
2. **Acceptance rate by period** — bar chart grouped by submission period
3. **Response time stats** — avg/median/p90 + 6-month monthly trend (line chart)
4. **Pipeline health** — items per stage with stuck detection (>14 days)
5. **Genre distribution** — pie chart of submissions by primary genre
6. **Submitter diversity** — new vs returning per period + genre spread of accepted submitters
7. **Reader alignment** — vote consensus rate vs final decisions (table)

## Test plan
- [x] `pnpm type-check` passes (all 13 packages)
- [x] 11 unit tests in `editorial-analytics.service.spec.ts` pass
- [x] Lint clean (API + web)
- [ ] Manual: navigate to `/editor/editorial-analytics`, verify charts render with seed data
- [ ] Manual: verify filters update all chart sections
- [ ] Manual: verify nav entries visible for editor/admin roles

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `editorial-analytics.service.ts` | Integration tests with real DB | Unit tests with mocked tx | Matches existing `submission-analytics.service.spec.ts` pattern; integration tests can be added separately |
| `contributor-diversity-chart.tsx` | Grouped BarChart | Stacked BarChart | Stacked better shows total volume per period |
| `editorial-analytics-filters.tsx` | Genre from PrimaryGenre enum import | Hardcoded GENRES const | Avoids importing server-side enum in client component; values are static |