### PR TITLE
feat(web): brand styling pass — palette, fonts, dark mode, status colors, reading themes

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2,30 +2,31 @@
 @import "tw-animate-css";
 
 :root {
-  --background: hsl(0 0% 100%);
-  --foreground: hsl(0 0% 3.9%);
-  --card: hsl(0 0% 100%);
-  --card-foreground: hsl(0 0% 3.9%);
-  --popover: hsl(0 0% 100%);
-  --popover-foreground: hsl(0 0% 3.9%);
-  --primary: hsl(0 0% 9%);
-  --primary-foreground: hsl(0 0% 98%);
-  --secondary: hsl(0 0% 96.1%);
-  --secondary-foreground: hsl(0 0% 9%);
-  --muted: hsl(0 0% 96.1%);
-  --muted-foreground: hsl(0 0% 45.1%);
-  --accent: hsl(0 0% 96.1%);
-  --accent-foreground: hsl(0 0% 9%);
-  --destructive: hsl(0 84.2% 60.2%);
-  --destructive-foreground: hsl(0 0% 98%);
-  --border: hsl(0 0% 89.8%);
-  --input: hsl(0 0% 89.8%);
-  --ring: hsl(0 0% 3.9%);
-  --chart-1: hsl(12 76% 61%);
-  --chart-2: hsl(173 58% 39%);
-  --chart-3: hsl(197 37% 24%);
-  --chart-4: hsl(43 74% 66%);
-  --chart-5: hsl(27 87% 67%);
+  /* Brand palette — Warm Cream / Near Black / Deep Navy / Copper */
+  --background: hsl(42 47% 89%);
+  --foreground: hsl(0 0% 7%);
+  --card: hsl(41 35% 91%);
+  --card-foreground: hsl(0 0% 7%);
+  --popover: hsl(41 35% 91%);
+  --popover-foreground: hsl(0 0% 7%);
+  --primary: hsl(230 27% 13%);
+  --primary-foreground: hsl(42 47% 89%);
+  --secondary: hsl(41 35% 91%);
+  --secondary-foreground: hsl(0 0% 7%);
+  --muted: hsl(35 24% 86%);
+  --muted-foreground: hsl(37 9% 44%);
+  --accent: hsl(25 55% 52%);
+  --accent-foreground: hsl(42 47% 89%);
+  --destructive: hsl(11 52% 47%);
+  --destructive-foreground: hsl(42 47% 89%);
+  --border: hsl(35 22% 80%);
+  --input: hsl(35 22% 80%);
+  --ring: hsl(25 55% 52%);
+  --chart-1: hsl(230 27% 13%);
+  --chart-2: hsl(25 55% 52%);
+  --chart-3: hsl(140 25% 33%);
+  --chart-4: hsl(38 65% 45%);
+  --chart-5: hsl(206 25% 48%);
   --radius: 0.5rem;
   /* Sidebar — permanent dark surface (same in both themes) */
   --sidebar-background: 230 26.5% 13.3%;
@@ -34,33 +35,47 @@
   --sidebar-accent: 213.3 17.9% 29.6%;
   --sidebar-border: 213.3 17.9% 29.6%;
   --sidebar-muted: 35.5 22% 80.4%;
+  /* Semantic status colors */
+  --status-success: hsl(140 25% 33%);
+  --status-success-foreground: hsl(42 47% 89%);
+  --status-warning: hsl(38 65% 38%);
+  --status-warning-foreground: hsl(0 0% 7%);
+  --status-error: hsl(11 52% 47%);
+  --status-error-foreground: hsl(42 47% 89%);
+  --status-info: hsl(35 9% 55%);
+  --status-info-foreground: hsl(0 0% 7%);
+  --status-active: hsl(25 55% 52%);
+  --status-active-foreground: hsl(42 47% 89%);
+  --status-held: hsl(206 25% 48%);
+  --status-held-foreground: hsl(42 47% 89%);
 }
 
 .dark {
-  --background: hsl(0 0% 3.9%);
-  --foreground: hsl(0 0% 98%);
-  --card: hsl(0 0% 3.9%);
-  --card-foreground: hsl(0 0% 98%);
-  --popover: hsl(0 0% 3.9%);
-  --popover-foreground: hsl(0 0% 98%);
-  --primary: hsl(0 0% 98%);
-  --primary-foreground: hsl(0 0% 9%);
-  --secondary: hsl(0 0% 14.9%);
-  --secondary-foreground: hsl(0 0% 98%);
-  --muted: hsl(0 0% 14.9%);
-  --muted-foreground: hsl(0 0% 63.9%);
-  --accent: hsl(0 0% 14.9%);
-  --accent-foreground: hsl(0 0% 98%);
-  --destructive: hsl(0 62.8% 30.6%);
-  --destructive-foreground: hsl(0 0% 98%);
-  --border: hsl(0 0% 14.9%);
-  --input: hsl(0 0% 14.9%);
-  --ring: hsl(0 0% 83.1%);
-  --chart-1: hsl(220 70% 50%);
-  --chart-2: hsl(160 60% 45%);
-  --chart-3: hsl(30 80% 55%);
-  --chart-4: hsl(280 65% 60%);
-  --chart-5: hsl(340 75% 55%);
+  /* Dark theme — Deep Navy background, Warm Cream foreground */
+  --background: hsl(230 27% 13%);
+  --foreground: hsl(42 47% 89%);
+  --card: hsl(228 22% 19%);
+  --card-foreground: hsl(42 47% 89%);
+  --popover: hsl(228 22% 19%);
+  --popover-foreground: hsl(42 47% 89%);
+  --primary: hsl(42 47% 89%);
+  --primary-foreground: hsl(230 27% 13%);
+  --secondary: hsl(213 18% 30%);
+  --secondary-foreground: hsl(42 47% 89%);
+  --muted: hsl(222 18% 22%);
+  --muted-foreground: hsl(35 22% 80%);
+  --accent: hsl(25 55% 52%);
+  --accent-foreground: hsl(42 47% 89%);
+  --destructive: hsl(11 55% 55%);
+  --destructive-foreground: hsl(42 47% 89%);
+  --border: hsl(213 18% 30%);
+  --input: hsl(213 18% 30%);
+  --ring: hsl(25 55% 52%);
+  --chart-1: hsl(230 30% 65%);
+  --chart-2: hsl(25 60% 60%);
+  --chart-3: hsl(140 30% 55%);
+  --chart-4: hsl(38 60% 60%);
+  --chart-5: hsl(206 30% 60%);
   /* Sidebar — permanent dark surface (same in both themes) */
   --sidebar-background: 230 26.5% 13.3%;
   --sidebar-foreground: 42.2 47.4% 88.8%;
@@ -68,6 +83,12 @@
   --sidebar-accent: 213.3 17.9% 29.6%;
   --sidebar-border: 213.3 17.9% 29.6%;
   --sidebar-muted: 35.5 22% 80.4%;
+  /* Semantic status colors — lightened for dark backgrounds */
+  --status-success: hsl(140 30% 55%);
+  --status-warning: hsl(38 55% 60%);
+  --status-error: hsl(11 55% 58%);
+  --status-info: hsl(35 12% 65%);
+  --status-held: hsl(206 30% 60%);
 }
 
 @theme inline {
@@ -101,12 +122,46 @@
   --color-sidebar-accent: hsl(var(--sidebar-accent));
   --color-sidebar-border: hsl(var(--sidebar-border));
   --color-sidebar-muted: hsl(var(--sidebar-muted));
+  --color-status-success: var(--status-success);
+  --color-status-success-foreground: var(--status-success-foreground);
+  --color-status-warning: var(--status-warning);
+  --color-status-warning-foreground: var(--status-warning-foreground);
+  --color-status-error: var(--status-error);
+  --color-status-error-foreground: var(--status-error-foreground);
+  --color-status-info: var(--status-info);
+  --color-status-info-foreground: var(--status-info-foreground);
+  --color-status-active: var(--status-active);
+  --color-status-active-foreground: var(--status-active-foreground);
+  --color-status-held: var(--status-held);
+  --color-status-held-foreground: var(--status-held-foreground);
+  --color-reading-bg: var(--reading-bg);
+  --color-reading-fg: var(--reading-fg);
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
 }
 
 @custom-variant dark (&:is(.dark *));
+
+/* Reading themes — scoped to ManuscriptRenderer via data attribute */
+[data-reading-theme="light"] {
+  --reading-bg: hsl(42 47% 89%);
+  --reading-fg: hsl(0 0% 7%);
+}
+
+[data-reading-theme="sepia"] {
+  --reading-bg: hsl(36 35% 85%);
+  --reading-fg: hsl(18 12% 15%);
+}
+
+[data-reading-theme="dark"] {
+  --reading-bg: hsl(230 27% 13%);
+  --reading-fg: hsl(35 22% 80%);
+}
+
+[data-reading-theme] {
+  transition: background-color 150ms ease, color 150ms ease;
+}
 
 /* Density tokens — scoped via data-density attribute set by DensityProvider */
 [data-density="comfortable"] {
@@ -166,5 +221,9 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-family: var(--font-lato), ui-sans-serif, system-ui, sans-serif;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-playfair), ui-serif, Georgia, serif;
   }
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,17 +1,7 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { playfairDisplay, lato } from "@/lib/fonts";
 import "./globals.css";
 import { Providers } from "@/components/providers";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Colophony - Submissions Platform",
