### PR TITLE
fix(api): pass --legacy to pnpm deploy in the Docker build

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -23,8 +23,12 @@ RUN pnpm --filter @colophony/auth-client build
 RUN pnpm --filter @colophony/plugin-sdk build
 RUN pnpm --filter @colophony/api-contracts build
 RUN pnpm --filter @colophony/api build
-# Deploy creates a standalone directory with production deps (pnpm's Docker approach)
-RUN pnpm --filter @colophony/api deploy --prod /app/deploy
+# Deploy creates a standalone directory with production deps (pnpm's Docker approach).
+# --legacy is required from pnpm 10: the default implementation refuses to deploy a
+# workspace without inject-workspace-packages=true. Legacy is also the behaviour the
+# runner stage below expects — it leaves workspace packages out of /app/deploy, which
+# is why their dist/ and package.json are copied in explicitly.
+RUN pnpm --filter @colophony/api deploy --prod --legacy /app/deploy
 
 # Stage 3: runner — production image
 FROM node:22-alpine AS runner

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -69,6 +69,7 @@
 - [ ] Reduce the `apps/api` ESLint rule suppressions — `recommendedTypeChecked` is enabled but `no-explicit-any` and five `no-unsafe-*` rules are switched off, which neutralises most of its value. At minimum promote `no-floating-promises` from `warn` to `error`, since unhandled rejections in Fastify handlers are a production failure mode — (DEVLOG 2026-07-25)
 - [ ] Enable `noUncheckedIndexedAccess` in `packages/typescript-config/base.json` — package by package (`types` and `api-contracts` first, then `db`, `api`, `web`) — (DEVLOG 2026-07-25)
 - [ ] Add `tseslint.configs.recommendedTypeChecked` to `apps/web/eslint.config.mjs` — the web app is currently unlinted for `no-floating-promises`, `no-misused-promises`, `await-thenable`, and the `no-unsafe-*` family, unlike `apps/api`. Expect a large first-run count; start the noisiest rules at `warn` — (DEVLOG 2026-07-25)
+- [ ] [P2] Stop passing `SENTRY_AUTH_TOKEN` as a Docker build ARG — `apps/web/Dockerfile` lines 34–35 take it as `ARG` then promote it to `ENV`. Build ARGs are recorded in image history, so the token is recoverable from any built image; `docker build` warns about this (`SecretsUsedInArgOrEnv`). Use a BuildKit secret mount (`RUN --mount=type=secret,id=sentry_auth_token`) and pass it via `--secret` from the deploy workflow instead — (DEVLOG 2026-07-26)
 
 ---
 
@@ -343,6 +344,9 @@
 ### CI
 
 - [x] [P2] CI path filtering for Playwright suites — skip irrelevant E2E suites on PRs based on changed files; `.github/scripts/detect-changes.sh` with fail-open strategy — (DEVLOG 2026-02-24; done 2026-02-24)
+- [ ] [P1] Stop the Deploy workflow reporting `success` on no-op runs — when `prepare` sets `skip`, Build and both deploy jobs are skipped and the run still concludes `success`. On 2026-07-25/26 four such runs interleaved with real failures, so a total deployment outage read as intermittent flakiness and went unnoticed for about seven hours. Either fail the run when `skip` is set for a `workflow_run` trigger on `main`, or surface "deployed / not deployed" somewhere that does not depend on reading each run's job list — (DEVLOG 2026-07-26)
+- [ ] [P2] Make Coverage Report a required status check — #494 reached `mergeStateStatus: CLEAN` with Coverage Report unresolved, so the job can fail without blocking a merge. That is how an infrastructure flake (or a real coverage regression) becomes invisible — (DEVLOG 2026-07-26)
+- [ ] [P3] Consider a registry pull-through cache or retry for service containers — Coverage Report failed on 2026-07-26 when Docker Hub timed out three times pulling `postgres:16-alpine`, killing `Initialize containers` before any test ran. Passed on retry — (DEVLOG 2026-07-26)
 
 ### Dev Environment
 


### PR DESCRIPTION
## Problem

Staging deployment fails during `docker compose build`:

```
ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE  By default, starting from pnpm v10, we only
deploy from workspaces that have "inject-workspace-packages=true" set

target api: failed to solve: process "/bin/sh -c pnpm --filter @colophony/api
deploy --prod /app/deploy" did not complete successfully: exit code: 1
```

pnpm 10 (#464) changed `pnpm deploy` to refuse workspaces without
`inject-workspace-packages=true`. `apps/api/Dockerfile` has used plain
`pnpm deploy` since the initial commit, so the first production-shaped build
after that upgrade broke. It hits both the `api` and `demo-migrate` targets.

This was masked until now: the deploy workflow's Build gate failed earlier in the
pipeline (#494), so the staging job had not run since the pnpm 10 upgrade landed.

## Fix

Add `--legacy`.

This preserves existing behaviour rather than changing it. The runner stage copies
each workspace package's `dist/` and `package.json` into `node_modules` by hand
(lines 43–53) *because* `pnpm deploy` leaves them out. Switching to injected
workspace packages would place them there too, duplicating what the explicit COPY
steps already provide and changing image contents — a larger change than the
failure warrants.

`apps/api/Dockerfile` is the only `pnpm deploy` call site in the repo.

## Verification

Built `apps/api/Dockerfile` locally — the previously failing step now succeeds.
Inspected the resulting image:

| Check | Result |
| --- | --- |
| `dist/main.js` | present |
| Drizzle migrations | 68 files |
| 5 workspace packages | `dist/` + `package.json` all present |
| Production deps (`fastify`) | present |
| devDependencies (`typescript`) | absent — `--prod` still honoured |
| `node dist/main.js` | reaches env validation; no `Cannot find module` |

Also built `apps/web/Dockerfile` successfully. Its targets were `CANCELED` rather
than failed in the staging log, so they were unverified — this confirms no second
failure is queued behind this one.

## Note (not addressed here)

The web image build emits two pre-existing warnings, unrelated to this change:

```
SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data
  (ARG "SENTRY_AUTH_TOKEN") (line 34)
```

A build ARG is recorded in image history, so the Sentry token is recoverable from
the image. Worth a follow-up using a BuildKit secret mount instead.
