### PR TITLE
fix(web): remove race in form editor E2E multi-field test

### DIFF
--- a/apps/web/e2e/forms/form-editor.spec.ts
+++ b/apps/web/e2e/forms/form-editor.spec.ts
@@ -129,22 +129,25 @@ test.describe("Form Editor (/editor/forms/[formId])", () => {
         timeout: 10_000,
       });
 
-      // Add Short Text
+      // One "Remove field" button is rendered per field on the canvas, so this
+      // count is the observable signal that a click actually committed a field.
+      const fields = authedPage.getByRole("button", { name: "Remove field" });
+
+      // Each click must be confirmed before issuing the next one. Firing all
+      // three and only asserting the total at the end races the canvas re-render:
+      // a click can land while the list is rebuilding and be dropped, leaving a
+      // count of 2 that never recovers.
       await authedPage.getByRole("button", { name: "Short Text" }).click();
-      await expect(authedPage.getByText("No fields yet")).not.toBeVisible({
-        timeout: 10_000,
-      });
+      await expect(fields).toHaveCount(1, { timeout: 10_000 });
 
-      // Add Long Text
       await authedPage.getByRole("button", { name: "Long Text" }).click();
+      await expect(fields).toHaveCount(2, { timeout: 10_000 });
 
-      // Add Dropdown
       await authedPage.getByRole("button", { name: "Dropdown" }).click();
+      await expect(fields).toHaveCount(3, { timeout: 10_000 });
 
-      // Should have 3 remove buttons (one per field)
-      await expect(
-        authedPage.getByRole("button", { name: "Remove field" }),
-      ).toHaveCount(3, { timeout: 10_000 });
+      // The empty state is gone once any field exists.
+      await expect(authedPage.getByText("No fields yet")).not.toBeVisible();
     } finally {
       await deleteFormDefinition(form.id);
     }


### PR DESCRIPTION
Unblocks #464. Test-only change, no production code touched.

## The failure

`adds multiple field types` clicks three field-palette buttons in succession, but only waits for an observable change after the **first**, then asserts all three landed:

```ts
await page.getByRole("button", { name: "Short Text" }).click();
await expect(page.getByText("No fields yet")).not.toBeVisible({ timeout: 10_000 });

await page.getByRole("button", { name: "Long Text" }).click();   // no wait
await page.getByRole("button", { name: "Dropdown" }).click();    // no wait

await expect(page.getByRole("button", { name: "Remove field" }))
  .toHaveCount(3, { timeout: 10_000 });
```

If the canvas re-renders between clicks, one is dropped and the count never recovers. The observed log shows exactly that — fields arriving progressively and stalling:

```
Expected: 3
Received: 2
  3 × locator resolved to 1 element
  11 × locator resolved to 2 elements
```

Every other test in this file asserts a state change after each interaction. This one was the outlier.

## The fix

Confirm each click via the per-field `Remove field` count before issuing the next. Same intent (three distinct field types), no race. The empty-state assertion is kept, moved to the end where it is unambiguous.

## This is pre-existing, not a regression

Across the last 15 CI runs, Forms E2E failed on 4 — and **every one changed `pnpm-lock.yaml`**:

| Run | Forms E2E |
|---|---|
| `main` | pass |
| #463 (no dep changes) | pass |
| 4× dependabot *github-actions* PRs | pass |
| 3× dependabot **npm** PRs (`minor-and-patch-*`) | **fail** |
| #464 (lockfile rewrite) | **fail** |

Lockfile changes cold-cache the CI install and build, slowing the runner enough to lose the race. No dependency *behaviour* is involved — #464 moved no package version, it rewrote specifiers and deduplicated. Left unfixed this will keep failing on roughly every dependabot npm PR, as it already has three times.

## Merge order

Land this on main first. Because PR CI runs the head merged with its base, re-running #464 afterwards picks the fix up with no rebase of the stack.

## Verification

`tsc --noEmit -p tsconfig.e2e.json` clean, `eslint --max-warnings 0` clean, prettier clean. The Playwright suite itself runs in CI.