### PR TITLE
fix(web): landing page UX polish — logotype morph, consult rebrand, mobile nav

### DIFF
--- a/apps/api/src/routes/public.routes.ts
+++ b/apps/api/src/routes/public.routes.ts
@@ -1,19 +1,15 @@
 import type { FastifyInstance } from 'fastify';
 import { db, organizations, users, demoRequests } from '@colophony/db';
 import { eq } from 'drizzle-orm';
-import { slugSchema, demoLoginRequestSchema } from '@colophony/types';
-import { z } from 'zod';
+import {
+  slugSchema,
+  demoLoginRequestSchema,
+  consultRequestSchema,
+} from '@colophony/types';
 import { responseTimeTransparencyService } from '../services/response-time-transparency.service.js';
 import { getGlobalRegistry } from '../adapters/registry-accessor.js';
 import type { EmailAdapter } from '@colophony/plugin-sdk';
 import type { Env } from '../config/env.js';
-
-const demoRequestSchema = z.object({
-  name: z.string().min(1).max(256),
-  email: z.string().email().max(320),
-  magazine: z.string().min(1).max(256),
-  message: z.string().max(5000).optional(),
-});
 
 const DEMO_RATE_LIMIT_MAX = 5;
 const DEMO_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
@@ -107,7 +103,7 @@ export async function registerPublicRoutes(
     }
 
     // Validate input
