### PR TITLE
feat(hopper): writer platform schema foundation

### DIFF
--- a/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
+++ b/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
@@ -72,6 +72,11 @@ const RLS_TABLES = [
   'contest_groups',
   'contest_judges',
   'contest_results',
+  // Writer Platform
+  'simsub_groups',
+  'simsub_group_submissions',
+  'portfolio_entries',
+  'reader_feedback',
 ];
 
 /** RLS tables where app_user has full DML (excludes audit_events which is SELECT-only + function, journal_directory which is SELECT-only).
@@ -370,7 +375,8 @@ describe('RLS Infrastructure', () => {
       // - Nullable org policies (tested separately): audit_events, retention_policies, user_consents
       // - User-scoped (current_user_id()): manuscripts, manuscript_versions, files,
       //   external_submissions, correspondence, writer_profiles, identity_migrations,
-      //   journal_directory, user_keys
+      //   journal_directory, user_keys, simsub_groups, simsub_group_submissions,
+      //   portfolio_entries
       // - Subquery-based: sim_sub_checks, piece_transfers
       const orgPolicyExceptions = new Set([
         'audit_events',
@@ -387,6 +393,9 @@ describe('RLS Infrastructure', () => {
         'sim_sub_checks',
         'piece_transfers',
         'user_keys',
+        'simsub_groups',
+        'simsub_group_submissions',
+        'portfolio_entries',
       ]);
 
       const orgScopedTables = RLS_TABLES.filter(

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -522,17 +522,19 @@
 
 ## Track 14 — Writer Platform Enhancements (Post-Launch)
 
-> **Status:** Planned. Some features depend on Track 13 contributor infrastructure (portfolio entries link to `contributor_publications`).
+> **Status:** In progress. Schema foundation (P1) complete. Service layer and frontend pending.
 
 ### Code
 
-- [ ] [P1] `simultaneous_submission_groups` schema — user-scoped sim-sub groupings linking native + external submissions of same work. Auto-withdraw prompt on acceptance — (design system session 2026-03-28)
-- [ ] [P1] `portfolio_entries` schema — three types: `colophony_verified` (from contributor_publications), `federation_verified` (future federation sync), `external` (manual). Forward-declares `federation_source_instance` + `federation_entry_id` columns — (design system session 2026-03-28)
-- [ ] [P1] `reader_feedback` schema — org-configurable tags (JSONB), short comment (280 chars), forwardable boolean. Opt-in per org. Anonymous reader identity on forwarded feedback — (design system session 2026-03-28)
+- [x] [P1] `simultaneous_submission_groups` schema — user-scoped sim-sub groupings linking native + external submissions of same work. Auto-withdraw prompt on acceptance — (design system session 2026-03-28; done 2026-03-29)
+- [x] [P1] `portfolio_entries` schema — three types: `colophony_verified` (from contributor_publications), `federation_verified` (future federation sync), `external` (manual). Forward-declares `federation_source_instance` + `federation_entry_id` columns — (design system session 2026-03-28; done 2026-03-29)
+- [x] [P1] `reader_feedback` schema — org-configurable tags (JSONB), short comment (280 chars), forwardable boolean. Opt-in per org. Anonymous reader identity on forwarded feedback — (design system session 2026-03-28; done 2026-03-29)
 - [ ] [P2] Sim-sub management UI — group creation, linked submission view, auto-withdraw on acceptance at any Colophony magazine, manual withdraw reminder for external submissions — (design system session 2026-03-28)
 - [ ] [P2] Response time transparency — aggregation query over local submission records, displayed on magazine public profile + submission form. `source` field (local vs federated) for future federation data. Org opt-out available — (design system session 2026-03-28)
 - [ ] [P2] Feedback on rejection flow — reader tags/comments during scoring, editor inclusion of anonymized feedback in rejection notice, org-level feature toggle (default off) — (design system session 2026-03-28)
 - [ ] [P3] Writer sidebar updates — Sim-Sub Groups nav item, Portfolio badges (verified/federated/external), Analytics personal response time stats — (design system session 2026-03-28)
+- [ ] [P1] Reader feedback service: defense-in-depth org match on submission_id — service must verify `submission.organizationId === orgId` before insert to prevent cross-org feedback — (Codex branch review 2026-03-29)
+- [ ] [P2] Sim-sub junction service: ownership validation on referenced records — service must verify `simsubGroup.userId`, `submission.submitterId`, and `externalSubmission.userId` match the caller before insert — (Codex branch review 2026-03-29)
 
 ---
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,32 @@ Newest entries first.
 
 ---
 
+## 2026-03-29 — Writer Platform Schema Foundation (Track 14 P1)
+
+### Done
+
+- Track 14 PR 1: schema foundation for 3 writer platform features
+- 4 new DB tables in `writer-platform.ts`: `simsub_groups` (user-scoped), `simsub_group_submissions` (junction with XOR CHECK + partial unique indexes), `portfolio_entries` (user-scoped, 3 types with federation forward-declarations), `reader_feedback` (org-scoped, dual RLS)
+- 2 new enums: `PortfolioEntryType`, `SimsubGroupStatus`
+- Migration 0065 with full RLS + FORCE ROW LEVEL SECURITY + GRANTs for all 4 tables
+- 21 Zod schemas across 3 new type files (`simsub-group.ts`, `portfolio-entry.ts`, `reader-feedback.ts`)
+- 11 audit actions, 3 audit resources, 3 discriminated union param interfaces
+- 6 new API key scopes (read/write per feature)
+- Reader feedback org settings (`readerFeedbackEnabled`, `readerFeedbackTags`) added to `orgSettingsSchema`
+- RLS infrastructure test updated: 4 new tables, 3 user-scoped exceptions
+- Codex plan review: 3 Important findings addressed (reviewer_user_id NOT NULL+SET NULL conflict, org settings validation gap, wrong RLS setting names in verification)
+
+### Decisions
+
+- D1: Sim-sub groups user-scoped — writers group subs across orgs
+- D2: Junction table uses two nullable FKs + XOR CHECK — preserves referential integrity for both native and external submissions
+- D3: Portfolio entries user-scoped — belongs to writer, like manuscripts
+- D4: Reader feedback org-scoped + submitter forwarded read — dual RLS policy
+- D5: Reader feedback opt-in via existing `organizations.settings` JSONB (updated orgSettingsSchema)
+- D6: Single `writer-platform.ts` schema file — follows `business-ops.ts` pattern
+
+---
+
 ## 2026-03-29 — Contest Management (Track 13 P2, closes Track 13)
 
 ### Done

--- a/packages/db/migrations/0065_writer_platform.sql
+++ b/packages/db/migrations/0065_writer_platform.sql
@@ -1,0 +1,169 @@
+-- Writer Platform Enhancements (Track 14)
+-- New enums: PortfolioEntryType, SimsubGroupStatus
+-- New tables: simsub_groups, simsub_group_submissions, portfolio_entries, reader_feedback
+
+--> statement-breakpoint
+CREATE TYPE "public"."PortfolioEntryType" AS ENUM('colophony_verified', 'federation_verified', 'external');
+
+--> statement-breakpoint
+CREATE TYPE "public"."SimsubGroupStatus" AS ENUM('ACTIVE', 'RESOLVED', 'WITHDRAWN');
+
+--> statement-breakpoint
+CREATE TABLE "simsub_groups" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" uuid NOT NULL,
+  "name" varchar(255) NOT NULL,
+  "manuscript_id" uuid,
+  "status" "SimsubGroupStatus" NOT NULL DEFAULT 'ACTIVE',
+  "notes" text,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "simsub_groups_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT "simsub_groups_manuscript_id_manuscripts_id_fk" FOREIGN KEY ("manuscript_id") REFERENCES "public"."manuscripts"("id") ON DELETE SET NULL ON UPDATE NO ACTION
+);
+
+--> statement-breakpoint
+ALTER TABLE "simsub_groups" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "simsub_groups" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+CREATE POLICY "user_owner" ON "simsub_groups" AS PERMISSIVE FOR ALL USING (user_id = current_user_id());
+
+--> statement-breakpoint
+CREATE INDEX "simsub_groups_user_id_idx" ON "simsub_groups" USING btree ("user_id");
+--> statement-breakpoint
+CREATE INDEX "simsub_groups_user_status_idx" ON "simsub_groups" USING btree ("user_id", "status");
+--> statement-breakpoint
+CREATE INDEX "simsub_groups_manuscript_id_idx" ON "simsub_groups" USING btree ("manuscript_id");
+
+--> statement-breakpoint
+CREATE TABLE "simsub_group_submissions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" uuid NOT NULL,
+  "simsub_group_id" uuid NOT NULL,
+  "submission_id" uuid,
+  "external_submission_id" uuid,
+  "added_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "simsub_group_submissions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT "simsub_group_submissions_simsub_group_id_simsub_groups_id_fk" FOREIGN KEY ("simsub_group_id") REFERENCES "public"."simsub_groups"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT "simsub_group_submissions_submission_id_submissions_id_fk" FOREIGN KEY ("submission_id") REFERENCES "public"."submissions"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT "simsub_group_submissions_external_submission_id_external_submissions_id_fk" FOREIGN KEY ("external_submission_id") REFERENCES "public"."external_submissions"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+--> statement-breakpoint
+ALTER TABLE "simsub_group_submissions" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "simsub_group_submissions" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+CREATE POLICY "simsub_group_submissions_user_owner" ON "simsub_group_submissions" AS PERMISSIVE FOR ALL USING (user_id = current_user_id());
+
+--> statement-breakpoint
+ALTER TABLE "simsub_group_submissions" ADD CONSTRAINT "simsub_group_submissions_source_xor"
+  CHECK ((submission_id IS NOT NULL)::int + (external_submission_id IS NOT NULL)::int = 1);
+
+--> statement-breakpoint
+CREATE INDEX "simsub_group_submissions_group_id_idx" ON "simsub_group_submissions" USING btree ("simsub_group_id");
+--> statement-breakpoint
+CREATE INDEX "simsub_group_submissions_submission_id_idx" ON "simsub_group_submissions" USING btree ("submission_id");
+--> statement-breakpoint
+CREATE INDEX "simsub_group_submissions_external_id_idx" ON "simsub_group_submissions" USING btree ("external_submission_id");
+
+--> statement-breakpoint
+CREATE UNIQUE INDEX "simsub_group_submissions_group_submission_idx"
+  ON "simsub_group_submissions" ("simsub_group_id", "submission_id")
+  WHERE submission_id IS NOT NULL;
+
+--> statement-breakpoint
+CREATE UNIQUE INDEX "simsub_group_submissions_group_external_idx"
+  ON "simsub_group_submissions" ("simsub_group_id", "external_submission_id")
+  WHERE external_submission_id IS NOT NULL;
+
+--> statement-breakpoint
+CREATE TABLE "portfolio_entries" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" uuid NOT NULL,
+  "type" "PortfolioEntryType" NOT NULL,
+  "title" varchar(500) NOT NULL,
+  "publication_name" varchar(500) NOT NULL,
+  "published_at" timestamptz,
+  "url" varchar(2048),
+  "contributor_publication_id" uuid,
+  "federation_source_instance" varchar(512),
+  "federation_entry_id" uuid,
+  "notes" text,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "portfolio_entries_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT "portfolio_entries_contributor_publication_id_contributor_publications_id_fk" FOREIGN KEY ("contributor_publication_id") REFERENCES "public"."contributor_publications"("id") ON DELETE SET NULL ON UPDATE NO ACTION
+);
+
+--> statement-breakpoint
+ALTER TABLE "portfolio_entries" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "portfolio_entries" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+CREATE POLICY "portfolio_entries_user_owner" ON "portfolio_entries" AS PERMISSIVE FOR ALL USING (user_id = current_user_id());
+
+--> statement-breakpoint
+CREATE INDEX "portfolio_entries_user_id_idx" ON "portfolio_entries" USING btree ("user_id");
+--> statement-breakpoint
+CREATE INDEX "portfolio_entries_user_type_idx" ON "portfolio_entries" USING btree ("user_id", "type");
+--> statement-breakpoint
+CREATE INDEX "portfolio_entries_contributor_publication_id_idx" ON "portfolio_entries" USING btree ("contributor_publication_id");
+
+--> statement-breakpoint
+CREATE TABLE "reader_feedback" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "submission_id" uuid NOT NULL,
+  "reviewer_user_id" uuid,
+  "tags" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "comment" varchar(280),
+  "is_forwardable" boolean NOT NULL DEFAULT false,
+  "forwarded_at" timestamptz,
+  "forwarded_by" uuid,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "reader_feedback_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT "reader_feedback_submission_id_submissions_id_fk" FOREIGN KEY ("submission_id") REFERENCES "public"."submissions"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT "reader_feedback_reviewer_user_id_users_id_fk" FOREIGN KEY ("reviewer_user_id") REFERENCES "public"."users"("id") ON DELETE SET NULL ON UPDATE NO ACTION,
+  CONSTRAINT "reader_feedback_forwarded_by_users_id_fk" FOREIGN KEY ("forwarded_by") REFERENCES "public"."users"("id") ON DELETE SET NULL ON UPDATE NO ACTION
+);
+
+--> statement-breakpoint
+ALTER TABLE "reader_feedback" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "reader_feedback" FORCE ROW LEVEL SECURITY;
+
+--> statement-breakpoint
+CREATE POLICY "reader_feedback_org_isolation" ON "reader_feedback" AS PERMISSIVE FOR ALL USING (organization_id = current_org_id());
+
+--> statement-breakpoint
+CREATE POLICY "reader_feedback_submitter_forwarded_read" ON "reader_feedback" AS PERMISSIVE FOR SELECT USING (
+  forwarded_at IS NOT NULL AND submission_id IN (
+    SELECT id FROM submissions WHERE submitter_id = current_user_id()
+  )
+);
+
+--> statement-breakpoint
+CREATE INDEX "reader_feedback_organization_id_idx" ON "reader_feedback" USING btree ("organization_id");
+--> statement-breakpoint
+CREATE INDEX "reader_feedback_submission_id_idx" ON "reader_feedback" USING btree ("submission_id");
+--> statement-breakpoint
+CREATE INDEX "reader_feedback_reviewer_user_id_idx" ON "reader_feedback" USING btree ("reviewer_user_id");
+--> statement-breakpoint
+CREATE INDEX "reader_feedback_org_submission_idx" ON "reader_feedback" USING btree ("organization_id", "submission_id");
+--> statement-breakpoint
+CREATE INDEX "reader_feedback_tags_gin_idx" ON "reader_feedback" USING gin ("tags" jsonb_path_ops);
+
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON "simsub_groups" TO app_user;
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON "simsub_group_submissions" TO app_user;
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON "portfolio_entries" TO app_user;
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON "reader_feedback" TO app_user;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1782000000000,
       "tag": "0064_contest_management",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1782200000000,
+      "tag": "0065_writer_platform",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -356,3 +356,19 @@ export const paymentTransactionDirectionEnum = pgEnum(
   "PaymentTransactionDirection",
   ["inbound", "outbound"],
 );
+
+// ---------------------------------------------------------------------------
+// Writer Platform
+// ---------------------------------------------------------------------------
+
+export const portfolioEntryTypeEnum = pgEnum("PortfolioEntryType", [
+  "colophony_verified",
+  "federation_verified",
+  "external",
+]);
+
+export const simsubGroupStatusEnum = pgEnum("SimsubGroupStatus", [
+  "ACTIVE",
+  "RESOLVED",
+  "WITHDRAWN",
+]);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -34,4 +34,5 @@ export * from "./workspace-collections";
 export * from "./invitations";
 export * from "./business-ops";
 export * from "./contests";
+export * from "./writer-platform";
 export * from "./relations";

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -34,6 +34,12 @@ import {
   paymentTransactions,
 } from "./business-ops";
 import { contestGroups, contestJudges, contestResults } from "./contests";
+import {
+  simsubGroups,
+  simsubGroupSubmissions,
+  portfolioEntries,
+  readerFeedback,
+} from "./writer-platform";
 
 // --- organizations ---
 
@@ -62,6 +68,7 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   contestGroups: many(contestGroups),
   contestJudges: many(contestJudges),
   contestResults: many(contestResults),
+  readerFeedback: many(readerFeedback),
 }));
 
 // --- users ---
@@ -80,6 +87,8 @@ export const usersRelations = relations(users, ({ many }) => ({
   writerProfiles: many(writerProfiles),
   savedQueuePresets: many(savedQueuePresets),
   workspaceCollections: many(workspaceCollections),
+  simsubGroups: many(simsubGroups),
+  portfolioEntries: many(portfolioEntries),
 }));
 
 // --- organization_members ---
@@ -150,6 +159,7 @@ export const manuscriptsRelations = relations(manuscripts, ({ one, many }) => ({
   }),
   versions: many(manuscriptVersions),
   externalSubmissions: many(externalSubmissions),
+  simsubGroups: many(simsubGroups),
 }));
 
 // --- manuscript_versions ---
@@ -230,6 +240,8 @@ export const submissionsRelations = relations(submissions, ({ one, many }) => ({
   pipelineItems: many(pipelineItems),
   correspondence: many(correspondence),
   workspaceItems: many(workspaceItems),
+  simsubGroupSubmissions: many(simsubGroupSubmissions),
+  readerFeedback: many(readerFeedback),
 }));
 
 // --- submission_history ---
@@ -521,6 +533,7 @@ export const externalSubmissionsRelations = relations(
       references: [journalDirectory.id],
     }),
     correspondence: many(correspondence),
+    simsubGroupSubmissions: many(simsubGroupSubmissions),
   }),
 );
 
@@ -713,5 +726,85 @@ export const contestResultsRelations = relations(contestResults, ({ one }) => ({
   disbursement: one(paymentTransactions, {
     fields: [contestResults.disbursementId],
     references: [paymentTransactions.id],
+  }),
+}));
+
+// --- simsub_groups ---
+
+export const simsubGroupsRelations = relations(
+  simsubGroups,
+  ({ one, many }) => ({
+    user: one(users, {
+      fields: [simsubGroups.userId],
+      references: [users.id],
+    }),
+    manuscript: one(manuscripts, {
+      fields: [simsubGroups.manuscriptId],
+      references: [manuscripts.id],
+    }),
+    submissions: many(simsubGroupSubmissions),
+  }),
+);
+
+// --- simsub_group_submissions ---
+
+export const simsubGroupSubmissionsRelations = relations(
+  simsubGroupSubmissions,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [simsubGroupSubmissions.userId],
+      references: [users.id],
+    }),
+    group: one(simsubGroups, {
+      fields: [simsubGroupSubmissions.simsubGroupId],
+      references: [simsubGroups.id],
+    }),
+    submission: one(submissions, {
+      fields: [simsubGroupSubmissions.submissionId],
+      references: [submissions.id],
+    }),
+    externalSubmission: one(externalSubmissions, {
+      fields: [simsubGroupSubmissions.externalSubmissionId],
+      references: [externalSubmissions.id],
+    }),
+  }),
+);
+
+// --- portfolio_entries ---
+
+export const portfolioEntriesRelations = relations(
+  portfolioEntries,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [portfolioEntries.userId],
+      references: [users.id],
+    }),
+    contributorPublication: one(contributorPublications, {
+      fields: [portfolioEntries.contributorPublicationId],
+      references: [contributorPublications.id],
+    }),
+  }),
+);
+
+// --- reader_feedback ---
+
+export const readerFeedbackRelations = relations(readerFeedback, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [readerFeedback.organizationId],
+    references: [organizations.id],
+  }),
+  submission: one(submissions, {
+    fields: [readerFeedback.submissionId],
+    references: [submissions.id],
+  }),
+  reviewer: one(users, {
+    fields: [readerFeedback.reviewerUserId],
+    references: [users.id],
+    relationName: "readerFeedbackReviewer",
+  }),
+  forwarder: one(users, {
+    fields: [readerFeedback.forwardedBy],
+    references: [users.id],
+    relationName: "readerFeedbackForwarder",
   }),
 }));

--- a/packages/db/src/schema/writer-platform.ts
+++ b/packages/db/src/schema/writer-platform.ts
@@ -1,0 +1,207 @@
+import {
+  pgTable,
+  pgPolicy,
+  uuid,
+  varchar,
+  text,
+  boolean,
+  jsonb,
+  timestamp,
+  index,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { portfolioEntryTypeEnum, simsubGroupStatusEnum } from "./enums";
+import { organizations } from "./organizations";
+import { users } from "./users";
+import { manuscripts } from "./manuscripts";
+import { submissions } from "./submissions";
+import { externalSubmissions } from "./writer-workspace";
+import { contributorPublications } from "./business-ops";
+
+// ---------------------------------------------------------------------------
+// simsub_groups — User-scoped simultaneous submission groupings
+// ---------------------------------------------------------------------------
+
+const userOwnerPolicy = pgPolicy("user_owner", {
+  for: "all",
+  using: sql`user_id = current_user_id()`,
+});
+
+export const simsubGroups = pgTable(
+  "simsub_groups",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    name: varchar("name", { length: 255 }).notNull(),
+    manuscriptId: uuid("manuscript_id").references(() => manuscripts.id, {
+      onDelete: "set null",
+    }),
+    status: simsubGroupStatusEnum("status").notNull().default("ACTIVE"),
+    notes: text("notes"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("simsub_groups_user_id_idx").on(table.userId),
+    index("simsub_groups_user_status_idx").on(table.userId, table.status),
+    index("simsub_groups_manuscript_id_idx").on(table.manuscriptId),
+    userOwnerPolicy,
+  ],
+).enableRLS();
+
+// ---------------------------------------------------------------------------
+// simsub_group_submissions — Junction: groups ↔ submissions (native or external)
+// CHECK constraint (migration-only): exactly one of submission_id or external_submission_id
+// Partial unique indexes (migration-only): prevent duplicates per source type
+// ---------------------------------------------------------------------------
+
+export const simsubGroupSubmissions = pgTable(
+  "simsub_group_submissions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    simsubGroupId: uuid("simsub_group_id")
+      .notNull()
+      .references(() => simsubGroups.id, { onDelete: "cascade" }),
+    submissionId: uuid("submission_id").references(() => submissions.id, {
+      onDelete: "cascade",
+    }),
+    externalSubmissionId: uuid("external_submission_id").references(
+      () => externalSubmissions.id,
+      { onDelete: "cascade" },
+    ),
+    addedAt: timestamp("added_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("simsub_group_submissions_group_id_idx").on(table.simsubGroupId),
+    index("simsub_group_submissions_submission_id_idx").on(table.submissionId),
+    index("simsub_group_submissions_external_id_idx").on(
+      table.externalSubmissionId,
+    ),
+    pgPolicy("simsub_group_submissions_user_owner", {
+      for: "all",
+      using: sql`user_id = current_user_id()`,
+    }),
+  ],
+).enableRLS();
+
+// ---------------------------------------------------------------------------
+// portfolio_entries — User-scoped publication portfolio
+// Three types: colophony_verified, federation_verified (future), external
+// ---------------------------------------------------------------------------
+
+export const portfolioEntries = pgTable(
+  "portfolio_entries",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    type: portfolioEntryTypeEnum("type").notNull(),
+    title: varchar("title", { length: 500 }).notNull(),
+    publicationName: varchar("publication_name", { length: 500 }).notNull(),
+    publishedAt: timestamp("published_at", { withTimezone: true }),
+    url: varchar("url", { length: 2048 }),
+    contributorPublicationId: uuid("contributor_publication_id").references(
+      () => contributorPublications.id,
+      { onDelete: "set null" },
+    ),
+    // Forward-declared for federation sync — no code writes to these yet
+    federationSourceInstance: varchar("federation_source_instance", {
+      length: 512,
+    }),
+    federationEntryId: uuid("federation_entry_id"),
+    notes: text("notes"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("portfolio_entries_user_id_idx").on(table.userId),
+    index("portfolio_entries_user_type_idx").on(table.userId, table.type),
+    index("portfolio_entries_contributor_publication_id_idx").on(
+      table.contributorPublicationId,
+    ),
+    pgPolicy("portfolio_entries_user_owner", {
+      for: "all",
+      using: sql`user_id = current_user_id()`,
+    }),
+  ],
+).enableRLS();
+
+// ---------------------------------------------------------------------------
+// reader_feedback — Org-scoped feedback from readers on submissions
+// Opt-in per org (via organizations.settings JSONB)
+// Anonymized when forwarded to writers
+// ---------------------------------------------------------------------------
+
+export const readerFeedback = pgTable(
+  "reader_feedback",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    submissionId: uuid("submission_id")
+      .notNull()
+      .references(() => submissions.id, { onDelete: "cascade" }),
+    reviewerUserId: uuid("reviewer_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    tags: jsonb("tags")
+      .$type<string[]>()
+      .notNull()
+      .default(sql`'[]'::jsonb`),
+    comment: varchar("comment", { length: 280 }),
+    isForwardable: boolean("is_forwardable").notNull().default(false),
+    forwardedAt: timestamp("forwarded_at", { withTimezone: true }),
+    forwardedBy: uuid("forwarded_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("reader_feedback_organization_id_idx").on(table.organizationId),
+    index("reader_feedback_submission_id_idx").on(table.submissionId),
+    index("reader_feedback_reviewer_user_id_idx").on(table.reviewerUserId),
+    index("reader_feedback_org_submission_idx").on(
+      table.organizationId,
+      table.submissionId,
+    ),
+    index("reader_feedback_tags_gin_idx").using(
+      "gin",
+      sql`${table.tags} jsonb_path_ops`,
+    ),
+    pgPolicy("reader_feedback_org_isolation", {
+      for: "all",
+      using: sql`organization_id = current_org_id()`,
+    }),
+    pgPolicy("reader_feedback_submitter_forwarded_read", {
+      for: "select",
+      using: sql`forwarded_at IS NOT NULL AND submission_id IN (
+        SELECT id FROM submissions WHERE submitter_id = current_user_id()
+      )`,
+    }),
+  ],
+).enableRLS();

--- a/packages/types/src/__tests__/portfolio-entry.spec.ts
+++ b/packages/types/src/__tests__/portfolio-entry.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import {
+  portfolioEntryTypeSchema,
+  createPortfolioEntrySchema,
+  updatePortfolioEntrySchema,
+  listPortfolioEntriesSchema,
+} from "../portfolio-entry";
+
+const UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("portfolioEntryTypeSchema", () => {
+  it("accepts valid types", () => {
+    expect(portfolioEntryTypeSchema.parse("colophony_verified")).toBe(
+      "colophony_verified",
+    );
+    expect(portfolioEntryTypeSchema.parse("federation_verified")).toBe(
+      "federation_verified",
+    );
+    expect(portfolioEntryTypeSchema.parse("external")).toBe("external");
+  });
+
+  it("rejects invalid type", () => {
+    expect(() => portfolioEntryTypeSchema.parse("unknown")).toThrow();
+  });
+});
+
+describe("createPortfolioEntrySchema", () => {
+  it("parses valid input", () => {
+    const result = createPortfolioEntrySchema.parse({
+      title: "My Poem",
+      publicationName: "Poetry Magazine",
+    });
+    expect(result.title).toBe("My Poem");
+    expect(result.publicationName).toBe("Poetry Magazine");
+  });
+
+  it("accepts optional url", () => {
+    const result = createPortfolioEntrySchema.parse({
+      title: "My Poem",
+      publicationName: "Poetry Magazine",
+      url: "https://example.com/poem",
+    });
+    expect(result.url).toBe("https://example.com/poem");
+  });
+
+  it("rejects invalid url", () => {
+    expect(() =>
+      createPortfolioEntrySchema.parse({
+        title: "My Poem",
+        publicationName: "Poetry Magazine",
+        url: "not-a-url",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("updatePortfolioEntrySchema", () => {
+  it("accepts partial update", () => {
+    const result = updatePortfolioEntrySchema.parse({
+      id: UUID,
+      title: "New Title",
+    });
+    expect(result.title).toBe("New Title");
+  });
+
+  it("rejects update with no fields", () => {
+    expect(() => updatePortfolioEntrySchema.parse({ id: UUID })).toThrow();
+  });
+});
+
+describe("listPortfolioEntriesSchema", () => {
+  it("applies defaults", () => {
+    const result = listPortfolioEntriesSchema.parse({});
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+  });
+
+  it("accepts type filter", () => {
+    const result = listPortfolioEntriesSchema.parse({ type: "external" });
+    expect(result.type).toBe("external");
+  });
+});

--- a/packages/types/src/__tests__/reader-feedback.spec.ts
+++ b/packages/types/src/__tests__/reader-feedback.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  readerFeedbackSettingsSchema,
+  createReaderFeedbackSchema,
+  forwardReaderFeedbackSchema,
+  listReaderFeedbackSchema,
+} from "../reader-feedback";
+
+const UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("readerFeedbackSettingsSchema", () => {
+  it("applies defaults", () => {
+    const result = readerFeedbackSettingsSchema.parse({});
+    expect(result.enabled).toBe(false);
+    expect(result.availableTags).toEqual([]);
+  });
+
+  it("accepts configured tags", () => {
+    const result = readerFeedbackSettingsSchema.parse({
+      enabled: true,
+      availableTags: ["voice", "imagery", "structure"],
+    });
+    expect(result.enabled).toBe(true);
+    expect(result.availableTags).toHaveLength(3);
+  });
+
+  it("rejects too many tags", () => {
+    const tags = Array.from({ length: 21 }, (_, i) => `tag${i}`);
+    expect(() =>
+      readerFeedbackSettingsSchema.parse({ availableTags: tags }),
+    ).toThrow();
+  });
+});
+
+describe("createReaderFeedbackSchema", () => {
+  it("parses valid input", () => {
+    const result = createReaderFeedbackSchema.parse({
+      submissionId: UUID,
+      tags: ["voice"],
+      comment: "Strong opening",
+    });
+    expect(result.submissionId).toBe(UUID);
+    expect(result.tags).toEqual(["voice"]);
+    expect(result.comment).toBe("Strong opening");
+  });
+
+  it("defaults isForwardable to false", () => {
+    const result = createReaderFeedbackSchema.parse({
+      submissionId: UUID,
+    });
+    expect(result.isForwardable).toBe(false);
+  });
+
+  it("rejects comment over 280 chars", () => {
+    expect(() =>
+      createReaderFeedbackSchema.parse({
+        submissionId: UUID,
+        comment: "x".repeat(281),
+      }),
+    ).toThrow();
+  });
+
+  it("rejects too many tags", () => {
+    expect(() =>
+      createReaderFeedbackSchema.parse({
+        submissionId: UUID,
+        tags: ["a", "b", "c", "d", "e", "f"],
+      }),
+    ).toThrow();
+  });
+});
+
+describe("forwardReaderFeedbackSchema", () => {
+  it("parses valid input", () => {
+    const result = forwardReaderFeedbackSchema.parse({ feedbackId: UUID });
+    expect(result.feedbackId).toBe(UUID);
+  });
+
+  it("rejects non-uuid", () => {
+    expect(() =>
+      forwardReaderFeedbackSchema.parse({ feedbackId: "not-a-uuid" }),
+    ).toThrow();
+  });
+});
+
+describe("listReaderFeedbackSchema", () => {
+  it("parses valid input with defaults", () => {
+    const result = listReaderFeedbackSchema.parse({ submissionId: UUID });
+    expect(result.submissionId).toBe(UUID);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+  });
+});

--- a/packages/types/src/__tests__/simsub-group.spec.ts
+++ b/packages/types/src/__tests__/simsub-group.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import {
+  simsubGroupStatusSchema,
+  createSimsubGroupSchema,
+  updateSimsubGroupSchema,
+  addSimsubGroupSubmissionSchema,
+  removeSimsubGroupSubmissionSchema,
+  listSimsubGroupsSchema,
+} from "../simsub-group";
+
+const UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("simsubGroupStatusSchema", () => {
+  it("accepts valid statuses", () => {
+    expect(simsubGroupStatusSchema.parse("ACTIVE")).toBe("ACTIVE");
+    expect(simsubGroupStatusSchema.parse("RESOLVED")).toBe("RESOLVED");
+    expect(simsubGroupStatusSchema.parse("WITHDRAWN")).toBe("WITHDRAWN");
+  });
+
+  it("rejects invalid status", () => {
+    expect(() => simsubGroupStatusSchema.parse("INVALID")).toThrow();
+  });
+});
+
+describe("createSimsubGroupSchema", () => {
+  it("parses valid input", () => {
+    const result = createSimsubGroupSchema.parse({ name: "My Poem" });
+    expect(result.name).toBe("My Poem");
+  });
+
+  it("trims whitespace", () => {
+    const result = createSimsubGroupSchema.parse({ name: "  My Poem  " });
+    expect(result.name).toBe("My Poem");
+  });
+
+  it("rejects empty name", () => {
+    expect(() => createSimsubGroupSchema.parse({ name: "" })).toThrow();
+  });
+});
+
+describe("updateSimsubGroupSchema", () => {
+  it("accepts partial update with name", () => {
+    const result = updateSimsubGroupSchema.parse({
+      id: UUID,
+      name: "New Name",
+    });
+    expect(result.name).toBe("New Name");
+  });
+
+  it("accepts partial update with status", () => {
+    const result = updateSimsubGroupSchema.parse({
+      id: UUID,
+      status: "RESOLVED",
+    });
+    expect(result.status).toBe("RESOLVED");
+  });
+
+  it("rejects update with no fields", () => {
+    expect(() => updateSimsubGroupSchema.parse({ id: UUID })).toThrow();
+  });
+});
+
+describe("addSimsubGroupSubmissionSchema", () => {
+  it("accepts native submission", () => {
+    const result = addSimsubGroupSubmissionSchema.parse({
+      groupId: UUID,
+      submissionId: UUID,
+    });
+    expect(result.submissionId).toBe(UUID);
+  });
+
+  it("accepts external submission", () => {
+    const result = addSimsubGroupSubmissionSchema.parse({
+      groupId: UUID,
+      externalSubmissionId: UUID,
+    });
+    expect(result.externalSubmissionId).toBe(UUID);
+  });
+
+  it("rejects both submission types", () => {
+    expect(() =>
+      addSimsubGroupSubmissionSchema.parse({
+        groupId: UUID,
+        submissionId: UUID,
+        externalSubmissionId: UUID,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects neither submission type", () => {
+    expect(() =>
+      addSimsubGroupSubmissionSchema.parse({ groupId: UUID }),
+    ).toThrow();
+  });
+});
+
+describe("removeSimsubGroupSubmissionSchema", () => {
+  it("accepts native submission", () => {
+    const result = removeSimsubGroupSubmissionSchema.parse({
+      groupId: UUID,
+      submissionId: UUID,
+    });
+    expect(result.submissionId).toBe(UUID);
+  });
+
+  it("rejects both submission types", () => {
+    expect(() =>
+      removeSimsubGroupSubmissionSchema.parse({
+        groupId: UUID,
+        submissionId: UUID,
+        externalSubmissionId: UUID,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects neither submission type", () => {
+    expect(() =>
+      removeSimsubGroupSubmissionSchema.parse({ groupId: UUID }),
+    ).toThrow();
+  });
+});
+
+describe("listSimsubGroupsSchema", () => {
+  it("applies defaults", () => {
+    const result = listSimsubGroupsSchema.parse({});
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+  });
+
+  it("accepts status filter", () => {
+    const result = listSimsubGroupsSchema.parse({ status: "ACTIVE" });
+    expect(result.status).toBe("ACTIVE");
+  });
+});

--- a/packages/types/src/api-key.ts
+++ b/packages/types/src/api-key.ts
@@ -55,6 +55,12 @@ export const apiKeyScopeSchema = z
     "payment-transactions:write",
     "contests:read",
     "contests:write",
+    "simsub-groups:read",
+    "simsub-groups:write",
+    "portfolio:read",
+    "portfolio:write",
+    "reader-feedback:read",
+    "reader-feedback:write",
   ])
   .describe("Permission scope for the API key");
 

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -309,6 +309,23 @@ export const AuditActions = {
   CONTEST_RESULT_DELETED: "CONTEST_RESULT_DELETED",
   CONTEST_WINNERS_ANNOUNCED: "CONTEST_WINNERS_ANNOUNCED",
   CONTEST_PRIZE_DISBURSED: "CONTEST_PRIZE_DISBURSED",
+
+  // Sim-sub group lifecycle
+  SIMSUB_GROUP_CREATED: "SIMSUB_GROUP_CREATED",
+  SIMSUB_GROUP_UPDATED: "SIMSUB_GROUP_UPDATED",
+  SIMSUB_GROUP_DELETED: "SIMSUB_GROUP_DELETED",
+  SIMSUB_GROUP_SUBMISSION_ADDED: "SIMSUB_GROUP_SUBMISSION_ADDED",
+  SIMSUB_GROUP_SUBMISSION_REMOVED: "SIMSUB_GROUP_SUBMISSION_REMOVED",
+
+  // Portfolio entry lifecycle
+  PORTFOLIO_ENTRY_CREATED: "PORTFOLIO_ENTRY_CREATED",
+  PORTFOLIO_ENTRY_UPDATED: "PORTFOLIO_ENTRY_UPDATED",
+  PORTFOLIO_ENTRY_DELETED: "PORTFOLIO_ENTRY_DELETED",
+
+  // Reader feedback lifecycle
+  READER_FEEDBACK_CREATED: "READER_FEEDBACK_CREATED",
+  READER_FEEDBACK_FORWARDED: "READER_FEEDBACK_FORWARDED",
+  READER_FEEDBACK_DELETED: "READER_FEEDBACK_DELETED",
 } as const;
 
 export type AuditAction = (typeof AuditActions)[keyof typeof AuditActions];
@@ -356,6 +373,9 @@ export const AuditResources = {
   PAYMENT_TRANSACTION: "payment_transaction",
   CONTEST: "contest",
   CONTEST_GROUP: "contest_group",
+  SIMSUB_GROUP: "simsub_group",
+  PORTFOLIO_ENTRY: "portfolio_entry",
+  READER_FEEDBACK: "reader_feedback",
 } as const;
 
 export type AuditResource =
@@ -797,6 +817,32 @@ export interface ContestAuditParams extends BaseAuditParams {
     | typeof AuditActions.CONTEST_PRIZE_DISBURSED;
 }
 
+export interface SimsubGroupAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.SIMSUB_GROUP;
+  action:
+    | typeof AuditActions.SIMSUB_GROUP_CREATED
+    | typeof AuditActions.SIMSUB_GROUP_UPDATED
+    | typeof AuditActions.SIMSUB_GROUP_DELETED
+    | typeof AuditActions.SIMSUB_GROUP_SUBMISSION_ADDED
+    | typeof AuditActions.SIMSUB_GROUP_SUBMISSION_REMOVED;
+}
+
+export interface PortfolioEntryAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.PORTFOLIO_ENTRY;
+  action:
+    | typeof AuditActions.PORTFOLIO_ENTRY_CREATED
+    | typeof AuditActions.PORTFOLIO_ENTRY_UPDATED
+    | typeof AuditActions.PORTFOLIO_ENTRY_DELETED;
+}
+
+export interface ReaderFeedbackAuditParams extends BaseAuditParams {
+  resource: typeof AuditResources.READER_FEEDBACK;
+  action:
+    | typeof AuditActions.READER_FEEDBACK_CREATED
+    | typeof AuditActions.READER_FEEDBACK_FORWARDED
+    | typeof AuditActions.READER_FEEDBACK_DELETED;
+}
+
 /** Union of all resource-specific param types. */
 export type AuditLogParams =
   | UserAuditParams
