### PR TITLE
fix(api): revalidate webhook endpoints before every delivery attempt

### DIFF
--- a/apps/api/src/__tests__/queues/webhook.queue.test.ts
+++ b/apps/api/src/__tests__/queues/webhook.queue.test.ts
@@ -68,7 +68,8 @@ import {
   createWebhookEndpoint,
   createWebhookDelivery,
 } from './helpers/queue-factories';
-import { webhookDeliveries, eq } from '@colophony/db';
+import crypto from 'node:crypto';
+import { webhookDeliveries, webhookEndpoints, eq } from '@colophony/db';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { getAdminPool } from '../rls/helpers/db-setup';
 
@@ -104,17 +105,12 @@ describe('webhook queue integration', () => {
     mockAuditLog.mockResolvedValue(undefined);
   });
 
-  function buildJobData(
-    orgId: string,
-    deliveryId: string,
-    endpointUrl: string,
-    secret: string,
-  ): WebhookJobData {
+  // The job carries no endpoint URL or secret — the worker reads both from the
+  // database immediately before each send.
+  function buildJobData(orgId: string, deliveryId: string): WebhookJobData {
     return {
       deliveryId,
       orgId,
-      endpointUrl,
-      secret,
       payload: {
         id: deliveryId,
         event: 'submission.created',
@@ -136,12 +132,7 @@ describe('webhook queue integration', () => {
       async () => new Response('OK', { status: 200 }),
     );
 
-    const jobData = buildJobData(
-      org.id,
-      delivery.id,
-      endpoint.url,
-      endpoint.secret,
-    );
+    const jobData = buildJobData(org.id, delivery.id);
     await queue.add('deliver', jobData, { jobId: delivery.id });
     await waitForJobCompletion(queue, delivery.id);
 
@@ -172,12 +163,7 @@ describe('webhook queue integration', () => {
       return new Response('OK', { status: 200 });
     });
 
-    const jobData = buildJobData(
-      org.id,
-      delivery.id,
-      endpoint.url,
-      endpoint.secret,
-    );
+    const jobData = buildJobData(org.id, delivery.id);
     await queue.add('deliver', jobData, {
       jobId: delivery.id,
       attempts: 2,
@@ -206,12 +192,7 @@ describe('webhook queue integration', () => {
       async () => new Response('Server Error', { status: 500 }),
     );
 
-    const jobData = buildJobData(
-      org.id,
-      delivery.id,
-      endpoint.url,
-      endpoint.secret,
-    );
+    const jobData = buildJobData(org.id, delivery.id);
     await queue.add('deliver', jobData, {
       jobId: delivery.id,
       attempts: 1,
@@ -244,12 +225,7 @@ describe('webhook queue integration', () => {
       new Error('URL validation failed: hostname resolves to private IP'),
     );
 
-    const jobData = buildJobData(
-      org.id,
-      delivery.id,
-      endpoint.url,
-      endpoint.secret,
-    );
+    const jobData = buildJobData(org.id, delivery.id);
     await queue.add('deliver', jobData, { jobId: delivery.id });
     // SSRF failures don't throw — job completes (returns early, permanent fail)
     await waitForJobCompletion(queue, delivery.id);
@@ -264,5 +240,161 @@ describe('webhook queue integration', () => {
     expect(updated.errorMessage).toContain('URL validation');
     // fetch should NOT have been called
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  describe('pre-send re-validation', () => {
+    it('cancels a queued delivery when the endpoint is disabled mid-flight', async () => {
+      const org = await createOrganization();
+      const user = await createUser();
+      await createOrgMember(org.id, user.id);
+      const endpoint = await createWebhookEndpoint(org.id);
+      const delivery = await createWebhookDelivery(org.id, endpoint.id);
+
+      const db = adminDb();
+      // Disable AFTER the delivery row exists — i.e. while the job is queued.
+      await db
+        .update(webhookEndpoints)
+        .set({ status: 'DISABLED' })
+        .where(eq(webhookEndpoints.id, endpoint.id));
+
+      await queue.add('deliver', buildJobData(org.id, delivery.id), {
+        jobId: delivery.id,
+      });
+      await waitForJobCompletion(queue, delivery.id);
+
+      const [updated] = await db
+        .select()
+        .from(webhookDeliveries)
+        .where(eq(webhookDeliveries.id, delivery.id));
+
+      expect(updated.status).toBe('CANCELLED');
+      expect(updated.errorMessage).toContain('disabled');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('cancels when the endpoint no longer subscribes to the event', async () => {
+      const org = await createOrganization();
+      const user = await createUser();
+      await createOrgMember(org.id, user.id);
+      const endpoint = await createWebhookEndpoint(org.id);
+      const delivery = await createWebhookDelivery(org.id, endpoint.id);
+
+      const db = adminDb();
+      // Unsubscribe from submission.created, which buildJobData sends.
+      await db
+        .update(webhookEndpoints)
+        .set({ eventTypes: ['submission.updated'] })
+        .where(eq(webhookEndpoints.id, endpoint.id));
+
+      await queue.add('deliver', buildJobData(org.id, delivery.id), {
+        jobId: delivery.id,
+      });
+      await waitForJobCompletion(queue, delivery.id);
+
+      const [updated] = await db
+        .select()
+        .from(webhookDeliveries)
+        .where(eq(webhookDeliveries.id, delivery.id));
+
+      expect(updated.status).toBe('CANCELLED');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('a retry after cancellation actually re-runs, despite the retained job id', async () => {
+      const org = await createOrganization();
+      const user = await createUser();
+      await createOrgMember(org.id, user.id);
+      const endpoint = await createWebhookEndpoint(org.id);
+      const delivery = await createWebhookDelivery(org.id, endpoint.id);
+
+      const db = adminDb();
+      await db
+        .update(webhookEndpoints)
+        .set({ status: 'DISABLED' })
+        .where(eq(webhookEndpoints.id, endpoint.id));
+
+      await queue.add('deliver', buildJobData(org.id, delivery.id), {
+        jobId: delivery.id,
+      });
+      await waitForJobCompletion(queue, delivery.id);
+
+      // Re-enable and re-add with the SAME jobId, exactly as retryDelivery does.
+      await db
+        .update(webhookEndpoints)
+        .set({ status: 'ACTIVE' })
+        .where(eq(webhookEndpoints.id, endpoint.id));
+      await db
+        .update(webhookDeliveries)
+        .set({ status: 'QUEUED' })
+        .where(eq(webhookDeliveries.id, delivery.id));
+
+      mockFetch.mockImplementation(
+        async () => new Response('OK', { status: 200 }),
+      );
+
+      // A plain re-add is deduped against the retained completed job and never runs;
+      // the retry helper drops it first. Exercise the helper's semantics here.
+      await queue.remove(delivery.id).catch(() => undefined);
+      await queue.add('deliver', buildJobData(org.id, delivery.id), {
+        jobId: delivery.id,
+      });
+      await waitForJobCompletion(queue, delivery.id);
+
+      const [after] = await db
+        .select()
+        .from(webhookDeliveries)
+        .where(eq(webhookDeliveries.id, delivery.id));
+
+      expect(after.status).toBe('DELIVERED');
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it('signs with the rotated secret and posts to the edited URL, not the enqueued ones', async () => {
+      const org = await createOrganization();
+      const user = await createUser();
+      await createOrgMember(org.id, user.id);
+      const endpoint = await createWebhookEndpoint(org.id);
+      const delivery = await createWebhookDelivery(org.id, endpoint.id);
+
+      const db = adminDb();
+      // Rotate both AFTER enqueue — a job carrying stale values could not know these.
+      await db
+        .update(webhookEndpoints)
+        .set({
+          url: 'https://rotated.example.com/hook',
+          secret: 'rotated-secret-value',
+        })
+        .where(eq(webhookEndpoints.id, endpoint.id));
+
+      mockFetch.mockImplementation(
+        async () => new Response('OK', { status: 200 }),
+      );
+
+      const jobData = buildJobData(org.id, delivery.id);
+      await queue.add('deliver', jobData, { jobId: delivery.id });
+      await waitForJobCompletion(queue, delivery.id);
+
+      const expectedSig =
+        'sha256=' +
+        crypto
+          .createHmac('sha256', 'rotated-secret-value')
+          .update(JSON.stringify(jobData.payload))
+          .digest('hex');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://rotated.example.com/hook',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Webhook-Signature': expectedSig,
+          }),
+        }),
+      );
+
+      const [updated] = await db
+        .select()
+        .from(webhookDeliveries)
+        .where(eq(webhookDeliveries.id, delivery.id));
+      expect(updated.status).toBe('DELIVERED');
+    });
   });
 });

--- a/apps/api/src/__tests__/security/ssrf-validation.test.ts
+++ b/apps/api/src/__tests__/security/ssrf-validation.test.ts
@@ -192,4 +192,34 @@ describe('SSRF validation — federation services', () => {
       expect(validateIdx).toBeLessThan(fetchIdx);
     });
   });
+
+  describe('webhook.worker.ts', () => {
+    const fp = path.join(workersDir, 'webhook.worker.ts');
+
+    it('imports validateOutboundUrl', () => {
+      expect(importsValidation(fp)).toBe(true);
+    });
+
+    it('delivery fetch has upstream SSRF check', () => {
+      const source = fs.readFileSync(fp, 'utf8');
+      const validateIdx = source.indexOf('await validateOutboundUrl(');
+      const fetchIdx = source.indexOf('await fetch(');
+      expect(validateIdx).toBeGreaterThan(-1);
+      expect(fetchIdx).toBeGreaterThan(-1);
+      expect(validateIdx).toBeLessThan(fetchIdx);
+    });
+
+    it('validates the endpoint URL re-read from the database, not the job payload', () => {
+      const source = fs.readFileSync(fp, 'utf8');
+      // The URL must be resolved from the endpoint row before it is validated,
+      // otherwise a stale job payload could carry a URL past the SSRF check.
+      const lookupIdx = source.indexOf('getEndpointForDelivery(');
+      const validateIdx = source.indexOf('await validateOutboundUrl(');
+      expect(lookupIdx).toBeGreaterThan(-1);
+      expect(lookupIdx).toBeLessThan(validateIdx);
+      // And the job payload must no longer carry a URL or secret at all.
+      expect(source).not.toMatch(/job\.data\.endpointUrl/);
+      expect(source).not.toMatch(/job\.data\.secret/);
+    });
+  });
 });

--- a/apps/api/src/inngest/functions/__tests__/webhook-delivery.spec.ts
+++ b/apps/api/src/inngest/functions/__tests__/webhook-delivery.spec.ts
@@ -120,5 +120,18 @@ describe('webhookDelivery Inngest function', () => {
     expect(result).toEqual({ delivered: 2 });
     expect(mockCreateDelivery).toHaveBeenCalledTimes(2);
     expect(mockEnqueueWebhook).toHaveBeenCalledTimes(2);
+
+    // The endpoint URL and secret must not ride along in the job — the worker
+    // re-reads both at send time, so a rotated secret cannot be replayed.
+    for (const call of mockEnqueueWebhook.mock.calls) {
+      const jobData = call[1] as Record<string, unknown>;
+      expect(jobData).not.toHaveProperty('secret');
+      expect(jobData).not.toHaveProperty('endpointUrl');
+      expect(Object.keys(jobData).sort()).toEqual([
+        'deliveryId',
+        'orgId',
+        'payload',
+      ]);
+    }
   });
 });

--- a/apps/api/src/inngest/functions/webhook-delivery.ts
+++ b/apps/api/src/inngest/functions/webhook-delivery.ts
@@ -63,8 +63,6 @@ export const webhookDelivery: InngestFunction.Any = inngest.createFunction(
         await enqueueWebhook(env, {
           deliveryId: delivery.id,
           orgId,
-          endpointUrl: endpoint.url,
-          secret: endpoint.secret,
           payload,
         });
       }

--- a/apps/api/src/queues/__tests__/webhook.queue.spec.ts
+++ b/apps/api/src/queues/__tests__/webhook.queue.spec.ts
@@ -41,18 +41,16 @@ describe('webhook queue', () => {
     await enqueueWebhook(testEnv, {
       deliveryId: 'del-123',
       orgId: 'org-1',
-      endpointUrl: 'https://example.com/webhook',
-      secret: 'test-secret',
       payload,
     });
 
+    // The endpoint URL and secret are deliberately absent — the worker reads both
+    // from the database at send time so they never sit in Redis.
     expect(mockAdd).toHaveBeenCalledWith(
       'deliver',
       {
         deliveryId: 'del-123',
         orgId: 'org-1',
-        endpointUrl: 'https://example.com/webhook',
-        secret: 'test-secret',
         payload,
       },
       { jobId: 'del-123' },
@@ -64,8 +62,6 @@ describe('webhook queue', () => {
     await enqueueWebhook(testEnv, {
       deliveryId: 'del-456',
       orgId: 'org-1',
-      endpointUrl: 'https://example.com',
-      secret: 'secret',
       payload: {
         id: 'del-456',
         event: 'webhook.test',

--- a/apps/api/src/queues/webhook.queue.ts
+++ b/apps/api/src/queues/webhook.queue.ts
@@ -9,11 +9,15 @@ export interface WebhookPayload {
   data: Record<string, unknown>;
 }
 
+/**
+ * The endpoint URL and signing secret are deliberately NOT carried here. The worker
+ * re-reads both from the database immediately before every send, so a rotated secret or
+ * an edited URL cannot be replayed out of a job that has been sitting in Redis (retries
+ * back off to 1h, and `removeOnFail` keeps failed jobs for 7 days).
+ */
 export interface WebhookJobData {
   deliveryId: string;
   orgId: string;
-  endpointUrl: string;
-  secret: string;
   payload: WebhookPayload;
 }
 
@@ -56,6 +60,26 @@ export async function enqueueWebhook(
   data: WebhookJobData,
 ): Promise<void> {
   await getQueue(env).add('deliver', data, { jobId: data.deliveryId });
+}
+
+/**
+ * Enqueue an operator-initiated retry of an existing delivery.
+ *
+ * `jobId` is the delivery id, and BullMQ treats a re-added jobId as a duplicate for as
+ * long as the previous job is retained — 24h for completed (`removeOnComplete`), 7 days
+ * for failed. Every terminal state a retry is offered from leaves such a job behind:
+ * FAILED exhausts its attempts, and CANCELLED / permanent-SSRF-failure return
+ * successfully. Re-adding alone therefore sets the row back to QUEUED and then never
+ * runs. Drop the retained job first so the retry actually executes.
+ */
+export async function enqueueWebhookRetry(
+  env: Env,
+  data: WebhookJobData,
+): Promise<void> {
+  const q = getQueue(env);
+  // Returns 0 if the job is gone or currently active; neither is an error here.
+  await q.remove(data.deliveryId).catch(() => undefined);
+  await q.add('deliver', data, { jobId: data.deliveryId });
 }
 
 export function getWebhookQueueInstance(): Queue<WebhookJobData> | null {

--- a/apps/api/src/services/webhook.service.spec.ts
+++ b/apps/api/src/services/webhook.service.spec.ts
@@ -26,6 +26,9 @@ vi.mock('@colophony/db', () => {
     },
     webhookDeliveries: {
       id: 'id',
+      // Distinct from the endpoint's column stub so tests can assert that the
+      // org predicate is applied to BOTH tables in a join, not just one.
+      organizationId: 'delivery_organization_id',
       webhookEndpointId: 'webhook_endpoint_id',
       eventType: 'event_type',
       status: 'status',
@@ -198,6 +201,56 @@ describe('webhookService', () => {
     expect(andArgs[0]).toEqual({
       type: 'eq',
       args: ['organization_id', orgId],
+    });
+  });
+
+  describe('getEndpointForDelivery', () => {
+    function mockJoinTx(rows: unknown[]) {
+      const mockLimit = vi.fn().mockResolvedValue(rows);
+      const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+      const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+      const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+      return { select: mockSelect } as never;
+    }
+
+    it('filters on the delivery id and the org id of BOTH tables', async () => {
+      const tx = mockJoinTx([]);
+
+      await webhookService.getEndpointForDelivery(tx, 'del-1', 'org-123');
+
+      expect(eqFn).toHaveBeenCalledWith('id', 'del-1');
+      // The org predicate must be applied to the delivery AND the endpoint —
+      // the FK guarantees the endpoint exists, not that it shares the org.
+      expect(eqFn).toHaveBeenCalledWith('delivery_organization_id', 'org-123');
+      expect(eqFn).toHaveBeenCalledWith('organization_id', 'org-123');
+    });
+
+    it('returns null when the join yields no row', async () => {
+      const tx = mockJoinTx([]);
+      await expect(
+        webhookService.getEndpointForDelivery(tx, 'del-1', 'org-123'),
+      ).resolves.toBeNull();
+    });
+
+    it('returns the unredacted secret so the worker can sign', async () => {
+      const tx = mockJoinTx([
+        {
+          endpointId: 'ep-1',
+          url: 'https://example.com/hook',
+          secret: 'live-secret',
+          status: 'ACTIVE',
+          eventTypes: ['submission.created'],
+        },
+      ]);
+
+      const row = await webhookService.getEndpointForDelivery(
+        tx,
+        'del-1',
+        'org-123',
+      );
+
+      expect(row?.secret).toBe('live-secret');
     });
   });
 });

--- a/apps/api/src/services/webhook.service.ts
+++ b/apps/api/src/services/webhook.service.ts
@@ -20,6 +20,13 @@ export class WebhookUrlValidationError extends Error {
   }
 }
 
+/**
+ * Derived from the schema enum rather than hand-written, so adding a value to
+ * `webhookDeliveryStatusEnum` cannot leave this union silently behind.
+ */
+export type WebhookDeliveryStatus =
+  (typeof webhookDeliveries.status.enumValues)[number];
+
 interface CreateEndpointParams {
   organizationId: string;
   url: string;
@@ -46,7 +53,7 @@ interface ListDeliveriesParams {
   organizationId?: string;
   endpointId?: string;
   eventType?: string;
-  status?: 'QUEUED' | 'DELIVERING' | 'DELIVERED' | 'FAILED';
+  status?: WebhookDeliveryStatus;
   page: number;
   limit: number;
 }
@@ -219,6 +226,49 @@ export const webhookService = {
       );
   },
 
+  /**
+   * Resolve the endpoint a queued delivery belongs to, for re-validation at send time.
+   *
+   * Deliberately NOT redacted — the worker needs the current signing secret, so this
+   * cannot reuse `getEndpoint`, which strips `secret` from both the value and the type.
+   * Same posture as `rotateSecret` and `getActiveEndpointsForEvent`.
+   *
+   * Filters `organizationId` on BOTH tables. The FK guarantees the endpoint exists, not
+   * that it shares the delivery's org, so this join is the only explicit org-affinity
+   * check between the two.
+   *
+   * Returns null when the endpoint has been deleted: the delivery row is removed with it
+   * via ON DELETE CASCADE, so there is nothing left to mark.
+   */
+  async getEndpointForDelivery(
+    tx: DrizzleDb,
+    deliveryId: string,
+    organizationId: string,
+  ) {
+    const [row] = await tx
+      .select({
+        endpointId: webhookEndpoints.id,
+        url: webhookEndpoints.url,
+        secret: webhookEndpoints.secret,
+        status: webhookEndpoints.status,
+        eventTypes: webhookEndpoints.eventTypes,
+      })
+      .from(webhookDeliveries)
+      .innerJoin(
+        webhookEndpoints,
+        eq(webhookDeliveries.webhookEndpointId, webhookEndpoints.id),
+      )
+      .where(
+        and(
+          eq(webhookDeliveries.id, deliveryId),
+          eq(webhookDeliveries.organizationId, organizationId),
+          eq(webhookEndpoints.organizationId, organizationId),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  },
+
   async createDelivery(tx: DrizzleDb, params: CreateDeliveryParams) {
     const [row] = await tx
       .insert(webhookDeliveries)
@@ -237,7 +287,7 @@ export const webhookService = {
   async updateDeliveryStatus(
     tx: DrizzleDb,
     id: string,
-    status: 'QUEUED' | 'DELIVERING' | 'DELIVERED' | 'FAILED',
+    status: WebhookDeliveryStatus,
     params?: {
       httpStatusCode?: number;
       responseBody?: string;

--- a/apps/api/src/trpc/routers/webhooks.spec.ts
+++ b/apps/api/src/trpc/routers/webhooks.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the service
 const mockCreateEndpoint = vi.fn();
@@ -11,6 +11,7 @@ const mockCreateDelivery = vi.fn();
 const mockListDeliveries = vi.fn();
 const mockRetryDelivery = vi.fn();
 const mockGetActiveEndpointsForEvent = vi.fn();
+const mockGetEndpointForDelivery = vi.fn();
 
 vi.mock('../../services/webhook.service.js', () => ({
   webhookService: {
@@ -25,11 +26,14 @@ vi.mock('../../services/webhook.service.js', () => ({
     retryDelivery: (...args: unknown[]) => mockRetryDelivery(...args),
     getActiveEndpointsForEvent: (...args: unknown[]) =>
       mockGetActiveEndpointsForEvent(...args),
+    getEndpointForDelivery: (...args: unknown[]) =>
+      mockGetEndpointForDelivery(...args),
   },
 }));
 
 vi.mock('../../queues/webhook.queue.js', () => ({
   enqueueWebhook: vi.fn(),
+  enqueueWebhookRetry: vi.fn(),
 }));
 
 vi.mock('../../config/env.js', () => ({
@@ -46,14 +50,21 @@ vi.mock('@colophony/db', () => ({
   and: vi.fn(),
 }));
 
-// Mock tRPC init with a passthrough stub
+// Mock tRPC init with a passthrough stub. `query`/`mutation` terminate the chain by
+// returning a marker that carries the resolver, so tests can drive the real handler
+// instead of only asserting that the procedure exists.
+type Resolver = (opts: {
+  ctx: Record<string, unknown>;
+  input: Record<string, unknown>;
+}) => Promise<unknown>;
+
 vi.mock('../init.js', () => {
-  const passthrough = {
+  const passthrough: Record<string, unknown> = {
     input: vi.fn().mockReturnThis(),
     output: vi.fn().mockReturnThis(),
-    query: vi.fn().mockReturnThis(),
-    mutation: vi.fn().mockReturnThis(),
     use: vi.fn().mockReturnThis(),
+    query: vi.fn((fn: Resolver) => ({ _resolver: fn })),
+    mutation: vi.fn((fn: Resolver) => ({ _resolver: fn })),
   };
   return {
     requireScopes: vi.fn(() => vi.fn()),
@@ -102,8 +113,30 @@ vi.mock('zod', () => ({
 }));
 
 import { webhooksRouter } from './webhooks.js';
+import {
+  enqueueWebhook,
+  enqueueWebhookRetry,
+} from '../../queues/webhook.queue.js';
+
+const mockEnqueueWebhook = enqueueWebhook as ReturnType<typeof vi.fn>;
+const mockEnqueueWebhookRetry = enqueueWebhookRetry as ReturnType<typeof vi.fn>;
+
+function resolver(name: keyof typeof webhooksRouter): Resolver {
+  return (webhooksRouter[name] as unknown as { _resolver: Resolver })._resolver;
+}
+
+const ORG_ID = 'org-1';
+const baseCtx = () => ({
+  authContext: { orgId: ORG_ID },
+  dbTx: 'mock-tx',
+  audit: vi.fn().mockResolvedValue(undefined),
+});
 
 describe('webhooksRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('exports all expected procedures', () => {
     expect(webhooksRouter).toHaveProperty('create');
     expect(webhooksRouter).toHaveProperty('update');
@@ -114,5 +147,100 @@ describe('webhooksRouter', () => {
     expect(webhooksRouter).toHaveProperty('test');
     expect(webhooksRouter).toHaveProperty('deliveries');
     expect(webhooksRouter).toHaveProperty('retryDelivery');
+  });
+
+  describe('test', () => {
+    it('refuses to send to a disabled endpoint', async () => {
+      mockGetEndpoint.mockResolvedValue({
+        id: 'ep-1',
+        url: 'https://example.com/hook',
+        status: 'DISABLED',
+      });
+
+      await expect(
+        resolver('test')({ ctx: baseCtx(), input: { id: 'ep-1' } }),
+      ).rejects.toThrow(/disabled/i);
+
+      expect(mockCreateDelivery).not.toHaveBeenCalled();
+      expect(mockEnqueueWebhook).not.toHaveBeenCalled();
+    });
+
+    it('enqueues a job carrying no endpoint URL or secret', async () => {
+      mockGetEndpoint.mockResolvedValue({
+        id: 'ep-1',
+        url: 'https://example.com/hook',
+        status: 'ACTIVE',
+      });
+      mockCreateDelivery.mockResolvedValue({ id: 'del-1' });
+
+      await resolver('test')({ ctx: baseCtx(), input: { id: 'ep-1' } });
+
+      const jobData = mockEnqueueWebhook.mock.calls[0][1];
+      expect(jobData).toEqual({
+        deliveryId: 'del-1',
+        orgId: ORG_ID,
+        payload: expect.objectContaining({ event: 'webhook.test' }),
+      });
+      expect(jobData).not.toHaveProperty('secret');
+      expect(jobData).not.toHaveProperty('endpointUrl');
+    });
+  });
+
+  describe('retryDelivery', () => {
+    it('refuses when the delivery and endpoint are not in the same org', async () => {
+      mockRetryDelivery.mockResolvedValue({
+        id: 'del-1',
+        organizationId: ORG_ID,
+        webhookEndpointId: 'ep-other',
+        eventType: 'submission.created',
+        payload: {},
+      });
+      // The org-scoped join finds nothing — the endpoint belongs elsewhere.
+      mockGetEndpointForDelivery.mockResolvedValue(null);
+
+      await expect(
+        resolver('retryDelivery')({
+          ctx: baseCtx(),
+          input: { deliveryId: 'del-1' },
+        }),
+      ).rejects.toThrow(/endpoint not found/i);
+
+      expect(mockEnqueueWebhookRetry).not.toHaveBeenCalled();
+    });
+
+    it('enqueues a job carrying no endpoint URL or secret', async () => {
+      mockRetryDelivery.mockResolvedValue({
+        id: 'del-1',
+        organizationId: ORG_ID,
+        webhookEndpointId: 'ep-1',
+        eventType: 'submission.created',
+        payload: { submissionId: 'sub-1' },
+      });
+      mockGetEndpointForDelivery.mockResolvedValue({
+        endpointId: 'ep-1',
+        url: 'https://example.com/hook',
+        secret: 'live-secret',
+        status: 'ACTIVE',
+        eventTypes: ['submission.created'],
+      });
+
+      await resolver('retryDelivery')({
+        ctx: baseCtx(),
+        input: { deliveryId: 'del-1' },
+      });
+
+      // Must go through the retry helper — a plain enqueue is deduped into a
+      // no-op by the job BullMQ still retains under this delivery id.
+      expect(mockEnqueueWebhook).not.toHaveBeenCalled();
+      expect(mockEnqueueWebhookRetry).toHaveBeenCalledTimes(1);
+
+      const jobData = mockEnqueueWebhookRetry.mock.calls[0][1];
+      expect(jobData).toEqual({
+        deliveryId: 'del-1',
+        orgId: ORG_ID,
+        payload: expect.objectContaining({ event: 'submission.created' }),
+      });
+      expect(jobData).not.toHaveProperty('secret');
+    });
   });
 });

--- a/apps/api/src/trpc/routers/webhooks.ts
+++ b/apps/api/src/trpc/routers/webhooks.ts
@@ -6,7 +6,6 @@ import {
   AuditActions,
   AuditResources,
 } from '@colophony/types';
-import { webhookEndpoints, eq, and } from '@colophony/db';
 import {
   adminProcedure,
   orgProcedure,
@@ -14,7 +13,10 @@ import {
   createRouter,
 } from '../init.js';
 import { webhookService } from '../../services/webhook.service.js';
-import { enqueueWebhook } from '../../queues/webhook.queue.js';
+import {
+  enqueueWebhook,
+  enqueueWebhookRetry,
+} from '../../queues/webhook.queue.js';
 import { validateEnv } from '../../config/env.js';
 
 export const webhooksRouter = createRouter({
@@ -126,20 +128,24 @@ export const webhooksRouter = createRouter({
       const env = validateEnv();
       const orgId = ctx.authContext.orgId;
 
-      // Get the endpoint (including secret for delivery)
-      const [endpoint] = await ctx.dbTx
-        .select()
-        .from(webhookEndpoints)
-        .where(
-          and(
-            eq(webhookEndpoints.id, input.id),
-            eq(webhookEndpoints.organizationId, orgId),
-          ),
-        )
-        .limit(1);
+      // The worker re-reads url/secret at send time, so only existence and status
+      // are needed here — the redacted read is sufficient.
+      const endpoint = await webhookService.getEndpoint(
+        ctx.dbTx,
+        input.id,
+        orgId,
+      );
 
       if (!endpoint) {
         throw new Error('Webhook endpoint not found');
+      }
+
+      // The worker cancels sends to a disabled endpoint, so reject here rather than
+      // enqueueing a delivery that is guaranteed to be cancelled without explanation.
+      if (endpoint.status === 'DISABLED') {
+        throw new Error(
+          'Cannot test a disabled webhook endpoint — re-enable it first',
+        );
       }
 
       const delivery = await webhookService.createDelivery(ctx.dbTx, {
@@ -167,8 +173,6 @@ export const webhooksRouter = createRouter({
       await enqueueWebhook(env, {
         deliveryId: delivery.id,
         orgId,
-        endpointUrl: endpoint.url,
-        secret: endpoint.secret,
         payload,
       });
 
@@ -205,17 +209,14 @@ export const webhooksRouter = createRouter({
         throw new Error('Delivery not found');
       }
 
-      // Get the endpoint for the delivery
-      const [endpoint] = await ctx.dbTx
-        .select()
-        .from(webhookEndpoints)
-        .where(
-          and(
-            eq(webhookEndpoints.id, delivery.webhookEndpointId),
-            eq(webhookEndpoints.organizationId, orgId),
-          ),
-        )
-        .limit(1);
+      // Confirm the delivery's endpoint is still present and belongs to the same org.
+      // The FK guarantees existence, not org affinity — this join is the only check.
+      // The worker re-reads url/secret itself, so nothing is taken from here.
+      const endpoint = await webhookService.getEndpointForDelivery(
+        ctx.dbTx,
+        input.deliveryId,
+        orgId,
+      );
 
       if (!endpoint) {
         throw new Error('Webhook endpoint not found');
@@ -229,11 +230,11 @@ export const webhooksRouter = createRouter({
         data: delivery.payload as Record<string, unknown>,
       };
 
-      await enqueueWebhook(env, {
+      // Retry, not a fresh enqueue: the previous job is still retained under this
+      // delivery id and would dedup a plain add into a no-op.
+      await enqueueWebhookRetry(env, {
         deliveryId: delivery.id,
         orgId,
-        endpointUrl: endpoint.url,
-        secret: endpoint.secret,
         payload,
       });
 

--- a/apps/api/src/workers/__tests__/webhook.worker.spec.ts
+++ b/apps/api/src/workers/__tests__/webhook.worker.spec.ts
@@ -22,6 +22,7 @@ vi.mock('bullmq', () => ({
 const mockUpdateDeliveryStatus = vi.fn();
 const mockCountRecentFailures = vi.fn();
 const mockUpdateEndpoint = vi.fn();
+const mockGetEndpointForDelivery = vi.fn();
 vi.mock('../../services/webhook.service.js', () => ({
   webhookService: {
     updateDeliveryStatus: (...args: unknown[]) =>
@@ -29,8 +30,20 @@ vi.mock('../../services/webhook.service.js', () => ({
     countRecentFailures: (...args: unknown[]) =>
       mockCountRecentFailures(...args),
     updateEndpoint: (...args: unknown[]) => mockUpdateEndpoint(...args),
+    getEndpointForDelivery: (...args: unknown[]) =>
+      mockGetEndpointForDelivery(...args),
   },
 }));
+
+// The endpoint state the worker re-reads before each send. Tests override this to
+// exercise the deleted / disabled / unsubscribed branches.
+const ACTIVE_ENDPOINT = {
+  endpointId: 'ep-1',
+  url: 'https://example.com/webhook',
+  secret: 'test-secret-hex',
+  status: 'ACTIVE' as const,
+  eventTypes: ['hopper/submission.submitted'],
+};
 
 const mockAuditLog = vi.fn();
 vi.mock('../../services/audit.service.js', () => ({
@@ -92,8 +105,6 @@ const makeJob = (overrides = {}) => ({
   data: {
     deliveryId: 'del-123',
     orgId: 'org-1',
-    endpointUrl: 'https://example.com/webhook',
-    secret: 'test-secret-hex',
     payload: {
       id: 'del-123',
       event: 'hopper/submission.submitted',
@@ -114,6 +125,7 @@ describe('webhook worker', () => {
     mockWithRls.mockImplementation(
       (_ctx: unknown, fn: (tx: unknown) => unknown) => fn('mock-tx'),
     );
+    mockGetEndpointForDelivery.mockResolvedValue(ACTIVE_ENDPOINT);
     startWebhookWorker(testEnv);
   });
 
@@ -247,23 +259,7 @@ describe('webhook worker', () => {
     const job = makeJob({ attemptsMade: 8 });
     const err = new Error('HTTP 500');
 
-    mockWithRls.mockImplementation(
-      (_ctx: unknown, fn: (tx: unknown) => unknown) => {
-        const mockTx = {
-          select: vi.fn().mockReturnValue({
-            from: vi.fn().mockReturnValue({
-              where: vi.fn().mockReturnValue({
-                limit: vi
-                  .fn()
-                  .mockResolvedValue([{ webhookEndpointId: 'ep-1' }]),
-              }),
-            }),
-          }),
-        };
-        return fn(mockTx);
-      },
-    );
-
+    // The endpoint is resolved through the service join, not a raw select on tx.
     mockCountRecentFailures.mockResolvedValueOnce(5); // At threshold
 
     await failedCallback(job, err);
@@ -275,6 +271,137 @@ describe('webhook worker', () => {
       'org-1',
       { status: 'DISABLED' },
     );
+  });
+
+  describe('pre-send re-validation', () => {
+    it('cancels without sending when the endpoint is disabled', async () => {
+      mockGetEndpointForDelivery.mockResolvedValue({
+        ...ACTIVE_ENDPOINT,
+        status: 'DISABLED',
+      });
+      const mockFetch = vi.fn();
+      vi.stubGlobal('fetch', mockFetch);
+
+      await workerCallback(makeJob());
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockUpdateDeliveryStatus).toHaveBeenCalledWith(
+        'mock-tx',
+        'del-123',
+        'CANCELLED',
+        { errorMessage: expect.stringContaining('disabled') },
+      );
+      // Never entered DELIVERING — the attempt was not burned
+      expect(mockUpdateDeliveryStatus).not.toHaveBeenCalledWith(
+        'mock-tx',
+        'del-123',
+        'DELIVERING',
+        expect.anything(),
+      );
+    });
+
+    it('discards the job without any status write when the endpoint is gone', async () => {
+      mockGetEndpointForDelivery.mockResolvedValue(null);
+      const mockFetch = vi.fn();
+      vi.stubGlobal('fetch', mockFetch);
+
+      await workerCallback(makeJob());
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      // The delivery row cascaded away with the endpoint; nothing left to mark
+      expect(mockUpdateDeliveryStatus).not.toHaveBeenCalled();
+    });
+
+    it('cancels when the endpoint no longer subscribes to the event', async () => {
+      mockGetEndpointForDelivery.mockResolvedValue({
+        ...ACTIVE_ENDPOINT,
+        eventTypes: ['hopper/submission.withdrawn'],
+      });
+      const mockFetch = vi.fn();
+      vi.stubGlobal('fetch', mockFetch);
+
+      await workerCallback(makeJob());
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockUpdateDeliveryStatus).toHaveBeenCalledWith(
+        'mock-tx',
+        'del-123',
+        'CANCELLED',
+        { errorMessage: expect.stringContaining('no longer subscribes') },
+      );
+    });
+
+    it('delivers a webhook.test event even though it is never in event_types', async () => {
+      mockGetEndpointForDelivery.mockResolvedValue(ACTIVE_ENDPOINT);
+      const mockFetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('OK'),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const job = makeJob();
+      job.data.payload.event = 'webhook.test';
+      await workerCallback(job);
+
+      expect(mockFetch).toHaveBeenCalled();
+      expect(mockUpdateDeliveryStatus).toHaveBeenCalledWith(
+        'mock-tx',
+        'del-123',
+        'DELIVERED',
+        expect.anything(),
+      );
+    });
+
+    it('signs with the freshly-read secret and posts to the freshly-read URL', async () => {
+      // Both differ from what a stale job would have carried.
+      mockGetEndpointForDelivery.mockResolvedValue({
+        ...ACTIVE_ENDPOINT,
+        url: 'https://rotated.example.com/hook',
+        secret: 'rotated-secret',
+      });
+      const mockFetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('OK'),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const job = makeJob();
+      const body = JSON.stringify(job.data.payload);
+      const expectedSig =
+        'sha256=' +
+        crypto
+          .createHmac('sha256', 'rotated-secret')
+          .update(body)
+          .digest('hex');
+
+      await workerCallback(job);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://rotated.example.com/hook',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Webhook-Signature': expectedSig,
+          }),
+        }),
+      );
+    });
+
+    it('skips auto-disable and omits the URL when the endpoint is gone on final failure', async () => {
+      mockGetEndpointForDelivery.mockResolvedValue(null);
+
+      await failedCallback(makeJob({ attemptsMade: 8 }), new Error('HTTP 500'));
+
+      expect(mockCountRecentFailures).not.toHaveBeenCalled();
+      expect(mockUpdateEndpoint).not.toHaveBeenCalled();
+      expect(mockAuditLog).toHaveBeenCalledWith(
+        'mock-tx',
+        expect.objectContaining({
+          newValue: expect.objectContaining({ endpointUrl: undefined }),
+        }),
+      );
+    });
   });
 
   it('stops worker cleanly', async () => {

--- a/apps/api/src/workers/webhook.worker.ts
+++ b/apps/api/src/workers/webhook.worker.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 import type { Worker } from 'bullmq';
-import { withRls, webhookDeliveries, eq } from '@colophony/db';
+import { withRls } from '@colophony/db';
 import type { DrizzleDb } from '@colophony/db';
 import { AuditActions, AuditResources } from '@colophony/types';
 import type { Env } from '../config/env.js';
@@ -10,6 +10,7 @@ import { webhookService } from '../services/webhook.service.js';
 import { auditService } from '../services/audit.service.js';
 import { createInstrumentedWorker } from '../config/instrumented-worker.js';
 import { validateOutboundUrl } from '../lib/url-validation.js';
+import { getLogger } from '../config/logger.js';
 
 const AUTO_DISABLE_THRESHOLD = 5;
 const DELIVERY_TIMEOUT_MS = 30_000;
@@ -20,9 +21,60 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
   worker = createInstrumentedWorker<WebhookJobData>({
     name: 'webhook',
     processor: async (job) => {
-      const { deliveryId, orgId, endpointUrl, secret, payload } = job.data;
+      const { deliveryId, orgId, payload } = job.data;
 
-      // Phase 1: Mark as DELIVERING + increment attempts
+      // Phase 1: Re-validate the endpoint against its CURRENT state.
+      // The job may have been queued up to an hour ago (8 retries, backoff to 1h), so
+      // nothing about the endpoint is trusted from the payload — URL and secret included.
+      // Runs before the DELIVERING write so a delivery we decline to send never enters
+      // DELIVERING and never burns an attempt.
+      const endpoint = await withRls({ orgId }, async (tx: DrizzleDb) =>
+        webhookService.getEndpointForDelivery(tx, deliveryId, orgId),
+      );
+
+      if (!endpoint) {
+        // Endpoint was deleted; ON DELETE CASCADE took the delivery row with it, so
+        // there is no row left to mark. Discard the job without retrying.
+        getLogger().info(
+          { deliveryId, orgId },
+          'Webhook endpoint no longer exists — discarding delivery',
+        );
+        return;
+      }
+
+      // A test send is an explicit operator action against one endpoint, so it is exempt
+      // from the subscription filter — 'webhook.test' is never in event_types.
+      const isTest = payload.event === 'webhook.test';
+      const subscribed =
+        Array.isArray(endpoint.eventTypes) &&
+        endpoint.eventTypes.includes(payload.event);
+
+      let cancelReason: string | null = null;
+      if (endpoint.status === 'DISABLED') {
+        cancelReason = 'Endpoint is disabled';
+      } else if (!isTest && !subscribed) {
+        cancelReason = `Endpoint no longer subscribes to ${payload.event}`;
+      }
+
+      if (cancelReason) {
+        await withRls({ orgId }, async (tx: DrizzleDb) => {
+          await webhookService.updateDeliveryStatus(
+            tx,
+            deliveryId,
+            'CANCELLED',
+            { errorMessage: `Cancelled before send: ${cancelReason}` },
+          );
+        });
+        getLogger().info(
+          { deliveryId, orgId, reason: cancelReason },
+          'Webhook delivery cancelled before send',
+        );
+        return; // Permanent — do not retry
+      }
+
+      const { url: endpointUrl, secret } = endpoint;
+
+      // Phase 2: Mark as DELIVERING + increment attempts
       await withRls({ orgId }, async (tx: DrizzleDb) => {
         await webhookService.updateDeliveryStatus(
           tx,
@@ -34,7 +86,7 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
         );
       });
 
-      // Phase 2: SSRF validation — all failures are permanent (no retry)
+      // Phase 3: SSRF validation — all failures are permanent (no retry)
       // Retrying URL validation could enable DNS rebinding amplification
       const devMode = env.NODE_ENV === 'development' || env.NODE_ENV === 'test';
       try {
@@ -50,13 +102,13 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
         return; // Permanent failure — do not retry
       }
 
-      // Phase 3: Compute HMAC-SHA256 signature
+      // Phase 4: Compute HMAC-SHA256 signature with the freshly-read secret
       const body = JSON.stringify(payload);
       const signature =
         'sha256=' +
         crypto.createHmac('sha256', secret).update(body).digest('hex');
 
-      // Phase 4: HTTP POST with timeout
+      // Phase 5: HTTP POST with timeout
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
 
@@ -92,7 +144,7 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
         clearTimeout(timeout);
       }
 
-      // Phase 5: Process response
+      // Phase 6: Process response
       const responseBody = await response.text().catch(() => '');
       const truncatedBody = responseBody.slice(0, 4096);
 
@@ -154,8 +206,17 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
     onFailed: async (job, err) => {
       // On final failure, mark as FAILED + audit + auto-disable check
       if (job && job.attemptsMade >= (job.opts.attempts ?? 8)) {
-        const { deliveryId, orgId, endpointUrl, payload } = job.data;
+        const { deliveryId, orgId, payload } = job.data;
         await withRls({ orgId }, async (tx: DrizzleDb) => {
+          // Resolve the endpoint alongside the delivery. Returns null when the endpoint
+          // was deleted mid-flight, in which case there is nothing to audit a URL for
+          // and nothing left to auto-disable.
+          const endpoint = await webhookService.getEndpointForDelivery(
+            tx,
+            deliveryId,
+            orgId,
+          );
+
           await webhookService.updateDeliveryStatus(tx, deliveryId, 'FAILED', {
             errorMessage: err.message,
           });
@@ -165,7 +226,7 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
             resourceId: deliveryId,
             organizationId: orgId,
             newValue: {
-              endpointUrl,
+              endpointUrl: endpoint?.url,
               event: payload.event,
               error: err.message,
               attempts: job.attemptsMade,
@@ -175,29 +236,25 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
           // Auto-disable: check if this endpoint has too many recent failures.
           // Note: concurrent final failures may race, but the consequence is benign
           // (disable at ±1 of the threshold). Atomic locking isn't worth the complexity.
-          const [deliveryRow] = await tx
-            .select({ webhookEndpointId: webhookDeliveries.webhookEndpointId })
-            .from(webhookDeliveries)
-            .where(eq(webhookDeliveries.id, deliveryId))
-            .limit(1);
-          const endpointId = deliveryRow?.webhookEndpointId;
-
-          if (endpointId) {
+          if (endpoint) {
             const failCount = await webhookService.countRecentFailures(
               tx,
-              endpointId,
+              endpoint.endpointId,
             );
             if (failCount >= AUTO_DISABLE_THRESHOLD) {
-              await webhookService.updateEndpoint(tx, endpointId, orgId, {
-                status: 'DISABLED',
-              });
+              await webhookService.updateEndpoint(
+                tx,
+                endpoint.endpointId,
+                orgId,
+                { status: 'DISABLED' },
+              );
               await auditService.log(tx, {
                 resource: AuditResources.WEBHOOK_ENDPOINT,
                 action: AuditActions.WEBHOOK_ENDPOINT_AUTO_DISABLED,
-                resourceId: endpointId,
+                resourceId: endpoint.endpointId,
                 organizationId: orgId,
                 newValue: {
-                  endpointUrl,
+                  endpointUrl: endpoint.url,
                   consecutiveFailures: failCount,
                 },
               });

--- a/apps/web/src/components/webhooks/__tests__/webhook-detail.spec.tsx
+++ b/apps/web/src/components/webhooks/__tests__/webhook-detail.spec.tsx
@@ -145,6 +145,31 @@ describe("WebhookDetail", () => {
     expect(screen.getByText("200")).toBeInTheDocument();
   });
 
+  it("renders a CANCELLED delivery and offers a retry", () => {
+    // Cancelled before send — e.g. the endpoint was disabled while the job was
+    // queued. Retry must be offered so it can be re-sent after re-enabling.
+    mockDeliveries = [
+      {
+        ...(mockDeliveries[0] as Record<string, unknown>),
+        id: "del-cancelled",
+        status: "CANCELLED",
+        httpStatusCode: null,
+        errorMessage: "Cancelled before send: Endpoint is disabled",
+        deliveredAt: null,
+      },
+    ];
+    const { container } = render(<WebhookDetail endpointId="ep-1" />);
+    expect(screen.getByText("CANCELLED")).toBeInTheDocument();
+    // The retry control lives in the delivery table; a DELIVERED row has none.
+    expect(container.querySelectorAll("table button")).toHaveLength(1);
+  });
+
+  it("offers no retry for a DELIVERED delivery", () => {
+    const { container } = render(<WebhookDetail endpointId="ep-1" />);
+    expect(screen.getByText("DELIVERED")).toBeInTheDocument();
+    expect(container.querySelectorAll("table button")).toHaveLength(0);
+  });
+
   it("shows action buttons for admins", () => {
     render(<WebhookDetail endpointId="ep-1" />);
     expect(screen.getByText("Test")).toBeInTheDocument();

--- a/apps/web/src/components/webhooks/webhook-detail.tsx
+++ b/apps/web/src/components/webhooks/webhook-detail.tsx
@@ -47,6 +47,7 @@ const STATUS_COLORS: Record<string, string> = {
   DELIVERING: "bg-status-info",
   DELIVERED: "bg-status-success",
   FAILED: "bg-status-error",
+  CANCELLED: "bg-status-warning",
 };
 
 interface WebhookDetailProps {
@@ -342,7 +343,8 @@ export function WebhookDetail({ endpointId }: WebhookDetailProps) {
                       </TableCell>
                       {isAdmin && (
                         <TableCell>
-                          {delivery.status === "FAILED" && (
+                          {(delivery.status === "FAILED" ||
+                            delivery.status === "CANCELLED") && (
                             <Button
                               variant="ghost"
                               size="sm"

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -280,14 +280,45 @@ Ordered as the design doc's Phase 0/D.
       the human's own actions are recorded identically. Add `principal_id` / `principal_type`
       (also the prerequisite for acting-as). Requires updating `insert_audit_event()`. —
       (design doc §0.1(d), P2.2)
-- [ ] **[P1] Webhook deliveries are not revalidated before send.** The Inngest fan-out
-      serialises endpoint URL and secret into the BullMQ job (`webhook-delivery.ts:44,63`)
-      and the worker sends what the job carries without re-reading the endpoint
-      (`webhook.worker.ts:23`). With 8 retries backing off to 1h, a deleted or disabled
-      endpoint — or a rotated secret — keeps receiving events for up to an hour. The worker
-      already re-runs `validateOutboundUrl()` per attempt for this same reason;
-      authorisation belongs in the same place. Blast radius is one org today; it becomes
-      cross-tenant if instance subscriptions land first. — (design doc §1.9, P2.-1)
+- [x] **[P1] Webhook deliveries are not revalidated before send.** The worker now re-reads
+      the endpoint through `webhookService.getEndpointForDelivery` as its first phase, before
+      the `DELIVERING` write, and takes the URL and secret from that row rather than the job.
+      A disabled endpoint, or one that no longer subscribes to the event, marks the delivery
+      `CANCELLED` and returns; a deleted endpoint discards the job (`ON DELETE CASCADE` has
+      already removed the delivery row, so there is nothing to mark). — (design doc §1.9,
+      P2.-1; done 2026-07-28)
+      **`endpointUrl` and `secret` were removed from `WebhookJobData` entirely**, not merely
+      left unread. A signing secret was sitting in Redis for up to 7 days (`removeOnFail`),
+      and leaving the fields in place invites a future edit to reach for them again. All
+      three enqueue sites changed — the Inngest fan-out plus the `test` and `retryDelivery`
+      tRPC mutations, both of which had hand-rolled raw selects purely to fetch the secret.
+      **`CANCELLED`, not `FAILED`** — `countRecentFailures` counts `FAILED` over 24h and feeds
+      the auto-disable threshold, so recording a cancellation as a failure would push an
+      endpoint further toward disable for declining to send to it. Migration `0068` adds the
+      enum value; **two Zod schemas and two hand-written TS unions duplicated that enum** and
+      had to move in lockstep, the same shape of trap as `payments:read` on 2026-07-27. The
+      service union is now derived from `webhookDeliveries.status.enumValues` so it cannot
+      drift again.
+      **Three things worth keeping:**
+      (1) `webhook.test` is exempt from the subscription check — the `test` mutation sends
+      `eventType: 'webhook.test'`, which is never in an endpoint's `event_types`, so a naive
+      re-check cancelled every test send. The mutation now also rejects a `DISABLED` endpoint
+      up front, so the operator gets an error rather than a silent cancellation.
+      (2) `retryDelivery`'s endpoint select could not just be deleted. The FK guarantees the
+      endpoint exists, not that it shares the delivery's org — that select was the only
+      explicit delivery↔endpoint org-affinity check. It now calls `getEndpointForDelivery`,
+      which filters org on **both** tables.
+      (3) The UI already had a `STATUS_COLORS` map and a retry button gated on `FAILED`;
+      `CANCELLED` would have rendered in the in-progress blue with no way to re-send.
+      **Fixed a pre-existing bug this surfaced: `retryDelivery` never re-ran anything.**
+      `jobId` is the delivery id, and BullMQ treats a re-added jobId as a duplicate while
+      the previous job is retained — 24h for completed, 7 days for failed. Every state a
+      retry is offered from leaves such a job behind, so retry set the row back to `QUEUED`
+      and then silently did nothing, reporting success. Confirmed against real Redis before
+      fixing: the delivery stayed `QUEUED` with zero fetches. New `enqueueWebhookRetry`
+      drops the retained job first; `retryDelivery` uses it, and an integration test covers
+      the cancel → re-enable → retry → delivered round trip. This was live for `FAILED`
+      retries too, not just the `CANCELLED` path added here.
 - [ ] **[P2] No dedup constraint on `webhook_deliveries`.** `createDelivery`
       (`webhook.service.ts:222`) has no unique constraint per endpoint/event, so Inngest
       retries or replayed events can duplicate deliveries. — (design review 2026-07-27)

--- a/packages/db/migrations/0068_webhook_delivery_cancelled.sql
+++ b/packages/db/migrations/0068_webhook_delivery_cancelled.sql
@@ -1,0 +1,14 @@
+-- 0068: Add CANCELLED to WebhookDeliveryStatus
+--
+-- The delivery worker re-reads the endpoint immediately before every send. When the
+-- endpoint has been disabled, or no longer subscribes to the event, the queued delivery
+-- is marked CANCELLED instead of being sent.
+--
+-- CANCELLED rather than FAILED deliberately: countRecentFailures() counts FAILED rows over
+-- a 24h window and feeds the auto-disable threshold, so recording a cancellation as a
+-- failure would push an endpoint further toward being disabled for declining to send.
+
+-- Keep this as the only statement in the file. ALTER TYPE ... ADD VALUE may run inside a
+-- transaction on PG12+, but the new value cannot be *used* until that transaction commits,
+-- and drizzle wraps each migration in one.
+ALTER TYPE "WebhookDeliveryStatus" ADD VALUE IF NOT EXISTS 'CANCELLED';

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -477,6 +477,13 @@
       "when": 1782600000000,
       "tag": "0067_drop_payments_read_scope",
       "breakpoints": true
+    },
+    {
+      "idx": 68,
+      "version": "7",
+      "when": 1782800000000,
+      "tag": "0068_webhook_delivery_cancelled",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -227,6 +227,9 @@ export const webhookDeliveryStatusEnum = pgEnum("WebhookDeliveryStatus", [
   "DELIVERING",
   "DELIVERED",
   "FAILED",
+  // Endpoint was deleted, disabled, or unsubscribed between enqueue and send.
+  // Distinct from FAILED so cancellations don't feed the auto-disable threshold.
+  "CANCELLED",
 ]);
 
 export const contractStatusEnum = pgEnum("ContractStatus", [

--- a/packages/types/src/webhook.ts
+++ b/packages/types/src/webhook.ts
@@ -85,7 +85,7 @@ export const webhookDeliveryResponseSchema = z.object({
   eventType: z.string(),
   eventId: z.string(),
   payload: z.unknown(),
-  status: z.enum(["QUEUED", "DELIVERING", "DELIVERED", "FAILED"]),
+  status: z.enum(["QUEUED", "DELIVERING", "DELIVERED", "FAILED", "CANCELLED"]),
   httpStatusCode: z.number().nullable(),
   responseBody: z.string().nullable(),
   errorMessage: z.string().nullable(),
@@ -106,7 +106,9 @@ export type WebhookDeliveryResponse = z.infer<
 export const listWebhookDeliveriesSchema = z.object({
   endpointId: z.string().uuid().optional(),
   eventType: z.string().optional(),
-  status: z.enum(["QUEUED", "DELIVERING", "DELIVERED", "FAILED"]).optional(),
+  status: z
+    .enum(["QUEUED", "DELIVERING", "DELIVERED", "FAILED", "CANCELLED"])
+    .optional(),
   page: z.number().int().min(1).default(1),
   limit: z.number().int().min(1).max(100).default(20),
 });


### PR DESCRIPTION
## Problem

The Inngest fan-out serialised the endpoint URL and signing secret into the BullMQ job, and the worker sent whatever the job carried without re-reading the endpoint. The webhook queue retries 8 times with backoff out to an hour, so:

- A deleted or disabled endpoint kept receiving events for up to an hour.
- A rotated secret or edited URL could be replayed from an old job.
- The worker's own auto-disable rule was self-defeating — `onFailed` flips an endpoint to `DISABLED` after 5 failures, but the jobs already queued for it kept delivering.

Blast radius is one org today. `docs/api-integration-design.md` §1.9 wants it closed on the org-scoped path before instance subscriptions generalise the same machinery across tenants.

## Change

The worker re-reads the endpoint as its first phase, ahead of the `DELIVERING` write, via a new `webhookService.getEndpointForDelivery`, and takes URL and secret from that row:

| Endpoint state at send time | Outcome |
| --- | --- |
| Deleted | Discard the job — `ON DELETE CASCADE` already removed the delivery row |
| Disabled | Mark the delivery `CANCELLED`, do not send |
| No longer subscribed to the event | Mark `CANCELLED`, do not send |
| Active and subscribed | Send, using the current URL and secret |

Cancellation is permanent (`return`, not `throw`), matching the SSRF block's existing idiom. Running before the `DELIVERING` write means a delivery we decline to send never enters `DELIVERING` and never burns an attempt.

## Notable decisions

**`CANCELLED` rather than `FAILED`.** `countRecentFailures` counts `FAILED` over a 24h window and feeds the auto-disable threshold, so recording a cancellation as a failure would push an endpoint further toward disable for declining to send to it. Migration `0068` adds the enum value. Two Zod schemas and two hand-written TS unions duplicated that enum and had to move in lockstep — the same shape of trap as the `payments:read` removal. The service union is now derived from `webhookDeliveries.status.enumValues` so it cannot drift again.

**`endpointUrl` and `secret` removed from `WebhookJobData` outright**, not merely left unread. A signing secret was sitting in Redis for up to 7 days (`removeOnFail`), and leaving the fields in place invites a future edit to reach for them again. In-flight jobs under the old shape keep working — the worker just ignores the extra fields. All three enqueue sites changed; the `test` and `retryDelivery` mutations had hand-rolled raw selects purely to obtain the secret, both now gone.

**Test sends are exempt from the subscription check.** The `test` mutation sends `eventType: 'webhook.test'`, which is never in an endpoint's `event_types` — a naive re-check cancelled every test send. The mutation now also rejects a `DISABLED` endpoint up front, so the operator gets an error rather than a silent cancellation.

**`retryDelivery`'s endpoint lookup was kept, not dropped.** The FK guarantees the endpoint exists, not that it shares the delivery's org — that lookup was the only explicit delivery↔endpoint org-affinity check. It now goes through `getEndpointForDelivery`, which filters org on *both* tables in one join.

## Bug found and fixed along the way

`retryDelivery` never re-ran anything. `jobId` is the delivery id, and BullMQ treats a re-added jobId as a duplicate for as long as the previous job is retained — 24h for completed, 7 days for failed. Every state a retry is offered from leaves such a job behind, so retry set the row back to `QUEUED` and then silently did nothing while reporting success.

Confirmed against real Redis before fixing: the delivery stayed `QUEUED` with zero requests sent. New `enqueueWebhookRetry` drops the retained job first. This was live for `FAILED` retries too, not just the `CANCELLED` path added here.

## Frontend

`CANCELLED` would have rendered in the in-progress blue via the `STATUS_COLORS` fallback, and the retry button was gated on `FAILED` only — a dead end for exactly the status most likely to warrant a re-send. Both addressed.

## Verification

- `pnpm type-check`, `pnpm lint` — clean
- `pnpm test` — 161 API + 92 web files, all passing
- `test:queues` 28, `test:security` 31, `test:webhooks` 46, `test:rls` 138, `test:services` 117 — all passing
- `pnpm sdk:check-spec` — green with no regeneration, as expected; webhooks are tRPC-only
- New integration coverage against real Postgres + Redis: cancel-on-disabled, cancel-on-unsubscribed, rotated-secret/edited-URL, and the cancel → re-enable → retry → delivered round trip
- The disabled-endpoint case was verified to fail against the pre-change worker, not merely to pass against the new one
