### PR TITLE
fix(ci): make Playwright failures diagnosable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,7 +691,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report
-          path: apps/web/playwright-report/
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -774,7 +776,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-embed-report
-          path: apps/web/playwright-report/
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -857,7 +861,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-slate-report
-          path: apps/web/playwright-report/
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -940,7 +946,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-workspace-report
-          path: apps/web/playwright-report/
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -1023,7 +1031,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-forms-report
-          path: apps/web/playwright-report/
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -1106,7 +1116,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-organization-report
-          path: apps/web/playwright-report/
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -1188,7 +1200,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-analytics-report
-          path: apps/web/playwright-report/
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -1271,7 +1285,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-federation-report
-          path: apps/web/playwright-report/
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -1430,7 +1446,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-uploads-report
-          path: apps/web/playwright-report/
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -1557,7 +1575,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-oidc-report
-          path: apps/web/playwright-report/
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
           retention-days: 30
 
   # ──────────────────────────────────────────────────

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -60,7 +60,14 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: 1, // Single worker to avoid DB conflicts
-  reporter: process.env.CI ? "github" : "html",
+  // In CI, run BOTH reporters. "github" emits inline annotations on the PR, but
+  // it writes no files — on its own it leaves apps/web/playwright-report/ empty,
+  // so the workflow's upload step finds nothing and every failure lands with no
+  // trace, screenshot, or report to inspect. The html reporter produces that
+  // directory; `open: "never"` stops it trying to launch a browser on the runner.
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : [["html", { open: "never" }]],
   timeout: 30_000,
 
   globalSetup: "./e2e/global-setup.ts",


### PR DESCRIPTION
Prerequisite for fixing the E2E flakes, not a fix for them.

## The problem

E2E failures in CI produce **no trace, no screenshot, no report**. Every one of the ten upload steps logs:

```
##[warning]No files were found with the provided path: apps/web/playwright-report/.
No artifacts will be uploaded.
```

`playwright.config.ts` sets `reporter: CI ? "github" : "html"`. The `github` reporter emits inline PR annotations but writes **no files**, so `playwright-report/` is never created.

The galling part: `trace: "on-first-retry"` and `screenshot: "only-on-failure"` were already configured. The diagnostics were being generated and thrown away.

This is why the recent Federation failure couldn't be diagnosed beyond raw scrollback — I went looking for the trace artifact and there wasn't one.

## Changes

- Run **both** reporters in CI — `github` for annotations, `html` for the report directory. `open: "never"` stops the html reporter trying to launch a browser on the runner.
- Upload `apps/web/test-results/` alongside the report. That's where traces, screenshots, videos and `error-context.md` actually land; the report directory alone doesn't contain them.

## Verified

Ran a deliberately failing probe spec with `CI=true`:

```
apps/web/playwright-report/index.html          530 KB + trace viewer assets
apps/web/test-results/<test>/                  error-context.md, test-failed-1.png
apps/web/test-results/<test>-retry1/           + trace.zip
```

Both paths are gitignored and no `test:e2e:*` script passes `--reporter`, so the config is authoritative.

## What I deliberately did *not* do

No blanket increase to the global test or `expect` timeouts. The evidence doesn't support it:

- The Federation failures were `element(s) not found` after a **10s** timeout, and failed **identically on retry**. More time would not have changed the outcome.
- The Workspace failure wasn't a test issue at all — `docker pull postgres:16-alpine` failed three times against Docker Hub (`context deadline exceeded`). Infrastructure, not the suite.

Raising timeouts would slow every suite and hide real defects. With traces uploaded, the next occurrence gets diagnosed instead of guessed at.

## Correcting an earlier claim of mine

I previously said the E2E suite "fails intermittently on essentially every lockfile-changing PR." That was overstated. Checking Federation across the last 12 runs, most of those failures were the six security PRs failing at **install** (`ERR_PNPM_OUTDATED_LOCKFILE`), which fails every job in the matrix and inflated the apparent flake rate. The genuine intermittent rate is much lower — Federation once, RLS once, plus the Forms race already fixed in #470.