### PR TITLE
fix(ci): unblock dependency majors and remove E2E setup races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1552,8 +1552,11 @@ jobs:
             start-from-init --masterkey "MasterkeyNeedsToHave32Characters" --tlsMode disabled
       - name: Wait for Zitadel
         run: |
+          # /debug/healthz is liveness — it answers before the instance can
+          # serve API calls. /debug/ready is the readiness probe; waiting on
+          # healthz let provisioning race ahead and fail with gRPC code 14.
           echo "Waiting for Zitadel to be ready..."
-          timeout 180 bash -c 'until curl -sf http://localhost:8080/debug/healthz; do sleep 5; done'
+          timeout 180 bash -c 'until curl -sf http://localhost:8080/debug/ready; do sleep 5; done'
           echo "Zitadel is ready."
       - name: Provision Zitadel E2E config
         run: pnpm --filter @colophony/db exec tsx ../../scripts/setup-zitadel-e2e.ts

--- a/apps/api/src/__tests__/webhooks/documenso-webhook.test.ts
+++ b/apps/api/src/__tests__/webhooks/documenso-webhook.test.ts
@@ -75,8 +75,14 @@ describe('Documenso webhook integration', () => {
   });
 
   afterAll(async () => {
-    await app.close();
-    await globalTeardown();
+    // `app` is undefined when beforeAll failed. Calling .close() on it throws
+    // a TypeError that replaces the real setup error in the report, so guard
+    // it and make sure teardown runs either way.
+    try {
+      await app?.close();
+    } finally {
+      await globalTeardown();
+    }
   });
 
   beforeEach(async () => {

--- a/apps/api/src/__tests__/webhooks/stripe-webhook.test.ts
+++ b/apps/api/src/__tests__/webhooks/stripe-webhook.test.ts
@@ -84,8 +84,14 @@ describe('Stripe webhook integration', () => {
   });
 
   afterAll(async () => {
-    await app.close();
-    await globalTeardown();
+    // `app` is undefined when beforeAll failed. Calling .close() on it throws
+    // a TypeError that replaces the real setup error in the report, so guard
+    // it and make sure teardown runs either way.
+    try {
+      await app?.close();
+    } finally {
+      await globalTeardown();
+    }
   });
 
   beforeEach(async () => {

--- a/apps/api/src/__tests__/webhooks/tusd-webhook.test.ts
+++ b/apps/api/src/__tests__/webhooks/tusd-webhook.test.ts
@@ -81,8 +81,14 @@ describe('tusd webhook integration', () => {
   });
 
   afterAll(async () => {
-    await app.close();
-    await globalTeardown();
+    // `app` is undefined when beforeAll failed. Calling .close() on it throws
+    // a TypeError that replaces the real setup error in the report, so guard
+    // it and make sure teardown runs either way.
+    try {
+      await app?.close();
+    } finally {
+      await globalTeardown();
+    }
   });
 
   beforeEach(async () => {

--- a/apps/api/src/__tests__/webhooks/webhook-health.route.test.ts
+++ b/apps/api/src/__tests__/webhooks/webhook-health.route.test.ts
@@ -20,8 +20,14 @@ describe('GET /webhooks/health', () => {
   });
 
   afterAll(async () => {
-    await app.close();
-    await globalTeardown();
+    // `app` is undefined when beforeAll failed. Calling .close() on it throws
+    // a TypeError that replaces the real setup error in the report, so guard
+    // it and make sure teardown runs either way.
+    try {
+      await app?.close();
+    } finally {
+      await globalTeardown();
+    }
   });
 
   beforeEach(async () => {

--- a/apps/api/src/__tests__/webhooks/zitadel-webhook.test.ts
+++ b/apps/api/src/__tests__/webhooks/zitadel-webhook.test.ts
@@ -48,8 +48,14 @@ describe('Zitadel webhook integration', () => {
   });
 
   afterAll(async () => {
-    await app.close();
-    await globalTeardown();
+    // `app` is undefined when beforeAll failed. Calling .close() on it throws
+    // a TypeError that replaces the real setup error in the report, so guard
+    // it and make sure teardown runs either way.
+    try {
+      await app?.close();
+    } finally {
+      await globalTeardown();
+    }
   });
 
   beforeEach(async () => {

--- a/apps/api/src/config/env.spec.ts
+++ b/apps/api/src/config/env.spec.ts
@@ -183,4 +183,41 @@ describe('validateEnv', () => {
     });
     expect(envFalse.FEDERATION_ENABLED).toBe(false);
   });
+
+  // These four vars use `.optional().transform(...).pipe(z.string()....optional())`
+  // to treat an empty string the same as an unset variable — deployment tooling
+  // frequently writes `VAR=` rather than omitting the line. Dropping `.optional()`
+  // from the OUTER string makes the whole chain reject `undefined`, which takes
+  // down every environment that legitimately leaves these unset.
+  describe.each([
+    ['ZITADEL_AUTHORITY', 'https://auth.example.com', 'not-a-url'],
+    ['DOCUMENSO_API_URL', 'https://sign.example.com', 'not-a-url'],
+    ['SENTRY_DSN', 'https://abc@sentry.example.com/1', 'not-a-url'],
+    ['FEDERATION_CONTACT', 'editor@example.com', 'not-an-email'],
+  ])('optional env var %s', (key, valid, invalid) => {
+    it('is undefined when unset', () => {
+      const env = validateEnv(validBase) as Record<string, unknown>;
+      expect(env[key]).toBeUndefined();
+    });
+
+    it('treats an empty string as unset', () => {
+      const env = validateEnv({ ...validBase, [key]: '' }) as Record<
+        string,
+        unknown
+      >;
+      expect(env[key]).toBeUndefined();
+    });
+
+    it('accepts a well-formed value', () => {
+      const env = validateEnv({ ...validBase, [key]: valid }) as Record<
+        string,
+        unknown
+      >;
+      expect(env[key]).toBe(valid);
+    });
+
+    it('rejects a malformed value', () => {
+      expect(() => validateEnv({ ...validBase, [key]: invalid })).toThrow();
+    });
+  });
 });

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -85,6 +85,7 @@ const envSchema = z
     STRIPE_WEBHOOK_SECRET: z.string().optional(),
     ZITADEL_AUTHORITY: z
       .string()
+      .optional()
       .transform((v) => (v === '' ? undefined : v))
       .pipe(z.string().url().optional()),
     ZITADEL_CLIENT_ID: z.string().optional(),
@@ -120,6 +121,7 @@ const envSchema = z
       .transform((v) => v === 'true'),
     FEDERATION_CONTACT: z
       .string()
+      .optional()
       .transform((v) => (v === '' ? undefined : v))
       .pipe(z.string().email().optional()),
     FEDERATION_PRIVATE_KEY: z.string().optional(),
@@ -136,6 +138,7 @@ const envSchema = z
     // Documenso contract signing
     DOCUMENSO_API_URL: z
       .string()
+      .optional()
       .transform((v) => (v === '' ? undefined : v))
       .pipe(z.string().url().optional()),
     DOCUMENSO_API_KEY: z.string().optional(),
@@ -165,6 +168,7 @@ const envSchema = z
     // Monitoring — Sentry
     SENTRY_DSN: z
       .string()
+      .optional()
       .transform((v) => (v === '' ? undefined : v))
       .pipe(z.string().url().optional()),
     SENTRY_ENVIRONMENT: z.string().default('development'),

--- a/apps/api/src/templates/email/__tests__/custom-render.spec.ts
+++ b/apps/api/src/templates/email/__tests__/custom-render.spec.ts
@@ -4,8 +4,8 @@ import { renderCustomTemplate } from '../render.js';
 describe('renderCustomTemplate', () => {
   const orgName = 'The Paris Review';
 
-  it('interpolates merge fields in subject', () => {
-    const result = renderCustomTemplate(
+  it('interpolates merge fields in subject', async () => {
+    const result = await renderCustomTemplate(
       {
         subjectTemplate: 'New submission: {{submissionTitle}}',
         bodyHtml: '<p>A new submission has been received.</p>',
@@ -17,8 +17,8 @@ describe('renderCustomTemplate', () => {
     expect(result.subject).toBe('New submission: My Poem');
   });
 
-  it('interpolates merge fields in body', () => {
-    const result = renderCustomTemplate(
+  it('interpolates merge fields in body', async () => {
+    const result = await renderCustomTemplate(
       {
         subjectTemplate: 'Update',
         bodyHtml: '<p>Welcome to {{orgName}}.</p>',
@@ -30,8 +30,8 @@ describe('renderCustomTemplate', () => {
     expect(result.html).toContain('Welcome to The Paris Review.');
   });
 
-  it('sanitizes script tags from body', () => {
-    const result = renderCustomTemplate(
+  it('sanitizes script tags from body', async () => {
+    const result = await renderCustomTemplate(
       {
         subjectTemplate: 'Test',
         bodyHtml: '<p>Hello</p><script>alert(1)</script>',
@@ -44,8 +44,8 @@ describe('renderCustomTemplate', () => {
     expect(result.html).toContain('Hello');
   });
 
-  it('generates plain text from HTML', () => {
-    const result = renderCustomTemplate(
+  it('generates plain text from HTML', async () => {
+    const result = await renderCustomTemplate(
       {
         subjectTemplate: 'Test',
         bodyHtml: '<p>Hello <strong>World</strong></p>',
@@ -57,8 +57,8 @@ describe('renderCustomTemplate', () => {
     expect(result.text).toBe('Hello World');
   });
 
-  it('wraps body in MJML layout with orgName', () => {
-    const result = renderCustomTemplate(
+  it('wraps body in MJML layout with orgName', async () => {
+    const result = await renderCustomTemplate(
       {
         subjectTemplate: 'Test',
         bodyHtml: '<p>Content</p>',
@@ -71,8 +71,8 @@ describe('renderCustomTemplate', () => {
     expect(result.html).toContain('The Paris Review');
   });
 
-  it('replaces missing fields with empty string', () => {
-    const result = renderCustomTemplate(
+  it('replaces missing fields with empty string', async () => {
+    const result = await renderCustomTemplate(
       {
         subjectTemplate: 'Hello {{unknownField}}',
         bodyHtml: '<p>Greeting {{anotherMissing}}</p>',
@@ -97,8 +97,8 @@ describe('renderCustomTemplate', () => {
     { tags: ['needs revision'], comment: null },
   ];
 
-  it('renders {{readerFeedback}} scalar tag as default formatted block', () => {
-    const result = renderCustomTemplate(
+  it('renders {{readerFeedback}} scalar tag as default formatted block', async () => {
+    const result = await renderCustomTemplate(
       {
         subjectTemplate: 'Update on {{submissionTitle}}',
         bodyHtml:
@@ -115,8 +115,8 @@ describe('renderCustomTemplate', () => {
     expect(result.html).toContain('needs revision');
   });
 
-  it('renders {{#each readerFeedback}} with custom layout per item', () => {
-    const result = renderCustomTemplate(
+  it('renders {{#each readerFeedback}} with custom layout per item', async () => {
+    const result = await renderCustomTemplate(
       {
         subjectTemplate: 'Update',
         bodyHtml:
@@ -132,8 +132,8 @@ describe('renderCustomTemplate', () => {
     );
   });
 
-  it('includes feedback content in plain text output with line breaks', () => {
-    const result = renderCustomTemplate(
+  it('includes feedback content in plain text output with line breaks', async () => {
+    const result = await renderCustomTemplate(
       {
         subjectTemplate: 'Update',
         bodyHtml: '<p>Feedback:</p>{{readerFeedback}}',
@@ -149,8 +149,8 @@ describe('renderCustomTemplate', () => {
     expect(result.text).toContain('needs revision');
   });
 
-  it('renders nothing when readerFeedback array is empty', () => {
-    const result = renderCustomTemplate(
+  it('renders nothing when readerFeedback array is empty', async () => {
+    const result = await renderCustomTemplate(
       {
         subjectTemplate: 'Update',
         bodyHtml: '<p>Before</p>{{readerFeedback}}<p>After</p>',
@@ -164,8 +164,8 @@ describe('renderCustomTemplate', () => {
     expect(result.text).not.toContain('border-left');
   });
 
-  it('silently ignores readerFeedback when template does not reference it', () => {
-    const result = renderCustomTemplate(
+  it('silently ignores readerFeedback when template does not reference it', async () => {
+    const result = await renderCustomTemplate(
       {
         subjectTemplate: 'Update',
         bodyHtml: '<p>Thank you.</p>',
@@ -177,14 +177,14 @@ describe('renderCustomTemplate', () => {
     expect(result.text).toBe('Thank you.');
   });
 
-  it('escapes XSS in feedback values in final HTML', () => {
+  it('escapes XSS in feedback values in final HTML', async () => {
     const xssFeedback = [
       {
         tags: ['<script>alert(1)</script>'],
         comment: '<img onerror=alert(1)>',
       },
     ];
-    const result = renderCustomTemplate(
+    const result = await renderCustomTemplate(
       {
         subjectTemplate: 'Update',
         bodyHtml: '{{readerFeedback}}',
@@ -198,8 +198,8 @@ describe('renderCustomTemplate', () => {
     expect(result.html).not.toContain('<img');
   });
 
-  it('does not render HTML blocks in subject line for array fields', () => {
-    const result = renderCustomTemplate(
+  it('does not render HTML blocks in subject line for array fields', async () => {
+    const result = await renderCustomTemplate(
       {
         subjectTemplate: 'Feedback: {{readerFeedback}}',
         bodyHtml: '<p>Body</p>',

--- a/apps/api/src/templates/email/__tests__/render.spec.ts
+++ b/apps/api/src/templates/email/__tests__/render.spec.ts
@@ -3,9 +3,9 @@ import { renderEmailTemplate, renderMjml } from '../render.js';
 import type { TemplateName } from '../types.js';
 
 describe('renderMjml', () => {
-  it('converts MJML to HTML', () => {
+  it('converts MJML to HTML', async () => {
     const mjml = `<mjml><mj-body><mj-section><mj-column><mj-text>Hello</mj-text></mj-column></mj-section></mj-body></mjml>`;
-    const result = renderMjml(mjml);
+    const result = await renderMjml(mjml);
     expect(result.html).toContain('Hello');
     expect(result.html).toContain('<!doctype html>');
   });
@@ -81,8 +81,8 @@ describe('renderEmailTemplate', () => {
   ];
 
   for (const { name, data } of templates) {
-    it(`renders ${name} template with html, text, and subject`, () => {
-      const result = renderEmailTemplate(name, data);
+    it(`renders ${name} template with html, text, and subject`, async () => {
+      const result = await renderEmailTemplate(name, data);
       expect(result.html).toBeTruthy();
       expect(result.html).toContain('<!doctype html>');
       expect(result.text).toBeTruthy();
@@ -90,10 +90,10 @@ describe('renderEmailTemplate', () => {
     });
   }
 
-  it('throws for unknown template', () => {
-    expect(() =>
+  it('rejects for unknown template', async () => {
+    await expect(
       renderEmailTemplate('nonexistent' as TemplateName, {}),
-    ).toThrow('Unknown email template');
+    ).rejects.toThrow('Unknown email template');
   });
 
   describe('submission-rejected with reader feedback', () => {
@@ -104,14 +104,14 @@ describe('renderEmailTemplate', () => {
       orgName: 'Test Lit Mag',
     };
 
-    it('does not include feedback section when no feedback provided', () => {
-      const result = renderEmailTemplate('submission-rejected', baseData);
+    it('does not include feedback section when no feedback provided', async () => {
+      const result = await renderEmailTemplate('submission-rejected', baseData);
       expect(result.text).not.toContain('Reader feedback');
       expect(result.html).not.toContain('Reader feedback');
     });
 
-    it('includes feedback section when readerFeedback is present', () => {
-      const result = renderEmailTemplate('submission-rejected', {
+    it('includes feedback section when readerFeedback is present', async () => {
+      const result = await renderEmailTemplate('submission-rejected', {
         ...baseData,
         readerFeedback: [
           { tags: ['engaging', 'well-written'], comment: 'Great pacing' },
@@ -131,8 +131,8 @@ describe('renderEmailTemplate', () => {
       expect(result.html).toContain('Great pacing');
     });
 
-    it('escapes HTML in feedback tags and comments', () => {
-      const result = renderEmailTemplate('submission-rejected', {
+    it('escapes HTML in feedback tags and comments', async () => {
+      const result = await renderEmailTemplate('submission-rejected', {
         ...baseData,
         readerFeedback: [
           {

--- a/apps/api/src/templates/email/render.ts
+++ b/apps/api/src/templates/email/render.ts
@@ -15,22 +15,31 @@ export interface RenderedEmail {
   subject: string;
 }
 
-export function renderMjml(mjmlString: string): { html: string } {
-  const result = mjml2html(mjmlString, { validationLevel: 'soft' });
+/**
+ * mjml 5 returns a Promise from mjml2html; mjml 4 returned the result
+ * synchronously. Promise.resolve() normalizes both, so the render layer is
+ * async regardless of which major is installed.
+ */
+export async function renderMjml(
+  mjmlString: string,
+): Promise<{ html: string }> {
+  const result = await Promise.resolve(
+    mjml2html(mjmlString, { validationLevel: 'soft' }),
+  );
   return { html: result.html };
 }
 
-export function renderEmailTemplate(
+export async function renderEmailTemplate(
   name: TemplateName,
   data: Record<string, unknown>,
-): RenderedEmail {
+): Promise<RenderedEmail> {
   const renderer = templates[name];
   if (!renderer) {
     throw new Error(`Unknown email template: ${name}`);
   }
 
   const { mjml, text, subject } = renderer(data);
-  const { html } = renderMjml(mjml);
+  const { html } = await renderMjml(mjml);
 
   return { html, text, subject };
 }
@@ -39,11 +48,11 @@ export function renderEmailTemplate(
  * Render a custom (user-defined) email template with merge field
  * interpolation, HTML sanitization, and MJML layout wrapping.
  */
-export function renderCustomTemplate(
+export async function renderCustomTemplate(
   customTemplate: { subjectTemplate: string; bodyHtml: string },
   data: Record<string, unknown>,
   orgName: string,
-): RenderedEmail {
+): Promise<RenderedEmail> {
   // Interpolate merge fields in subject (scalar-only — no HTML blocks)
   const subject = interpolateMergeFields(customTemplate.subjectTemplate, data);
 
@@ -59,7 +68,7 @@ export function renderCustomTemplate(
     `<mj-text>${sanitizedBody}</mj-text>`,
     orgName,
   );
-  const { html } = renderMjml(mjmlString);
+  const { html } = await renderMjml(mjmlString);
 
   // Generate plain text: convert block elements to newlines before stripping
   const textFriendly = sanitizedBody

--- a/apps/api/src/trpc/routers/email-templates.ts
+++ b/apps/api/src/trpc/routers/email-templates.ts
@@ -128,7 +128,7 @@ export const emailTemplatesRouter = createRouter({
     .output(emailTemplatePreviewSchema)
     .mutation(async ({ input }) => {
       const sampleData = TEMPLATE_SAMPLE_DATA[input.templateName];
-      const rendered = renderCustomTemplate(
+      const rendered = await renderCustomTemplate(
         {
           subjectTemplate: input.subjectTemplate,
           bodyHtml: input.bodyHtml,

--- a/apps/api/src/workers/email.worker.ts
+++ b/apps/api/src/workers/email.worker.ts
@@ -56,13 +56,13 @@ export function startEmailWorker(
 
         if (customTemplate) {
           const orgNameVal = templateData.orgName ?? '';
-          rendered = renderCustomTemplate(
+          rendered = await renderCustomTemplate(
             customTemplate,
             templateData,
             String(orgNameVal),
           );
         } else {
-          rendered = renderEmailTemplate(
+          rendered = await renderEmailTemplate(
             templateName as TemplateName,
             templateData,
           );

--- a/apps/api/vitest.config.integration-base.ts
+++ b/apps/api/vitest.config.integration-base.ts
@@ -13,13 +13,22 @@ export const integrationBase = defineConfig({
     globals: false,
     setupFiles: ['../../test/vitest-console-setup.ts'],
     testTimeout: 30_000,
+    // Integration `beforeAll` hooks do MORE work than a typical test — they
+    // run globalSetup() (schema reset, pool warm-up) and build a Fastify app.
+    // Leaving hookTimeout at its 10s default gave setup a third of the budget
+    // an individual test gets, so a slow CI runner failed in the hook rather
+    // than in any assertion. Keep the two in step.
+    hookTimeout: 30_000,
+    // `fileParallelism: false` is what actually serializes these suites — they
+    // share one test database, so two files must never run at once.
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    // NOTE: this previously also set `poolOptions.forks.singleFork: true`.
+    // Vitest 4 removed `poolOptions` entirely, so that setting had stopped
+    // doing anything and only emitted a deprecation warning on every run.
+    // Removing it is a no-op; serialization comes from fileParallelism above.
+    // Adopting the v4 equivalent (`isolate: false`) would be a real change to
+    // cross-file module isolation and is deliberately NOT done here.
     env: {
       DATABASE_URL:
         process.env.DATABASE_APP_URL ??

--- a/scripts/setup-zitadel-dev.ts
+++ b/scripts/setup-zitadel-dev.ts
@@ -26,7 +26,7 @@ import {
   TEST_USER_PASSWORD,
   TEST_USER_FIRST,
   TEST_USER_LAST,
-  waitForHealth,
+  waitForReady,
   getAdminToken,
   findOrCreateProject,
   findOrCreateOidcApp,
@@ -84,7 +84,7 @@ async function main() {
   console.log("=== Zitadel Dev Setup ===\n");
 
   // 1. Wait for Zitadel
-  await waitForHealth();
+  await waitForReady();
 
   // 2. Get admin token
   console.log("\nReading admin PAT...");

--- a/scripts/setup-zitadel-e2e.ts
+++ b/scripts/setup-zitadel-e2e.ts
@@ -25,7 +25,7 @@ import {
   TEST_USER_PASSWORD,
   TEST_USER_FIRST,
   TEST_USER_LAST,
-  waitForHealth,
+  waitForReady,
   getAdminToken,
   findOrCreateProject,
   findOrCreateOidcApp,
@@ -58,8 +58,8 @@ const API_ENV_PATH = resolve(__dirname, "../apps/api/.env");
 async function main() {
   console.log("=== Zitadel E2E Setup ===\n");
 
-  // 1. Wait for Zitadel
-  await waitForHealth();
+  // 1. Wait for Zitadel to be able to serve API traffic (not merely alive)
+  await waitForReady();
 
   // 2. Get admin token (PAT from start-from-init machine user)
   console.log("\nReading admin PAT...");

--- a/scripts/zitadel-helpers.ts
+++ b/scripts/zitadel-helpers.ts
@@ -37,24 +37,35 @@ export interface ApiResponse<T> {
   data: T;
 }
 
-export async function waitForHealth(
-  maxRetries = 30,
+/**
+ * Block until Zitadel can actually serve API traffic.
+ *
+ * `/debug/healthz` is a LIVENESS probe — it answers as soon as the HTTP
+ * listener binds, which happens well before the instance is usable. Calling
+ * the management API in that window fails with gRPC code 14 (UNAVAILABLE)
+ * and `dial tcp [::1]:8080: connect: connection refused`, because Zitadel's
+ * own HTTP-to-gRPC gateway is dialling a gRPC server that has not come up
+ * yet. `/debug/ready` is the READINESS probe and stays non-200 until the
+ * instance is initialized, so that is what we wait on.
+ */
+export async function waitForReady(
+  maxRetries = 60,
   intervalMs = 2000,
 ): Promise<void> {
   console.log(`Waiting for Zitadel at ${ZITADEL_URL}...`);
   for (let i = 0; i < maxRetries; i++) {
     try {
-      const res = await fetch(`${ZITADEL_URL}/debug/healthz`);
+      const res = await fetch(`${ZITADEL_URL}/debug/ready`);
       if (res.ok) {
-        console.log("Zitadel is healthy.");
+        console.log("Zitadel is ready.");
         return;
       }
     } catch {
-      // Not ready yet
+      // Not listening yet
     }
     await new Promise((r) => setTimeout(r, intervalMs));
   }
-  throw new Error(`Zitadel not healthy after ${maxRetries * intervalMs}ms`);
+  throw new Error(`Zitadel not ready after ${maxRetries * intervalMs}ms`);
 }
 
 /**
@@ -84,23 +95,66 @@ export function getAdminToken(): string {
   return pat;
 }
 
+/** gRPC status code for UNAVAILABLE — the request never reached the service. */
+const GRPC_UNAVAILABLE = 14;
+
+/**
+ * True when a response means "Zitadel could not be reached", as opposed to
+ * "Zitadel considered the request and said no". Only the former is retried:
+ * the request never executed, so replaying it cannot duplicate a resource.
+ */
+function isTransient(status: number, data: unknown): boolean {
+  if (status === 502 || status === 503 || status === 504) return true;
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    (data as { code?: number }).code === GRPC_UNAVAILABLE
+  );
+}
+
 export async function zitadelApi<T>(
   token: string,
   path: string,
   method: string = "POST",
   body?: unknown,
   baseUrl: string = ZITADEL_URL,
+  maxAttempts = 5,
 ): Promise<ApiResponse<T>> {
-  const res = await fetch(`${baseUrl}${path}`, {
-    method,
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    ...(body ? { body: JSON.stringify(body) } : {}),
-  });
-  const data = (await res.json().catch(() => ({}))) as T;
-  return { ok: res.ok, status: res.status, data };
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const res = await fetch(`${baseUrl}${path}`, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        ...(body ? { body: JSON.stringify(body) } : {}),
+      });
+      const data = (await res.json().catch(() => ({}))) as T;
+
+      if (attempt < maxAttempts && isTransient(res.status, data)) {
+        console.log(
+          `  ${method} ${path} unavailable (attempt ${attempt}/${maxAttempts}), retrying...`,
+        );
+        await new Promise((r) => setTimeout(r, attempt * 1000));
+        continue;
+      }
+
+      return { ok: res.ok, status: res.status, data };
+    } catch (err) {
+      // Connection-level failure (refused/reset) — same transient class.
+      lastError = err;
+      if (attempt === maxAttempts) break;
+      console.log(
+        `  ${method} ${path} connection failed (attempt ${attempt}/${maxAttempts}), retrying...`,
+      );
+      await new Promise((r) => setTimeout(r, attempt * 1000));
+    }
+  }
+
+  throw lastError;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Four CI failures, each traced to a root cause. Every claim below was verified rather than inferred.

## 1. zod 4.4 breaks env validation — blocks #486

Four vars used this shape:

```ts
ZITADEL_AUTHORITY: z
  .string()                                  // <- not optional
  .transform((v) => (v === '' ? undefined : v))
  .pipe(z.string().url().optional()),
```

The outer `z.string()` was never optional. It only accepted an unset variable because zod 4.3 let an optional `.pipe()` target swallow `undefined`. zod 4.4.3 correctly rejects it, so `validateEnv()` threw and the API refused to boot — which is why **all ten Playwright suites** failed on #486, not just the unit tests.

Verified by running the real `env.spec.ts` against each zod version:

| | zod 4.3.6 (pinned) | zod 4.4.3 (#486) |
|---|---|---|
| before fix | 39 pass | **30 fail** |
| after fix | 39 pass | 39 pass |

The fix is behaviour-identical on 4.3.6, so it lands safely ahead of the bump. Added a `describe.each` regression test covering unset / empty-string / valid / malformed for all four vars — the empty-string case is the reason the `.pipe()` exists at all (deployment tooling writes `VAR=` rather than omitting the line).

## 2. mjml 5 makes rendering async — blocks #485

`mjml2html` returns a Promise in mjml 5. `renderMjml` / `renderEmailTemplate` / `renderCustomTemplate` are now async and normalize with `Promise.resolve()`, which is correct under both majors (and keeps `@typescript-eslint/await-thenable` satisfied while mjml 4 is still installed). Both production call sites were already in async contexts.

## 3. Zitadel OIDC E2E — wrong readiness probe

Provisioning waited on `/debug/healthz`. That is the **liveness** probe: it answers as soon as the HTTP listener binds, well before the instance can serve API traffic. Calls landing in that window fail with gRPC code 14 and `dial tcp [::1]:8080: connect: connection refused` — Zitadel's own HTTP-to-gRPC gateway dialling a server that is not up yet.

Now waits on `/debug/ready`. Confirmed both routes exist in the pinned `zitadel:v4.10.1` image before relying on it. `zitadelApi` also retries responses that mean "could not reach Zitadel"; a definitive rejection is **not** retried, so no resource can be created twice. Verified against a stub server: readiness gating works, a code-14 response recovers on retry, and a 409 is attempted exactly once.

## 4. Webhook integration tests — hook starved of time, teardown masked the error

`testTimeout` was raised to 30s for integration suites but `hookTimeout` was left at its 10s default. `beforeAll` does *more* work than any single test (schema reset, pool warm-up, Fastify build) yet got a third of the budget, so a slow runner failed in setup rather than in an assertion.

Teardown then did `await app.close()` where `app` is `undefined` if setup failed, throwing a `TypeError` that **replaced the real error** in the report. Guarded in all five webhook suites, with `globalTeardown` in a `finally` so shared resources are released either way.

Verified the config change takes effect: a deliberate 12s `beforeAll` now passes where it previously failed at 10s.

## Also

`poolOptions.forks.singleFork` is removed. Vitest 4 dropped `poolOptions` entirely, so it had stopped doing anything and only emitted a deprecation warning on every integration run — removing it is a behavioural no-op. Serialization comes from `fileParallelism: false`. Adopting the v4 equivalent (`isolate: false`) would be a real change to cross-file isolation and is deliberately **not** done here.

## Deliberately not included

- **No blanket timeout increases.** The Slate failure was investigated and does *not* justify one: of four failing Slate jobs, three were infrastructure (two the zod bug above, one a Docker Hub outage). The single genuine failure re-failed identically on retry with `element(s) not found` — more time would not have helped. No trace exists because that run predates #483; the diagnostics merged there will capture one on recurrence.
- **SDK drift on #486 is not fixed here.** It is caused by that PR's prettier 3.8.1 → 3.9.6 bump reformatting the generated client. Confirmed main is drift-free at prettier 3.8.1. It can only be fixed on the dependabot branch: rebase, then `pnpm sdk:generate` and commit.

## Verification

- `pnpm turbo run type-check` — 13/13
- `pnpm turbo run lint` — 7/7
- API unit suite — 1773 passed / 157 files