### PR TITLE
chore(deploy): provision staging S3, demo site, clean up Coolify

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,19 +122,11 @@ jobs:
             set -e
             cd ${{ vars.STAGING_APP_DIR }}
 
-            echo "=== Pre-deploy diagnostics ==="
-            echo "Current commit: $(git rev-parse HEAD)"
-            echo "Working tree status:"
-            git status --short
-            echo "Target ref: ${{ needs.prepare.outputs.ref }}"
-
             echo "=== Updating source ==="
             git fetch origin main
             git reset --hard ${{ needs.prepare.outputs.ref }}
             git clean -fd
             echo "Checked out: $(git rev-parse HEAD)"
-            echo "Landing components:"
-            ls -la apps/web/src/components/landing/ 2>/dev/null || echo "MISSING"
 
             echo "=== Building images ==="
             docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo build --no-cache
@@ -144,23 +136,7 @@ jobs:
             docker ps -q --filter "name=colophony-" | xargs -r docker stop || true
             docker ps -aq --filter "name=colophony-" | xargs -r docker rm -f || true
 
-            # Fully stop Coolify (migrated to Caddy in PR #336) — it auto-restarts its proxy
-            echo "=== Removing Coolify ==="
-            systemctl stop coolify.service 2>/dev/null || true
-            systemctl disable coolify.service 2>/dev/null || true
-            docker stop coolify-proxy 2>/dev/null && docker rm -f coolify-proxy 2>/dev/null || true
-            docker stop coolify 2>/dev/null && docker rm -f coolify 2>/dev/null || true
-            # Stop any other Coolify-managed containers
-            docker ps -q --filter "label=coolify.managed=true" | xargs -r docker stop 2>/dev/null || true
-            docker ps -aq --filter "label=coolify.managed=true" | xargs -r docker rm -f 2>/dev/null || true
-            # Final safety net
-            fuser -k 80/tcp 2>/dev/null || true
-            fuser -k 443/tcp 2>/dev/null || true
-            sleep 3
-            echo "Port 80 after cleanup:" && (ss -tlnp sport = :80 || true)
-
             echo "=== Starting containers ==="
-            # up -d can fail if non-critical services (garage, demo) have issues — don't abort
             docker compose -f docker-compose.prod.yml --env-file .env.staging up -d 2>&1 || echo "::warning::Some services failed to start"
             docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo up -d --no-recreate 2>&1 || echo "::warning::Demo services failed to start"
             echo "Waiting for services..."

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -563,7 +563,7 @@ services:
         apk add --no-cache postgresql16-client bash
         /app/scripts/init-prod.sh
         echo "Running demo seed..."
-        cd /app && npx tsx packages/db/src/seed-demo.ts
+        cd /app && ./packages/db/node_modules/.bin/tsx packages/db/src/seed-demo.ts
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-colophony}:${POSTGRES_PASSWORD}@postgres:5432/colophony_demo
       DATABASE_APP_URL: postgresql://app_user:${APP_USER_PASSWORD}@postgres:5432/colophony_demo

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -593,11 +593,11 @@
 
 ### Staging Provisioning
 