@@ -24,9 +14,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${playfairDisplay.variable} ${lato.variable} antialiased`}
       >
         <Providers>{children}</Providers>
       </body>

--- a/apps/web/src/components/analytics/editorial/pipeline-health-chart.tsx
+++ b/apps/web/src/components/analytics/editorial/pipeline-health-chart.tsx
@@ -82,7 +82,9 @@ export function PipelineHealthChart({ filter }: PipelineHealthChartProps) {
                       </p>
                       <p
                         className={
-                          d.stuckCount > 0 ? "text-red-500 font-medium" : ""
+                          d.stuckCount > 0
+                            ? "text-status-error font-medium"
+                            : ""
                         }
                       >
                         Stuck (&gt;14d): {d.stuckCount}

--- a/apps/web/src/components/analytics/editorial/reader-alignment-table.tsx
+++ b/apps/web/src/components/analytics/editorial/reader-alignment-table.tsx
@@ -76,9 +76,9 @@ export function ReaderAlignmentTable({ filter }: ReaderAlignmentTableProps) {
                     <td className="py-2 pr-4 text-right">{row.voteCount}</td>
                     <td className="py-2 text-center">
                       {row.matched ? (
-                        <span className="text-green-600">Yes</span>
+                        <span className="text-status-success">Yes</span>
                       ) : (
-                        <span className="text-red-500">No</span>
+                        <span className="text-status-error">No</span>
                       )}
                     </td>
                   </tr>

--- a/apps/web/src/components/editor/detail-pane.tsx
+++ b/apps/web/src/components/editor/detail-pane.tsx
@@ -9,6 +9,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { BookOpen, Loader2, AlertCircle } from "lucide-react";
+import { ReadingThemeSelector } from "@/components/manuscripts/reading-theme-selector";
 import type { ProseMirrorDoc } from "@colophony/types";
 import { useCallback, useState } from "react";
 
@@ -150,21 +151,24 @@ function DeepReadView({
                 </p>
               )}
             </div>
-            {hasSmartTextMarks && (
-              <div className="flex items-center gap-2">
-                <Switch
-                  id="show-as-submitted"
-                  checked={showAsSubmitted}
-                  onCheckedChange={setShowAsSubmitted}
-                />
-                <Label
-                  htmlFor="show-as-submitted"
-                  className="text-xs text-muted-foreground"
-                >
-                  As submitted
-                </Label>
-              </div>
-            )}
+            <div className="flex items-center gap-4">
+              <ReadingThemeSelector />
+              {hasSmartTextMarks && (
+                <div className="flex items-center gap-2">
+                  <Switch
+                    id="show-as-submitted"
+                    checked={showAsSubmitted}
+                    onCheckedChange={setShowAsSubmitted}
+                  />
+                  <Label
+                    htmlFor="show-as-submitted"
+                    className="text-xs text-muted-foreground"
+                  >
+                    As submitted
+                  </Label>
+                </div>
+              )}
+            </div>
           </div>
 
           {/* Extraction status (transient states only) */}

--- a/apps/web/src/components/editor/triage-list.tsx
+++ b/apps/web/src/components/editor/triage-list.tsx
@@ -207,13 +207,11 @@ function AgeBadge({
   if (TERMINAL_STATUSES.has(status) || !submittedAt) return null;
 
   const days = differenceInDays(new Date(), new Date(submittedAt));
-  let colorClass =
-    "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300";
+  let colorClass = "bg-status-success/10 text-status-success";
   if (days > 30) {
-    colorClass = "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300";
+    colorClass = "bg-status-error/10 text-status-error";
   } else if (days >= 14) {
-    colorClass =
-      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300";
+    colorClass = "bg-status-warning/10 text-status-warning";
   }
 
   return (

--- a/apps/web/src/components/embed/embed-resubmit.tsx
+++ b/apps/web/src/components/embed/embed-resubmit.tsx
@@ -207,7 +207,7 @@ export function EmbedResubmit({ statusToken, apiUrl }: EmbedResubmitProps) {
   if (step === "success") {
     return (
       <div className="max-w-md mx-auto text-center py-16 px-4">
-        <CheckCircle className="h-12 w-12 text-green-600 mx-auto mb-4" />
+        <CheckCircle className="h-12 w-12 text-status-success mx-auto mb-4" />
         <h2 className="text-lg font-semibold">Resubmission Received</h2>
         <p className="text-sm text-muted-foreground mt-2">
           Your revised manuscript has been submitted successfully. A new
@@ -258,11 +258,11 @@ export function EmbedResubmit({ statusToken, apiUrl }: EmbedResubmitProps) {
 
         {/* Revision Notes */}
         {context?.revisionNotes && (
-          <div className="rounded-md bg-blue-50 p-4">
-            <p className="text-xs font-medium text-blue-800 uppercase tracking-wide mb-1">
+          <div className="rounded-md bg-status-info/5 p-4">
+            <p className="text-xs font-medium text-status-info uppercase tracking-wide mb-1">
               Editor&apos;s Revision Notes
             </p>
-            <p className="text-sm text-blue-900 whitespace-pre-wrap">
+            <p className="text-sm whitespace-pre-wrap">
               {context.revisionNotes}
             </p>
           </div>
@@ -331,7 +331,7 @@ export function EmbedResubmit({ statusToken, apiUrl }: EmbedResubmitProps) {
               {u.progress < 100 ? (
                 <Progress value={u.progress} className="w-20 h-2" />
               ) : (
-                <CheckCircle className="h-4 w-4 text-green-600 shrink-0" />
+                <CheckCircle className="h-4 w-4 text-status-success shrink-0" />
               )}
             </div>
           ))}
@@ -372,14 +372,20 @@ function ScanBadge({ status }: { status: string }) {
   switch (status) {
     case "CLEAN":
       return (
-        <Badge variant="outline" className="bg-green-100 text-green-800 gap-1">
+        <Badge
+          variant="outline"
+          className="bg-status-success/10 text-status-success gap-1"
+        >
           <CheckCircle className="h-3 w-3" />
           Clean
         </Badge>
       );
     case "INFECTED":
       return (
-        <Badge variant="outline" className="bg-red-100 text-red-800 gap-1">
+        <Badge
+          variant="outline"
+          className="bg-status-error/10 text-status-error gap-1"
+        >
           <AlertCircle className="h-3 w-3" />
           Infected
         </Badge>
@@ -388,7 +394,7 @@ function ScanBadge({ status }: { status: string }) {
       return (
         <Badge
           variant="outline"
-          className="bg-yellow-100 text-yellow-800 gap-1"
+          className="bg-status-info/10 text-status-info gap-1"
         >
           <Loader2 className="h-3 w-3 animate-spin" />
           Scanning
@@ -396,7 +402,10 @@ function ScanBadge({ status }: { status: string }) {
       );
     default:
       return (
-        <Badge variant="outline" className="bg-gray-100 text-gray-800 gap-1">
+        <Badge
+          variant="outline"
+          className="bg-status-info/10 text-status-info gap-1"
+        >
           <Clock className="h-3 w-3" />
           Pending
         </Badge>

--- a/apps/web/src/components/embed/embed-status-check.tsx
+++ b/apps/web/src/components/embed/embed-status-check.tsx
@@ -33,13 +33,13 @@ const WRITER_STATUS_ICONS: Record<
 };
 
 const WRITER_STATUS_COLORS: Record<WriterStatus, string> = {
-  DRAFT: "bg-gray-100 text-gray-800",
-  RECEIVED: "bg-blue-100 text-blue-800",
-  IN_REVIEW: "bg-yellow-100 text-yellow-800",
-  REVISION_REQUESTED: "bg-amber-100 text-amber-800",
-  ACCEPTED: "bg-green-100 text-green-800",
-  DECISION_SENT: "bg-slate-100 text-slate-600",
-  WITHDRAWN: "bg-gray-100 text-gray-800",
+  DRAFT: "bg-status-info/10 text-status-info",
+  RECEIVED: "bg-status-info/10 text-status-info",
+  IN_REVIEW: "bg-status-info/10 text-status-info",
+  REVISION_REQUESTED: "bg-status-warning/10 text-status-warning",
+  ACCEPTED: "bg-status-success/10 text-status-success",
+  DECISION_SENT: "bg-status-info/10 text-status-info",
+  WITHDRAWN: "bg-status-held/10 text-status-held",
 };
 
 interface EmbedStatusCheckProps {
@@ -132,7 +132,8 @@ export function EmbedStatusCheck({
 
   const StatusIcon = WRITER_STATUS_ICONS[data.writerStatus] ?? Clock;
   const statusColor =
-    WRITER_STATUS_COLORS[data.writerStatus] ?? "bg-yellow-100 text-yellow-800";
+    WRITER_STATUS_COLORS[data.writerStatus] ??
+    "bg-status-warning/10 text-status-warning";
 
   return (
     <div className="max-w-md mx-auto py-12 px-4">

--- a/apps/web/src/components/embed/embed-success.tsx
+++ b/apps/web/src/components/embed/embed-success.tsx
@@ -17,7 +17,7 @@ export function EmbedSuccess({
 
   return (
     <div className="flex flex-col items-center text-center py-8 space-y-4">
-      <CheckCircle className="h-16 w-16 text-green-600" />
+      <CheckCircle className="h-16 w-16 text-status-success" />
       <div>
         <h2 className="text-xl font-semibold">Submission Received</h2>
         <p className="text-sm text-muted-foreground mt-2">

--- a/apps/web/src/components/embed/embed-upload-section.tsx
+++ b/apps/web/src/components/embed/embed-upload-section.tsx
@@ -45,27 +45,27 @@ const scanStatusConfig: Record<
   PENDING: {
     label: "Pending scan",
     icon: Clock,
-    className: "bg-gray-100 text-gray-800",
+    className: "bg-status-info/10 text-status-info",
   },
   SCANNING: {
     label: "Scanning...",
     icon: Loader2,
-    className: "bg-blue-100 text-blue-800",
+    className: "bg-status-info/10 text-status-info",
   },
   CLEAN: {
     label: "Clean",
     icon: CheckCircle,
-    className: "bg-green-100 text-green-800",
+    className: "bg-status-success/10 text-status-success",
   },
   INFECTED: {
     label: "Infected",
     icon: AlertCircle,
-    className: "bg-red-100 text-red-800",
+    className: "bg-status-error/10 text-status-error",
   },
   FAILED: {
     label: "Scan failed",
     icon: AlertCircle,
-    className: "bg-orange-100 text-orange-800",
+    className: "bg-status-held/10 text-status-held",
   },
 };
 
@@ -303,7 +303,7 @@ export function EmbedUploadSection({
         {scannedFiles.some(
           (f) => f.scanStatus === "PENDING" || f.scanStatus === "SCANNING",
         ) && (
-          <p className="text-sm text-yellow-600 dark:text-yellow-400">
+          <p className="text-sm text-status-warning">
             Files are being scanned. You can submit after all scans complete.
           </p>
         )}

--- a/apps/web/src/components/embed/response-time-display.tsx
+++ b/apps/web/src/components/embed/response-time-display.tsx
@@ -43,7 +43,7 @@ function TrendIndicator({
 
   if (diff < 0) {
     return (
-      <span className="inline-flex items-center gap-1 text-xs text-green-600">
+      <span className="inline-flex items-center gap-1 text-xs text-status-success">
         <TrendingDown className="h-3 w-3" />
         Getting faster
       </span>
@@ -51,7 +51,7 @@ function TrendIndicator({
   }
 
   return (
-    <span className="inline-flex items-center gap-1 text-xs text-amber-600">
+    <span className="inline-flex items-center gap-1 text-xs text-status-warning">
       <TrendingUp className="h-3 w-3" />
       Getting slower
     </span>

--- a/apps/web/src/components/federation/__tests__/peer-list.spec.tsx
+++ b/apps/web/src/components/federation/__tests__/peer-list.spec.tsx
@@ -130,8 +130,8 @@ describe("PeerList", () => {
     render(<PeerList />);
     const dots = document.querySelectorAll(".rounded-full");
     const classes = Array.from(dots).map((d) => d.className);
-    expect(classes.some((c) => c.includes("bg-green-500"))).toBe(true);
-    expect(classes.some((c) => c.includes("bg-yellow-500"))).toBe(true);
+    expect(classes.some((c) => c.includes("bg-status-success"))).toBe(true);
+    expect(classes.some((c) => c.includes("bg-status-warning"))).toBe(true);
   });
 
   it("Initiate Trust button renders for admin users", () => {

--- a/apps/web/src/components/federation/federation-overview.tsx
+++ b/apps/web/src/components/federation/federation-overview.tsx
@@ -122,7 +122,7 @@ export function FederationOverview() {
                 {config?.enabled ? (
                   <Badge
                     variant="outline"
-                    className="border-green-500 text-green-700"
+                    className="border-status-success text-status-success"
                   >
                     Enabled
                   </Badge>
@@ -286,7 +286,7 @@ export function FederationOverview() {
             <div className="flex items-center gap-2">
               <Badge
                 variant="outline"
-                className="border-green-500 text-green-700"
+                className="border-status-success text-status-success"
               >
                 {peerCounts.active} Active
               </Badge>
@@ -294,7 +294,7 @@ export function FederationOverview() {
             <div className="flex items-center gap-2">
               <Badge
                 variant="outline"
-                className="border-yellow-500 text-yellow-700"
+                className="border-status-warning text-status-warning"
               >
                 {peerCounts.pendingInbound} Pending Inbound
               </Badge>
@@ -302,7 +302,7 @@ export function FederationOverview() {
             <div className="flex items-center gap-2">
               <Badge
                 variant="outline"
-                className="border-yellow-500 text-yellow-700"
+                className="border-status-warning text-status-warning"
               >
                 {peerCounts.pendingOutbound} Pending Outbound
               </Badge>

--- a/apps/web/src/components/federation/hub-admin.tsx
+++ b/apps/web/src/components/federation/hub-admin.tsx
@@ -27,9 +27,9 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { format } from "date-fns";
 
 const STATUS_COLORS: Record<string, string> = {
-  active: "border-green-500 text-green-700",
-  suspended: "border-yellow-500 text-yellow-700",
-  revoked: "border-red-500 text-red-700",
+  active: "border-status-success text-status-success",
+  suspended: "border-status-warning text-status-warning",
+  revoked: "border-status-error text-status-error",
 };
 
 type Tab = "all" | "active" | "suspended" | "revoked";

--- a/apps/web/src/components/federation/hub-instance-detail.tsx
+++ b/apps/web/src/components/federation/hub-instance-detail.tsx
@@ -22,9 +22,9 @@ import { toast } from "sonner";
 import { format } from "date-fns";
 
 const STATUS_COLORS: Record<string, string> = {
-  active: "border-green-500 text-green-700",
-  suspended: "border-yellow-500 text-yellow-700",
-  revoked: "border-red-500 text-red-700",
+  active: "border-status-success text-status-success",
+  suspended: "border-status-warning text-status-warning",
+  revoked: "border-status-error text-status-error",
 };
 
 interface HubInstanceDetailProps {

--- a/apps/web/src/components/federation/migration-detail.tsx
+++ b/apps/web/src/components/federation/migration-detail.tsx
@@ -22,16 +22,16 @@ import { toast } from "sonner";
 import { format } from "date-fns";
 
 const STATUS_COLORS: Record<string, string> = {
-  PENDING: "border-yellow-500 text-yellow-700",
-  PENDING_APPROVAL: "border-orange-500 text-orange-700",
-  APPROVED: "border-blue-500 text-blue-700",
-  BUNDLE_SENT: "border-blue-500 text-blue-700",
-  PROCESSING: "border-blue-500 text-blue-700",
-  COMPLETED: "border-green-500 text-green-700",
-  REJECTED: "border-red-500 text-red-700",
-  FAILED: "border-red-500 text-red-700",
-  EXPIRED: "border-gray-400 text-gray-600",
-  CANCELLED: "border-gray-400 text-gray-600",
+  PENDING: "border-status-warning text-status-warning",
+  PENDING_APPROVAL: "border-status-held text-status-held",
+  APPROVED: "border-status-info text-status-info",
+  BUNDLE_SENT: "border-status-info text-status-info",
+  PROCESSING: "border-status-info text-status-info",
+  COMPLETED: "border-status-success text-status-success",
+  REJECTED: "border-status-error text-status-error",
+  FAILED: "border-status-error text-status-error",
+  EXPIRED: "border-status-info text-status-info",
+  CANCELLED: "border-status-info text-status-info",
 };
 
 const TERMINAL_STATUSES = new Set([

--- a/apps/web/src/components/federation/migration-list.tsx
+++ b/apps/web/src/components/federation/migration-list.tsx
@@ -34,21 +34,21 @@ import {
 import { format } from "date-fns";
 
 const STATUS_COLORS: Record<string, string> = {
-  PENDING: "border-yellow-500 text-yellow-700",
-  PENDING_APPROVAL: "border-orange-500 text-orange-700",
-  APPROVED: "border-blue-500 text-blue-700",
-  BUNDLE_SENT: "border-blue-500 text-blue-700",
-  PROCESSING: "border-blue-500 text-blue-700",
-  COMPLETED: "border-green-500 text-green-700",
-  REJECTED: "border-red-500 text-red-700",
-  FAILED: "border-red-500 text-red-700",
-  EXPIRED: "border-gray-400 text-gray-600",
-  CANCELLED: "border-gray-400 text-gray-600",
+  PENDING: "border-status-warning text-status-warning",
+  PENDING_APPROVAL: "border-status-held text-status-held",
+  APPROVED: "border-status-info text-status-info",
+  BUNDLE_SENT: "border-status-info text-status-info",
+  PROCESSING: "border-status-info text-status-info",
+  COMPLETED: "border-status-success text-status-success",
+  REJECTED: "border-status-error text-status-error",
+  FAILED: "border-status-error text-status-error",
+  EXPIRED: "border-status-info text-status-info",
+  CANCELLED: "border-status-info text-status-info",
 };
 
 const DIRECTION_COLORS: Record<string, string> = {
-  inbound: "border-blue-500 text-blue-700",
-  outbound: "border-purple-500 text-purple-700",
+  inbound: "border-status-info text-status-info",
+  outbound: "border-status-held text-status-held",
 };
 
 type Tab =
@@ -110,10 +110,10 @@ export function MigrationList() {
 
       {/* Pending approval banner */}
       {pendingApproval && pendingApproval.length > 0 && (
-        <Card className="border-orange-200 bg-orange-50">
+        <Card className="border-status-held/30 bg-status-held/10">
           <CardContent className="flex items-center gap-3 py-3">
-            <AlertTriangle className="h-5 w-5 text-orange-600" />
-            <p className="text-sm text-orange-800">
+            <AlertTriangle className="h-5 w-5 text-status-held" />
+            <p className="text-sm text-status-held">
               <strong>{pendingApproval.length}</strong> migration
               {pendingApproval.length === 1 ? "" : "s"} pending your approval
             </p>

--- a/apps/web/src/components/federation/peer-list.tsx
+++ b/apps/web/src/components/federation/peer-list.tsx
@@ -22,11 +22,11 @@ import { InitiateTrustDialog } from "./initiate-trust-dialog";
 import { formatDistanceToNow } from "date-fns";
 
 const PEER_STATUS_COLORS: Record<string, string> = {
-  active: "bg-green-500",
-  pending_outbound: "bg-yellow-500",
-  pending_inbound: "bg-amber-500",
-  rejected: "bg-red-500",
-  revoked: "bg-red-500",
+  active: "bg-status-success",
+  pending_outbound: "bg-status-warning",
+  pending_inbound: "bg-status-warning",
+  rejected: "bg-status-error",
+  revoked: "bg-status-error",
 };
 
 const STATUS_LABELS: Record<string, string> = {
@@ -142,7 +142,7 @@ export function PeerList() {
                       <TableCell>
                         <div className="flex items-center gap-2">
                           <span
-                            className={`inline-block h-2 w-2 rounded-full ${PEER_STATUS_COLORS[peer.status] ?? "bg-gray-400"}`}
+                            className={`inline-block h-2 w-2 rounded-full ${PEER_STATUS_COLORS[peer.status] ?? "bg-status-info"}`}
                           />
                           {STATUS_LABELS[peer.status] ?? peer.status}
                         </div>

--- a/apps/web/src/components/federation/sim-sub-admin.tsx
+++ b/apps/web/src/components/federation/sim-sub-admin.tsx
@@ -38,10 +38,10 @@ import { toast } from "sonner";
 import { format } from "date-fns";
 
 const RESULT_COLORS: Record<string, string> = {
-  CLEAR: "border-green-500 text-green-700",
-  CONFLICT: "border-red-500 text-red-700",
-  PARTIAL: "border-yellow-500 text-yellow-700",
-  SKIPPED: "border-gray-400 text-gray-600",
+  CLEAR: "border-status-success text-status-success",
+  CONFLICT: "border-status-error text-status-error",
+  PARTIAL: "border-status-warning text-status-warning",
+  SKIPPED: "border-status-info text-status-info",
 };
 
 export function SimSubAdmin() {

--- a/apps/web/src/components/federation/transfer-detail.tsx
+++ b/apps/web/src/components/federation/transfer-detail.tsx
@@ -30,13 +30,13 @@ import { toast } from "sonner";
 import { format } from "date-fns";
 
 const STATUS_COLORS: Record<string, string> = {
-  PENDING: "border-yellow-500 text-yellow-700",
-  FILES_REQUESTED: "border-blue-500 text-blue-700",
-  COMPLETED: "border-green-500 text-green-700",
-  REJECTED: "border-red-500 text-red-700",
-  FAILED: "border-red-500 text-red-700",
-  CANCELLED: "border-gray-400 text-gray-600",
-  EXPIRED: "border-gray-400 text-gray-600",
+  PENDING: "border-status-warning text-status-warning",
+  FILES_REQUESTED: "border-status-info text-status-info",
+  COMPLETED: "border-status-success text-status-success",
+  REJECTED: "border-status-error text-status-error",
+  FAILED: "border-status-error text-status-error",
+  CANCELLED: "border-status-info text-status-info",
+  EXPIRED: "border-status-info text-status-info",
 };
 
 const CANCELLABLE_STATUSES = new Set(["PENDING", "FILES_REQUESTED"]);

--- a/apps/web/src/components/federation/transfer-list.tsx
+++ b/apps/web/src/components/federation/transfer-list.tsx
@@ -21,13 +21,13 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { format } from "date-fns";
 
 const STATUS_COLORS: Record<string, string> = {
-  PENDING: "border-yellow-500 text-yellow-700",
-  FILES_REQUESTED: "border-blue-500 text-blue-700",
-  COMPLETED: "border-green-500 text-green-700",
-  REJECTED: "border-red-500 text-red-700",
-  FAILED: "border-red-500 text-red-700",
-  CANCELLED: "border-gray-400 text-gray-600",
-  EXPIRED: "border-gray-400 text-gray-600",
+  PENDING: "border-status-warning text-status-warning",
+  FILES_REQUESTED: "border-status-info text-status-info",
+  COMPLETED: "border-status-success text-status-success",
+  REJECTED: "border-status-error text-status-error",
+  FAILED: "border-status-error text-status-error",
+  CANCELLED: "border-status-info text-status-info",
+  EXPIRED: "border-status-info text-status-info",
 };
 
 type Tab = "all" | "pending" | "completed" | "failed";

--- a/apps/web/src/components/form-builder/form-status-badge.tsx
+++ b/apps/web/src/components/form-builder/form-status-badge.tsx
@@ -13,19 +13,17 @@ const statusConfig: Record<
 > = {
   DRAFT: {
     label: "Draft",
-    className: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+    className: "bg-status-info/10 text-status-info",
     icon: FileEdit,
   },
   PUBLISHED: {
     label: "Published",
-    className:
-      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    className: "bg-status-success/10 text-status-success",
     icon: CheckCircle,
   },
   ARCHIVED: {
     label: "Archived",
-    className:
-      "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
+    className: "bg-status-held/10 text-status-held",
     icon: Archive,
   },
 };

--- a/apps/web/src/components/form-builder/sortable-field-item.tsx
+++ b/apps/web/src/components/form-builder/sortable-field-item.tsx
@@ -73,7 +73,7 @@ export function SortableFieldItem({
         "flex items-center gap-2 rounded-lg border p-3 bg-background transition-colors",
         isSelected && "ring-2 ring-primary border-primary",
         isDragging && "opacity-50",
-        field.branchId && "ml-4 border-l-2 border-l-blue-400",
+        field.branchId && "ml-4 border-l-2 border-l-status-info",
       )}
     >
       <button
@@ -91,7 +91,7 @@ export function SortableFieldItem({
         type="button"
       >
         {field.hasBranching ? (
-          <GitBranch className="h-4 w-4 text-blue-500 shrink-0" />
+          <GitBranch className="h-4 w-4 text-status-info shrink-0" />
         ) : (
           <Icon className="h-4 w-4 text-muted-foreground shrink-0" />
         )}

--- a/apps/web/src/components/layout/__tests__/sidebar.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/sidebar.spec.tsx
@@ -98,16 +98,12 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const submissionsLink = screen.getByText("My Submissions").closest("a");
-    // Active: has "bg-sidebar-accent" as a standalone class
-    expect(submissionsLink?.className).toMatch(
-      /(?:^|\s)bg-sidebar-accent(?:\s|$)/,
-    );
+    // Active: has copper border
+    expect(submissionsLink?.className).toMatch(/border-sidebar-primary/);
 
     const settingsLink = screen.getByText("Settings").closest("a");
-    // Inactive: should NOT have standalone "bg-sidebar-accent" (hover: is fine)
-    expect(settingsLink?.className).not.toMatch(
-      /(?:^|\s)bg-sidebar-accent(?:\s|$)/,
-    );
+    // Inactive: should NOT have copper border
+    expect(settingsLink?.className).not.toMatch(/border-sidebar-primary/);
   });
 
   it("should apply active class to settings when on settings path", () => {
@@ -115,9 +111,7 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const settingsLink = screen.getByText("Settings").closest("a");
-    expect(settingsLink?.className).toMatch(
-      /(?:^|\s)bg-sidebar-accent(?:\s|$)/,
-    );
+    expect(settingsLink?.className).toMatch(/border-sidebar-primary/);
   });
 
   it("should render Colophony brand link", () => {
@@ -153,13 +147,11 @@ describe("Sidebar", () => {
 
     const dashboardLink = screen.getByText("Editor Dashboard").closest("a");
     // /editor uses exact match — should NOT be active on /editor/forms
-    expect(dashboardLink?.className).not.toMatch(
-      /(?:^|\s)bg-sidebar-accent(?:\s|$)/,
-    );
+    expect(dashboardLink?.className).not.toMatch(/border-sidebar-primary/);
 
     const formsLink = screen.getByText("Forms").closest("a");
     // /editor/forms uses startsWith — should be active
-    expect(formsLink?.className).toMatch(/(?:^|\s)bg-sidebar-accent(?:\s|$)/);
+    expect(formsLink?.className).toMatch(/border-sidebar-primary/);
   });
 
   it("should highlight Editor Dashboard only on exact /editor path", () => {
@@ -168,9 +160,7 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const dashboardLink = screen.getByText("Editor Dashboard").closest("a");
-    expect(dashboardLink?.className).toMatch(
-      /(?:^|\s)bg-sidebar-accent(?:\s|$)/,
-    );
+    expect(dashboardLink?.className).toMatch(/border-sidebar-primary/);
   });
 
   it("should show Federation link in Operations section when isAdmin", () => {
@@ -200,12 +190,10 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const formsLink = screen.getByText("Forms").closest("a");
-    expect(formsLink?.className).toMatch(/(?:^|\s)bg-sidebar-accent(?:\s|$)/);
+    expect(formsLink?.className).toMatch(/border-sidebar-primary/);
 
     const dashboardLink = screen.getByText("Editor Dashboard").closest("a");
-    expect(dashboardLink?.className).not.toMatch(
-      /(?:^|\s)bg-sidebar-accent(?:\s|$)/,
-    );
+    expect(dashboardLink?.className).not.toMatch(/border-sidebar-primary/);
   });
 
   it("should highlight active group header", () => {
@@ -271,10 +259,10 @@ describe("Sidebar", () => {
     expect(sidebar?.className).toMatch(/bg-sidebar-background/);
   });
 
-  it("should apply copper color to active nav item", () => {
+  it("should apply copper border to active nav item", () => {
     mockPathname = "/workspace";
     render(<Sidebar />);
     const dashboardLink = screen.getByText("Dashboard").closest("a");
-    expect(dashboardLink?.className).toMatch(/text-sidebar-primary/);
+    expect(dashboardLink?.className).toMatch(/border-sidebar-primary/);
   });
 });

--- a/apps/web/src/components/layout/breadcrumb-bar.tsx
+++ b/apps/web/src/components/layout/breadcrumb-bar.tsx
@@ -25,9 +25,7 @@ export function BreadcrumbBar() {
       {context.pageName && (
         <>
           <ChevronRight className="h-3 w-3 text-muted-foreground/40" />
-          <span className="text-sm text-muted-foreground/80">
-            {context.pageName}
-          </span>
+          <span className="text-sm text-foreground">{context.pageName}</span>
         </>
       )}
     </nav>

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -16,6 +16,7 @@ import {
 import { Menu, Search } from "lucide-react";
 import { Sidebar } from "./sidebar";
 import { NotificationBell } from "@/components/notifications/notification-bell";
+import { ThemeToggle } from "./theme-toggle";
 import { useCommandPalette } from "@/components/command-palette/command-palette";
 import { modifierSymbol } from "@/lib/platform";
 
@@ -83,6 +84,7 @@ export function Header() {
         {isAuthenticated ? (
           <div className="flex items-center space-x-4">
             <CommandPaletteTrigger />
+            <ThemeToggle />
             <OrgSwitcher />
             <NotificationBell />
             <UserMenu />

--- a/apps/web/src/components/layout/org-switcher.tsx
+++ b/apps/web/src/components/layout/org-switcher.tsx
@@ -16,13 +16,11 @@ import {
 import { Badge } from "@/components/ui/badge";
 
 const roleColors: Record<string, string> = {
-  ADMIN: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
-  EDITOR: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
-  PRODUCTION:
-    "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
-  BUSINESS_OPS:
-    "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200",
-  READER: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+  ADMIN: "bg-status-error/10 text-status-error",
+  EDITOR: "bg-status-info/10 text-status-info",
+  PRODUCTION: "bg-status-held/10 text-status-held",
+  BUSINESS_OPS: "bg-status-warning/10 text-status-warning",
+  READER: "bg-status-info/10 text-status-info",
 };
 
 export function OrgSwitcher() {

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -37,7 +37,7 @@ function NavGroup({
       {showDivider && <div className="my-2 border-t border-sidebar-border" />}
       <p
         className={cn(
-          "px-3 text-xs font-semibold uppercase tracking-wider",
+          "px-3 text-[12px] font-semibold uppercase tracking-wider",
           active ? "text-sidebar-foreground" : "text-sidebar-muted",
         )}
       >
@@ -50,10 +50,10 @@ function NavGroup({
             key={item.name}
             href={item.href}
             className={cn(
-              "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors",
+              "flex items-center gap-3 px-3 py-2 text-[13px] transition-colors",
               isActive
-                ? "bg-sidebar-accent text-sidebar-primary"
-                : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-primary",
+                ? "text-sidebar-foreground border-l-2 border-sidebar-primary"
+                : "text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-foreground",
             )}
           >
             <item.icon className="h-4 w-4" />

--- a/apps/web/src/components/layout/theme-toggle.tsx
+++ b/apps/web/src/components/layout/theme-toggle.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Sun, Moon, Monitor } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+const themeConfig = {
+  light: { icon: Sun, next: "dark" as const, label: "Light mode" },
+  dark: { icon: Moon, next: "system" as const, label: "Dark mode" },
+  system: { icon: Monitor, next: "light" as const, label: "System theme" },
+} as const;
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const config = themeConfig[(theme as keyof typeof themeConfig) ?? "light"];
+  const Icon = config.icon;
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setTheme(config.next)}
+            className="h-8 w-8"
+            data-testid="theme-toggle"
+          >
+            <Icon className="h-4 w-4" />
+            <span className="sr-only">{config.label}</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{config.label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/src/components/layout/theme-toggle.tsx
+++ b/apps/web/src/components/layout/theme-toggle.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useSyncExternalStore } from "react";
 import { useTheme } from "next-themes";
 import { Sun, Moon, Monitor } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -16,8 +17,35 @@ const themeConfig = {
   system: { icon: Monitor, next: "light" as const, label: "System theme" },
 } as const;
 
+// SSR-safe mount detection via useSyncExternalStore (avoids setState-in-effect lint)
+const subscribe = () => () => {};
+const getSnapshot = () => true;
+const getServerSnapshot = () => false;
+
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme();
+  const mounted = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+
+  // Avoid hydration mismatch: render placeholder until mounted
+  if (!mounted) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8"
+        data-testid="theme-toggle"
+        disabled
+      >
+        <Sun className="h-4 w-4" />
+        <span className="sr-only">Toggle theme</span>
+      </Button>
+    );
+  }
+
   const config = themeConfig[(theme as keyof typeof themeConfig) ?? "light"];
   const Icon = config.icon;
 

--- a/apps/web/src/components/layout/user-menu.tsx
+++ b/apps/web/src/components/layout/user-menu.tsx
@@ -65,7 +65,7 @@ export function UserMenu() {
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onClick={() => logout()}
-          className="cursor-pointer text-red-600 focus:text-red-600"
+          className="cursor-pointer text-destructive focus:text-destructive"
         >
           <LogOut className="mr-2 h-4 w-4" />
           Sign out

--- a/apps/web/src/components/manuscripts/manuscript-diff.tsx
+++ b/apps/web/src/components/manuscripts/manuscript-diff.tsx
@@ -45,10 +45,7 @@ export function ManuscriptDiff({
       {diff.map((part, i) => {
         if (part.added) {
           return (
-            <span
-              key={i}
-              className="bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-300"
-            >
+            <span key={i} className="bg-status-success/10 text-status-success">
               {part.value}
             </span>
           );
@@ -57,7 +54,7 @@ export function ManuscriptDiff({
           return (
             <span
               key={i}
-              className="bg-red-100 text-red-900 line-through dark:bg-red-900/30 dark:text-red-300"
+              className="bg-status-error/10 text-status-error line-through"
             >
               {part.value}
             </span>

--- a/apps/web/src/components/manuscripts/manuscript-renderer.tsx
+++ b/apps/web/src/components/manuscripts/manuscript-renderer.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { literata } from "@/lib/fonts";
 import { cn } from "@/lib/utils";
+import { useReadingTheme } from "@/hooks/use-reading-theme";
 import type {
   ProseMirrorDoc,
   ProseMirrorNode,
@@ -37,6 +38,7 @@ export function ManuscriptRenderer({
   initialAnchor,
 }: ManuscriptRendererProps) {
   const genre = content.attrs?.genre_hint ?? "prose";
+  const { readingTheme } = useReadingTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const anchorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastReportedIndex = useRef<number>(-1);
@@ -103,7 +105,12 @@ export function ManuscriptRenderer({
   return (
     <div
       ref={containerRef}
-      className={cn(literata.className, "text-foreground", className)}
+      data-reading-theme={readingTheme}
+      className={cn(literata.className, "rounded-lg p-4", className)}
+      style={{
+        backgroundColor: "var(--reading-bg)",
+        color: "var(--reading-fg)",
+      }}
     >
       {genre === "poetry" ? (
         <PoetryRenderer

--- a/apps/web/src/components/manuscripts/manuscript-version-files.tsx
+++ b/apps/web/src/components/manuscripts/manuscript-version-files.tsx
@@ -41,27 +41,27 @@ const scanStatusConfig: Record<
   PENDING: {
     label: "Pending scan",
     icon: Clock,
-    className: "bg-gray-100 text-gray-800",
+    className: "bg-status-info/10 text-status-info",
   },
   SCANNING: {
     label: "Scanning...",
     icon: Loader2,
-    className: "bg-blue-100 text-blue-800",
+    className: "bg-status-info/10 text-status-info",
   },
   CLEAN: {
     label: "Clean",
     icon: CheckCircle,
-    className: "bg-green-100 text-green-800",
+    className: "bg-status-success/10 text-status-success",
   },
   INFECTED: {
     label: "Infected",
     icon: AlertCircle,
-    className: "bg-red-100 text-red-800",
+    className: "bg-status-error/10 text-status-error",
   },
   FAILED: {
     label: "Scan failed",
     icon: AlertCircle,
-    className: "bg-orange-100 text-orange-800",
+    className: "bg-status-held/10 text-status-held",
   },
 };
 

--- a/apps/web/src/components/manuscripts/reading-theme-selector.tsx
+++ b/apps/web/src/components/manuscripts/reading-theme-selector.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useReadingTheme, type ReadingTheme } from "@/hooks/use-reading-theme";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+const themes: { value: ReadingTheme; label: string; swatch: string }[] = [
+  { value: "light", label: "Light", swatch: "bg-[hsl(42_47%_89%)]" },
+  { value: "sepia", label: "Sepia", swatch: "bg-[hsl(36_35%_85%)]" },
+  { value: "dark", label: "Dark", swatch: "bg-[hsl(230_27%_13%)]" },
+];
+
+interface ReadingThemeSelectorProps {
+  className?: string;
+}
+
+export function ReadingThemeSelector({ className }: ReadingThemeSelectorProps) {
+  const { readingTheme, setReadingTheme } = useReadingTheme();
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div className={cn("flex items-center gap-1.5", className)}>
+        {themes.map(({ value, label, swatch }) => (
+          <Tooltip key={value}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => setReadingTheme(value)}
+                className={cn(
+                  "h-5 w-5 rounded-full border transition-shadow",
+                  swatch,
+                  readingTheme === value
+                    ? "ring-2 ring-accent ring-offset-1"
+                    : "ring-0 hover:ring-1 hover:ring-muted-foreground/30",
+                )}
+                aria-label={`${label} reading theme`}
+                aria-pressed={readingTheme === value}
+              />
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{label}</TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/src/components/operations/__tests__/health-card-grid.spec.tsx
+++ b/apps/web/src/components/operations/__tests__/health-card-grid.spec.tsx
@@ -115,7 +115,7 @@ describe("HealthCardGrid", () => {
     expect(screen.getByText("3 active")).toBeInTheDocument();
     // The metric should have green styling (healthy)
     const metric = screen.getByText("3 active");
-    expect(metric.className).toContain("text-green-700");
+    expect(metric.className).toContain("text-status-success");
   });
 
   it("derives degraded federation status when peers pending", () => {
@@ -130,9 +130,9 @@ describe("HealthCardGrid", () => {
 
     expect(screen.getByText("1 active")).toBeInTheDocument();
     expect(screen.getByText("1 pending")).toBeInTheDocument();
-    // Degraded = yellow
+    // Degraded = warning
     const metric = screen.getByText("1 active");
-    expect(metric.className).toContain("text-yellow-700");
+    expect(metric.className).toContain("text-status-warning");
   });
 
   it("derives correct queue status from job counts", () => {
@@ -152,9 +152,9 @@ describe("HealthCardGrid", () => {
 
     expect(screen.getByText("15 waiting")).toBeInTheDocument();
     expect(screen.getByText("3 failed")).toBeInTheDocument();
-    // failed > 0 = degraded = yellow
+    // failed > 0 = degraded = warning
     const metric = screen.getByText("15 waiting");
-    expect(metric.className).toContain("text-yellow-700");
+    expect(metric.className).toContain("text-status-warning");
   });
 
   it("derives correct webhook status from provider health", () => {
@@ -187,9 +187,9 @@ describe("HealthCardGrid", () => {
 
     expect(screen.getByText("2/3 healthy")).toBeInTheDocument();
     expect(screen.getByText("Stale: stripe")).toBeInTheDocument();
-    // stale = degraded = yellow
+    // stale = degraded = warning
     const metric = screen.getByText("2/3 healthy");
-    expect(metric.className).toContain("text-yellow-700");
+    expect(metric.className).toContain("text-status-warning");
   });
 
   it("shows loading state while queries pending", () => {

--- a/apps/web/src/components/operations/__tests__/health-card.spec.tsx
+++ b/apps/web/src/components/operations/__tests__/health-card.spec.tsx
@@ -26,7 +26,7 @@ describe("HealthCard", () => {
     );
 
     const metric = screen.getByText("OK");
-    expect(metric.className).toContain("text-green-700");
+    expect(metric.className).toContain("text-status-success");
   });
 
   it("applies yellow styling for degraded status", () => {
@@ -40,7 +40,7 @@ describe("HealthCard", () => {
     );
 
     const metric = screen.getByText("3 stale");
-    expect(metric.className).toContain("text-yellow-700");
+    expect(metric.className).toContain("text-status-warning");
   });
 
   it("applies red styling for unhealthy status", () => {
@@ -54,7 +54,7 @@ describe("HealthCard", () => {
     );
 
     const metric = screen.getByText("5 failed");
-    expect(metric.className).toContain("text-red-700");
+    expect(metric.className).toContain("text-status-error");
   });
 
   it("renders skeleton when status is loading", () => {

--- a/apps/web/src/components/operations/health-card.tsx
+++ b/apps/web/src/components/operations/health-card.tsx
@@ -27,16 +27,16 @@ const STATUS_STYLES: Record<
   { text: string; border: string }
 > = {
   healthy: {
-    text: "text-green-700 dark:text-green-400",
-    border: "border-l-green-500",
+    text: "text-status-success",
+    border: "border-l-status-success",
   },
   degraded: {
-    text: "text-yellow-700 dark:text-yellow-400",
-    border: "border-l-yellow-500",
+    text: "text-status-warning",
+    border: "border-l-status-warning",
   },
   unhealthy: {
-    text: "text-red-700 dark:text-red-400",
-    border: "border-l-red-500",
+    text: "text-status-error",
+    border: "border-l-status-error",
   },
   unknown: {
     text: "text-muted-foreground",

--- a/apps/web/src/components/operations/queue-health-detail.tsx
+++ b/apps/web/src/components/operations/queue-health-detail.tsx
@@ -30,9 +30,8 @@ interface QueueHealthDetailProps {
 }
 
 function statusColor(failed: number, waiting: number): string {
-  if (failed > 10) return "text-red-700 dark:text-red-400";
-  if (failed > 0 || waiting >= 50)
-    return "text-yellow-700 dark:text-yellow-400";
+  if (failed > 10) return "text-status-error";
+  if (failed > 0 || waiting >= 50) return "text-status-warning";
   return "text-muted-foreground";
 }
 

--- a/apps/web/src/components/organizations/create-org-form.tsx
+++ b/apps/web/src/components/organizations/create-org-form.tsx
@@ -133,7 +133,7 @@ export function CreateOrgForm() {
                           {isChecking ? (
                             <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
                           ) : isAvailable === true ? (
-                            <Check className="h-4 w-4 text-green-600" />
+                            <Check className="h-4 w-4 text-status-success" />
                           ) : isAvailable === false ? (
                             <X className="h-4 w-4 text-destructive" />
                           ) : null}

--- a/apps/web/src/components/organizations/member-list.tsx
+++ b/apps/web/src/components/organizations/member-list.tsx
@@ -37,13 +37,11 @@ import { UserPlus, Trash2 } from "lucide-react";
 import type { Role } from "@colophony/types";
 
 const roleColors: Record<string, string> = {
-  ADMIN: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
-  EDITOR: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
-  PRODUCTION:
-    "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
-  BUSINESS_OPS:
-    "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200",
-  READER: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+  ADMIN: "bg-status-error/10 text-status-error",
+  EDITOR: "bg-status-info/10 text-status-info",
+  PRODUCTION: "bg-status-held/10 text-status-held",
+  BUSINESS_OPS: "bg-status-warning/10 text-status-warning",
+  READER: "bg-status-info/10 text-status-info",
 };
 
 export function MemberList() {

--- a/apps/web/src/components/periods/period-list.tsx
+++ b/apps/web/src/components/periods/period-list.tsx
@@ -184,7 +184,7 @@ export function PeriodList() {
                       {item.isContest && (
                         <Badge
                           variant="outline"
-                          className="ml-2 text-xs text-amber-600 border-amber-300"
+                          className="ml-2 text-xs text-status-warning border-status-warning/30"
                         >
                           <Trophy className="mr-1 h-3 w-3" />
                           Contest

--- a/apps/web/src/components/periods/period-status-badge.tsx
+++ b/apps/web/src/components/periods/period-status-badge.tsx
@@ -15,19 +15,17 @@ const statusConfig: Record<
 > = {
   UPCOMING: {
     label: "Upcoming",
-    className: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+    className: "bg-status-info/10 text-status-info",
     icon: Clock,
   },
   OPEN: {
     label: "Open",
-    className:
-      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    className: "bg-status-success/10 text-status-success",
     icon: CheckCircle,
   },
   CLOSED: {
     label: "Closed",
-    className:
-      "bg-gray-50 text-gray-500 dark:bg-gray-900 dark:text-gray-400 border-gray-200 dark:border-gray-700",
+    className: "bg-status-info/10 text-status-info",
     icon: Lock,
   },
 };

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -2,11 +2,12 @@
 
 import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "next-themes";
 import { trpc, getTrpcClient } from "@/lib/trpc";
 
 /**
  * Root providers component
- * Wraps the app with tRPC and TanStack Query providers.
+ * Wraps the app with theme, tRPC, and TanStack Query providers.
  */
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -26,8 +27,12 @@ export function Providers({ children }: { children: React.ReactNode }) {
   const [trpcClient] = useState(() => getTrpcClient());
 
   return (
-    <trpc.Provider client={trpcClient} queryClient={queryClient}>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </trpc.Provider>
+    <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+      <trpc.Provider client={trpcClient} queryClient={queryClient}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </trpc.Provider>
+    </ThemeProvider>
   );
 }

--- a/apps/web/src/components/sim-sub/group-status-badge.tsx
+++ b/apps/web/src/components/sim-sub/group-status-badge.tsx
@@ -15,18 +15,17 @@ const statusConfig: Record<
 > = {
   ACTIVE: {
     label: "Active",
-    className: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+    className: "bg-status-info/10 text-status-info",
     icon: Circle,
   },
   RESOLVED: {
     label: "Resolved",
-    className:
-      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    className: "bg-status-success/10 text-status-success",
     icon: CheckCircle,
   },
   WITHDRAWN: {
     label: "Withdrawn",
-    className: "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400",
+    className: "bg-status-held/10 text-status-held",
     icon: XCircle,
   },
 };

--- a/apps/web/src/components/slate/__tests__/production-aging.spec.ts
+++ b/apps/web/src/components/slate/__tests__/production-aging.spec.ts
@@ -116,16 +116,16 @@ describe("getHandoffStatus", () => {
 });
 
 describe("getAgingColor", () => {
-  it("returns green classes for on-track", () => {
+  it("returns success classes for on-track", () => {
     const color = getAgingColor("on-track");
-    expect(color.text).toContain("green");
-    expect(color.bg).toContain("green");
-    expect(color.badge).toContain("green");
+    expect(color.text).toContain("status-success");
+    expect(color.bg).toContain("status-success");
+    expect(color.badge).toContain("status-success");
   });
 
-  it("returns red classes for overdue", () => {
+  it("returns error classes for overdue", () => {
     const color = getAgingColor("overdue");
-    expect(color.text).toContain("red");
+    expect(color.text).toContain("status-error");
   });
 });
 

--- a/apps/web/src/components/slate/cms-connection-detail.tsx
+++ b/apps/web/src/components/slate/cms-connection-detail.tsx
@@ -238,7 +238,7 @@ export function CmsConnectionDetail({
                 </p>
                 <div className="flex items-center gap-2 mt-1">
                   <span
-                    className={`inline-block h-2 w-2 rounded-full ${connection.isActive ? "bg-green-500" : "bg-gray-300"}`}
+                    className={`inline-block h-2 w-2 rounded-full ${connection.isActive ? "bg-status-success" : "bg-status-info"}`}
                   />
                   <span className="text-sm">
                     {connection.isActive ? "Active" : "Inactive"}

--- a/apps/web/src/components/slate/cms-connection-list.tsx
+++ b/apps/web/src/components/slate/cms-connection-list.tsx
@@ -179,7 +179,7 @@ export function CmsConnectionList() {
                       </TableCell>
                       <TableCell>
                         <span
-                          className={`inline-block h-2 w-2 rounded-full ${connection.isActive ? "bg-green-500" : "bg-gray-300"}`}
+                          className={`inline-block h-2 w-2 rounded-full ${connection.isActive ? "bg-status-success" : "bg-status-info"}`}
                         />
                       </TableCell>
                       <TableCell className="text-muted-foreground">

--- a/apps/web/src/components/slate/issue-status-badge.tsx
+++ b/apps/web/src/components/slate/issue-status-badge.tsx
@@ -13,30 +13,27 @@ const statusConfig: Record<
 > = {
   PLANNING: {
     label: "Planning",
-    className: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+    className: "bg-status-info/10 text-status-info",
     icon: Pencil,
   },
   ASSEMBLING: {
     label: "Assembling",
-    className:
-      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+    className: "bg-status-warning/10 text-status-warning",
     icon: Layers,
   },
   READY: {
     label: "Ready",
-    className:
-      "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+    className: "bg-status-held/10 text-status-held",
     icon: CheckCircle,
   },
   PUBLISHED: {
     label: "Published",
-    className:
-      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    className: "bg-status-success/10 text-status-success",
     icon: Globe,
   },
   ARCHIVED: {
     label: "Archived",
-    className: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+    className: "bg-status-info/10 text-status-info",
     icon: Archive,
   },
 };

--- a/apps/web/src/components/slate/pipeline-stage-badge.tsx
+++ b/apps/web/src/components/slate/pipeline-stage-badge.tsx
@@ -21,40 +21,37 @@ const stageConfig: Record<
 > = {
   COPYEDIT_PENDING: {
     label: "Copyedit Pending",
-    className: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+    className: "bg-status-info/10 text-status-info",
     icon: Clock,
   },
   COPYEDIT_IN_PROGRESS: {
     label: "Copyediting",
-    className:
-      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+    className: "bg-status-warning/10 text-status-warning",
     icon: Pencil,
   },
   AUTHOR_REVIEW: {
     label: "Author Review",
-    className:
-      "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
+    className: "bg-status-held/10 text-status-held",
     icon: Eye,
   },
   PROOFREAD: {
     label: "Proofreading",
-    className: "bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-200",
+    className: "bg-status-info/10 text-status-info",
     icon: BookOpen,
   },
   READY_TO_PUBLISH: {
     label: "Ready to Publish",
-    className:
-      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    className: "bg-status-success/10 text-status-success",
     icon: CheckCircle,
   },
   PUBLISHED: {
     label: "Published",
-    className: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+    className: "bg-status-info/10 text-status-info",
     icon: Globe,
   },
   WITHDRAWN: {
     label: "Withdrawn",
-    className: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+    className: "bg-status-error/10 text-status-error",
     icon: Ban,
   },
 };

--- a/apps/web/src/components/slate/production-aging.ts
+++ b/apps/web/src/components/slate/production-aging.ts
@@ -61,23 +61,21 @@ export function getAgingColor(status: AgingStatus): {
   switch (status) {
     case "on-track":
       return {
-        text: "text-green-700 dark:text-green-400",
-        bg: "bg-green-100 dark:bg-green-900/30",
-        badge:
-          "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+        text: "text-status-success",
+        bg: "bg-status-success/10",
+        badge: "bg-status-success/10 text-status-success",
       };
     case "at-risk":
       return {
-        text: "text-yellow-700 dark:text-yellow-400",
-        bg: "bg-yellow-100 dark:bg-yellow-900/30",
-        badge:
-          "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+        text: "text-status-warning",
+        bg: "bg-status-warning/10",
+        badge: "bg-status-warning/10 text-status-warning",
       };
     case "overdue":
       return {
-        text: "text-red-700 dark:text-red-400",
-        bg: "bg-red-100 dark:bg-red-900/30",
-        badge: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+        text: "text-status-error",
+        bg: "bg-status-error/10",
+        badge: "bg-status-error/10 text-status-error",
       };
   }
 }

--- a/apps/web/src/components/slate/production-pipeline-table.tsx
+++ b/apps/web/src/components/slate/production-pipeline-table.tsx
@@ -114,7 +114,7 @@ export function ProductionPipelineTable({
                     <span
                       className={
                         aging === "overdue"
-                          ? "text-red-700 dark:text-red-400 font-medium"
+                          ? "text-status-error font-medium"
                           : "text-muted-foreground"
                       }
                     >
@@ -134,7 +134,7 @@ export function ProductionPipelineTable({
                 </TableCell>
                 <TableCell>
                   {handoff === "waiting-external" ? (
-                    <span className="text-orange-700 dark:text-orange-400 text-sm">
+                    <span className="text-status-held text-sm">
                       Waiting: Author
                     </span>
                   ) : (

--- a/apps/web/src/components/slate/production-stats-cards.tsx
+++ b/apps/web/src/components/slate/production-stats-cards.tsx
@@ -20,22 +20,22 @@ const cards = [
   {
     key: "onTrack" as const,
     label: "On Track",
-    color: "text-green-700 dark:text-green-400",
+    color: "text-status-success",
   },
   {
     key: "atRisk" as const,
     label: "At Risk",
-    color: "text-yellow-700 dark:text-yellow-400",
+    color: "text-status-warning",
   },
   {
     key: "overdue" as const,
     label: "Overdue",
-    color: "text-red-700 dark:text-red-400",
+    color: "text-status-error",
   },
   {
     key: "waiting" as const,
     label: "Waiting",
-    color: "text-blue-700 dark:text-blue-400",
+    color: "text-status-held",
   },
 ];
 

--- a/apps/web/src/components/slate/publication-status-badge.tsx
+++ b/apps/web/src/components/slate/publication-status-badge.tsx
@@ -13,13 +13,12 @@ const statusConfig: Record<
 > = {
   ACTIVE: {
     label: "Active",
-    className:
-      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    className: "bg-status-success/10 text-status-success",
     icon: CheckCircle,
   },
   ARCHIVED: {
     label: "Archived",
-    className: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+    className: "bg-status-info/10 text-status-info",
     icon: Archive,
   },
 };

--- a/apps/web/src/components/submissions/editor-submission-queue.tsx
+++ b/apps/web/src/components/submissions/editor-submission-queue.tsx
@@ -87,13 +87,11 @@ function AgeBadge({
     return <span className="text-muted-foreground">{"\u2014"}</span>;
   }
   const days = differenceInDays(new Date(), new Date(submittedAt));
-  let colorClass =
-    "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300";
+  let colorClass = "bg-status-success/10 text-status-success";
   if (days > 30) {
-    colorClass = "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300";
+    colorClass = "bg-status-error/10 text-status-error";
   } else if (days >= 14) {
-    colorClass =
-      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300";
+    colorClass = "bg-status-warning/10 text-status-warning";
   }
   return (
     <span

--- a/apps/web/src/components/submissions/file-upload.tsx
+++ b/apps/web/src/components/submissions/file-upload.tsx
@@ -40,27 +40,27 @@ const scanStatusConfig: Record<
   PENDING: {
     label: "Pending scan",
     icon: Clock,
-    className: "bg-gray-100 text-gray-800",
+    className: "bg-status-info/10 text-status-info",
   },
   SCANNING: {
     label: "Scanning...",
     icon: Loader2,
-    className: "bg-blue-100 text-blue-800",
+    className: "bg-status-info/10 text-status-info",
   },
   CLEAN: {
     label: "Clean",
     icon: CheckCircle,
-    className: "bg-green-100 text-green-800",
+    className: "bg-status-success/10 text-status-success",
   },
   INFECTED: {
     label: "Infected",
     icon: AlertCircle,
-    className: "bg-red-100 text-red-800",
+    className: "bg-status-error/10 text-status-error",
   },
   FAILED: {
     label: "Scan failed",
     icon: AlertCircle,
-    className: "bg-orange-100 text-orange-800",
+    className: "bg-status-held/10 text-status-held",
   },
 };
 
@@ -121,7 +121,7 @@ function UploadingFileItem({
           <ScanStatusBadge status={upload.scanStatus} />
         )}
         {upload.status === "complete" && (
-          <CheckCircle className="h-5 w-5 text-green-600" />
+          <CheckCircle className="h-5 w-5 text-status-success" />
         )}
         {upload.status === "error" && (
           <AlertCircle className="h-5 w-5 text-destructive" />
@@ -388,7 +388,7 @@ export function FileUpload({
         {existingFiles?.some(
           (f) => f.scanStatus === "PENDING" || f.scanStatus === "SCANNING",
         ) && (
-          <p className="text-sm text-yellow-600 dark:text-yellow-400">
+          <p className="text-sm text-status-warning">
             Some files are still being scanned. You can submit after all scans
             complete.
           </p>

--- a/apps/web/src/components/submissions/reviewer-list.tsx
+++ b/apps/web/src/components/submissions/reviewer-list.tsx
@@ -61,7 +61,10 @@ export function ReviewerList({ submissionId }: ReviewerListProps) {
                 {reviewer.reviewerRole}
               </Badge>
               {reviewer.readAt ? (
-                <Badge variant="default" className="text-xs gap-1 bg-green-600">
+                <Badge
+                  variant="default"
+                  className="text-xs gap-1 bg-status-success text-white"
+                >
                   <Eye className="h-3 w-3" />
                   Read{" "}
                   {formatDistanceToNow(new Date(reviewer.readAt), {

--- a/apps/web/src/components/submissions/revise-and-resubmit-card.tsx
+++ b/apps/web/src/components/submissions/revise-and-resubmit-card.tsx
@@ -62,33 +62,31 @@ export function ReviseAndResubmitCard({
   };
 
   return (
-    <Card className="border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950">
+    <Card className="border-status-warning/30 bg-status-warning/5">
       <CardHeader>
         <div className="flex items-center gap-2">
-          <AlertTriangle className="h-5 w-5 text-amber-600 dark:text-amber-400" />
-          <CardTitle className="text-amber-900 dark:text-amber-100">
+          <AlertTriangle className="h-5 w-5 text-status-warning" />
+          <CardTitle className="text-status-warning">
             Revision Requested
           </CardTitle>
         </div>
-        <CardDescription className="text-amber-800 dark:text-amber-200">
+        <CardDescription>
           The editors have requested revisions. Please review their notes and
           submit an updated manuscript version.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         {revisionNotes && (
-          <div className="rounded-md bg-white p-4 dark:bg-amber-900/30">
-            <p className="text-sm font-medium text-amber-900 dark:text-amber-100 mb-1">
-              Revision Notes
-            </p>
-            <p className="text-sm text-amber-800 dark:text-amber-200 whitespace-pre-wrap">
+          <div className="rounded-md bg-background p-4">
+            <p className="text-sm font-medium mb-1">Revision Notes</p>
+            <p className="text-sm text-muted-foreground whitespace-pre-wrap">
               {revisionNotes}
             </p>
           </div>
         )}
 
         <div className="space-y-2">
-          <label className="text-sm font-medium text-amber-900 dark:text-amber-100">
+          <label className="text-sm font-medium">
             Select a manuscript version to resubmit
           </label>
           <Select

--- a/apps/web/src/components/submissions/sim-sub-conflict-display.tsx
+++ b/apps/web/src/components/submissions/sim-sub-conflict-display.tsx
@@ -75,15 +75,15 @@ export function SimSubConflictDisplay({
       {policyRequirement && !policyRequirement.acknowledgedAt && (
         <Alert
           variant="default"
-          className="border-amber-500 bg-amber-50 dark:bg-amber-950/20"
+          className="border-status-warning bg-status-warning/5"
         >
-          <AlertTriangle className="h-4 w-4 text-amber-600" />
-          <AlertTitle className="text-amber-800 dark:text-amber-200">
+          <AlertTriangle className="h-4 w-4 text-status-warning" />
+          <AlertTitle className="text-status-warning">
             {policyRequirement.type === "withdraw"
               ? "Withdrawal Required"
               : "Notification Required"}
           </AlertTitle>
-          <AlertDescription className="text-amber-700 dark:text-amber-300">
+          <AlertDescription>
             {policyRequirement.type === "withdraw" ? (
               <>
                 This publication requires you to withdraw from other

--- a/apps/web/src/components/submissions/status-badge.tsx
+++ b/apps/web/src/components/submissions/status-badge.tsx
@@ -29,47 +29,42 @@ const statusConfig: Record<
 > = {
   DRAFT: {
     label: "Draft",
-    className: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+    className: "bg-status-info/10 text-status-info",
     icon: FileEdit,
   },
   SUBMITTED: {
     label: "Submitted",
-    className: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+    className: "bg-status-info/10 text-status-info",
     icon: Send,
   },
   UNDER_REVIEW: {
     label: "Under Review",
-    className:
-      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+    className: "bg-status-info/10 text-status-info",
     icon: Eye,
   },
   ACCEPTED: {
     label: "Accepted",
-    className:
-      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    className: "bg-status-success/10 text-status-success",
     icon: CheckCircle,
   },
   REJECTED: {
     label: "Rejected",
-    className: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+    className: "bg-status-error/10 text-status-error",
     icon: XCircle,
   },
   HOLD: {
     label: "On Hold",
-    className:
-      "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
+    className: "bg-status-held/10 text-status-held",
     icon: Pause,
   },
   REVISE_AND_RESUBMIT: {
     label: "Revise & Resubmit",
-    className:
-      "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200",
+    className: "bg-status-warning/10 text-status-warning",
     icon: RotateCcw,
   },
   WITHDRAWN: {
     label: "Withdrawn",
-    className:
-      "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+    className: "bg-status-held/10 text-status-held",
     icon: Ban,
   },
 };

--- a/apps/web/src/components/submissions/status-transition.tsx
+++ b/apps/web/src/components/submissions/status-transition.tsx
@@ -132,7 +132,7 @@ export function StatusTransition({
               onClick={() => setSelectedStatus(status)}
               className={
                 isDecision
-                  ? "font-[var(--font-playfair)] italic font-bold"
+                  ? "[font-family:var(--font-playfair),ui-serif,Georgia,serif] italic font-bold"
                   : undefined
               }
             >

--- a/apps/web/src/components/submissions/status-transition.tsx
+++ b/apps/web/src/components/submissions/status-transition.tsx
@@ -122,15 +122,24 @@ export function StatusTransition({
   return (
     <>
       <div className="flex flex-wrap gap-2">
-        {allowedTransitions.map((status) => (
-          <Button
-            key={status}
-            variant={statusButtonVariants[status]}
-            onClick={() => setSelectedStatus(status)}
-          >
-            {statusLabels[status]}
-          </Button>
-        ))}
+        {allowedTransitions.map((status) => {
+          const isDecision =
+            status === "ACCEPTED" || status === "REJECTED" || status === "HOLD";
+          return (
+            <Button
+              key={status}
+              variant={statusButtonVariants[status]}
+              onClick={() => setSelectedStatus(status)}
+              className={
+                isDecision
+                  ? "font-[var(--font-playfair)] italic font-bold"
+                  : undefined
+              }
+            >
+              {statusLabels[status]}
+            </Button>
+          );
+        })}
       </div>
 
       <Dialog

--- a/apps/web/src/components/submissions/voting-panel.tsx
+++ b/apps/web/src/components/submissions/voting-panel.tsx
@@ -177,13 +177,13 @@ export function VotingPanel({
             <div className="space-y-2">
               <Label className="text-sm font-medium">Summary</Label>
               <div className="flex gap-3 text-sm">
-                <span className="text-green-600">
+                <span className="text-status-success">
                   Accept: {summary.acceptCount}
                 </span>
-                <span className="text-red-600">
+                <span className="text-status-error">
                   Reject: {summary.rejectCount}
                 </span>
-                <span className="text-yellow-600">
+                <span className="text-status-warning">
                   Maybe: {summary.maybeCount}
                 </span>
               </div>

--- a/apps/web/src/components/submissions/writer-status-badge.tsx
+++ b/apps/web/src/components/submissions/writer-status-badge.tsx
@@ -28,36 +28,31 @@ const writerStatusConfig: Record<
   }
 > = {
   DRAFT: {
-    className: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+    className: "bg-status-info/10 text-status-info",
     icon: FileEdit,
   },
   RECEIVED: {
-    className: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+    className: "bg-status-info/10 text-status-info",
     icon: Send,
   },
   IN_REVIEW: {
-    className:
-      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+    className: "bg-status-info/10 text-status-info",
     icon: Eye,
   },
   REVISION_REQUESTED: {
-    className:
-      "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200",
+    className: "bg-status-warning/10 text-status-warning",
     icon: RotateCcw,
   },
   ACCEPTED: {
-    className:
-      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    className: "bg-status-success/10 text-status-success",
     icon: CheckCircle,
   },
   DECISION_SENT: {
-    className:
-      "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300",
+    className: "bg-status-info/10 text-status-info",
     icon: MessageCircle,
   },
   WITHDRAWN: {
-    className:
-      "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+    className: "bg-status-held/10 text-status-held",
     icon: Ban,
   },
 };

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -14,10 +14,10 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground shadow-xs hover:bg-destructive/90",
         outline:
-          "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background shadow-xs hover:bg-secondary hover:text-secondary-foreground",
         secondary:
           "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-secondary hover:text-secondary-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -11,7 +11,7 @@ function Card({
     <div
       ref={ref}
       className={cn(
-        "rounded-xl border bg-card text-card-foreground shadow-sm",
+        "rounded-xl border bg-card text-card-foreground shadow-[0_1px_3px_0_hsl(35_22%_80%/0.3)]",
         className,
       )}
       {...props}

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -115,7 +115,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default gap-2 select-none items-center rounded-xs px-2 py-1.5 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default gap-2 select-none items-center rounded-xs px-2 py-1.5 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent/15 data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className,
     )}
     {...props}

--- a/apps/web/src/components/webhooks/webhook-detail.tsx
+++ b/apps/web/src/components/webhooks/webhook-detail.tsx
@@ -43,10 +43,10 @@ import { SecretDisplayDialog } from "./secret-display-dialog";
 const SKELETON_ITEMS = Array.from({ length: 5 });
 
 const STATUS_COLORS: Record<string, string> = {
-  QUEUED: "bg-yellow-500",
-  DELIVERING: "bg-blue-500",
-  DELIVERED: "bg-green-500",
-  FAILED: "bg-red-500",
+  QUEUED: "bg-status-warning",
+  DELIVERING: "bg-status-info",
+  DELIVERED: "bg-status-success",
+  FAILED: "bg-status-error",
 };
 
 interface WebhookDetailProps {
@@ -259,8 +259,8 @@ export function WebhookDetail({ endpointId }: WebhookDetailProps) {
                 <span
                   className={`inline-block h-2 w-2 rounded-full ${
                     endpoint.status === "ACTIVE"
-                      ? "bg-green-500"
-                      : "bg-gray-300"
+                      ? "bg-status-success"
+                      : "bg-status-info"
                   }`}
                 />
                 <span className="text-sm">{endpoint.status}</span>
@@ -325,7 +325,7 @@ export function WebhookDetail({ endpointId }: WebhookDetailProps) {
                         <div className="flex items-center gap-2">
                           <span
                             className={`inline-block h-2 w-2 rounded-full ${
-                              STATUS_COLORS[delivery.status] ?? "bg-gray-300"
+                              STATUS_COLORS[delivery.status] ?? "bg-status-info"
                             }`}
                           />
                           <span className="text-sm">{delivery.status}</span>

--- a/apps/web/src/components/webhooks/webhook-list.tsx
+++ b/apps/web/src/components/webhooks/webhook-list.tsx
@@ -115,8 +115,8 @@ export function WebhookList() {
                           <span
                             className={`inline-block h-2 w-2 rounded-full ${
                               endpoint.status === "ACTIVE"
-                                ? "bg-green-500"
-                                : "bg-gray-300"
+                                ? "bg-status-success"
+                                : "bg-status-info"
                             }`}
                           />
                           <span className="text-sm">{endpoint.status}</span>

--- a/apps/web/src/components/workspace/correspondence-archive.tsx
+++ b/apps/web/src/components/workspace/correspondence-archive.tsx
@@ -69,9 +69,9 @@ export function CorrespondenceArchive() {
                 {/* Direction icon */}
                 <div className="mt-0.5">
                   {item.direction === "inbound" ? (
-                    <ArrowDownLeft className="h-4 w-4 text-blue-500" />
+                    <ArrowDownLeft className="h-4 w-4 text-status-info" />
                   ) : (
-                    <ArrowUpRight className="h-4 w-4 text-green-500" />
+                    <ArrowUpRight className="h-4 w-4 text-status-success" />
                   )}
                 </div>
 
@@ -100,7 +100,7 @@ export function CorrespondenceArchive() {
                       })}
                     </span>
                     {item.source === "colophony" && (
-                      <span className="text-blue-500">via Colophony</span>
+                      <span className="text-status-info">via Colophony</span>
                     )}
                   </div>
                 </div>

--- a/apps/web/src/components/workspace/csr-status-badge.tsx
+++ b/apps/web/src/components/workspace/csr-status-badge.tsx
@@ -36,16 +36,16 @@ const statusConfig: Record<
 };
 
 const statusColors: Record<CSRStatus, string> = {
-  draft: "bg-gray-100 text-gray-800",
-  sent: "bg-blue-100 text-blue-800",
-  in_review: "bg-yellow-100 text-yellow-800",
-  hold: "bg-orange-100 text-orange-800",
-  accepted: "bg-green-100 text-green-800",
-  rejected: "bg-red-100 text-red-800",
-  withdrawn: "bg-gray-100 text-gray-800",
-  no_response: "bg-gray-100 text-gray-600",
-  revise: "bg-purple-100 text-purple-800",
-  unknown: "bg-gray-100 text-gray-600",
+  draft: "bg-status-info/10 text-status-info",
+  sent: "bg-status-info/10 text-status-info",
+  in_review: "bg-status-info/10 text-status-info",
+  hold: "bg-status-held/10 text-status-held",
+  accepted: "bg-status-success/10 text-status-success",
+  rejected: "bg-status-error/10 text-status-error",
+  withdrawn: "bg-status-held/10 text-status-held",
+  no_response: "bg-status-info/10 text-status-info",
+  revise: "bg-status-warning/10 text-status-warning",
+  unknown: "bg-status-info/10 text-status-info",
 };
 
 interface CsrStatusBadgeProps {

--- a/apps/web/src/components/workspace/import-review.tsx
+++ b/apps/web/src/components/workspace/import-review.tsx
@@ -49,7 +49,7 @@ export function ImportReview({
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
-            <CheckCircle2 className="h-5 w-5 text-green-600" />
+            <CheckCircle2 className="h-5 w-5 text-status-success" />
             Import Complete
           </CardTitle>
         </CardHeader>
@@ -79,7 +79,7 @@ export function ImportReview({
         <CardContent>
           <div className="grid gap-3 sm:grid-cols-3">
             <div className="flex items-center gap-2">
-              <CheckCircle2 className="h-4 w-4 text-green-600" />
+              <CheckCircle2 className="h-4 w-4 text-status-success" />
               <span className="text-sm">
                 <strong>{validation.validRows}</strong> valid rows
               </span>
@@ -95,7 +95,7 @@ export function ImportReview({
             )}
             {warningCount > 0 && (
               <div className="flex items-center gap-2">
-                <AlertTriangle className="h-4 w-4 text-yellow-600" />
+                <AlertTriangle className="h-4 w-4 text-status-warning" />
                 <span className="text-sm">
                   <strong>{warningCount}</strong> row
                   {warningCount !== 1 ? "s" : ""} with warnings
@@ -148,7 +148,7 @@ export function ImportReview({
       {warningCount > 0 && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-base text-yellow-600">
+            <CardTitle className="text-base text-status-warning">
               Warnings ({warningCount})
             </CardTitle>
           </CardHeader>
@@ -188,7 +188,7 @@ export function ImportReview({
       {duplicateCount > 0 && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-base text-yellow-600">
+            <CardTitle className="text-base text-status-warning">
               Possible Duplicates ({duplicateCount})
             </CardTitle>
           </CardHeader>

--- a/apps/web/src/hooks/use-reading-theme.tsx
+++ b/apps/web/src/hooks/use-reading-theme.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+export type ReadingTheme = "light" | "sepia" | "dark";
+
+const STORAGE_KEY = "colophony-reading-theme";
+const VALID_THEMES: ReadingTheme[] = ["light", "sepia", "dark"];
+
+function isValidTheme(value: unknown): value is ReadingTheme {
+  return (
+    typeof value === "string" && VALID_THEMES.includes(value as ReadingTheme)
+  );
+}
+
+// Listeners for store changes
+const listeners = new Set<() => void>();
+function emitChange() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function subscribe(callback: () => void) {
+  listeners.add(callback);
+  // Also listen for cross-tab changes via storage event
+  const handleStorage = (e: StorageEvent) => {
+    if (e.key === STORAGE_KEY) callback();
+  };
+  window.addEventListener("storage", handleStorage);
+  return () => {
+    listeners.delete(callback);
+    window.removeEventListener("storage", handleStorage);
+  };
+}
+
+function getSnapshot(): ReadingTheme {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return isValidTheme(stored) ? stored : "light";
+}
+
+function getServerSnapshot(): ReadingTheme {
+  return "light";
+}
+
+/**
+ * Self-contained hook for reading theme preference.
+ * Persisted to localStorage, independent of the app's light/dark theme.
+ * No Provider needed — all consumers share the same localStorage key.
+ */
+export function useReadingTheme() {
+  const readingTheme = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+
+  const setReadingTheme = useCallback((theme: ReadingTheme) => {
+    localStorage.setItem(STORAGE_KEY, theme);
+    emitChange();
+  }, []);
+
+  return { readingTheme, setReadingTheme };
+}

--- a/apps/web/src/lib/fonts.ts
+++ b/apps/web/src/lib/fonts.ts
@@ -1,8 +1,23 @@
-import { Literata } from "next/font/google";
+import { Literata, Playfair_Display, Lato } from "next/font/google";
 
 export const literata = Literata({
   subsets: ["latin"],
   axes: ["opsz"],
   display: "swap",
   variable: "--font-literata",
+});
+
+export const playfairDisplay = Playfair_Display({
+  subsets: ["latin"],
+  weight: ["400", "700"],
+  style: ["normal", "italic"],
+  display: "swap",
+  variable: "--font-playfair",
+});
+
+export const lato = Lato({
+  subsets: ["latin"],
+  weight: ["300", "400", "700", "900"],
+  display: "swap",
+  variable: "--font-lato",
 });

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -790,3 +790,70 @@ To avoid migrations when federation sync arrives, the following are present in t
 | Responsive strategy    | Desktop-first; mobile limited to writer status checks                                         | Editorial workflows need desktop viewports. Writers check status on mobile. Build responsive for WriterLayout only; defer mobile editorial.                                         |
 | Sidebar surface        | Permanent dark navy (#191c2b), same in both themes                                            | Anchors the interface. Sub-brand preheaders use Muted Cream on navy. Warm Cream text, copper active states.                                                                         |
 | Sub-brand UI presence  | Sidebar preheader + layout breadcrumb bar (Hopper, Slate, Register). Relay system-level only. | Sub-brands provide identity and context without navigation friction. Preheader is visible but recessive. Relay is infrastructure, not a destination.                                |
+
+---
+
+## Section 10: Brand Token System
+
+### 10.1 Source Palette
+
+| Name            | Hex       | HSL                | CSS Variable           | Usage                                           |
+| --------------- | --------- | ------------------ | ---------------------- | ----------------------------------------------- |
+| Deep Navy       | `#191c2b` | `hsl(230 27% 13%)` | `--primary` (light)    | Primary buttons, dark backgrounds, sidebar      |
+| Warm Cream      | `#f0e8d5` | `hsl(42 47% 89%)`  | `--background` (light) | Light background, workspace surfaces            |
+| Light Parchment | `#f0ebe0` | `hsl(41 35% 91%)`  | `--card` (light)       | Card backgrounds, popovers                      |
+| Copper          | `#c87941` | `hsl(25 55% 52%)`  | `--accent`             | Critical actions, meaningful state changes ONLY |
+| Muted Cream     | `#d8cfc2` | `hsl(35 22% 80%)`  | `--border`             | Borders, input borders, secondary text          |
+| Near Black      | `#121212` | `hsl(0 0% 7%)`     | `--foreground` (light) | Primary text (light theme)                      |
+| Slate           | `#3E4A59` | `hsl(213 18% 30%)` | `--secondary` (dark)   | Secondary surfaces (dark theme)                 |
+
+### 10.2 Theme Architecture
+
+- **Light theme:** Warm Cream background, Near Black text, Light Parchment cards, Deep Navy primary buttons.
+- **Dark theme:** Deep Navy background, Warm Cream text, lighter navy cards, Warm Cream primary buttons.
+- **Sidebar:** Permanent dark surface — Deep Navy in both themes. Provides a consistent architectural anchor.
+- **Theme switching:** `next-themes` with `attribute="class"`, `defaultTheme="light"`, `enableSystem`. Toggle in header.
+
+### 10.3 Typography Stack
+
+| Context        | Typeface                            | Weights            | Usage                                                                                                      |
+| -------------- | ----------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------- |
+| **Headings**   | Playfair Display                    | 400, 700 + Italic  | h1–h6 elements. Italic reserved for "productive friction" moments (Accept, Decline, Hold labels).          |
+| **Body / UI**  | Lato                                | 300, 400, 700, 900 | All interface text, labels, controls, navigation.                                                          |
+| **Manuscript** | Literata (variable, optical sizing) | full range         | ManuscriptRenderer ONLY. Never appears in interface chrome. Lato/Playfair never appear inside manuscripts. |
+
+### 10.4 Semantic Status Colors
+
+Six semantic status colors replace all hardcoded Tailwind color classes. Defined as CSS variables that change between light and dark themes.
+
+| Semantic           | Light HSL                          | Dark HSL           | Usage                                            |
+| ------------------ | ---------------------------------- | ------------------ | ------------------------------------------------ |
+| `--status-success` | `hsl(140 25% 33%)` (sage green)    | `hsl(140 30% 55%)` | Accepted, healthy, on-track, clean, connected    |
+| `--status-warning` | `hsl(38 65% 38%)` (warm amber)     | `hsl(38 55% 60%)`  | R&R, aging, approaching deadline, degraded       |
+| `--status-error`   | `hsl(11 52% 47%)` (brick red)      | `hsl(11 55% 58%)`  | Rejected, overdue, unhealthy, infected, failed   |
+| `--status-info`    | `hsl(35 9% 55%)` (muted warm gray) | `hsl(35 12% 65%)`  | Draft, submitted, under review, neutral, pending |
+| `--status-active`  | `hsl(25 55% 52%)` (copper)         | same               | Interactive elements, links (same as `--accent`) |
+| `--status-held`    | `hsl(206 25% 48%)` (dusty blue)    | `hsl(206 30% 60%)` | Hold, withdrawn, waiting, external handoff       |
+
+**Usage pattern:** `bg-status-{name}/10 text-status-{name}` for badge backgrounds with text. No `dark:` variants needed — CSS variables handle theme switching.
+
+### 10.5 ManuscriptRenderer Reading Themes
+
+Independent of the app's light/dark theme. Scoped via `data-reading-theme` attribute on the renderer wrapper.
+
+| Theme | Background                    | Text                          | Description                                                   |
+| ----- | ----------------------------- | ----------------------------- | ------------------------------------------------------------- |
+| Light | Warm Cream `hsl(42 47% 89%)`  | Near Black `hsl(0 0% 7%)`     | Matches app light workspace. Archival paper feel.             |
+| Sepia | Deeper warm `hsl(36 35% 85%)` | Dark brown `hsl(18 12% 15%)`  | Lower contrast for long reading. Aged paper under warm light. |
+| Dark  | Deep Navy `hsl(230 27% 13%)`  | Muted Cream `hsl(35 22% 80%)` | Matches dark theme background. Warm cream text, not white.    |
+
+Reading theme selector uses circular color swatches (visually distinct from the Sun/Moon app theme toggle).
+
+### 10.6 Brand Rules
+
+- **No cool or neutral grays.** All neutrals maintain warmth.
+- **No pure white (`#ffffff`) or pure black (`#000000`).** Use Warm Cream and Near Black.
+- **Copper is never decorative.** It marks meaningful interaction or state change.
+- **No bright, saturated neon colors.** All status/semantic colors are muted and warm-toned.
+- **Playfair Display Italic marks productive friction.** Decision labels only (Accept, Decline, Hold). Not navigation, form labels, or buttons.
+- **Outline/ghost button hover uses secondary (parchment), not accent (copper).** Copper hover would make every button feel like a critical action.

