### PR TITLE
fix(deploy): fully stop Coolify service to prevent proxy auto-restart

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,13 +144,20 @@ jobs:
             docker ps -q --filter "name=colophony-" | xargs -r docker stop || true
             docker ps -aq --filter "name=colophony-" | xargs -r docker rm -f || true
 
-            # Remove leftover Coolify proxy (migrated to Caddy in PR #336)
-            echo "=== Clearing port 80/443 ==="
-            docker stop coolify-proxy 2>/dev/null && docker rm coolify-proxy 2>/dev/null && echo "Removed coolify-proxy" || true
-            # Safety net: kill any remaining process on port 80/443
+            # Fully stop Coolify (migrated to Caddy in PR #336) — it auto-restarts its proxy
+            echo "=== Removing Coolify ==="
+            systemctl stop coolify.service 2>/dev/null || true
+            systemctl disable coolify.service 2>/dev/null || true
+            docker stop coolify-proxy 2>/dev/null && docker rm -f coolify-proxy 2>/dev/null || true
+            docker stop coolify 2>/dev/null && docker rm -f coolify 2>/dev/null || true
+            # Stop any other Coolify-managed containers
+            docker ps -q --filter "label=coolify.managed=true" | xargs -r docker stop 2>/dev/null || true
+            docker ps -aq --filter "label=coolify.managed=true" | xargs -r docker rm -f 2>/dev/null || true
+            # Final safety net
             fuser -k 80/tcp 2>/dev/null || true
             fuser -k 443/tcp 2>/dev/null || true
-            sleep 2
+            sleep 3
+            echo "Port 80 after cleanup:" && (ss -tlnp sport = :80 || true)
 
             echo "=== Starting containers ==="
             docker compose -f docker-compose.prod.yml --env-file .env.staging up -d


### PR DESCRIPTION
## Summary

- Stop and disable `coolify.service` systemd unit
- Remove `coolify-proxy` AND `coolify` containers
- Remove any containers with `coolify.managed=true` label
- `fuser -k` as final safety net
- Verify port 80 is clear with `ss` before starting

**Why the previous fix didn't work:** PR #424 removed `coolify-proxy` but Coolify's auto-restart mechanism (either Docker restart policy or the Coolify systemd service) recreated it within seconds. We need to stop Coolify at the source.

## Test plan

- [ ] Deploy logs show Coolify service stopped/disabled
- [ ] `ss` output after cleanup shows port 80 clear
- [ ] Caddy starts and binds port 80 successfully
- [ ] staging.colophony.pub shows the new marketing landing page