### PR TITLE
fix(web): demo polish — external subs seed, demo URL routing, logotype SVG

### DIFF
--- a/.claude/hooks/pre-push-branch.js
+++ b/.claude/hooks/pre-push-branch.js
@@ -10,6 +10,8 @@
  *   3. Open PR via `gh pr create`
  */
 
+const { execSync } = require('child_process');
+
 const command = process.env.CLAUDE_TOOL_ARGS_command || '';
 
 // Only check git push commands
@@ -23,7 +25,6 @@ if (!command.includes('git push')) {
 const pushToMainPattern = /git push\b.*(?:\s|:)(main|master)(?:\s|$)/;
 
 if (pushToMainPattern.test(command)) {
-  // Output JSON to block the action
   const result = {
     decision: "block",
     reason: "Cannot push directly to main — it is a protected branch.\n" +
@@ -34,6 +35,28 @@ if (pushToMainPattern.test(command)) {
   };
   console.log(JSON.stringify(result));
   process.exit(0);
+}
+
+// Detect pushing to a branch whose PR was already merged (remote tracking ref deleted)
+try {
+  const branchInfo = execSync('git branch -vv --no-color 2>/dev/null', { encoding: 'utf8' });
+  const currentLine = branchInfo.split('\n').find(l => l.startsWith('*'));
+  if (currentLine && currentLine.includes(': gone]')) {
+    const branchName = currentLine.replace(/^\*\s+/, '').split(/\s/)[0];
+    const result = {
+      decision: "block",
+      reason: `Branch '${branchName}' has a deleted remote tracking ref (PR was likely merged).\n` +
+        "Pushing here will recreate the remote branch but won't reopen the PR.\n" +
+        "Create a new branch instead:\n" +
+        `  1. git checkout -b <new-branch>  (from current commits)\n` +
+        "  2. git push -u origin <new-branch>\n" +
+        "  3. gh pr create --title '...' --body '...'"
+    };
+    console.log(JSON.stringify(result));
+    process.exit(0);
+  }
+} catch {
+  // If git command fails, don't block — fail open
 }
 
 process.exit(0);

--- a/apps/web/src/components/landing/landing-demo-form.tsx
+++ b/apps/web/src/components/landing/landing-demo-form.tsx
@@ -16,8 +16,15 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import Link from "next/link";
 import { useInView } from "@/hooks/use-in-view";
+
+function getDemoUrl() {
+  if (typeof window === "undefined") return "/demo";
+  const host = window.location.hostname;
+  if (host.startsWith("demo.")) return "/demo";
+  const proto = window.location.protocol;
+  return `${proto}//demo.${host}/demo`;
+}
 
 const demoFormSchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -186,12 +193,12 @@ export function LandingDemoForm() {
             </Button>
             <p className="text-center text-sm text-muted-foreground">
               Or{" "}
-              <Link
-                href="/demo"
+              <a
+                href={getDemoUrl()}
                 className="text-primary hover:text-primary/80 font-medium underline underline-offset-4"
               >
                 try the demo now
-              </Link>{" "}
+              </a>{" "}
               &mdash; no account needed.
             </p>
           </form>

--- a/apps/web/src/components/landing/landing-header.tsx
+++ b/apps/web/src/components/landing/landing-header.tsx
@@ -4,6 +4,14 @@ import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
+function getDemoUrl() {
+  if (typeof window === "undefined") return "/demo";
+  const host = window.location.hostname;
+  if (host.startsWith("demo.")) return "/demo";
+  const proto = window.location.protocol;
+  return `${proto}//demo.${host}/demo`;
+}
+
 const navLinks = [
   { label: "Features", href: "#features" },
   { label: "For Writers", href: "#writers" },
@@ -49,7 +57,7 @@ export function LandingHeader({ onSignIn }: LandingHeaderProps) {
             Sign in
           </button>
           <Button variant="ghost" asChild className="hidden md:inline-flex">
-            <Link href="/demo">Try Demo</Link>
+            <a href={getDemoUrl()}>Try Demo</a>
           </Button>
           <Button
             asChild

--- a/apps/web/src/components/landing/landing-header.tsx
+++ b/apps/web/src/components/landing/landing-header.tsx
@@ -31,8 +31,8 @@ export function LandingHeader({ onSignIn }: LandingHeaderProps) {
           <Image
             src="/logos/logotype-dark.svg"
             alt="Colophony"
-            width={160}
-            height={32}
+            width={200}
+            height={40}
             priority
           />
         </Link>

--- a/apps/web/src/components/landing/landing-hero.tsx
+++ b/apps/web/src/components/landing/landing-hero.tsx
@@ -1,9 +1,16 @@
 "use client";
 
 import Image from "next/image";
-import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { ExternalLink } from "lucide-react";
+
+function getDemoUrl() {
+  if (typeof window === "undefined") return "/demo";
+  const host = window.location.hostname;
+  if (host.startsWith("demo.")) return "/demo";
+  const proto = window.location.protocol;
+  return `${proto}//demo.${host}/demo`;
+}
 
 interface LandingHeroProps {
   onRequestDemo: () => void;
@@ -34,7 +41,7 @@ export function LandingHero({ onRequestDemo }: LandingHeroProps) {
           </p>
           <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <Button size="lg" className="px-8 text-base" asChild>
-              <Link href="/demo">Try the Demo</Link>
+              <a href={getDemoUrl()}>Try the Demo</a>
             </Button>
             <Button
               size="lg"

--- a/apps/web/src/components/layout/__tests__/sidebar.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/sidebar.spec.tsx
@@ -116,7 +116,7 @@ describe("Sidebar", () => {
 
   it("should render Colophony brand link", () => {
     render(<Sidebar />);
-    const brandLink = screen.getByText("Colophony").closest("a");
+    const brandLink = screen.getByRole("link", { name: /Colophony/ });
     expect(brandLink).toHaveAttribute("href", "/");
   });
 

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useSyncExternalStore } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuth } from "@/hooks/use-auth";
@@ -73,8 +74,23 @@ export function Header() {
         <MobileMenu key={pathname} />
 
         {/* Logo */}
-        <Link href="/" className="flex items-center space-x-2 mr-6">
-          <span className="font-bold text-lg">Colophony</span>
+        <Link href="/" className="mr-6" aria-label="Colophony home">
+          <Image
+            src="/logos/logotype-light.svg"
+            alt="Colophony"
+            width={120}
+            height={24}
+            className="hidden dark:block"
+            priority
+          />
+          <Image
+            src="/logos/logotype-dark.svg"
+            alt="Colophony"
+            width={120}
+            height={24}
+            className="block dark:hidden"
+            priority
+          />
         </Link>
 
         {/* Spacer */}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
@@ -128,8 +129,21 @@ export function Sidebar() {
     <div className="flex flex-col h-full bg-sidebar-background">
       {/* Header */}
       <div className="flex h-14 items-center border-b border-sidebar-border px-4">
-        <Link href="/" className="font-bold text-lg text-sidebar-foreground">
-          Colophony
+        <Link href="/" aria-label="Colophony home">
+          <Image
+            src="/logos/logotype-light.svg"
+            alt="Colophony"
+            width={120}
+            height={24}
+            className="hidden dark:block"
+          />
+          <Image
+            src="/logos/logotype-dark.svg"
+            alt="Colophony"
+            width={120}
+            height={24}
+            className="block dark:hidden"
+          />
         </Link>
       </div>
 

--- a/docs/devlog/2026-04.md
+++ b/docs/devlog/2026-04.md
@@ -21,11 +21,18 @@ Newest entries first.
   - Fixed `demo-reset.sh` missing `--env-file` flag on all `docker compose` commands
 - First green deploy with smoke tests (previously failing because demo endpoints returned 000)
 - Updated staging SSH memory: app directory is `/opt/colophony` (not `/root/colophony`)
+- Added 7 external submission records to demo seed (Ploughshares, Kenyon Review, Tin House, One Story, The Sun, Orion, AGNI) — Writer Workspace dashboard stats were showing all zeros because `externalSubmissions` table was never seeded
+- Fixed demo "Try Demo" links on main site: pointed to `/demo` on same origin (route not found), now derives `demo.<hostname>/demo` URL from current hostname
+- Replaced plain sans-serif "Colophony" text in dashboard header and sidebar with theme-aware logotype SVG (dark/light variants via `dark:hidden`/`dark:block`); bumped landing page logotype from 160px to 200px
+- Added pre-push hook check: blocks pushing to branches whose remote tracking ref was deleted (merged PR), suggests creating a new branch instead
+- Visual QA of demo site via Chrome DevTools: verified all seed data renders correctly across writer and editor views (manuscripts, submissions, pipeline, contracts, issues, contributors, payments, collections, external submissions)
 
 ### Decisions
 
 - Reused existing credentials from running containers rather than regenerating (avoids breaking Postgres/Redis/Zitadel state)
 - Fixed demo-migrate tsx via direct path rather than adding tsx to root package.json (builder image already has it in workspace node_modules)
+- Dashboard stats (Pending/Accepted/Rejected) query `externalSubmissions` table (writer's tracker for other magazines), not internal Colophony `submissions` — this is correct behavior, not a bug
+- Landing page hero logomark with scroll-to-nav animation deferred to a future session
 
 ## 2026-04-07 — Staging Deploy Fix (Landing Page Not Updating)
 

--- a/packages/db/src/seed-demo.ts
+++ b/packages/db/src/seed-demo.ts
@@ -46,6 +46,7 @@ import {
   payments,
   workspaceCollections,
   workspaceItems,
+  externalSubmissions,
 } from "./schema";
 
 // ---------------------------------------------------------------------------
@@ -1002,6 +1003,80 @@ async function seedDemo(tx: DrizzleDb) {
 
   console.log(
     "  Editor workspace: 1 collection, 2 items (with reading position)",
+  );
+
+  // =========================================================================
+  // 11. External submissions (writer's submission tracker for other magazines)
+  // =========================================================================
+
+  await tx.insert(externalSubmissions).values([
+    {
+      userId: writer!.id,
+      manuscriptId: poetryMs!.id,
+      journalName: "Ploughshares",
+      status: "accepted",
+      sentAt: daysAgo(90),
+      respondedAt: daysAgo(30),
+      method: "Submittable",
+      notes: "Guest editor loved the tidal imagery.",
+    },
+    {
+      userId: writer!.id,
+      manuscriptId: poetryMs!.id,
+      journalName: "The Kenyon Review",
+      status: "rejected",
+      sentAt: daysAgo(120),
+      respondedAt: daysAgo(75),
+      method: "Submittable",
+      notes: "Form rejection — 60 days.",
+    },
+    {
+      userId: writer!.id,
+      manuscriptId: fictionMs!.id,
+      journalName: "Tin House",
+      status: "sent",
+      sentAt: daysAgo(14),
+      method: "Submittable",
+    },
+    {
+      userId: writer!.id,
+      manuscriptId: fictionMs!.id,
+      journalName: "One Story",
+      status: "in_review",
+      sentAt: daysAgo(45),
+      method: "email",
+      notes: "Received personal note from reader — moved to second round.",
+    },
+    {
+      userId: writer!.id,
+      manuscriptId: nonfictionMs!.id,
+      journalName: "The Sun Magazine",
+      status: "sent",
+      sentAt: daysAgo(21),
+      method: "postal",
+    },
+    {
+      userId: writer!.id,
+      manuscriptId: nonfictionMs!.id,
+      journalName: "Orion Magazine",
+      status: "rejected",
+      sentAt: daysAgo(100),
+      respondedAt: daysAgo(55),
+      method: "Submittable",
+      notes: "Encouraging rejection — asked to see future work.",
+    },
+    {
+      userId: writer!.id,
+      journalName: "AGNI",
+      status: "no_response",
+      sentAt: daysAgo(180),
+      method: "Submittable",
+      notes: "Past their stated response window. Assuming rejection.",
+    },
+  ]);
+
+  console.log(
+    "  External submissions: 7 (2 accepted/rejected, 3 pending, 2 rejected/no-response)",
   );
 
   console.log("\nDemo seed complete.");


### PR DESCRIPTION
## Summary

- **External submission seed data** — adds 7 external submissions for Elena Vasquez (Ploughshares, Kenyon Review, Tin House, etc.) so the Writer Workspace dashboard stats show real numbers instead of all zeros
- **Demo URL routing fix** — landing page "Try Demo" links now navigate to the demo subdomain (`demo.<host>/demo`) instead of `/demo` on the same origin, which caused route-not-found errors
- **Logotype SVG in header/sidebar** — replaces plain sans-serif "Colophony" text with the proper logotype SVG, theme-aware (dark/light variants). Bumps landing page logotype from 160px to 200px.

## Test plan

- [x] Demo dashboard stats verified on staging (Manuscripts: 3, Pending: 3, Accepted: 1, Rejected: 2)
- [ ] Demo URL routing: clicking "Try Demo" on staging.colophony.pub navigates to demo.staging.colophony.pub/demo
- [ ] Logotype renders correctly in header and sidebar (dark and light themes)
- [ ] Landing page logotype is larger and readable