### PR TITLE
fix(e2e): authenticate Playwright as an interactive session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,8 +530,12 @@ jobs:
           node-version-file: .nvmrc
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
+      # auth-client is needed because the scope-enforcement suite builds the real
+      # auth hook, which imports createJwksVerifier. Vitest resolves workspace
+      # packages through `exports` -> dist/, so an unbuilt dep fails to resolve
+      # rather than failing a test.
       - name: Build workspace dependencies
-        run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/types --filter=@colophony/api-contracts --filter=@colophony/plugin-sdk
+        run: pnpm turbo run build --filter=@colophony/db --filter=@colophony/auth-client --filter=@colophony/types --filter=@colophony/api-contracts --filter=@colophony/plugin-sdk
       - name: Run security tests
         run: pnpm --filter @colophony/api test:security
         env:

--- a/apps/api/src/__tests__/security/helpers/auth-app.ts
+++ b/apps/api/src/__tests__/security/helpers/auth-app.ts
@@ -1,0 +1,123 @@
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
+import { createHash, randomBytes } from 'node:crypto';
+import type { Env } from '../../../config/env.js';
+import authPlugin from '../../../hooks/auth.js';
+import orgContextPlugin from '../../../hooks/org-context.js';
+import dbContextPlugin from '../../../hooks/db-context.js';
+import auditPlugin from '../../../hooks/audit.js';
+import { appRouter } from '../../../trpc/router.js';
+import { createContext } from '../../../trpc/context.js';
+import { createTestEnv } from '../../webhooks/helpers/webhook-app.js';
+import { getAdminPool } from '../../rls/helpers/db-setup.js';
+
+/**
+ * Build a Fastify instance with the real auth chain and the real tRPC router.
+ *
+ * Mirrors main.ts's hook order (auth -> orgContext -> dbContext -> audit) but
+ * omits rate limiting, queues, and the REST/SSE surfaces so the suite needs no
+ * Redis. The point is to exercise `requireScopes` and `internalOnly` against a
+ * genuine `api_keys` row and the real `verify_api_key()` lookup, rather than a
+ * hand-built AuthContext.
+ *
+ * Prefer the two named builders below — the auth mode is not a free parameter.
+ */
+async function buildAuthApp(envOverrides?: Partial<Env>) {
+  const env: Env = createTestEnv(envOverrides);
+
+  const app = Fastify({ logger: false, maxParamLength: 500 });
+
+  await app.register(authPlugin, { env });
+  await app.register(orgContextPlugin);
+  await app.register(dbContextPlugin);
+  await app.register(auditPlugin);
+
+  await app.register(fastifyTRPCPlugin, {
+    prefix: '/trpc',
+    trpcOptions: { router: appRouter, createContext },
+  });
+
+  await app.ready();
+  return app;
+}
+
+/**
+ * An app that can authenticate API keys.
+ *
+ * Must NOT be NODE_ENV=test. When `isTest && !verifyToken`, hooks/auth.ts takes
+ * the test-header branch and returns early — either honouring `x-test-user-id`
+ * or 401ing — so the `X-Api-Key` branch below it is unreachable. The two auth
+ * modes are mutually exclusive by construction, which is also why the E2E
+ * suites stopped being able to use keys once the gate was opened.
+ */
+export function buildApiKeyApp(
+  envOverrides?: Partial<Env>,
+): Promise<FastifyInstance> {
+  return buildAuthApp({
+    NODE_ENV: 'development',
+    ZITADEL_AUTHORITY: undefined,
+    DEV_AUTH_BYPASS: false,
+    ...envOverrides,
+  });
+}
+
+/**
+ * An app that accepts the interactive test headers — the mode Playwright runs
+ * against. Requires NODE_ENV=test and no JWKS verifier.
+ */
+export function buildInteractiveApp(
+  envOverrides?: Partial<Env>,
+): Promise<FastifyInstance> {
+  return buildAuthApp({
+    NODE_ENV: 'test',
+    ZITADEL_AUTHORITY: undefined,
+    ...envOverrides,
+  });
+}
+
+/**
+ * Insert a real API key row and return the plaintext key.
+ *
+ * Written through the admin pool because `api_keys` is RLS-protected and the
+ * caller has no org context yet. The hash must match api-key.service's
+ * `hashKey` (plain sha256 hex) or `verify_api_key()` will not find the row.
+ */
+export async function insertApiKey(params: {
+  orgId: string;
+  userId: string;
+  scopes: string[];
+  name?: string;
+}): Promise<{ id: string; plainKey: string }> {
+  const plainKey = `col_test_${randomBytes(32).toString('hex')}`;
+  const keyHash = createHash('sha256').update(plainKey).digest('hex');
+
+  const result = await getAdminPool().query<{ id: string }>(
+    `INSERT INTO api_keys
+       (organization_id, created_by, name, key_hash, key_prefix, scopes)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id`,
+    [
+      params.orgId,
+      params.userId,
+      params.name ?? `scope-enforcement-${Date.now()}`,
+      keyHash,
+      plainKey.slice(0, 12),
+      JSON.stringify(params.scopes),
+    ],
+  );
+
+  return { id: result.rows[0].id, plainKey };
+}
+
+/** Read audit actions written for an org, most recent first. */
+export async function recentAuditActions(orgId: string): Promise<string[]> {
+  const result = await getAdminPool().query<{ action: string }>(
+    `SELECT action FROM audit_events
+      WHERE organization_id = $1 OR organization_id IS NULL
+      ORDER BY created_at DESC
+      LIMIT 20`,
+    [orgId],
+  );
+  return result.rows.map((r) => r.action);
+}

