### PR TITLE
fix(ci): compare disk space in bytes, and split the combined E2E run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,9 +141,13 @@ jobs:
             docker image prune -af
             df -h / | tail -1
 
-            AVAIL_G=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
-            if [ "${AVAIL_G:-0}" -lt 20 ]; then
-              echo "::error::Only ${AVAIL_G}G free after pruning; need 20G to build. Investigate before retrying."
+            # Compare bytes, not `df -BG`: that rounds UP, so 19.1GiB free
+            # reports as "20G" and passes a `-lt 20` test — the guard would wave
+            # through exactly the build it exists to stop.
+            AVAIL_B=$(df -B1 --output=avail / | tail -1 | tr -dc '0-9')
+            MIN_B=$((20 * 1024 * 1024 * 1024))
+            if [ "${AVAIL_B:-0}" -lt "$MIN_B" ]; then
+              echo "::error::Only $((${AVAIL_B:-0} / 1024 / 1024 / 1024))G free after pruning; need 20G to build. Investigate before retrying."
               exit 1
             fi
 
@@ -248,9 +252,13 @@ jobs:
             docker image prune -af
             df -h / | tail -1
 
-            AVAIL_G=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
-            if [ "${AVAIL_G:-0}" -lt 20 ]; then
-              echo "::error::Only ${AVAIL_G}G free after pruning; need 20G to build. Investigate before retrying."
+            # Compare bytes, not `df -BG`: that rounds UP, so 19.1GiB free
+            # reports as "20G" and passes a `-lt 20` test — the guard would wave
+            # through exactly the build it exists to stop.
+            AVAIL_B=$(df -B1 --output=avail / | tail -1 | tr -dc '0-9')
+            MIN_B=$((20 * 1024 * 1024 * 1024))
+            if [ "${AVAIL_B:-0}" -lt "$MIN_B" ]; then
+              echo "::error::Only $((${AVAIL_B:-0} / 1024 / 1024 / 1024))G free after pruning; need 20G to build. Investigate before retrying."
               exit 1
             fi
 

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -35,18 +35,26 @@ function getRequestedProjects(): Set<string> {
     }
   }
 
-  // If no --project flag, all projects will run
+  // No --project flag: every project the config exposes will run. The config
+  // partitions those on OIDC_E2E (see playwright.config.ts) because one API
+  // server cannot hold both auth modes at once, so mirror that partition here.
+  // Listing all ten unconditionally would demand infrastructure for suites the
+  // run will not execute — Zitadel for a non-OIDC pass, tusd and Garage for the
+  // OIDC one — and fail the run before a single test executes.
   if (projects.size === 0) {
-    projects.add("submissions");
-    projects.add("uploads");
-    projects.add("oidc");
-    projects.add("embed");
-    projects.add("slate");
-    projects.add("workspace");
-    projects.add("forms");
-    projects.add("organization");
-    projects.add("analytics");
-    projects.add("federation");
+    if (process.env.OIDC_E2E === "true") {
+      projects.add("oidc");
+    } else {
+      projects.add("submissions");
+      projects.add("uploads");
+      projects.add("embed");
+      projects.add("slate");
+      projects.add("workspace");
+      projects.add("forms");
+      projects.add("organization");
+      projects.add("analytics");
+      projects.add("federation");
+    }
   }
 
   return projects;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,7 @@
     "test:e2e:organization": "playwright test --project organization",
     "test:e2e:analytics": "playwright test --project analytics",
     "test:e2e:federation": "playwright test --project federation",
-    "test:e2e:all": "OIDC_E2E=true playwright test",
+    "test:e2e:all": "playwright test && OIDC_E2E=true playwright test",
     "test:e2e:ui": "playwright test --ui",
     "e2e:setup-oidc": "tsx ../../scripts/setup-zitadel-e2e.ts",
     "clean": "rm -rf .next"

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -155,7 +155,15 @@ export default defineConfig({
       testDir: "./e2e/federation",
       use: { ...devices["Desktop Chrome"] },
     },
-  ],
+    // The shared API server can only be in one auth mode at a time (see
+    // webServer below): NODE_ENV=test with the interactive header, or a real
+    // JWKS verifier for the oidc suite. One run cannot host both, so partition
+    // the projects on the same flag that picks the mode. Doing it here rather
+    // than by listing project names in a package script means a newly added
+    // suite is included automatically instead of being silently skipped.
+  ].filter((project) =>
+    isOidcE2e ? project.name === "oidc" : project.name !== "oidc",
+  ),
 
   webServer: [
     {


### PR DESCRIPTION
Two defects, one from each of the previous two merges, found by reviewing those
merges retrospectively.

## The disk guard rounded the wrong way

The pruning added in #516 came with a floor that refuses to build under 20G free.
It read the number with `df -BG`, which **rounds up** — so a host with 19.1GiB
free reports `20G` and passes `-lt 20`. The guard would have waved through
exactly the build it exists to stop.

Verified the rounding direction rather than assuming it: on a host with
153.007GiB actually free, `df -BG` reports `154G`.

Now compares bytes against `20 * 1024^3`. Checked both sides of the boundary —
19.0G fails, 21G passes.

The pruning itself is working. First post-merge deploy reclaimed 110.7MB before
the build and 2.657GB after, and staging is steady at 133G free.

## `test:e2e:all` could not work in either direction

`OIDC_E2E=true playwright test` runs *every* project with the flag set, which
starts the shared API server with a real JWKS verifier instead of `NODE_ENV=test`
and an empty authority. Since #515 the nine non-OIDC suites authenticate with
`x-test-user-id`, which `hooks/auth.ts` accepts only when no verifier exists — so
all nine 401.

Dropping the flag inverts the problem: the `oidc` suite then has no Zitadel
config. One API server cannot hold both auth modes at once, so no single
invocation can cover all ten suites.

Fixed by partitioning the projects on the same flag that selects the auth mode,
so a run only ever contains suites the server can actually authenticate, and
making the script take two passes. Deliberately done in the config rather than by
naming projects in the package script: a list in a script silently omits any
suite added later, which is the failure mode that would recur.

Verified both directions resolve correctly:

- default → the nine interactive suites
- `OIDC_E2E=true` → `oidc` alone
- the ten per-suite scripts still resolve unchanged

CI never used the combined script — it invokes each suite individually — which is
why #515 went green through 22 jobs while leaving this behind.

## Verification

- `pnpm type-check`, `pnpm lint` clean
- `deploy.yml` and `package.json` parse; guard boundary tested both sides
- Playwright project resolution confirmed in both modes

## Also: global-setup prerequisites

Partitioning the projects exposed a third defect. `getRequestedProjects()` in
`e2e/global-setup.ts` falls back to a hardcoded list of all ten projects when no
`--project` flag is present, which no longer matches what a bare `playwright test`
runs.

That meant a prerequisite check for suites the run would not execute: the
non-OIDC pass demanded a reachable Zitadel despite running no OIDC tests, and the
OIDC pass demanded tusd and Garage despite running no upload tests. Either fails
the run before a single test executes.

The fallback now mirrors the same partition. CI is unaffected either way, since it
always passes `--project`.