### PR TITLE
fix(scripts): add Origin header to tusd OPTIONS smoke test

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -96,7 +96,9 @@ else
 fi
 
 # --- 5. tusd tus headers ---
-TUS_HEADERS=$(curl -sI --max-time 10 -X OPTIONS "${BASE_URL}/upload" 2>/dev/null || true)
+TUS_HEADERS=$(curl -sI --max-time 10 -X OPTIONS \
+  -H "Origin: ${BASE_URL}" \
+  "${BASE_URL}/upload" 2>/dev/null || true)
 if echo "$TUS_HEADERS" | grep -qi "Tus-Resumable"; then
   pass "OPTIONS /upload — Tus-Resumable header present"
 else


### PR DESCRIPTION
The tusd preflight check in `scripts/smoke-test.sh` sent `OPTIONS /upload`
without an `Origin` header, so it exercised a bare OPTIONS request rather than a
real CORS preflight. tusd's `-cors-allow-headers` flag replaces the default
header set rather than appending to it, which makes an origin-less probe a weak
signal — it can pass while a genuine browser preflight fails.

Sends `Origin: ${BASE_URL}` with the request, matching how the `/trpc` CORS
check in the same script already works.

Originally written during the nginx-era deploy work and closed unmerged when
that stack was replaced; the check itself still applies to the current Caddy
setup.