### PR TITLE
feat(web): sub-brand UI — navy sidebar, preheaders, breadcrumbs

### DIFF
--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -3,6 +3,7 @@
 import { ProtectedRoute } from "@/components/auth/protected-route";
 import { Header } from "@/components/layout/header";
 import { Sidebar } from "@/components/layout/sidebar";
+import { BreadcrumbBar } from "@/components/layout/breadcrumb-bar";
 import { Toaster } from "@/components/ui/sonner";
 import { DensityProvider } from "@/hooks/use-density";
 import { CommandPaletteProvider } from "@/components/command-palette/command-palette";
@@ -20,12 +21,13 @@ export default function DashboardLayout({
             <Header />
             <div className="flex-1 flex">
               {/* Sidebar - hidden on mobile */}
-              <aside className="hidden md:flex w-64 flex-col border-r">
+              <aside className="hidden md:flex w-64 flex-col border-r border-sidebar-border">
                 <Sidebar />
               </aside>
 
               {/* Main content */}
               <main className="flex-1 overflow-auto">
+                <BreadcrumbBar />
                 <div className="container py-6">{children}</div>
               </main>
             </div>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -27,6 +27,13 @@
   --chart-4: hsl(43 74% 66%);
   --chart-5: hsl(27 87% 67%);
   --radius: 0.5rem;
+  /* Sidebar — permanent dark surface (same in both themes) */
+  --sidebar-background: 230 26.5% 13.3%;
+  --sidebar-foreground: 42.2 47.4% 88.8%;
+  --sidebar-primary: 24.9 55.1% 52%;
+  --sidebar-accent: 213.3 17.9% 29.6%;
+  --sidebar-border: 213.3 17.9% 29.6%;
+  --sidebar-muted: 35.5 22% 80.4%;
 }
 
 .dark {
@@ -54,6 +61,13 @@
   --chart-3: hsl(30 80% 55%);
   --chart-4: hsl(280 65% 60%);
   --chart-5: hsl(340 75% 55%);
+  /* Sidebar — permanent dark surface (same in both themes) */
+  --sidebar-background: 230 26.5% 13.3%;
+  --sidebar-foreground: 42.2 47.4% 88.8%;
+  --sidebar-primary: 24.9 55.1% 52%;
+  --sidebar-accent: 213.3 17.9% 29.6%;
+  --sidebar-border: 213.3 17.9% 29.6%;
+  --sidebar-muted: 35.5 22% 80.4%;
 }
 
 @theme inline {
@@ -81,6 +95,12 @@
   --color-chart-3: var(--chart-3);
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
+  --color-sidebar-background: hsl(var(--sidebar-background));
+  --color-sidebar-foreground: hsl(var(--sidebar-foreground));
+  --color-sidebar-primary: hsl(var(--sidebar-primary));
+  --color-sidebar-accent: hsl(var(--sidebar-accent));
+  --color-sidebar-border: hsl(var(--sidebar-border));
+  --color-sidebar-muted: hsl(var(--sidebar-muted));
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);

--- a/apps/web/src/components/layout/__tests__/breadcrumb-bar.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/breadcrumb-bar.spec.tsx
@@ -1,0 +1,103 @@
+import { vi } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { BreadcrumbBar } from "../breadcrumb-bar";
+
+let mockPathname = "/";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => mockPathname,
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("BreadcrumbBar", () => {
+  beforeEach(() => {
+    mockPathname = "/";
+  });
+
+  it("should render sub-brand, group, and page for /editor/queue", () => {
+    mockPathname = "/editor/queue";
+    render(<BreadcrumbBar />);
+
+    expect(screen.getByText("Hopper")).toBeInTheDocument();
+    expect(screen.getByText("Editorial")).toBeInTheDocument();
+    expect(screen.getByText("Reading Queue")).toBeInTheDocument();
+  });
+
+  it("should render sub-brand, group, and page for /slate/pipeline", () => {
+    mockPathname = "/slate/pipeline";
+    render(<BreadcrumbBar />);
+
+    expect(screen.getByText("Slate")).toBeInTheDocument();
+    expect(screen.getByText("Production")).toBeInTheDocument();
+    expect(screen.getByText("Pipeline")).toBeInTheDocument();
+  });
+
+  it("should render sub-brand, group, and page for /operations", () => {
+    mockPathname = "/operations";
+    render(<BreadcrumbBar />);
+
+    expect(screen.getByText("Register")).toBeInTheDocument();
+    expect(screen.getByText("Operations")).toBeInTheDocument();
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+  });
+
+  it("should handle detail routes via prefix match", () => {
+    mockPathname = "/editor/collections/abc-123";
+    render(<BreadcrumbBar />);
+
+    expect(screen.getByText("Hopper")).toBeInTheDocument();
+    expect(screen.getByText("Editorial")).toBeInTheDocument();
+    expect(screen.getByText("Collections")).toBeInTheDocument();
+  });
+
+  it("should render nothing for unmatched routes", () => {
+    mockPathname = "/auth/callback";
+    const { container } = render(<BreadcrumbBar />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("should render group-only context for non-nav routes under a group prefix", () => {
+    // /editor/something-not-in-nav should still resolve to Editorial
+    mockPathname = "/editor/some-unknown-page";
+    render(<BreadcrumbBar />);
+
+    expect(screen.getByText("Hopper")).toBeInTheDocument();
+    expect(screen.getByText("Editorial")).toBeInTheDocument();
+    // No page name — just sub-brand and group
+    expect(screen.queryByText("some-unknown-page")).not.toBeInTheDocument();
+  });
+
+  it("should render breadcrumb for workspace routes", () => {
+    mockPathname = "/workspace/analytics";
+    render(<BreadcrumbBar />);
+
+    expect(screen.getByText("Hopper")).toBeInTheDocument();
+    expect(screen.getByText("Writing")).toBeInTheDocument();
+    expect(screen.getByText("Analytics")).toBeInTheDocument();
+  });
+
+  it("should have breadcrumb aria-label", () => {
+    mockPathname = "/workspace";
+    render(<BreadcrumbBar />);
+
+    const nav = screen.getByRole("navigation");
+    expect(nav).toHaveAttribute("aria-label", "Breadcrumb");
+  });
+
+  it("should use longest prefix match for nested routes", () => {
+    // /editor/forms/new should match /editor/forms (Forms), not /editor (Editor Dashboard)
+    mockPathname = "/editor/forms/new";
+    render(<BreadcrumbBar />);
+
+    expect(screen.getByText("Forms")).toBeInTheDocument();
+    expect(screen.queryByText("Editor Dashboard")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/__tests__/breadcrumb-bar.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/breadcrumb-bar.spec.tsx
@@ -92,6 +92,17 @@ describe("BreadcrumbBar", () => {
     expect(nav).toHaveAttribute("aria-label", "Breadcrumb");
   });
 
+  it("should not match dashboard root for detail routes like /editor/[id]", () => {
+    // /editor/123 should NOT match /editor (Editor Dashboard) — exact-match route
+    // Should fall back to group-only context
+    mockPathname = "/editor/123";
+    render(<BreadcrumbBar />);
+
+    expect(screen.getByText("Hopper")).toBeInTheDocument();
+    expect(screen.getByText("Editorial")).toBeInTheDocument();
+    expect(screen.queryByText("Editor Dashboard")).not.toBeInTheDocument();
+  });
+
   it("should use longest prefix match for nested routes", () => {
     // /editor/forms/new should match /editor/forms (Forms), not /editor (Editor Dashboard)
     mockPathname = "/editor/forms/new";

--- a/apps/web/src/components/layout/__tests__/sidebar.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/sidebar.spec.tsx
@@ -5,12 +5,16 @@ import { Sidebar } from "../sidebar";
 
 // --- Mutable mock state ---
 let mockIsEditor = false;
+let mockIsProduction = false;
+let mockIsBusinessOps = false;
 let mockIsAdmin = false;
 let mockPathname = "/";
 
 vi.mock("@/hooks/use-organization", () => ({
   useOrganization: () => ({
     isEditor: mockIsEditor,
+    isProduction: mockIsProduction,
+    isBusinessOps: mockIsBusinessOps,
     isAdmin: mockIsAdmin,
   }),
 }));
@@ -46,6 +50,8 @@ describe("Sidebar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsEditor = false;
+    mockIsProduction = false;
+    mockIsBusinessOps = false;
     mockIsAdmin = false;
     mockPathname = "/";
   });
@@ -92,12 +98,16 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const submissionsLink = screen.getByText("My Submissions").closest("a");
-    // Active: has "bg-accent" as a standalone class (not hover:bg-accent)
-    expect(submissionsLink?.className).toMatch(/(?:^|\s)bg-accent(?:\s|$)/);
+    // Active: has "bg-sidebar-accent" as a standalone class
+    expect(submissionsLink?.className).toMatch(
+      /(?:^|\s)bg-sidebar-accent(?:\s|$)/,
+    );
 
     const settingsLink = screen.getByText("Settings").closest("a");
-    // Inactive: should NOT have standalone "bg-accent" (hover:bg-accent is fine)
-    expect(settingsLink?.className).not.toMatch(/(?:^|\s)bg-accent(?:\s|$)/);
+    // Inactive: should NOT have standalone "bg-sidebar-accent" (hover: is fine)
+    expect(settingsLink?.className).not.toMatch(
+      /(?:^|\s)bg-sidebar-accent(?:\s|$)/,
+    );
   });
 
   it("should apply active class to settings when on settings path", () => {
@@ -105,7 +115,9 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const settingsLink = screen.getByText("Settings").closest("a");
-    expect(settingsLink?.className).toMatch(/(?:^|\s)bg-accent(?:\s|$)/);
+    expect(settingsLink?.className).toMatch(
+      /(?:^|\s)bg-sidebar-accent(?:\s|$)/,
+    );
   });
 
   it("should render Colophony brand link", () => {
@@ -141,11 +153,13 @@ describe("Sidebar", () => {
 
     const dashboardLink = screen.getByText("Editor Dashboard").closest("a");
     // /editor uses exact match — should NOT be active on /editor/forms
-    expect(dashboardLink?.className).not.toMatch(/(?:^|\s)bg-accent(?:\s|$)/);
+    expect(dashboardLink?.className).not.toMatch(
+      /(?:^|\s)bg-sidebar-accent(?:\s|$)/,
+    );
 
     const formsLink = screen.getByText("Forms").closest("a");
     // /editor/forms uses startsWith — should be active
-    expect(formsLink?.className).toMatch(/(?:^|\s)bg-accent(?:\s|$)/);
+    expect(formsLink?.className).toMatch(/(?:^|\s)bg-sidebar-accent(?:\s|$)/);
   });
 
   it("should highlight Editor Dashboard only on exact /editor path", () => {
@@ -154,7 +168,9 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const dashboardLink = screen.getByText("Editor Dashboard").closest("a");
-    expect(dashboardLink?.className).toMatch(/(?:^|\s)bg-accent(?:\s|$)/);
+    expect(dashboardLink?.className).toMatch(
+      /(?:^|\s)bg-sidebar-accent(?:\s|$)/,
+    );
   });
 
   it("should show Federation link in Operations section when isAdmin", () => {
@@ -184,10 +200,12 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const formsLink = screen.getByText("Forms").closest("a");
-    expect(formsLink?.className).toMatch(/(?:^|\s)bg-accent(?:\s|$)/);
+    expect(formsLink?.className).toMatch(/(?:^|\s)bg-sidebar-accent(?:\s|$)/);
 
     const dashboardLink = screen.getByText("Editor Dashboard").closest("a");
-    expect(dashboardLink?.className).not.toMatch(/(?:^|\s)bg-accent(?:\s|$)/);
+    expect(dashboardLink?.className).not.toMatch(
+      /(?:^|\s)bg-sidebar-accent(?:\s|$)/,
+    );
   });
 
   it("should highlight active group header", () => {
@@ -195,7 +213,7 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const writingHeader = screen.getByText("Writing");
-    expect(writingHeader.className).toMatch(/text-foreground/);
+    expect(writingHeader.className).toMatch(/text-sidebar-foreground/);
   });
 
   it("should not highlight inactive group headers", () => {
@@ -204,6 +222,59 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const editorialHeader = screen.getByText("Editorial");
-    expect(editorialHeader.className).toMatch(/text-muted-foreground/);
+    expect(editorialHeader.className).toMatch(/text-sidebar-muted/);
+  });
+
+  // --- Sub-brand preheader tests ---
+
+  it("should render HOPPER preheader above Writing group", () => {
+    render(<Sidebar />);
+    expect(screen.getByText("Hopper")).toBeInTheDocument();
+  });
+
+  it("should not repeat HOPPER preheader above Editorial", () => {
+    mockIsEditor = true;
+    render(<Sidebar />);
+    const hopperLabels = screen.getAllByText("Hopper");
+    expect(hopperLabels).toHaveLength(1);
+  });
+
+  it("should render SLATE preheader above Production", () => {
+    mockIsProduction = true;
+    render(<Sidebar />);
+    expect(screen.getByText("Slate")).toBeInTheDocument();
+  });
+
+  it("should not repeat SLATE preheader above Business", () => {
+    mockIsProduction = true;
+    mockIsBusinessOps = true;
+    render(<Sidebar />);
+    const slateLabels = screen.getAllByText("Slate");
+    expect(slateLabels).toHaveLength(1);
+  });
+
+  it("should render REGISTER preheader when admin", () => {
+    mockIsAdmin = true;
+    render(<Sidebar />);
+    expect(screen.getByText("Register")).toBeInTheDocument();
+  });
+
+  it("should not render REGISTER preheader when not admin", () => {
+    mockIsAdmin = false;
+    render(<Sidebar />);
+    expect(screen.queryByText("Register")).not.toBeInTheDocument();
+  });
+
+  it("should apply navy sidebar background", () => {
+    render(<Sidebar />);
+    const sidebar = screen.getByRole("navigation").parentElement;
+    expect(sidebar?.className).toMatch(/bg-sidebar-background/);
+  });
+
+  it("should apply copper color to active nav item", () => {
+    mockPathname = "/workspace";
+    render(<Sidebar />);
+    const dashboardLink = screen.getByText("Dashboard").closest("a");
+    expect(dashboardLink?.className).toMatch(/text-sidebar-primary/);
   });
 });

--- a/apps/web/src/components/layout/breadcrumb-bar.tsx
+++ b/apps/web/src/components/layout/breadcrumb-bar.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { ChevronRight } from "lucide-react";
+import { resolveNavContext } from "@/lib/navigation";
+
+export function BreadcrumbBar() {
+  const pathname = usePathname();
+  const context = resolveNavContext(pathname);
+
+  if (!context) return null;
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="flex items-center gap-1.5 px-6 pt-4 pb-0"
+    >
+      <span className="text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground/60">
+        {context.subBrand}
+      </span>
+      <ChevronRight className="h-3 w-3 text-muted-foreground/40" />
+      <span className="text-sm text-muted-foreground">
+        {context.groupLabel}
+      </span>
+      {context.pageName && (
+        <>
+          <ChevronRight className="h-3 w-3 text-muted-foreground/40" />
+          <span className="text-sm text-muted-foreground/80">
+            {context.pageName}
+          </span>
+        </>
+      )}
+    </nav>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -4,14 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { useOrganization } from "@/hooks/use-organization";
-import {
-  writingNavigation,
-  editorialNavigation,
-  productionNavigation,
-  businessNavigation,
-  operationsNavigation,
-  type NavItem,
-} from "@/lib/navigation";
+import { navGroups, type NavItem, type SubBrand } from "@/lib/navigation";
 
 function isActiveLink(pathname: string, href: string): boolean {
   if (href === "/editor") return pathname === "/editor";
@@ -41,11 +34,11 @@ function NavGroup({
 
   return (
     <>
-      {showDivider && <div className="my-4 border-t" />}
+      {showDivider && <div className="my-2 border-t border-sidebar-border" />}
       <p
         className={cn(
           "px-3 text-xs font-semibold uppercase tracking-wider",
-          active ? "text-foreground" : "text-muted-foreground",
+          active ? "text-sidebar-foreground" : "text-sidebar-muted",
         )}
       >
         {label}
@@ -59,8 +52,8 @@ function NavGroup({
             className={cn(
               "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors",
               isActive
-                ? "bg-accent text-accent-foreground"
-                : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                ? "bg-sidebar-accent text-sidebar-primary"
+                : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-primary",
             )}
           >
             <item.icon className="h-4 w-4" />
@@ -72,59 +65,80 @@ function NavGroup({
   );
 }
 
+interface SubBrandPreheaderProps {
+  name: SubBrand;
+  isFirst: boolean;
+}
+
+function SubBrandPreheader({ name, isFirst }: SubBrandPreheaderProps) {
+  return (
+    <p
+      className={cn(
+        "px-3 font-medium text-[11px] uppercase tracking-[0.1em] text-sidebar-muted",
+        isFirst ? "mt-1" : "mt-5",
+        "mb-1",
+      )}
+    >
+      {name}
+    </p>
+  );
+}
+
 export function Sidebar() {
   const pathname = usePathname();
   const { isEditor, isProduction, isBusinessOps, isAdmin } = useOrganization();
 
+  const roleCheck: Record<string, boolean> = {
+    editor: isEditor,
+    production: isProduction,
+    business_ops: isBusinessOps,
+    admin: isAdmin,
+  };
+
+  const visibleGroups = navGroups.filter(
+    (g) => g.role === null || roleCheck[g.role],
+  );
+
+  // Precompute which groups need a sub-brand preheader (first occurrence of each sub-brand)
+  const seen = new Set<SubBrand>();
+  const preheaderFlags = visibleGroups.map((group) => {
+    const show = !seen.has(group.subBrand);
+    seen.add(group.subBrand);
+    return show;
+  });
+
   return (
-    <div className="flex flex-col h-full bg-background">
+    <div className="flex flex-col h-full bg-sidebar-background">
       {/* Header */}
-      <div className="flex h-14 items-center border-b px-4">
-        <Link href="/" className="font-bold text-lg">
+      <div className="flex h-14 items-center border-b border-sidebar-border px-4">
+        <Link href="/" className="font-bold text-lg text-sidebar-foreground">
           Colophony
         </Link>
       </div>
 
       {/* Navigation */}
       <nav className="flex-1 space-y-1 p-2" aria-label="Main navigation">
-        <NavGroup
-          label="Writing"
-          items={writingNavigation}
-          pathname={pathname}
-          showDivider={false}
-        />
+        {visibleGroups.map((group, index) => {
+          const showPreheader = preheaderFlags[index];
+          const isFirstGroup = index === 0;
 
-        {isEditor && (
-          <NavGroup
-            label="Editorial"
-            items={editorialNavigation}
-            pathname={pathname}
-          />
-        )}
-
-        {isProduction && (
-          <NavGroup
-            label="Production"
-            items={productionNavigation}
-            pathname={pathname}
-          />
-        )}
-
-        {isBusinessOps && (
-          <NavGroup
-            label="Business"
-            items={businessNavigation}
-            pathname={pathname}
-          />
-        )}
-
-        {isAdmin && (
-          <NavGroup
-            label="Operations"
-            items={operationsNavigation}
-            pathname={pathname}
-          />
-        )}
+          return (
+            <div key={group.label}>
+              {showPreheader && (
+                <SubBrandPreheader
+                  name={group.subBrand}
+                  isFirst={isFirstGroup}
+                />
+              )}
+              <NavGroup
+                label={group.label}
+                items={[...group.items]}
+                pathname={pathname}
+                showDivider={!showPreheader && !isFirstGroup}
+              />
+            </div>
+          );
+        })}
       </nav>
     </div>
   );

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -109,23 +109,103 @@ export const operationsNavigation: NavItem[] = [
   },
 ];
 
-/** All nav groups with their label and role requirement */
+export type SubBrand = "Hopper" | "Slate" | "Register";
+
+/** All nav groups with their label, role requirement, and sub-brand */
 export const navGroups = [
-  { label: "Writing", items: writingNavigation, role: null },
-  { label: "Editorial", items: editorialNavigation, role: "editor" as const },
+  {
+    label: "Writing",
+    items: writingNavigation,
+    role: null,
+    subBrand: "Hopper" as const,
+  },
+  {
+    label: "Editorial",
+    items: editorialNavigation,
+    role: "editor" as const,
+    subBrand: "Hopper" as const,
+  },
   {
     label: "Production",
     items: productionNavigation,
     role: "production" as const,
+    subBrand: "Slate" as const,
   },
   {
     label: "Business",
     items: businessNavigation,
     role: "business_ops" as const,
+    subBrand: "Slate" as const,
   },
   {
     label: "Operations",
     items: operationsNavigation,
     role: "admin" as const,
+    subBrand: "Register" as const,
   },
 ] as const;
+
+export interface NavContext {
+  subBrand: SubBrand;
+  groupLabel: string;
+  pageName: string | null;
+}
+
+/**
+ * Resolve the navigation context for a given pathname.
+ * Uses longest-prefix matching against nav items.
+ * Returns null if no group matches.
+ */
+export function resolveNavContext(pathname: string): NavContext | null {
+  let bestMatch: {
+    subBrand: SubBrand;
+    groupLabel: string;
+    pageName: string;
+    matchLength: number;
+  } | null = null;
+
+  for (const group of navGroups) {
+    for (const item of group.items) {
+      // Exact match for dashboard routes, prefix match for others
+      const isMatch =
+        pathname === item.href || pathname.startsWith(item.href + "/");
+      if (isMatch && item.href.length > (bestMatch?.matchLength ?? 0)) {
+        bestMatch = {
+          subBrand: group.subBrand,
+          groupLabel: group.label,
+          pageName: item.name,
+          matchLength: item.href.length,
+        };
+      }
+    }
+  }
+
+  if (bestMatch) {
+    return {
+      subBrand: bestMatch.subBrand,
+      groupLabel: bestMatch.groupLabel,
+      pageName: bestMatch.pageName,
+    };
+  }
+
+  // Fallback: check if pathname falls under a group's common prefix
+  // e.g., /editor/something-not-in-nav still belongs to Editorial
+  for (const group of navGroups) {
+    for (const item of group.items) {
+      // Check if the pathname shares a base path with any item in the group
+      const basePath = item.href.split("/").slice(0, 2).join("/");
+      if (
+        basePath.length > 1 &&
+        (pathname === basePath || pathname.startsWith(basePath + "/"))
+      ) {
+        return {
+          subBrand: group.subBrand,
+          groupLabel: group.label,
+          pageName: null,
+        };
+      }
+    }
+  }
+
+  return null;
+}

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -151,9 +151,19 @@ export interface NavContext {
   pageName: string | null;
 }
 
+// Dashboard roots that require exact-match only (same logic as sidebar isActiveLink)
+const exactMatchRoutes = new Set([
+  "/editor",
+  "/slate",
+  "/workspace",
+  "/business",
+  "/operations",
+]);
+
 /**
  * Resolve the navigation context for a given pathname.
- * Uses longest-prefix matching against nav items.
+ * Uses longest-prefix matching against nav items, with exact-match
+ * enforcement for dashboard root routes (same rules as sidebar).
  * Returns null if no group matches.
  */
 export function resolveNavContext(pathname: string): NavContext | null {
@@ -166,9 +176,10 @@ export function resolveNavContext(pathname: string): NavContext | null {
 
   for (const group of navGroups) {
     for (const item of group.items) {
-      // Exact match for dashboard routes, prefix match for others
-      const isMatch =
-        pathname === item.href || pathname.startsWith(item.href + "/");
+      const isExactOnly = exactMatchRoutes.has(item.href);
+      const isMatch = isExactOnly
+        ? pathname === item.href
+        : pathname === item.href || pathname.startsWith(item.href + "/");
       if (isMatch && item.href.length > (bestMatch?.matchLength ?? 0)) {
         bestMatch = {
           subBrand: group.subBrand,

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -168,6 +168,31 @@ Operations                       (ADMIN)
 - **URL-driven.** Each nav item is a route. Browser back/forward works naturally. Bookmarkable. Linkable.
 - **Implicit shell transition.** Navigating from a Writing page to a Reading page changes the layout shell (and therefore density context) via the route's layout component — a Next.js layout boundary, not a mode toggle.
 
+### Sub-brand identity
+
+Colophony's four subsystems (Hopper, Slate, Register, Relay) appear as quiet structural labels in the UI. They provide identity and context without adding navigation friction.
+
+| Sub-brand    | Sidebar groups        | Rationale                                                          |
+| ------------ | --------------------- | ------------------------------------------------------------------ |
+| **Hopper**   | Writing + Editorial   | Full submission lifecycle — writer's side and editor's side        |
+| **Slate**    | Production + Business | Post-acceptance: pipeline, issue assembly, payments, rights        |
+| **Register** | Operations            | Identity, org configuration, federation, system health             |
+| **Relay**    | _(system-level only)_ | Communications infrastructure — docs, architecture, marketing only |
+
+**Sidebar surface:** The sidebar is a permanent dark surface — Deep Navy (`#191c2b`) in both light and dark themes. This anchors the interface and provides a stable background for the sub-brand preheaders.
+
+**Sidebar preheader:** The sub-brand name appears as a subtle preheader above the first activity group within that sub-brand. When a sub-brand spans multiple groups (Hopper → Writing + Editorial), the preheader appears only once above the first group.
+
+Preheader styling:
+
+- Font: Medium weight, 11px, uppercase, letter-spacing 0.1em
+- Color: Muted Cream (`#d8cfc2`) — fainter than group labels
+- Spacing: 16–20px above (separates from previous sub-brand), 4–6px below (tight to its first group)
+
+**Breadcrumb bar:** A layout-level breadcrumb bar renders above page content: `Sub-brand > Group > Page`. Derived automatically from the pathname via `resolveNavContext()` in `navigation.ts`. Uses longest-prefix matching; falls back to group-level context for detail/non-nav routes; renders nothing for unmatched routes.
+
+**Relay exception:** Relay does not appear in the sidebar, breadcrumbs, or page headers. It appears in documentation, architecture diagrams, and marketing. Relay is architecturally real but not a user destination — communications surface inside both Hopper (correspondence) and Register (webhooks).
+
 ### Quick access
 
 - **Recents list** at the top of the sidebar: last 3-5 visited submissions/pages, with Cmd+K command palette for instant jump. Provides the quick-access benefit of tabs without persistent visual weight.
@@ -748,18 +773,20 @@ To avoid migrations when federation sync arrives, the following are present in t
 
 ## Appendix A: Design Decision Log
 
-| Decision               | Choice                                                      | Rationale                                                                                                                                                                           |
-| ---------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Density mechanism      | Layout shells with DensityProvider context                  | Shell -> context -> component gets dependency direction right. Role determines density, not per-component props.                                                                    |
-| Navigation model       | Unified sidebar with 4 activity groups                      | Reading + Editing merged into "Editorial" — split wasn't justified by distinct nav items. Route-driven shell transitions.                                                           |
-| Editor UX model        | Split pane with collapsible list + deep-read mode           | Editors read literature, not emails. The reading pane needs room to breathe. Triage and deep-read are different cognitive modes.                                                    |
-| State visibility       | Role-filtered projections                                   | Writers must not see internal editorial states. Each role sees only states relevant to their decision authority.                                                                    |
-| Writer-facing statuses | Org-configurable names                                      | Different magazines have different transparency cultures. Editorial voice decision, not software decision.                                                                          |
-| Editor workspace       | Generic collection primitive                                | One primitive (named, ordered, annotated collection) replaces holds, bookmarks, comparison sets, reading lists. Let editorial culture determine usage.                              |
-| Typography             | Genre-aware with strong house opinion                       | Render literature like literature. Constrained editor preferences (size, theme, line-height) around exceptional defaults.                                                           |
-| Production view        | Issue-centric with time-visible pipeline                    | Production thinks in issues and deadlines, not submissions. Time pressure must be visible. Prototype multiple approaches.                                                           |
-| Manuscript storage     | ProseMirror JSON with custom literary nodes and marks       | Decouple rendering from source format (.docx, .pdf). Preserve authorial intent. TipTap/ProseMirror already in the stack — extend rather than invent.                                |
-| Private notes          | Always invisible to writers, no toggle                      | An editor's desk reasoning is never submitter-facing. Making it configurable invites mistakes.                                                                                      |
-| Reading position       | Content-anchored (paragraph/char offset), not scroll offset | Scroll offsets break on any layout change (font size, resize, browser update). Content anchors are stable across rendering contexts.                                                |
-| Smart typography       | On by default, bypass per submission, store both forms      | Some writers use straight quotes or double hyphens intentionally. Storing both normalized and original in the intermediate format makes normalization reversible without data loss. |
-| Responsive strategy    | Desktop-first; mobile limited to writer status checks       | Editorial workflows need desktop viewports. Writers check status on mobile. Build responsive for WriterLayout only; defer mobile editorial.                                         |
+| Decision               | Choice                                                                                        | Rationale                                                                                                                                                                           |
+| ---------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Density mechanism      | Layout shells with DensityProvider context                                                    | Shell -> context -> component gets dependency direction right. Role determines density, not per-component props.                                                                    |
+| Navigation model       | Unified sidebar with 5 activity groups                                                        | Reading + Editing merged into "Editorial" — split wasn't justified by distinct nav items. Route-driven shell transitions.                                                           |
+| Editor UX model        | Split pane with collapsible list + deep-read mode                                             | Editors read literature, not emails. The reading pane needs room to breathe. Triage and deep-read are different cognitive modes.                                                    |
+| State visibility       | Role-filtered projections                                                                     | Writers must not see internal editorial states. Each role sees only states relevant to their decision authority.                                                                    |
+| Writer-facing statuses | Org-configurable names                                                                        | Different magazines have different transparency cultures. Editorial voice decision, not software decision.                                                                          |
+| Editor workspace       | Generic collection primitive                                                                  | One primitive (named, ordered, annotated collection) replaces holds, bookmarks, comparison sets, reading lists. Let editorial culture determine usage.                              |
+| Typography             | Genre-aware with strong house opinion                                                         | Render literature like literature. Constrained editor preferences (size, theme, line-height) around exceptional defaults.                                                           |
+| Production view        | Issue-centric with time-visible pipeline                                                      | Production thinks in issues and deadlines, not submissions. Time pressure must be visible. Prototype multiple approaches.                                                           |
+| Manuscript storage     | ProseMirror JSON with custom literary nodes and marks                                         | Decouple rendering from source format (.docx, .pdf). Preserve authorial intent. TipTap/ProseMirror already in the stack — extend rather than invent.                                |
+| Private notes          | Always invisible to writers, no toggle                                                        | An editor's desk reasoning is never submitter-facing. Making it configurable invites mistakes.                                                                                      |
+| Reading position       | Content-anchored (paragraph/char offset), not scroll offset                                   | Scroll offsets break on any layout change (font size, resize, browser update). Content anchors are stable across rendering contexts.                                                |
+| Smart typography       | On by default, bypass per submission, store both forms                                        | Some writers use straight quotes or double hyphens intentionally. Storing both normalized and original in the intermediate format makes normalization reversible without data loss. |
+| Responsive strategy    | Desktop-first; mobile limited to writer status checks                                         | Editorial workflows need desktop viewports. Writers check status on mobile. Build responsive for WriterLayout only; defer mobile editorial.                                         |
+| Sidebar surface        | Permanent dark navy (#191c2b), same in both themes                                            | Anchors the interface. Sub-brand preheaders use Muted Cream on navy. Warm Cream text, copper active states.                                                                         |
+| Sub-brand UI presence  | Sidebar preheader + layout breadcrumb bar (Hopper, Slate, Register). Relay system-level only. | Sub-brands provide identity and context without navigation friction. Preheader is visible but recessive. Relay is infrastructure, not a destination.                                |

--- a/docs/devlog/2026-03.md
+++ b/docs/devlog/2026-03.md
@@ -4,6 +4,27 @@ Newest entries first.
 
 ---
 
+## 2026-03-31 — Sub-Brand UI Treatment
+
+### Done
+
+- Added navy sidebar with branded color tokens (Deep Navy, Warm Cream, Copper, Slate, Muted Cream) — permanent dark surface, same in both themes
+- Added sub-brand preheaders (Hopper, Slate, Register) above first group of each sub-brand in the sidebar
+- Created layout-level BreadcrumbBar component with longest-prefix pathname matching via `resolveNavContext()`
+- Refactored sidebar to iterate `navGroups` with role lookup instead of hardcoding individual group arrays
+- Updated DESIGN_SYSTEM.md Section 4 (sub-brand mapping, preheader specs, breadcrumb format, Relay exception) and Appendix A (2 new decision rows)
+- 35 tests: 8 new sidebar preheader tests, 9 new breadcrumb-bar tests, existing sidebar tests updated for navy classes
+- Codex plan review: 3 Important findings all addressed in implementation (prefix-matching breadcrumbs, layout-level bar instead of per-page, navGroups iteration); 2 Suggestions addressed (browser title deferred, Geist instead of Lato)
+
+### Decisions
+
+- Layout-level breadcrumb bar instead of per-page PageHeader: 59 components have h1 elements, layout-level approach avoids touching any of them
+- Browser title format deferred: route-level `generateMetadata` is the right place, separate concern from sub-brand visual treatment
+- Geist `font-medium` for preheaders: Lato not in font stack; upcoming styling pass can add it and preheader classes won't need changing
+- Relay excluded from UI: architecturally real but not a user destination — communications surface inside Hopper (correspondence) and Register (webhooks)
+
+---
+
 ## 2026-03-31 — @faker-js/faker 8 → 10 Upgrade
 
 ### Done


### PR DESCRIPTION
## Summary

- Add sub-brand identity labels (Hopper, Slate, Register) to the sidebar as preheaders and a layout-level breadcrumb bar
- Restyle sidebar as a permanent dark navy surface with branded color tokens (Deep Navy, Warm Cream, Copper, Slate, Muted Cream)
- Refactor sidebar to iterate `navGroups` with role lookup instead of hardcoding individual group arrays
- Add `resolveNavContext()` with longest-prefix pathname matching and exact-match enforcement for dashboard roots
- Update DESIGN_SYSTEM.md Section 4 and Appendix A with sub-brand mapping, preheader specs, breadcrumb format, and Relay exception

## Test plan

- [ ] 36 unit tests pass (8 sidebar preheader + 10 breadcrumb-bar + 18 existing sidebar)
- [ ] Type-check clean (`pnpm type-check`)
- [ ] Lint clean (`pnpm --filter @colophony/web lint`)
- [ ] Visual QA: Navy sidebar with cream text, copper active states
- [ ] Visual QA: "HOPPER" preheader above Writing, not repeated above Editorial
- [ ] Visual QA: "SLATE" preheader above Production, not repeated above Business
- [ ] Visual QA: "REGISTER" preheader above Operations (admin only)
- [ ] Visual QA: Breadcrumb bar shows on all dashboard pages
- [ ] Visual QA: Detail pages (e.g., `/editor/collections/[id]`) show correct group context
- [ ] Visual QA: Mobile sidebar sheet shows navy + preheaders correctly

## Code Review

- **Plan review (Codex):** 3 Important findings all addressed in implementation (prefix-matching breadcrumbs, layout-level bar instead of per-page, navGroups iteration); 2 Suggestions addressed (browser title deferred, Geist instead of Lato)
- **Branch review (Codex):** 1 P2 finding addressed — exact-match dashboard roots in `resolveNavContext()` to prevent `/editor/123` from matching "Editor Dashboard"