### PR TITLE
fix(deploy): add --no-cache to Docker build to prevent stale images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
             cd ${{ vars.STAGING_APP_DIR }}
             git fetch origin main
             git checkout ${{ needs.prepare.outputs.ref }}
-            docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo build
+            docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo build --no-cache
             docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo up -d
             echo "Waiting for services..."
             sleep 15
@@ -188,7 +188,7 @@ jobs:
             cd ${{ vars.PRODUCTION_APP_DIR }}
             git fetch origin main
             git checkout ${{ needs.prepare.outputs.ref }}
-            docker compose -f docker-compose.prod.yml --env-file .env.prod build
+            docker compose -f docker-compose.prod.yml --env-file .env.prod build --no-cache
             docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
             echo "Waiting for health checks..."
             sleep 15

--- a/apps/api/src/services/invitation.service.spec.ts
+++ b/apps/api/src/services/invitation.service.spec.ts
@@ -74,8 +74,8 @@ function createMockTx() {
     tokenPrefix: 'col_inv_',
     status: 'PENDING',
     invitedBy: 'user-1',
-    expiresAt: new Date('2026-04-03'),
-    createdAt: new Date('2026-03-27'),
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    createdAt: new Date(),
   });
 
   const updateChain = createChain({
@@ -162,8 +162,8 @@ describe('invitation.service', () => {
             roles: ['EDITOR'],
             status: 'PENDING',
             invited_by: 'user-1',
-            expires_at: new Date('2026-04-03'),
-            created_at: new Date('2026-03-27'),
+            expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+            created_at: new Date(),
             organization_name: 'Test Org',
           },
         ],
@@ -286,8 +286,8 @@ describe('invitation.service', () => {
             roles: ['EDITOR'],
             status: 'ACCEPTED',
             invited_by: 'user-1',
-            expires_at: new Date('2026-04-03'),
-            created_at: new Date('2026-03-27'),
+            expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+            created_at: new Date(),
             organization_name: 'Test Org',
           },
         ],
@@ -348,7 +348,7 @@ describe('invitation.service', () => {
     it('throws InvitationEmailMismatchError when emails differ', async () => {
       // acceptToken returns null
       mockPoolQuery.mockResolvedValueOnce({ rows: [] });
-      // verifyToken returns invitation with different email
+      // verifyToken returns invitation with different email (not expired)
       mockPoolQuery.mockResolvedValueOnce({
         rows: [
           {
@@ -358,8 +358,8 @@ describe('invitation.service', () => {
             roles: ['EDITOR'],
             status: 'PENDING',
             invited_by: 'user-1',
-            expires_at: new Date('2026-04-03'),
-            created_at: new Date('2026-03-27'),
+            expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+            created_at: new Date(),
             organization_name: 'Test Org',
           },
         ],


### PR DESCRIPTION
## Summary

- Add `--no-cache` flag to `docker compose build` in both staging and production deploy steps
- Prevents Docker's layer cache from serving stale build artifacts when source code changes between deploys

**Root cause:** The marketing landing page (PR #411) and branding (PRs #408-#409) were merged to `main` and deployed, but Docker reused cached build layers containing the old Next.js build output. The staging site was serving the old "Submissions Management Platform" page instead of the new marketing landing page.

## Test plan

- [ ] Merge this PR and verify the deploy workflow triggers
- [ ] Confirm staging.colophony.pub shows the new marketing landing page after deploy
- [ ] Verify build time increase is acceptable (~2-3 min longer without cache)