### PR TITLE
test(hopper): reading anchor test coverage

### DIFF
--- a/apps/api/src/services/collection.service.spec.ts
+++ b/apps/api/src/services/collection.service.spec.ts
@@ -70,7 +70,7 @@ import {
 } from './collection.service.js';
 import { assertEditorOrAdmin } from './errors.js';
 import { ilike, or } from 'drizzle-orm';
-import { eq } from '@colophony/db';
+import { eq, and, submissions } from '@colophony/db';
 import type { ServiceContext } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -320,6 +320,28 @@ describe('collectionService', () => {
 
       const result = await collectionService.getItems(tx, 'missing', ORG_ID);
       expect(result).toEqual([]);
+    });
+
+    it('joins submissions with org-scoped predicate (defense-in-depth)', async () => {
+      const itemsWithTitle = [{ ...fakeItem, submissionTitle: 'Poem A' }];
+      const getByIdChain = createSelectChain([fakeCollection]);
+      const itemsChain = createSelectChain(itemsWithTitle);
+
+      const selectFn = vi
+        .fn()
+        .mockReturnValueOnce(getByIdChain.select())
+        .mockReturnValueOnce(itemsChain.select());
+      const tx = { select: selectFn } as never;
+
+      await collectionService.getItems(tx, COLLECTION_ID, ORG_ID);
+
+      // leftJoin receives submissions table ref
+      expect(itemsChain.leftJoin).toHaveBeenCalled();
+      expect(itemsChain.leftJoin.mock.calls[0][0]).toBe(submissions);
+      // and() was called to combine two eq() conditions
+      expect(and).toHaveBeenCalled();
+      // eq() was called with submissions.organizationId + the org ID (defense-in-depth)
+      expect(eq).toHaveBeenCalledWith(submissions.organizationId, ORG_ID);
     });
   });
 
@@ -657,6 +679,56 @@ describe('collectionService', () => {
       const setArg = updateChain.set.mock.calls[0][0];
       expect(setArg.notes).toBe('Great piece');
       expect(setArg.touchedAt).toBeInstanceOf(Date);
+    });
+
+    it('persists readingAnchor when provided', async () => {
+      const getByIdChain = createSelectChain([fakeCollection]);
+      const anchor = { nodeIndex: 5, charOffset: 0 };
+      const updatedItem = { ...fakeItem, readingAnchor: anchor };
+      const updateChain = createUpdateChain([updatedItem]);
+
+      const tx = {
+        select: getByIdChain.select,
+        update: updateChain.update,
+      } as never;
+
+      const result = await collectionService.updateItem(
+        tx,
+        COLLECTION_ID,
+        ITEM_ID,
+        { readingAnchor: anchor },
+        ORG_ID,
+        USER_ID,
+      );
+
+      expect(result).toEqual(updatedItem);
+      const setArg = updateChain.set.mock.calls[0][0];
+      expect(setArg.readingAnchor).toEqual(anchor);
+      expect(setArg.touchedAt).toBeInstanceOf(Date);
+    });
+
+    it('clears readingAnchor when null is passed', async () => {
+      const getByIdChain = createSelectChain([fakeCollection]);
+      const updatedItem = { ...fakeItem, readingAnchor: null };
+      const updateChain = createUpdateChain([updatedItem]);
+
+      const tx = {
+        select: getByIdChain.select,
+        update: updateChain.update,
+      } as never;
+
+      const result = await collectionService.updateItem(
+        tx,
+        COLLECTION_ID,
+        ITEM_ID,
+        { readingAnchor: null },
+        ORG_ID,
+        USER_ID,
+      );
+
+      expect(result).toEqual(updatedItem);
+      const setArg = updateChain.set.mock.calls[0][0];
+      expect(setArg.readingAnchor).toBeNull();
     });
   });
 

--- a/apps/web/src/components/editor/__tests__/detail-pane.spec.tsx
+++ b/apps/web/src/components/editor/__tests__/detail-pane.spec.tsx
@@ -5,7 +5,7 @@ import { DetailPane, type WorkspaceContext } from "../detail-pane";
 // --- Mutable mock state ---
 let mockSubmission: Record<string, unknown> | undefined;
 let mockIsPending = false;
-let mockMutate: ReturnType<typeof vi.fn>;
+let mockMutate: (...args: unknown[]) => void;
 let mockInvalidate: ReturnType<typeof vi.fn>;
 
 // --- Capture ManuscriptRenderer props ---
