### PR TITLE
feat(api): fail the build on a tRPC procedure declaring no guard

### DIFF
--- a/apps/api/src/trpc/guard-coverage.spec.ts
+++ b/apps/api/src/trpc/guard-coverage.spec.ts
@@ -1,0 +1,254 @@
+/**
+ * Guard coverage across the whole tRPC surface.
+ *
+ * `X-Api-Key` is accepted on every non-public route, `/trpc/*` included — tRPC
+ * is internal by intent, not by mechanism. A procedure is therefore only out of
+ * an API key's reach if it declares one of two things: a `requireScopes(...)`
+ * guard, or an `internal*Procedure` builder. A procedure declaring neither is
+ * callable by any valid key holding any scope.
+ *
+ * P0.1/P0.1b closed the ten routers that had no guard. This suite is what stops
+ * the eleventh appearing: it reads every procedure's middleware chain out of the
+ * built `appRouter` and fails on one that declares neither.
+ *
+ * DECLARES, not "is protected" — the distinction is load-bearing. A
+ * `requireScopes` declaration is also its enforcement. `internalOnly` is not,
+ * yet: while `TRPC_INTERNAL_ONLY_ENFORCE` is false it audits the call and lets
+ * it through, so the internal procedures counted here remain reachable by any
+ * key until P0.5 flips the flag. The last test pins the enforced behaviour so
+ * that gap stays visible rather than implied.
+ *
+ * Introspection only — no service is mocked because tests 1-5 never invoke a
+ * procedure, and test 6 rejects at middleware index 0, before any service is
+ * reached.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { apiKeyScopeSchema } from '@colophony/types';
+
+const { envState } = vi.hoisted(() => ({
+  envState: { TRPC_INTERNAL_ONLY_ENFORCE: false },
+}));
+
+vi.mock('../config/env.js', () => ({
+  validateEnv: () => envState,
+}));
+
+import { appRouter } from './router.js';
+import { readGuardTags, type GuardTag } from './init.js';
+import type { TRPCContext } from './context.js';
+
+/**
+ * Procedures that deliberately declare neither guard.
+ *
+ * Every entry here is callable by any API key holding any scope. Nothing that
+ * reads or writes tenant data belongs in this list — the reason must explain
+ * why the procedure is safe without a guard, not merely why it lacks one.
+ */
+const UNGUARDED_PROCEDURES: Record<string, string> = {
+  health:
+    'Liveness probe. Takes no input, touches no database, and returns a ' +
+    'constant. Allowlisted in the auth hook, so it is reachable without any ' +
+    'credential at all — a scope guard would be decorative.',
+};
+
+/** Router keys in `appRouter` whose procedures are all internal-only. */
+const INTERNAL_ROUTERS = [
+  'federation',
+  'gdpr',
+  'hub',
+  'migrations',
+  'ops',
+  'simsub',
+  'transfers',
+] as const;
+
+interface BuiltProcedure {
+  _def: { middlewares?: readonly unknown[] };
+}
+
+interface ProcedureEntry {
+  path: string;
+  guards: GuardTag[];
+}
+
+function allProcedures(): ProcedureEntry[] {
+  const procedures = appRouter._def.procedures as unknown as Record<
+    string,
+    BuiltProcedure
+  >;
+
+  return Object.entries(procedures).map(([path, procedure]) => ({
+    path,
+    guards: readGuardTags(procedure._def.middlewares ?? []),
+  }));
+}
+
+function isUnguarded(entry: ProcedureEntry): boolean {
+  return entry.guards.length === 0;
+}
+
+describe('tRPC guard coverage (P0.4)', () => {
+  beforeEach(() => {
+    envState.TRPC_INTERNAL_ONLY_ENFORCE = false;
+  });
+
+  it('introspects a plausible number of procedures', () => {
+    // Guards against the whole suite silently passing because the shape of
+    // `_def.procedures` changed under a tRPC upgrade and every assertion below
+    // started iterating an empty list.
+    expect(allProcedures().length).toBeGreaterThan(250);
+  });
+
+  it('every procedure declares a scope guard or the internal guard', () => {
+    const offenders = allProcedures()
+      .filter(isUnguarded)
+      .map((entry) => entry.path)
+      .filter((path) => !(path in UNGUARDED_PROCEDURES))
+      .sort();
+
+    expect(
+      offenders,
+      offenders.length === 0
+        ? ''
+        : `These tRPC procedures declare neither guard, so any API key with ` +
+            `any scope can call them:\n\n` +
+            offenders.map((p) => `  - ${p}`).join('\n') +
+            `\n\nAdd .use(requireScopes('<scope>')) if the procedure is meant ` +
+            `to have a REST equivalent, or build it from ` +
+            `internalAdminProcedure / internalAuthedProcedure if it is ` +
+            `operator-console only. If it genuinely needs neither, add it to ` +
+            `UNGUARDED_PROCEDURES with a reason.`,
+    ).toEqual([]);
+  });
+
+  it('no procedure declares an empty scope list', () => {
+    // requireScopes() with no arguments passes [] to checkApiKeyScopes, whose
+    // `missing.length === 0` check then allows everything. A vacuous guard
+    // reads exactly like a real one at the call site.
+    const vacuous = allProcedures()
+      .filter((entry) =>
+        entry.guards.some(
+          (guard) => guard.kind === 'scopes' && guard.scopes.length === 0,
+        ),
+      )
+      .map((entry) => entry.path)
+      .sort();
+
+    expect(vacuous).toEqual([]);
+  });
+
+  it('scope guards name only scopes defined in apiKeyScopeSchema', () => {
+    // A typo'd scope string denies silently and permanently — no key can ever
+    // hold a scope that is not in the enum.
+    const unknown = allProcedures()
+      .flatMap((entry) =>
+        entry.guards
+          .filter((guard) => guard.kind === 'scopes')
+          .flatMap((guard) => guard.scopes)
+          .filter((scope) => !apiKeyScopeSchema.safeParse(scope).success)
+          .map((scope) => `${entry.path} -> ${scope}`),
+      )
+      .sort();
+
+    expect(unknown).toEqual([]);
+  });
+
+  it('every UNGUARDED_PROCEDURES entry still exists and is still unguarded', () => {
+    const byPath = new Map(
+      allProcedures().map((entry) => [entry.path, entry] as const),
+    );
+
+    const stale = Object.keys(UNGUARDED_PROCEDURES)
+      .map((path) => {
+        const entry = byPath.get(path);
+        if (!entry) return `${path} (no longer exists — remove this entry)`;
+        if (!isUnguarded(entry))
+          return `${path} (now declares a guard — remove this entry)`;
+        return null;
+      })
+      .filter((problem): problem is string => problem !== null)
+      .sort();
+
+    expect(stale).toEqual([]);
+  });
+
+  it('the seven internal routers declare the internal guard throughout', () => {
+    const downgraded = allProcedures()
+      .filter((entry) =>
+        INTERNAL_ROUTERS.some((router) => entry.path.startsWith(`${router}.`)),
+      )
+      .filter((entry) => !entry.guards.some((g) => g.kind === 'internal'))
+      .map((entry) => entry.path)
+      .sort();
+
+    expect(downgraded).toEqual([]);
+  });
+
+  it('every internal-guarded procedure denies an API key once enforcement is on', async () => {
+    // The behavioural counterpart to the declaration checks above: proves the
+    // boundary actually rejects, for all internal procedures rather than the
+    // single one scope-enforcement.spec.ts covers.
+    envState.TRPC_INTERNAL_ONLY_ENFORCE = true;
+
+    const context: TRPCContext = {
+      authContext: {
+        userId: '00000000-0000-4000-a000-000000000001',
+        email: 'key@example.com',
+        emailVerified: true,
+        authMethod: 'apikey',
+        apiKeyId: '00000000-0000-4000-a000-0000000000ff',
+        apiKeyScopes: ['manuscripts:read'],
+        orgId: '00000000-0000-4000-a000-000000000010',
+        roles: ['ADMIN'],
+      },
+      dbTx: {} as TRPCContext['dbTx'],
+      audit: vi.fn(),
+    } as unknown as TRPCContext;
+
+    const caller = (
+      appRouter as unknown as {
+        createCaller: (ctx: TRPCContext) => Record<string, unknown>;
+      }
+    ).createCaller(context);
+
+    const internalPaths = allProcedures()
+      .filter((entry) => entry.guards.some((g) => g.kind === 'internal'))
+      .map((entry) => entry.path);
+
+    expect(internalPaths.length).toBeGreaterThan(0);
+
+    const admitted: string[] = [];
+
+    for (const path of internalPaths) {
+      const invoke = path
+        .split('.')
+        .reduce<unknown>(
+          (node, segment) => (node as Record<string, unknown>)[segment],
+          caller,
+        ) as (input?: unknown) => Promise<unknown>;
+
+      // internalOnly sits at middleware index 0 on both internal builders, so
+      // it throws before the role check and before input is parsed — undefined
+      // input is fine, and no service is reached.
+      const outcome = await invoke(undefined).then(
+        () => 'resolved' as const,
+        (error: unknown) => error,
+      );
+
+      const denied =
+        outcome !== 'resolved' &&
+        (outcome as { code?: string })?.code === 'FORBIDDEN';
+
+      if (!denied) admitted.push(path);
+    }
+
+    expect(
+      admitted,
+      admitted.length === 0
+        ? ''
+        : `These procedures declare internalOnly but did not reject an API ` +
+            `key under TRPC_INTERNAL_ONLY_ENFORCE=true:\n` +
+            admitted.map((p) => `  - ${p}`).join('\n'),
+    ).toEqual([]);
+  });
+});

