### PR TITLE
fix(api): scope apiKeyService list/revoke/delete to the caller's org

### DIFF
--- a/apps/api/src/__tests__/rls/api-key-service.test.ts
+++ b/apps/api/src/__tests__/rls/api-key-service.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Defense-in-depth: apiKeyService's explicit organization predicates.
+ *
+ * This suite is the deliberate mirror of `__tests__/security/defense-in-depth.test.ts`,
+ * which proves RLS isolates tenants when a service carries no explicit filter. Here we
+ * prove the other layer: that the explicit filter isolates tenants when RLS is not
+ * there to help.
+ *
+ * That is why every query below runs over the ADMIN pool. It connects as role `test`,
+ * which is `rolsuper = t, rolbypassrls = t`, so RLS does not apply — not even the
+ * `FORCE ROW LEVEL SECURITY` set on `api_keys` by `0008_api_keys_rls.sql`, which binds
+ * the table owner but not a superuser. The only thing separating org A's keys from
+ * org B's in these tests is the `WHERE organization_id = $orgId` clause in the service.
+ *
+ * Consequence: if someone deletes those predicates, this file fails while every other
+ * test in the repo still passes. Do not "fix" it by switching to the app pool — that
+ * reinstates RLS and the suite would pass with or without the predicates, testing
+ * nothing.
+ */
+import crypto from 'node:crypto';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { eq } from 'drizzle-orm';
+import { apiKeys, type Organization, type User } from '@colophony/db';
+import { globalSetup, getAdminPool } from './helpers/db-setup';
+import { truncateAllTables } from './helpers/cleanup';
+import {
+  createOrganization,
+  createUser,
+  createOrgMember,
+} from './helpers/factories';
+import { apiKeyService } from '../../services/api-key.service.js';
+
+type ServiceTx = Parameters<typeof apiKeyService.list>[0];
+
+/**
+ * A Drizzle handle over the RLS-bypassing admin pool, shaped as the `tx` the service
+ * expects. The cast mirrors `helpers/factories.ts` — `@colophony/db` and the test tree
+ * resolve drizzle through different optional peer-dep contexts, so the types diverge
+ * while the runtime is a single copy.
+ */
+function adminTx(): ServiceTx {
+  return drizzle(getAdminPool());
+}
+
+function adminDb(): ReturnType<typeof drizzle> {
+  return drizzle(getAdminPool());
+}
+
+interface SeededKey {
+  id: string;
+  organizationId: string;
+  revokedAt: Date | null;
+}
+
+async function createApiKey(
+  organizationId: string,
+  createdBy: string,
+  name: string,
+): Promise<SeededKey> {
+  const [row] = await adminDb()
+    .insert(apiKeys)
+    .values({
+      organizationId,
+      createdBy,
+      name,
+      // Unique per row — `key_hash` carries a UNIQUE constraint.
+      keyHash: crypto.randomBytes(32).toString('hex'),
+      keyPrefix: 'col_live_',
+      scopes: ['api-keys:read'],
+    })
+    .returning();
+  return row;
+}
+
+/** Read a key back over the admin pool, bypassing RLS — used to assert writes. */
+async function readKey(keyId: string): Promise<SeededKey | null> {
+  const rows = await adminDb()
+    .select()
+    .from(apiKeys)
+    .where(eq(apiKeys.id, keyId));
+  return rows[0] ?? null;
+}
+
+const PAGINATION = { page: 1, limit: 20 };
+
+describe('apiKeyService defense-in-depth (RLS bypassed)', () => {
+  let orgA: Organization;
+  let orgB: Organization;
+  let userA: User;
+  let userB: User;
+  let keyA: SeededKey;
+  let keyB: SeededKey;
+
+  beforeAll(async () => {
+    await globalSetup();
+    await truncateAllTables();
+
+    orgA = await createOrganization({ name: 'Org Alpha' });
+    orgB = await createOrganization({ name: 'Org Beta' });
+    userA = await createUser();
+    userB = await createUser();
+    await createOrgMember(orgA.id, userA.id, { roles: ['ADMIN'] });
+    await createOrgMember(orgB.id, userB.id, { roles: ['ADMIN'] });
+  });
+
+  // Fresh keys per test: revoke/delete mutate, so the cases must not depend on
+  // each other's ordering.
+  beforeEach(async () => {
+    await adminDb().delete(apiKeys);
+    keyA = await createApiKey(orgA.id, userA.id, 'Alpha Key');
+    keyB = await createApiKey(orgB.id, userB.id, 'Beta Key');
+  });
+
+  afterAll(async () => {
+    await truncateAllTables();
+  });
+
+  describe('list', () => {
+    it("returns only the caller's org keys", async () => {
+      const result = await apiKeyService.list(adminTx(), PAGINATION, orgA.id);
+
+      expect(result.items.map((k) => k.id)).toEqual([keyA.id]);
+      expect(result.items.map((k) => k.id)).not.toContain(keyB.id);
+    });
+
+    it('scopes the total count to the org', async () => {
+      // Without a predicate on the count query, `total` reports every org's keys
+      // even when `items` is correctly filtered — the pagination metadata leaks a
+      // row count across tenants.
+      const result = await apiKeyService.list(adminTx(), PAGINATION, orgA.id);
+
+      expect(result.total).toBe(1);
+      expect(result.totalPages).toBe(1);
+    });
+
+    it('never returns keyHash', async () => {
+      const result = await apiKeyService.list(adminTx(), PAGINATION, orgA.id);
+
+      expect(result.items[0]).not.toHaveProperty('keyHash');
+    });
+  });
+
+  describe('revoke', () => {
+    it('returns null for a key in another org and writes nothing', async () => {
+      const result = await apiKeyService.revoke(adminTx(), keyB.id, orgA.id);
+
+      expect(result).toBeNull();
+
+      const stored = await readKey(keyB.id);
+      expect(stored?.revokedAt).toBeNull();
+    });
+
+    it("revokes a key in the caller's own org", async () => {
+      const result = await apiKeyService.revoke(adminTx(), keyA.id, orgA.id);
+
+      expect(result?.id).toBe(keyA.id);
+      expect(result?.revokedAt).toBeInstanceOf(Date);
+
+      const stored = await readKey(keyA.id);
+      expect(stored?.revokedAt).not.toBeNull();
+    });
+  });
+
+  describe('delete', () => {
+    it('returns null for a key in another org and leaves the row in place', async () => {
+      const result = await apiKeyService.delete(adminTx(), keyB.id, orgA.id);
+
+      expect(result).toBeNull();
+      expect(await readKey(keyB.id)).not.toBeNull();
+    });
+
+    it("deletes a key in the caller's own org", async () => {
+      const result = await apiKeyService.delete(adminTx(), keyA.id, orgA.id);
+
+      expect(result?.id).toBe(keyA.id);
+      expect(await readKey(keyA.id)).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/rest/routers/api-keys.spec.ts
+++ b/apps/api/src/rest/routers/api-keys.spec.ts
@@ -134,6 +134,14 @@ describe('api-keys REST router', () => {
       const call = client(apiKeysRouter.list, orgContext(['READER']));
       const result = await call({ page: 1, limit: 20 });
       expect(result.items).toHaveLength(1);
+      // The org ID must reach the service — it carries the explicit tenant
+      // predicate, so a dropped argument silently widens the query to RLS alone.
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.list).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ page: 1, limit: 20 }),
+        ORG_ID,
+      );
     });
 
     it('lists a key holding a scope the enum no longer declares', async () => {
@@ -248,6 +256,12 @@ describe('api-keys REST router', () => {
       const result = await call({ keyId: KEY_ID });
 
       expect(result.id).toBe(KEY_ID);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.revoke).toHaveBeenCalledWith(
+        expect.anything(),
+        KEY_ID,
+        ORG_ID,
+      );
       expect(ctx.audit).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'API_KEY_REVOKED',
@@ -287,6 +301,12 @@ describe('api-keys REST router', () => {
       const result = await call({ keyId: KEY_ID });
 
       expect(result).toEqual({ success: true });
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.delete).toHaveBeenCalledWith(
+        expect.anything(),
+        KEY_ID,
+        ORG_ID,
+      );
       expect(ctx.audit).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'API_KEY_DELETED',

--- a/apps/api/src/rest/routers/api-keys.ts
+++ b/apps/api/src/rest/routers/api-keys.ts
@@ -58,7 +58,7 @@ const list = orgProcedure
   .input(restPaginationQuery)
   .output(paginatedApiKeysSchema)
   .handler(async ({ input, context }) => {
-    return apiKeyService.list(context.dbTx, input);
+    return apiKeyService.list(context.dbTx, input, context.authContext.orgId);
   });
 
 const create = adminProcedure
@@ -105,7 +105,11 @@ const revoke = adminProcedure
   .input(keyIdParam)
   .output(revokeApiKeyResponseSchema)
   .handler(async ({ input, context }) => {
-    const revoked = await apiKeyService.revoke(context.dbTx, input.keyId);
+    const revoked = await apiKeyService.revoke(
+      context.dbTx,
+      input.keyId,
+      context.authContext.orgId,
+    );
     if (!revoked) {
       throw new ORPCError('NOT_FOUND', { message: 'API key not found' });
     }
@@ -130,7 +134,11 @@ const del = adminProcedure
   .input(keyIdParam)
   .output(successResponseSchema)
   .handler(async ({ input, context }) => {
-    const deleted = await apiKeyService.delete(context.dbTx, input.keyId);
+    const deleted = await apiKeyService.delete(
+      context.dbTx,
+      input.keyId,
+      context.authContext.orgId,
+    );
     if (!deleted) {
       throw new ORPCError('NOT_FOUND', { message: 'API key not found' });
     }

--- a/apps/api/src/services/api-key.service.spec.ts
+++ b/apps/api/src/services/api-key.service.spec.ts
@@ -29,7 +29,58 @@ vi.mock('@colophony/db', () => ({
   DrizzleDb: {},
 }));
 
+import { eq, apiKeys } from '@colophony/db';
 import { apiKeyService } from './api-key.service.js';
+
+const LIST_ITEMS = [
+  {
+    id: 'key-1',
+    name: 'Key 1',
+    scopes: ['submissions:read'],
+    keyPrefix: 'col_live_',
+    createdAt: new Date(),
+    expiresAt: null,
+    lastUsedAt: null,
+    revokedAt: null,
+  },
+];
+
+/**
+ * `list()` calls `tx.select()` twice under Promise.all — once for the page, once for
+ * the count — and each chain now carries a `.where()` link. Returning a different
+ * chain per call is what lets both resolve to their own shape.
+ */
+function makeListTx(
+  items: typeof LIST_ITEMS,
+  count: number,
+): Parameters<typeof apiKeyService.list>[0] {
+  let callCount = 0;
+  return {
+    select: vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // Page query: from → where → orderBy → limit → offset
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockResolvedValue(items),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      // Count query: from → where → resolves
+      return {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count }]),
+        }),
+      };
+    }),
+  } as unknown as Parameters<typeof apiKeyService.list>[0];
+}
 
 describe('apiKeyService', () => {
   beforeEach(() => {
@@ -145,7 +196,7 @@ describe('apiKeyService', () => {
           ]),
       } as unknown as Parameters<typeof apiKeyService.revoke>[0];
 
-      const result = await apiKeyService.revoke(mockTx, 'key-1');
+      const result = await apiKeyService.revoke(mockTx, 'key-1', 'org-1');
       expect(result).not.toBeNull();
       expect(result?.revokedAt).toBeInstanceOf(Date);
     });
@@ -158,66 +209,20 @@ describe('apiKeyService', () => {
         returning: vi.fn().mockResolvedValue([]),
       } as unknown as Parameters<typeof apiKeyService.revoke>[0];
 
-      const result = await apiKeyService.revoke(mockTx, 'nonexistent');
+      const result = await apiKeyService.revoke(mockTx, 'nonexistent', 'org-1');
       expect(result).toBeNull();
     });
   });
 
   describe('list', () => {
     it('returns paginated results without keyHash', async () => {
-      const items = [
-        {
-          id: 'key-1',
-          name: 'Key 1',
-          scopes: ['submissions:read'],
-          keyPrefix: 'col_live_',
-          createdAt: new Date(),
-          expiresAt: null,
-          lastUsedAt: null,
-          revokedAt: null,
-        },
-      ];
+      const result = await apiKeyService.list(
+        makeListTx(LIST_ITEMS, 1),
+        { page: 1, limit: 20 },
+        'org-1',
+      );
 
-      const mockTx = {
-        select: vi.fn().mockReturnValue({
-          from: vi.fn().mockReturnValue({
-            orderBy: vi.fn().mockReturnValue({
-              limit: vi.fn().mockReturnValue({
-                offset: vi.fn().mockResolvedValue(items),
-              }),
-            }),
-          }),
-        }),
-      } as unknown as Parameters<typeof apiKeyService.list>[0];
-
-      // Mock the count query — list() calls tx.select() twice via Promise.all
-      // We need to override select to return different chains for the two calls
-      let callCount = 0;
-      (mockTx as unknown as { select: ReturnType<typeof vi.fn> }).select = vi
-        .fn()
-        .mockImplementation(() => {
-          callCount++;
-          if (callCount === 1) {
-            // Items query
-            return {
-              from: vi.fn().mockReturnValue({
-                orderBy: vi.fn().mockReturnValue({
-                  limit: vi.fn().mockReturnValue({
-                    offset: vi.fn().mockResolvedValue(items),
-                  }),
-                }),
-              }),
-            };
-          }
-          // Count query
-          return {
-            from: vi.fn().mockResolvedValue([{ count: 1 }]),
-          };
-        });
-
-      const result = await apiKeyService.list(mockTx, { page: 1, limit: 20 });
-
-      expect(result.items).toEqual(items);
+      expect(result.items).toEqual(LIST_ITEMS);
       expect(result.total).toBe(1);
       expect(result.page).toBe(1);
       expect(result.totalPages).toBe(1);
@@ -225,6 +230,59 @@ describe('apiKeyService', () => {
       for (const item of result.items) {
         expect(item).not.toHaveProperty('keyHash');
       }
+    });
+  });
+
+  /**
+   * These assert the *predicates*, not the results. The mock `tx` returns whatever it
+   * is told regardless of the WHERE clause, so a "wrong org returns null" test here
+   * would pass with the filter removed. Asserting on the mocked `eq()` is what
+   * actually fails when a predicate goes missing.
+   *
+   * The real proof lives in `src/__tests__/rls/api-key-service.test.ts`, which runs
+   * these queries against Postgres over an RLS-bypassing connection.
+   */
+  describe('defense-in-depth: organization predicates', () => {
+    it('list filters both the page and the count query on organization_id', async () => {
+      await apiKeyService.list(
+        makeListTx(LIST_ITEMS, 1),
+        { page: 1, limit: 20 },
+        'org-1',
+      );
+
+      const orgPredicates = vi
+        .mocked(eq)
+        .mock.calls.filter(
+          ([col, val]) => col === apiKeys.organizationId && val === 'org-1',
+        );
+      // Twice: once for the page query, once for the count query. A count query
+      // without the predicate reports every org's key total.
+      expect(orgPredicates).toHaveLength(2);
+    });
+
+    it('revoke filters on organization_id', async () => {
+      const mockTx = {
+        update: vi.fn().mockReturnThis(),
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([]),
+      } as unknown as Parameters<typeof apiKeyService.revoke>[0];
+
+      await apiKeyService.revoke(mockTx, 'key-1', 'org-1');
+
+      expect(eq).toHaveBeenCalledWith(apiKeys.organizationId, 'org-1');
+    });
+
+    it('delete filters on organization_id', async () => {
+      const mockTx = {
+        delete: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([]),
+      } as unknown as Parameters<typeof apiKeyService.delete>[0];
+
+      await apiKeyService.delete(mockTx, 'key-1', 'org-1');
+
+      expect(eq).toHaveBeenCalledWith(apiKeys.organizationId, 'org-1');
     });
   });
 });

--- a/apps/api/src/services/api-key.service.ts
+++ b/apps/api/src/services/api-key.service.ts
@@ -65,10 +65,13 @@ export const apiKeyService = {
   },
 
   /**
-   * List API keys for the current org (RLS handles filtering).
-   * Never returns keyHash.
+   * List API keys for an org. Filters on organizationId explicitly, with RLS as the
+   * backstop rather than the only defence. Never returns keyHash.
+   *
+   * The count query carries the predicate too — without it, `total` reports every
+   * org's key count while `items` is correctly scoped.
    */
-  async list(tx: DrizzleDb, pagination: PaginationInput) {
+  async list(tx: DrizzleDb, pagination: PaginationInput, orgId: string) {
     const { page, limit } = pagination;
     const offset = (page - 1) * limit;
 
@@ -85,10 +88,14 @@ export const apiKeyService = {
           revokedAt: apiKeys.revokedAt,
         })
         .from(apiKeys)
+        .where(eq(apiKeys.organizationId, orgId))
         .orderBy(apiKeys.createdAt)
         .limit(limit)
         .offset(offset),
-      tx.select({ count: sql<number>`count(*)::int` }).from(apiKeys),
+      tx
+        .select({ count: sql<number>`count(*)::int` })
+        .from(apiKeys)
+        .where(eq(apiKeys.organizationId, orgId)),
     ]);
 
     const total = countResult[0]?.count ?? 0;
