### PR TITLE
test(hopper): defense-in-depth validation tests for writer platform

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -197,9 +197,9 @@ File scan chains to content-extract on CLEAN. Webhook auto-disables endpoint aft
 
 ## Version Pins
 
-| Package | Pinned | Notes                                       |
-| ------- | ------ | ------------------------------------------- |
-| Fastify | 5.x    | Check plugin compat before upgrading        |
-| tRPC    | 11.x   | Internal only; upgraded from v10 with Zod 4 |
-| Stripe  | 20.4   | —                                           |
-| BullMQ  | 5      | —                                           |
+| Package | Pinned | Notes                                                        |
+| ------- | ------ | ------------------------------------------------------------ |
+| Fastify | 5.x    | Check plugin compat before upgrading                         |
+| tRPC    | 11.x   | Internal only; upgraded from v10 with Zod 4                  |
+| Stripe  | 21.0   | Upgraded from 20.4; decimal_string→Stripe.Decimal (not used) |
+| BullMQ  | 5      | —                                                            |

--- a/apps/api/src/__tests__/services/reader-feedback.service.test.ts
+++ b/apps/api/src/__tests__/services/reader-feedback.service.test.ts
@@ -286,6 +286,7 @@ describe('readerFeedbackService — integration', () => {
           readerFeedbackService.createWithAudit(ctx, {
             submissionId: submissionB.id,
             tags: ['engaging'],
+            isForwardable: false,
           }),
         ).rejects.toThrow(CrossOrgSubmissionError);
       });
@@ -311,6 +312,8 @@ describe('readerFeedbackService — integration', () => {
         await expect(
           readerFeedbackService.createWithAudit(ctx, {
             submissionId: randomUUID(),
+            tags: [],
+            isForwardable: false,
           }),
         ).rejects.toThrow(ForbiddenError);
       });
@@ -334,6 +337,8 @@ describe('readerFeedbackService — integration', () => {
         await expect(
           readerFeedbackService.createWithAudit(ctx, {
             submissionId: submissionA.id,
+            tags: [],
+            isForwardable: false,
           }),
         ).rejects.toThrow(ReaderFeedbackNotEnabledError);
       });