@@ -839,7 +885,10 @@ export type AuditLogParams =
   | RightsAgreementAuditParams
   | PaymentTransactionAuditParams
   | ContestGroupAuditParams
-  | ContestAuditParams;
+  | ContestAuditParams
+  | SimsubGroupAuditParams
+  | PortfolioEntryAuditParams
+  | ReaderFeedbackAuditParams;
 
 // ---------------------------------------------------------------------------
 // Query/response schemas for audit endpoints

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -44,3 +44,6 @@ export * from "./contributor";
 export * from "./rights-agreement";
 export * from "./payment-transaction";
 export * from "./contest";
+export * from "./simsub-group";
+export * from "./portfolio-entry";
+export * from "./reader-feedback";

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -255,5 +255,14 @@ export const orgSettingsSchema = z.object({
     .optional()
     .describe("Custom writer-facing status display names"),
   roleDisplayNames: roleDisplayNamesSchema,
+  readerFeedbackEnabled: z
+    .boolean()
+    .default(false)
+    .describe("Whether reader feedback is enabled for this org"),
+  readerFeedbackTags: z
+    .array(z.string().max(50))
+    .max(20)
+    .default([])
+    .describe("Available feedback tags readers can select from"),
 });
 export type OrgSettings = z.infer<typeof orgSettingsSchema>;

