### PR TITLE
feat(api): enforce the internal-only tRPC boundary by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,10 +99,10 @@ RATE_LIMIT_KEY_PREFIX=colophony:rl
 # =============================================================================
 # The tRPC routers that exist only to serve the operator console (federation,
 # gdpr, hub, migration, ops, simsub, transfer) admit interactive sessions only.
-# false — record API-key attempts as API_KEY_INTERNAL_ROUTE audit events and
-#         let them through, so real usage can be measured first
-# true  — reject them with 403
-# TRPC_INTERNAL_ONLY_ENFORCE=false
+# true  — reject API keys with 403 (default since 2026-07-27)
+# false — record the attempt as an API_KEY_INTERNAL_ROUTE audit event and let
+#         it through; the revert lever, not a normal setting
+# TRPC_INTERNAL_ONLY_ENFORCE=true
 
 # =============================================================================
 # VIRUS SCANNING (ClamAV - optional for dev)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,6 +129,24 @@ jobs:
             git clean -fd
             echo "Checked out: $(git rev-parse HEAD)"
 
+            # Builds run with --no-cache, so every deploy writes a fresh set of
+            # layers and leaves the previous set unreferenced. Without this the
+            # disk fills silently and the deploy dies mid `pnpm install` with
+            # ENOSPC. Build cache is referenced by nothing, and `image prune`
+            # keeps any image still held by a container, so neither can remove
+            # something the running stack needs.
+            echo "=== Reclaiming disk ==="
+            df -h / | tail -1
+            docker builder prune -af
+            docker image prune -af
+            df -h / | tail -1
+
+            AVAIL_G=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+            if [ "${AVAIL_G:-0}" -lt 20 ]; then
+              echo "::error::Only ${AVAIL_G}G free after pruning; need 20G to build. Investigate before retrying."
+              exit 1
+            fi
+
             echo "=== Building images ==="
             docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo build --no-cache
 
@@ -143,6 +161,12 @@ jobs:
             echo "Waiting for services..."
             sleep 15
             docker compose -f docker-compose.prod.yml --env-file .env.staging --profile demo ps
+
+            # The previous version's images are unreferenced now that the new
+            # containers are up.
+            echo "=== Reclaiming disk (post-deploy) ==="
+            docker image prune -af
+            df -h / | tail -1
 
       - name: Verify deployment
         run: |
@@ -216,6 +240,20 @@ jobs:
             git clean -fd
             echo "Checked out: $(git rev-parse HEAD)"
 
+            # See the staging job for why this is here: --no-cache builds leave
+            # the previous layer set unreferenced, and nothing else reclaims it.
+            echo "=== Reclaiming disk ==="
+            df -h / | tail -1
+            docker builder prune -af
+            docker image prune -af
+            df -h / | tail -1
+
+            AVAIL_G=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+            if [ "${AVAIL_G:-0}" -lt 20 ]; then
+              echo "::error::Only ${AVAIL_G}G free after pruning; need 20G to build. Investigate before retrying."
+              exit 1
+            fi
+
             echo "=== Building images ==="
             docker compose -f docker-compose.prod.yml --env-file .env.prod build --no-cache
 
@@ -237,6 +275,10 @@ jobs:
             echo "Waiting for health checks..."
             sleep 15
             docker compose -f docker-compose.prod.yml ps
+
+            echo "=== Reclaiming disk (post-deploy) ==="
+            docker image prune -af
+            df -h / | tail -1
 
       - name: Verify deployment
         run: |

--- a/apps/api/src/__tests__/security/scope-enforcement.test.ts
+++ b/apps/api/src/__tests__/security/scope-enforcement.test.ts
@@ -159,8 +159,11 @@ describe('requireScopes — real API key through the tRPC router', () => {
   });
 });
 
