### PR TITLE
fix(deploy): separate core and demo service recreation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,7 +140,9 @@ jobs:
             docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo build --no-cache
 
             echo "=== Recreating containers ==="
-            docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo up -d --force-recreate
+            docker compose -f docker-compose.prod.yml --env-file .env.staging up -d --force-recreate
+            echo "Starting demo services (if provisioned)..."
+            docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo up -d --no-recreate 2>&1 || echo "::warning::Demo services failed to start — may need provisioning"
             echo "Waiting for services..."
             sleep 15
             docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo ps


### PR DESCRIPTION
## Summary

- Force-recreate only core services (no `--profile demo`)
- Start demo services with `--no-recreate` and warn-only on failure
- Prevents `demo-migrate` exit 127 from failing the entire deploy

**Root cause from PR #419 diagnostics:**
1. Server was on commit `17fc3dc` (stale) — previous deploys' `git checkout` wasn't updating properly
2. `git reset --hard` fixed the source code issue
3. Build completed successfully with new landing page components
4. **`--force-recreate` restarted `demo-migrate`**, which failed (exit 127) because the demo DB hasn't been provisioned yet
5. Cascading failure took down `garage` and failed the deploy

## Test plan

- [ ] Merge and verify core services come up with `--force-recreate`
- [ ] Demo services should either stay stopped or warn (not fail)
- [ ] Confirm staging.colophony.pub shows the new marketing landing page