--- a/packages/types/src/portfolio-entry.ts
+++ b/packages/types/src/portfolio-entry.ts
@@ -1,0 +1,120 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Portfolio Entry — user-scoped publication portfolio
+// ---------------------------------------------------------------------------
+
+export const portfolioEntryTypeSchema = z
+  .enum(["colophony_verified", "federation_verified", "external"])
+  .describe("Source type of the portfolio entry");
+
+export type PortfolioEntryType = z.infer<typeof portfolioEntryTypeSchema>;
+
+// --- Response schema ---
+
+export const portfolioEntrySchema = z.object({
+  id: z.string().uuid().describe("Unique identifier"),
+  userId: z.string().uuid().describe("Owner user ID"),
+  type: portfolioEntryTypeSchema,
+  title: z.string().describe("Published work title"),
+  publicationName: z.string().describe("Journal/magazine name"),
+  publishedAt: z.date().nullable().describe("Publication date"),
+  url: z.string().nullable().describe("Link to published work"),
+  contributorPublicationId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("Linked contributor_publication (colophony_verified only)"),
+  federationSourceInstance: z
+    .string()
+    .nullable()
+    .describe("Federation source instance (future)"),
+  federationEntryId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("Federation entry ID (future)"),
+  notes: z.string().nullable().describe("Private notes"),
+  createdAt: z.date().describe("When the entry was created"),
+  updatedAt: z.date().describe("When the entry was last updated"),
+});
+
+export type PortfolioEntry = z.infer<typeof portfolioEntrySchema>;
+
+// --- Create schema (external entries only — colophony_verified created automatically) ---
+
+export const createPortfolioEntrySchema = z.object({
+  title: z.string().trim().min(1).max(500).describe("Published work title"),
+  publicationName: z
+    .string()
+    .trim()
+    .min(1)
+    .max(500)
+    .describe("Journal/magazine name"),
+  publishedAt: z.coerce.date().optional().describe("Publication date"),
+  url: z.string().url().max(2048).optional().describe("Link to published work"),
+  notes: z.string().max(5000).optional().describe("Private notes"),
+});
+
+export type CreatePortfolioEntryInput = z.infer<
+  typeof createPortfolioEntrySchema
+>;
+
+// --- Update schema ---
+
+export const updatePortfolioEntrySchema = z
+  .object({
+    id: z.string().uuid().describe("Entry ID to update"),
+    title: z.string().trim().min(1).max(500).optional().describe("New title"),
+    publicationName: z
+      .string()
+      .trim()
+      .min(1)
+      .max(500)
+      .optional()
+      .describe("New publication name"),
+    publishedAt: z.coerce
+      .date()
+      .nullable()
+      .optional()
+      .describe("Updated publication date"),
+    url: z
+      .string()
+      .url()
+      .max(2048)
+      .nullable()
+      .optional()
+      .describe("Updated URL"),
+    notes: z.string().max(5000).nullable().optional().describe("Updated notes"),
+  })
+  .refine(
+    (data) =>
+      data.title !== undefined ||
+      data.publicationName !== undefined ||
+      data.publishedAt !== undefined ||
+      data.url !== undefined ||
+      data.notes !== undefined,
+    { message: "At least one field to update is required" },
+  );
+
+export type UpdatePortfolioEntryInput = z.infer<
+  typeof updatePortfolioEntrySchema
+>;
+
+// --- List schema ---
+
+export const listPortfolioEntriesSchema = z.object({
+  type: portfolioEntryTypeSchema.optional().describe("Filter by entry type"),
+  page: z.number().int().min(1).default(1).describe("Page number (1-based)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page (1-100, default 20)"),
+});
+
+export type ListPortfolioEntriesInput = z.infer<
+  typeof listPortfolioEntriesSchema
+>;

