### PR TITLE
fix(web): correct GitHub org links and update README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,6 @@ By contributing to Colophony, you agree that your contributions will be licensed
 
 ## Reporting Issues
 
-- **Bugs and feature requests:** [GitHub Issues](https://github.com/colophony-project/colophony/issues)
+- **Bugs and feature requests:** [GitHub Issues](https://github.com/wordshepherd/colophony/issues)
 - **Security vulnerabilities:** See [SECURITY.md](SECURITY.md) for our disclosure policy. Email security@colophony.pub.
 - **Code of conduct concerns:** conduct@colophony.pub

--- a/README.md
+++ b/README.md
@@ -21,22 +21,38 @@ Colophony is designed for independent literary publications that want full contr
 
 ## Features
 
-- **Form builder** with custom fields, file uploads (resumable via tus), and embeddable submission forms
-- **Review pipeline** with configurable stages, assignments, and bulk actions
-- **Publication workflow** — copyediting, contract management (Documenso integration), and issue assembly
-- **CMS publishing** with adapter support for static site generators
-- **Notifications** — email (SMTP/SendGrid), webhooks, and in-app messaging
+### For Editors
+
+- **Form builder** — custom fields, conditional logic, multi-page wizards, file uploads (resumable via tus), and embeddable iframe widget for third-party sites
+- **Review pipeline** — configurable stages, reviewer assignments, voting/scoring, blind review mode, batch operations, discussion threads, and distraction-free reading mode
+- **Publication workflow** — copyediting with .docx round-trip, contract management (Documenso integration), and issue assembly
+- **CMS publishing** — WordPress and Ghost adapters with external ID tracking
+- **Editorial analytics** — acceptance rates, response time distribution, pipeline health, genre breakdown, and contributor diversity metrics
+- **Business operations** — contributor management, rights agreements with reversion tracking, revenue reporting, and contest management with anonymous judging
+- **5 org roles** — Admin, Editor, Reader, Production, and Business Ops with role-specific access controls
+
+### For Writers
+
+- **Writer workspace** — manuscript library, submission tracking across magazines, and personal analytics
+- **External submission tracking** — log submissions to non-Colophony journals with import flows for Submittable, Chill Subs, and generic CSV
+- **Sim-sub group management** — track simultaneous submissions of the same work with auto-withdraw prompts on acceptance
+- **Portfolio** — verified publications (from Colophony) and manually-added external credits
+- **Reader feedback** — opt-in anonymized reader comments included with rejection notices
+- **Response time transparency** — aggregated response stats displayed on magazine profiles
+
+### Platform
+
 - **Cross-instance federation** — discover and trust other Colophony instances
 - **Simultaneous submission detection** via the Blind Simultaneous Attestation Protocol (BSAP) — federated instances can detect overlapping submissions without revealing manuscript content or author identity to each other
-- **Writer workspace** — personal portfolio, submission tracking, and analytics across magazines
+- **Notifications** — email (SMTP/SendGrid), webhooks, in-app messaging via SSE
 - **Data portability** — export/import via the Common Submission Record (CSR) format
-- **Plugin system** — extend functionality with SDK-based plugins and UI extensions
-- **Analytics** — submission metrics for editors, personal stats for writers
+- **Plugin system** — SDK-based plugins with typed hooks, UI extension points, and a plugin gallery
+- **Email invitations** — invite team members by link without requiring a pre-existing account
 
 ## Quick Start
 
 ```bash
-git clone https://github.com/colophony-project/colophony.git
+git clone https://github.com/wordshepherd/colophony.git
 cd colophony
 pnpm docker:up        # PostgreSQL, Redis, Garage, Zitadel
 pnpm install
@@ -50,13 +66,13 @@ Prerequisites: Node.js >= 22, pnpm 9.15+, Docker, [hivemind](https://github.com/
 
 ## Tech Stack
 
-| Layer        | Technologies                                               |
-| ------------ | ---------------------------------------------------------- |
-| **Frontend** | Next.js 16, React 19, TypeScript, Tailwind CSS, shadcn/ui  |
-| **Backend**  | Fastify 5, TypeScript, Drizzle ORM, BullMQ                 |
-| **Auth**     | Zitadel (OIDC)                                             |
-| **Data**     | PostgreSQL 16+ (RLS), Redis 7+, Garage (S3-compatible)     |
-| **Infra**    | Docker Compose (self-hosted), Hetzner VPS (Docker Compose) |
+| Layer        | Technologies                                              |
+| ------------ | --------------------------------------------------------- |
+| **Frontend** | Next.js 16, React 19, TypeScript, Tailwind CSS, shadcn/ui |
+| **Backend**  | Fastify 5, TypeScript, Drizzle ORM, BullMQ, Inngest       |
+| **Auth**     | Zitadel (OIDC)                                            |
+| **Data**     | PostgreSQL 16+ (RLS), Redis 7+, Garage (S3-compatible)    |
+| **Infra**    | Docker Compose, Caddy (TLS + routing), Hetzner VPS        |
 
 ## Documentation
 
@@ -81,8 +97,8 @@ Client SDKs are available for [TypeScript](sdks/typescript/) and [Python](sdks/p
 
 Colophony supports two deployment models:
 
-- **Self-hosted** — Docker Compose with PostgreSQL, Redis, Garage, and Zitadel
-- **Managed hosting** — Hetzner VPS with Docker Compose (see [docs/deployment.md](docs/deployment.md))
+- **Self-hosted** — Docker Compose with PostgreSQL, Redis, Garage, Zitadel, and Caddy for TLS termination
+- **Managed hosting** — Hetzner VPS with Docker Compose and Caddy (see [docs/deployment.md](docs/deployment.md))
 
 ## License
 

--- a/apps/web/src/components/landing/landing-footer.tsx
+++ b/apps/web/src/components/landing/landing-footer.tsx
@@ -3,17 +3,17 @@ import Image from "next/image";
 const footerLinks = [
   {
     label: "GitHub",
-    href: "https://github.com/colophony-project",
+    href: "https://github.com/wordshepherd/colophony",
     external: true,
   },
   {
     label: "Documentation",
-    href: "https://github.com/colophony-project/colophony#readme",
+    href: "https://github.com/wordshepherd/colophony#readme",
     external: true,
   },
   {
     label: "License (AGPL-3.0)",
-    href: "https://github.com/colophony-project/colophony/blob/main/LICENSE",
+    href: "https://github.com/wordshepherd/colophony/blob/main/LICENSE",
     external: true,
   },
   { label: "Contact", href: "#consult", external: false },

--- a/apps/web/src/components/landing/landing-hero.tsx
+++ b/apps/web/src/components/landing/landing-hero.tsx
@@ -57,7 +57,7 @@ export function LandingHero({
             </Button>
             <Button variant="ghost" size="lg" className="text-base" asChild>
               <a
-                href="https://github.com/colophony-project"
+                href="https://github.com/wordshepherd/colophony"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/docs/devlog/2026-04.md
+++ b/docs/devlog/2026-04.md
@@ -2,6 +2,21 @@
 
 Newest entries first.
 
+## 2026-04-11 — GitHub Links Fix + README Update
+
+### Done
+
+- Fixed all GitHub org links across 5 files: `colophony-project` (nonexistent) → `wordshepherd/colophony` (landing-hero, landing-footer, README, CONTRIBUTING, governance)
+- Updated README features section: reorganized by audience (editors/writers/platform), added all shipped features from Tracks 7-14 (editorial workflow, business ops, writer platform, embeddable forms, email invitations, custom roles)
+- Updated README tech stack: added Inngest (workflow orchestration) and Caddy (TLS + routing)
+- Updated README deployment section: mentions Caddy for both self-hosted and managed hosting
+
+### Decisions
+
+- README features organized by audience (editors, writers, platform) rather than flat list — matches how prospects evaluate the product
+
+---
+
 ## 2026-04-08 — Landing Page UX Polish
 
 ### Done

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -28,7 +28,7 @@ There are no formal contributor tiers or committees. Contributors who demonstrat
 
 ## Proposing Changes
 
-**Bug reports and feature requests** — open a [GitHub Issue](https://github.com/colophony-project/colophony/issues). Provide enough context for someone unfamiliar with the problem to understand it.
+**Bug reports and feature requests** — open a [GitHub Issue](https://github.com/wordshepherd/colophony/issues). Provide enough context for someone unfamiliar with the problem to understand it.
 
 **Major changes** — new components, architectural shifts, federation protocol changes, or anything that would affect multiple tracks — should be proposed as a GitHub Issue with the `proposal` label. A good proposal includes:
 
@@ -75,7 +75,7 @@ This governance model will evolve as the project grows. Possible future changes 
 
 Colophony is licensed under AGPL-3.0-or-later, which ensures the codebase remains forkable regardless of project status or maintainer availability.
 
-Community input on governance changes is welcome via [GitHub Issues](https://github.com/colophony-project/colophony/issues). This document will be updated to reflect reality as it changes — not to describe aspirations.
+Community input on governance changes is welcome via [GitHub Issues](https://github.com/wordshepherd/colophony/issues). This document will be updated to reflect reality as it changes — not to describe aspirations.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Fixed all GitHub links across 5 files: `colophony-project` (404) → `wordshepherd/colophony`
- Updated README to reflect current state: features reorganized by audience (editors/writers/platform) with all Tracks 7-14 features, tech stack updated (Inngest, Caddy), deployment section updated

## Test plan

- [ ] Verify all GitHub links resolve (hero button, footer links, README clone URL, CONTRIBUTING issues link, governance issues links)
- [ ] README renders correctly on GitHub (markdown tables, headers, links)