### PR TITLE
docs: update devlog for 2026-04-08 staging provisioning session

### DIFF
--- a/docs/devlog/2026-04.md
+++ b/docs/devlog/2026-04.md
@@ -2,6 +2,31 @@
 
 Newest entries first.
 
+## 2026-04-08 — Staging Provisioning (Garage S3, Demo Site, Coolify Cleanup)
+
+### Done
+
+- Provisioned Garage S3 on staging: generated 4 secrets, wrote complete `.env.staging` (preserving existing Postgres/Redis/Zitadel/Inngest credentials from running containers), Garage healthy with `submissions` + `quarantine` buckets
+- Connected tusd to Garage S3: file uploads verified via `Tus-Resumable: 1.0.0` header
+- Confirmed Coolify fully removed from staging: systemd unit `not-found`, removed orphaned `coolify-redis` and `coolify-db` containers
+- Cleaned deploy workflow (PR #428): removed Coolify cleanup block (systemctl, container removal, fuser port kill), removed verbose pre-deploy diagnostics (git status, landing component ls)
+- Set up demo site end-to-end:
+  - DNS A record for `demo.staging.colophony.pub` via Cloudflare
+  - Created `colophony_demo` database with `app_user` RLS grants
+  - Created `demo-submissions` and `demo-quarantine` S3 buckets with RWO access
+  - Fixed `demo-migrate` tsx path bug (`npx tsx` not found in builder image; changed to `./packages/db/node_modules/.bin/tsx`)
+  - Ran demo seed: 3 orgs, 5 users, submissions pipeline data
+  - Demo login endpoint verified: `POST /v1/public/demo/login` returns user data
+  - Installed 4-hour cron reset (`scripts/demo-reset.sh`)
+  - Fixed `demo-reset.sh` missing `--env-file` flag on all `docker compose` commands
+- First green deploy with smoke tests (previously failing because demo endpoints returned 000)
+- Updated staging SSH memory: app directory is `/opt/colophony` (not `/root/colophony`)
+
+### Decisions
+
+- Reused existing credentials from running containers rather than regenerating (avoids breaking Postgres/Redis/Zitadel state)
+- Fixed demo-migrate tsx via direct path rather than adding tsx to root package.json (builder image already has it in workspace node_modules)
+
 ## 2026-04-07 — Staging Deploy Fix (Landing Page Not Updating)
 
 ### Done


### PR DESCRIPTION
## Summary

- DEVLOG entry for 2026-04-08 session: Garage S3 provisioning, demo site setup, Coolify cleanup, deploy workflow cleanup

## Test plan

- [x] Doc-only change, no code impact