--- a/packages/types/src/reader-feedback.ts
+++ b/packages/types/src/reader-feedback.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Reader Feedback — org-scoped feedback from readers on submissions
+// ---------------------------------------------------------------------------
+
+// --- Org settings for reader feedback feature ---
+
+export const readerFeedbackSettingsSchema = z.object({
+  enabled: z
+    .boolean()
+    .default(false)
+    .describe("Whether reader feedback is enabled for this org"),
+  availableTags: z
+    .array(z.string().max(50))
+    .max(20)
+    .default([])
+    .describe("Org-configured feedback tags readers can select from"),
+});
+
+export type ReaderFeedbackSettings = z.infer<
+  typeof readerFeedbackSettingsSchema
+>;
+
+// --- Response schemas ---
+
+export const readerFeedbackSchema = z.object({
+  id: z.string().uuid().describe("Unique identifier"),
+  organizationId: z.string().uuid().describe("Organization ID"),
+  submissionId: z.string().uuid().describe("Submission being reviewed"),
+  reviewerUserId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("Who left the feedback"),
+  tags: z.array(z.string()).describe("Selected feedback tags"),
+  comment: z
+    .string()
+    .nullable()
+    .describe("Short feedback comment (max 280 chars)"),
+  isForwardable: z
+    .boolean()
+    .describe("Whether this can be forwarded to the writer"),
+  forwardedAt: z
+    .date()
+    .nullable()
+    .describe("When the feedback was forwarded (null = not forwarded)"),
+  forwardedBy: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("Editor who forwarded the feedback"),
+  createdAt: z.date().describe("When the feedback was created"),
+  updatedAt: z.date().describe("When the feedback was last updated"),
+});
+
+export type ReaderFeedback = z.infer<typeof readerFeedbackSchema>;
+
+/** Writer-facing response: reviewer identity stripped for anonymity. */
+export const readerFeedbackWriterSchema = z.object({
+  id: z.string().uuid().describe("Feedback ID"),
+  submissionId: z.string().uuid().describe("Submission ID"),
+  tags: z.array(z.string()).describe("Selected feedback tags"),
+  comment: z.string().nullable().describe("Short feedback comment"),
+  forwardedAt: z.date().nullable().describe("When the feedback was forwarded"),
+});
+
+export type ReaderFeedbackWriter = z.infer<typeof readerFeedbackWriterSchema>;
+
+// --- Create schema ---
+
+export const createReaderFeedbackSchema = z.object({
+  submissionId: z.string().uuid().describe("Submission to leave feedback on"),
+  tags: z
+    .array(z.string().max(50))
+    .max(5)
+    .default([])
+    .describe("Selected feedback tags"),
+  comment: z
+    .string()
+    .max(280)
+    .optional()
+    .describe("Short feedback comment (max 280 chars)"),
+  isForwardable: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Whether this can be forwarded to the writer"),
+});
+
+export type CreateReaderFeedbackInput = z.infer<
+  typeof createReaderFeedbackSchema
+>;
+
+// --- Forward schema ---
+
+export const forwardReaderFeedbackSchema = z.object({
+  feedbackId: z.string().uuid().describe("ID of the feedback to forward"),
+});
+
+export type ForwardReaderFeedbackInput = z.infer<
+  typeof forwardReaderFeedbackSchema
+>;
+
+// --- List schema ---
+
+export const listReaderFeedbackSchema = z.object({
+  submissionId: z.string().uuid().describe("Filter by submission ID"),
+  page: z.number().int().min(1).default(1).describe("Page number (1-based)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page (1-100, default 20)"),
+});
+
+export type ListReaderFeedbackInput = z.infer<typeof listReaderFeedbackSchema>;

