### PR TITLE
chore: group dependabot security updates so they include the lockfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,29 @@ updates:
     groups:
       # Group minor/patch updates to reduce PR noise
       minor-and-patch:
+        applies-to: version-updates
         update-types:
           - "minor"
           - "patch"
+      # Security updates are grouped deliberately, not for noise reduction.
+      #
+      # Ungrouped security updates are raised per-manifest (titled "... in
+      # /apps/api"). In a pnpm workspace the lockfile lives only at the repo
+      # root, so a per-manifest update rewrites apps/*/package.json and leaves
+      # pnpm-lock.yaml untouched. Every install path here uses
+      # --frozen-lockfile, so those PRs fail at install with:
+      #
+      #   ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile"
+      #   because pnpm-lock.yaml is not up to date with <ROOT>/apps/api/package.json
+      #
+      # Grouped updates are resolved at the workspace root and do include the
+      # lockfile. Routing security updates through the same path is what makes
+      # them installable. `@dependabot recreate` does not fix the ungrouped
+      # ones — verified on #472, which regenerated still missing the lockfile.
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
     reviewers:
       - "dmahaffey"
 


### PR DESCRIPTION
All six open npm security PRs (#471–476) are unmergeable. Each rewrites a workspace manifest without touching `pnpm-lock.yaml`, so every CI job fails at install:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/apps/api/package.json
```

Every install path here — all CI jobs and both Dockerfiles — uses `--frozen-lockfile`, so a manifest-only bump cannot pass.

## These are security updates, and they're real

Not routine version bumps. They carry dependabot's default `javascript` label rather than the `labels:` configured in `dependabot.yml`, they're scoped per-manifest (`... in /apps/api`), and they cite advisories:

| PR | Advisory |
|---|---|
| #472 fastify | CVE-2026-33806 / GHSA-247c-9743-5963 |
| #476 next | GHSA-4633-3j49-mh5q, GHSA-4c39-4ccg-62r3, GHSA-68g3-v927-f742 |
| #474 sanitize-html | security vulnerability |

So this isn't tidiness — actual CVE fixes are sitting unmergeable.

## Why they omit the lockfile

Security updates ignore the `groups` block unless a group declares `applies-to: security-updates`, so they were raised individually and per-manifest. A per-manifest update can't maintain the lockfile, because in a pnpm workspace the lockfile exists **only at the repo root**.

The grouped version-update PR (#477) *does* include `pnpm-lock.yaml` — the grouped path resolves at the workspace root and works. This change routes security updates through it.

## Ruled out

- **`@dependabot recreate` does not fix it.** #472 regenerated at 20:42 and still contained only `apps/api/package.json`. Tried on all six.
- **Not caused by the exact pinning in #464.** Reproduced locally on current `main`: setting `"fastify": "5.8.5"` and running `pnpm install --lockfile-only` updates both `apps/api/package.json` and `pnpm-lock.yaml` in 5.7s. The repo side is fine.

## Honest limitation

This cannot be proven green in CI — validating it requires a dependabot run against the merged config. If the regenerated PRs still omit the lockfile, the fallback is to apply the six advisories by hand in a single PR (manifest + lockfile together), which is worth doing regardless given they're CVEs.

Also pins the existing group to `applies-to: version-updates`, which was the implicit default — no behaviour change, just explicit.