-describe('internalOnly — the boundary P0.5 will enforce', () => {
-  it('admits an API key while TRPC_INTERNAL_ONLY_ENFORCE is false', async () => {
+describe('internalOnly — the boundary enforced since P0.5', () => {
+  // Enforcement is the default since 2026-07-27. This pins the log-only
+  // fallback that TRPC_INTERNAL_ONLY_ENFORCE=false still buys — the revert
+  // path has to keep working, or the flag is not a lever.
+  it('falls back to admitting an API key when explicitly set to false', async () => {
     setInternalOnlyEnforce(false);
     app = await buildApiKeyApp();
     const { org, user } = await seedOrgWithAdmin();
@@ -188,6 +191,32 @@ describe('internalOnly — the boundary P0.5 will enforce', () => {
 
   it('rejects an API key with 403 once enforcement is on', async () => {
     setInternalOnlyEnforce(true);
+    app = await buildApiKeyApp();
+    const { org, user } = await seedOrgWithAdmin();
+    const key = await insertApiKey({
+      orgId: org.id,
+      userId: user.id,
+      scopes: ['submissions:read'],
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `${INTERNAL_ROUTE}?input=${INTERNAL_INPUT}`,
+      headers: {
+        'x-api-key': key.plainKey,
+        'x-organization-id': org.id,
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toContain('not available to API keys');
+  });
+
+  // The other cases here all set the flag explicitly, so none of them would
+  // notice the schema default silently reverting to 'false'. This one pins the
+  // deployed behaviour: unset must mean enforcing.
+  it('enforces by default when the variable is not set at all', async () => {
+    delete process.env.TRPC_INTERNAL_ONLY_ENFORCE;
     app = await buildApiKeyApp();
     const { org, user } = await seedOrgWithAdmin();
     const key = await insertApiKey({

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -110,11 +110,13 @@ const envSchema = z
     // Status token TTL
     STATUS_TOKEN_TTL_DAYS: z.coerce.number().int().positive().default(90),
 
-    // tRPC internal-only boundary. False = log attempts and allow them through
-    // (observation window). True = reject non-interactive credentials.
+    // tRPC internal-only boundary. True = reject non-interactive credentials
+    // on the seven operator-console routers. False reverts to log-only, which
+    // records the attempt as an API_KEY_INTERNAL_ROUTE audit event and lets it
+    // through — the observation window, closed 2026-07-27.
     TRPC_INTERNAL_ONLY_ENFORCE: z
       .enum(['true', 'false'])
-      .default('false')
+      .default('true')
       .transform((v) => v === 'true'),
 
     FEDERATION_RATE_LIMIT_FAIL_MODE: z

--- a/apps/api/src/trpc/guard-coverage.spec.ts
+++ b/apps/api/src/trpc/guard-coverage.spec.ts
@@ -11,12 +11,12 @@
  * the eleventh appearing: it reads every procedure's middleware chain out of the
  * built `appRouter` and fails on one that declares neither.
  *
- * DECLARES, not "is protected" — the distinction is load-bearing. A
- * `requireScopes` declaration is also its enforcement. `internalOnly` is not,
- * yet: while `TRPC_INTERNAL_ONLY_ENFORCE` is false it audits the call and lets
- * it through, so the internal procedures counted here remain reachable by any
- * key until P0.5 flips the flag. The last test pins the enforced behaviour so
- * that gap stays visible rather than implied.
+ * DECLARES, not "is protected" — the distinction was load-bearing while the
+ * two guards differed. A `requireScopes` declaration is also its enforcement;
+ * `internalOnly` only declared, and audited the crossing, until P0.5 flipped
+ * `TRPC_INTERNAL_ONLY_ENFORCE` to true on 2026-07-27. Both now enforce on
+ * declaration. The last test pins that, so a revert to log-only cannot pass
+ * silently.
  *
  * Introspection only — no service is mocked because tests 1-5 never invoke a
  * procedure, and test 6 rejects at middleware index 0, before any service is

--- a/apps/api/src/trpc/init.ts
+++ b/apps/api/src/trpc/init.ts
@@ -299,9 +299,10 @@ const INTERACTIVE_AUTH_METHODS: readonly string[] = ['oidc', 'demo', 'test'];
 /**
  * Restricts a procedure to interactive human sessions.
  *
- * Log-only until TRPC_INTERNAL_ONLY_ENFORCE=true: non-interactive callers are
- * audited and let through, so real usage can be measured before the boundary
- * starts rejecting. An unauthenticated caller is rejected in both modes.
+ * Enforcing by default: a non-interactive caller is audited and rejected with
+ * 403. TRPC_INTERNAL_ONLY_ENFORCE=false reverts to log-only, auditing the
+ * crossing and letting it through — kept as a revert lever, not a normal
+ * setting. An unauthenticated caller is rejected in both modes, unaudited.
  */
 const internalOnlyMiddleware = t.middleware(async ({ ctx, path, next }) => {
   if (!ctx.authContext) {
@@ -371,8 +372,8 @@ export const adminProcedure = t.procedure.use(isAdmin);
 export const businessOpsProcedure = t.procedure.use(isBusinessOps);
 
 // Internal-only variants. `internalOnly` runs FIRST so that a non-interactive
-// credential is logged even when the role check would have rejected it anyway —
-// otherwise the observation window undercounts real usage.
+// credential is audited and rejected on the boundary rather than incidentally
+// on its role — the audit trail should say why the call was actually refused.
 export const internalAuthedProcedure = t.procedure
   .use(internalOnly)
   .use(isAuthed);

--- a/apps/api/src/trpc/routers/__tests__/scope-enforcement.spec.ts
+++ b/apps/api/src/trpc/routers/__tests__/scope-enforcement.spec.ts
@@ -230,7 +230,11 @@ describe('tRPC scope enforcement (P0.1b)', () => {
   // equivalent, internalOnly covers the ones that never will. Either alone
   // leaves a way in.
   describe('internal-only routers (P0.1)', () => {
-    it('lets an API key reach federation while the window is open', async () => {
+    // Enforcement is the default since 2026-07-27; this covers the revert
+    // path, not pending behaviour.
+    it('lets an API key reach federation when explicitly set to log-only', async () => {
+      envState.TRPC_INTERNAL_ONLY_ENFORCE = false;
+
       await expect(
         keyCaller(['manuscripts:read']).federation.getConfig(),
       ).resolves.toBeDefined();

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -141,6 +141,8 @@ services:
       FEDERATION_RATE_LIMIT_FAIL_MODE: ${FEDERATION_RATE_LIMIT_FAIL_MODE:-open}
       # Status tokens
       STATUS_TOKEN_TTL_DAYS: ${STATUS_TOKEN_TTL_DAYS:-90}
+      # Internal tRPC boundary. Set false only to revert to log-only.
+      TRPC_INTERNAL_ONLY_ENFORCE: ${TRPC_INTERNAL_ONLY_ENFORCE:-true}
       # Background jobs (Inngest)
       INNGEST_EVENT_KEY: ${INNGEST_EVENT_KEY:-}
       INNGEST_SIGNING_KEY: ${INNGEST_SIGNING_KEY:-}
@@ -620,6 +622,10 @@ services:
       METRICS_ENABLED: "false"
       FEDERATION_ENABLED: "false"
       INNGEST_DEV: "true"
+      # A no-op here in practice — the demo API authenticates as `demo`, which
+      # is on the interactive allowlist — but set explicitly so the deployed
+      # value never depends on the schema default.
+      TRPC_INTERNAL_ONLY_ENFORCE: ${TRPC_INTERNAL_ONLY_ENFORCE:-true}
     depends_on:
       demo-migrate:
         condition: service_completed_successfully

--- a/docs/api-integration-design.md
+++ b/docs/api-integration-design.md
@@ -1090,6 +1090,21 @@ Since Colophony has no external users yet (architecture.md §6.1), step 2 will v
 return nothing, and the sequence collapses to a formality. Run it anyway — it costs one
 flag and it is the difference between knowing and assuming.
 
+**Resolved 2026-07-27 — steps 2–4 done, on evidence rather than elapsed time.** The
+prediction above was right, and the month was not what made it verifiable. Staging, the only
+deployed environment, has **never held an API key** (`api_keys` is empty across an
+`audit_events` history from 2026-04-08), so no call of this shape was possible there
+regardless of how long anyone waited. Every shipped client that sends `X-Api-Key` is
+REST-only, and the web tRPC client sends interactive credentials exclusively. The 71
+`API_KEY_INTERNAL_ROUTE` rows in the dev database were 67 parts test-suite self-observation.
+
+What the window could never have delivered is worth stating, because it is the reason the
+calendar was the wrong instrument: elapsed time with no traffic is not evidence about future
+traffic. `X-Api-Key` is accepted on every non-public route, so a hand-rolled request reaches
+`federation.getConfig` whether or not anyone has tried it yet — which is an argument for
+enforcing sooner, not later. The durable guarantee is the test that now pins the default
+(`apps/api/src/__tests__/security/scope-enforcement.test.ts`), not the observation period.
+
 ---
 
 ## 5. Implementation sequence (reviewable PRs)
@@ -1118,7 +1133,7 @@ parallel.
 | **P0.2**  | Rewrite `scripts/export-openapi.ts` to use `OpenAPIGenerator` in-process. Regenerate `sdks/openapi.json` (+36 operations). **Per D4: stop committing generated SDKs, move generation to CI release.**                                    | Low — large deletion, mechanical                  |
 | **P0.3**  | CI: **invert** the existing `sdk-check` job (`ci.yml:1610`) — diff the regenerated _spec_ against source, not the SDK against the spec. Per D4, delete the SDK-regeneration half.                                                        | Low — a correction, not an addition (finding (b)) |
 | **P0.4**  | CI: coverage manifest test (M4). Seed the manifest from §1.2–1.5.                                                                                                                                                                        | Low                                               |
-| **P0.5**  | Flip `internalOnly` to enforcing after the observation window. Remove or wire the two dead scopes (`webhooks:manage`, `payments:read`).                                                                                                  | Medium — behaviour change                         |
+| **P0.5**  | Flip `internalOnly` to enforcing. **Done 2026-07-27**; the observation window was closed early on the evidence in §4. `webhooks:manage` was consumed by P0.1b; `payments:read` removal is split out as P0.5b.                            | Medium — behaviour change                         |
 
 _P0.1 is one middleware and it is the single highest-value change here; review it for the
 allowlist, not the router list. P0.2 is the largest diff and contains no logic — with D4 it

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -78,6 +78,25 @@
 - [ ] Add `tseslint.configs.recommendedTypeChecked` to `apps/web/eslint.config.mjs` — the web app is currently unlinted for `no-floating-promises`, `no-misused-promises`, `await-thenable`, and the `no-unsafe-*` family, unlike `apps/api`. Expect a large first-run count; start the noisiest rules at `warn` — (DEVLOG 2026-07-25)
 - [ ] [P2] Stop passing `SENTRY_AUTH_TOKEN` as a Docker build ARG — `apps/web/Dockerfile` lines 34–35 take it as `ARG` then promote it to `ENV`. Build ARGs are recorded in image history, so the token is recoverable from any built image; `docker build` warns about this (`SecretsUsedInArgOrEnv`). Use a BuildKit secret mount (`RUN --mount=type=secret,id=sentry_auth_token`) and pass it via `--secret` from the deploy workflow instead — (DEVLOG 2026-07-26)
 - [ ] [P3] Spot-check rendered email output after the mjml 5 upgrade — 5.0.0 replaced `html-minifier`/`js-beautify` with `htmlnano` + `cssnano`, so the emitted HTML differs in whitespace and minification from 4.x. Unit tests and the staging smoke suite both pass, which covers the render path but not client rendering; send one templated email and one custom template through the email queue and compare against a 4.x capture — (DEVLOG 2026-07-26b)
+- [ ] [P1] No disk alerting, and the monitoring stack cannot report its own host failing.
+      Staging filled its 150G disk on 2026-07-27 and nothing warned: all six rules in
+      `docker/prometheus/alert-rules.yml` are application-level (error rate, queue depth, DB
+      pool, health endpoint, latency, job failures), there is no node-exporter, and no
+      filesystem metric is scraped. `HealthEndpointDown` would have been the closest match,
+      but Prometheus, Loki and Grafana were themselves in a restart loop from the same full
+      disk — the stack is co-located with what it monitors, so it fails exactly when needed.
+      Wants node-exporter plus a `DiskSpaceLow` rule, and an external check that does not run
+      on the box it watches. — (found 2026-07-27 during the staging outage)
+- [ ] [P2] Reconsider `--no-cache` on every deploy build (`deploy.yml` staging and
+      production). It guarantees maximum layer churn — each deploy writes a fresh set and
+      strands the previous one — which is what filled the staging disk. Pruning now runs
+      either side of the build, so this is no longer urgent, but the flag buys little on a
+      tree that already changes every deploy and costs a full rebuild each time. Removing it
+      changes build semantics, so it wants its own PR. — (found 2026-07-27)
+- [ ] [P3] Confirm whether staging is meant to have database backups.
+      `walg-entrypoint: WALG_S3_PREFIX not set — backups disabled` appears on every staging
+      postgres start. If that is deliberate for staging, note it in `docs/deployment.md`; if
+      not, it is a gap that has been silent for months. — (found 2026-07-27)
 - [ ] [P3] Seed data ages out of a long-lived dev database, and `db:seed` will not repair it. Submission periods are seeded at fixed offsets from the seed date, so `quarterly-review` eventually has no open period — which fails 11 of 13 `embed` tests with `No open period found`. `pnpm db:seed` is idempotent-by-skip, so it is a no-op once data exists; only the destructive `db:reset` refreshes the dates. CI is unaffected (it seeds fresh each run), so this only ever bites locally, and it looks like a code regression rather than stale data. Either make the seed refresh period dates when they have closed, or have `global-setup.ts` fail with a "run `pnpm db:reset`" message when no open period exists for the seed org — (found 2026-07-27 while verifying the E2E auth rework)
 
 ---
@@ -140,19 +159,53 @@ Ordered as the design doc's Phase 0/D.
         REST-parity name-matching, which this does not attempt, and seeding a
         "has REST equivalent" list from a spec 36 operations stale would bake in wrong
         data. Per-procedure parity classification moves to P1.1–P1.4.
-        **Note the gate asserts declaration, not denial.** `requireScopes` declares and
-        enforces in one step; `internalOnly` only declares while
-        `TRPC_INTERNAL_ONLY_ENFORCE` is `false`, so those 29 procedures stay reachable by
-        any key until P0.5. The suite's last test pins the enforced behaviour across all
-        29 so the gap stays visible.
-  - [ ] **P0.5** — flip `TRPC_INTERNAL_ONLY_ENFORCE` to `true` after the observation
-        window; decide `payments:read`. **No longer blocked** — the E2E rework landed
-        2026-07-27. The window is the only remaining gate: the design doc prescribes
-        querying `audit_events` for `API_KEY_INTERNAL_ROUTE` after ~a month of
-        observation (i.e. from 2026-07-27), shipping REST equivalents for anything real
-        that turns up, then flipping. Verified the flip is safe: the federation suite
-        passes 16/16 with `TRPC_INTERNAL_ONLY_ENFORCE=true`, against 4/16 on the
-        pre-rework tree.
+        **The gate asserted declaration, not denial** — which mattered while the two
+        guards differed: `requireScopes` declares and enforces in one step, whereas
+        `internalOnly` only declared while `TRPC_INTERNAL_ONLY_ENFORCE` was `false`,
+        leaving those 29 procedures reachable by any key. P0.5 closed that on
+        2026-07-27; the suite's last test pins the enforced behaviour across all 29, so
+        a revert to log-only cannot pass silently.
+  - [x] **P0.5** — `TRPC_INTERNAL_ONLY_ENFORCE` now defaults to `true`; an API key
+        calling any of the 29 internal procedures gets a 403. The variable is also
+        threaded into `docker-compose.prod.yml` for both `api` and `api-demo`, which
+        previously enumerated every other var and omitted this one — so before this
+        change there was no way to set it in a deployed container at all.
+        **The month-long observation window was closed early, deliberately.** It was
+        prescribed to find real API-key usage of these routes, but nothing could
+        generate any: the design doc already conceded it would "very probably return
+        nothing" (§4), and the evidence below is stronger than a calendar. Note what it
+        does and does not show — it is a _compatibility_ inventory, not a reachability
+        proof. The auth hook accepts `X-Api-Key` on any non-public route
+        (`apps/api/src/hooks/auth.ts:264`), so a hand-rolled request reaches
+        `federation.getConfig` today. That is precisely the hole this closes. - **Staging, the only deployed environment** — `api_keys` holds **zero rows**,
+        so no key has ever existed there, across an `audit_events` history running
+        2026-04-08 → 2026-07-27. No `API_KEY_*` event of any kind was ever recorded.
+        This is the decisive evidence: not "nothing was logged", but "no credential
+        capable of it ever existed". - **No shipped client sends a key to `/trpc/*`** — `packages/api-client`
+        (`src/client.ts:89`) and `sdks/typescript` (`src/client.ts:76`) set
+        `X-Api-Key` but are REST-only with no tRPC transport; `sdks/python` is
+        generated from the same REST spec; `scripts/simsub-qa.ts` uses a key against
+        `/federation/sim-sub/*` REST paths; the web tRPC client sends only
+        `Authorization` / `X-Demo-User-Id` / `x-organization-id`
+        (`apps/web/src/lib/trpc.ts:83-105`), both allowlisted. - **Playwright** authenticates interactively since #515, and `NODE_ENV=test`
+        makes key auth unreachable. The federation suite passes 16/16 under
+        enforcement, against 4/16 on the pre-rework tree. - **Dev DB** held 71 `API_KEY_INTERNAL_ROUTE` events, 67 of them stamped
+        `enforced: true` — i.e. emitted by the tests that pin enforced behaviour. The
+        window was observing the test suite observing itself.
+        `apps/api/src/__tests__/security/scope-enforcement.test.ts` now pins the
+        default with the variable unset, so a silent revert to log-only fails the
+        build. — done 2026-07-27
+  - [ ] **P0.5b** — remove the dead `payments:read` scope. **Decision taken
+        2026-07-27: remove it.** It is enforced nowhere, and every payment-adjacent
+        guard uses the distinct `payment-transactions:*` scope
+        (`apps/api/src/trpc/routers/payment-transactions.ts`). Split out of P0.5
+        because it is materially larger than the flag flip: `packages/types/src/api-key.ts:24`,
+        the seeded read-only key at `packages/db/src/seed.ts:444`, and three CI-gated
+        generated artefacts (`sdks/openapi.json`, `sdks/typescript/src/generated/`,
+        `sdks/python/colophony/models/`) that `sdk-check` diffs in all three directions.
+        Note the latent break: `apiKeyResponseSchema` validates `scopes` on the
+        `apiKeys.list` output, so any pre-existing DB row still holding the scope throws
+        after removal — the seed row must go in the same change.
   - [x] **[P1] Playwright suites authenticated as API keys, which blocked P0.5.**
         Every suite minted a `col_test_` key and set it as a browser header, so E2E ran
         as `authMethod: 'apikey'`. The fixtures now use the interactive test path
@@ -230,7 +283,8 @@ Ordered as the design doc's Phase 0/D.
       (`webhook.service.ts:222`) has no unique constraint per endpoint/event, so Inngest
       retries or replayed events can duplicate deliveries. — (design review 2026-07-27)
 - [ ] **[P2] One dead scope left.** `payments:read` is declared in `apiKeyScopeSchema` and
-      enforced nowhere; it needs a decision (P0.5). `webhooks:manage` was consumed by the
+      enforced nowhere. **Decision taken 2026-07-27: remove it** — tracked as P0.5b above,
+      where the removal's real cost is scoped. `webhooks:manage` was consumed by the
       tRPC webhooks router in P0.1b rather than waiting for REST P1.1. —
       (design doc §0.1(e); updated 2026-07-27)
 - [ ] **[P2] REST spec coverage.** Only 7 of 17 REST routers have a `.spec.ts`. —

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -137,7 +137,7 @@ curl http://localhost/health
 | `SMTP_PASS`                  | SMTP password                                                      | (empty)     |
 | `SMTP_FROM`                  | SMTP sender address                                                | (empty)     |
 | `FEDERATION_ENABLED`         | Enable federation features                                         | `false`     |
-| `TRPC_INTERNAL_ONLY_ENFORCE` | Reject API keys on internal-only tRPC routers (`false` = log only) | `false`     |
+| `TRPC_INTERNAL_ONLY_ENFORCE` | Reject API keys on internal-only tRPC routers (`false` = log only) | `true`      |
 | `SENTRY_DSN`                 | Sentry error tracking DSN                                          | (empty)     |
 | `METRICS_ENABLED`            | Enable Prometheus `/metrics`                                       | `false`     |
 


### PR DESCRIPTION
Closes the second half of the tRPC API-key bypass, and fixes the deploy-time disk
leak found while gathering the evidence for it.

## The boundary

`TRPC_INTERNAL_ONLY_ENFORCE` now defaults to `true`. An API key calling any of the
29 procedures on the seven operator-console routers (`federation`, `gdpr`, `hub`,
`migration`, `ops`, `simsub`, `transfer`) gets a 403 rather than being audited and
let through.

The variable is also added to `docker-compose.prod.yml` for both `api` and
`api-demo`. No compose service uses `env_file` and every other variable is listed
explicitly, so until now this one could not be set in a deployed container at all —
the flip would have worked but could not have been reverted without a code change.

## Why the observation window is closed early

The plan of record was to watch `audit_events` for a month before flipping. That
gate is replaced with evidence, which is the stronger instrument here:

- **Staging has never held an API key.** `api_keys` is empty, across an
  `audit_events` history running 2026-04-08 to 2026-07-27, with no `API_KEY_*`
  event of any kind. Not "nothing was logged" — no credential capable of it ever
  existed.
- **No shipped client sends a key to `/trpc/*`.** `packages/api-client` and
  `sdks/typescript` set `X-Api-Key` but are REST-only with no tRPC transport;
  `sdks/python` is generated from the same spec; `scripts/simsub-qa.ts` uses REST
  paths; the web tRPC client sends only interactive credentials.
- **Playwright** authenticates interactively since #515, and passes 16/16 on the
  federation suite under enforcement.
- The events that had accumulated in development were 67 parts test suite
  observing itself — stamped `enforced: true`, i.e. emitted by the tests that pin
  enforced behaviour.

Worth stating plainly what this does **not** show. It is a compatibility
inventory, not a reachability proof: `X-Api-Key` is accepted on every non-public
route, so a hand-rolled request reaches `federation.getConfig` today whether or not
anyone has tried. That argues for enforcing sooner rather than later. What the
inventory establishes is the narrower thing the window was actually meant to
answer — nothing we ship breaks.

Every existing test set the flag explicitly, so none would have caught the default
silently reverting. There is now one that runs with the variable unset and asserts
403; the two cases that asserted the pre-flip behaviour are reframed as coverage of
the log-only revert path, which stays supported.

## The disk leak

Staging filled its 150G disk and was down for several hours — postgres, prometheus,
loki and grafana in restart loops, four consecutive deploys failing on `ENOSPC`.
Both deploy scripts build with `--no-cache`, so each run strands the previous layer
set, and nothing reclaimed them: 218 images (67.5GB reclaimable) plus 1670
build-cache entries (63GB).

Pruning now runs either side of the build, with a pre-build floor of 20G that fails
the job with a clear message instead of dying partway through an install. Build
cache is referenced by nothing and `image prune` retains images held by a container
in any state, so neither can remove something the running stack needs.
`docker system prune` would not be safe: it also removes stopped containers, which
on a half-started host means deleting the containers holding the images needed to
recover.

Staging has been restored — 187GB reclaimed, all containers up, `/ready` returning
200.

## Also here

- Decision recorded to remove the dead `payments:read` scope, filed separately as
  P0.5b. Removal reaches the seeded key and three CI-gated SDK artefacts, and
  `apiKeyResponseSchema` validates `apiKeys.list` output, so a stale row holding the
  scope would throw once the enum drops it.
- Three backlog items from the outage: no disk alerting (the monitoring stack is
  co-located with what it monitors, so it died with the host and could not report
  it), whether `--no-cache` still earns its cost, and whether staging is meant to
  have database backups.

## Verification

- `pnpm type-check`, `pnpm lint` clean
- API unit suite: 1816 passed
- Security integration suite: 28 passed, including the new default-pinning case