--- a/apps/api/src/trpc/init.ts
+++ b/apps/api/src/trpc/init.ts
@@ -201,13 +201,59 @@ const isBusinessOps = t.middleware(({ ctx, next }) => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Guard tagging
+// ---------------------------------------------------------------------------
+
+/**
+ * Marks a middleware as one of the two guards that keep a tRPC procedure out of
+ * an API key's reach. Read by `guard-coverage.spec.ts`, which fails the build on
+ * a procedure declaring neither.
+ *
+ * Tagging is necessary because neither guard is identifiable by reference:
+ * `requireScopes` mints a fresh closure per call, and both are anonymous inside
+ * `t.middleware(...)`. tRPC keeps the function object itself in
+ * `procedure._def.middlewares`, so a non-enumerable property on it survives
+ * builder composition intact.
+ */
+export const TRPC_GUARD = Symbol.for('colophony.trpc.guard');
+
+export type GuardTag =
+  { kind: 'scopes'; scopes: readonly ApiKeyScope[] } | { kind: 'internal' };
+
+/**
+ * Tags the underlying function of a middleware builder, returning the builder
+ * unchanged. Takes the builder rather than the raw function so the middleware
+ * body keeps tRPC's parameter inference.
+ */
+function tagGuard<TBuilder extends { _middlewares: readonly unknown[] }>(
+  middleware: TBuilder,
+  tag: GuardTag,
+): TBuilder {
+  const fn = middleware._middlewares[0];
+  /* c8 ignore next 3 -- defensive: tRPC always populates _middlewares[0] */
+  if (typeof fn !== 'function') {
+    throw new Error('Cannot tag guard: middleware builder has no function');
+  }
+  Object.defineProperty(fn, TRPC_GUARD, { value: tag, enumerable: false });
+  return middleware;
+}
+
+/** Reads the guard tags declared on a built procedure's middleware chain. */
+export function readGuardTags(middlewares: readonly unknown[]): GuardTag[] {
+  return middlewares
+    .filter((mw): mw is object => typeof mw === 'function')
+    .map((mw) => (mw as Record<symbol, GuardTag | undefined>)[TRPC_GUARD])
+    .filter((tag): tag is GuardTag => tag !== undefined);
+}
+
 /**
  * Factory: returns tRPC middleware that enforces API key scopes.
  * OIDC/test auth bypasses the check (scopes are API-key-only).
  * Must be chained after isAuthed or hasOrgContext.
  */
 export function requireScopes(...scopes: ApiKeyScope[]) {
-  return t.middleware(async ({ ctx, next }) => {
+  const middleware = t.middleware(async ({ ctx, next }) => {
     if (!ctx.authContext) {
       throw new TRPCError({
         code: 'UNAUTHORIZED',
@@ -231,6 +277,8 @@ export function requireScopes(...scopes: ApiKeyScope[]) {
 
     return next();
   });
+
+  return tagGuard(middleware, { kind: 'scopes', scopes });
 }
 
 /**
@@ -255,7 +303,7 @@ const INTERACTIVE_AUTH_METHODS: readonly string[] = ['oidc', 'demo', 'test'];
  * audited and let through, so real usage can be measured before the boundary
  * starts rejecting. An unauthenticated caller is rejected in both modes.
  */
-export const internalOnly = t.middleware(async ({ ctx, path, next }) => {
+const internalOnlyMiddleware = t.middleware(async ({ ctx, path, next }) => {
   if (!ctx.authContext) {
     throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
   }
@@ -287,6 +335,10 @@ export const internalOnly = t.middleware(async ({ ctx, path, next }) => {
   }
 
   return next();
+});
+
+export const internalOnly = tagGuard(internalOnlyMiddleware, {
+  kind: 'internal',
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/trpc/routers/embed-tokens.spec.ts
+++ b/apps/api/src/trpc/routers/embed-tokens.spec.ts
@@ -178,4 +178,95 @@ describe('embedTokens router', () => {
       ).rejects.toThrow('Admin role required');
     });
   });
+
+  /**
+   * Until the P0.4 coverage gate landed, create and revoke declared no scope
+   * guard — so any API key, holding any scope, could mint or revoke an embed
+   * token for the org. The role check alone did not help: a key inherits its
+   * creator's roles, and embed tokens are created by admins.
+   *
+   * `init.js` is deliberately not mocked in this suite, so these exercise the
+   * real `requireScopes` middleware.
+   */
+  describe('API key scope enforcement (P0.4)', () => {
+    const PERIOD_ID = 'b2222222-2222-2222-a222-222222222222';
+    const TOKEN_ID = 'a1111111-1111-1111-a111-111111111111';
+
+    function keyCaller(scopes: string[]) {
+      return createCaller(
+        orgContext(['ADMIN'], {
+          authContext: {
+            userId: 'user-1',
+            email: 'key@example.com',
+            emailVerified: true,
+            authMethod: 'apikey',
+            apiKeyId: 'key-1',
+            apiKeyScopes: scopes,
+            orgId: 'org-1',
+            roles: ['ADMIN'],
+          },
+        } as Partial<TRPCContext>),
+      );
+    }
+
+    it('denies create to a key without periods:write', async () => {
+      await expect(
+        keyCaller(['manuscripts:read']).embedTokens.create({
+          submissionPeriodId: PERIOD_ID,
+          allowedOrigins: ['https://example.com'],
+        }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockEmbedTokenService.create).not.toHaveBeenCalled();
+    });
+
+    it('denies create to a key holding only the read scope', async () => {
+      await expect(
+        keyCaller(['periods:read']).embedTokens.create({
+          submissionPeriodId: PERIOD_ID,
+          allowedOrigins: ['https://example.com'],
+        }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+
+    it('denies revoke to a key without periods:write', async () => {
+      await expect(
+        keyCaller(['periods:read']).embedTokens.revoke({ tokenId: TOKEN_ID }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockEmbedTokenService.revoke).not.toHaveBeenCalled();
+    });
+
+    it('admits create to a key holding periods:write', async () => {
+      mockEmbedTokenService.create.mockResolvedValueOnce({
+        id: TOKEN_ID,
+        submissionPeriodId: PERIOD_ID,
+        tokenPrefix: 'col_emb_',
+        plainTextToken: 'col_emb_abcdef1234567890abcdef1234567890',
+        allowedOrigins: ['https://example.com'],
+        themeConfig: null,
+        active: true,
+        createdAt: new Date(),
+        expiresAt: null,
+      });
+
+      await expect(
+        keyCaller(['periods:write']).embedTokens.create({
+          submissionPeriodId: PERIOD_ID,
+          allowedOrigins: ['https://example.com'],
+        }),
+      ).resolves.toMatchObject({ id: TOKEN_ID });
+    });
+
+    it('leaves interactive sessions unaffected — they carry no scopes at all', async () => {
+      mockEmbedTokenService.revoke.mockResolvedValueOnce({
+        id: TOKEN_ID,
+        active: false,
+      });
+
+      await expect(
+        createCaller(orgContext(['ADMIN'])).embedTokens.revoke({
+          tokenId: TOKEN_ID,
+        }),
+      ).resolves.toMatchObject({ id: TOKEN_ID, active: false });
+    });
+  });
 });

--- a/apps/api/src/trpc/routers/embed-tokens.ts
+++ b/apps/api/src/trpc/routers/embed-tokens.ts
@@ -19,6 +19,7 @@ import { embedTokenService } from '../../services/embed-token.service.js';
 
 export const embedTokensRouter = createRouter({
   create: adminProcedure
+    .use(requireScopes('periods:write'))
     .input(createEmbedTokenSchema)
     .output(createEmbedTokenResponseSchema)
     .mutation(async ({ ctx, input }) => {
@@ -63,6 +64,7 @@ export const embedTokensRouter = createRouter({
     }),
 
   revoke: adminProcedure
+    .use(requireScopes('periods:write'))
     .input(revokeEmbedTokenSchema)
     .output(z.object({ id: z.string().uuid(), active: z.boolean() }))
     .mutation(async ({ ctx, input }) => {

--- a/apps/api/src/trpc/routers/organizations.spec.ts
+++ b/apps/api/src/trpc/routers/organizations.spec.ts
@@ -54,12 +54,19 @@ vi.mock('../../config/env.js', () => ({
   }),
 }));
 
+// Hoisted so the scope-enforcement tests below can reference the mock directly
+// rather than through `invitationService.acceptWithAudit`, which trips
+// @typescript-eslint/unbound-method.
+const { mockAcceptWithAudit } = vi.hoisted(() => ({
+  mockAcceptWithAudit: vi.fn().mockResolvedValue({}),
+}));
+
 vi.mock('../../services/invitation.service.js', () => ({
   invitationService: {
     listPending: vi.fn().mockResolvedValue([]),
     revokeWithAudit: vi.fn().mockResolvedValue({}),
     resendWithAudit: vi.fn().mockResolvedValue({}),
-    acceptWithAudit: vi.fn().mockResolvedValue({}),
+    acceptWithAudit: mockAcceptWithAudit,
   },
   InvitationNotFoundError: class InvitationNotFoundError extends Error {
     name = 'InvitationNotFoundError';
@@ -514,6 +521,82 @@ describe('organizations tRPC router', () => {
           roles: ['READER'],
         }),
       ).rejects.toThrow('last admin');
+    });
+  });
+
+  /**
+   * Until the P0.4 coverage gate landed, accept was the one procedure in this
+   * router declaring no scope guard — every sibling already had one. An API key
+   * holding any scope could therefore accept an invitation on behalf of its
+   * creator, joining them to an org.
+   *
+   * `init.js` is deliberately not mocked in this suite, so these exercise the
+   * real `requireScopes` middleware.
+   */
+  describe('organizations.invitations.accept — API key scope enforcement (P0.4)', () => {
+    function keyCaller(scopes: string[]) {
+      return createCaller(
+        makeContext({
+          authContext: {
+            userId: USER_ID,
+            zitadelUserId: ZITADEL_USER_ID,
+            email: 'key@example.com',
+            emailVerified: true,
+            authMethod: 'apikey',
+            apiKeyId: '00000000-0000-4000-a000-0000000000ff',
+            apiKeyScopes: scopes,
+          },
+          dbTx: {} as never,
+          audit: vi.fn(),
+        } as Partial<TRPCContext>),
+      );
+    }
+
+    it('denies a key holding only organizations:read', async () => {
+      await expect(
+        keyCaller(['organizations:read']).organizations.invitations.accept({
+          token: 'plain-invitation-token',
+        }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockAcceptWithAudit).not.toHaveBeenCalled();
+    });
+
+    it('denies a key holding an unrelated scope', async () => {
+      await expect(
+        keyCaller(['manuscripts:read']).organizations.invitations.accept({
+          token: 'plain-invitation-token',
+        }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+
+    it('admits a key holding organizations:write', async () => {
+      mockAcceptWithAudit.mockResolvedValueOnce({
+        invitationId: '00000000-0000-4000-a000-000000000030',
+        organizationId: ORG_ID,
+        memberId: MEMBER_ID,
+        roles: ['READER'],
+      });
+
+      await expect(
+        keyCaller(['organizations:write']).organizations.invitations.accept({
+          token: 'plain-invitation-token',
+        }),
+      ).resolves.toMatchObject({ organizationId: ORG_ID });
+    });
+
+    it('leaves interactive sessions unaffected — they carry no scopes at all', async () => {
+      mockAcceptWithAudit.mockResolvedValueOnce({
+        invitationId: '00000000-0000-4000-a000-000000000030',
+        organizationId: ORG_ID,
+        memberId: MEMBER_ID,
+        roles: ['READER'],
+      });
+
+      await expect(
+        createCaller(
+          authedContext({ dbTx: {} as never }),
+        ).organizations.invitations.accept({ token: 'plain-invitation-token' }),
+      ).resolves.toMatchObject({ organizationId: ORG_ID });
     });
   });
 });

--- a/apps/api/src/trpc/routers/organizations.ts
+++ b/apps/api/src/trpc/routers/organizations.ts
@@ -155,6 +155,7 @@ const invitationsRouter = createRouter({
     }),
 
   accept: userProcedure
+    .use(requireScopes('organizations:write'))
     .input(acceptInvitationSchema)
     .output(acceptInvitationResultSchema)
     .mutation(async ({ ctx, input }) => {

--- a/apps/web/e2e/helpers/organization-fixtures.ts
+++ b/apps/web/e2e/helpers/organization-fixtures.ts
@@ -161,7 +161,11 @@ export const test = base.extend<{
     const apiKey = await createApiKey({
       orgId: inviteeOrg.id,
       userId: inviteTarget.id,
-      scopes: ["organizations:read", "users:read"],
+      // organizations:write is required by invitations.accept, which this page
+      // is built to drive. Kept inline rather than folded into ORG_E2E_SCOPES
+      // because the invitee is deliberately a different, lower-privilege
+      // principal than the org admin.
+      scopes: ["organizations:read", "organizations:write", "users:read"],
       name: `e2e-invitee-${Date.now()}`,
     });
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -118,8 +118,25 @@ Ordered as the design doc's Phase 0/D.
         `notification-preferences`, `webhooks`. New scopes `notifications:read`,
         `notifications:write`, `webhooks:read`; `webhooks:manage` now consumed. Enforcing
         immediately (denials audit as `API_KEY_SCOPE_DENIED`). — done 2026-07-27
-  - [ ] **P0.4** — coverage manifest test. Until it lands, nothing _keeps_ the boundary
-        closed: a new procedure declaring neither guard reopens it silently.
+  - [x] **P0.4** — guard coverage gate. `apps/api/src/trpc/guard-coverage.spec.ts` reads
+        every procedure's middleware chain out of the built `appRouter` and fails on one
+        declaring neither `requireScopes(...)` nor an `internal*Procedure` builder.
+        Also pins the seven internal routers against a silent downgrade to a plain scope
+        guard, rejects vacuous `requireScopes()` (an empty list allows everything), and
+        rejects scope strings absent from `apiKeyScopeSchema`. Found and closed three live
+        gaps: `embedTokens.create`, `embedTokens.revoke` (`periods:write`) and
+        `organizations.invitations.accept` (`organizations:write`). — done 2026-07-27
+        **Narrower than design doc §1.6 M4**, which specifies a three-list manifest
+        (REST-equivalent / internal-only / deferred) across all 301 procedures. Only the
+        mechanical half shipped: M4's argument for a manifest over a heuristic is about
+        REST-parity name-matching, which this does not attempt, and seeding a
+        "has REST equivalent" list from a spec 36 operations stale would bake in wrong
+        data. Per-procedure parity classification moves to P1.1–P1.4.
+        **Note the gate asserts declaration, not denial.** `requireScopes` declares and
+        enforces in one step; `internalOnly` only declares while
+        `TRPC_INTERNAL_ONLY_ENFORCE` is `false`, so those 29 procedures stay reachable by
+        any key until P0.5. The suite's last test pins the enforced behaviour across all
+        29 so the gap stays visible.
   - [ ] **P0.5** — flip `TRPC_INTERNAL_ONLY_ENFORCE` to `true` after the observation
         window; decide `payments:read`. **Blocked on the E2E auth model** — see below.
   - [ ] **[P1] Playwright suites authenticate as API keys, which blocks P0.5.**
@@ -134,6 +151,14 @@ Ordered as the design doc's Phase 0/D.
         (`x-test-user-id`, already supported in `hooks/auth.ts`) instead of a key, so
         E2E exercises the same auth class the web app actually uses. —
         (discovered 2026-07-27 during P0.1b)
+        **(3) The `*_E2E_SCOPES` naming convention is not universal, so grepping for it
+        is not a reliable audit.** `organization-fixtures.ts` mints a _second_ key inline
+        for the `inviteePage` fixture with its own scope array — deliberately, since the
+        invitee is a lower-privilege principal than the org admin. Adding
+        `organizations:write` to `invitations.accept` in P0.4 broke four accept-side
+        tests until that inline array was updated too. `scopes:` is the search key that
+        finds every grant; there are nine across `apps/web/e2e/helpers/`. The rework
+        should collapse both onto the interactive path. — (found 2026-07-27 during P0.4)
 - [ ] **[P0] The CI "SDK Drift Check" validates the wrong direction.** `ci.yml:1610`
       regenerates the TS SDK _from_ the committed spec and diffs that — it never checks the
       spec against `apps/api/src/rest/routers/`. Green on every run for five months while the


### PR DESCRIPTION
Closes **P0.4** from `docs/api-integration-design.md`.

## Why

`X-Api-Key` is accepted on every non-public route, `/trpc/*` included — tRPC is
internal by intent, not by mechanism. A procedure is only out of a key's reach
if it declares one of two things: a `requireScopes(...)` guard, or an
`internal*Procedure` builder. One declaring neither is callable by any valid key
holding any scope.

#509 added those guards to the ten routers that had none. Nothing stopped an
eleventh appearing — a procedure written the obvious way inherits no guard, and
no test, lint rule, or checklist caught it.

## What

`apps/api/src/trpc/guard-coverage.spec.ts` reads each procedure's middleware
chain off the built `appRouter`, so it sees what the router actually composed
rather than what the source appears to say. Seven assertions:

| Assertion | Catches |
| --- | --- |
| every procedure declares a guard | the new unguarded procedure |
| the seven internal routers declare the internal guard throughout | a silent downgrade to a plain scope guard |
| no procedure declares an empty scope list | `requireScopes()` — `[]` means "missing nothing", so it allows everything |
| scope guards name only scopes in `apiKeyScopeSchema` | a typo'd scope, which would deny silently and permanently |
| every `UNGUARDED_PROCEDURES` entry still exists and is still unguarded | the exception list rotting into a lie |
| every internal-guarded procedure denies a key once enforcement is on | the boundary failing open under `TRPC_INTERNAL_ONLY_ENFORCE=true` |
| introspects a plausible number of procedures | the whole suite passing vacuously if `_def` changes shape under a tRPC upgrade |

Both guards now carry a `TRPC_GUARD` symbol tag applied in `init.ts`. Neither is
identifiable by reference — `requireScopes` mints a fresh closure per call and
both are anonymous inside `t.middleware` — but tRPC keeps the function object
itself in `procedure._def.middlewares`, so a non-enumerable property survives
builder composition. **A new guard middleware must be tagged the same way or the
gate will not see it.**

The exception list has one entry: `health`, which takes no input, touches no
database, and is allowlisted in the auth hook anyway.

## Gaps closed

The gate found three procedures declaring neither guard — 269 `requireScopes`
calls plus 29 internal-builder procedures against 301 total:

| Procedure | Scope added |
| --- | --- |
| `embedTokens.create` | `periods:write` |
| `embedTokens.revoke` | `periods:write` |
| `organizations.invitations.accept` | `organizations:write` |

Both scopes already existed in `apiKeyScopeSchema`, so `sdks/openapi.json` does
not fall further behind. `periods:write` mirrors `embedTokens.listByPeriod`,
which already required `periods:read`.

## Declaration is not denial

`requireScopes` declares and enforces in one step. `internalOnly` only declares
while `TRPC_INTERNAL_ONLY_ENFORCE` is `false` — it audits the call and lets it
through — so those 29 procedures stay reachable by any key until P0.5 flips the
flag. Test names, failure messages, and the file docblock all say "declares"
rather than "is protected", and the last test pins the enforced behaviour across
all 29 so the gap stays visible rather than implied. This PR does not change the
flag and does not gate P0.5.

## E2E

`organization-fixtures.ts` mints a *second* key inline for the `inviteePage`
fixture, with its own scope array rather than `ORG_E2E_SCOPES` — deliberately,
since the invitee is a lower-privilege principal than the org admin. It needs
`organizations:write` too. Verified by reverting just that line: four
accept-side invitation tests fail without it, all 11 pass with it.

Grepping for `*_E2E_SCOPES` does not find that grant. `scopes:` is the search
key that finds all nine across `apps/web/e2e/helpers/`. Noted on the existing P1
E2E-auth backlog item.

## Verification

- API suite: 1810 passed (1794 before, +16 here), `type-check` and `lint` clean
- Web unit: 768 passed
- `organization/invitations.spec.ts`: 11/11 passed against live infra
- Gate proven to bite, not just pass — stripped a `requireScopes` call and
  confirmed the failure names `embedTokens.create` with a remedy; separately
  downgraded a `simsub` procedure from the internal builder to a scope guard and
  confirmed the internal-router pin catches it while the general gate correctly
  stays green

## Plan Overrides

| File | Planned | Actual | Rationale |
| --- | --- | --- | --- |
| `guard-coverage.spec.ts` | Three-list manifest over all 301 procedures per design doc §1.6 M4 | Mechanical gate + one-entry exception list | M4's case for a manifest over a heuristic is about REST-parity name-matching, which this does not attempt; guard presence is a direct runtime fact. Seeding "has REST equivalent" from a spec 36 operations stale would bake in wrong data. Parity classification moves to P1.1–P1.4 |
| `embed-tokens.spec.ts`, `organizations.spec.ts` | Add per-procedure scope assertions to `scope-enforcement.spec.ts` | Added them to the two routers' own specs | Neither mocks `init.js`, so the real `requireScopes` runs and the service mocks already exist there. Routing through `scope-enforcement.spec.ts` would have dragged the whole organizations service graph into it for no added coverage |