@@ -103,34 +110,14 @@ export const apiKeyService = {
   },
 
   /**
-   * Get a single API key by ID. RLS scoped.
+   * Revoke an API key by setting revokedAt. Scoped to the org explicitly, so a key
+   * belonging to another org returns null rather than being revoked.
    */
-  async getById(tx: DrizzleDb, keyId: string) {
-    const [row] = await tx
-      .select({
-        id: apiKeys.id,
-        name: apiKeys.name,
-        scopes: apiKeys.scopes,
-        keyPrefix: apiKeys.keyPrefix,
-        createdAt: apiKeys.createdAt,
-        expiresAt: apiKeys.expiresAt,
-        lastUsedAt: apiKeys.lastUsedAt,
-        revokedAt: apiKeys.revokedAt,
-      })
-      .from(apiKeys)
-      .where(eq(apiKeys.id, keyId))
-      .limit(1);
-    return row ?? null;
-  },
-
-  /**
-   * Revoke an API key by setting revokedAt.
-   */
-  async revoke(tx: DrizzleDb, keyId: string) {
+  async revoke(tx: DrizzleDb, keyId: string, orgId: string) {
     const [updated] = await tx
       .update(apiKeys)
       .set({ revokedAt: new Date() })
-      .where(and(eq(apiKeys.id, keyId)))
+      .where(and(eq(apiKeys.id, keyId), eq(apiKeys.organizationId, orgId)))
       .returning({
         id: apiKeys.id,
         name: apiKeys.name,
@@ -140,12 +127,12 @@ export const apiKeyService = {
   },
 
   /**
-   * Hard delete an API key.
+   * Hard delete an API key. Scoped to the org explicitly.
    */
-  async delete(tx: DrizzleDb, keyId: string) {
+  async delete(tx: DrizzleDb, keyId: string, orgId: string) {
     const [deleted] = await tx
       .delete(apiKeys)
-      .where(eq(apiKeys.id, keyId))
+      .where(and(eq(apiKeys.id, keyId), eq(apiKeys.organizationId, orgId)))
       .returning({ id: apiKeys.id });
     return deleted ?? null;
   },

--- a/apps/api/src/trpc/routers/api-keys.spec.ts
+++ b/apps/api/src/trpc/routers/api-keys.spec.ts
@@ -84,7 +84,13 @@ describe('apiKeys router', () => {
       const result = await caller.apiKeys.list({ page: 1, limit: 20 });
 
       expect(result).toEqual(keys);
-      expect(mockApiKeyService.list).toHaveBeenCalledOnce();
+      // The org ID must reach the service — it carries the explicit tenant
+      // predicate, so a dropped argument silently widens the query to RLS alone.
+      expect(mockApiKeyService.list).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ page: 1, limit: 20 }),
+        'org-1',
+      );
     });
 
     it('lists a key holding a scope the enum no longer declares', async () => {
@@ -213,6 +219,11 @@ describe('apiKeys router', () => {
       });
 
       expect(result.revokedAt).toBeInstanceOf(Date);
+      expect(mockApiKeyService.revoke).toHaveBeenCalledWith(
+        expect.anything(),
+        'a1111111-1111-1111-a111-111111111111',
+        'org-1',
+      );
       expect(ctx.audit).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'API_KEY_REVOKED',
@@ -256,6 +267,11 @@ describe('apiKeys router', () => {
       });
 
       expect(result).toEqual({ success: true });
+      expect(mockApiKeyService.delete).toHaveBeenCalledWith(
+        expect.anything(),
+        'a1111111-1111-1111-a111-111111111111',
+        'org-1',
+      );
       expect(ctx.audit).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'API_KEY_DELETED',

--- a/apps/api/src/trpc/routers/api-keys.ts
+++ b/apps/api/src/trpc/routers/api-keys.ts
@@ -30,7 +30,7 @@ export const apiKeysRouter = createRouter({
     .output(paginatedResponseSchema(apiKeyResponseSchema))
     .query(
       async ({ ctx, input }): Promise<PaginatedResponse<ApiKeyResponse>> => {
-        return apiKeyService.list(ctx.dbTx, input);
+        return apiKeyService.list(ctx.dbTx, input, ctx.authContext.orgId);
       },
     ),
 
@@ -59,7 +59,11 @@ export const apiKeysRouter = createRouter({
     .input(revokeApiKeySchema)
     .output(revokeApiKeyResponseSchema)
     .mutation(async ({ ctx, input }) => {
-      const revoked = await apiKeyService.revoke(ctx.dbTx, input.keyId);
+      const revoked = await apiKeyService.revoke(
+        ctx.dbTx,
+        input.keyId,
+        ctx.authContext.orgId,
+      );
       if (!revoked) {
         throw new TRPCError({
           code: 'NOT_FOUND',
@@ -79,7 +83,11 @@ export const apiKeysRouter = createRouter({
     .input(deleteApiKeySchema)
     .output(successResponseSchema)
     .mutation(async ({ ctx, input }) => {
-      const deleted = await apiKeyService.delete(ctx.dbTx, input.keyId);
+      const deleted = await apiKeyService.delete(
+        ctx.dbTx,
+        input.keyId,
+        ctx.authContext.orgId,
+      );
       if (!deleted) {
         throw new TRPCError({
           code: 'NOT_FOUND',

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -291,17 +291,33 @@ Ordered as the design doc's Phase 0/D.
 - [ ] **[P2] No dedup constraint on `webhook_deliveries`.** `createDelivery`
       (`webhook.service.ts:222`) has no unique constraint per endpoint/event, so Inngest
       retries or replayed events can duplicate deliveries. — (design review 2026-07-27)
-- [ ] **[P1] `apiKeyService` carries no explicit `organizationId` predicate.** `list`
+- [x] **[P1] `apiKeyService` carries no explicit `organizationId` predicate.** `list`
       (`apps/api/src/services/api-key.service.ts:71`), `revoke` (`:129`) and `delete`
-      (`:145`) rely on RLS alone, and no caller passes an org ID
+      (`:145`) relied on RLS alone, and no caller passed an org ID
       (`apps/api/src/rest/routers/api-keys.ts:61,108,133`). `revoke`'s
       `where(and(eq(apiKeys.id, keyId)))` — a single condition wrapped in `and()` —
-      reads like a filter that was removed rather than never added. This is the one
-      place the defense-in-depth rule for tenant queries is unmet: RLS is doing the
-      whole job, so a context-setting bug degrades straight to cross-tenant access
+      read like a filter that was removed rather than never added. This was the one
+      place the defense-in-depth rule for tenant queries was unmet: RLS was doing the
+      whole job, so a context-setting bug degraded straight to cross-tenant access
       with nothing behind it. Pre-existing; deliberately left out of P0.5b so a
       multi-tenancy change would not ride inside a scope cleanup —
-      (found 2026-07-28 while removing `payments:read`)
+      (found 2026-07-28 while removing `payments:read`; done 2026-07-28)
+      All three now take a required `orgId` and filter on it, matching the house
+      `(tx, id|input, orgId)` convention. **`getById` was deleted rather than fixed** —
+      it had zero callers and zero tests, and was the one method returning a full key
+      row by ID with no org predicate; less surface beats more.
+      **The count query needed the predicate too**, which is the easy half to miss:
+      with only the page query filtered, `items` is correct while `total` reports every
+      org's key count.
+      **Verification is the point of this one.** Both existing router specs mock the
+      service outright and the service spec stubs `eq`/`and` to identity functions, so
+      before this change all 35 tests passed with or without a predicate. The new
+      `apps/api/src/__tests__/rls/api-key-service.test.ts` runs the service over the
+      **admin pool** (`rolsuper`/`rolbypassrls`), where RLS — including the `FORCE` set
+      by `0008_api_keys_rls.sql` — does not apply, so the `WHERE` clause is the only
+      thing isolating tenants. It failed 4/7 on the pre-change tree. It is the
+      deliberate mirror of `__tests__/security/defense-in-depth.test.ts`, which proves
+      the opposite direction; do not "fix" it by switching to the app pool.
 - [ ] **[P3] `apiKeysContract.revoke` has drifted from its handler.** The contract
       declares `apiKeyResponseSchema` (`packages/api-contracts/src/api-keys.ts:77`)
       while the procedure returns `revokeApiKeyResponseSchema` — a full key object


### PR DESCRIPTION
## Summary

`apiKeyService.list`, `revoke` and `delete` carried no organization predicate, so
tenant isolation on the credential table rested entirely on RLS. Our
multi-tenancy rules require an explicit `WHERE organization_id = orgId` behind
RLS for exactly this reason — a context-setting bug otherwise degrades straight
to cross-tenant access with nothing behind it.

All three now take a required `orgId`, following the `(tx, id|input, orgId)`
order used across the service layer. `revoke`'s `where(and(eq(apiKeys.id, keyId)))`
— a single condition wrapped in a no-op `and()` — becomes a real conjunction.

Two details worth flagging:

- **`list` filters its count query too.** With only the page query scoped,
  `items` is correct while `total` reports every organization's key count.
- **`getById` is removed rather than fixed.** No callers, no tests, and it was
  the one method returning a full key row by ID with no org predicate.

`create` is unchanged — it already wrote `organizationId` explicitly, so
reordering its arguments would be churn without a safety gain. `verifyKey` and
`touchLastUsed` are also unchanged: they resolve a key *before* its organization
is known, which is why they run through SECURITY DEFINER functions.

No contract, schema or SDK changes, and no migration — this is a query-layer
change only.

## Why the new test matters

Before this change, **all 35 existing tests passed with or without a predicate**.
Both router specs mock the service outright, and the service spec stubs
`eq`/`and` to identity functions, so nothing anywhere asserted a `WHERE` clause.
Adding the predicates would have been invisible to the suite — and so would
removing them again later.

`apps/api/src/__tests__/rls/api-key-service.test.ts` closes that. It drives the
service over the **admin connection**, which is `rolsuper`/`rolbypassrls`, so RLS
does not apply — not even the `FORCE ROW LEVEL SECURITY` set on `api_keys` by
`0008_api_keys_rls.sql`, which binds the table owner but not a superuser. The
`WHERE` clause is therefore the only thing separating one org's keys from
another's.

Run against the unmodified service, it fails 4 of 7; the 3 that pass are the ones
that do not depend on the predicate. It is the deliberate mirror of
`__tests__/security/defense-in-depth.test.ts`, which proves RLS holds when a
predicate is absent. Switching it to the app pool would make it pass either way
and test nothing.

## Verification

| Check | Result |
| --- | --- |
| `pnpm --filter @colophony/api test:rls` | 138 passed / 13 files |
| `pnpm --filter @colophony/api test:security` | 28 passed |
| `pnpm test` (workspace) | 12/12 tasks green |
| api-key specs (service + REST + tRPC) | 38 passed |
| `pnpm type-check` / `pnpm lint` | clean |

Router specs were also tightened to assert the org ID is actually forwarded —
they previously asserted only call count or return value, so a dropped argument
would have gone unnoticed.

Closes the P1 item filed on 2026-07-28 while removing `payments:read`, which was
deliberately kept out of #520 so a multi-tenancy change would not ride inside a
scope cleanup.