--- a/docs/devlog/2026-04.md
+++ b/docs/devlog/2026-04.md
@@ -1,0 +1,29 @@
+# Development Log — April 2026
+
+Newest entries first.
+
+## 2026-04-01 — Platform Styling Pass (Brand Identity to Code)
+
+### Done
+
+- Replaced default shadcn/ui neutral palette with Colophony brand identity across 70 files
+- Theme tokens: Deep Navy, Warm Cream, Copper, Light Parchment mapped to all shadcn/ui CSS variables (light + dark themes)
+- Typography: Playfair Display (headings) + Lato (body/UI) replacing Geist; Literata stays ManuscriptRenderer-only
+- Dark mode: next-themes integration with ThemeToggle (light/dark/system cycle) in header
+- Semantic status colors: 6 CSS variables (success/warning/error/info/active/held) replacing hardcoded Tailwind classes across 51 component files and 4 test files
+- ManuscriptRenderer reading themes: light/sepia/dark scoped via data-reading-theme attribute; useReadingTheme hook (useSyncExternalStore + localStorage); ReadingThemeSelector with circular color swatches
+- Sidebar refinement: copper left border on active items (replacing background highlight), 80% opacity inactive text, 12px activity group labels
+- Breadcrumb: current page segment at full foreground contrast
+- Component refinements: outline/ghost button hover to secondary (not copper), warm-tinted card shadows, command palette selection at 15% copper opacity, Playfair Bold Italic on Accept/Reject/Hold decision labels
+- Chart colors harmonized with brand family (navy, copper, sage, amber, dusty blue)
+- DESIGN_SYSTEM.md Section 10: brand token system documentation (palette, typography, status colors, reading themes, brand rules)
+- Codex plan review: 3 Important findings all addressed before implementation (status migration scope expanded 30→47 files, reading theme hook changed from Context/Provider to self-contained, productive friction target corrected to status-transition.tsx)
+- All 758 web unit tests passing
+
+### Decisions
+
+- next-themes with `defaultTheme="light"` + `enableSystem`: dark theme is a first-class part of the brand identity, not an afterthought
+- Self-contained `useReadingTheme` hook (useSyncExternalStore + localStorage) instead of Context/Provider — reading theme is a global user preference, not component-scoped state
+- Outline/ghost button hover uses `bg-secondary` (parchment) instead of `bg-accent` (copper) — copper is never decorative per brand guidelines
+- Bold Italic (not Regular Italic) for productive friction on decision buttons — Regular Italic too fragile at 13-14px button-label size
+- Chart colors derived from brand family (navy, copper, sage green, warm amber, dusty blue) for visual consistency on analytics dashboards