-- [ ] [P2] Provision Garage S3 on staging — add GARAGE_RPC_SECRET, GARAGE_ADMIN_TOKEN, GARAGE_S3_ACCESS_KEY, GARAGE_S3_SECRET_KEY to .env.staging; run start-garage.sh layout assign — (DEVLOG 2026-04-07, deploy diagnostics)
-- [ ] [P2] Provision tusd on staging — smoke test shows `OPTIONS /upload — Tus-Resumable header missing`; tusd container likely needs S3 config — (DEVLOG 2026-04-07, smoke test)
-- [ ] [P2] Demo one-time server setup — DNS for demo.staging.colophony.pub, init-demo-db.sh, Garage demo buckets, 4-hour cron reset. See docs/demo/deploy-checklist.md — (DEVLOG 2026-04-02, handoff)
-- [ ] [P3] Remove Coolify cleanup from deploy workflow — `systemctl stop/disable coolify.service` and coolify container removal can be removed once confirmed Coolify is gone permanently; currently runs every deploy as safety net — (DEVLOG 2026-04-07)
-- [ ] [P3] Clean up deploy diagnostics — remove verbose ss/echo diagnostics from deploy.yml once deploy is stable for a few sessions — (DEVLOG 2026-04-07)
+- [x] [P2] Provision Garage S3 on staging — add GARAGE_RPC_SECRET, GARAGE_ADMIN_TOKEN, GARAGE_S3_ACCESS_KEY, GARAGE_S3_SECRET_KEY to .env.staging; run start-garage.sh layout assign — (DEVLOG 2026-04-07, deploy diagnostics; done 2026-04-08)
+- [x] [P2] Provision tusd on staging — smoke test shows `OPTIONS /upload — Tus-Resumable header missing`; tusd container likely needs S3 config — (DEVLOG 2026-04-07, smoke test; done 2026-04-08 — tusd connected to Garage, Tus-Resumable header present)
+- [x] [P2] Demo one-time server setup — DNS for demo.staging.colophony.pub, init-demo-db.sh, Garage demo buckets, 4-hour cron reset. See docs/demo/deploy-checklist.md — (DEVLOG 2026-04-02, handoff; done 2026-04-08)
+- [x] [P3] Remove Coolify cleanup from deploy workflow — `systemctl stop/disable coolify.service` and coolify container removal can be removed once confirmed Coolify is gone permanently; currently runs every deploy as safety net — (DEVLOG 2026-04-07; done 2026-04-08 — Coolify confirmed gone, systemd unit not-found, leftover coolify-redis/coolify-db removed)
+- [x] [P3] Clean up deploy diagnostics — remove verbose ss/echo diagnostics from deploy.yml once deploy is stable for a few sessions — (DEVLOG 2026-04-07; done 2026-04-08)
 
 ### Monitoring
 

--- a/scripts/demo-reset.sh
+++ b/scripts/demo-reset.sh
@@ -12,6 +12,7 @@
 set -euo pipefail
 
 COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+ENV_FILE="${ENV_FILE:-.env.staging}"
 DEMO_DB="colophony_demo"
 PGUSER="${POSTGRES_USER:-colophony}"
 
@@ -19,12 +20,12 @@ echo "=== Demo reset starting at $(date -u '+%Y-%m-%dT%H:%M:%SZ') ==="
 
 # 1. Drop and recreate the public schema (also drop drizzle schema so migrations re-run)
 echo "Dropping schemas..."
-docker compose -f "$COMPOSE_FILE" --profile demo exec -T postgres \
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" --profile demo exec -T postgres \
   psql -U "$PGUSER" -d "$DEMO_DB" -c "DROP SCHEMA IF EXISTS drizzle CASCADE; DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;"
 
 # 2. Re-grant default privileges (lost when schema is dropped)
 echo "Re-granting privileges..."
-docker compose -f "$COMPOSE_FILE" --profile demo exec -T postgres \
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" --profile demo exec -T postgres \
   psql -U "$PGUSER" -d "$DEMO_DB" <<SQL
 GRANT USAGE ON SCHEMA public TO app_user;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user;
@@ -34,6 +35,6 @@ SQL
 
 # 3. Run demo-migrate (migrations + seed via builder image)
 echo "Running migrations and seed..."
-docker compose -f "$COMPOSE_FILE" --profile demo run --rm demo-migrate
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" --profile demo run --rm demo-migrate
 
 echo "=== Demo reset complete at $(date -u '+%Y-%m-%dT%H:%M:%SZ') ==="


### PR DESCRIPTION
## Summary

- **Garage S3 provisioned on staging** — generated credentials, wrote `.env.staging`, buckets created (`submissions`, `quarantine`, `demo-submissions`, `demo-quarantine`), tusd connected and serving uploads
- **Demo site fully set up** — DNS (demo.staging.colophony.pub), database created with RLS grants, seed data loaded, demo login working, 4-hour cron reset installed
- **Coolify fully removed** — confirmed systemd unit gone, removed orphaned coolify-redis/coolify-db containers, removed Coolify cleanup block and verbose diagnostics from deploy.yml
- **Bug fixes** — `demo-migrate` `npx tsx` → direct path (tsx not in root node_modules), `demo-reset.sh` missing `--env-file` flag

## Test plan

- [x] Garage health: `curl -sf http://localhost:3903/health` (on server)
- [x] tusd: `OPTIONS /upload` returns `Tus-Resumable: 1.0.0`
- [x] Demo frontend: `https://demo.staging.colophony.pub/` returns 200
- [x] Demo login: `POST /v1/public/demo/login` returns user data
- [x] All containers healthy: `docker ps` shows healthy status
- [ ] CI passes on this PR
- [ ] Next deploy via GitHub Actions succeeds with cleaned-up workflow