### PR TITLE
fix(ci): give the deploy build gate a valid NEXT_PUBLIC_API_URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,7 +90,10 @@ jobs:
       - name: Build all packages
         run: pnpm build
         env:
-          NEXT_PUBLIC_API_URL: placeholder
+          # This job is a build gate — it uploads no artifacts. Servers rebuild
+          # via `docker compose build` with real values from .env.staging/.env.prod.
+          # The value only has to satisfy the URL validation in apps/web/src/env.ts.
+          NEXT_PUBLIC_API_URL: https://placeholder.invalid
 
   # ──────────────────────────────────────────────────
   # Deploy to staging via SSH + Docker Compose


### PR DESCRIPTION
## Problem

Every Deploy run that reached the Build job has failed since 2026-07-25 20:33 UTC:

```
⨯ Failed to load next.config.ts
Error: Invalid client environment variables:
  NEXT_PUBLIC_API_URL: Invalid URL
    at parseClient (src/env.ts:86:26)
```

`deploy.yml` passed `NEXT_PUBLIC_API_URL: placeholder` to `pnpm build`. That
literal dates to the initial commit and was inert until build-time environment
validation landed in #465 — `next.config.ts` imports `apps/web/src/env.ts`, so
`z.string().url()` now runs during `next build` and rejects it.

The Deploy runs that reported success in this window were no-ops where Prepare
set `skip` and Build plus both deploy jobs were skipped. **Nothing has reached
staging or production since 2026-07-25 20:26 UTC.**

## Fix

Use a syntactically valid dummy URL.

The Build job uploads no artifacts — it is a gate. The servers rebuild via
`docker compose build` using real values from `.env.staging` / `.env.prod`, so
the value here only has to satisfy validation. `SKIP_ENV_VALIDATION=1` would
also unblock it, but that disables the check #465 just added.

## Verification

`pnpm build` with the new value: 8 successful, 8 total. Before the change the
same command reproduces the CI failure at 6 of 8, with `@colophony/web#build`
failing on the error above.