### PR DESCRIPTION
## Summary

- Replace default shadcn/ui neutral palette with Colophony brand identity (Deep Navy, Warm Cream, Copper, Light Parchment) across light and dark themes
- Add Playfair Display (headings) + Lato (body) typography, replacing Geist; Literata stays ManuscriptRenderer-only
- Add dark mode via next-themes with ThemeToggle in header (light/dark/system cycle)
- Migrate all 51 component files from hardcoded Tailwind status colors to 6 semantic CSS variables (success/warning/error/info/active/held)
- Add ManuscriptRenderer reading themes (light/sepia/dark) with circular swatch selector, independent of app theme
- Refine sidebar (copper border active states), breadcrumbs (full contrast current page), buttons (secondary hover), cards (warm shadow), command palette (subtle accent)
- Add Playfair Bold Italic on Accept/Reject/Hold decision labels ("productive friction")
- Document brand token system in DESIGN_SYSTEM.md Section 10

## Test plan

- [x] Type-check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] All 758 web unit tests pass (`pnpm test`)
- [ ] Visual QA: verify brand palette across all pages in both themes
- [ ] Visual QA: check all 3 reading themes (light/sepia/dark) in ManuscriptRenderer
- [ ] Visual QA: verify WCAG AA contrast on semantic status colors
- [ ] Visual QA: confirm copper is only used on interactive/meaningful elements
- [ ] Visual QA: verify Playfair Bold Italic reads well on decision buttons at 13-14px

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| globals.css | `--destructive` dark: `hsl(11 55% 58%)` | `hsl(11 55% 55%)` | Fine-tuned during implementation for better contrast |
| sidebar.tsx | Activity group labels always full-opacity cream | Toggle between `text-sidebar-foreground`/`text-sidebar-muted` based on active state | Pre-existing behavior from sub-brand PR, provides useful visual feedback |