### PR TITLE
docs: correct stale vitest config docs and update backlog

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -54,6 +54,8 @@
 - [x] CI: add Playwright submission E2E job (20 tests, needs Postgres service) — (DEVLOG 2026-02-18; done 2026-02-19)
 - [x] CI: add Playwright uploads E2E job (6 tests, needs tusd + MinIO services) — (DEVLOG 2026-02-19; done 2026-02-19 PR #115)
 - [x] CI: add Playwright OIDC E2E job (6 tests, needs Zitadel service) — (DEVLOG 2026-02-19; done 2026-02-19 PR #115)
+- [ ] [P2] Investigate the Workspace E2E 404 if it recurs — one CI run returned a genuine HTTP 404 for every `/workspace/*` route (24 tests, both attempts) while sibling `(dashboard)` suites passed. Ruled out: dependency bumps, missing/gitignored source, `notFound()` calls, and un-compiled-route timing (trace shows the 404 eleven minutes after server start). Passed on rerun and every run since, so runner-side. `error-context.md` in the report artifact carries the page snapshot — (DEVLOG 2026-07-25)
+- [ ] [P3] Consider capturing the Next dev server's startup output in the Playwright CI jobs — during the 404 investigation only six `[WebServer]` lines were recorded and no Next "Ready"/compile output, which limited diagnosis — (DEVLOG 2026-07-25)
 
 ### Housekeeping
 
@@ -266,6 +268,9 @@
 ### [P3] Low — Unused or minimal impact
 
 - [x] nodemailer 7 → 8 — already at v8.0.1; bumped @types/nodemailer 7.0.9 → 7.0.11 — (dependabot #77; done 2026-02-26)
+- [x] nodemailer 8 → 9 — security update; clean against the existing `@types/nodemailer` 7.0.11, no adapter changes needed — (dependabot #490; done 2026-07-25)
+- [x] mjml 4 → 5 — `mjml2html` returns a Promise in v5; render layer made async and normalized with `Promise.resolve()` so it works under both majors — (dependabot #475 / #488; done 2026-07-25)
+- [x] zod 4.3 → 4.4 — surfaced a latent `env.ts` bug where an optional `.pipe()` target sat behind a non-optional outer `z.string()` — (dependabot #489; done 2026-07-25)
 
 ### Upgrade order notes
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -291,7 +291,7 @@ const appPool = new Pool({
 | `organization-service.test.ts`   | —     | Org service operations under RLS                             |
 | `audit-write-path.test.ts`       | —     | Audit write path under RLS                                   |
 
-**Config:** `apps/api/vitest.config.rls.ts` — `singleFork: true` (sequential execution, shared pools), `fileParallelism: false`.
+**Config:** `apps/api/vitest.config.rls.ts` — `fileParallelism: false` (sequential execution, shared pools).
 
 **Running:**
 
@@ -319,7 +319,21 @@ Tests verify the full webhook handler path: HTTP request → signature/auth veri
 
 **Mocked:** Stripe SDK (`constructEvent`), Zitadel signature verification, BullMQ (`enqueueFileScan`), S3 operations. Redis rate limiting degrades gracefully when unavailable.
 
-**Config:** `apps/api/vitest.config.webhooks.ts` — `singleFork: true`, `fileParallelism: false`, `DATABASE_URL` pointed at test DB, `NODE_ENV: 'test'`.
+**Config:** `apps/api/vitest.config.webhooks.ts` — `fileParallelism: false`, `DATABASE_URL` pointed at test DB, `NODE_ENV: 'test'`. Shared settings live in `vitest.config.integration-base.ts`.
+
+> **Vitest 4 removed `poolOptions`.** The base config used to set
+> `poolOptions.forks.singleFork: true`; v4 ignores it entirely and only emits a
+> deprecation warning, so it was removed. Serialization comes from
+> `fileParallelism: false` — these suites share one test database and must never
+> run two files at once. The v4 equivalent of `singleFork` is `isolate: false`,
+> which is deliberately NOT set: it would change cross-file module isolation.
+
+> **`hookTimeout` does not inherit from `testTimeout`.** Integration `beforeAll`
+> hooks do more work than any single test (schema reset, pool warm-up, Fastify
+> build) but defaulted to 10s against the suite's 30s, so slow runners failed in
+> setup rather than in an assertion. Both are now 30s. Teardown must also guard
+> against failed setup — `await app?.close()` in a `try`/`finally`, since calling
+> `.close()` on an undefined app throws a `TypeError` that replaces the real error.
 
 **Running:**
 
@@ -346,7 +360,7 @@ Tests verify the full enqueue → BullMQ picks up → processor runs → DB stat
 
 **Mocked:** S3 storage adapter, ClamAV (`clamscan`), email adapter, `globalThis.fetch`, Inngest client, SSRF validation, Prometheus metrics, Sentry, logger.
 
-**Config:** `apps/api/vitest.config.queues.ts` — `singleFork: true`, `fileParallelism: false`, `DATABASE_URL` + `REDIS_HOST`/`REDIS_PORT` pointed at test infra.
+**Config:** `apps/api/vitest.config.queues.ts` — `fileParallelism: false`, `DATABASE_URL` + `REDIS_HOST`/`REDIS_PORT` pointed at test infra.
 
 **Running:**
 
@@ -579,7 +593,7 @@ All unit test suites run with randomized test ordering to detect order-dependent
 
 Vitest prints the shuffle seed in output — use `--sequence.seed=<N>` to reproduce a specific ordering.
 
-Integration test configs (`vitest.config.rls.ts`, `vitest.config.services.ts`, `vitest.config.webhooks.ts`, `vitest.config.queues.ts`, `vitest.config.security.ts`) are **excluded from shuffle** because they use `singleFork: true` + `fileParallelism: false` with shared database state where test ordering matters.
+Integration test configs (`vitest.config.rls.ts`, `vitest.config.services.ts`, `vitest.config.webhooks.ts`, `vitest.config.queues.ts`, `vitest.config.security.ts`) are **excluded from shuffle** because they use `fileParallelism: false` with shared database state where test ordering matters.
 
 ### No Retries
 
@@ -677,9 +691,11 @@ Playwright tests use separate ports (API: 4010, Web: 3010) to avoid conflicting 
 
 Vitest resolves workspace packages via `exports` field pointing to `dist/`. CI must run `pnpm build` for dependency packages (`@colophony/db`, `@colophony/types`, `@colophony/auth-client`, `@colophony/api-client`) before running tests.
 
-### RLS `singleFork: true` requirement
+### RLS sequential-execution requirement
 
-RLS tests use `singleFork: true` + `fileParallelism: false` because test files share database pools and rely on sequential `set_config` + `COMMIT`/`ROLLBACK` within transactions. Parallel execution would cause GUC context bleed between tests.
+RLS tests use `fileParallelism: false` because test files share database pools and rely on sequential `set_config` + `COMMIT`/`ROLLBACK` within transactions. Parallel execution would cause GUC context bleed between tests.
+
+This previously also set `poolOptions.forks.singleFork: true`. Vitest 4 removed `poolOptions`, so that setting had stopped doing anything — `fileParallelism: false` is what actually enforces the ordering.
 
 ### Console error/warn enforcement
 


### PR DESCRIPTION
Doc follow-up to this session's E2E reliability work (#483, #488, #489, #490 — all merged).

## `docs/testing.md` — corrected stale config

Five places described `poolOptions.forks.singleFork: true` as active configuration. **Vitest 4 removed `poolOptions` entirely**, so that setting had silently stopped applying and only emitted a deprecation warning on every integration run. It was removed from the config in #488; the docs now reflect that `fileParallelism: false` is what actually serializes the suites.

Two adjacent traps documented alongside it:

- **`hookTimeout` does not inherit from `testTimeout`.** Integration `beforeAll` hooks do more work than any single test (schema reset, pool warm-up, Fastify build) but defaulted to 10s against the suite's 30s, so slow runners failed in setup rather than in an assertion.
- **Teardown must guard against failed setup.** `await app.close()` on an undefined `app` throws a `TypeError` that replaces the real error in the report — which is exactly what hid the timeout above.

Deliberately **not** changed: the v4 equivalent of `singleFork` is `isolate: false`, which would be a real change to cross-file module isolation. Noted in the doc as an explicit non-adoption.

## `docs/backlog.md`

Checked off: nodemailer 8 → 9, mjml 4 → 5, zod 4.3 → 4.4.

Added:
- `[P2]` the unexplained Workspace E2E 404 — records what has been ruled out (dependency bumps, missing source, `notFound()` calls, un-compiled-route timing) and where the evidence lives, so a recurrence doesn't restart the investigation
- `[P3]` capture the Next dev-server startup output in the Playwright CI jobs — only six `[WebServer]` lines were recorded during that investigation, with no Next "Ready"/compile output

## `.gitignore`

Moves machine-local patterns to `.git/info/exclude`. They only ever applied to individual working copies, so listing them in the tracked ignore file enumerated local tooling for every reader without ignoring anything for anyone else. Verified all patterns still resolve — `git check-ignore` now reports `.git/info/exclude` for each, and nothing new appears as untracked.