### PR TITLE
fix(deploy): make docker compose up non-fatal for staging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,9 +160,9 @@ jobs:
             echo "Port 80 after cleanup:" && (ss -tlnp sport = :80 || true)
 
             echo "=== Starting containers ==="
-            docker compose -f docker-compose.prod.yml --env-file .env.staging up -d
-            echo "Starting demo services (if provisioned)..."
-            docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo up -d --no-recreate 2>&1 || echo "::warning::Demo services failed to start — may need provisioning"
+            # up -d can fail if non-critical services (garage, demo) have issues — don't abort
+            docker compose -f docker-compose.prod.yml --env-file .env.staging up -d 2>&1 || echo "::warning::Some services failed to start"
+            docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo up -d --no-recreate 2>&1 || echo "::warning::Demo services failed to start"
             echo "Waiting for services..."
             sleep 15
             docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo ps


### PR DESCRIPTION
## Summary

- Make `docker compose up -d` warn-only instead of fatal (`|| echo ::warning::`)
- The deploy's own verify step (`curl /ready`) is the real health gate

**Context:** PR #425 successfully removed Coolify and cleared port 80. The remaining failure is Garage's health check timing out because `GARAGE_RPC_SECRET` isn't in `.env.staging` (S3 not provisioned yet). With `set -e`, this kills the entire deploy before the actual health check step can run — even though postgres, redis, api, web, and caddy all started fine.

## Test plan

- [ ] Deploy completes past the `up -d` step (Garage warning expected)
- [ ] Verify step (`curl /ready`) passes
- [ ] staging.colophony.pub shows the new marketing landing page