### PR TITLE
fix(deploy): use down + up instead of force-recreate to avoid port conflicts

### DIFF
--- a/.claude/hooks/pre-pr-rebase-check.js
+++ b/.claude/hooks/pre-pr-rebase-check.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+/**
+ * PreToolUse hook for Bash commands.
+ * Before creating a PR, ensures the current branch is rebased on latest origin/main.
+ * Prevents merge conflicts from stale branches.
+ */
+
+const { execSync } = require('child_process');
+
+const command = process.env.CLAUDE_TOOL_ARGS_command || '';
+
+// Only check gh pr create commands
+if (!command.includes('gh pr create')) {
+  process.exit(0);
+}
+
+try {
+  // Fetch latest main
+  execSync('git fetch origin main', { stdio: 'pipe' });
+
+  // Check if current branch is up to date with origin/main
+  const behindCount = execSync('git rev-list --count HEAD..origin/main', {
+    encoding: 'utf-8',
+  }).trim();
+
+  if (behindCount !== '0') {
+    const currentBranch = execSync('git branch --show-current', {
+      encoding: 'utf-8',
+    }).trim();
+
+    console.error(
+      JSON.stringify({
+        decision: 'block',
+        reason: `Branch "${currentBranch}" is ${behindCount} commit(s) behind origin/main. Rebase first to avoid merge conflicts:\n\n  git fetch origin main && git rebase origin/main\n\nThen push and retry the PR.`,
+      })
+    );
+    process.exit(0);
+  }
+
+  // Check for merge conflicts with main
+  const mergeBase = execSync('git merge-base HEAD origin/main', {
+    encoding: 'utf-8',
+  }).trim();
+  const mainHead = execSync('git rev-parse origin/main', {
+    encoding: 'utf-8',
+  }).trim();
+
+  if (mergeBase !== mainHead) {
+    console.error(
+      JSON.stringify({
+        decision: 'block',
+        reason:
+          'Branch has diverged from origin/main. Rebase first:\n\n  git fetch origin main && git rebase origin/main',
+      })
+    );
+    process.exit(0);
+  }
+} catch (err) {
+  // Don't block on hook errors (e.g., no network for fetch)
+  console.error(
+    JSON.stringify({
+      decision: 'warn',
+      reason: `Pre-PR rebase check failed: ${err.message}. Proceeding anyway.`,
+    })
+  );
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/pre-pr-rebase-check.js",
+            "if": "Bash(gh pr create*)"
+          }
+        ]
+      },
+      {
         "matcher": "ExitPlanMode",
         "hooks": [
           {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,8 +139,11 @@ jobs:
             echo "=== Building images ==="
             docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo build --no-cache
 
-            echo "=== Recreating containers ==="
-            docker compose -f docker-compose.prod.yml --env-file .env.staging up -d --force-recreate
+            echo "=== Stopping old containers ==="
+            docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo down --remove-orphans || true
+
+            echo "=== Starting containers ==="
+            docker compose -f docker-compose.prod.yml --env-file .env.staging up -d
             echo "Starting demo services (if provisioned)..."
             docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo up -d --no-recreate 2>&1 || echo "::warning::Demo services failed to start — may need provisioning"
             echo "Waiting for services..."
@@ -222,8 +225,11 @@ jobs:
             echo "=== Building images ==="
             docker compose -f docker-compose.prod.yml --env-file .env.prod build --no-cache
 
-            echo "=== Recreating containers ==="
-            docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --force-recreate
+            echo "=== Stopping old containers ==="
+            docker compose -f docker-compose.prod.yml --env-file .env.prod down --remove-orphans || true
+
+            echo "=== Starting containers ==="
+            docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
             echo "Waiting for health checks..."
             sleep 15
             docker compose -f docker-compose.prod.yml ps


### PR DESCRIPTION
## Summary

- Replace `--force-recreate` with `down --remove-orphans` followed by `up -d`
- Cleanly stops all containers before starting new ones, avoiding port 80 bind conflicts
- Applies to both staging and production deploy steps

**Root cause from PR #420 deploy failure:**
The `--force-recreate` flag tears down and recreates containers in-place, but Caddy doesn't release port 80 fast enough before the new container tries to bind. Additionally, the `garage` service timed out waiting on a dependency. Using `down` first ensures clean shutdown before `up` starts fresh containers from the newly built images.

## Test plan

- [ ] Merge and verify deploy completes without port conflicts
- [ ] Confirm staging.colophony.pub shows the new marketing landing page
- [ ] Verify all core services are healthy (postgres, redis, api, web, caddy)