### PR TITLE
chore(e2e): capture the Next dev server log in Playwright CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -694,6 +694,7 @@ jobs:
           path: |
             apps/web/playwright-report/
             apps/web/test-results/
+            apps/web/next-e2e.log
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -779,6 +780,7 @@ jobs:
           path: |
             apps/web/playwright-report/
             apps/web/test-results/
+            apps/web/next-e2e.log
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -864,6 +866,7 @@ jobs:
           path: |
             apps/web/playwright-report/
             apps/web/test-results/
+            apps/web/next-e2e.log
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -949,6 +952,7 @@ jobs:
           path: |
             apps/web/playwright-report/
             apps/web/test-results/
+            apps/web/next-e2e.log
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -1034,6 +1038,7 @@ jobs:
           path: |
             apps/web/playwright-report/
             apps/web/test-results/
+            apps/web/next-e2e.log
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -1119,6 +1124,7 @@ jobs:
           path: |
             apps/web/playwright-report/
             apps/web/test-results/
+            apps/web/next-e2e.log
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -1203,6 +1209,7 @@ jobs:
           path: |
             apps/web/playwright-report/
             apps/web/test-results/
+            apps/web/next-e2e.log
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -1288,6 +1295,7 @@ jobs:
           path: |
             apps/web/playwright-report/
             apps/web/test-results/
+            apps/web/next-e2e.log
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -1449,6 +1457,7 @@ jobs:
           path: |
             apps/web/playwright-report/
             apps/web/test-results/
+            apps/web/next-e2e.log
           retention-days: 30
 
   # ──────────────────────────────────────────────────
@@ -1581,6 +1590,7 @@ jobs:
           path: |
             apps/web/playwright-report/
             apps/web/test-results/
+            apps/web/next-e2e.log
           retention-days: 30
 
   # ──────────────────────────────────────────────────

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -28,6 +28,23 @@ const E2E_API_PORT = 4010;
 const E2E_WEB_PORT = 3010;
 
 /**
+ * Where the Next dev server's own output is kept.
+ *
+ * Playwright's `webServer.stdout` defaults to "ignore" (only `stderr` defaults
+ * to "pipe"), so Next's `Ready` line, its per-route `Compiling`/`Compiled`
+ * output, and any Turbopack diagnostic were being discarded — which is why past
+ * investigations of the intermittent `(dashboard)` 404 had six `[WebServer]`
+ * stderr warnings to work from and nothing else.
+ *
+ * Teeing to a file rather than setting `stdout: "pipe"` keeps the job log
+ * readable and, more importantly, produces an artifact that outlives the run.
+ * Path is relative to `cwd` below, which is the repo root.
+ *
+ * See docs/backlog.md, Track 1 QA/Testing.
+ */
+const NEXT_DEV_LOG = "apps/web/next-e2e.log";
+
+/**
  * When OIDC_E2E=true, load real Zitadel config for OIDC project tests.
  * Otherwise, use fake values for submissions/uploads projects.
  */
@@ -156,7 +173,8 @@ export default defineConfig({
       },
     },
     {
-      command: "pnpm --filter @colophony/web dev",
+      // `2>&1 | tee` rather than `stdout: "pipe"` — see NEXT_DEV_LOG above.
+      command: `pnpm --filter @colophony/web dev 2>&1 | tee ${NEXT_DEV_LOG}`,
       url: `http://localhost:${E2E_WEB_PORT}`,
       // Always start fresh — reusing a server started without the test OIDC
       // env vars causes an auth storage key mismatch (injectAuth writes to a


### PR DESCRIPTION
Unblocks diagnosis of the intermittent `(dashboard)` route-group 404 (Track 1
QA/Testing in `docs/backlog.md`, three occurrences 2026-07-25/26/27).

## Why we have had no evidence

Playwright's `webServer.stdout` defaults to `"ignore"`; only `stderr` defaults to
`"pipe"`. So Next's `Ready` line, its per-route `Compiling`/`Compiled` output,
and any Turbopack diagnostic have been discarded on every run. The six
`[WebServer]` lines captured on 2026-07-25 were stderr warnings — everything that
would have identified the fault was on stdout.

## What changed

Tee the web server's combined output to `apps/web/next-e2e.log`, and add it to
the artifact upload in all ten Playwright jobs. Teeing rather than
`stdout: "pipe"` keeps the job log readable and produces an artifact that
outlives the run. `*.log` is already gitignored.

## Why this makes the next occurrence diagnosable

The log carries Next's per-request timing, verified locally:

```
GET /submissions/<id>/edit 200 in 983ms (next.js: 925ms, application-code: 58ms)
GET /submissions/<id>/edit 200 in  60ms (next.js:  24ms, application-code: 35ms)
```

The first request to a route compiles it; later ones do not. That distinguishes
four causes on a recurrence:

| Log shows | Cause |
| --- | --- |
| 404 with no compile activity | route discovery / manifest |
| compile diagnostic | entry compile failure |
| log absent or truncated mid-compile | worker or process death |
| successful compile, then 404 | router and manifest disagreeing |

## Why this is the right first step

The 2026-07-27 occurrence localised the fault precisely. Tests run sequentially
in one server process, and the failures were exactly the three that navigate to
`/submissions/[id]/edit` — the first of which is that route's **first request in
the process's lifetime**. Its already-compiled sibling `/submissions/[id]` passed
before and after, in the same process.

That also corrects the backlog's claim that un-compiled-route timing was ruled
out because the 404 arrived eleven minutes after server start. `next dev --turbo`
compiles on first request to a route, not on a timer, so time-since-boot was
never the relevant measure.

Ruled out separately, so the log is aimed at what remains: no shared component
trait across the three failing routes (async server component, `"use client"`,
and plain server component respectively), no `.next` cache in CI (pnpm store
only), no `notFound()` anywhere in `apps/web/src/app/`, and `reuseExistingServer`
is false for web in CI regardless. The 404 response carries `X-Powered-By:
Next.js` with RSC `Vary` headers and no error indicator — the router matching
nothing, not a 500.

## Deliberately not included

**No route pre-warming probe.** Requesting the target routes before a suite would
compile them ahead of the tests and mask the very failure being diagnosed. If the
log later points at resource pressure, `free -h`/`df -h` around the Playwright
step is a cheap follow-up.

**Not switching E2E to `next build` + `next start`.** That would remove lazy
compilation and very likely the flake with it, and would make E2E exercise what
actually deploys — but it costs a web build per E2E job across nine suites, and
it would destroy the evidence trail before the cause is known. Worth doing after
the log identifies the fault, not instead of it.

## Verification

- `submission-detail.spec.ts` 8/8 pass locally with the change; the log is
  written and contains the `Ready` line, Turbopack banner, and per-request timings
- Teardown still clean — nothing listening on 3010/4010 and no Next process
  survives the run, confirming the added pipe does not break process management
- `type-check` and `lint` clean; workflow YAML parses and all ten upload steps
  include the new path