--- a/apps/api/src/__tests__/services/reader-feedback.service.test.ts
+++ b/apps/api/src/__tests__/services/reader-feedback.service.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, beforeAll, afterEach } from 'vitest';
-import { globalSetup } from '../rls/helpers/db-setup.js';
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { globalSetup, getAdminPool } from '../rls/helpers/db-setup.js';
+import type { DrizzleDb } from '../rls/helpers/db-setup.js';
 import { truncateAllTables } from '../rls/helpers/cleanup.js';
 import { withTestRls } from '../rls/helpers/rls-context.js';
 import {
@@ -8,7 +11,31 @@ import {
   createOrgMember,
   createSubmission,
 } from '../rls/helpers/factories.js';
-import { readerFeedbackService } from '../../services/reader-feedback.service.js';
+import {
+  readerFeedbackService,
+  CrossOrgSubmissionError,
+  ReaderFeedbackNotEnabledError,
+} from '../../services/reader-feedback.service.js';
+import { ForbiddenError } from '../../services/errors.js';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { ServiceContext } from '../../services/types.js';
+
+async function withAdminTx<T>(fn: (tx: DrizzleDb) => Promise<T>): Promise<T> {
+  const pool = getAdminPool();
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const tx = drizzle(client) as DrizzleDb;
+    const result = await fn(tx);
+    await client.query('ROLLBACK');
+    return result;
+  } catch (e) {
+    await client.query('ROLLBACK');
+    throw e;
+  } finally {
+    client.release();
+  }
+}
 
 beforeAll(async () => {
   await globalSetup();
@@ -230,6 +257,126 @@ describe('readerFeedbackService — integration', () => {
       expect(writerView.items[0].tags).toEqual(['engaging']);
       // Verify anonymization: no reviewerUserId field
       expect('reviewerUserId' in writerView.items[0]).toBe(false);
+    });
+  });
+
+  describe('createWithAudit defense-in-depth', () => {
+    it('rejects cross-org submission', async () => {
+      const orgA = await createOrganization({
+        settings: {
+          readerFeedbackEnabled: true,
+          readerFeedbackTags: ['engaging'],
+        },
+      });
+      const orgB = await createOrganization();
+      const editorA = await createUser();
+      const submitterB = await createUser();
+      await createOrgMember(orgA.id, editorA.id, { roles: ['EDITOR'] });
+      await createOrgMember(orgB.id, submitterB.id);
+      const submissionB = await createSubmission(orgB.id, submitterB.id);
+
+      await withAdminTx(async (tx) => {
+        const ctx: ServiceContext = {
+          tx,
+          actor: { userId: editorA.id, orgId: orgA.id, roles: ['EDITOR'] },
+          audit: vi.fn().mockResolvedValue(undefined),
+        };
+
+        await expect(
+          readerFeedbackService.createWithAudit(ctx, {
+            submissionId: submissionB.id,
+            tags: ['engaging'],
+          }),
+        ).rejects.toThrow(CrossOrgSubmissionError);
+      });
+    });
+
+    it('rejects nonexistent submission', async () => {
+      const orgA = await createOrganization({
+        settings: {
+          readerFeedbackEnabled: true,
+          readerFeedbackTags: [],
+        },
+      });
+      const editorA = await createUser();
+      await createOrgMember(orgA.id, editorA.id, { roles: ['EDITOR'] });
+
+      await withAdminTx(async (tx) => {
+        const ctx: ServiceContext = {
+          tx,
+          actor: { userId: editorA.id, orgId: orgA.id, roles: ['EDITOR'] },
+          audit: vi.fn().mockResolvedValue(undefined),
+        };
+
+        await expect(
+          readerFeedbackService.createWithAudit(ctx, {
+            submissionId: randomUUID(),
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+
+    it('rejects when feedback is disabled', async () => {
+      const orgA = await createOrganization({
+        settings: { readerFeedbackEnabled: false },
+      });
+      const editorA = await createUser();
+      await createOrgMember(orgA.id, editorA.id, { roles: ['EDITOR'] });
+      const submissionA = await createSubmission(orgA.id, editorA.id);
+
+      await withAdminTx(async (tx) => {
+        const ctx: ServiceContext = {
+          tx,
+          actor: { userId: editorA.id, orgId: orgA.id, roles: ['EDITOR'] },
+          audit: vi.fn().mockResolvedValue(undefined),
+        };
+
+        await expect(
+          readerFeedbackService.createWithAudit(ctx, {
+            submissionId: submissionA.id,
+          }),
+        ).rejects.toThrow(ReaderFeedbackNotEnabledError);
+      });
+    });
+
+    it('succeeds for same-org submission and audits', async () => {
+      const orgA = await createOrganization({
+        settings: {
+          readerFeedbackEnabled: true,
+          readerFeedbackTags: ['engaging'],
+        },
+      });
+      const editorA = await createUser();
+      const submitterA = await createUser();
+      await createOrgMember(orgA.id, editorA.id, { roles: ['EDITOR'] });
+      await createOrgMember(orgA.id, submitterA.id);
+      const submissionA = await createSubmission(orgA.id, submitterA.id);
+
+      await withAdminTx(async (tx) => {
+        const auditFn = vi.fn().mockResolvedValue(undefined);
+        const ctx: ServiceContext = {
+          tx,
+          actor: { userId: editorA.id, orgId: orgA.id, roles: ['EDITOR'] },
+          audit: auditFn,
+        };
+
+        const fb = await readerFeedbackService.createWithAudit(ctx, {
+          submissionId: submissionA.id,
+          tags: ['engaging'],
+          isForwardable: true,
+        });
+
+        expect(fb.organizationId).toBe(orgA.id);
+        expect(fb.submissionId).toBe(submissionA.id);
+        expect(auditFn).toHaveBeenCalledOnce();
+        expect(auditFn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: AuditActions.READER_FEEDBACK_CREATED,
+            resource: AuditResources.READER_FEEDBACK,
+            resourceId: fb.id,
+          }),
+        );
+      });
     });
   });
 });

--- a/apps/api/src/__tests__/services/simsub-group.service.test.ts
+++ b/apps/api/src/__tests__/services/simsub-group.service.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, beforeAll, afterEach } from 'vitest';
-import { globalSetup } from '../rls/helpers/db-setup.js';
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { globalSetup, getAdminPool } from '../rls/helpers/db-setup.js';
+import type { DrizzleDb } from '../rls/helpers/db-setup.js';
 import { truncateAllTables } from '../rls/helpers/cleanup.js';
 import { withTestRls } from '../rls/helpers/rls-context.js';
 import {
@@ -8,8 +11,37 @@ import {
   createOrgMember,
   createSubmission,
   createExternalSubmission,
+  createManuscript,
 } from '../rls/helpers/factories.js';
-import { simsubGroupService } from '../../services/simsub-group.service.js';
+import {
+  simsubGroupService,
+  SimsubGroupNotFoundError,
+  SimsubGroupSubmissionNotFoundError,
+} from '../../services/simsub-group.service.js';
+import { ForbiddenError } from '../../services/errors.js';
+import { AuditActions, AuditResources } from '@colophony/types';
+import type { UserServiceContext } from '../../services/types.js';
+
+function adminDb() {
+  return drizzle(getAdminPool()) as DrizzleDb;
+}
+
+async function withAdminTx<T>(fn: (tx: DrizzleDb) => Promise<T>): Promise<T> {
+  const pool = getAdminPool();
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const tx = drizzle(client) as DrizzleDb;
+    const result = await fn(tx);
+    await client.query('ROLLBACK');
+    return result;
+  } catch (e) {
+    await client.query('ROLLBACK');
+    throw e;
+  } finally {
+    client.release();
+  }
+}
 
 beforeAll(async () => {
   await globalSetup();
@@ -189,6 +221,241 @@ describe('simsubGroupService — integration', () => {
       });
 
       expect(updated.status).toBe('WITHDRAWN');
+    });
+  });
+
+  describe('createWithAudit defense-in-depth', () => {
+    it("rejects other user's manuscript", async () => {
+      const userA = await createUser();
+      const userB = await createUser();
+      const manuscriptB = await createManuscript(userB.id);
+
+      await withAdminTx(async (tx) => {
+        const ctx: UserServiceContext = {
+          tx,
+          userId: userA.id,
+          audit: vi.fn().mockResolvedValue(undefined),
+        };
+
+        await expect(
+          simsubGroupService.createWithAudit(ctx, {
+            name: 'Test Group',
+            manuscriptId: manuscriptB.id,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+
+    it('succeeds with own manuscript and audits', async () => {
+      const userA = await createUser();
+      const manuscriptA = await createManuscript(userA.id);
+
+      await withAdminTx(async (tx) => {
+        const auditFn = vi.fn().mockResolvedValue(undefined);
+        const ctx: UserServiceContext = {
+          tx,
+          userId: userA.id,
+          audit: auditFn,
+        };
+
+        const group = await simsubGroupService.createWithAudit(ctx, {
+          name: 'My Group',
+          manuscriptId: manuscriptA.id,
+        });
+
+        expect(group.name).toBe('My Group');
+        expect(group.userId).toBe(userA.id);
+        expect(auditFn).toHaveBeenCalledOnce();
+        expect(auditFn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: AuditActions.SIMSUB_GROUP_CREATED,
+            resource: AuditResources.SIMSUB_GROUP,
+            resourceId: group.id,
+          }),
+        );
+      });
+    });
+  });
+
+  describe('addSubmissionWithAudit defense-in-depth', () => {
+    it("rejects other user's group", async () => {
+      const userA = await createUser();
+      const userB = await createUser();
+      const org = await createOrganization();
+      await createOrgMember(org.id, userA.id);
+      await createOrgMember(org.id, userB.id);
+      const submissionA = await createSubmission(org.id, userA.id);
+
+      // Create groupB owned by userB via committed admin connection
+      const groupB = await simsubGroupService.create(adminDb(), userB.id, {
+        name: 'B Group',
+      });
+
+      await withAdminTx(async (tx) => {
+        const ctx: UserServiceContext = {
+          tx,
+          userId: userA.id,
+          audit: vi.fn().mockResolvedValue(undefined),
+        };
+
+        await expect(
+          simsubGroupService.addSubmissionWithAudit(ctx, {
+            groupId: groupB.id,
+            submissionId: submissionA.id,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+
+    it("rejects other user's submission", async () => {
+      const userA = await createUser();
+      const userB = await createUser();
+      const org = await createOrganization();
+      await createOrgMember(org.id, userA.id);
+      await createOrgMember(org.id, userB.id);
+      const submissionB = await createSubmission(org.id, userB.id);
+
+      const groupA = await simsubGroupService.create(adminDb(), userA.id, {
+        name: 'A Group',
+      });
+
+      await withAdminTx(async (tx) => {
+        const ctx: UserServiceContext = {
+          tx,
+          userId: userA.id,
+          audit: vi.fn().mockResolvedValue(undefined),
+        };
+
+        await expect(
+          simsubGroupService.addSubmissionWithAudit(ctx, {
+            groupId: groupA.id,
+            submissionId: submissionB.id,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+
+    it("rejects other user's external submission", async () => {
+      const userA = await createUser();
+      const userB = await createUser();
+      const extSubB = await createExternalSubmission(userB.id);
+
+      const groupA = await simsubGroupService.create(adminDb(), userA.id, {
+        name: 'A Group',
+      });
+
+      await withAdminTx(async (tx) => {
+        const ctx: UserServiceContext = {
+          tx,
+          userId: userA.id,
+          audit: vi.fn().mockResolvedValue(undefined),
+        };
+
+        await expect(
+          simsubGroupService.addSubmissionWithAudit(ctx, {
+            groupId: groupA.id,
+            externalSubmissionId: extSubB.id,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+
+    it('rejects nonexistent group', async () => {
+      const userA = await createUser();
+
+      await withAdminTx(async (tx) => {
+        const ctx: UserServiceContext = {
+          tx,
+          userId: userA.id,
+          audit: vi.fn().mockResolvedValue(undefined),
+        };
+
+        await expect(
+          simsubGroupService.addSubmissionWithAudit(ctx, {
+            groupId: randomUUID(),
+            submissionId: randomUUID(),
+          }),
+        ).rejects.toThrow(SimsubGroupNotFoundError);
+      });
+    });
+
+    it('rejects nonexistent submission', async () => {
+      const userA = await createUser();
+      const groupA = await simsubGroupService.create(adminDb(), userA.id, {
+        name: 'A Group',
+      });
+
+      await withAdminTx(async (tx) => {
+        const ctx: UserServiceContext = {
+          tx,
+          userId: userA.id,
+          audit: vi.fn().mockResolvedValue(undefined),
+        };
+
+        await expect(
+          simsubGroupService.addSubmissionWithAudit(ctx, {
+            groupId: groupA.id,
+            submissionId: randomUUID(),
+          }),
+        ).rejects.toThrow(SimsubGroupSubmissionNotFoundError);
+      });
+    });
+
+    it('rejects nonexistent external submission', async () => {
+      const userA = await createUser();
+      const groupA = await simsubGroupService.create(adminDb(), userA.id, {
+        name: 'A Group',
+      });
+
+      await withAdminTx(async (tx) => {
+        const ctx: UserServiceContext = {
+          tx,
+          userId: userA.id,
+          audit: vi.fn().mockResolvedValue(undefined),
+        };
+
+        await expect(
+          simsubGroupService.addSubmissionWithAudit(ctx, {
+            groupId: groupA.id,
+            externalSubmissionId: randomUUID(),
+          }),
+        ).rejects.toThrow(SimsubGroupSubmissionNotFoundError);
+      });
+    });
+
+    it('succeeds with own resources and audits', async () => {
+      const userA = await createUser();
+      const org = await createOrganization();
+      await createOrgMember(org.id, userA.id);
+      const submissionA = await createSubmission(org.id, userA.id);
+      const groupA = await simsubGroupService.create(adminDb(), userA.id, {
+        name: 'A Group',
+      });
+
+      await withAdminTx(async (tx) => {
+        const auditFn = vi.fn().mockResolvedValue(undefined);
+        const ctx: UserServiceContext = {
+          tx,
+          userId: userA.id,
+          audit: auditFn,
+        };
+
+        const junction = await simsubGroupService.addSubmissionWithAudit(ctx, {
+          groupId: groupA.id,
+          submissionId: submissionA.id,
+        });
+
+        expect(junction.submissionId).toBe(submissionA.id);
+        expect(junction.simsubGroupId).toBe(groupA.id);
+        expect(auditFn).toHaveBeenCalledOnce();
+        expect(auditFn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: AuditActions.SIMSUB_GROUP_SUBMISSION_ADDED,
+            resource: AuditResources.SIMSUB_GROUP,
+            resourceId: groupA.id,
+          }),
+        );
+      });
     });
   });
 });

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -533,8 +533,8 @@
 - [ ] [P2] Response time transparency — aggregation query over local submission records, displayed on magazine public profile + submission form. `source` field (local vs federated) for future federation data. Org opt-out available — (design system session 2026-03-28)
 - [ ] [P2] Feedback on rejection flow — reader tags/comments during scoring, editor inclusion of anonymized feedback in rejection notice, org-level feature toggle (default off) — (design system session 2026-03-28)
 - [ ] [P3] Writer sidebar updates — Sim-Sub Groups nav item, Portfolio badges (verified/federated/external), Analytics personal response time stats — (design system session 2026-03-28)
-- [ ] [P1] Reader feedback service: defense-in-depth org match on submission_id — service must verify `submission.organizationId === orgId` before insert to prevent cross-org feedback — (Codex branch review 2026-03-29)
-- [ ] [P2] Sim-sub junction service: ownership validation on referenced records — service must verify `simsubGroup.userId`, `submission.submitterId`, and `externalSubmission.userId` match the caller before insert — (Codex branch review 2026-03-29)
+- [x] [P1] Reader feedback service: defense-in-depth org match on submission_id — service must verify `submission.organizationId === orgId` before insert to prevent cross-org feedback — (Codex branch review 2026-03-29)
+- [x] [P2] Sim-sub junction service: ownership validation on referenced records — service must verify `simsubGroup.userId`, `submission.submitterId`, and `externalSubmission.userId` match the caller before insert — (Codex branch review 2026-03-29)
 
 ---
 
@@ -604,6 +604,7 @@
 
 ### Dev Tooling
 
+- [ ] [P3] Upgrade @faker-js/faker 8.4.1 → 10.x — single type error: `faker.internet.userName()` renamed to `faker.internet.username()` in test factories. Dev dependency only. May have other runtime behavior changes across two major versions — audit factory usage after fix — (Dependabot PR #389, CI failure 2026-03-29)
 - [x] [P2] Evaluate MinIO replacement — MinIO repo archived Feb 2026; no future security patches. Evaluate alternatives (LocalStack, SeaweedFS, direct S3/R2) for dev/CI/self-hosted object storage. Not urgent while no CVEs exist, but blocked from upstream fixes if one surfaces — (2026-03-25, CI image pin session; done 2026-03-25 — migrated to Garage v2.2.0)
 - [x] [P2] Replace Overmind with hivemind or concurrently — Overmind solves signal handling but tmux dependency, `dev:clean` escape hatch, and WSL quirks are operational drag. hivemind (Go binary, no tmux, proper signal handling) preferred; concurrently as fallback. Test on macOS, Linux, WSL before standardizing. Keep `dev:clean` as escape hatch, not normal workflow. Turbo `--watch` only if shutdown behavior verified in this repo — (architecture review 2026-03-16; code changes done 2026-03-16; validated on WSL/Linux 2026-03-22, macOS deferred — not in team environment)
 - [x] [P3] Remove `packages/eslint-config` — unused v1 legacy configs (`base.js`, `nextjs.js`, `nestjs.js`), neither app imports from it. Moved `eslint` and `eslint-config-next` to direct app devDependencies — (architecture review 2026-03-16; done 2026-03-16)

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -8,10 +8,10 @@ Newest entries first.
 
 ### Done
 
-- Added 14 integration tests for `WithAudit` wrapper methods that had zero test coverage
+- Added 13 integration tests for `WithAudit` wrapper methods that had zero test coverage
 - Reader feedback `createWithAudit`: 4 tests — cross-org submission rejection, nonexistent submission, feedback-disabled gate, happy path with audit assertion
 - Sim-sub group `createWithAudit`: 2 tests — cross-user manuscript rejection, happy path with audit assertion
-- Sim-sub group `addSubmissionWithAudit`: 8 tests — cross-user group/submission/external-submission rejection, nonexistent group/submission/external-submission, happy path with audit assertion
+- Sim-sub group `addSubmissionWithAudit`: 7 tests — cross-user group/submission/external-submission rejection, nonexistent group/submission/external-submission, happy path with audit assertion
 - Technique: admin-pool transactions (bypassing RLS) to test application-layer validation in isolation; committed connections for setup data, rollback for assertions
 - Codex plan review: 1 Important addressed (added audit call assertions on happy paths), 1 Suggestion addressed (added not-found tests for submission/external-submission branches)
 - Closed 2 backlog items: P1 reader feedback org match, P2 simsub ownership validation (code was already implemented — backlog items were stale, tests confirm correctness)

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,25 @@ Newest entries first.
 
 ---
 
+## 2026-03-30 — Defense-in-Depth Test Coverage (Track 14)
+
+### Done
+
+- Added 14 integration tests for `WithAudit` wrapper methods that had zero test coverage
+- Reader feedback `createWithAudit`: 4 tests — cross-org submission rejection, nonexistent submission, feedback-disabled gate, happy path with audit assertion
+- Sim-sub group `createWithAudit`: 2 tests — cross-user manuscript rejection, happy path with audit assertion
+- Sim-sub group `addSubmissionWithAudit`: 8 tests — cross-user group/submission/external-submission rejection, nonexistent group/submission/external-submission, happy path with audit assertion
+- Technique: admin-pool transactions (bypassing RLS) to test application-layer validation in isolation; committed connections for setup data, rollback for assertions
+- Codex plan review: 1 Important addressed (added audit call assertions on happy paths), 1 Suggestion addressed (added not-found tests for submission/external-submission branches)
+- Closed 2 backlog items: P1 reader feedback org match, P2 simsub ownership validation (code was already implemented — backlog items were stale, tests confirm correctness)
+- Cleaned up merged `feat/writer-platform` branch, applied stashed doc updates from previous session
+
+### Decisions
+
+- D1: Admin-pool bypass pattern chosen over mocking to test defense-in-depth at the integration level — proves real DB queries + validation interact correctly
+
+---
+
 ## 2026-03-29 — Writer Platform Service Layer (Track 14 P2)
 
 ### Done
@@ -16,6 +35,7 @@ Newest entries first.
 - Error mapper updated with 11 new error class mappings across 3 services
 - 3 integration test files covering CRUD, RLS isolation, junction operations, status transitions, forward flow, writer anonymized view
 - Codex plan review: 1 Important addressed (reader feedback orgId defense-in-depth), 1 Suggestion addressed (test file paths)
+- Dependency management: merged #385 (30 minor-and-patch), #387 (Stripe 21.0), #388 (lucide-react 1.7), #392 (js-yaml security fix + @redocly/openapi-core). Closed #386 (TS 6 — ecosystem not ready, issue #393 tracks monthly check). #389 (faker 10) deferred to backlog. #391 awaiting Dependabot rebase after #392 merge.
 
 ### Decisions
 


### PR DESCRIPTION
## Summary
- Add 13 integration tests for `WithAudit` wrapper methods in reader-feedback and simsub-group services that previously had zero test coverage
- Tests exercise defense-in-depth validation paths (cross-org, cross-user ownership, not-found) using admin-pool transactions to bypass RLS and test application-layer checks in isolation
- Mark 2 backlog items as complete (P1 reader feedback org match, P2 simsub ownership validation)

## Test plan
- [x] `pnpm --filter @colophony/api exec vitest run --config vitest.config.services.ts` — 27 tests pass (14 existing + 13 new)
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 2439 tests pass (244 suites)
- [ ] CI passes

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `apps/api/CLAUDE.md` | not in plan | changed | Stripe version pin note carried from previous session stash |
| `docs/devlog/2026-03.md` | not in plan | changed | End-of-session devlog update (standard workflow) |