--- a/packages/types/src/simsub-group.ts
+++ b/packages/types/src/simsub-group.ts
@@ -1,0 +1,148 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Sim-Sub Group — user-scoped simultaneous submission groupings
+// ---------------------------------------------------------------------------
+
+export const simsubGroupStatusSchema = z
+  .enum(["ACTIVE", "RESOLVED", "WITHDRAWN"])
+  .describe("Status of the sim-sub group");
+
+export type SimsubGroupStatus = z.infer<typeof simsubGroupStatusSchema>;
+
+// --- Response schemas ---
+
+export const simsubGroupSchema = z.object({
+  id: z.string().uuid().describe("Unique identifier"),
+  userId: z.string().uuid().describe("Owner user ID"),
+  name: z.string().describe("Human-readable group name"),
+  manuscriptId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("Optional linked manuscript"),
+  status: simsubGroupStatusSchema,
+  notes: z.string().nullable().describe("Private notes"),
+  createdAt: z.date().describe("When the group was created"),
+  updatedAt: z.date().describe("When the group was last updated"),
+});
+
+export type SimsubGroup = z.infer<typeof simsubGroupSchema>;
+
+export const simsubGroupSubmissionSchema = z.object({
+  id: z.string().uuid().describe("Junction row ID"),
+  simsubGroupId: z.string().uuid().describe("Parent group ID"),
+  submissionId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("Native submission ID (XOR with externalSubmissionId)"),
+  externalSubmissionId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe("External submission ID (XOR with submissionId)"),
+  addedAt: z.date().describe("When the submission was added to the group"),
+});
+
+export type SimsubGroupSubmission = z.infer<typeof simsubGroupSubmissionSchema>;
+
+export const simsubGroupDetailSchema = simsubGroupSchema.extend({
+  submissions: z
+    .array(simsubGroupSubmissionSchema)
+    .describe("Submissions in this group"),
+});
+
+export type SimsubGroupDetail = z.infer<typeof simsubGroupDetailSchema>;
+
+// --- Create/Update schemas ---
+
+export const createSimsubGroupSchema = z.object({
+  name: z.string().trim().min(1).max(255).describe("Human-readable group name"),
+  manuscriptId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Optional link to source manuscript"),
+  notes: z.string().max(5000).optional().describe("Private notes"),
+});
+
+export type CreateSimsubGroupInput = z.infer<typeof createSimsubGroupSchema>;
+
+export const updateSimsubGroupSchema = z
+  .object({
+    id: z.string().uuid().describe("Group ID to update"),
+    name: z.string().trim().min(1).max(255).optional().describe("New name"),
+    status: simsubGroupStatusSchema.optional().describe("New status"),
+    notes: z.string().max(5000).nullable().optional().describe("Updated notes"),
+  })
+  .refine(
+    (data) =>
+      data.name !== undefined ||
+      data.status !== undefined ||
+      data.notes !== undefined,
+    { message: "At least one field to update is required" },
+  );
+
+export type UpdateSimsubGroupInput = z.infer<typeof updateSimsubGroupSchema>;
+
+export const addSimsubGroupSubmissionSchema = z
+  .object({
+    groupId: z.string().uuid().describe("Target group ID"),
+    submissionId: z.string().uuid().optional().describe("Native submission ID"),
+    externalSubmissionId: z
+      .string()
+      .uuid()
+      .optional()
+      .describe("External submission ID"),
+  })
+  .refine(
+    (data) =>
+      (data.submissionId != null) !== (data.externalSubmissionId != null),
+    { message: "Exactly one of submissionId or externalSubmissionId required" },
+  );
+
+export type AddSimsubGroupSubmissionInput = z.infer<
+  typeof addSimsubGroupSubmissionSchema
+>;
+
+export const removeSimsubGroupSubmissionSchema = z
+  .object({
+    groupId: z.string().uuid().describe("Target group ID"),
+    submissionId: z.string().uuid().optional().describe("Native submission ID"),
+    externalSubmissionId: z
+      .string()
+      .uuid()
+      .optional()
+      .describe("External submission ID"),
+  })
+  .refine(
+    (data) =>
+      (data.submissionId != null) !== (data.externalSubmissionId != null),
+    { message: "Exactly one of submissionId or externalSubmissionId required" },
+  );
+
+export type RemoveSimsubGroupSubmissionInput = z.infer<
+  typeof removeSimsubGroupSubmissionSchema
+>;
+
+// --- List schema ---
+
+export const listSimsubGroupsSchema = z.object({
+  status: simsubGroupStatusSchema.optional().describe("Filter by group status"),
+  manuscriptId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Filter by linked manuscript"),
+  page: z.number().int().min(1).default(1).describe("Page number (1-based)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe("Items per page (1-100, default 20)"),
+});
+
+export type ListSimsubGroupsInput = z.infer<typeof listSimsubGroupsSchema>;


### PR DESCRIPTION
## Summary

- Track 14 PR 1: schema foundation for 3 writer platform features
- 4 new DB tables: `simsub_groups`, `simsub_group_submissions`, `portfolio_entries`, `reader_feedback`
- 2 new enums, migration 0065 with full RLS + FORCE RLS + GRANTs
- 21 Zod schemas across 3 new type files, 11 audit actions, 3 resources, 6 API key scopes
- Reader feedback org settings added to `orgSettingsSchema`
- RLS infrastructure test updated (4 new tables, 3 user-scoped exceptions)

## Design Decisions

| # | Decision | Choice |
|---|----------|--------|
| D1 | Sim-sub group scoping | User-scoped (cross-org by design) |
| D2 | Sim-sub junction FKs | Two nullable FKs + XOR CHECK constraint |
| D3 | Portfolio entry scoping | User-scoped (like manuscripts) |
| D4 | Reader feedback scoping | Org-scoped + submitter forwarded read (dual RLS) |
| D5 | Reader feedback opt-in | Existing organizations.settings JSONB |
| D6 | Schema file structure | Single writer-platform.ts (follows business-ops.ts pattern) |

## Code Review

- **plan review:** 3 Important findings addressed (reviewer_user_id NOT NULL conflict, org settings validation gap, RLS setting names)
- **branch review:** 1 P1 + 1 P2 finding — both are service-layer concerns deferred to PR 2 (added to backlog)

## Test plan

- [x] `pnpm type-check` — all 13 packages pass
- [x] `pnpm test` (API) — 156 suites, 1712 tests pass
- [x] `pnpm test` (web) — 88 suites, 727 tests pass
- [ ] `pnpm db:migrate` — migration 0065 applies cleanly (CI validates)
- [ ] RLS infrastructure test — 4 new tables verified (CI validates)