### PR TITLE
fix(deploy): diagnose and kill processes holding port 80/443

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,9 +141,16 @@ jobs:
 
             echo "=== Stopping old containers ==="
             docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo down --remove-orphans --timeout 30 || true
-            # Kill any containers still holding ports (handles inconsistent state from prior failed deploys)
             docker ps -q --filter "name=colophony-" | xargs -r docker stop || true
             docker ps -aq --filter "name=colophony-" | xargs -r docker rm -f || true
+
+            echo "=== Checking port 80/443 ==="
+            echo "Port 80:" && (ss -tlnp sport = :80 || true)
+            echo "Port 443:" && (ss -tlnp sport = :443 || true)
+            echo "Docker containers on port 80:" && (docker ps --filter "publish=80" --format '{{.Names}} {{.Status}}' || true)
+            # Kill anything holding port 80/443 (e.g., leftover Coolify/Traefik)
+            fuser -k 80/tcp 2>/dev/null || true
+            fuser -k 443/tcp 2>/dev/null || true
             sleep 2
 
             echo "=== Starting containers ==="
@@ -233,6 +240,13 @@ jobs:
             docker compose -f docker-compose.prod.yml --env-file .env.prod down --remove-orphans --timeout 30 || true
             docker ps -q --filter "name=colophony-" | xargs -r docker stop || true
             docker ps -aq --filter "name=colophony-" | xargs -r docker rm -f || true
+
+            echo "=== Checking port 80/443 ==="
+            echo "Port 80:" && (ss -tlnp sport = :80 || true)
+            echo "Port 443:" && (ss -tlnp sport = :443 || true)
+            echo "Docker containers on port 80:" && (docker ps --filter "publish=80" --format '{{.Names}} {{.Status}}' || true)
+            fuser -k 80/tcp 2>/dev/null || true
+            fuser -k 443/tcp 2>/dev/null || true
             sleep 2
 
             echo "=== Starting containers ==="


### PR DESCRIPTION
## Summary

- Add `ss` and `docker ps` diagnostics to identify what's holding port 80/443 after compose down
- Add `fuser -k` to kill any process on port 80/443 before starting containers
- Applies to both staging and production

**Root cause:** compose down correctly stops and removes Caddy, but 44 seconds later the new Caddy can't bind port 80. Something else on the server is grabbing the port — likely a leftover Coolify/Traefik proxy from the previous deployment infrastructure (migrated in PR #336). The `ss` output will identify it, and `fuser -k` will clear it.

## Test plan

- [ ] Merge and check deploy logs for `ss` output identifying what's on port 80
- [ ] `fuser -k` should clear the port and allow Caddy to start
- [ ] Confirm staging.colophony.pub shows the new marketing landing page
- [ ] Once identified, remove the offending service permanently