-    const parsed = demoRequestSchema.safeParse(request.body);
+    const parsed = consultRequestSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.status(400).send({
         error: 'Invalid request',

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Toaster } from "@/components/ui/sonner";
 import { getUserManager } from "@/lib/oidc";
 import { LandingHeader } from "@/components/landing/landing-header";
 import { LandingHero } from "@/components/landing/landing-hero";
+import { LogotypeMorph } from "@/components/landing/logotype-morph";
 import {
   LandingTwoSides,
   LandingDifferentiators,
@@ -17,6 +18,8 @@ import { LandingFooter } from "@/components/landing/landing-footer";
 export default function Home() {
   const router = useRouter();
   const [checking, setChecking] = useState(true);
+  const heroLogoRef = useRef<HTMLDivElement>(null);
+  const headerLogoRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const userManager = getUserManager();
@@ -41,7 +44,7 @@ export default function Home() {
   }, [router]);
 
   if (checking) {
-    return null;
+    return <div className="dark min-h-screen bg-background" />;
   }
 
   const handleSignIn = () => {
@@ -51,15 +54,19 @@ export default function Home() {
     }
   };
 
-  const scrollToDemo = () => {
-    document.getElementById("demo")?.scrollIntoView({ behavior: "smooth" });
+  const scrollToConsult = () => {
+    document.getElementById("consult")?.scrollIntoView({ behavior: "smooth" });
   };
 
   return (
-    <div className="dark min-h-screen scroll-smooth bg-background text-foreground">
-      <LandingHeader onSignIn={handleSignIn} />
+    <div className="dark min-h-screen scroll-smooth bg-background text-foreground animate-in fade-in duration-300">
+      <LandingHeader onSignIn={handleSignIn} headerLogoRef={headerLogoRef} />
+      <LogotypeMorph heroSlotRef={heroLogoRef} headerSlotRef={headerLogoRef} />
       <main>
-        <LandingHero onRequestDemo={scrollToDemo} />
+        <LandingHero
+          onRequestConsult={scrollToConsult}
+          heroLogoRef={heroLogoRef}
+        />
         <LandingTwoSides />
         <LandingDifferentiators />
         <LandingDeployment />

--- a/apps/web/src/components/landing/landing-demo-form.tsx
+++ b/apps/web/src/components/landing/landing-demo-form.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -17,23 +16,11 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { useInView } from "@/hooks/use-in-view";
-
-function getDemoUrl() {
-  if (typeof window === "undefined") return "/demo";
-  const host = window.location.hostname;
-  if (host.startsWith("demo.")) return "/demo";
-  const proto = window.location.protocol;
-  return `${proto}//demo.${host}/demo`;
-}
-
-const demoFormSchema = z.object({
-  name: z.string().min(1, "Name is required"),
-  email: z.string().email("Please enter a valid email address"),
-  magazine: z.string().min(1, "Magazine name is required"),
-  message: z.string().optional(),
-});
-
-type DemoFormData = z.infer<typeof demoFormSchema>;
+import { getDemoUrl } from "@/lib/demo-url";
+import {
+  consultRequestSchema,
+  type ConsultRequestData,
+} from "@colophony/types";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
 
@@ -41,8 +28,8 @@ export function LandingDemoForm() {
   const { ref, isInView } = useInView(0.1);
   const [submitting, setSubmitting] = useState(false);
 
-  const form = useForm<DemoFormData>({
-    resolver: zodResolver(demoFormSchema),
+  const form = useForm<ConsultRequestData>({
+    resolver: zodResolver(consultRequestSchema),
     defaultValues: {
       name: "",
       email: "",
@@ -51,7 +38,7 @@ export function LandingDemoForm() {
     },
   });
 
-  async function onSubmit(data: DemoFormData) {
+  async function onSubmit(data: ConsultRequestData) {
     setSubmitting(true);
     try {
       const res = await fetch(`${API_URL}/v1/public/demo-requests`, {
@@ -82,7 +69,7 @@ export function LandingDemoForm() {
 
   return (
     <section
-      id="demo"
+      id="consult"
       className="scroll-mt-20 border-t border-border/50 py-24 md:py-32"
     >
       <div
@@ -93,11 +80,12 @@ export function LandingDemoForm() {
       >
         <div className="text-center">
           <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
-            See Colophony in action
+            Let&rsquo;s talk about your magazine
           </h2>
           <p className="mt-4 text-lg text-muted-foreground">
-            We&rsquo;d love to walk you through the platform. Tell us about your
-            magazine and we&rsquo;ll set up a time.
+            Tell us about your editorial workflow and we&rsquo;ll discuss how
+            Colophony can help. No obligation, no sales pitch&mdash;just a
+            conversation.
           </p>
         </div>
 
@@ -189,7 +177,7 @@ export function LandingDemoForm() {
               disabled={submitting}
               className="w-full bg-accent text-accent-foreground hover:bg-accent/90 text-base"
             >
-              {submitting ? "Sending..." : "Request a Demo"}
+              {submitting ? "Sending..." : "Request a Consult"}
             </Button>
             <p className="text-center text-sm text-muted-foreground">
               Or{" "}

--- a/apps/web/src/components/landing/landing-footer.tsx
+++ b/apps/web/src/components/landing/landing-footer.tsx
@@ -6,15 +6,17 @@ const footerLinks = [
     href: "https://github.com/colophony-project",
     external: true,
   },
-  // TODO: Add documentation URL when docs site is live
-  { label: "Documentation", href: "#", external: false },
+  {
+    label: "Documentation",
+    href: "https://github.com/colophony-project/colophony#readme",
+    external: true,
+  },
   {
     label: "License (AGPL-3.0)",
     href: "https://github.com/colophony-project/colophony/blob/main/LICENSE",
     external: true,
   },
-  // TODO: Add contact page or email when ready
-  { label: "Contact", href: "#demo", external: false },
+  { label: "Contact", href: "#consult", external: false },
 ] as const;
 
 export function LandingFooter() {

--- a/apps/web/src/components/landing/landing-header.tsx
+++ b/apps/web/src/components/landing/landing-header.tsx
@@ -1,16 +1,15 @@
 "use client";
 
-import Image from "next/image";
-import Link from "next/link";
+import { useState, type RefObject } from "react";
+import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
-
-function getDemoUrl() {
-  if (typeof window === "undefined") return "/demo";
-  const host = window.location.hostname;
-  if (host.startsWith("demo.")) return "/demo";
-  const proto = window.location.protocol;
-  return `${proto}//demo.${host}/demo`;
-}
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { getDemoUrl } from "@/lib/demo-url";
 
 const navLinks = [
   { label: "Features", href: "#features" },
@@ -19,23 +18,76 @@ const navLinks = [
   { label: "Hosting", href: "#hosting" },
 ] as const;
 
-interface LandingHeaderProps {
-  onSignIn: () => void;
+function LandingMobileMenu({ onSignIn }: { onSignIn: () => void }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button variant="ghost" size="icon" className="md:hidden">
+          <Menu className="h-5 w-5" />
+          <span className="sr-only">Toggle menu</span>
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="left" className="w-64">
+        <SheetTitle className="sr-only">Navigation</SheetTitle>
+        <nav className="mt-8 flex flex-col gap-4">
+          {navLinks.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              onClick={() => setOpen(false)}
+              className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {link.label}
+            </a>
+          ))}
+          <hr className="border-border/50" />
+          <button
+            onClick={() => {
+              onSignIn();
+              setOpen(false);
+            }}
+            className="text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Sign in
+          </button>
+          <Button variant="ghost" asChild className="justify-start">
+            <a href={getDemoUrl()} onClick={() => setOpen(false)}>
+              Try Demo
+            </a>
+          </Button>
+          <Button
+            asChild
+            className="justify-start bg-accent text-accent-foreground hover:bg-accent/90"
+          >
+            <a href="#consult" onClick={() => setOpen(false)}>
+              Request a Consult
+            </a>
+          </Button>
+        </nav>
+      </SheetContent>
+    </Sheet>
+  );
 }
 
-export function LandingHeader({ onSignIn }: LandingHeaderProps) {
+interface LandingHeaderProps {
+  onSignIn: () => void;
+  headerLogoRef: RefObject<HTMLDivElement | null>;
+}
+
+export function LandingHeader({ onSignIn, headerLogoRef }: LandingHeaderProps) {
   return (
     <header className="sticky top-0 z-50 border-b border-border/50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6 lg:px-8">
-        <Link href="/" aria-label="Colophony home">
-          <Image
-            src="/logos/logotype-dark.svg"
-            alt="Colophony"
-            width={200}
-            height={40}
-            priority
+        <div className="flex items-center gap-2">
+          <LandingMobileMenu onSignIn={onSignIn} />
+          {/* Logotype header slot — invisible placeholder for the morph animation target */}
+          <div
+            ref={headerLogoRef}
+            className="h-10 w-[200px]"
+            aria-hidden="true"
           />
-        </Link>
+        </div>
 
         <nav className="hidden items-center gap-8 md:flex" aria-label="Main">
           {navLinks.map((link) => (
@@ -61,9 +113,9 @@ export function LandingHeader({ onSignIn }: LandingHeaderProps) {
           </Button>
           <Button
             asChild
-            className="bg-accent text-accent-foreground hover:bg-accent/90"
+            className="hidden bg-accent text-accent-foreground hover:bg-accent/90 md:inline-flex"
           >
-            <a href="#demo">Request a Demo</a>
+            <a href="#consult">Request a Consult</a>
           </Button>
         </div>
       </div>

--- a/apps/web/src/components/landing/landing-hero.tsx
+++ b/apps/web/src/components/landing/landing-hero.tsx
@@ -1,22 +1,20 @@
 "use client";
 
+import type { RefObject } from "react";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { ExternalLink } from "lucide-react";
-
-function getDemoUrl() {
-  if (typeof window === "undefined") return "/demo";
-  const host = window.location.hostname;
-  if (host.startsWith("demo.")) return "/demo";
-  const proto = window.location.protocol;
-  return `${proto}//demo.${host}/demo`;
-}
+import { getDemoUrl } from "@/lib/demo-url";
 
 interface LandingHeroProps {
-  onRequestDemo: () => void;
+  onRequestConsult: () => void;
+  heroLogoRef: RefObject<HTMLDivElement | null>;
 }
 
-export function LandingHero({ onRequestDemo }: LandingHeroProps) {
+export function LandingHero({
+  onRequestConsult,
+  heroLogoRef,
+}: LandingHeroProps) {
   return (
     <section className="relative overflow-hidden pb-24 pt-20 md:pb-32 md:pt-28">
       {/* Subtle radial gradient behind hero */}
@@ -31,6 +29,12 @@ export function LandingHero({ onRequestDemo }: LandingHeroProps) {
 
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-3xl text-center">
+          {/* Logotype hero slot — invisible placeholder sized for the morph animation */}
+          <div
+            ref={heroLogoRef}
+            className="mx-auto mb-8 w-full max-w-3xl aspect-[5/2]"
+            aria-hidden="true"
+          />
           <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
             The editorial workflow your magazine deserves.
           </h1>
@@ -47,9 +51,9 @@ export function LandingHero({ onRequestDemo }: LandingHeroProps) {
               size="lg"
               variant="outline"
               className="px-8 text-base"
-              onClick={onRequestDemo}
+              onClick={onRequestConsult}
             >
-              Request a Demo
+              Request a Consult
             </Button>
             <Button variant="ghost" size="lg" className="text-base" asChild>
               <a

--- a/apps/web/src/components/landing/logotype-morph.tsx
+++ b/apps/web/src/components/landing/logotype-morph.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { RefObject } from "react";
+import Link from "next/link";
+import { useLogotypeMorph } from "@/hooks/use-logotype-morph";
+
+interface LogotypeMorphProps {
+  heroSlotRef: RefObject<HTMLDivElement | null>;
+  headerSlotRef: RefObject<HTMLDivElement | null>;
+}
+
+export function LogotypeMorph({
+  heroSlotRef,
+  headerSlotRef,
+}: LogotypeMorphProps) {
+  const { style, isLocked } = useLogotypeMorph(heroSlotRef, headerSlotRef);
+
+  if (!style) return null;
+
+  const img = (
+    // eslint-disable-next-line @next/next/no-img-element -- fixed-position animated element; Next Image doesn't support dynamic inline sizing
+    <img
+      src="/logos/logotype-dark.svg"
+      alt="Colophony"
+      style={{
+        position: style.position,
+        left: style.left,
+        top: style.top,
+        width: style.width,
+        height: style.height,
+        zIndex: style.zIndex,
+        pointerEvents: style.pointerEvents,
+        willChange: style.willChange,
+      }}
+    />
+  );
+
+  if (isLocked) {
+    return (
+      <Link
+        href="/"
+        aria-label="Colophony home"
+        style={{
+          position: "fixed",
+          left: style.left,
+          top: style.top,
+          width: style.width,
+          height: style.height,
+          zIndex: style.zIndex,
+          display: "block",
+        }}
+      >
+        {img}
+      </Link>
+    );
+  }
+
+  return img;
+}

--- a/apps/web/src/hooks/use-logotype-morph.ts
+++ b/apps/web/src/hooks/use-logotype-morph.ts
@@ -62,7 +62,8 @@ export function useLogotypeMorph(
     const end = heroAbsBottom - HEADER_HEIGHT;
     const range = end - start;
 
-    const progress = range > 0 ? clamp(window.scrollY / range, 0, 1) : 0;
+    const progress =
+      range > 0 ? clamp((window.scrollY - start) / range, 0, 1) : 0;
     const eased = easeOutCubic(progress);
     const locked = progress >= 0.99;
 
@@ -100,7 +101,7 @@ export function useLogotypeMorph(
 
     window.addEventListener("scroll", onScroll, { passive: true });
 
-    // Recalculate on resize
+    // Recalculate on element resize (dimension changes)
     const observer = new ResizeObserver(() => {
       cancelAnimationFrame(rafId.current);
       rafId.current = requestAnimationFrame(update);
@@ -108,8 +109,16 @@ export function useLogotypeMorph(
     observer.observe(heroSlot);
     observer.observe(headerSlot);
 
+    // Recalculate on window resize (position changes without dimension changes)
+    function onResize() {
+      cancelAnimationFrame(rafId.current);
+      rafId.current = requestAnimationFrame(update);
+    }
+    window.addEventListener("resize", onResize, { passive: true });
+
     return () => {
       window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onResize);
       cancelAnimationFrame(rafId.current);
       observer.disconnect();
     };

--- a/apps/web/src/hooks/use-logotype-morph.ts
+++ b/apps/web/src/hooks/use-logotype-morph.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+
+function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+interface MorphStyle {
+  position: "fixed";
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  zIndex: number;
+  pointerEvents: "none" | "auto";
+  willChange: "transform" | "auto";
+}
+
+interface MorphResult {
+  style: MorphStyle | null;
+  isLocked: boolean;
+}
+
+const HEADER_HEIGHT = 64;
+
+/**
+ * Scroll-driven logotype morph hook.
+ * Interpolates a fixed-position element between a hero slot (large, centered)
+ * and a header slot (small, left-aligned) based on scroll progress.
+ */
+export function useLogotypeMorph(
+  heroSlotRef: RefObject<HTMLDivElement | null>,
+  headerSlotRef: RefObject<HTMLDivElement | null>,
+): MorphResult {
+  const [style, setStyle] = useState<MorphStyle | null>(null);
+  const [isLocked, setIsLocked] = useState(false);
+  const rafId = useRef<number>(0);
+
+  const update = useCallback(() => {
+    const heroSlot = heroSlotRef.current;
+    const headerSlot = headerSlotRef.current;
+    if (!heroSlot || !headerSlot) return;
+
+    const heroRect = heroSlot.getBoundingClientRect();
+    const headerRect = headerSlot.getBoundingClientRect();
+
+    // Progress: 0 when hero slot is fully visible, 1 when its bottom reaches header bottom
+    const heroAbsTop = heroRect.top + window.scrollY;
+    const heroAbsBottom = heroAbsTop + heroRect.height;
+    const start = heroAbsTop - HEADER_HEIGHT;
+    const end = heroAbsBottom - HEADER_HEIGHT;
+    const range = end - start;
+
+    const progress = range > 0 ? clamp(window.scrollY / range, 0, 1) : 0;
+    const eased = easeOutCubic(progress);
+    const locked = progress >= 0.99;
+
+    const left = heroRect.left + (headerRect.left - heroRect.left) * eased;
+    const top = heroRect.top + (headerRect.top - heroRect.top) * eased;
+    const width = heroRect.width + (headerRect.width - heroRect.width) * eased;
+    const height =
+      heroRect.height + (headerRect.height - heroRect.height) * eased;
+
+    setStyle({
+      position: "fixed",
+      left,
+      top,
+      width,
+      height,
+      zIndex: 51,
+      pointerEvents: locked ? "auto" : "none",
+      willChange: locked ? "auto" : "transform",
+    });
+    setIsLocked(locked);
+  }, [heroSlotRef, headerSlotRef]);
+
+  useEffect(() => {
+    const heroSlot = heroSlotRef.current;
+    const headerSlot = headerSlotRef.current;
+    if (!heroSlot || !headerSlot) return;
+
+    function onScroll() {
+      cancelAnimationFrame(rafId.current);
+      rafId.current = requestAnimationFrame(update);
+    }
+
+    // Initial position
+    update();
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+
+    // Recalculate on resize
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(rafId.current);
+      rafId.current = requestAnimationFrame(update);
+    });
+    observer.observe(heroSlot);
+    observer.observe(headerSlot);
+
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      cancelAnimationFrame(rafId.current);
+      observer.disconnect();
+    };
+  }, [heroSlotRef, headerSlotRef, update]);
+
+  return { style, isLocked };
+}

--- a/apps/web/src/lib/demo-url.ts
+++ b/apps/web/src/lib/demo-url.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns the URL for the demo site.
+ * On the demo subdomain itself, returns a relative path.
+ * Otherwise, constructs the demo subdomain URL.
+ */
+export function getDemoUrl(): string {
+  if (typeof window === "undefined") return "/demo";
+  const host = window.location.hostname;
+  if (host.startsWith("demo.")) return "/demo";
+  const proto = window.location.protocol;
+  return `${proto}//demo.${host}/demo`;
+}

--- a/docs/devlog/2026-04.md
+++ b/docs/devlog/2026-04.md
@@ -2,6 +2,27 @@
 
 Newest entries first.
 
+## 2026-04-08 — Landing Page UX Polish
+
+### Done
+
+- Built hero logotype scroll-to-nav animation: full-width masthead (5:2 aspect, max-w-3xl) morphs smoothly to header slot (200x40) on scroll via RAF interpolation + ResizeObserver for resize safety
+- Renamed all "Request a Demo" CTAs to "Request a Consult" (header, hero, form section) — demo is now freely accessible, consult framing fits better
+- Rebranded the demo form section: id `#demo` → `#consult`, heading → "Let's talk about your magazine", subtitle reworded for consult framing
+- Added mobile hamburger navigation to landing page: Sheet-based menu with nav links, sign in, Try Demo, Request a Consult. CTA hidden from mobile header bar to prevent overflow (Codex review finding)
+- Extracted `getDemoUrl()` to shared utility (`apps/web/src/lib/demo-url.ts`) — was duplicated in 3 landing components
+- Extracted `consultRequestSchema` to `@colophony/types` — shared between web form and API route, removing Zod schema duplication (Codex review finding)
+- Fixed footer placeholder links: Documentation → GitHub README, Contact → `#consult`
+- Added auth loading state: dark background instead of blank white flash during OIDC check, with fade-in animation on content load
+
+### Decisions
+
+- Single fixed-element strategy for logotype morph (vs two-element crossfade) — smoother "migration" visual
+- Mobile CTA moved into Sheet menu only (not doubled in header bar) — prevents overflow on narrow viewports
+- Hero logotype uses native SVG viewBox aspect (5:2) rather than the compressed 5:1 used in header — gives it a taller, more prominent masthead presence
+
+---
+
 ## 2026-04-08 — Staging Provisioning (Garage S3, Demo Site, Coolify Cleanup)
 
 ### Done

--- a/packages/types/src/demo.ts
+++ b/packages/types/src/demo.ts
@@ -1,5 +1,14 @@
 import { z } from "zod";
 
+export const consultRequestSchema = z.object({
+  name: z.string().min(1).max(256),
+  email: z.string().email().max(320),
+  magazine: z.string().min(1).max(256),
+  message: z.string().max(5000).optional(),
+});
+
+export type ConsultRequestData = z.infer<typeof consultRequestSchema>;
+
 export const demoLoginRequestSchema = z.object({
   role: z.enum(["writer", "editor"]),
 });


### PR DESCRIPTION
## Summary

- Hero logotype scroll-to-nav animation: full-width masthead morphs smoothly to header slot on scroll (RAF + ResizeObserver interpolation)
- Rename "Request a Demo" → "Request a Consult" across all CTAs and anchors (demo is now freely accessible)
- Add mobile hamburger navigation (Sheet-based) to landing page
- Extract `getDemoUrl()` to shared utility and `consultRequestSchema` to `@colophony/types`
- Fix footer placeholder links and add auth loading state (no white flash)

## Plan Overrides

| File | Planned | Actual | Rationale |
|------|---------|--------|-----------|
| `landing-header.tsx` | "Try Demo" visible on mobile header bar | Both CTAs hidden on mobile, moved into Sheet | plan review flagged overflow risk from hamburger + logo slot + two buttons on narrow viewports |

## Test plan

- [ ] Load landing page — large logotype appears centered above H1 as masthead
- [ ] Scroll down — logotype smoothly shrinks and moves to header left slot
- [ ] Scroll back up — animation reverses
- [ ] Resize window at various scroll positions — no stale positioning
- [ ] Test at mobile viewport (< 768px) — hamburger menu opens Sheet with all nav items
- [ ] All "Request a Consult" buttons work and scroll to `#consult` section
- [ ] Footer "Documentation" opens GitHub README, "Contact" scrolls to consult form
- [ ] Hard refresh — dark background shown during auth check, no white flash
- [ ] `pnpm type-check` passes
- [ ] `pnpm test` passes (758 tests)