### PR TITLE
fix(deploy): force clean checkout and container recreate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,11 +119,28 @@ jobs:
           username: ${{ secrets.STAGING_USER }}
           key: ${{ secrets.STAGING_SSH_KEY }}
           script: |
+            set -e
             cd ${{ vars.STAGING_APP_DIR }}
+
+            echo "=== Pre-deploy diagnostics ==="
+            echo "Current commit: $(git rev-parse HEAD)"
+            echo "Working tree status:"
+            git status --short
+            echo "Target ref: ${{ needs.prepare.outputs.ref }}"
+
+            echo "=== Updating source ==="
             git fetch origin main
-            git checkout ${{ needs.prepare.outputs.ref }}
+            git reset --hard ${{ needs.prepare.outputs.ref }}
+            git clean -fd
+            echo "Checked out: $(git rev-parse HEAD)"
+            echo "Landing components:"
+            ls -la apps/web/src/components/landing/ 2>/dev/null || echo "MISSING"
+
+            echo "=== Building images ==="
             docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo build --no-cache
-            docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo up -d
+
+            echo "=== Recreating containers ==="
+            docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo up -d --force-recreate
             echo "Waiting for services..."
             sleep 15
             docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo ps
@@ -185,11 +202,26 @@ jobs:
           username: ${{ secrets.PRODUCTION_USER }}
           key: ${{ secrets.PRODUCTION_SSH_KEY }}
           script: |
+            set -e
             cd ${{ vars.PRODUCTION_APP_DIR }}
+
+            echo "=== Pre-deploy diagnostics ==="
+            echo "Current commit: $(git rev-parse HEAD)"
+            echo "Working tree status:"
+            git status --short
+            echo "Target ref: ${{ needs.prepare.outputs.ref }}"
+
+            echo "=== Updating source ==="
             git fetch origin main
-            git checkout ${{ needs.prepare.outputs.ref }}
+            git reset --hard ${{ needs.prepare.outputs.ref }}
+            git clean -fd
+            echo "Checked out: $(git rev-parse HEAD)"
+
+            echo "=== Building images ==="
             docker compose -f docker-compose.prod.yml --env-file .env.prod build --no-cache
-            docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+
+            echo "=== Recreating containers ==="
+            docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --force-recreate
             echo "Waiting for health checks..."
             sleep 15
             docker compose -f docker-compose.prod.yml ps


### PR DESCRIPTION
## Summary

- Replace `git checkout` with `git reset --hard` + `git clean -fd` to ensure clean working tree
- Add `--force-recreate` to `docker compose up` to ensure new containers
- Add diagnostic logging (current commit, git status, file existence checks)
- Add `set -e` for fail-fast on errors

**Context:** PR #418 added `--no-cache` to fix Docker layer caching, but staging still serves the old landing page. Local Docker builds produce the correct output, so the issue is on the staging server — likely a dirty working tree preventing `git checkout` from fully updating, or containers not being recreated. We can't SSH to diagnose directly, so this PR adds both the fix and diagnostics.

## Test plan

- [ ] Merge and verify deploy workflow triggers
- [ ] Check deploy job logs for diagnostic output (commit SHA, landing component files)
- [ ] Confirm staging.colophony.pub shows the new marketing landing page