--- a/apps/api/src/__tests__/security/scope-enforcement.test.ts
+++ b/apps/api/src/__tests__/security/scope-enforcement.test.ts
@@ -1,0 +1,228 @@
+/**
+ * End-to-end scope and internal-boundary enforcement for API keys.
+ *
+ * These drive a real `api_keys` row through the real auth hook and the real
+ * tRPC router, so they cover what the unit tests cannot: that
+ * `verify_api_key()` resolves the key, that `requireScopes` actually denies an
+ * under-scoped one, and that `internalOnly` rejects a key while admitting an
+ * interactive session.
+ *
+ * This suite exists because the Playwright suites used to provide that
+ * coverage incidentally — they authenticated as API keys. They now use the
+ * interactive test path, for which `requireScopes` is a no-op, so the
+ * enforcement evidence has to live here.
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { globalSetup } from '../rls/helpers/db-setup.js';
+import { truncateAllTables } from '../rls/helpers/cleanup.js';
+import {
+  createOrganization,
+  createUser,
+  createOrgMember,
+} from '../rls/helpers/factories.js';
+import {
+  buildApiKeyApp,
+  buildInteractiveApp,
+  insertApiKey,
+  recentAuditActions,
+} from './helpers/auth-app.js';
+
+/** A scope-guarded orgProcedure: requireScopes('notifications:read'). */
+const SCOPED_ROUTE = '/trpc/notifications.unreadCount';
+/** An internalAuthedProcedure — no role requirement, so only the guard differs. */
+const INTERNAL_ROUTE = '/trpc/migrations.list';
+const INTERNAL_INPUT = encodeURIComponent(JSON.stringify({}));
+
+let app: FastifyInstance;
+
+async function seedOrgWithAdmin() {
+  const org = await createOrganization();
+  const user = await createUser();
+  // createOrgMember defaults roles to ['ADMIN'].
+  await createOrgMember(org.id, user.id);
+  return { org, user };
+}
+
+/**
+ * `internalOnly` reads the flag via `validateEnv()` — i.e. straight from
+ * process.env at request time, not from the Env handed to buildApp. Setting it
+ * on the app would silently do nothing, so drive process.env instead.
+ */
+function setInternalOnlyEnforce(value: boolean): void {
+  process.env.TRPC_INTERNAL_ONLY_ENFORCE = value ? 'true' : 'false';
+}
+
+const originalEnforce = process.env.TRPC_INTERNAL_ONLY_ENFORCE;
+
+beforeAll(async () => {
+  await globalSetup();
+});
+
+afterEach(async () => {
+  await app?.close();
+  await truncateAllTables();
+  if (originalEnforce === undefined) {
+    delete process.env.TRPC_INTERNAL_ONLY_ENFORCE;
+  } else {
+    process.env.TRPC_INTERNAL_ONLY_ENFORCE = originalEnforce;
+  }
+});
+
+afterAll(async () => {
+  await app?.close();
+});
+
+describe('requireScopes — real API key through the tRPC router', () => {
+  it('denies an under-scoped key with 403 insufficient_scope', async () => {
+    app = await buildApiKeyApp();
+    const { org, user } = await seedOrgWithAdmin();
+    const key = await insertApiKey({
+      orgId: org.id,
+      userId: user.id,
+      // Deliberately omits notifications:read.
+      scopes: ['submissions:read'],
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: SCOPED_ROUTE,
+      headers: {
+        'x-api-key': key.plainKey,
+        'x-organization-id': org.id,
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toContain('notifications:read');
+  });
+
+  it('allows a correctly scoped key', async () => {
+    app = await buildApiKeyApp();
+    const { org, user } = await seedOrgWithAdmin();
+    const key = await insertApiKey({
+      orgId: org.id,
+      userId: user.id,
+      scopes: ['notifications:read'],
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: SCOPED_ROUTE,
+      headers: {
+        'x-api-key': key.plainKey,
+        'x-organization-id': org.id,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).result.data.count).toBe(0);
+  });
+
+  it('writes an API_KEY_SCOPE_DENIED audit row on denial', async () => {
+    app = await buildApiKeyApp();
+    const { org, user } = await seedOrgWithAdmin();
+    const key = await insertApiKey({
+      orgId: org.id,
+      userId: user.id,
+      scopes: ['submissions:read'],
+    });
+
+    await app.inject({
+      method: 'GET',
+      url: SCOPED_ROUTE,
+      headers: {
+        'x-api-key': key.plainKey,
+        'x-organization-id': org.id,
+      },
+    });
+
+    // The row survives only because the tRPC adapter turns a TRPCError into a
+    // normal reply, so db-context COMMITs rather than ROLLBACKs.
+    expect(await recentAuditActions(org.id)).toContain('API_KEY_SCOPE_DENIED');
+  });
+
+  it('is a no-op for interactive auth — the same route needs no scopes', async () => {
+    app = await buildInteractiveApp();
+    const { org, user } = await seedOrgWithAdmin();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: SCOPED_ROUTE,
+      headers: {
+        'x-test-user-id': user.id,
+        'x-organization-id': org.id,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+describe('internalOnly — the boundary P0.5 will enforce', () => {
+  it('admits an API key while TRPC_INTERNAL_ONLY_ENFORCE is false', async () => {
+    setInternalOnlyEnforce(false);
+    app = await buildApiKeyApp();
+    const { org, user } = await seedOrgWithAdmin();
+    const key = await insertApiKey({
+      orgId: org.id,
+      userId: user.id,
+      scopes: ['submissions:read'],
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `${INTERNAL_ROUTE}?input=${INTERNAL_INPUT}`,
+      headers: {
+        'x-api-key': key.plainKey,
+        'x-organization-id': org.id,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    // Log-only mode still records the crossing.
+    expect(await recentAuditActions(org.id)).toContain(
+      'API_KEY_INTERNAL_ROUTE',
+    );
+  });
+
+  it('rejects an API key with 403 once enforcement is on', async () => {
+    setInternalOnlyEnforce(true);
+    app = await buildApiKeyApp();
+    const { org, user } = await seedOrgWithAdmin();
+    const key = await insertApiKey({
+      orgId: org.id,
+      userId: user.id,
+      scopes: ['submissions:read'],
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `${INTERNAL_ROUTE}?input=${INTERNAL_INPUT}`,
+      headers: {
+        'x-api-key': key.plainKey,
+        'x-organization-id': org.id,
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toContain('not available to API keys');
+  });
+
+  it('admits an interactive session under enforcement — this is what unblocks the E2E suites', async () => {
+    setInternalOnlyEnforce(true);
+    app = await buildInteractiveApp();
+    const { org, user } = await seedOrgWithAdmin();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `${INTERNAL_ROUTE}?input=${INTERNAL_INPUT}`,
+      headers: {
+        'x-test-user-id': user.id,
+        'x-organization-id': org.id,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/apps/api/src/__tests__/webhooks/tusd-webhook.test.ts
+++ b/apps/api/src/__tests__/webhooks/tusd-webhook.test.ts
@@ -36,9 +36,15 @@ vi.mock('../../queues/file-scan.queue.js', () => ({
   enqueueFileScan: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Hoisted so the mock fn is a plain vi.fn() rather than an unbound method
+// reference — the same pattern as mockMoveBetweenBuckets below.
+const { mockVerifyKey } = vi.hoisted(() => ({
+  mockVerifyKey: vi.fn(),
+}));
+
 vi.mock('../../services/api-key.service.js', () => ({
   apiKeyService: {
-    verifyKey: vi.fn().mockResolvedValue(null),
+    verifyKey: mockVerifyKey,
     touchLastUsed: vi.fn(),
   },
 }));
@@ -67,6 +73,34 @@ vi.mock('../../adapters/registry-accessor.js', () => ({
 
 import { enqueueFileScan } from '../../queues/file-scan.queue.js';
 const mockEnqueueFileScan = vi.mocked(enqueueFileScan);
+
+// Default: no key resolves. Individual tests queue a result with
+// mockResolvedValueOnce. clearAllMocks() keeps implementations, so this
+// survives beforeEach.
+mockVerifyKey.mockResolvedValue(null);
+
+/** Shape returned by apiKeyService.verifyKey for a healthy key. */
+function validKeyResult(userId: string, scopes: string[]) {
+  return {
+    apiKey: {
+      id: 'a0000000-0000-4000-8000-000000000001',
+      organizationId: 'b0000000-0000-4000-8000-000000000001',
+      createdBy: userId,
+      name: 'tusd-test-key',
+      scopes,
+      expiresAt: null,
+      revokedAt: null,
+      lastUsedAt: null,
+      createdAt: new Date(),
+    },
+    creator: {
+      id: userId,
+      email: 'key-creator@example.com',
+      emailVerified: true,
+      deletedAt: null,
+    },
+  };
+}
 
 function adminDb() {
   return drizzle(getAdminPool());
@@ -199,6 +233,57 @@ describe('tusd webhook integration', () => {
       const body = res.json();
       expect(body.RejectUpload).toBe(true);
       expect(body.HTTPResponse.StatusCode).toBe(401);
+    });
+
+    // The uploads Playwright suite used to be the only thing exercising this
+    // branch end to end; it now authenticates via X-Test-User-Id, so the
+    // API-key path needs coverage here. Note the branch sits ABOVE the
+    // NODE_ENV==='test' one in tusd.webhook.ts, so it stays reachable even
+    // though this app runs with NODE_ENV=test.
+    it('forwarded X-Api-Key with files:write → resolves the creator and allows', async () => {
+      const { org, user, version } = await createManuscriptScenario();
+      mockVerifyKey.mockResolvedValueOnce(
+        validKeyResult(user.id, ['files:write', 'files:read']),
+      );
+
+      const payload = createPreCreatePayload({
+        manuscriptVersionId: version.id,
+        orgId: org.id,
+      });
+      payload.Event.HTTPRequest.Header = {
+        'X-Api-Key': ['col_live_whatever'],
+        'X-Organization-Id':
+          payload.Event.HTTPRequest.Header['X-Organization-Id'],
+      } as unknown as typeof payload.Event.HTTPRequest.Header;
+
+      const res = await postTusd(payload);
+      expect(res.statusCode).toBe(200);
+      // Allowed: the creator resolved to the manuscript-version owner.
+      expect(res.json()).toEqual({});
+      expect(mockVerifyKey).toHaveBeenCalledWith('col_live_whatever');
+    });
+
+    it('forwarded X-Api-Key without files:write → RejectUpload 403', async () => {
+      const { org, version } = await createManuscriptScenario();
+      mockVerifyKey.mockResolvedValueOnce(
+        validKeyResult('c0000000-0000-4000-8000-000000000001', ['files:read']),
+      );
+
+      const payload = createPreCreatePayload({
+        manuscriptVersionId: version.id,
+        orgId: org.id,
+      });
+      payload.Event.HTTPRequest.Header = {
+        'X-Api-Key': ['col_live_underscoped'],
+        'X-Organization-Id':
+          payload.Event.HTTPRequest.Header['X-Organization-Id'],
+      } as unknown as typeof payload.Event.HTTPRequest.Header;
+
+      const res = await postTusd(payload);
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.RejectUpload).toBe(true);
+      expect(body.HTTPResponse.StatusCode).toBe(403);
     });
 
     it('missing manuscript-version-id → RejectUpload 400', async () => {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -172,6 +172,12 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
       'X-Request-Id',
       'X-Api-Key',
       'X-Demo-User-Id',
+      // Interactive test auth (hooks/auth.ts). Only honoured when
+      // NODE_ENV=test and no JWKS verifier is configured; listing them here
+      // is what lets the cross-origin E2E browser send them at all.
+      'X-Test-User-Id',
+      'X-Test-Email',
+      'X-Test-Zitadel-Id',
     ],
     exposedHeaders: [
       'X-RateLimit-Limit',

--- a/apps/web/e2e/analytics/fixtures.ts
+++ b/apps/web/e2e/analytics/fixtures.ts
@@ -8,29 +8,9 @@
  * all Playwright suites via detect-changes.sh shared prefix matching.
  */
 
-import { test as base, expect, type Page, devices } from "@playwright/test";
-import { buildStorageState, setupPageAuth } from "../helpers/auth";
-import {
-  getOrgBySlug,
-  getUserByEmail,
-  createApiKey,
-  deleteApiKey,
-} from "../helpers/db";
-
-/** Editor user profile (EDITOR role in quarterly-review org) */
-const EDITOR_USER_PROFILE = {
-  sub: "seed-zitadel-editor-001",
-  email: "reader@quarterlyreview.org",
-  name: "Test Editor",
-};
-
-/** All scopes needed for Analytics E2E tests */
-const ANALYTICS_SCOPES = [
-  "submissions:read",
-  "organizations:read",
-  "periods:read",
-  "users:read",
-];
+import { test as base, expect, type Page } from "@playwright/test";
+import { createAuthedContext, EDITOR_USER_PROFILE } from "../helpers/auth";
+import { getOrgBySlug, getUserByEmail } from "../helpers/db";
 
 interface SeedOrg {
   id: string;
@@ -43,15 +23,9 @@ interface SeedUser {
   email: string;
 }
 
-interface TestApiKey {
-  id: string;
-  plainKey: string;
-}
-
 export const test = base.extend<{
   seedOrg: SeedOrg;
   seedEditor: SeedUser;
-  testApiKey: TestApiKey;
   authedPage: Page;
 }>({
   seedOrg: async ({}, use) => {
@@ -74,32 +48,12 @@ export const test = base.extend<{
     await use(user);
   },
 
-  testApiKey: async ({ seedOrg, seedEditor }, use) => {
-    const key = await createApiKey({
-      orgId: seedOrg.id,
-      userId: seedEditor.id,
-      scopes: ANALYTICS_SCOPES,
-      name: `e2e-analytics-${Date.now()}`,
-    });
-
-    await use(key);
-
-    await deleteApiKey(key.id);
-  },
-
-  authedPage: async ({ browser, seedOrg, testApiKey, baseURL }, use) => {
-    const context = await browser.newContext({
-      ...devices["Desktop Chrome"],
-      baseURL: baseURL ?? undefined,
-      storageState: buildStorageState(seedOrg.id, EDITOR_USER_PROFILE),
-    });
-
-    const page = await context.newPage();
-
-    await setupPageAuth(
-      page,
+  authedPage: async ({ browser, seedOrg, seedEditor, baseURL }, use) => {
+    const { context, page } = await createAuthedContext(
+      browser,
+      baseURL ?? undefined,
       seedOrg.id,
-      testApiKey.plainKey,
+      seedEditor.id,
       EDITOR_USER_PROFILE,
     );
 

--- a/apps/web/e2e/federation/federation-admin.spec.ts
+++ b/apps/web/e2e/federation/federation-admin.spec.ts
@@ -63,8 +63,10 @@ test.describe("Federation Overview", () => {
     // Capabilities list
     await expect(page.getByText("Capabilities")).toBeVisible();
 
-    // Public key area
-    await expect(page.getByText("Public Key")).toBeVisible();
+    // Public key area. `exact` matters: getByText does case-insensitive
+    // substring matching, so a bare "Public Key" also matches the rendered PEM
+    // body ("-----BEGIN PUBLIC KEY-----") and trips strict mode.
+    await expect(page.getByText("Public Key", { exact: true })).toBeVisible();
   });
 });
 

--- a/apps/web/e2e/federation/fixtures.ts
+++ b/apps/web/e2e/federation/fixtures.ts
@@ -2,19 +2,22 @@
  * Federation-specific Playwright test fixtures.
  *
  * Uses the ADMIN user (editor@quarterlyreview.org) — federation endpoints
- * require adminProcedure. Audit router requires audit:read scope.
+ * require adminProcedure.
+ *
+ * Most of this suite drives `internalOnly` routers (federation, simsub,
+ * transfer, migration, hub). Those admit only interactive auth methods, so the
+ * suite passes under TRPC_INTERNAL_ONLY_ENFORCE=true precisely because it
+ * authenticates as `authMethod: 'test'` rather than as an API key.
  *
  * Co-located in e2e/federation/ (not e2e/helpers/) to avoid triggering
  * all Playwright suites via detect-changes.sh shared prefix matching.
  */
 
-import { test as base, expect, type Page, devices } from "@playwright/test";
-import { buildStorageState, setupPageAuth } from "../helpers/auth";
+import { test as base, expect, type Page } from "@playwright/test";
+import { createAuthedContext, ADMIN_USER_PROFILE } from "../helpers/auth";
 import {
   getOrgBySlug,
   getUserByEmail,
-  createApiKey,
-  deleteApiKey,
   createSubmission,
   deleteSubmission,
   createManuscript,
@@ -34,21 +37,6 @@ import {
   deleteIdentityMigration,
 } from "./federation-db";
 
-/** Admin user profile (ADMIN role in quarterly-review org) */
-const ADMIN_USER_PROFILE = {
-  sub: "seed-zitadel-admin-001",
-  email: "editor@quarterlyreview.org",
-  name: "Test Admin",
-};
-
-/** All scopes needed for Federation E2E tests */
-const FEDERATION_SCOPES = [
-  "audit:read",
-  "submissions:read",
-  "organizations:read",
-  "users:read",
-];
-
 interface SeedOrg {
   id: string;
   name: string;
@@ -58,11 +46,6 @@ interface SeedOrg {
 interface SeedUser {
   id: string;
   email: string;
-}
-
-interface TestApiKey {
-  id: string;
-  plainKey: string;
 }
 
 interface FederationData {
@@ -85,7 +68,6 @@ interface FederationData {
 export const test = base.extend<{
   seedOrg: SeedOrg;
   seedAdmin: SeedUser;
-  testApiKey: TestApiKey;
   authedPage: Page;
   federationData: FederationData;
 }>({
@@ -109,32 +91,12 @@ export const test = base.extend<{
     await use(user);
   },
 
-  testApiKey: async ({ seedOrg, seedAdmin }, use) => {
-    const key = await createApiKey({
-      orgId: seedOrg.id,
-      userId: seedAdmin.id,
-      scopes: FEDERATION_SCOPES,
-      name: `e2e-federation-${Date.now()}`,
-    });
-
-    await use(key);
-
-    await deleteApiKey(key.id);
-  },
-
-  authedPage: async ({ browser, seedOrg, testApiKey, baseURL }, use) => {
-    const context = await browser.newContext({
-      ...devices["Desktop Chrome"],
-      baseURL: baseURL ?? undefined,
-      storageState: buildStorageState(seedOrg.id, ADMIN_USER_PROFILE),
-    });
-
-    const page = await context.newPage();
-
-    await setupPageAuth(
-      page,
+  authedPage: async ({ browser, seedOrg, seedAdmin, baseURL }, use) => {
+    const { context, page } = await createAuthedContext(
+      browser,
+      baseURL ?? undefined,
       seedOrg.id,
-      testApiKey.plainKey,
+      seedAdmin.id,
       ADMIN_USER_PROFILE,
     );
 

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -45,6 +45,8 @@ function getRequestedProjects(): Set<string> {
     projects.add("workspace");
     projects.add("forms");
     projects.add("organization");
+    projects.add("analytics");
+    projects.add("federation");
   }
 
   return projects;

--- a/apps/web/e2e/helpers/auth.ts
+++ b/apps/web/e2e/helpers/auth.ts
@@ -1,28 +1,60 @@
 /**
  * Auth injection helper for Playwright E2E tests.
  *
- * Provides two layers of auth state injection:
+ * Provides three layers of auth state injection:
  * 1. BrowserContext storageState — pre-populates localStorage BEFORE any page
  *    loads (zero race condition with page JS)
  * 2. addInitScript — re-sets localStorage on every subsequent navigation as a
  *    safety net (handles client-side navigations that could clear storage)
- * 3. Route interception — swaps the fake OIDC Bearer token for a real API key
- *    on all tRPC requests
+ * 3. Route interception — swaps the fake OIDC Bearer token for the interactive
+ *    test-auth header on all API requests
  *
- * This uses the real API key auth path — no API code changes needed.
+ * Auth class: this drives the API's **interactive** test path
+ * (`x-test-user-id`, apps/api/src/hooks/auth.ts), which yields
+ * `authMethod: 'test'`. That is the same class the real web app uses, so E2E
+ * exercises the guards real users hit: role checks apply, `requireScopes` is a
+ * no-op, and `internalOnly` routers admit the request.
+ *
+ * The path is gated on NODE_ENV=test AND no JWKS verifier; playwright.config.ts
+ * sets both on the API webServer. Roles still come from `organization_members`,
+ * so a suite expresses privilege via its seed user's membership, not scopes.
  */
 
-import type { Page } from "@playwright/test";
+import type { Browser, Page } from "@playwright/test";
+import { devices } from "@playwright/test";
 
 export const OIDC_AUTHORITY = "http://test-idp:8080";
 export const OIDC_CLIENT_ID = "test-client";
 export const OIDC_STORAGE_KEY = `oidc.user:${OIDC_AUTHORITY}:${OIDC_CLIENT_ID}`;
 
-interface UserProfile {
+export interface UserProfile {
   sub: string;
   email: string;
   name: string;
 }
+
+/**
+ * The three seed identities from packages/db/src/seed.ts, hoisted here so the
+ * suites share one definition. Roles come from `organization_members`:
+ * admin=ADMIN, editor=EDITOR, writer=READER (in quarterly-review).
+ */
+export const ADMIN_USER_PROFILE: UserProfile = {
+  sub: "seed-zitadel-admin-001",
+  email: "editor@quarterlyreview.org",
+  name: "Test Admin",
+};
+
+export const EDITOR_USER_PROFILE: UserProfile = {
+  sub: "seed-zitadel-editor-001",
+  email: "reader@quarterlyreview.org",
+  name: "Test Editor",
+};
+
+export const WRITER_USER_PROFILE: UserProfile = {
+  sub: "seed-zitadel-writer-001",
+  email: "writer@example.com",
+  name: "Test Writer",
+};
 
 /**
  * Build the OIDC user object for localStorage injection.
@@ -70,12 +102,16 @@ export function buildStorageState(orgId: string, userProfile: UserProfile) {
  *
  * Must be called after the page is created but before navigating to any URL.
  * - addInitScript re-sets localStorage on every page load (safety net)
- * - page.route intercepts tRPC calls to swap Bearer for API key
+ * - page.route intercepts API calls to swap Bearer for the test-auth header
+ *
+ * `userId` is the local users.id UUID, not the Zitadel sub. The auth hook does
+ * no lookup and no validation on it — a wrong value surfaces later as
+ * `403 not_a_member` from org-context, or as silently empty RLS results.
  */
 export async function setupPageAuth(
   page: Page,
   orgId: string,
-  apiKey: string,
+  userId: string,
   userProfile: UserProfile,
 ): Promise<void> {
   const oidcUserJson = JSON.stringify(buildOidcUser(userProfile));
@@ -97,8 +133,8 @@ export async function setupPageAuth(
     { storageKey: OIDC_STORAGE_KEY, orgId, json: oidcUserJson },
   );
 
-  // Intercept ALL API requests (tRPC + SSE + REST): remove fake Bearer
-  // token and add real API key. Must cover all API endpoints, not just
+  // Intercept ALL API requests (tRPC + SSE + REST): remove the fake Bearer
+  // token and add the test-auth header. Must cover all API endpoints, not just
   // /trpc/**, because non-tRPC requests (e.g. /api/notifications/stream)
   // carry the fake OIDC Bearer token which triggers AUTH_TOKEN_INVALID — after
   // 10 failures the per-IP auth throttle blocks ALL requests from localhost.
@@ -111,13 +147,44 @@ export async function setupPageAuth(
       const request = route.request();
       const headers = { ...request.headers() };
 
-      // Remove the fake OIDC Bearer token
+      // Remove the fake OIDC Bearer token. Still required: the auth hook checks
+      // Bearer before the test headers, so leaving it would 401 and poison the
+      // per-IP throttle.
       delete headers["authorization"];
 
-      // Add the real API key
-      headers["x-api-key"] = apiKey;
+      headers["x-test-user-id"] = userId;
+      headers["x-test-email"] = userProfile.email;
+      headers["x-test-zitadel-id"] = userProfile.sub;
 
       await route.continue({ headers });
     },
   );
+}
+
+/**
+ * Create a browser context + page authenticated as `userId` in `orgId`.
+ *
+ * Collapses the ~20-line body that was duplicated verbatim across every
+ * `authedPage` fixture. Callers own teardown: `await context.close()`.
+ */
+export async function createAuthedContext(
+  browser: Browser,
+  baseURL: string | undefined,
+  orgId: string,
+  userId: string,
+  userProfile: UserProfile,
+): Promise<{
+  context: Awaited<ReturnType<Browser["newContext"]>>;
+  page: Page;
+}> {
+  const context = await browser.newContext({
+    ...devices["Desktop Chrome"],
+    baseURL,
+    storageState: buildStorageState(orgId, userProfile),
+  });
+
+  const page = await context.newPage();
+  await setupPageAuth(page, orgId, userId, userProfile);
+
+  return { context, page };
 }

--- a/apps/web/e2e/helpers/db.ts
+++ b/apps/web/e2e/helpers/db.ts
@@ -5,7 +5,6 @@
  * to bypass RLS for creating test orgs, memberships, and other fixtures.
  */
 
-import { randomBytes, createHash } from "crypto";
 import { Pool } from "pg";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { eq, and, lte, gte } from "drizzle-orm";
@@ -13,7 +12,6 @@ import {
   organizations,
   users,
   organizationMembers,
-  apiKeys,
   submissions,
   submissionPeriods,
   manuscripts,
@@ -170,52 +168,6 @@ export async function createUser(data: {
       email: users.email,
     });
   return row;
-}
-
-/**
- * Create an API key for testing.
- * Returns the plain key for use in test auth headers.
- */
-export async function createApiKey(data: {
-  orgId: string;
-  userId: string;
-  scopes: string[];
-  name?: string;
-}): Promise<{ id: string; plainKey: string }> {
-  const db = getDb();
-  const rawKey = randomBytes(32).toString("hex");
-  const plainKey = `col_test_${rawKey}`;
-  const keyHash = createHash("sha256").update(plainKey).digest("hex");
-  const keyPrefix = plainKey.slice(0, 12);
-
-  const [row] = await db
-    .insert(apiKeys)
-    .values({
-      organizationId: data.orgId,
-      createdBy: data.userId,
-      name: data.name ?? `e2e-test-key-${Date.now()}`,
-      keyHash,
-      keyPrefix,
-      scopes: data.scopes,
-    })
-    .returning({
-      id: apiKeys.id,
-    });
-
-  return { id: row.id, plainKey };
-}
-
-/**
- * Delete an API key by ID.
- */
-export async function deleteApiKey(keyId: string): Promise<void> {
-  const db = getDb();
-  await db
-    .delete(apiKeys)
-    .where(eq(apiKeys.id, keyId))
-    .catch(() => {
-      // Ignore if already deleted
-    });
 }
 
 /**

--- a/apps/web/e2e/helpers/fixtures.ts
+++ b/apps/web/e2e/helpers/fixtures.ts
@@ -1,30 +1,18 @@
 /**
  * Custom Playwright test fixtures for E2E tests.
  *
- * Provides authenticated page context with seed data lookups and
- * API key management. Each test gets a fresh API key that is
- * cleaned up after the test.
+ * Provides an authenticated page context with seed data lookups.
  *
  * Auth strategy: create a BrowserContext with pre-populated localStorage
  * (storageState) so OIDC user + currentOrgId are available before any page
  * JS executes. This eliminates the race condition between addInitScript and
- * page JavaScript reading localStorage.
+ * page JavaScript reading localStorage. Requests are then authenticated to the
+ * API via the interactive test path (`x-test-user-id`) — see ./auth.
  */
 
-import { test as base, expect, type Page, devices } from "@playwright/test";
-import { buildStorageState, setupPageAuth } from "./auth";
-import { getOrgBySlug, getUserByEmail, createApiKey, deleteApiKey } from "./db";
-
-/** All scopes needed for submission flow E2E tests */
-const E2E_SCOPES = [
-  "notifications:read",
-  "submissions:read",
-  "submissions:write",
-  "files:read",
-  "files:write",
-  "users:read",
-  "organizations:read",
-];
+import { test as base, expect, type Page } from "@playwright/test";
+import { createAuthedContext, WRITER_USER_PROFILE } from "./auth";
+import { getOrgBySlug, getUserByEmail } from "./db";
 
 interface SeedOrg {
   id: string;
@@ -37,30 +25,17 @@ interface SeedUser {
   email: string;
 }
 
-interface TestApiKey {
-  id: string;
-  plainKey: string;
-}
-
-const TEST_USER_PROFILE = {
-  sub: "seed-zitadel-writer-001",
-  email: "writer@example.com",
-  name: "Test Writer",
-};
-
 /**
  * Extended Playwright test with auth fixtures.
  *
  * Fixtures:
  * - `seedOrg` — the "quarterly-review" seed org
- * - `seedUser` — the "writer@example.com" seed user
- * - `testApiKey` — a fresh API key for the seed user (cleaned up after test)
- * - `authedPage` — a Page with auth injected (OIDC + API key interception)
+ * - `seedUser` — the "writer@example.com" seed user (READER in that org)
+ * - `authedPage` — a Page authenticated as that user
  */
 export const test = base.extend<{
   seedOrg: SeedOrg;
   seedUser: SeedUser;
-  testApiKey: TestApiKey;
   authedPage: Page;
 }>({
   seedOrg: async ({}, use) => {
@@ -83,38 +58,13 @@ export const test = base.extend<{
     await use(user);
   },
 
-  testApiKey: async ({ seedOrg, seedUser }, use) => {
-    const key = await createApiKey({
-      orgId: seedOrg.id,
-      userId: seedUser.id,
-      scopes: E2E_SCOPES,
-      name: `e2e-test-${Date.now()}`,
-    });
-
-    await use(key);
-
-    // Cleanup
-    await deleteApiKey(key.id);
-  },
-
-  authedPage: async ({ browser, seedOrg, testApiKey, baseURL }, use) => {
-    // Create a fresh context with pre-populated localStorage.
-    // This ensures OIDC user + currentOrgId exist BEFORE any page JS runs,
-    // eliminating the race condition between addInitScript and JS execution.
-    const context = await browser.newContext({
-      ...devices["Desktop Chrome"],
-      baseURL: baseURL ?? undefined,
-      storageState: buildStorageState(seedOrg.id, TEST_USER_PROFILE),
-    });
-
-    const page = await context.newPage();
-
-    // Set up route interception + addInitScript safety net
-    await setupPageAuth(
-      page,
+  authedPage: async ({ browser, seedOrg, seedUser, baseURL }, use) => {
+    const { context, page } = await createAuthedContext(
+      browser,
+      baseURL ?? undefined,
       seedOrg.id,
-      testApiKey.plainKey,
-      TEST_USER_PROFILE,
+      seedUser.id,
+      WRITER_USER_PROFILE,
     );
 
     await use(page);

--- a/apps/web/e2e/helpers/forms-fixtures.ts
+++ b/apps/web/e2e/helpers/forms-fixtures.ts
@@ -8,32 +8,14 @@
  * test use, with automatic cleanup in teardown.
  */
 
-import { test as base, expect, type Page, devices } from "@playwright/test";
-import { buildStorageState, setupPageAuth } from "./auth";
-import { getOrgBySlug, getUserByEmail, createApiKey, deleteApiKey } from "./db";
+import { test as base, expect, type Page } from "@playwright/test";
+import { createAuthedContext, ADMIN_USER_PROFILE } from "./auth";
+import { getOrgBySlug, getUserByEmail } from "./db";
 import {
   createFormDefinition,
   createFormField,
   deleteFormDefinition,
 } from "./forms-db";
-
-/** Admin user profile (ADMIN role in quarterly-review org) */
-const ADMIN_USER_PROFILE = {
-  sub: "seed-zitadel-admin-001",
-  email: "editor@quarterlyreview.org",
-  name: "Test Admin",
-};
-
-/** All scopes needed for Forms E2E tests */
-const FORMS_E2E_SCOPES = [
-  "notifications:read",
-  "forms:read",
-  "forms:write",
-  "submissions:read",
-  "submissions:write",
-  "users:read",
-  "organizations:read",
-];
 
 interface SeedOrg {
   id: string;
@@ -46,11 +28,6 @@ interface SeedUser {
   email: string;
 }
 
-interface TestApiKey {
-  id: string;
-  plainKey: string;
-}
-
 interface FormData {
   form: { id: string; name: string; status: string };
   fields: Array<{ id: string; fieldKey: string }>;
@@ -59,7 +36,6 @@ interface FormData {
 export const test = base.extend<{
   seedOrg: SeedOrg;
   seedAdmin: SeedUser;
-  testApiKey: TestApiKey;
   authedPage: Page;
   formData: FormData;
 }>({
@@ -83,32 +59,12 @@ export const test = base.extend<{
     await use(user);
   },
 
-  testApiKey: async ({ seedOrg, seedAdmin }, use) => {
-    const key = await createApiKey({
-      orgId: seedOrg.id,
-      userId: seedAdmin.id,
-      scopes: FORMS_E2E_SCOPES,
-      name: `e2e-forms-${Date.now()}`,
-    });
-
-    await use(key);
-
-    await deleteApiKey(key.id);
-  },
-
-  authedPage: async ({ browser, seedOrg, testApiKey, baseURL }, use) => {
-    const context = await browser.newContext({
-      ...devices["Desktop Chrome"],
-      baseURL: baseURL ?? undefined,
-      storageState: buildStorageState(seedOrg.id, ADMIN_USER_PROFILE),
-    });
-
-    const page = await context.newPage();
-
-    await setupPageAuth(
-      page,
+  authedPage: async ({ browser, seedOrg, seedAdmin, baseURL }, use) => {
+    const { context, page } = await createAuthedContext(
+      browser,
+      baseURL ?? undefined,
       seedOrg.id,
-      testApiKey.plainKey,
+      seedAdmin.id,
       ADMIN_USER_PROFILE,
     );
 

--- a/apps/web/e2e/helpers/organization-fixtures.ts
+++ b/apps/web/e2e/helpers/organization-fixtures.ts
@@ -8,35 +8,17 @@
  * invite/remove tests, with automatic cleanup in teardown.
  */
 
-import { test as base, expect, type Page, devices } from "@playwright/test";
-import { buildStorageState, setupPageAuth } from "./auth";
+import { test as base, expect, type Page } from "@playwright/test";
+import { createAuthedContext, ADMIN_USER_PROFILE } from "./auth";
 import {
   getOrgBySlug,
   getUserByEmail,
-  createApiKey,
-  deleteApiKey,
   createUser,
   deleteUser,
   createOrg,
   deleteOrg,
   addMember,
 } from "./db";
-
-/** Admin user profile (ADMIN role in quarterly-review org) */
-const ADMIN_USER_PROFILE = {
-  sub: "seed-zitadel-admin-001",
-  email: "editor@quarterlyreview.org",
-  name: "Test Admin",
-};
-
-/** All scopes needed for Organization E2E tests */
-const ORG_E2E_SCOPES = [
-  "notifications:read",
-  "notifications:write",
-  "organizations:read",
-  "organizations:write",
-  "users:read",
-];
 
 interface SeedOrg {
   id: string;
@@ -49,11 +31,6 @@ interface SeedUser {
   email: string;
 }
 
-interface TestApiKey {
-  id: string;
-  plainKey: string;
-}
-
 interface InviteTarget {
   id: string;
   email: string;
@@ -62,7 +39,6 @@ interface InviteTarget {
 export const test = base.extend<{
   seedOrg: SeedOrg;
   seedAdmin: SeedUser;
-  testApiKey: TestApiKey;
   authedPage: Page;
   inviteTarget: InviteTarget;
   inviteeOrg: SeedOrg;
@@ -88,32 +64,12 @@ export const test = base.extend<{
     await use(user);
   },
 
-  testApiKey: async ({ seedOrg, seedAdmin }, use) => {
-    const key = await createApiKey({
-      orgId: seedOrg.id,
-      userId: seedAdmin.id,
-      scopes: ORG_E2E_SCOPES,
-      name: `e2e-org-${Date.now()}`,
-    });
-
-    await use(key);
-
-    await deleteApiKey(key.id);
-  },
-
-  authedPage: async ({ browser, seedOrg, testApiKey, baseURL }, use) => {
-    const context = await browser.newContext({
-      ...devices["Desktop Chrome"],
-      baseURL: baseURL ?? undefined,
-      storageState: buildStorageState(seedOrg.id, ADMIN_USER_PROFILE),
-    });
-
-    const page = await context.newPage();
-
-    await setupPageAuth(
-      page,
+  authedPage: async ({ browser, seedOrg, seedAdmin, baseURL }, use) => {
+    const { context, page } = await createAuthedContext(
+      browser,
+      baseURL ?? undefined,
       seedOrg.id,
-      testApiKey.plainKey,
+      seedAdmin.id,
       ADMIN_USER_PROFILE,
     );
 
@@ -136,12 +92,18 @@ export const test = base.extend<{
   },
 
   /**
-   * Separate org for invitee API key auth.
+   * Separate org so the invitee has somewhere to be a member of.
    *
-   * The org-context hook requires the API key creator to be a member of
-   * the key's org. The invitee isn't a member of the seed org, so we
-   * create a dedicated org where the invitee IS a member. The accept
-   * endpoint uses SECURITY DEFINER functions that operate cross-org.
+   * The org-context hook resolves `X-Organization-Id` against
+   * `organization_members` and returns 403 not_a_member if the user has no
+   * roles there. The invitee is by definition not yet a member of the seed
+   * org, so without this they could not load the dashboard chrome at all
+   * (the notification bell alone calls an org-scoped procedure). The accept
+   * endpoint itself is a `userProcedure` and works cross-org via SECURITY
+   * DEFINER functions.
+   *
+   * This is not an API-key artefact — the same membership check applies to
+   * interactive auth.
    */
   inviteeOrg: async ({ inviteTarget }, use) => {
     const org = await createOrg({
@@ -155,39 +117,30 @@ export const test = base.extend<{
 
   /**
    * Playwright page authenticated as the inviteTarget user.
-   * Used for accept-side invitation tests.
+   *
+   * Used for accept-side invitation tests. The invitee is deliberately a
+   * lower-privilege principal than the org admin — that distinction now rides
+   * entirely on their READER membership in `inviteeOrg`, which is how the real
+   * product expresses it.
    */
   inviteePage: async ({ browser, inviteeOrg, inviteTarget, baseURL }, use) => {
-    const apiKey = await createApiKey({
-      orgId: inviteeOrg.id,
-      userId: inviteTarget.id,
-      // organizations:write is required by invitations.accept, which this page
-      // is built to drive. Kept inline rather than folded into ORG_E2E_SCOPES
-      // because the invitee is deliberately a different, lower-privilege
-      // principal than the org admin.
-      scopes: ["organizations:read", "organizations:write", "users:read"],
-      name: `e2e-invitee-${Date.now()}`,
-    });
-
     const inviteeProfile = {
       sub: `e2e-zitadel-invite-${inviteTarget.id}`,
       email: inviteTarget.email,
       name: "Test Invitee",
     };
 
-    const context = await browser.newContext({
-      ...devices["Desktop Chrome"],
-      baseURL: baseURL ?? undefined,
-      storageState: buildStorageState(inviteeOrg.id, inviteeProfile),
-    });
-
-    const page = await context.newPage();
-    await setupPageAuth(page, inviteeOrg.id, apiKey.plainKey, inviteeProfile);
+    const { context, page } = await createAuthedContext(
+      browser,
+      baseURL ?? undefined,
+      inviteeOrg.id,
+      inviteTarget.id,
+      inviteeProfile,
+    );
 
     await use(page);
 
     await context.close();
-    await deleteApiKey(apiKey.id);
   },
 });
 

--- a/apps/web/e2e/helpers/reader-fixtures.ts
+++ b/apps/web/e2e/helpers/reader-fixtures.ts
@@ -6,25 +6,9 @@
  * restricted UI (no editor/admin navigation, read-only settings).
  */
 
-import { test as base, expect, type Page, devices } from "@playwright/test";
-import { buildStorageState, setupPageAuth } from "./auth";
-import { getOrgBySlug, getUserByEmail, createApiKey, deleteApiKey } from "./db";
-
-/** Writer user profile (READER role in quarterly-review org) */
-const READER_USER_PROFILE = {
-  sub: "seed-zitadel-writer-001",
-  email: "writer@example.com",
-  name: "Test Reader",
-};
-
-/** Read-only scopes for READER E2E tests */
-const READER_E2E_SCOPES = [
-  "notifications:read",
-  "organizations:read",
-  "submissions:read",
-  "users:read",
-  "periods:read",
-];
+import { test as base, expect, type Page } from "@playwright/test";
+import { createAuthedContext, WRITER_USER_PROFILE } from "./auth";
+import { getOrgBySlug, getUserByEmail } from "./db";
 
 interface SeedOrg {
   id: string;
@@ -37,15 +21,9 @@ interface SeedUser {
   email: string;
 }
 
-interface TestApiKey {
-  id: string;
-  plainKey: string;
-}
-
 export const test = base.extend<{
   seedOrg: SeedOrg;
   seedReader: SeedUser;
-  testApiKey: TestApiKey;
   authedPage: Page;
 }>({
   seedOrg: async ({}, use) => {
@@ -68,33 +46,13 @@ export const test = base.extend<{
     await use(user);
   },
 
-  testApiKey: async ({ seedOrg, seedReader }, use) => {
-    const key = await createApiKey({
-      orgId: seedOrg.id,
-      userId: seedReader.id,
-      scopes: READER_E2E_SCOPES,
-      name: `e2e-reader-${Date.now()}`,
-    });
-
-    await use(key);
-
-    await deleteApiKey(key.id);
-  },
-
-  authedPage: async ({ browser, seedOrg, testApiKey, baseURL }, use) => {
-    const context = await browser.newContext({
-      ...devices["Desktop Chrome"],
-      baseURL: baseURL ?? undefined,
-      storageState: buildStorageState(seedOrg.id, READER_USER_PROFILE),
-    });
-
-    const page = await context.newPage();
-
-    await setupPageAuth(
-      page,
+  authedPage: async ({ browser, seedOrg, seedReader, baseURL }, use) => {
+    const { context, page } = await createAuthedContext(
+      browser,
+      baseURL ?? undefined,
       seedOrg.id,
-      testApiKey.plainKey,
-      READER_USER_PROFILE,
+      seedReader.id,
+      WRITER_USER_PROFILE,
     );
 
     await use(page);

--- a/apps/web/e2e/helpers/slate-fixtures.ts
+++ b/apps/web/e2e/helpers/slate-fixtures.ts
@@ -9,13 +9,11 @@
  * with automatic cleanup in teardown.
  */
 
-import { test as base, expect, type Page, devices } from "@playwright/test";
-import { buildStorageState, setupPageAuth } from "./auth";
+import { test as base, expect, type Page } from "@playwright/test";
+import { createAuthedContext, ADMIN_USER_PROFILE } from "./auth";
 import {
   getOrgBySlug,
   getUserByEmail,
-  createApiKey,
-  deleteApiKey,
   createSubmission,
   deleteSubmission,
 } from "./db";
@@ -29,31 +27,6 @@ import {
   cleanupSlateData,
 } from "./slate-db";
 
-/** Admin user profile (ADMIN role in quarterly-review org) */
-const ADMIN_USER_PROFILE = {
-  sub: "seed-zitadel-admin-001",
-  email: "editor@quarterlyreview.org",
-  name: "Test Admin",
-};
-
-/** All scopes needed for Slate E2E tests */
-const SLATE_E2E_SCOPES = [
-  "notifications:read",
-  "publications:read",
-  "publications:write",
-  "pipeline:read",
-  "pipeline:write",
-  "issues:read",
-  "issues:write",
-  "contracts:read",
-  "contracts:write",
-  "cms:read",
-  "cms:write",
-  "submissions:read",
-  "users:read",
-  "organizations:read",
-];
-
 interface SeedOrg {
   id: string;
   name: string;
@@ -63,11 +36,6 @@ interface SeedOrg {
 interface SeedUser {
   id: string;
   email: string;
-}
-
-interface TestApiKey {
-  id: string;
-  plainKey: string;
 }
 
 interface SlateData {
@@ -83,7 +51,6 @@ interface SlateData {
 export const test = base.extend<{
   seedOrg: SeedOrg;
   seedAdmin: SeedUser;
-  testApiKey: TestApiKey;
   authedPage: Page;
   slateData: SlateData;
 }>({
@@ -107,32 +74,12 @@ export const test = base.extend<{
     await use(user);
   },
 
-  testApiKey: async ({ seedOrg, seedAdmin }, use) => {
-    const key = await createApiKey({
-      orgId: seedOrg.id,
-      userId: seedAdmin.id,
-      scopes: SLATE_E2E_SCOPES,
-      name: `e2e-slate-${Date.now()}`,
-    });
-
-    await use(key);
-
-    await deleteApiKey(key.id);
-  },
-
-  authedPage: async ({ browser, seedOrg, testApiKey, baseURL }, use) => {
-    const context = await browser.newContext({
-      ...devices["Desktop Chrome"],
-      baseURL: baseURL ?? undefined,
-      storageState: buildStorageState(seedOrg.id, ADMIN_USER_PROFILE),
-    });
-
-    const page = await context.newPage();
-
-    await setupPageAuth(
-      page,
+  authedPage: async ({ browser, seedOrg, seedAdmin, baseURL }, use) => {
+    const { context, page } = await createAuthedContext(
+      browser,
+      baseURL ?? undefined,
       seedOrg.id,
-      testApiKey.plainKey,
+      seedAdmin.id,
       ADMIN_USER_PROFILE,
     );
 

--- a/apps/web/e2e/helpers/upload.ts
+++ b/apps/web/e2e/helpers/upload.ts
@@ -101,13 +101,19 @@ export async function disconnectUploadDb(): Promise<void> {
 }
 
 /**
- * Set up tus request interception to swap Bearer token for API key.
+ * Set up tus request interception to swap the Bearer token for test auth.
  *
- * Mirrors the tRPC interception pattern in auth.ts — intercepts all
- * requests to tusd (localhost:1080) and replaces the Authorization
- * header with X-Api-Key.
+ * Mirrors the interception pattern in auth.ts — intercepts all requests to
+ * tusd (localhost:1080) and replaces the Authorization header with
+ * X-Test-User-Id.
+ *
+ * tusd forwards this to the webhook via `-hooks-http-forward-headers`
+ * (docker-compose.e2e.yml); the pre-create and post-finish handlers read it in
+ * their `NODE_ENV === 'test'` branch. That branch sits last in the chain
+ * (api-key -> embed-token -> status-token -> test), so it is only reached
+ * because we no longer forward a key.
  */
-export async function setupTusAuth(page: Page, apiKey: string): Promise<void> {
+export async function setupTusAuth(page: Page, userId: string): Promise<void> {
   await page.route("**/localhost:1080/**", async (route) => {
     const request = route.request();
     const headers = { ...request.headers() };
@@ -115,8 +121,7 @@ export async function setupTusAuth(page: Page, apiKey: string): Promise<void> {
     // Remove the fake OIDC Bearer token
     delete headers["authorization"];
 
-    // Add the real API key
-    headers["x-api-key"] = apiKey;
+    headers["x-test-user-id"] = userId;
 
     await route.continue({ headers });
   });

--- a/apps/web/e2e/helpers/workspace-fixtures.ts
+++ b/apps/web/e2e/helpers/workspace-fixtures.ts
@@ -8,36 +8,14 @@
  * and correspondence for test use, with automatic cleanup in teardown.
  */
 
-import { test as base, expect, type Page, devices } from "@playwright/test";
-import { buildStorageState, setupPageAuth } from "./auth";
-import { getOrgBySlug, getUserByEmail, createApiKey, deleteApiKey } from "./db";
+import { test as base, expect, type Page } from "@playwright/test";
+import { createAuthedContext, WRITER_USER_PROFILE } from "./auth";
+import { getOrgBySlug, getUserByEmail } from "./db";
 import {
   createExternalSubmission,
   createCorrespondence,
   cleanupWorkspaceData,
 } from "./workspace-db";
-
-/** Writer user profile (READER role in quarterly-review org) */
-const WRITER_USER_PROFILE = {
-  sub: "seed-zitadel-writer-001",
-  email: "writer@example.com",
-  name: "Test Writer",
-};
-
-/** All scopes needed for Workspace E2E tests */
-const WORKSPACE_E2E_SCOPES = [
-  "notifications:read",
-  "external-submissions:read",
-  "external-submissions:write",
-  "correspondence:read",
-  "correspondence:write",
-  "csr:read",
-  "csr:write",
-  "manuscripts:read",
-  "journal-directory:read",
-  "users:read",
-  "organizations:read",
-];
 
 interface SeedOrg {
   id: string;
@@ -50,11 +28,6 @@ interface SeedUser {
   email: string;
 }
 
-interface TestApiKey {
-  id: string;
-  plainKey: string;
-}
-
 interface WorkspaceData {
   externalSubmission: { id: string; journalName: string; status: string };
   correspondence: { id: string };
@@ -63,7 +36,6 @@ interface WorkspaceData {
 export const test = base.extend<{
   seedOrg: SeedOrg;
   seedWriter: SeedUser;
-  testApiKey: TestApiKey;
   authedPage: Page;
   workspaceData: WorkspaceData;
 }>({
@@ -87,32 +59,12 @@ export const test = base.extend<{
     await use(user);
   },
 
-  testApiKey: async ({ seedOrg, seedWriter }, use) => {
-    const key = await createApiKey({
-      orgId: seedOrg.id,
-      userId: seedWriter.id,
-      scopes: WORKSPACE_E2E_SCOPES,
-      name: `e2e-workspace-${Date.now()}`,
-    });
-
-    await use(key);
-
-    await deleteApiKey(key.id);
-  },
-
-  authedPage: async ({ browser, seedOrg, testApiKey, baseURL }, use) => {
-    const context = await browser.newContext({
-      ...devices["Desktop Chrome"],
-      baseURL: baseURL ?? undefined,
-      storageState: buildStorageState(seedOrg.id, WRITER_USER_PROFILE),
-    });
-
-    const page = await context.newPage();
-
-    await setupPageAuth(
-      page,
+  authedPage: async ({ browser, seedOrg, seedWriter, baseURL }, use) => {
+    const { context, page } = await createAuthedContext(
+      browser,
+      baseURL ?? undefined,
       seedOrg.id,
-      testApiKey.plainKey,
+      seedWriter.id,
       WRITER_USER_PROFILE,
     );
 

--- a/apps/web/e2e/organization/org-delete.spec.ts
+++ b/apps/web/e2e/organization/org-delete.spec.ts
@@ -1,41 +1,20 @@
 /**
  * Organization deletion E2E tests.
  *
- * These tests create disposable orgs because:
- * 1. We can't delete the seed org (it's used by other suites)
- * 2. API keys are org-scoped — the seed org key won't work for a different org
+ * These tests create disposable orgs because we can't delete the seed org —
+ * it is used by every other suite.
  *
- * Each test creates its own disposable org + API key + authedPage.
+ * Each test creates its own disposable org + authedPage. The admin must be an
+ * ADMIN member of the disposable org: org-context resolves the
+ * X-Organization-Id header against `organization_members` and 403s otherwise.
  */
 
-import { test as base, expect, devices, type Browser } from "@playwright/test";
-import { buildStorageState, setupPageAuth } from "../helpers/auth";
-import {
-  createOrg,
-  deleteOrg,
-  addMember,
-  getUserByEmail,
-  createApiKey,
-  deleteApiKey,
-} from "../helpers/db";
-
-/** Admin user profile (ADMIN role) */
-const ADMIN_USER_PROFILE = {
-  sub: "seed-zitadel-admin-001",
-  email: "editor@quarterlyreview.org",
-  name: "Test Admin",
-};
-
-const ORG_E2E_SCOPES = [
-  "notifications:read",
-  "notifications:write",
-  "organizations:read",
-  "organizations:write",
-  "users:read",
-];
+import { test as base, expect, type Browser } from "@playwright/test";
+import { createAuthedContext, ADMIN_USER_PROFILE } from "../helpers/auth";
+import { createOrg, deleteOrg, addMember, getUserByEmail } from "../helpers/db";
 
 /**
- * Create a disposable org with admin membership and API key,
+ * Create a disposable org with admin membership,
  * returning an authedPage bound to that org.
  */
 async function createDisposableOrgContext(browser: Browser, baseURL: string) {
@@ -54,32 +33,22 @@ async function createDisposableOrgContext(browser: Browser, baseURL: string) {
   if (!admin) throw new Error("Seed admin not found");
   await addMember(org.id, admin.id, "ADMIN");
 
-  // Create API key scoped to this org
-  const apiKey = await createApiKey({
-    orgId: org.id,
-    userId: admin.id,
-    scopes: ORG_E2E_SCOPES,
-    name: `e2e-delete-${suffix}`,
-  });
-
-  // Create authed browser context
-  const context = await browser.newContext({
-    ...devices["Desktop Chrome"],
+  const { context, page } = await createAuthedContext(
+    browser,
     baseURL,
-    storageState: buildStorageState(org.id, ADMIN_USER_PROFILE),
-  });
+    org.id,
+    admin.id,
+    ADMIN_USER_PROFILE,
+  );
 
-  const page = await context.newPage();
-  await setupPageAuth(page, org.id, apiKey.plainKey, ADMIN_USER_PROFILE);
-
-  return { org, apiKey, page, context };
+  return { org, page, context };
 }
 
 base.describe("Delete Organization", () => {
   base(
     "delete button disabled until org name typed",
     async ({ browser, baseURL }) => {
-      const { org, apiKey, page, context } = await createDisposableOrgContext(
+      const { org, page, context } = await createDisposableOrgContext(
         browser,
         baseURL ?? "http://localhost:3010",
       );
@@ -112,14 +81,13 @@ base.describe("Delete Organization", () => {
         await expect(confirmButton).toBeEnabled();
       } finally {
         await context.close();
-        await deleteApiKey(apiKey.id);
         await deleteOrg(org.id);
       }
     },
   );
 
   base("deletes org after confirmation", async ({ browser, baseURL }) => {
-    const { org, apiKey, page, context } = await createDisposableOrgContext(
+    const { org, page, context } = await createDisposableOrgContext(
       browser,
       baseURL ?? "http://localhost:3010",
     );
@@ -147,7 +115,6 @@ base.describe("Delete Organization", () => {
       await page.waitForURL("**/", { timeout: 10000 });
     } finally {
       await context.close();
-      await deleteApiKey(apiKey.id);
       // Idempotent — org may already be deleted by the test
       await deleteOrg(org.id);
     }

--- a/apps/web/e2e/uploads/file-upload.spec.ts
+++ b/apps/web/e2e/uploads/file-upload.spec.ts
@@ -85,9 +85,9 @@ test.describe("File Upload (/submissions/:id — edit mode)", () => {
 
   test("uploads a file and shows it in file list", async ({
     authedPage,
-    testApiKey,
+    seedUser,
   }) => {
-    await setupTusAuth(authedPage, testApiKey.plainKey);
+    await setupTusAuth(authedPage, seedUser.id);
     await authedPage.goto(`/submissions/${submissionId}`);
 
     // Click Edit to enter edit mode
@@ -114,11 +114,8 @@ test.describe("File Upload (/submissions/:id — edit mode)", () => {
     });
   });
 
-  test("shows upload progress indicator", async ({
-    authedPage,
-    testApiKey,
-  }) => {
-    await setupTusAuth(authedPage, testApiKey.plainKey);
+  test("shows upload progress indicator", async ({ authedPage, seedUser }) => {
+    await setupTusAuth(authedPage, seedUser.id);
     await authedPage.goto(`/submissions/${submissionId}`);
     await authedPage.getByRole("button", { name: /edit/i }).click();
 
@@ -139,9 +136,9 @@ test.describe("File Upload (/submissions/:id — edit mode)", () => {
 
   test("uploaded file has CLEAN scan status in database", async ({
     authedPage,
-    testApiKey,
+    seedUser,
   }) => {
-    await setupTusAuth(authedPage, testApiKey.plainKey);
+    await setupTusAuth(authedPage, seedUser.id);
     await authedPage.goto(`/submissions/${submissionId}`);
     await authedPage.getByRole("button", { name: /edit/i }).click();
 
@@ -166,8 +163,8 @@ test.describe("File Upload (/submissions/:id — edit mode)", () => {
     expect(uploaded!.scanStatus).toBe("CLEAN");
   });
 
-  test("can delete an uploaded file", async ({ authedPage, testApiKey }) => {
-    await setupTusAuth(authedPage, testApiKey.plainKey);
+  test("can delete an uploaded file", async ({ authedPage, seedUser }) => {
+    await setupTusAuth(authedPage, seedUser.id);
     await authedPage.goto(`/submissions/${submissionId}`);
     await authedPage.getByRole("button", { name: /edit/i }).click();
 
@@ -210,9 +207,9 @@ test.describe("File Upload (/submissions/:id — edit mode)", () => {
 
   test("rejects invalid MIME type (client-side)", async ({
     authedPage,
-    testApiKey,
+    seedUser,
   }) => {
-    await setupTusAuth(authedPage, testApiKey.plainKey);
+    await setupTusAuth(authedPage, seedUser.id);
     await authedPage.goto(`/submissions/${submissionId}`);
     await authedPage.getByRole("button", { name: /edit/i }).click();
 
@@ -240,8 +237,8 @@ test.describe("File Upload (/submissions/:id — edit mode)", () => {
     expect(exe).toBeUndefined();
   });
 
-  test("uploads multiple files", async ({ authedPage, testApiKey }) => {
-    await setupTusAuth(authedPage, testApiKey.plainKey);
+  test("uploads multiple files", async ({ authedPage, seedUser }) => {
+    await setupTusAuth(authedPage, seedUser.id);
     await authedPage.goto(`/submissions/${submissionId}`);
     await authedPage.getByRole("button", { name: /edit/i }).click();
 

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -6,10 +6,17 @@ import { defineConfig, devices } from "@playwright/test";
 /**
  * Playwright configuration for browser E2E tests.
  *
- * Three projects:
- * - submissions: existing tests (fake OIDC + API key interception, no external services)
+ * Ten projects. Most need nothing beyond Postgres and seed data; three have
+ * external prerequisites:
  * - uploads: requires tusd + Garage (docker-compose.e2e.yml)
  * - oidc: requires Zitadel (docker-compose --profile auth)
+ * - embed: public embed forms, no authenticated principal
+ *
+ * Auth model: every suite except `oidc` and `embed` authenticates through the
+ * API's interactive test path (`x-test-user-id`, apps/api/src/hooks/auth.ts).
+ * That path is gated on NODE_ENV=test AND the absence of a JWKS verifier, so
+ * the API webServer below sets both. `oidc` drives a real Zitadel login and
+ * therefore keeps the verifier.
  *
  * IMPORTANT: Playwright's webServer.env replaces process.env entirely for child
  * processes. We must load .env files and spread process.env to ensure DATABASE_URL
@@ -165,6 +172,15 @@ export default defineConfig({
         // Raise rate limits for E2E: tests × ~5 requests each can exceed default 60/min
         RATE_LIMIT_DEFAULT_MAX: "1000",
         RATE_LIMIT_AUTH_MAX: "1000",
+        // Enable the interactive test-auth path (x-test-user-id). It requires
+        // BOTH NODE_ENV=test and no JWKS verifier — see hooks/auth.ts. The
+        // empty ZITADEL_AUTHORITY is load-bearing: apps/api/.env sets a real
+        // one, which reaches this process via dotenv above and the API's own
+        // --env-file-if-exists. Its zod schema maps '' -> undefined before the
+        // .url() check, so this clears it rather than failing validation.
+        // Node's --env-file does not override an already-set variable, so this
+        // wins over apps/api/.env.
+        ...(isOidcE2e ? {} : { NODE_ENV: "test", ZITADEL_AUTHORITY: "" }),
         ...(isOidcE2e && {
           ZITADEL_AUTHORITY: oidcAuthority,
           // Zitadel JWT aud contains the project_id as the resource audience

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -21,6 +21,6 @@ services:
       - -hooks-http
       - http://host.docker.internal:4010/webhooks/tusd
       - -hooks-http-forward-headers
-      - Authorization,X-Organization-Id,X-Api-Key
+      - Authorization,X-Organization-Id,X-Api-Key,X-Test-User-Id
       - -behind-proxy
       - -verbose

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -78,6 +78,7 @@
 - [ ] Add `tseslint.configs.recommendedTypeChecked` to `apps/web/eslint.config.mjs` — the web app is currently unlinted for `no-floating-promises`, `no-misused-promises`, `await-thenable`, and the `no-unsafe-*` family, unlike `apps/api`. Expect a large first-run count; start the noisiest rules at `warn` — (DEVLOG 2026-07-25)
 - [ ] [P2] Stop passing `SENTRY_AUTH_TOKEN` as a Docker build ARG — `apps/web/Dockerfile` lines 34–35 take it as `ARG` then promote it to `ENV`. Build ARGs are recorded in image history, so the token is recoverable from any built image; `docker build` warns about this (`SecretsUsedInArgOrEnv`). Use a BuildKit secret mount (`RUN --mount=type=secret,id=sentry_auth_token`) and pass it via `--secret` from the deploy workflow instead — (DEVLOG 2026-07-26)
 - [ ] [P3] Spot-check rendered email output after the mjml 5 upgrade — 5.0.0 replaced `html-minifier`/`js-beautify` with `htmlnano` + `cssnano`, so the emitted HTML differs in whitespace and minification from 4.x. Unit tests and the staging smoke suite both pass, which covers the render path but not client rendering; send one templated email and one custom template through the email queue and compare against a 4.x capture — (DEVLOG 2026-07-26b)
+- [ ] [P3] Seed data ages out of a long-lived dev database, and `db:seed` will not repair it. Submission periods are seeded at fixed offsets from the seed date, so `quarterly-review` eventually has no open period — which fails 11 of 13 `embed` tests with `No open period found`. `pnpm db:seed` is idempotent-by-skip, so it is a no-op once data exists; only the destructive `db:reset` refreshes the dates. CI is unaffected (it seeds fresh each run), so this only ever bites locally, and it looks like a code regression rather than stale data. Either make the seed refresh period dates when they have closed, or have `global-setup.ts` fail with a "run `pnpm db:reset`" message when no open period exists for the seed org — (found 2026-07-27 while verifying the E2E auth rework)
 
 ---
 
@@ -145,27 +146,36 @@ Ordered as the design doc's Phase 0/D.
         any key until P0.5. The suite's last test pins the enforced behaviour across all
         29 so the gap stays visible.
   - [ ] **P0.5** — flip `TRPC_INTERNAL_ONLY_ENFORCE` to `true` after the observation
-        window; decide `payments:read`. **Blocked on the E2E auth model** — see below.
-  - [ ] **[P1] Playwright suites authenticate as API keys, which blocks P0.5.**
-        `e2e/helpers/*-fixtures.ts` mint a real `col_test_` key per suite and set it as
-        a browser header, so every E2E request carries `authMethod: 'apikey'` rather
-        than an interactive session. Consequences: (1) every scope added to a tRPC
-        procedure must also be added to each suite's `*_E2E_SCOPES` array — this is
-        what broke CI on the P0.1b branch; (2) `federation-admin.spec.ts` and the
-        `/settings` account-deletion path drive `internalOnly` routers, so they pass
-        only while the boundary is log-only and **will 403 the moment P0.5 flips it**.
-        Fix by having the fixtures use the interactive test-auth path
-        (`x-test-user-id`, already supported in `hooks/auth.ts`) instead of a key, so
-        E2E exercises the same auth class the web app actually uses. —
-        (discovered 2026-07-27 during P0.1b)
-        **(3) The `*_E2E_SCOPES` naming convention is not universal, so grepping for it
-        is not a reliable audit.** `organization-fixtures.ts` mints a _second_ key inline
-        for the `inviteePage` fixture with its own scope array — deliberately, since the
-        invitee is a lower-privilege principal than the org admin. Adding
-        `organizations:write` to `invitations.accept` in P0.4 broke four accept-side
-        tests until that inline array was updated too. `scopes:` is the search key that
-        finds every grant; there are nine across `apps/web/e2e/helpers/`. The rework
-        should collapse both onto the interactive path. — (found 2026-07-27 during P0.4)
+        window; decide `payments:read`. **No longer blocked** — the E2E rework landed
+        2026-07-27. The window is the only remaining gate: the design doc prescribes
+        querying `audit_events` for `API_KEY_INTERNAL_ROUTE` after ~a month of
+        observation (i.e. from 2026-07-27), shipping REST equivalents for anything real
+        that turns up, then flipping. Verified the flip is safe: the federation suite
+        passes 16/16 with `TRPC_INTERNAL_ONLY_ENFORCE=true`, against 4/16 on the
+        pre-rework tree.
+  - [x] **[P1] Playwright suites authenticated as API keys, which blocked P0.5.**
+        Every suite minted a `col_test_` key and set it as a browser header, so E2E ran
+        as `authMethod: 'apikey'`. The fixtures now use the interactive test path
+        (`x-test-user-id` → `authMethod: 'test'`), so scopes are a no-op, all ten scope
+        arrays are gone, and `internalOnly` routers admit the suites. Privilege is
+        expressed through `organization_members` roles instead. — done 2026-07-27
+        **Three things the original entry got wrong, worth keeping:**
+        (1) The count was **ten** grant sites, not nine — the nine counted raw `scopes:`
+        hits inside `helpers/` (two of which were plumbing in `db.ts`) and missed
+        `analytics/fixtures.ts`, `federation/fixtures.ts`, and a spec-local copy in
+        `organization/org-delete.spec.ts` entirely.
+        (2) `x-test-user-id` was "already supported" but **not reachable** — it needs
+        `NODE_ENV=test` AND no JWKS verifier, and `apps/api/.env` supplies a
+        `ZITADEL_AUTHORITY` that reached the E2E server. Opening it also required
+        adding the header to CORS `allowedHeaders` and to tusd's forwarded-header list.
+        (3) `inviteeOrg` was **not** an API-key artefact and could not be deleted — the
+        `organization_members` check in org-context applies identically to interactive
+        auth.
+        **The two auth modes are mutually exclusive.** `NODE_ENV=test` makes the auth
+        hook return before the `X-Api-Key` branch, so a test-mode app cannot
+        authenticate keys at all. Key admission moved to
+        `apps/api/src/__tests__/security/scope-enforcement.test.ts`, plus a tusd
+        API-key case in `tusd-webhook.test.ts`.
 - [x] **[P0] The CI "SDK Drift Check" validated the wrong direction.** It regenerated the TS
       SDK _from_ the committed spec and diffed that — never checking the spec against
       `apps/api/src/rest/routers/`. Green on every run for five months while the spec fell 36


### PR DESCRIPTION
## Why

Every Playwright suite minted a real `col_test_` API key and injected it as
`x-api-key`, so E2E ran as `authMethod: 'apikey'` while the browser rendered as
an OIDC user. Three consequences:

1. Every scope added to a tRPC procedure had to be mirrored into a per-suite
   array — this broke CI twice, on the P0.1b and P0.4 branches.
2. The federation suite passed only because the internal-route boundary is
   still log-only, so it would have 403'd the moment `TRPC_INTERNAL_ONLY_ENFORCE`
   flipped. That is what blocked P0.5.
3. E2E exercised a different auth class than real users, so it proved less than
   it appeared to.

## What changed

The suites now authenticate through the API's interactive test path
(`x-test-user-id` → `authMethod: 'test'`), the same class the web app uses.
Scopes are a no-op for interactive auth and internal-only routers admit it, so
all ten scope arrays are gone and privilege is expressed through
`organization_members` roles instead — which is how the product expresses it.

The path was already implemented but unreachable. It needs `NODE_ENV=test` *and*
no JWKS verifier, and `apps/api/.env` supplies a `ZITADEL_AUTHORITY` that reaches
the E2E server through both `dotenv` and the API's own `--env-file`. The
webServer env now sets both, relying on the schema mapping `''` to `undefined`.
CORS `allowedHeaders` and tusd's forwarded-header list gain the header. The
`oidc` project is excluded — it drives a real Zitadel login and keeps its
verifier.

Also collapses the `authedPage` body and user profiles, which were duplicated
near-verbatim across eight fixture files, into `helpers/auth.ts`.

## Replacing the lost coverage

The suites were the only end-to-end exercise of API-key admission. New
`__tests__/security/scope-enforcement.test.ts` drives a real `api_keys` row
through the real auth hook and tRPC router: under-scoped keys are denied with
the missing scope named, correctly scoped ones pass, denials leave an audit row,
and the internal boundary rejects a key while admitting an interactive session
under enforcement. A tusd API-key pre-create case covers the upload path.

Building that surfaced a constraint worth recording: **the two auth modes are
mutually exclusive.** `NODE_ENV=test` makes the auth hook return before the
`X-Api-Key` branch, so a test-mode app cannot authenticate keys at all. The
helper exposes them as separate builders rather than one parameterised call.

## Verification

Unit/integration: 2,798 passing, plus 7 new security and 2 new webhook tests.
`type-check` and `lint` clean.

Playwright, all converted suites passing: submissions 20, organization 32,
slate 30, workspace 24, forms 16, federation 16, uploads 6, analytics 6.

**The P0.5 unblock, measured:** the federation suite passes 16/16 with
`TRPC_INTERNAL_ONLY_ENFORCE=true`. On the pre-rework tree the same run passes
**4/16** — the 12 failures being exactly the tests that drive `internalOnly`
routers. That control confirms the flag propagates and the pass is real.

P0.5 itself still waits on its observation window (~a month from 2026-07-27),
per the design doc; it is no longer blocked on anything in the test suite.

## Also here

- Fixes a pre-existing strict-mode violation in `federation-admin.spec.ts`:
  `getByText("Public Key")` matched both the label and the rendered PEM body,
  since `getByText` does case-insensitive substring matching. Fails identically
  on `main`.
- Backlogs a latent local-only trap found while verifying: seeded submission
  periods age out, and `db:seed` is idempotent-by-skip so it cannot repair them.
  Once `quarterly-review` has no open period, 11 of 13 `embed` tests fail with
  `No open period found` and it reads like a code regression. CI is unaffected —
  it seeds fresh each run.

## Not fixed here

`embed` (11 failures) and `oidc` (3 failures) fail on this branch, and fail
identically on `main`. Both are pre-existing local environment issues — stale
seed dates and stale Zitadel provisioning respectively — not regressions from
this change.