@@ -49,11 +49,11 @@ vi.mock("@/lib/trpc", () => ({
       updateItem: {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         useMutation: (opts: any) => ({
-          mutate: (...args: unknown[]) => {
-            mockMutate(...args);
+          mutate: (input: unknown) => {
+            mockMutate(input);
             opts?.onSuccess?.(
               undefined,
-              args[0] as Record<string, unknown>,
+              input as Record<string, unknown>,
               undefined,
             );
           },

--- a/apps/web/src/components/editor/__tests__/detail-pane.spec.tsx
+++ b/apps/web/src/components/editor/__tests__/detail-pane.spec.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DetailPane, type WorkspaceContext } from "../detail-pane";
+
+// --- Mutable mock state ---
+let mockSubmission: Record<string, unknown> | undefined;
+let mockIsPending = false;
+let mockMutate: ReturnType<typeof vi.fn>;
+let mockInvalidate: ReturnType<typeof vi.fn>;
+
+// --- Capture ManuscriptRenderer props ---
+let capturedRendererProps: Record<string, unknown> = {};
+
+beforeEach(() => {
+  mockMutate = vi.fn();
+  mockInvalidate = vi.fn();
+  mockIsPending = false;
+  capturedRendererProps = {};
+  mockSubmission = {
+    id: "sub-1",
+    title: "Test Poem",
+    submitterEmail: "writer@example.com",
+    coverLetter: null,
+    content: "First paragraph.\n\nSecond paragraph.",
+    manuscript: null,
+  };
+});
+
+vi.mock("@/lib/fonts", () => ({
+  literata: { className: "literata-mock" },
+}));
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    useUtils: () => ({
+      collections: {
+        getItems: { invalidate: mockInvalidate },
+      },
+    }),
+    submissions: {
+      getById: {
+        useQuery: () => ({
+          data: mockSubmission,
+          isPending: mockIsPending,
+        }),
+      },
+    },
+    collections: {
+      updateItem: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        useMutation: (opts: any) => ({
+          mutate: (...args: unknown[]) => {
+            mockMutate(...args);
+            opts?.onSuccess?.(
+              undefined,
+              args[0] as Record<string, unknown>,
+              undefined,
+            );
+          },
+          isPending: false,
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock("@/components/submissions/submission-detail", () => ({
+  SubmissionDetail: () => <div data-testid="submission-detail" />,
+}));
+
+vi.mock("@/components/manuscripts/manuscript-renderer", () => ({
+  ManuscriptRenderer: (props: Record<string, unknown>) => {
+    capturedRendererProps = props;
+    return <div data-testid="manuscript-renderer" />;
+  },
+}));
+
+vi.mock("@/hooks/use-density", () => ({
+  DensityProvider: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/lib/manuscript", () => ({
+  textToProseMirrorDoc: (text: string) => ({
+    type: "doc",
+    content: text.split("\n\n").map((t) => ({ type: "paragraph", text: t })),
+  }),
+}));
+
+describe("DetailPane", () => {
+  const workspaceContext: WorkspaceContext = {
+    collectionId: "col-1",
+    itemId: "item-1",
+    readingAnchor: { nodeIndex: 3, charOffset: 0 },
+  };
+
+  it("passes onAnchorChange and initialAnchor when workspaceContext is provided", () => {
+    render(
+      <DetailPane
+        submissionId="sub-1"
+        mode="deep-read"
+        workspaceContext={workspaceContext}
+      />,
+    );
+
+    expect(screen.getByTestId("manuscript-renderer")).toBeTruthy();
+    expect(capturedRendererProps.onAnchorChange).toBeTypeOf("function");
+    expect(capturedRendererProps.initialAnchor).toEqual({ nodeIndex: 3 });
+  });
+
+  it("omits onAnchorChange when no workspaceContext", () => {
+    render(<DetailPane submissionId="sub-1" mode="deep-read" />);
+
+    expect(screen.getByTestId("manuscript-renderer")).toBeTruthy();
+    expect(capturedRendererProps.onAnchorChange).toBeUndefined();
+  });
+
+  it("calls updateItem.mutate with correct shape on anchor change", () => {
+    render(
+      <DetailPane
+        submissionId="sub-1"
+        mode="deep-read"
+        workspaceContext={workspaceContext}
+      />,
+    );
+
+    // Trigger the anchor callback passed to ManuscriptRenderer
+    const onAnchorChange = capturedRendererProps.onAnchorChange as (anchor: {
+      nodeIndex: number;
+    }) => void;
+    onAnchorChange({ nodeIndex: 7 });
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      id: "col-1",
+      itemId: "item-1",
+      readingAnchor: { nodeIndex: 7, charOffset: 0 },
+    });
+  });
+});

--- a/apps/web/src/components/manuscripts/__tests__/manuscript-renderer.spec.tsx
+++ b/apps/web/src/components/manuscripts/__tests__/manuscript-renderer.spec.tsx
@@ -236,4 +236,119 @@ describe("ManuscriptRenderer", () => {
     expect(blockquote).toBeTruthy();
     expect(blockquote?.textContent).toBe("Quoted text.");
   });
+
+  // -------------------------------------------------------------------------
+  // Reading anchor behavior
+  // -------------------------------------------------------------------------
+
+  describe("reading anchor", () => {
+    const threeNodeDoc = makeDoc({
+      content: [
+        { type: "paragraph", text: "First." },
+        { type: "paragraph", text: "Second." },
+        { type: "paragraph", text: "Third." },
+      ],
+    });
+
+    it("renders data-node-index attributes on each top-level node", () => {
+      const { container } = render(
+        <ManuscriptRenderer content={threeNodeDoc} />,
+      );
+
+      const indexed = container.querySelectorAll("[data-node-index]");
+      expect(indexed).toHaveLength(3);
+      expect((indexed[0] as HTMLElement).dataset.nodeIndex).toBe("0");
+      expect((indexed[1] as HTMLElement).dataset.nodeIndex).toBe("1");
+      expect((indexed[2] as HTMLElement).dataset.nodeIndex).toBe("2");
+    });
+
+    it("scrolls to initialAnchor node on mount", async () => {
+      const scrollMock = vi.fn();
+      Element.prototype.scrollIntoView = scrollMock;
+
+      const rafSpy = vi
+        .spyOn(window, "requestAnimationFrame")
+        .mockImplementation((cb) => {
+          cb(0);
+          return 0;
+        });
+
+      render(
+        <ManuscriptRenderer
+          content={threeNodeDoc}
+          initialAnchor={{ nodeIndex: 1 }}
+        />,
+      );
+
+      expect(scrollMock).toHaveBeenCalledWith({ block: "start" });
+
+      rafSpy.mockRestore();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (Element.prototype as any).scrollIntoView;
+    });
+
+    it("fires onAnchorChange with topmost visible index after debounce", () => {
+      vi.useFakeTimers();
+      let observerCallback: IntersectionObserverCallback | undefined;
+      const mockDisconnect = vi.fn();
+
+      const MockObserver = vi.fn().mockImplementation(function (
+        this: IntersectionObserver,
+        cb: IntersectionObserverCallback,
+      ) {
+        observerCallback = cb;
+        this.disconnect = mockDisconnect;
+        this.observe = vi.fn();
+        this.unobserve = vi.fn();
+        this.takeRecords = vi.fn().mockReturnValue([]);
+        this.root = null;
+        this.rootMargin = "";
+        this.thresholds = [0];
+      });
+      vi.stubGlobal("IntersectionObserver", MockObserver);
+
+      const onChange = vi.fn();
+      render(
+        <ManuscriptRenderer content={threeNodeDoc} onAnchorChange={onChange} />,
+      );
+
+      expect(MockObserver).toHaveBeenCalled();
+
+      // Simulate nodes 1 and 2 becoming visible
+      observerCallback!(
+        [
+          {
+            isIntersecting: true,
+            target: { dataset: { nodeIndex: "2" } },
+          },
+          {
+            isIntersecting: true,
+            target: { dataset: { nodeIndex: "1" } },
+          },
+        ] as unknown as IntersectionObserverEntry[],
+        {} as IntersectionObserver,
+      );
+
+      // Not called yet (2s debounce)
+      expect(onChange).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(2000);
+
+      expect(onChange).toHaveBeenCalledWith({ nodeIndex: 1 });
+
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    });
+
+    it("does not create IntersectionObserver when onAnchorChange is omitted", () => {
+      const MockObserver = vi.fn();
+      vi.stubGlobal("IntersectionObserver", MockObserver);
+
+      render(<ManuscriptRenderer content={threeNodeDoc} />);
+
+      expect(MockObserver).not.toHaveBeenCalled();
+
+      vi.unstubAllGlobals();
+    });
+  });
 });

--- a/apps/web/src/components/manuscripts/__tests__/manuscript-renderer.spec.tsx
+++ b/apps/web/src/components/manuscripts/__tests__/manuscript-renderer.spec.tsx
@@ -301,9 +301,9 @@ describe("ManuscriptRenderer", () => {
         this.observe = vi.fn();
         this.unobserve = vi.fn();
         this.takeRecords = vi.fn().mockReturnValue([]);
-        this.root = null;
-        this.rootMargin = "";
-        this.thresholds = [0];
+        Object.defineProperty(this, "root", { value: null });
+        Object.defineProperty(this, "rootMargin", { value: "" });
+        Object.defineProperty(this, "thresholds", { value: [0] });
       });
       vi.stubGlobal("IntersectionObserver", MockObserver);
 

--- a/apps/web/src/components/manuscripts/__tests__/manuscript-renderer.spec.tsx
+++ b/apps/web/src/components/manuscripts/__tests__/manuscript-renderer.spec.tsx
@@ -263,6 +263,7 @@ describe("ManuscriptRenderer", () => {
     });
 
     it("scrolls to initialAnchor node on mount", async () => {
+      const originalScrollIntoView = Element.prototype.scrollIntoView;
       const scrollMock = vi.fn();
       Element.prototype.scrollIntoView = scrollMock;
 
@@ -283,8 +284,7 @@ describe("ManuscriptRenderer", () => {
       expect(scrollMock).toHaveBeenCalledWith({ block: "start" });
 
       rafSpy.mockRestore();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      delete (Element.prototype as any).scrollIntoView;
+      Element.prototype.scrollIntoView = originalScrollIntoView;
     });
 
     it("fires onAnchorChange with topmost visible index after debounce", () => {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -496,7 +496,7 @@
 - [x] [P3] Service test for `getByIdAsOwner` ownership check and error types — (Codex branch review 2026-03-26; done 2026-03-27)
 - [x] [P2] Collection service unit tests — 24 tests (CRUD, visibility filtering, cross-tenant validation, audit logging, reorder) in `collection.service.spec.ts` — (Codex branch review 2026-03-26; done 2026-03-27)
 - [x] [P2] Reading anchor wiring — ManuscriptRenderer IntersectionObserver tracking, collection detail reading mode, updateCollectionItemSchema + service whitelist, defense-in-depth fix for getItems() submissions join — (design system session 2026-03-28; done 2026-03-28)
-- [ ] [P3] Reading anchor test coverage — unit tests for: readingAnchor persistence in updateItem, org-scoped join predicate in getItems, ManuscriptRenderer anchor restore/callback, collection reading mode UI, scope guard (queue context = no anchor) — (Codex branch review drift 2026-03-28)
+- [x] [P3] Reading anchor test coverage — unit tests for: readingAnchor persistence in updateItem, org-scoped join predicate in getItems, ManuscriptRenderer anchor restore/callback, collection reading mode UI, scope guard (queue context = no anchor) — (Codex branch review drift 2026-03-28; done 2026-03-31)
 
 ---
 

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,23 @@ Newest entries first.
 
 ---
 
+## 2026-03-31 — Reading Anchor Test Coverage (Track 12)
+
+### Done
+
+- 10 new tests covering the reading anchor feature across backend and frontend
+- Backend (`collection.service.spec.ts`): readingAnchor persistence, null clearing, org-scoped join predicate defense-in-depth assertion
+- ManuscriptRenderer: data-node-index attributes, initialAnchor scroll restore, IntersectionObserver debounce callback, no observer without onAnchorChange
+- DetailPane (`detail-pane.spec.tsx`, new file): anchor callback wiring with/without workspaceContext, mutate payload shape
+- Codex plan review: 1 Important addressed (corrected leftJoin assertion approach — evaluated `and()` result, not callback)
+
+### Decisions
+
+- Local mocks for IntersectionObserver/scrollIntoView/requestAnimationFrame (no global test shims)
+- Prop capture pattern for DetailPane tests — mock ManuscriptRenderer captures props object for assertion
+
+---
+
 ## 2026-03-31 — Close Out Track 14 Code Items
 
 ### Done


### PR DESCRIPTION
## Summary

- Add 10 tests covering the reading anchor feature across backend and frontend
- Backend: readingAnchor persistence in `updateItem()`, null clearing, org-scoped join predicate defense-in-depth
- ManuscriptRenderer: `data-node-index` attributes, `initialAnchor` scroll restore, `IntersectionObserver` debounce, no observer without callback
- DetailPane (new test file): anchor callback wiring with/without `workspaceContext`, mutate payload shape

Closes Track 12 backlog item: reading anchor test coverage.

## Test plan

- [x] `pnpm --filter @colophony/api test -- collection.service.spec` — 28 tests pass (3 new)
- [x] `pnpm --filter @colophony/web test -- manuscript-renderer.spec` — 17 tests pass (4 new)
- [x] `pnpm --filter @colophony/web test -- detail-pane.spec` — 3 tests pass (all new)
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 2719 tests pass