### PR TITLE
feat(hopper): custom template array support for reader feedback

### DIFF
--- a/apps/api/src/services/email-template.service.spec.ts
+++ b/apps/api/src/services/email-template.service.spec.ts
@@ -32,8 +32,10 @@ import {
   emailTemplateService,
   EmailTemplateNotFoundError,
   InvalidMergeFieldError,
+  InvalidTemplateSyntaxError,
   sanitizeTemplateHtml,
   validateMergeFields,
+  validateSubjectMergeFields,
   interpolateMergeFields,
   interpolateMergeFieldsBody,
   interpolateBlockFields,
@@ -147,6 +149,44 @@ describe('validateMergeFields', () => {
     expect(() =>
       validateMergeFields('{{readerFeedback}}', 'submission-received'),
     ).toThrow(InvalidMergeFieldError);
+  });
+
+  it('rejects unclosed {{#each}} blocks', () => {
+    expect(() =>
+      validateMergeFields(
+        '{{#each readerFeedback}}<p>{{this.comment}}</p>',
+        'submission-rejected',
+      ),
+    ).toThrow(InvalidTemplateSyntaxError);
+  });
+
+  it('rejects mismatched {{#each}} and {{/each}} counts', () => {
+    expect(() =>
+      validateMergeFields(
+        '{{#each readerFeedback}}{{#each readerFeedback}}{{/each}}',
+        'submission-rejected',
+      ),
+    ).toThrow(InvalidTemplateSyntaxError);
+  });
+});
+
+describe('validateSubjectMergeFields', () => {
+  it('allows scalar merge fields in subject', () => {
+    expect(() =>
+      validateSubjectMergeFields(
+        '{{submissionTitle}} — {{orgName}}',
+        'submission-rejected',
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects {{#each}} blocks in subject', () => {
+    expect(() =>
+      validateSubjectMergeFields(
+        '{{#each readerFeedback}}{{this.comment}}{{/each}}',
+        'submission-rejected',
+      ),
+    ).toThrow(InvalidTemplateSyntaxError);
   });
 });
 

--- a/apps/api/src/services/email-template.service.spec.ts
+++ b/apps/api/src/services/email-template.service.spec.ts
@@ -35,6 +35,9 @@ import {
   sanitizeTemplateHtml,
   validateMergeFields,
   interpolateMergeFields,
+  interpolateMergeFieldsBody,
+  interpolateBlockFields,
+  renderDefaultArrayBlock,
 } from './email-template.service.js';
 
 // ---------------------------------------------------------------------------
@@ -115,6 +118,36 @@ describe('validateMergeFields', () => {
       validateMergeFields('<p>{{badField}}</p>', 'submission-accepted'),
     ).toThrow(InvalidMergeFieldError);
   });
+
+  it('allows {{readerFeedback}} for submission-rejected', () => {
+    expect(() =>
+      validateMergeFields('{{readerFeedback}}', 'submission-rejected'),
+    ).not.toThrow();
+  });
+
+  it('allows {{#each readerFeedback}} block for submission-rejected', () => {
+    expect(() =>
+      validateMergeFields(
+        '{{#each readerFeedback}}{{this.comment}}{{/each}}',
+        'submission-rejected',
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects {{#each}} with invalid field name', () => {
+    expect(() =>
+      validateMergeFields(
+        '{{#each invalidField}}{{this.x}}{{/each}}',
+        'submission-rejected',
+      ),
+    ).toThrow(InvalidMergeFieldError);
+  });
+
+  it('rejects {{readerFeedback}} for templates that do not allow it', () => {
+    expect(() =>
+      validateMergeFields('{{readerFeedback}}', 'submission-received'),
+    ).toThrow(InvalidMergeFieldError);
+  });
 });
 
 describe('interpolateMergeFields', () => {
@@ -132,6 +165,139 @@ describe('interpolateMergeFields', () => {
   it('replaces missing fields with empty string', () => {
     const result = interpolateMergeFields('Hello {{name}}', {});
     expect(result).toBe('Hello ');
+  });
+
+  it('replaces array fields with empty string (scalar-only)', () => {
+    const result = interpolateMergeFields('Feedback: {{readerFeedback}}', {
+      readerFeedback: [{ tags: ['good'], comment: 'Nice' }],
+    });
+    expect(result).toBe('Feedback: ');
+  });
+});
+
+describe('interpolateBlockFields', () => {
+  const feedback = [
+    { tags: ['compelling voice', 'strong imagery'], comment: 'Great prose.' },
+    { tags: ['needs revision'], comment: null },
+  ];
+
+  it('expands {{#each}} blocks with item data', () => {
+    const result = interpolateBlockFields(
+      '{{#each items}}<li>{{this.tags}} - {{this.comment}}</li>{{/each}}',
+      { items: feedback },
+    );
+    expect(result).toContain('compelling voice, strong imagery - Great prose.');
+    expect(result).toContain('needs revision - ');
+  });
+
+  it('renders nothing for empty array', () => {
+    const result = interpolateBlockFields('{{#each items}}X{{/each}}', {
+      items: [],
+    });
+    expect(result).toBe('');
+  });
+
+  it('renders nothing for missing field', () => {
+    const result = interpolateBlockFields('{{#each items}}X{{/each}}', {});
+    expect(result).toBe('');
+  });
+
+  it('auto-joins array-of-primitives with commas', () => {
+    const result = interpolateBlockFields(
+      '{{#each items}}[{{this.tags}}]{{/each}}',
+      { items: [{ tags: ['a', 'b', 'c'] }] },
+    );
+    expect(result).toBe('[a, b, c]');
+  });
+
+  it('escapes HTML in {{this.comment}} to prevent XSS', () => {
+    const result = interpolateBlockFields(
+      '{{#each items}}{{this.comment}}{{/each}}',
+      { items: [{ comment: '<script>alert(1)</script>' }] },
+    );
+    expect(result).not.toContain('<script>');
+    expect(result).toContain('&lt;script&gt;');
+  });
+
+  it('escapes HTML in {{this.tags}} to prevent XSS', () => {
+    const result = interpolateBlockFields(
+      '{{#each items}}{{this.tags}}{{/each}}',
+      { items: [{ tags: ['<img onerror=alert(1)>'] }] },
+    );
+    expect(result).not.toContain('<img');
+    expect(result).toContain('&lt;img');
+  });
+});
+
+describe('renderDefaultArrayBlock', () => {
+  it('renders reader feedback with tags and comments', () => {
+    const result = renderDefaultArrayBlock(
+      [
+        { tags: ['voice', 'imagery'], comment: 'Nice work.' },
+        { tags: ['pacing'], comment: null },
+      ],
+      'readerFeedback',
+    );
+    expect(result).toContain('voice, imagery');
+    expect(result).toContain('Nice work.');
+    expect(result).toContain('pacing');
+    expect(result).toContain('border-left');
+  });
+
+  it('escapes HTML in feedback values', () => {
+    const result = renderDefaultArrayBlock(
+      [{ tags: ['<b>bold</b>'], comment: '<script>xss</script>' }],
+      'readerFeedback',
+    );
+    expect(result).not.toContain('<script>');
+    expect(result).not.toContain('<b>bold</b>');
+    expect(result).toContain('&lt;b&gt;');
+  });
+});
+
+describe('interpolateMergeFieldsBody', () => {
+  const feedback = [{ tags: ['voice'], comment: 'Great work.' }];
+
+  it('renders {{readerFeedback}} scalar tag as default block', () => {
+    const result = interpolateMergeFieldsBody(
+      '<p>Feedback:</p>{{readerFeedback}}',
+      { readerFeedback: feedback },
+    );
+    expect(result).toContain('voice');
+    expect(result).toContain('Great work.');
+    expect(result).toContain('border-left');
+  });
+
+  it('renders {{#each}} blocks with custom layout', () => {
+    const result = interpolateMergeFieldsBody(
+      '{{#each readerFeedback}}<div>{{this.comment}}</div>{{/each}}',
+      { readerFeedback: feedback },
+    );
+    expect(result).toContain('<div>Great work.</div>');
+  });
+
+  it('renders empty string for empty array', () => {
+    const result = interpolateMergeFieldsBody('Feedback: {{readerFeedback}}', {
+      readerFeedback: [],
+    });
+    expect(result).toBe('Feedback: ');
+  });
+
+  it('handles mixed scalar and block fields', () => {
+    const result = interpolateMergeFieldsBody(
+      'Hi {{name}}, {{#each items}}<li>{{this.comment}}</li>{{/each}}',
+      { name: 'Alice', items: [{ comment: 'Nice' }] },
+    );
+    expect(result).toContain('Hi Alice,');
+    expect(result).toContain('<li>Nice</li>');
+  });
+
+  it('does not break existing scalar interpolation', () => {
+    const result = interpolateMergeFieldsBody(
+      'Hello {{name}}, welcome to {{org}}',
+      { name: 'Alice', org: 'Acme' },
+    );
+    expect(result).toBe('Hello Alice, welcome to Acme');
   });
 });
 

--- a/apps/api/src/services/email-template.service.ts
+++ b/apps/api/src/services/email-template.service.ts
@@ -8,6 +8,7 @@ import {
   type UpsertEmailTemplateInput,
 } from '@colophony/types';
 import type { ServiceContext } from './types.js';
+import { escapeHtml } from '../templates/email/escape-html.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -48,11 +49,25 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     'h1',
     'h2',
     'h3',
+    'div',
   ],
   allowedAttributes: {
     a: ['href', 'target', 'rel'],
+    div: ['style'],
+    p: ['style'],
   },
   allowedSchemes: ['http', 'https', 'mailto'],
+  allowedStyles: {
+    div: {
+      'margin-bottom': [/.*/],
+      'padding-left': [/.*/],
+      'border-left': [/.*/],
+    },
+    p: {
+      color: [/.*/],
+      'font-size': [/.*/],
+    },
+  },
 };
 
 /** Sanitize HTML to the same allowlist as Tiptap content in templates.ts. */
@@ -63,18 +78,34 @@ export function sanitizeTemplateHtml(html: string): string {
 const MERGE_FIELD_RE = /\{\{(\w+)\}\}/g;
 
 /**
- * Validate that all `{{field}}` placeholders in `text` are allowed for the
- * given template. Throws {@link InvalidMergeFieldError} on the first invalid
- * field.
+ * Validate that all `{{field}}` placeholders and `{{#each field}}` blocks in
+ * `text` are allowed for the given template. Throws
+ * {@link InvalidMergeFieldError} on the first invalid field.
+ *
+ * `{{this.prop}}` inside blocks is not validated against the top-level list
+ * (the dot prevents matching `\w+`).
  */
 export function validateMergeFields(
   text: string,
   templateName: EmailTemplateName,
 ): void {
   const allowed = TEMPLATE_MERGE_FIELDS[templateName];
+
+  // Strip {{#each field}}...{{/each}} blocks, validating the block field name
+  const withoutBlocks = text.replace(
+    /\{\{#each\s+(\w+)\}\}[\s\S]*?\{\{\/each\}\}/g,
+    (_, field: string) => {
+      if (!allowed.includes(field)) {
+        throw new InvalidMergeFieldError(field, templateName);
+      }
+      return '';
+    },
+  );
+
+  // Validate remaining scalar {{field}} placeholders
   const re = /\{\{(\w+)\}\}/g;
   let match: RegExpExecArray | null;
-  while ((match = re.exec(text)) !== null) {
+  while ((match = re.exec(withoutBlocks)) !== null) {
     if (!allowed.includes(match[1])) {
       throw new InvalidMergeFieldError(match[1], templateName);
     }
@@ -82,8 +113,9 @@ export function validateMergeFields(
 }
 
 /**
- * Replace `{{field}}` placeholders with values from `data`. Missing fields
- * are replaced with an empty string.
+ * Replace `{{field}}` placeholders with scalar values from `data`. Arrays are
+ * replaced with an empty string (use {@link interpolateMergeFieldsBody} for
+ * HTML body content that supports arrays).
  */
 export function interpolateMergeFields(
   template: string,
@@ -91,7 +123,95 @@ export function interpolateMergeFields(
 ): string {
   return template.replace(MERGE_FIELD_RE, (_, field: string) => {
     const value = data[field];
-    return value != null ? String(value) : '';
+    if (value == null || Array.isArray(value)) return '';
+    return String(value);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Block interpolation — {{#each field}}...{{/each}} for array data
+// ---------------------------------------------------------------------------
+
+const BLOCK_RE = /\{\{#each\s+(\w+)\}\}([\s\S]*?)\{\{\/each\}\}/g;
+const INNER_FIELD_RE = /\{\{this\.(\w+)\}\}/g;
+
+/**
+ * Process `{{#each field}}...{{/each}}` blocks. Each array item's inner
+ * `{{this.prop}}` references are replaced with HTML-escaped values.
+ * Arrays-of-primitives (e.g. `tags: string[]`) auto-join with `, `.
+ */
+export function interpolateBlockFields(
+  template: string,
+  data: Record<string, unknown>,
+): string {
+  return template.replace(BLOCK_RE, (_, fieldName: string, inner: string) => {
+    const value = data[fieldName];
+    if (!Array.isArray(value) || value.length === 0) return '';
+
+    return (value as Array<Record<string, unknown>>)
+      .map((item) =>
+        inner.replace(INNER_FIELD_RE, (__, prop: string) => {
+          const v = item[prop];
+          if (Array.isArray(v))
+            return v.map((s) => escapeHtml(String(s))).join(', ');
+          return v != null ? escapeHtml(String(v)) : '';
+        }),
+      )
+      .join('');
+  });
+}
+
+/**
+ * Render a default HTML block for an array merge field used as a scalar tag
+ * (e.g. `{{readerFeedback}}`). Matches the built-in template visual style.
+ */
+export function renderDefaultArrayBlock(
+  items: Array<Record<string, unknown>>,
+  fieldName: string,
+): string {
+  if (fieldName === 'readerFeedback') {
+    return items
+      .map((item) => {
+        const tags = Array.isArray(item.tags)
+          ? (item.tags as string[]).map(escapeHtml).join(', ')
+          : '';
+        const comment = item.comment ? escapeHtml(String(item.comment)) : '';
+        const tagLine = tags
+          ? `<p style="color:#6b7280;font-size:13px">${tags}</p>`
+          : '';
+        const commentLine = comment ? `<p>${comment}</p>` : '';
+        return `<div style="margin-bottom:12px;padding-left:12px;border-left:3px solid #e5e7eb">${tagLine}${commentLine}</div>`;
+      })
+      .join('');
+  }
+  // Generic fallback for future array fields
+  return items
+    .map((item) => `<li>${escapeHtml(JSON.stringify(item))}</li>`)
+    .join('');
+}
+
+/**
+ * Full merge field interpolation for HTML body content. Supports both
+ * `{{#each field}}...{{/each}}` blocks and `{{field}}` scalar/array shorthand.
+ */
+export function interpolateMergeFieldsBody(
+  template: string,
+  data: Record<string, unknown>,
+): string {
+  // First pass: expand {{#each}}...{{/each}} blocks
+  const withBlocks = interpolateBlockFields(template, data);
+
+  // Second pass: replace scalar {{field}} placeholders
+  return withBlocks.replace(MERGE_FIELD_RE, (_, field: string) => {
+    const value = data[field];
+    if (value == null) return '';
+    if (Array.isArray(value)) {
+      return renderDefaultArrayBlock(
+        value as Array<Record<string, unknown>>,
+        field,
+      );
+    }
+    return String(value);
   });
 }
 

--- a/apps/api/src/services/email-template.service.ts
+++ b/apps/api/src/services/email-template.service.ts
@@ -28,6 +28,13 @@ export class InvalidMergeFieldError extends Error {
   }
 }
 
+export class InvalidTemplateSyntaxError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidTemplateSyntaxError';
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -80,7 +87,8 @@ const MERGE_FIELD_RE = /\{\{(\w+)\}\}/g;
 /**
  * Validate that all `{{field}}` placeholders and `{{#each field}}` blocks in
  * `text` are allowed for the given template. Throws
- * {@link InvalidMergeFieldError} on the first invalid field.
+ * {@link InvalidMergeFieldError} on the first invalid field, or
+ * {@link InvalidTemplateSyntaxError} on malformed block syntax.
  *
  * `{{this.prop}}` inside blocks is not validated against the top-level list
  * (the dot prevents matching `\w+`).
@@ -90,6 +98,15 @@ export function validateMergeFields(
   templateName: EmailTemplateName,
 ): void {
   const allowed = TEMPLATE_MERGE_FIELDS[templateName];
+
+  // Detect unclosed {{#each}} blocks (opening without matching close)
+  const opens = text.match(/\{\{#each\s+\w+\}\}/g) ?? [];
+  const closes = text.match(/\{\{\/each\}\}/g) ?? [];
+  if (opens.length !== closes.length) {
+    throw new InvalidTemplateSyntaxError(
+      'Unclosed {{#each}} block — every {{#each field}} must have a matching {{/each}}',
+    );
+  }
 
   // Strip {{#each field}}...{{/each}} blocks, validating the block field name
   const withoutBlocks = text.replace(
@@ -110,6 +127,24 @@ export function validateMergeFields(
       throw new InvalidMergeFieldError(match[1], templateName);
     }
   }
+}
+
+/**
+ * Validate subject template — scalar `{{field}}` only, no `{{#each}}` blocks.
+ * Subjects are rendered with scalar-only interpolation; block syntax would
+ * appear as raw markup in outgoing email subject lines.
+ */
+export function validateSubjectMergeFields(
+  text: string,
+  templateName: EmailTemplateName,
+): void {
+  if (/\{\{#each\s/.test(text)) {
+    throw new InvalidTemplateSyntaxError(
+      '{{#each}} blocks are not allowed in subject templates — use scalar merge fields only',
+    );
+  }
+  // Delegate scalar validation to the standard validator
+  validateMergeFields(text, templateName);
 }
 
 /**
@@ -278,7 +313,7 @@ export const emailTemplateService = {
     const { templateName, subjectTemplate, bodyHtml } = input;
 
     // Validate merge fields in both subject and body
-    validateMergeFields(subjectTemplate, templateName);
+    validateSubjectMergeFields(subjectTemplate, templateName);
     validateMergeFields(bodyHtml, templateName);
 
     // Sanitize body HTML

--- a/apps/api/src/templates/email/__tests__/custom-render.spec.ts
+++ b/apps/api/src/templates/email/__tests__/custom-render.spec.ts
@@ -84,4 +84,131 @@ describe('renderCustomTemplate', () => {
     expect(result.subject).toBe('Hello ');
     expect(result.text).toContain('Greeting');
   });
+
+  // -------------------------------------------------------------------------
+  // Array / block interpolation integration tests
+  // -------------------------------------------------------------------------
+
+  const feedback = [
+    {
+      tags: ['compelling voice', 'strong imagery'],
+      comment: 'Beautiful prose, but the ending felt rushed.',
+    },
+    { tags: ['needs revision'], comment: null },
+  ];
+
+  it('renders {{readerFeedback}} scalar tag as default formatted block', () => {
+    const result = renderCustomTemplate(
+      {
+        subjectTemplate: 'Update on {{submissionTitle}}',
+        bodyHtml:
+          '<p>Dear writer,</p><p>We received feedback:</p>{{readerFeedback}}',
+      },
+      { submissionTitle: 'My Poem', readerFeedback: feedback },
+      orgName,
+    );
+
+    expect(result.html).toContain('compelling voice, strong imagery');
+    expect(result.html).toContain(
+      'Beautiful prose, but the ending felt rushed.',
+    );
+    expect(result.html).toContain('needs revision');
+  });
+
+  it('renders {{#each readerFeedback}} with custom layout per item', () => {
+    const result = renderCustomTemplate(
+      {
+        subjectTemplate: 'Update',
+        bodyHtml:
+          '{{#each readerFeedback}}<p><strong>{{this.tags}}</strong>: {{this.comment}}</p>{{/each}}',
+      },
+      { readerFeedback: feedback },
+      orgName,
+    );
+
+    expect(result.html).toContain('compelling voice, strong imagery');
+    expect(result.html).toContain(
+      'Beautiful prose, but the ending felt rushed.',
+    );
+  });
+
+  it('includes feedback content in plain text output with line breaks', () => {
+    const result = renderCustomTemplate(
+      {
+        subjectTemplate: 'Update',
+        bodyHtml: '<p>Feedback:</p>{{readerFeedback}}',
+      },
+      { readerFeedback: feedback },
+      orgName,
+    );
+
+    expect(result.text).toContain('compelling voice, strong imagery');
+    expect(result.text).toContain(
+      'Beautiful prose, but the ending felt rushed.',
+    );
+    expect(result.text).toContain('needs revision');
+  });
+
+  it('renders nothing when readerFeedback array is empty', () => {
+    const result = renderCustomTemplate(
+      {
+        subjectTemplate: 'Update',
+        bodyHtml: '<p>Before</p>{{readerFeedback}}<p>After</p>',
+      },
+      { readerFeedback: [] },
+      orgName,
+    );
+
+    expect(result.text).toContain('Before');
+    expect(result.text).toContain('After');
+    expect(result.text).not.toContain('border-left');
+  });
+
+  it('silently ignores readerFeedback when template does not reference it', () => {
+    const result = renderCustomTemplate(
+      {
+        subjectTemplate: 'Update',
+        bodyHtml: '<p>Thank you.</p>',
+      },
+      { readerFeedback: feedback },
+      orgName,
+    );
+
+    expect(result.text).toBe('Thank you.');
+  });
+
+  it('escapes XSS in feedback values in final HTML', () => {
+    const xssFeedback = [
+      {
+        tags: ['<script>alert(1)</script>'],
+        comment: '<img onerror=alert(1)>',
+      },
+    ];
+    const result = renderCustomTemplate(
+      {
+        subjectTemplate: 'Update',
+        bodyHtml: '{{readerFeedback}}',
+      },
+      { readerFeedback: xssFeedback },
+      orgName,
+    );
+
+    expect(result.html).not.toContain('<script>');
+    // onerror appears as escaped text (&lt;img onerror=...) not as an active attribute
+    expect(result.html).not.toContain('<img');
+  });
+
+  it('does not render HTML blocks in subject line for array fields', () => {
+    const result = renderCustomTemplate(
+      {
+        subjectTemplate: 'Feedback: {{readerFeedback}}',
+        bodyHtml: '<p>Body</p>',
+      },
+      { readerFeedback: feedback },
+      orgName,
+    );
+
+    expect(result.subject).toBe('Feedback: ');
+    expect(result.subject).not.toContain('<div');
+  });
 });

--- a/apps/api/src/templates/email/escape-html.ts
+++ b/apps/api/src/templates/email/escape-html.ts
@@ -1,0 +1,8 @@
+/** Escape HTML special characters to prevent XSS in interpolated values. */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/apps/api/src/templates/email/layout.ts
+++ b/apps/api/src/templates/email/layout.ts
@@ -1,3 +1,5 @@
+import { escapeHtml } from './escape-html.js';
+
 export function wrapInLayout(bodyMjml: string, orgName: string): string {
   return `
 <mjml>
@@ -29,12 +31,4 @@ export function wrapInLayout(bodyMjml: string, orgName: string): string {
     </mj-section>
   </mj-body>
 </mjml>`;
-}
-
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
 }

--- a/apps/api/src/templates/email/render.ts
+++ b/apps/api/src/templates/email/render.ts
@@ -6,6 +6,7 @@ import { wrapInLayout } from './layout.js';
 import {
   sanitizeTemplateHtml,
   interpolateMergeFields,
+  interpolateMergeFieldsBody,
 } from '../../services/email-template.service.js';
 
 export interface RenderedEmail {
@@ -43,11 +44,11 @@ export function renderCustomTemplate(
   data: Record<string, unknown>,
   orgName: string,
 ): RenderedEmail {
-  // Interpolate merge fields in subject
+  // Interpolate merge fields in subject (scalar-only — no HTML blocks)
   const subject = interpolateMergeFields(customTemplate.subjectTemplate, data);
 
-  // Interpolate + sanitize body HTML
-  const interpolatedBody = interpolateMergeFields(
+  // Interpolate body HTML (supports {{#each}} blocks and array shorthand)
+  const interpolatedBody = interpolateMergeFieldsBody(
     customTemplate.bodyHtml,
     data,
   );
@@ -60,12 +61,17 @@ export function renderCustomTemplate(
   );
   const { html } = renderMjml(mjmlString);
 
-  // Generate plain text by stripping HTML
-  const text = sanitizeHtml(sanitizedBody, {
+  // Generate plain text: convert block elements to newlines before stripping
+  const textFriendly = sanitizedBody
+    .replace(/<\/div>/gi, '</div>\n')
+    .replace(/<\/p>/gi, '</p>\n')
+    .replace(/<br\s*\/?>/gi, '\n');
+  const text = sanitizeHtml(textFriendly, {
     allowedTags: [],
     allowedAttributes: {},
   })
     .replace(/&nbsp;/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
     .trim();
 
   return { html, text, subject };

--- a/apps/api/src/templates/email/templates.ts
+++ b/apps/api/src/templates/email/templates.ts
@@ -1,4 +1,5 @@
 import sanitizeHtml from 'sanitize-html';
+import { escapeHtml } from './escape-html.js';
 import type {
   TemplateName,
   SubmissionTemplateData,
@@ -437,12 +438,4 @@ function stripHtml(html: string): string {
   return sanitizeHtml(html, { allowedTags: [], allowedAttributes: {} })
     .replace(/&nbsp;/g, ' ')
     .trim();
-}
-
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
 }

--- a/apps/api/src/trpc/routers/email-templates.ts
+++ b/apps/api/src/trpc/routers/email-templates.ts
@@ -119,7 +119,7 @@ export const emailTemplatesRouter = createRouter({
           bodyHtml: input.bodyHtml,
         },
         sampleData,
-        sampleData.orgName ?? 'Your Magazine',
+        String(sampleData.orgName ?? 'Your Magazine'),
       );
 
       return {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -535,7 +535,9 @@
 - [ ] [P3] Writer sidebar updates — Sim-Sub Groups nav item, Portfolio badges (verified/federated/external), Analytics personal response time stats — (design system session 2026-03-28)
 - [x] [P1] Reader feedback service: defense-in-depth org match on submission_id — service must verify `submission.organizationId === orgId` before insert to prevent cross-org feedback — (Codex branch review 2026-03-29)
 - [x] [P2] Sim-sub junction service: ownership validation on referenced records — service must verify `simsubGroup.userId`, `submission.submitterId`, and `externalSubmission.userId` match the caller before insert — (Codex branch review 2026-03-29)
-- [ ] [P2] Custom rejection templates: reader feedback array support — `renderCustomTemplate()` only interpolates scalar merge fields; `readerFeedback` array is silently ignored for orgs with custom rejection email overrides. Need array/loop support in custom template renderer — (Codex branch review 2026-03-31)
+- [x] [P2] Custom rejection templates: reader feedback array support — `renderCustomTemplate()` only interpolates scalar merge fields; `readerFeedback` array is silently ignored for orgs with custom rejection email overrides. Need array/loop support in custom template renderer — (Codex branch review 2026-03-31; done 2026-03-31)
+- [ ] [P2] Defense-in-depth: `emailTemplateService.delete()` missing `organizationId` filter — deletes by `templateName` only (relies on RLS alone); should also filter on `organizationId` per defense-in-depth rule. Pre-existing issue in `apps/api/src/services/email-template.service.ts:209` — (Codex plan review 2026-03-31)
+- [ ] [P3] Custom template editor: surface `{{#each}}` syntax to editors — `TEMPLATE_ARRAY_FIELDS` metadata exported from `@colophony/types` but editor UI only consumes `mergeFields: string[]`; need data-path change to show array field documentation and `{{#each}}` syntax help — (Codex plan review 2026-03-31)
 
 ---
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,33 @@ Newest entries first.
 
 ---
 
+## 2026-03-31 — Custom Template Array Support (Track 14 P2)
+
+### Done
+
+- `{{#each field}}...{{/each}}` block syntax for custom email templates with `{{this.prop}}` inner references
+- `{{readerFeedback}}` scalar shorthand renders default styled block (left-bordered divs matching built-in template)
+- `interpolateMergeFieldsBody()` for HTML body (supports arrays), `interpolateMergeFields()` stays scalar-only (subjects)
+- `interpolateBlockFields()` and `renderDefaultArrayBlock()` in email-template.service.ts
+- `validateMergeFields()` updated to accept `{{#each}}` block syntax
+- `SANITIZE_OPTIONS` expanded for `div` with style attributes
+- Shared `escapeHtml` utility extracted from duplicated functions in templates.ts and layout.ts
+- `readerFeedback` added to allowed merge fields for submission-rejected template
+- `TEMPLATE_ARRAY_FIELDS` metadata constant for future editor UI
+- Preview endpoint type narrowing fix (`String()` cast for widened `TEMPLATE_SAMPLE_DATA`)
+- Improved plain text generation: block elements converted to newlines before HTML stripping
+- 20 new tests (14 unit + 6 integration), all passing
+- Codex plan review: 2 Important addressed (type widening, subject HTML blocks), 2 Suggestions acknowledged (UI metadata deferred, defense-in-depth delete pre-existing)
+
+### Decisions
+
+- D1: Handlebars-like `{{#each}}` syntax chosen for editor familiarity
+- D2: Subject lines stay scalar-only — arrays render as empty string in subjects to prevent HTML block markup
+- D3: `TEMPLATE_ARRAY_FIELDS` metadata exported but not wired into editor UI yet — follow-up task
+- D4: Pre-existing `emailTemplateService.delete()` missing `organizationId` filter deferred to backlog
+
+---
+
 ## 2026-03-31 — Feedback on Rejection Flow (Track 14 P2)
 
 ### Done

--- a/packages/types/src/email-templates.ts
+++ b/packages/types/src/email-templates.ts
@@ -46,6 +46,7 @@ export const TEMPLATE_MERGE_FIELDS: Record<
     "submitterEmail",
     "orgName",
     "editorComment",
+    "readerFeedback",
   ],
   "submission-withdrawn": [
     "submissionTitle",
@@ -82,7 +83,7 @@ export const TEMPLATE_MERGE_FIELDS: Record<
 
 export const TEMPLATE_SAMPLE_DATA: Record<
   EmailTemplateName,
-  Record<string, string>
+  Record<string, unknown>
 > = {
   "submission-received": {
     submissionTitle: "The Garden of Forking Paths",
@@ -106,6 +107,13 @@ export const TEMPLATE_SAMPLE_DATA: Record<
     orgName: "The Paris Review",
     editorComment:
       "While we admired the craft, it wasn't the right fit for our current issue.",
+    readerFeedback: [
+      {
+        tags: ["compelling voice", "strong imagery"],
+        comment: "Beautiful prose, but the ending felt rushed.",
+      },
+      { tags: ["needs revision"], comment: null },
+    ],
   },
   "submission-withdrawn": {
     submissionTitle: "The Garden of Forking Paths",
@@ -239,3 +247,26 @@ export const emailTemplateListItemSchema = z.object({
   isCustomized: z.boolean(),
   mergeFields: z.array(z.string()),
 });
+
+// ---------------------------------------------------------------------------
+// Array field metadata — describes fields that support {{#each}} block syntax
+// ---------------------------------------------------------------------------
+
+export const TEMPLATE_ARRAY_FIELDS: Record<
+  string,
+  {
+    label: string;
+    description: string;
+    innerFields: Array<{ name: string; label: string }>;
+  }
+> = {
+  readerFeedback: {
+    label: "Reader Feedback",
+    description:
+      "Anonymous feedback from readers. Use {{readerFeedback}} for default formatting, or {{#each readerFeedback}}...{{/each}} for custom layout.",
+    innerFields: [
+      { name: "tags", label: "Tags (comma-separated)" },
+      { name: "comment", label: "Comment" },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
- Add `{{#each field}}...{{/each}}` block syntax and `{{readerFeedback}}` scalar shorthand to the custom email template interpolation engine
- Orgs with custom rejection templates can now include anonymized reader feedback instead of silently dropping it
- Subject lines stay scalar-only; unclosed blocks and block syntax in subjects are rejected at validation time

## Changes
- `interpolateBlockFields()`, `renderDefaultArrayBlock()`, `interpolateMergeFieldsBody()` in email-template.service.ts
- `validateSubjectMergeFields()` and `InvalidTemplateSyntaxError` for stricter validation
- Shared `escapeHtml` utility extracted from templates.ts and layout.ts
- `SANITIZE_OPTIONS` expanded for `div` with style attributes
- Improved plain text generation with block-to-newline conversion
- Preview endpoint type narrowing fix
- `TEMPLATE_ARRAY_FIELDS` metadata for future editor UI

## Test plan
- [ ] 24 new tests (18 unit + 6 integration) — all passing locally
- [ ] Type-check passes across workspace (13 packages)
- [ ] Lint clean (API + web)
- [ ] Full unit test suite passes (2483 tests)
- [ ] CI passes

## code review
- Plan review: 2 Important + 2 Suggestions addressed in plan
- Branch review: P1 (subject block syntax) + P2 (unclosed blocks) fixed

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| email-template.service.ts | Single `validateMergeFields` | Added `validateSubjectMergeFields` + `InvalidTemplateSyntaxError` | branch review P1/P2: subject needs stricter validation, unclosed blocks must be rejected |