### PR TITLE
fix: identity page 503 for disabled federation; db:reset journal cleanup

### DIFF
--- a/apps/api/src/main.spec.ts
+++ b/apps/api/src/main.spec.ts
@@ -202,17 +202,21 @@ describe('Fastify app', () => {
     expect(response.headers['cache-control']).toBeUndefined();
   });
 
-  it('federation discovery routes return 404 when FEDERATION_ENABLED=false', async () => {
+  it('federation discovery routes return 503 when FEDERATION_ENABLED=false', async () => {
+    // Discovery routes are always registered so the identity page gets a
+    // proper 503 instead of a 404 when federation is disabled.
     const colophonyRes = await app.inject({
       method: 'GET',
       url: '/.well-known/colophony',
     });
-    expect(colophonyRes.statusCode).toBe(404);
+    expect(colophonyRes.statusCode).toBe(503);
+    expect(colophonyRes.json()).toEqual({ error: 'federation_disabled' });
 
     const webfingerRes = await app.inject({
       method: 'GET',
       url: '/.well-known/webfinger?resource=acct:test@example.com',
     });
-    expect(webfingerRes.statusCode).toBe(404);
+    expect(webfingerRes.statusCode).toBe(503);
+    expect(webfingerRes.json()).toEqual({ error: 'federation_disabled' });
   });
 });

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -241,11 +241,15 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
     await registerInngestRoutes(scope);
   });
 
+  // Instance metadata — always registered so the identity page gets a
+  // proper 503 ("federation_disabled") instead of a 404 when federation
+  // is not enabled.
+  await app.register(async (scope) => {
+    await registerFederationDiscoveryRoutes(scope, { env });
+  });
+
   // Federation — isolated scopes (public endpoints)
   if (env.FEDERATION_ENABLED) {
-    await app.register(async (scope) => {
-      await registerFederationDiscoveryRoutes(scope, { env });
-    });
     await app.register(async (scope) => {
       await registerFederationDidRoutes(scope, { env });
     });

--- a/apps/api/src/services/federation.service.ts
+++ b/apps/api/src/services/federation.service.ts
@@ -334,6 +334,12 @@ export const federationService = {
    * for cross-org public metadata (same pattern as org-context.ts:78).
    */
   async getInstanceMetadata(env: Env): Promise<FederationMetadata> {
+    // Fast path: check env flag before any DB queries so the identity
+    // page gets a clean 503 even when federation tables are empty.
+    if (!env.FEDERATION_ENABLED) {
+      throw new FederationDisabledError();
+    }
+
     const config = await this.getPublicConfig(env);
 
     if (!config.enabled) {
@@ -402,6 +408,10 @@ export const federationService = {
     env: Env,
     resource: string,
   ): Promise<WebFingerResponse> {
+    if (!env.FEDERATION_ENABLED) {
+      throw new FederationDisabledError();
+    }
+
     const config = await this.getPublicConfig(env);
 
     if (!config.enabled) {

--- a/docs/devlog/2026-04.md
+++ b/docs/devlog/2026-04.md
@@ -2,6 +2,28 @@
 
 Newest entries first.
 
+## 2026-04-01 — Full Manual QA Audit
+
+### Done
+
+- Systematic manual QA walkthrough of every major page and feature in the app
+  - Tested: Landing, Instance Identity, Auth flow, Org creation, My Submissions, Editor Dashboard, All Submissions, Submission Detail (with queue nav), Forms, Writer Workspace, Slate Production Dashboard, Business Dashboard, Operations Dashboard, Federation Admin, Org Settings, Notifications
+  - Tested dark mode across multiple pages — good contrast, proper theming
+  - Tested mobile viewport (390px) — hamburger menu, sidebar collapse, horizontal scroll tables, responsive landing page
+- Fixed Bug #1: Instance Identity page showed misleading "API server may be unavailable" error when federation was disabled
+  - Root cause: `.well-known/colophony` route not registered when `FEDERATION_ENABLED=false` → 404, but frontend only handled 503
+  - Fix: Register discovery routes unconditionally in `main.ts`; add env fast-path in `federationService.getInstanceMetadata()` and `resolveWebFinger()` before DB queries
+- Fixed Bug #2: `db:reset` lost all SQL functions, triggers, and grants
+  - Root cause: Script dropped `public` schema but preserved `drizzle` schema (migration journal), so `db:migrate` thought all migrations were applied and silently no-oped; `drizzle-kit push` fallback only created tables
+  - Fix: Drop `drizzle` schema alongside `public` so migrations run from clean state; eliminated fragile `push` fallback
+
+### Decisions
+
+- Always register `.well-known/colophony` route regardless of federation flag — cleaner than frontend workaround, and WebFinger benefits from same pattern
+- Drop `drizzle` schema in `db:reset` — root cause fix rather than working around the Drizzle silent no-op quirk
+
+---
+
 ## 2026-04-01 — Demo Prep: Withdrawal Cascade, Seed Data, Badge Animation
 
 ### Done

--- a/scripts/db-reset.sh
+++ b/scripts/db-reset.sh
@@ -19,6 +19,7 @@ fi
 
 echo "Dropping and recreating public schema (Zitadel database preserved)..."
 docker exec "$CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -c "
+  DROP SCHEMA IF EXISTS drizzle CASCADE;
   DROP SCHEMA IF EXISTS public CASCADE;
   CREATE SCHEMA public;
   GRANT ALL ON SCHEMA public TO $DB_USER;
@@ -27,17 +28,16 @@ docker exec "$CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -c "
   GRANT USAGE ON SCHEMA public TO audit_writer;
 "
 
-echo "Running migrations (replays SQL files to restore functions, triggers, extensions)..."
+echo "Running migrations from clean state (includes SQL functions, triggers, extensions)..."
 pnpm --filter @colophony/db migrate
 
-# drizzle-kit migrate() can silently no-op after DROP SCHEMA CASCADE.
-# Verify tables actually exist; fall back to drizzle-kit push if empty.
+# Verify tables actually exist after migration.
 TABLE_COUNT=$(docker exec "$CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -tAc \
   "SELECT count(*) FROM pg_tables WHERE schemaname = 'public';")
 
 if [ "$TABLE_COUNT" -eq 0 ]; then
-  echo "WARNING: migrate() produced no tables (known Drizzle quirk). Falling back to drizzle-kit push..."
-  pnpm --filter @colophony/db push
+  echo "ERROR: migrate() produced no tables. This is a Drizzle bug — check packages/db/drizzle.config.ts." >&2
+  exit 1
 fi
 
 echo "Restoring app_user DML permissions..."


### PR DESCRIPTION
## Summary

- **Identity page fix:** Always register `.well-known/colophony` discovery route so the Instance Identity page gets a proper 503 (`federation_disabled`) instead of a misleading 404 when federation is not enabled. Added env fast-path in `getInstanceMetadata()` and `resolveWebFinger()` to avoid 500 from DB queries on mocked/empty databases.
- **db:reset fix:** Drop the `drizzle` schema (migration journal) alongside `public` so `db:migrate` runs from a truly clean state. Eliminates the fragile `drizzle-kit push` fallback that silently lost SQL functions, triggers, and grants.

## Test plan

- [x] `main.spec.ts` — updated test expects 503 with `{ error: "federation_disabled" }` (was 404)
- [x] `discovery.routes.spec.ts` — 11 tests pass
- [x] `federation.service.spec.ts` — 37 tests pass
- [x] `ALLOW_DB_RESET=true pnpm db:reset` — verified functions, permissions, and seed all restored
- [x] Full type-check, lint, and unit test suite pass