### PR TITLE
fix(deploy): force-stop all colophony containers before starting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,7 +140,11 @@ jobs:
             docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo build --no-cache
 
             echo "=== Stopping old containers ==="
-            docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo down --remove-orphans || true
+            docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo down --remove-orphans --timeout 30 || true
+            # Kill any containers still holding ports (handles inconsistent state from prior failed deploys)
+            docker ps -q --filter "name=colophony-" | xargs -r docker stop || true
+            docker ps -aq --filter "name=colophony-" | xargs -r docker rm -f || true
+            sleep 2
 
             echo "=== Starting containers ==="
             docker compose -f docker-compose.prod.yml --env-file .env.staging up -d
@@ -226,7 +230,10 @@ jobs:
             docker compose -f docker-compose.prod.yml --env-file .env.prod build --no-cache
 
             echo "=== Stopping old containers ==="
-            docker compose -f docker-compose.prod.yml --env-file .env.prod down --remove-orphans || true
+            docker compose -f docker-compose.prod.yml --env-file .env.prod down --remove-orphans --timeout 30 || true
+            docker ps -q --filter "name=colophony-" | xargs -r docker stop || true
+            docker ps -aq --filter "name=colophony-" | xargs -r docker rm -f || true
+            sleep 2
 
             echo "=== Starting containers ==="
             docker compose -f docker-compose.prod.yml --env-file .env.prod up -d


### PR DESCRIPTION
## Summary

- Add explicit `docker stop` + `docker rm -f` for all `colophony-*` containers after `compose down`
- Add `--timeout 30` to `compose down` for graceful shutdown
- Add 2s sleep between stop and start for port release
- Applies to both staging and production

**Root cause:** `docker compose down` wasn't releasing Caddy's port 80. The previous failed deploy (#420's `--force-recreate`) left containers in inconsistent state that `compose down` couldn't match. The explicit `docker stop/rm` by container name prefix is a safety net that handles any state.

## Test plan

- [ ] Merge and verify deploy completes without port 80 conflict
- [ ] Confirm staging.colophony.pub shows the new marketing landing page
- [ ] Brief downtime expected during container restart (~15-30s)