### PR TITLE
Audit tenant isolation on the tables without RLS

### DIFF
--- a/apps/api/src/__tests__/rls/helpers/factories.ts
+++ b/apps/api/src/__tests__/rls/helpers/factories.ts
@@ -22,7 +22,6 @@ import {
   submissionDiscussions,
   submissionVotes,
   submissionReviewers,
-  portfolioEntries,
   type Organization,
   type User,
   type OrganizationMember,
@@ -355,7 +354,6 @@ export async function createWriterProfile(
 export type SubmissionDiscussionRow = typeof submissionDiscussions.$inferSelect;
 export type SubmissionVoteRow = typeof submissionVotes.$inferSelect;
 export type SubmissionReviewerRow = typeof submissionReviewers.$inferSelect;
-export type PortfolioEntryRow = typeof portfolioEntries.$inferSelect;
 
 export async function createSubmissionDiscussion(
   organizationId: string,
@@ -416,28 +414,10 @@ export async function createSubmissionReviewer(
   return reviewer;
 }
 
-/**
- * `portfolio_entries` is user-scoped (`user_id = current_user_id()`), not
- * org-scoped — it carries no `organization_id` column at all. Reads of it
- * therefore need `userId` in the RLS context, not `orgId`.
- */
-export async function createPortfolioEntry(
-  userId: string,
-  overrides?: Partial<PortfolioEntryRow>,
-): Promise<PortfolioEntryRow> {
-  const db = adminDb();
-  const [entry] = await db
-    .insert(portfolioEntries)
-    .values({
-      userId,
-      type: 'external',
-      title: faker.lorem.sentence(),
-      publicationName: faker.company.name(),
-      ...overrides,
-    })
-    .returning();
-  return entry;
-}
+// No `createPortfolioEntry` here on purpose: `portfolioService.list` reads
+// `submissions` and `external_submissions`, never `portfolio_entries`, so a
+// fixture for that table would seed rows no assertion observes. Add one when a
+// suite actually exercises `portfolio_entries_user_owner`.
 
 export interface TwoOrgScenario {
   orgA: Organization;

--- a/apps/api/src/__tests__/rls/helpers/factories.ts
+++ b/apps/api/src/__tests__/rls/helpers/factories.ts
@@ -19,6 +19,10 @@ import {
   externalSubmissions,
   correspondence,
   writerProfiles,
+  submissionDiscussions,
+  submissionVotes,
+  submissionReviewers,
+  portfolioEntries,
   type Organization,
   type User,
   type OrganizationMember,
@@ -336,6 +340,103 @@ export async function createWriterProfile(
     })
     .returning();
   return profile;
+}
+
+// ---------------------------------------------------------------------------
+// Submission-child fixtures.
+//
+// `createTwoOrgScenario` deliberately does not seed these — they are only
+// needed by suites that exercise the per-submission list methods. Without
+// them those suites assert "no org B rows" against an empty table, which is
+// true for the wrong reason. Seed explicitly and assert a non-zero org A
+// count first.
+// ---------------------------------------------------------------------------
+
+export type SubmissionDiscussionRow = typeof submissionDiscussions.$inferSelect;
+export type SubmissionVoteRow = typeof submissionVotes.$inferSelect;
+export type SubmissionReviewerRow = typeof submissionReviewers.$inferSelect;
+export type PortfolioEntryRow = typeof portfolioEntries.$inferSelect;
+
+export async function createSubmissionDiscussion(
+  organizationId: string,
+  submissionId: string,
+  authorId: string,
+  overrides?: Partial<SubmissionDiscussionRow>,
+): Promise<SubmissionDiscussionRow> {
+  const db = adminDb();
+  const [discussion] = await db
+    .insert(submissionDiscussions)
+    .values({
+      organizationId,
+      submissionId,
+      authorId,
+      content: faker.lorem.paragraph(),
+      ...overrides,
+    })
+    .returning();
+  return discussion;
+}
+
+export async function createSubmissionVote(
+  organizationId: string,
+  submissionId: string,
+  voterUserId: string,
+  overrides?: Partial<SubmissionVoteRow>,
+): Promise<SubmissionVoteRow> {
+  const db = adminDb();
+  const [vote] = await db
+    .insert(submissionVotes)
+    .values({
+      organizationId,
+      submissionId,
+      voterUserId,
+      decision: 'ACCEPT',
+      ...overrides,
+    })
+    .returning();
+  return vote;
+}
+
+export async function createSubmissionReviewer(
+  organizationId: string,
+  submissionId: string,
+  reviewerUserId: string,
+  overrides?: Partial<SubmissionReviewerRow>,
+): Promise<SubmissionReviewerRow> {
+  const db = adminDb();
+  const [reviewer] = await db
+    .insert(submissionReviewers)
+    .values({
+      organizationId,
+      submissionId,
+      reviewerUserId,
+      ...overrides,
+    })
+    .returning();
+  return reviewer;
+}
+
+/**
+ * `portfolio_entries` is user-scoped (`user_id = current_user_id()`), not
+ * org-scoped — it carries no `organization_id` column at all. Reads of it
+ * therefore need `userId` in the RLS context, not `orgId`.
+ */
+export async function createPortfolioEntry(
+  userId: string,
+  overrides?: Partial<PortfolioEntryRow>,
+): Promise<PortfolioEntryRow> {
+  const db = adminDb();
+  const [entry] = await db
+    .insert(portfolioEntries)
+    .values({
+      userId,
+      type: 'external',
+      title: faker.lorem.sentence(),
+      publicationName: faker.company.name(),
+      ...overrides,
+    })
+    .returning();
+  return entry;
 }
 
 export interface TwoOrgScenario {

--- a/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
+++ b/apps/api/src/__tests__/rls/rls-infrastructure.test.ts
@@ -4,6 +4,7 @@ import { globalSetup, getAdminPool, getAppPool } from './helpers/db-setup';
 const RLS_TABLES = [
   // Core
   'organization_members',
+  'organization_invitations',
   'form_definitions',
   'form_fields',
   'form_pages',
@@ -86,15 +87,120 @@ const RLS_TABLES_FULL_DML = RLS_TABLES.filter(
   (t) => t !== 'audit_events' && t !== 'journal_directory',
 );
 
-const NON_RLS_TABLES = [
-  'organizations',
-  'users',
-  'dsar_requests',
-  'stripe_webhook_events',
-  'outbox_events',
-  'zitadel_webhook_events',
-  'federation_config',
+/**
+ * Tables with no row-level security. On these, cross-tenant isolation depends
+ * either on an explicit `WHERE` clause in the service layer or on a table-level
+ * `REVOKE` — never on the database's own policy machinery.
+ *
+ * `expectedAppUserSelect` records which of the two is doing the work, and is
+ * asserted below. "No RLS" is only safe when something else is; see
+ * `docs/tenant-isolation-audit.md` and the per-site classification there.
+ */
+const NON_RLS_TABLES: ReadonlyArray<{
+  table: string;
+  expectedAppUserSelect: boolean;
+  why: string;
+}> = [
+  {
+    table: 'organizations',
+    expectedAppUserSelect: true,
+    why: 'Read before org context exists. Service-layer predicate only.',
+  },
+  {
+    table: 'users',
+    expectedAppUserSelect: true,
+    why: 'No organization_id column; scoped via org-bearing join partners.',
+  },
+  {
+    table: 'dsar_requests',
+    expectedAppUserSelect: true,
+    why: 'User-scoped, not org-scoped.',
+  },
+  {
+    table: 'demo_requests',
+    expectedAppUserSelect: true,
+    why: 'Public intake. KNOWN GAP: no RLS and no REVOKE — it postdates migration 0052, so ALTER DEFAULT PRIVILEGES left app_user full DML. Tracked in docs/backlog.md; flip this to false when the revoke lands.',
+  },
+  {
+    table: 'stripe_webhook_events',
+    expectedAppUserSelect: true,
+    why: 'Inbound dedup, written pre-auth.',
+  },
+  {
+    table: 'zitadel_webhook_events',
+    expectedAppUserSelect: true,
+    why: 'Inbound dedup, written pre-auth.',
+  },
+  {
+    table: 'documenso_webhook_events',
+    expectedAppUserSelect: true,
+    why: 'Inbound dedup, written pre-auth. DELETE revoked by migration 0052.',
+  },
+  {
+    table: 'outbox_events',
+    expectedAppUserSelect: true,
+    why: 'KNOWN GAP: migration 0022\'s comment claims "SELECT is not granted — only the superuser outbox poller reads/updates events", but app_user holds SELECT, INSERT, UPDATE and DELETE. GRANT is additive and removes nothing; ALTER DEFAULT PRIVILEGES in init-db.sh had already granted full DML — the same additive-GRANT trap already documented for DELETE on the append-only tables. Needs an explicit REVOKE, three-place discipline. Tracked in docs/backlog.md; flip this to false when it lands.',
+  },
+  // The three tables below are the ones documented as safe without RLS
+  // "because of a revoke". They are not. See REVOKES_DO_NOT_SURVIVE below.
+  {
+    table: 'federation_config',
+    expectedAppUserSelect: true,
+    why: 'KNOWN GAP: migration 0023 revokes ALL, but the revoke does not survive provisioning. See REVOKES_DO_NOT_SURVIVE.',
+  },
+  {
+    table: 'hub_registered_instances',
+    expectedAppUserSelect: true,
+    why: 'KNOWN GAP: migration 0029 revokes ALL, but the revoke does not survive provisioning. See REVOKES_DO_NOT_SURVIVE.',
+  },
+  {
+    table: 'hub_fingerprint_index',
+    expectedAppUserSelect: true,
+    why: 'KNOWN GAP: migration 0029 revokes ALL, but the revoke does not survive provisioning. See REVOKES_DO_NOT_SURVIVE.',
+  },
 ];
+
+/**
+ * REVOKES_DO_NOT_SURVIVE — the finding this file's privilege assertion exposed.
+ *
+ * `federation_config`, `hub_registered_instances` and `hub_fingerprint_index` are
+ * documented as safe despite having no RLS, on the grounds that migration
+ * `0029_hub_tables.sql:67` explicitly does `REVOKE ALL … FROM app_user`.
+ * Measured, `app_user` holds SELECT, INSERT, UPDATE and DELETE on all three, in
+ * both the test database and the dev database.
+ *
+ * The revokes are real; they are undone afterwards, in every provisioning path:
+ *
+ *   - `scripts/init-prod.sh` — Step 1 runs the migrations (applying the revokes),
+ *     then Step 2 issues `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN
+ *     SCHEMA public TO app_user` and re-revokes only the seven tables from
+ *     migrations 0052 and 0054. These three are not among them.
+ *   - `helpers/db-setup.ts` — same shape: blanket grant after migrations, then
+ *     re-revokes `audit_events` and `journal_directory` only. Its own comments
+ *     ("the broad GRANT above re-grants it — must revoke after") show the hazard
+ *     was known; the list was just incomplete.
+ *   - `pnpm db:reset` — uses `drizzle-kit push`, which syncs schema and never
+ *     executes migration SQL, so the revoke statements do not run at all.
+ *
+ * Consequence for P2.1: the design doc's `service_principals` recommendation is
+ * "no RLS **plus** REVOKE ALL, reads via SECURITY DEFINER", justified by the hub
+ * precedent being safe. Copying that pattern as written would leave the table of
+ * hashed cross-org credentials fully readable by `app_user` — precisely the
+ * instance-wide credential enumeration the recommendation exists to prevent.
+ *
+ * The expectations above therefore encode measured reality, not intent, so the
+ * gap is visible rather than assumed away. Flip each to `false` when a fix lands
+ * in all three places. Tracked in docs/backlog.md.
+ *
+ * NOT YET VERIFIED ON STAGING OR PRODUCTION — the reasoning above is a reading of
+ * `init-prod.sh` plus measurement of two local databases. Confirm against the
+ * deployed database before deciding severity.
+ */
+
+const NON_RLS_TABLE_NAMES = NON_RLS_TABLES.map((t) => t.table);
+
+/** Drizzle's own bookkeeping — not application data, classified by neither list. */
+const MIGRATION_BOOKKEEPING_TABLES = ['__drizzle_migrations'];
 
 describe('RLS Infrastructure', () => {
   beforeAll(async () => {
@@ -163,7 +269,7 @@ describe('RLS Infrastructure', () => {
         FROM pg_class
         WHERE relname = ANY($1)
       `,
-        [NON_RLS_TABLES],
+        [NON_RLS_TABLE_NAMES],
       );
 
       for (const row of rows) {
@@ -172,6 +278,83 @@ describe('RLS Infrastructure', () => {
           `${row.relname} should NOT have FORCE RLS`,
         ).toBe(false);
       }
+    });
+
+    /**
+     * "No RLS" is a decision to use table privileges instead. This asserts that
+     * decision was actually made rather than defaulted into — `init-db.sh` sets
+     * `ALTER DEFAULT PRIVILEGES ... GRANT SELECT, INSERT, UPDATE, DELETE`, so a
+     * new table is fully readable by `app_user` unless a migration revokes it.
+     */
+    it('should match the recorded app_user SELECT privilege on each non-RLS table', async () => {
+      const admin = getAdminPool();
+      for (const { table, expectedAppUserSelect, why } of NON_RLS_TABLES) {
+        const { rows } = await admin.query<{ has_priv: boolean }>(
+          `SELECT has_table_privilege('app_user', $1, 'SELECT') as has_priv`,
+          [table],
+        );
+        expect(
+          rows[0].has_priv,
+          `${table}: expected app_user SELECT = ${expectedAppUserSelect}. ${why}`,
+        ).toBe(expectedAppUserSelect);
+      }
+    });
+  });
+
+  /**
+   * The gate.
+   *
+   * Every other assertion in this file iterates one of the two lists, so a table
+   * absent from both is checked by nothing and passes silently. That is how
+   * `hub_fingerprint_index`, `documenso_webhook_events`, `demo_requests` and
+   * `hub_registered_instances` sat unclassified — and `demo_requests` shipped
+   * with neither RLS nor a revoke.
+   *
+   * Same argument as `src/trpc/guard-coverage.spec.ts` (P0.4) makes for the tRPC
+   * boundary: the policy needs a mechanism, not a note.
+   */
+  describe('Table classification is exhaustive', () => {
+    it('classifies every table in the public schema as either RLS or non-RLS', async () => {
+      const admin = getAdminPool();
+      const { rows } = await admin.query<{ tablename: string }>(
+        `SELECT tablename FROM pg_tables WHERE schemaname = 'public'`,
+      );
+
+      const actual = rows
+        .map((r) => r.tablename)
+        .filter((t) => !MIGRATION_BOOKKEEPING_TABLES.includes(t));
+      const classified = new Set([...RLS_TABLES, ...NON_RLS_TABLE_NAMES]);
+
+      const unclassified = actual.filter((t) => !classified.has(t)).sort();
+      expect(
+        unclassified,
+        `Unclassified table(s). Add each to RLS_TABLES (with enableRLS() + pgPolicy in the schema) ` +
+          `or to NON_RLS_TABLES with its compensating privilege, and record the read paths in ` +
+          `docs/tenant-isolation-audit.md.`,
+      ).toEqual([]);
+    });
+
+    it('has no stale entries — every classified table exists', async () => {
+      const admin = getAdminPool();
+      const { rows } = await admin.query<{ tablename: string }>(
+        `SELECT tablename FROM pg_tables WHERE schemaname = 'public'`,
+      );
+      const actual = new Set(rows.map((r) => r.tablename));
+
+      const missing = [...RLS_TABLES, ...NON_RLS_TABLE_NAMES]
+        .filter((t) => !actual.has(t))
+        .sort();
+      expect(
+        missing,
+        'Classified table(s) that no longer exist — remove them from the lists.',
+      ).toEqual([]);
+    });
+
+    it('classifies each table exactly once', () => {
+      const overlap = RLS_TABLES.filter((t) =>
+        NON_RLS_TABLE_NAMES.includes(t),
+      ).sort();
+      expect(overlap, 'Table(s) in both lists.').toEqual([]);
     });
   });
 

--- a/apps/api/src/__tests__/security/tenant-isolation-transitive.test.ts
+++ b/apps/api/src/__tests__/security/tenant-isolation-transitive.test.ts
@@ -36,7 +36,6 @@ import {
   createSubmissionDiscussion,
   createSubmissionVote,
   createSubmissionReviewer,
-  createPortfolioEntry,
 } from '../rls/helpers/factories.js';
 import { organizationService } from '../../services/organization.service.js';
 import { submissionService } from '../../services/submission.service.js';
@@ -87,7 +86,6 @@ async function seedOrg(label: string): Promise<Fixture> {
     decision: 'ACCEPT',
   });
   await createSubmissionReviewer(org.id, submission.id, user.id);
-  await createPortfolioEntry(user.id, { title: `${label} portfolio piece` });
 
   return {
     orgId: org.id,
@@ -215,11 +213,18 @@ describe('transitive tenant isolation (RLS is the only defense)', () => {
   });
 
   /**
-   * portfolio_entries_user_owner — `user_id = current_user_id()`, not org.
-   * Classified USER-SCOPED rather than TRANSITIVE: the native half carries an
-   * explicit `s.submitter_id = userId` predicate (`portfolio.service.ts:52`),
-   * while the `organizations` join at `:95` surfaces journal names and is
-   * searchable. Both halves are checked.
+   * submissions_org_isolation, reached through a raw-SQL join.
+   *
+   * Despite the name, `portfolioService.list` never queries `portfolio_entries`
+   * — it reads `submissions` and `external_submissions`, and `LEFT JOIN`s
+   * `organizations` at `:95` purely to surface journal names (which are also a
+   * search target at `:65`). So what is under test here is that join: the only
+   * predicate on the native half is `s.submitter_id = userId` (`:52`), and the
+   * org name of a submission belonging to another tenant must not appear.
+   *
+   * Classified USER-SCOPED for that reason — an explicit predicate, just not an
+   * org one. This does NOT cover `portfolio_entries_user_owner`; no service
+   * method in this suite reads that table.
    */
   it('portfolioService.list is user-scoped and leaks no other org journal name', async () => {
     const result = await withTestRls({ userId: a.userId }, (tx) =>

--- a/apps/api/src/__tests__/security/tenant-isolation-transitive.test.ts
+++ b/apps/api/src/__tests__/security/tenant-isolation-transitive.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Transitive tenant isolation — the service methods that carry NO explicit
+ * organization predicate.
+ *
+ * WHAT THIS PROVES: that RLS, on its own, isolates each of these paths today.
+ *
+ * WHAT THIS DOES NOT PROVE: that these methods satisfy the house defense-in-depth
+ * rule for tenant queries — always include an explicit `WHERE organization_id =
+ * orgId`, never rely solely on RLS. They do not. Every method below is on
+ * the fix list in `docs/tenant-isolation-audit.md` precisely because the database
+ * is the only thing separating tenants in it. A green run here means the backstop
+ * is intact — it is not permission to leave the predicate out.
+ *
+ * Every query therefore runs over the APP pool via `withTestRls`, which connects
+ * as `app_user` (`NOSUPERUSER`, `NOBYPASSRLS`) and sets `app.current_org` /
+ * `app.user_id` with `set_config(..., true)`. This is the deliberate opposite of
+ * `__tests__/rls/api-key-service.test.ts`, which drives the admin pool so that an
+ * explicit predicate is the only thing under test. Two directions, two files:
+ * that one isolates the `WHERE` clause, this one isolates the policy.
+ *
+ * Each test seeds BOTH orgs and asserts a non-zero org A count before asserting
+ * zero org B rows. Without that guard "no org B rows" is trivially true of an
+ * empty table, and four of these methods read tables `createTwoOrgScenario` does
+ * not populate.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { globalSetup } from '../rls/helpers/db-setup.js';
+import { truncateAllTables } from '../rls/helpers/cleanup.js';
+import { withTestRls } from '../rls/helpers/rls-context.js';
+import {
+  createOrganization,
+  createUser,
+  createOrgMember,
+  createSubmissionPeriod,
+  createSubmission,
+  createSubmissionDiscussion,
+  createSubmissionVote,
+  createSubmissionReviewer,
+  createPortfolioEntry,
+} from '../rls/helpers/factories.js';
+import { organizationService } from '../../services/organization.service.js';
+import { submissionService } from '../../services/submission.service.js';
+import { submissionDiscussionService } from '../../services/submission-discussion.service.js';
+import { submissionVoteService } from '../../services/submission-vote.service.js';
+import { submissionReviewerService } from '../../services/submission-reviewer.service.js';
+import { portfolioService } from '../../services/portfolio.service.js';
+
+// `withTestRls` hands back a `DrizzleDb` that already matches
+// `organizationService.listMembers`, so that call needs no cast. The others take
+// a schema-typed handle from a different peer-dep resolution of drizzle — same
+// runtime object, divergent types — hence `tx as never` at those sites only.
+const PAGINATION = { page: 1, limit: 50 };
+const LIST_INPUT = { ...PAGINATION };
+const EXPORT_INPUT = { ...PAGINATION, format: 'json' as const };
+const ADMIN_ROLES = ['ADMIN'] as const;
+
+/** Old enough that `listAgingByOrg(tx, 7)` will match it. */
+const LONG_AGO = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+
+interface Fixture {
+  orgId: string;
+  userId: string;
+  submissionId: string;
+  title: string;
+}
+
+async function seedOrg(label: string): Promise<Fixture> {
+  const org = await createOrganization({ name: `${label} Org` });
+  const user = await createUser();
+  await createOrgMember(org.id, user.id, { roles: ['ADMIN'] });
+  const period = await createSubmissionPeriod(org.id);
+
+  const title = `${label} manuscript`;
+  const submission = await createSubmission(org.id, user.id, {
+    submissionPeriodId: period.id,
+    title,
+    // Not DRAFT/ACCEPTED/REJECTED/WITHDRAWN, and submitted long ago, so the
+    // aging digest picks it up.
+    status: 'UNDER_REVIEW',
+    submittedAt: LONG_AGO,
+  });
+
+  await createSubmissionDiscussion(org.id, submission.id, user.id, {
+    content: `${label} discussion`,
+  });
+  await createSubmissionVote(org.id, submission.id, user.id, {
+    decision: 'ACCEPT',
+  });
+  await createSubmissionReviewer(org.id, submission.id, user.id);
+  await createPortfolioEntry(user.id, { title: `${label} portfolio piece` });
+
+  return {
+    orgId: org.id,
+    userId: user.id,
+    submissionId: submission.id,
+    title,
+  };
+}
+
+describe('transitive tenant isolation (RLS is the only defense)', () => {
+  let a: Fixture;
+  let b: Fixture;
+
+  beforeAll(async () => {
+    await globalSetup();
+    await truncateAllTables();
+    a = await seedOrg('Alpha');
+    b = await seedOrg('Beta');
+  });
+
+  afterAll(async () => {
+    await truncateAllTables();
+  });
+
+  // organization_members_org_isolation
+  it('organizationService.listMembers returns only the current org, in items and total', async () => {
+    const result = await withTestRls(
+      { orgId: a.orgId, userId: a.userId },
+      (tx) => organizationService.listMembers(tx, PAGINATION),
+    );
+
+    expect(result.items.length).toBeGreaterThan(0);
+    expect(result.items.map((m) => m.userId)).toEqual([a.userId]);
+    expect(result.items.map((m) => m.userId)).not.toContain(b.userId);
+    // The count query has no predicate either — if the policy stopped covering
+    // it, `total` would report both orgs while `items` stayed correct.
+    expect(result.total).toBe(1);
+  });
+
+  // submissions_org_isolation
+  it('submissionService.listAll returns only the current org, in items and total', async () => {
+    const result = await withTestRls(
+      { orgId: a.orgId, userId: a.userId },
+      (tx) => submissionService.listAll(tx as never, LIST_INPUT, ADMIN_ROLES),
+    );
+
+    expect(result.items.length).toBeGreaterThan(0);
+    expect(result.items.map((s) => s.id)).toEqual([a.submissionId]);
+    expect(result.items.map((s) => s.id)).not.toContain(b.submissionId);
+    expect(result.total).toBe(1);
+  });
+
+  // submissions_org_isolation
+  it('submissionService.exportAll returns only the current org', async () => {
+    const rows = await withTestRls({ orgId: a.orgId, userId: a.userId }, (tx) =>
+      submissionService.exportAll(tx as never, EXPORT_INPUT, ADMIN_ROLES),
+    );
+
+    const ids = (rows as Array<{ id: string }>).map((r) => r.id);
+    expect(ids.length).toBeGreaterThan(0);
+    expect(ids).toEqual([a.submissionId]);
+    expect(ids).not.toContain(b.submissionId);
+  });
+
+  // submissions_org_isolation — note the method is named ByOrg but takes no orgId
+  it('submissionService.listAgingByOrg returns only the current org', async () => {
+    const result = await withTestRls(
+      { orgId: a.orgId, userId: a.userId },
+      (tx) => submissionService.listAgingByOrg(tx as never, 7),
+    );
+
+    expect(result.submissions.length).toBeGreaterThan(0);
+    expect(result.submissions.map((s) => s.id)).toEqual([a.submissionId]);
+    expect(result.totalCount).toBe(1);
+  });
+
+  // submission_discussions_org_isolation
+  it('submissionDiscussionService.listBySubmission cannot read another org submission', async () => {
+    const own = await withTestRls({ orgId: a.orgId, userId: a.userId }, (tx) =>
+      submissionDiscussionService.listBySubmission(tx as never, a.submissionId),
+    );
+    expect(own.length).toBeGreaterThan(0);
+
+    // Org A context, org B's submission id — the policy, not the argument, is
+    // what must return nothing.
+    const foreign = await withTestRls(
+      { orgId: a.orgId, userId: a.userId },
+      (tx) =>
+        submissionDiscussionService.listBySubmission(
+          tx as never,
+          b.submissionId,
+        ),
+    );
+    expect(foreign).toHaveLength(0);
+  });
+
+  // submission_votes_org_isolation
+  it('submissionVoteService.listBySubmission cannot read another org submission', async () => {
+    const own = await withTestRls({ orgId: a.orgId, userId: a.userId }, (tx) =>
+      submissionVoteService.listBySubmission(tx as never, a.submissionId),
+    );
+    expect(own.length).toBeGreaterThan(0);
+
+    const foreign = await withTestRls(
+      { orgId: a.orgId, userId: a.userId },
+      (tx) =>
+        submissionVoteService.listBySubmission(tx as never, b.submissionId),
+    );
+    expect(foreign).toHaveLength(0);
+  });
+
+  // submission_reviewers_org_isolation (+ organization_members join)
+  it('submissionReviewerService.listBySubmission cannot read another org submission', async () => {
+    const own = await withTestRls({ orgId: a.orgId, userId: a.userId }, (tx) =>
+      submissionReviewerService.listBySubmission(tx as never, a.submissionId),
+    );
+    expect(own.length).toBeGreaterThan(0);
+
+    const foreign = await withTestRls(
+      { orgId: a.orgId, userId: a.userId },
+      (tx) =>
+        submissionReviewerService.listBySubmission(tx as never, b.submissionId),
+    );
+    expect(foreign).toHaveLength(0);
+  });
+
+  /**
+   * portfolio_entries_user_owner — `user_id = current_user_id()`, not org.
+   * Classified USER-SCOPED rather than TRANSITIVE: the native half carries an
+   * explicit `s.submitter_id = userId` predicate (`portfolio.service.ts:52`),
+   * while the `organizations` join at `:95` surfaces journal names and is
+   * searchable. Both halves are checked.
+   */
+  it('portfolioService.list is user-scoped and leaks no other org journal name', async () => {
+    const result = await withTestRls({ userId: a.userId }, (tx) =>
+      portfolioService.list(tx as never, a.userId, LIST_INPUT),
+    );
+
+    expect(result.items.length).toBeGreaterThan(0);
+    const serialized = JSON.stringify(result.items);
+    expect(serialized).toContain('Alpha');
+    expect(serialized).not.toContain('Beta');
+  });
+});

--- a/apps/api/src/__tests__/security/unprotected-table-callsites.test.ts
+++ b/apps/api/src/__tests__/security/unprotected-table-callsites.test.ts
@@ -38,10 +38,17 @@ const API_SRC = path.resolve(__dirname, '../..');
  *   - `alias(users, 'copyeditors')` — `pipeline.service.ts` does this ×6, and a
  *     bare-name grep for `from(users)` misses every one
  *   - `db.query.users.findFirst` — the relational API
- *   - raw `FROM users` / `JOIN organizations` inside `sql` blocks
+ *   - raw SQL inside `sql` blocks and `client.query(...)`
+ *
+ * The raw-SQL branch must cover writes as well as reads. `FROM` / `JOIN` alone
+ * catches `SELECT … FROM users` and `DELETE FROM users` (both present in
+ * `gdpr.service.ts`), but `UPDATE users SET …` and `INSERT INTO organizations …`
+ * have neither keyword, and the Drizzle branch does not apply because raw SQL
+ * has no `update(` / `into(` call. Those are writes to unprotected tables — the
+ * accesses that most need review — so they are matched explicitly.
  */
 const ACCESS_PATTERN =
-  /(?:from|innerJoin|leftJoin|rightJoin|fullJoin|alias|update|delete|into)\(\s*(?:users|organizations)\b|(?:db|tx)\.query\.(?:users|organizations)\b|(?:FROM|JOIN)\s+(?:users|organizations)\b/;
+  /(?:from|innerJoin|leftJoin|rightJoin|fullJoin|alias|update|delete|into)\(\s*(?:users|organizations)\b|(?:db|tx)\.query\.(?:users|organizations)\b|(?:FROM|JOIN|INTO|UPDATE)\s+(?:users|organizations)\b/i;
 
 /**
  * Files known to read or write `users` / `organizations`, each classified in

--- a/apps/api/src/__tests__/security/unprotected-table-callsites.test.ts
+++ b/apps/api/src/__tests__/security/unprotected-table-callsites.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Call-site tripwire for the two unprotected tables.
+ *
+ * THIS IS A REVIEW TRIPWIRE, NOT A SECURITY GATE. It is file-level, so a new
+ * query added to a file already on the list passes silently. Its only job is to
+ * make a `users` or `organizations` query appearing in a NEW file fail the
+ * build, so whoever adds it classifies it in `docs/tenant-isolation-audit.md`
+ * rather than it landing unreviewed.
+ *
+ * The load-bearing gate is `__tests__/rls/rls-infrastructure.test.ts`, which
+ * checks the live catalog. This one is cheap insurance on top.
+ *
+ * Why it exists at all: `users` and `organizations` have no RLS and no
+ * compensating REVOKE, so on those two tables an explicit `WHERE` clause in the
+ * service layer is the entire isolation story. Every read of them is worth a
+ * human deciding whether it is scoped, and this list is the record that someone
+ * did.
+ *
+ * Needs no database, but is named `.test.ts` and lives here deliberately:
+ * `vitest.config.ts` excludes `src/__tests__/security/**` and
+ * `vitest.config.security.ts` includes only `*.test.ts`, so a `.spec.ts` in this
+ * directory would be collected by no suite at all and silently never run.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+// `__dirname`, not `import.meta` — this package type-checks against a CommonJS
+// target, which rejects `import.meta` outright (TS1470). Matches
+// `../rls/helpers/db-setup.ts`.
+const API_SRC = path.resolve(__dirname, '../..');
+
+/**
+ * Every way the codebase reaches these tables. All four forms are represented in
+ * the tree today, and dropping any one of them makes the sweep incomplete:
+ *   - `.from(users)` / `.update(organizations)` — the common Drizzle builder
+ *   - `.leftJoin(users, ...)` — six files reach `users` ONLY this way
+ *   - `alias(users, 'copyeditors')` — `pipeline.service.ts` does this ×6, and a
+ *     bare-name grep for `from(users)` misses every one
+ *   - `db.query.users.findFirst` — the relational API
+ *   - raw `FROM users` / `JOIN organizations` inside `sql` blocks
+ */
+const ACCESS_PATTERN =
+  /(?:from|innerJoin|leftJoin|rightJoin|fullJoin|alias|update|delete|into)\(\s*(?:users|organizations)\b|(?:db|tx)\.query\.(?:users|organizations)\b|(?:FROM|JOIN)\s+(?:users|organizations)\b/;
+
+/**
+ * Files known to read or write `users` / `organizations`, each classified in
+ * `docs/tenant-isolation-audit.md`. Adding a file here without a corresponding
+ * entry in that document defeats the point.
+ */
+const CLASSIFIED_CALLSITE_FILES: readonly string[] = [
+  'hooks/auth.ts',
+  'hooks/org-context.ts',
+  'inngest/functions/cms-publish.ts',
+  'inngest/functions/contract-workflow.ts',
+  'inngest/functions/discussion-notifications.ts',
+  'inngest/functions/embed-submission-confirmation.ts',
+  'inngest/functions/reviewer-notifications.ts',
+  'inngest/functions/slate-notifications.ts',
+  'inngest/functions/submission-notifications.ts',
+  'inngest/functions/submission-response-reminder.ts',
+  'routes/public.routes.ts',
+  'services/contest.service.ts',
+  'services/correspondence.service.ts',
+  'services/csr.service.ts',
+  'services/embed-submission.service.ts',
+  'services/federation.service.ts',
+  'services/gdpr.service.ts',
+  'services/invitation.service.ts',
+  'services/migration-bundle.service.ts',
+  'services/migration.service.ts',
+  'services/organization.service.ts',
+  'services/pipeline.service.ts',
+  'services/portfolio.service.ts',
+  'services/response-time-transparency.service.ts',
+  'services/simsub-group.service.ts',
+  'services/simsub.service.ts',
+  'services/status-token.service.ts',
+  'services/submission-discussion.service.ts',
+  'services/submission-reviewer.service.ts',
+  'services/submission-vote.service.ts',
+  'services/submission.service.ts',
+  'services/transfer.service.ts',
+  'services/trust.service.ts',
+  'services/user.service.ts',
+  'webhooks/tusd.webhook.ts',
+  'webhooks/zitadel.webhook.ts',
+];
+
+function collectSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue;
+      collectSourceFiles(full, acc);
+      continue;
+    }
+    if (!entry.endsWith('.ts') || entry.endsWith('.spec.ts')) continue;
+    acc.push(full);
+  }
+  return acc;
+}
+
+describe('users / organizations call sites are classified', () => {
+  const actual = collectSourceFiles(API_SRC)
+    .filter((f) => ACCESS_PATTERN.test(readFileSync(f, 'utf8')))
+    .map((f) => path.relative(API_SRC, f).split(path.sep).join('/'))
+    .sort();
+
+  it('has no unclassified file reading users or organizations', () => {
+    const unclassified = actual.filter(
+      (f) => !CLASSIFIED_CALLSITE_FILES.includes(f),
+    );
+    expect(
+      unclassified,
+      'These files query `users` or `organizations`, which have NO row-level security — ' +
+        'an explicit WHERE clause is the only thing isolating tenants there. Classify each ' +
+        'new read in docs/tenant-isolation-audit.md, then add the file here.',
+    ).toEqual([]);
+  });
+
+  it('has no stale entries', () => {
+    const stale = CLASSIFIED_CALLSITE_FILES.filter((f) => !actual.includes(f));
+    expect(
+      stale,
+      'Listed file(s) no longer query users/organizations — remove them here and in the audit doc.',
+    ).toEqual([]);
+  });
+});

--- a/docs/api-integration-design.md
+++ b/docs/api-integration-design.md
@@ -597,14 +597,26 @@ That is fail-closed and it is the right default.
 Five failure modes need explicit handling.
 
 **F1 — The un-RLS'd tables.** `users` and `organizations` have no RLS at all (alongside
-`federationConfig`, `hubRegisteredInstances`, `outboxEvents`, and the webhook-event
-dedup tables). Cross-org isolation on those two is enforced _only_ by explicit
+`federationConfig`, `hubRegisteredInstances`, `hubFingerprintIndex`, `outboxEvents`,
+`dsarRequests`, `demoRequests`, and the webhook-event dedup tables — 11 in total).
+Cross-org isolation on those two is enforced _only_ by explicit
 `WHERE` clauses in the service layer. Today that is adequate because every principal is
 already pinned to one org and the surface that reads them is small. An instance principal
 removes the pin. Any service method touching `users` or `organizations` that does not
 filter explicitly becomes a cross-tenant enumeration path the moment such a principal
 exists. **This must be audited method-by-method before (a) ships**, and it is the single
 largest correctness risk in this design.
+
+**Audited 2026-07-28 — [`tenant-isolation-audit.md`](tenant-isolation-audit.md).** 73 sites
+across 36 files: 18 SCOPED, 3 USER-SCOPED, 12 TRANSITIVE (RLS-only), 34 BY-ID-ONLY, 6 deliberately
+UNFILTERED. No live vulnerability — every TRANSITIVE path is isolated by RLS today, now proven
+per method rather than assumed. The predicate work is 5 methods across 2 files, smaller than §2.6(1)
+feared.
+
+One correction the audit forced: `users` has **no `organizationId` column**, so the explicit
+predicate cannot go on that table. It goes on an org-bearing join partner
+(`organization_members`, `submissions`) or an `EXISTS`. "Thread `orgId` into every query" does not
+compile; "`users` can only ever be RLS-only" is the opposite error and excuses the gap.
 
 **F2 — Wrong org selected.** Today the guard is the membership check in
 `org-context.ts:112–133`: the caller must have a row in `organization_members`. An
@@ -978,10 +990,17 @@ A single magazine running its own instance sees exactly what it sees today.
 
 Called out per the brief's instruction to flag rather than paper over.
 
-1. **The `users` / `organizations` no-RLS exposure (F1) is the biggest unknown.** I verified
-   the tables lack RLS and that isolation depends on service-layer filtering. I did **not**
-   audit all 66 service modules for unfiltered reads. That audit is a prerequisite for (a),
-   not a follow-up, and it may change the effort estimate materially.
+1. ~~**The `users` / `organizations` no-RLS exposure (F1) is the biggest unknown.**~~
+   **Resolved 2026-07-28 — [`tenant-isolation-audit.md`](tenant-isolation-audit.md).** All 73
+   sites classified. The estimate moves in both directions: the predicate work on those two
+   tables is _smaller_ than feared (5 methods, 2 files), but the audit invalidated the premise
+   of P2.1. `federation_config` and both `hub_*` tables are documented as safe "because of a
+   revoke"; measured, `app_user` holds full DML on all three, because every provisioning path
+   issues a blanket `GRANT … ON ALL TABLES` after migrations and re-revokes only seven tables.
+   **P2.1 proposes exactly that pattern for `service_principals`** — implemented as written, the
+   hashed-credential table would be readable by `app_user`. Fix the three-place discipline and
+   assert it before P2.1 ships; §2.4's "the hub precedent is safe _because_ of a revoke" is not
+   currently true.
 2. **Whether `PgBouncer` transaction pooling interacts with leaving `app.user_id` unset.**
    The `SET LOCAL` contract is sound in transaction mode, but I have not tested the
    specific case of setting `app.current_org` without `app.user_id` on a pooled connection.
@@ -1260,8 +1279,10 @@ REST surface in Phase 4.
    but submitters have no org membership by design, so the v1 membership check excludes
    them. Needs a consent model that does not exist. Possibly a Register concern given
    federated identity already models cross-instance user agency.
-3. **The `users` / `organizations` no-RLS audit** (§2.6(1)) — scoped as P2.0, but its size
-   is unknown until someone reads the 66 service modules. May change Phase 2's estimate.
+3. ~~**The `users` / `organizations` no-RLS audit** (§2.6(1))~~ — **done 2026-07-28**,
+   [`tenant-isolation-audit.md`](tenant-isolation-audit.md). Replaced by a narrower open
+   question: the `REVOKE`-based privilege model does not survive provisioning (§2.6(1)), which
+   P2.1 depends on. Not yet verified against staging or production.
 4. **Normalising the two RLS idioms** (F6) — four schema files raise where twenty-four
    return NULL. Not urgent, not a vulnerability, but it should be a decision rather than an
    accident.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -271,6 +271,94 @@ Ordered as the design doc's Phase 0/D.
       `sdks/openapi.json` is not in `.prettierignore`, so the pre-commit hook formats it —
       the export now writes prettier-formatted output to keep `--check`'s byte comparison
       valid.
+- [x] **[P2.0 audit half] Tenant-isolation audit of `users` and `organizations`.** All 73 read
+      and write sites across 36 files classified in
+      [`docs/tenant-isolation-audit.md`](tenant-isolation-audit.md): 18 SCOPED, 3 USER-SCOPED,
+      12 TRANSITIVE (RLS-only), 34 BY-ID-ONLY, 6 deliberately UNFILTERED. Closes design doc
+      §2.6(1) and §8 item 3. — (design doc §5 Phase 2 P2.0; done 2026-07-28)
+      **`users` has no `organizationId` column**, so its explicit predicate goes on an
+      org-bearing join partner, not the table. Both naive readings are wrong: "thread `orgId`
+      everywhere" does not compile, and "`users` can only be RLS-only" excuses the gap.
+      **No live vulnerability** — every TRANSITIVE path is isolated by RLS today, and
+      `__tests__/security/tenant-isolation-transitive.test.ts` now proves that per method
+      instead of asserting it, with non-zero own-org guards so the checks cannot pass against
+      empty tables. Three gates keep the audit true; each was verified to fail before being
+      trusted. The predicate fixes are the items below.
+- [ ] **[P0] The `REVOKE`-based privilege model does not survive provisioning — and P2.1
+      depends on it.** The database package's RLS notes and design doc §2.4 both hold that
+      `federation_config`, `hub_registered_instances` and `hub_fingerprint_index` are safe
+      without RLS "because of a revoke" (migrations 0023, 0029). Measured, `app_user` holds
+      `SELECT, INSERT, UPDATE, DELETE` on all three, in both the test and dev databases. The
+      revokes run and are then undone: `init-prod.sh` issues
+      `GRANT … ON ALL TABLES … TO app_user` (`:63`) _after_ migrations and re-revokes only the
+      seven tables from 0052/0054; `helpers/db-setup.ts` re-revokes only `audit_events` and
+      `journal_directory`; `db:reset` uses `drizzle-kit push`, which never executes migration
+      SQL at all. `outbox_events` fails the same way for a different reason — migration 0022's
+      comment claims SELECT is withheld, but `GRANT` is additive and `ALTER DEFAULT PRIVILEGES`
+      had already granted full DML.
+      **This is why it is P0 rather than P2:** P2.1 specifies "no RLS **plus** `REVOKE ALL`,
+      reads via SECURITY DEFINER" for `service_principals`, justified explicitly by the hub
+      precedent. Built as written, the table of hashed cross-org credentials would be fully
+      readable by `app_user` — the instance-wide credential enumeration the design exists to
+      prevent. Fix the three-place discipline, then flip the pinned expectations in
+      `rls-infrastructure.test.ts`.
+      **Not yet verified on staging or production** — the finding is a reading of `init-prod.sh`
+      plus measurement of two local databases. Confirm against the deployed database first; that
+      check sets the severity. — (found 2026-07-28 during the P2.0 audit)
+- [ ] **[P1] `organizationService.listMembers` has no org predicate on either query.**
+      `apps/api/src/services/organization.service.ts:168` (page) and `:182` (`count(*)`) carry
+      no `WHERE` clause on any table — the only read of `users` in the codebase in that state.
+      RLS on `organization_members` is the sole defense. The direct analogue of #521, and the
+      first fix PR: the method already joins `organization_members`, so the fix is
+      `eq(organizationMembers.organizationId, orgId)` on a join it performs anyway, plus an
+      `orgId` parameter threaded from `ctx.authContext.orgId` / `context.authContext.orgId`.
+      **Both halves** — scoping only the page query leaves `total` reporting every org's member
+      count. — (found 2026-07-28 during the P2.0 audit)
+- [ ] **[P1] REST `POST /v1/invitations/accept` declares no scopes.**
+      `apps/api/src/rest/routers/organizations.ts:333` uses `userProcedure` with no
+      `requireScopes(...)`, while its tRPC twin (`trpc/routers/organizations.ts:157`) declares
+      `organizations:write`. The route is authenticated but scope-unconstrained and it writes
+      membership. `trpc/guard-coverage.spec.ts` reads the tRPC router only, so REST has no
+      equivalent build-time check — worth adding the mirror gate alongside the fix, since this
+      is the second REST/tRPC parity gap found in two sessions. — (found 2026-07-28 during the
+      P2.0 audit)
+- [ ] **[P2] `submission.service` list/export methods carry no org predicate.** `listAll`
+      (`:290`), `exportAll` (`:392`, up to 10 000 rows) and `listAgingByOrg` (`:1526`) build
+      their `where` from `status` / `period` / `search` / date only. `listAgingByOrg` is named
+      for a scoping it does not perform — its caller supplies the org through
+      `withRls({ orgId })` at `inngest/functions/submission-response-reminder.ts:64`, so it is
+      correct in practice and misleading to read. — (found 2026-07-28 during the P2.0 audit)
+- [ ] **[P2] `pipeline.service.ts:309` `updateStage` filters the read but not the write.** The
+      guard is `getById(tx, id, orgId)`; the `UPDATE` that follows is
+      `.where(eq(pipelineItems.id, id))` with no org predicate. Read-then-write with the
+      predicate on only one half. — (found 2026-07-28 during the P2.0 audit)
+- [ ] **[P2] `issue.service.ts:65,122` take `orgId?` as optional and apply the predicate
+      conditionally.** An optional org id is a silent bypass: omit the argument and the query
+      is unscoped, with nothing at the type level to flag it. Make it required, matching the
+      house `(tx, id|input, orgId)` convention. — (found 2026-07-28 during the P2.0 audit)
+- [ ] **[P2] `federation.service.ts:437` `resolveWebFinger` is laxer than its sibling.** It
+      filters on `email` alone, while `getUserDidDocument` (`:523`) filters `email` **and**
+      `isNull(deletedAt)` **and** `eq(isGuest, false)`. Both are unauthenticated federation
+      discovery endpoints, so a deleted or guest account is discoverable through one and not
+      the other. The asymmetry looks unintended. — (found 2026-07-28 during the P2.0 audit)
+- [ ] **[P2] `demo_requests` has neither RLS nor a `REVOKE`.** It postdates migration 0052, so
+      `ALTER DEFAULT PRIVILEGES` left `app_user` full DML and no later migration narrowed it.
+      Needs a revoke with the three-place discipline; `rls-infrastructure.test.ts` pins the
+      current state so the fix flips an expectation. — (found 2026-07-28 during the P2.0 audit)
+- [ ] **[P3] Delete `organizationService.addMemberWithAudit`.** Zero production callers
+      (`organization.service.ts:321`); the only three references are `vi.fn()` stubs in
+      `trpc/routers/organizations.spec.ts:17`, `trpc/routers/gdpr.spec.ts:35` and
+      `rest/routers/organizations.spec.ts:16` — spec files mocking a method their subject never
+      invokes. `inviteOrAddMemberWithAudit` reaches `addMember` directly at `:349`. Same shape
+      as the `getById` #521 deleted rather than fixed. — (found 2026-07-28 during the P2.0 audit)
+- [ ] **[P3] Email is a cross-tenant lookup key in eight places, four unauthenticated.**
+      `organization.service.ts:203`, `embed-submission.service.ts:92`/`:121`/`:138`,
+      `federation.service.ts:437`/`:523`, `simsub.service.ts:324`, `migration.service.ts:494`,
+      `auth.ts:456`. Sharpest edge: `embed-submission.service.ts:92` returns an existing user id
+      on an email match even when that account belongs to another tenant, attributing the embed
+      submission to them. Deliberate — it is how a known writer submitting through an embed gets
+      linked — but it wants a decision on identity semantics, not a patch. — (found 2026-07-28
+      during the P2.0 audit)
 - [ ] **[P1] No per-key rate limits.** `hooks/rate-limit-auth.ts:57` keys the authenticated
       window on `userId`, which for key auth is the key's _creator_ — so all of an admin's
       keys share one bucket with each other and with that admin's browser session. Key on
@@ -409,6 +497,13 @@ invitations were assumed missing and are in fact already exposed — see §0 of 
       recommendation is a separate `service_principals` table, flat capability strings with
       tenancy in a grant table, and org-visible/org-revocable grants. Four decisions gate the
       work (D1–D4, §5 Phase D). Not started.
+      **Hard preconditions, from the 2026-07-28 P2.0 audit — both must merge first:**
+      (1) the P0 `REVOKE`-does-not-survive-provisioning fix, because P2.1's table design is
+      built on a precedent that does not currently hold and would leave hashed cross-org
+      credentials readable by `app_user`; (2) every P1 explicit-predicate item above, because
+      the instance principal is precisely what removes the one-org pin those paths rely on.
+      Shipping the principal ahead of either turns a documented, contained gap into a reachable
+      one.
 - [x] Submitter role architecture: per-org role assignment vs global identity with per-org role bindings — **Resolved 2026-02-19:** Submitter is a global user capability, not an org role. Staff roles (`ADMIN/EDITOR/READER`) unchanged. Manuscript library is user-owned and cross-org. Follow/subscribe for org-to-writer comms. — (architecture doc Open Question #1)
 - [x] Self-serve org creation: managed hosting provisioning model vs self-hosted admin — **Partially resolved 2026-02-19:** Self-serve in both contexts. Managed hosting: free tier with quotas, paid upgrade, all features on all tiers. Self-hosted: no billing. Managed hosting infra deferred to post-Track 3. — (architecture doc Open Question #2)
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -351,6 +351,15 @@ Ordered as the design doc's Phase 0/D.
       `rest/routers/organizations.spec.ts:16` — spec files mocking a method their subject never
       invokes. `inviteOrAddMemberWithAudit` reaches `addMember` directly at `:349`. Same shape
       as the `getById` #521 deleted rather than fixed. — (found 2026-07-28 during the P2.0 audit)
+- [ ] **[P3] Widen the schema gate to policy semantics and schema↔migration consistency.**
+      `rls-infrastructure.test.ts` now asserts, per table, that classification is exhaustive,
+      that RLS and `FORCE` are on where expected, and that `app_user`'s SELECT privilege matches
+      a recorded expectation. It does **not** check that a policy says the right thing — a table
+      could carry a policy scoped to the wrong column, or a `USING` clause with the raising
+      `current_setting(...)::uuid` idiom where `current_org_id()` was intended, and pass. Nor
+      does it check that the Drizzle schema and the migration SQL agree, which is the class of
+      drift `db:verify` catches for FK constraints only. Deliberately left out of the P2.0 audit
+      as a separate concern from F1 and too large to ride inside it. — (plan review 2026-07-28)
 - [ ] **[P3] Email is a cross-tenant lookup key in eight places, four unauthenticated.**
       `organization.service.ts:203`, `embed-submission.service.ts:92`/`:121`/`:138`,
       `federation.service.ts:437`/`:523`, `simsub.service.ts:324`, `migration.service.ts:494`,

--- a/docs/tenant-isolation-audit.md
+++ b/docs/tenant-isolation-audit.md
@@ -1,0 +1,264 @@
+# Tenant Isolation Audit — `users` and `organizations`
+
+**Scope:** every read and write of the two tables that have no row-level security.
+**Date:** 2026-07-28. **Tree:** `fd9c905f`.
+**Motivating item:** P2.0 in [`api-integration-design.md`](api-integration-design.md) §5 Phase 2,
+opened by §2.3 F1 and left unresolved in §2.6(1) and §8 item 3.
+
+---
+
+## 1. Why this exists
+
+Sixty tables carry RLS. `users` and `organizations` do not, and neither has a compensating
+`REVOKE`. On those two, cross-tenant isolation is whatever the service layer's `WHERE` clause
+says it is — the database will not catch a mistake.
+
+That is tolerable today because every principal is pinned to exactly one organization: an API
+key belongs to one org, and an interactive session resolves one org through
+`organization_members`. The instance principal planned in Phase 2 removes the pin. From that
+point, any query that relies on the pin rather than on a predicate becomes a cross-tenant read.
+
+§2.6(1) of the design doc flagged the audit as unperformed and as a prerequisite rather than a
+follow-up, and noted it "may change the effort estimate materially". This is that audit.
+
+## 2. Where the predicate goes
+
+`users` has **no `organizationId` column** (`packages/db/src/schema/users.ts:15-33`). It is a
+global identity table by design — one person, one row, many orgs.
+
+That does not make a `users` read unscopeable. It means the predicate lands on an org-bearing
+**join partner** instead of on the table itself:
+
+| Table           | Explicit predicate                                                                   |
+| --------------- | ------------------------------------------------------------------------------------ |
+| `organizations` | On the table: `eq(organizations.id, orgId)`                                          |
+| `users`         | On the join partner: `eq(organizationMembers.organizationId, orgId)`, or an `EXISTS` |
+
+Both wrong conclusions are worth naming, because each licenses a different mistake:
+
+- _"Thread `orgId` into every query"_ — does not compile against `users`, and would produce
+  meaningless code if forced.
+- _"`users` reads can only ever be RLS-only"_ — false, and it excuses exactly the gap this audit
+  exists to close. `organizationService.listMembers` is the proof: it already joins
+  `organization_members`, so scoping it is one condition on a join it performs anyway.
+
+## 3. Method
+
+Four search angles, because no single one is complete:
+
+1. Builder calls — `from(users)`, `.update(organizations)`, `.insert(users)`, `.delete(...)`.
+2. Join calls — `.leftJoin(users, ...)`, `.innerJoin(organizations, ...)`. **Six files reach
+   `users` only this way** and are invisible to angle 1.
+3. `alias()` — `pipeline.service.ts` aliases `users` six times (`:129`, `:130`, `:188`, `:189`,
+   `:997`, `:998`) as `copyeditors` / `proofreaders`. A bare-name grep for `from(users)` misses
+   every one.
+4. Relational API and raw SQL — `db.query.users.findFirst`, and `FROM users` / `JOIN
+organizations` inside `sql` blocks.
+
+Confirmed no import aliasing (`import { users as … }`) anywhere in `apps/api/src` or
+`packages/db/src`, so bare-name matching is sound once all four angles are combined.
+
+Counts, page queries and write halves are treated as separate sites. #521 is the precedent: the
+paginated query was scoped and the `count(*)` was not, so `items` was correct while `total`
+reported every org's rows.
+
+## 4. Verdicts
+
+73 sites across 36 files.
+
+| Verdict         | Count | Meaning                                                                    |
+| --------------- | ----- | -------------------------------------------------------------------------- |
+| **SCOPED**      | 18    | Explicit org predicate, on the table or on an org-bearing join partner     |
+| **USER-SCOPED** | 3     | Explicit predicate, but on `user_id` / `submitter_id`, not org             |
+| **TRANSITIVE**  | 12    | No explicit predicate; an RLS policy on a joined table is the only defense |
+| **BY-ID-ONLY**  | 34    | Primary- or natural-key lookup; no org concept applies                     |
+| **UNFILTERED**  | 6     | No meaningful predicate                                                    |
+
+**None of these is a live vulnerability.** Every TRANSITIVE path is isolated by RLS today, which
+`apps/api/src/__tests__/security/tenant-isolation-transitive.test.ts` verifies per method rather
+than asserting. The finding is that 12 paths have one layer where the house rule for tenant
+queries — never rely solely on RLS, always include an explicit `WHERE organization_id = orgId`
+as defense-in-depth — requires two, and that the missing layer is the one the instance principal
+removes.
+
+### 4.1 TRANSITIVE — the fix list
+
+RLS-only. Ordered by exposure.
+
+| Site                                            | Method                      | Predicate present                   | Disposition |
+| ----------------------------------------------- | --------------------------- | ----------------------------------- | ----------- |
+| `services/organization.service.ts:168`          | `listMembers` page query    | **none**                            | fix — P1    |
+| `services/organization.service.ts:182`          | `listMembers` count query   | **none**                            | fix — P1    |
+| `services/submission.service.ts:290`            | `listAll`                   | `status` / `period` / `search` only | fix — P2    |
+| `services/submission.service.ts:392`            | `exportAll` (10 000 rows)   | same                                | fix — P2    |
+| `services/submission.service.ts:1526`           | `listAgingByOrg`            | date + status only                  | fix — P2    |
+| `services/submission.service.ts:571`            | `getById` submitter email   | id from scoped row                  | ok          |
+| `services/submission-discussion.service.ts:151` | `listBySubmission`          | `submissionId`                      | ok          |
+| `services/submission-discussion.service.ts:312` | `createWithAudit` re-read   | `id`                                | ok          |
+| `services/submission-vote.service.ts:217`       | `listBySubmission`          | `submissionId`                      | ok          |
+| `services/submission-vote.service.ts:360`       | `castVoteWithAudit` re-read | `id`                                | ok          |
+| `services/submission-reviewer.service.ts:121`   | `listBySubmission`          | `submissionId` + members join       | ok          |
+| `services/simsub-group.service.ts:134`          | `getDetail` journal names   | group id                            | ok          |
+| `inngest/functions/cms-publish.ts:64`           | issue pieces                | inside `withRls({ orgId })`         | ok          |
+| `inngest/functions/contract-workflow.ts:67`     | signer lookup               | inside `withRls({ orgId })`         | ok          |
+| `services/status-token.service.ts:89`           | `verifyToken` org settings  | org id from verified token          | ok          |
+| `services/csr.service.ts:99`                    | export org names            | ids from a `submitter_id` read      | ok          |
+| `services/migration-bundle.service.ts:99`       | bundle org names            | same                                | ok          |
+
+`organization.service.ts:168`/`:182` is the only site in the codebase reading `users` with **no
+`WHERE` clause on any table in the query**. Both halves need the predicate; scoping only the page
+query leaves `total` reporting every organization's member count.
+
+`listAgingByOrg` is named for a scoping it does not perform. Its caller supplies the org through
+`withRls({ orgId })` (`inngest/functions/submission-response-reminder.ts:64`), so it is correct in
+practice and misleading to read.
+
+### 4.2 USER-SCOPED
+
+| Site                               | Method                               | Predicate                         | Disposition                                       |
+| ---------------------------------- | ------------------------------------ | --------------------------------- | ------------------------------------------------- |
+| `services/portfolio.service.ts:95` | `list` — `LEFT JOIN organizations o` | `s.submitter_id = userId` (`:52`) | ok — journal name is also a search target (`:65`) |
+| `services/user.service.ts:17`      | `getProfile`                         | `users.id = $1`, caller's own id  | ok                                                |
+| `services/gdpr.service.ts:46`      | `deleteUser` existence check         | `users.id = $1`                   | ok                                                |
+
+### 4.3 UNFILTERED
+
+All six are deliberate. Recorded so the next audit does not re-open them.
+
+| Site                                                   | What                            | Why it is not a finding                                                              |
+| ------------------------------------------------------ | ------------------------------- | ------------------------------------------------------------------------------------ |
+| `inngest/functions/submission-response-reminder.ts:34` | reads every `organizations` row | Cron fan-out; filters `responseReminderEnabled` in JS, then enters `withRls` per org |
+| `services/trust.service.ts:399`                        | every non-opted-out org         | Inbound S2S trust request must create a peer row in each; loops `withRls` per org    |
+| `services/trust.service.ts:857`                        | same, hub-attested path         | As above                                                                             |
+| `services/organization.service.ts:77`                  | `INSERT INTO organizations`     | Bootstrap — the org does not exist yet                                               |
+| `services/embed-submission.service.ts:104`             | `INSERT INTO users` (guest)     | Unauthenticated embed intake                                                         |
+| `hooks/auth.ts:415`                                    | JIT user provisioning           | Runs before any org context exists                                                   |
+
+### 4.4 BY-ID-ONLY — cross-tenant lookup keys
+
+34 sites resolve a row by primary or natural key. Most are unremarkable. The ones worth naming
+share a property: **an email address is a cross-tenant lookup key**, and eight sites use it.
+
+| Site                                                        | Reachable without auth         |
+| ----------------------------------------------------------- | ------------------------------ |
+| `services/organization.service.ts:203` (`addMember`)        | no — ADMIN only                |
+| `services/embed-submission.service.ts:92`, `:121`, `:138`   | **yes** — embed intake         |
+| `services/federation.service.ts:437` (`resolveWebFinger`)   | **yes** — federation discovery |
+| `services/federation.service.ts:523` (`getUserDidDocument`) | **yes** — federation discovery |
+| `services/simsub.service.ts:324`                            | **yes** — inbound S2S          |
+| `services/migration.service.ts:494`                         | **yes** — inbound S2S          |
+| `hooks/auth.ts:456`                                         | no — JIT link on 23505         |
+
+Two observations:
+
+- `resolveWebFinger` (`:437`) filters on email alone. Its sibling `getUserDidDocument` (`:523`)
+  filters `email` **and** `isNull(deletedAt)` **and** `eq(isGuest, false)`. The asymmetry looks
+  unintended: the laxer of the two is the unauthenticated discovery endpoint, so a deleted or
+  guest account is discoverable through one path and not the other. Tracked as P2.
+- `embed-submission.service.ts:92` returns the existing user id when the email matches, including
+  when that account is a real user in another tenant — the embed submission is then attributed to
+  them. Deliberate (it is how a known writer submitting through an embed is linked), but it is the
+  sharpest edge of email-as-key and belongs in the P3 design question rather than a patch.
+
+### 4.5 SCOPED
+
+18 sites, no action. They are the pattern to copy: `eq(organizations.id, orgId)` for settings and
+name reads (`submission-notifications.ts:41`, `slate-notifications.ts:131`,
+`discussion-notifications.ts:34`, `submission-vote.service.ts:144`, and others), org-bearing join
+conditions in `contest.service.ts:386`/`:594`/`:635`, `pipeline.service.ts:129`/`:188`/`:997`, and
+`invitation.service.ts:166`.
+
+## 5. Legitimately cross-tenant families
+
+Whole categories that will always read these tables without an org predicate, because no org
+context exists at the point of the read:
+
+- **Pre-auth webhooks** — `webhooks/zitadel.webhook.ts` (9 sites, keyed on `zitadelUserId`),
+  `webhooks/tusd.webhook.ts:64`.
+- **Authentication** — `hooks/auth.ts` (4 sites). Resolving who the caller is necessarily
+  precedes knowing which org they are acting in.
+- **Org resolution** — `hooks/org-context.ts:80` checks the org in the header exists before the
+  membership check at `:112`.
+- **SECURITY DEFINER** — `list_user_organizations()` and `verify_api_key()` are cross-tenant by
+  construction; that is why they exist.
+- **Cron fan-out** — `submission-response-reminder.ts`.
+- **Federation S2S** — `trust.service.ts`, `migration.service.ts`, `simsub.service.ts`,
+  `federation.service.ts`. A remote instance supplies an identifier; resolving it is the point.
+- **Unauthenticated public and embed routes** — `routes/public.routes.ts`,
+  `services/embed-submission.service.ts`.
+
+## 6. Findings beyond the two tables
+
+Both surfaced while building the gate in
+`apps/api/src/__tests__/rls/rls-infrastructure.test.ts`, and both matter more than anything in §4.
+
+### 6.1 The `REVOKE`-based protection does not survive provisioning
+
+`federation_config`, `hub_registered_instances` and `hub_fingerprint_index` are documented as
+safe without RLS on the grounds that migration `0029_hub_tables.sql:67` explicitly does
+`REVOKE ALL … FROM app_user`.
+
+Measured, `app_user` holds `SELECT, INSERT, UPDATE, DELETE` on all three — in the test database
+and the dev database. The revokes execute; they are undone afterwards, in every path:
+
+- `scripts/init-prod.sh` — Step 1 runs migrations (applying the revokes), Step 2 then issues
+  `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_user` (`:63`) and
+  re-revokes only the seven tables from migrations 0052 and 0054 (`:76-87`). These three are not
+  among them.
+- `apps/api/src/__tests__/rls/helpers/db-setup.ts` — same shape; re-revokes `audit_events` and
+  `journal_directory` only. Its own comments ("the broad GRANT above re-grants it — must revoke
+  after") show the hazard was understood; the list was incomplete.
+- `pnpm db:reset` — uses `drizzle-kit push`, which syncs schema and never executes migration SQL,
+  so the revokes do not run at all.
+
+`outbox_events` fails the same way for a different reason: migration `0022`'s comment says
+"SELECT is not granted — only the superuser outbox poller reads/updates events", but `GRANT` is
+additive and removes nothing, and `ALTER DEFAULT PRIVILEGES` had already granted full DML. This is
+the additive-`GRANT` trap already documented for `DELETE` on the append-only tables, reappearing
+for `SELECT`.
+
+**Consequence for P2.1.** The design doc's `service_principals` recommendation is "no RLS **plus**
+`REVOKE ALL … FROM app_user`, reads via SECURITY DEFINER", justified explicitly by the hub
+precedent being safe. Implemented as written, the table holding hashed cross-org credentials would
+be fully readable by `app_user` — the instance-wide credential enumeration that recommendation
+exists to prevent. **P2.1 must not copy this pattern until the three-place discipline is fixed and
+asserted.**
+
+Not yet verified against staging or production. The reasoning is a reading of `init-prod.sh` plus
+measurement of two local databases; confirm against the deployed database before setting severity.
+
+### 6.2 Two tables were classified by nothing
+
+`organization_invitations` was absent from both `RLS_TABLES` and `NON_RLS_TABLES` in
+`rls-infrastructure.test.ts`, so none of that file's assertions covered it. It is correctly
+RLS'd with `FORCE` and a policy — it was simply unchecked. `demo_requests` was likewise
+unclassified, and has neither RLS nor a revoke.
+
+The exhaustiveness assertion added in this change closes the class: every table in `public` must
+appear in exactly one list.
+
+## 7. Estimate for Phase 2
+
+§2.6(1) asked whether this audit changes the Phase 2 estimate. It does, in both directions.
+
+- **Smaller than feared for `users`/`organizations`.** The predicate work is 5 methods across 2
+  service files, not a sweep of 66 modules. Most sites are BY-ID-ONLY or already scoped. Call it
+  one to two days including tests, split as P1 and P2 in the backlog.
+- **Larger than scoped for the privilege model.** §6.1 invalidates the premise of P2.1's table
+  design. Fixing the three-place discipline, adding assertions, and re-validating the
+  `service_principals` approach is new work that Phase 2 assumed it already had.
+
+The P1 items must merge before the instance principal ships; the backlog records that as a
+precondition on the Phase 2 entry.
+
+## 8. What keeps this true
+
+- `apps/api/src/__tests__/rls/rls-infrastructure.test.ts` — catalog-derived. Every table in
+  `public` must be classified; each unprotected table's `app_user` SELECT privilege is asserted
+  against a recorded expectation, so a silent re-grant fails the build.
+- `apps/api/src/__tests__/security/tenant-isolation-transitive.test.ts` — per-method proof that
+  RLS covers each §4.1 path, with a non-zero own-org assertion so the checks cannot pass against
+  empty tables.
+- `apps/api/src/__tests__/security/unprotected-table-callsites.test.ts` — file-level tripwire. A
+  `users` or `organizations` query in a new file fails until it is classified here. A nudge to
+  the reviewer, not a security boundary: a new query in an already-listed file passes.

--- a/docs/tenant-isolation-audit.md
+++ b/docs/tenant-isolation-audit.md
@@ -118,8 +118,14 @@ practice and misleading to read.
 | Site                               | Method                               | Predicate                         | Disposition                                       |
 | ---------------------------------- | ------------------------------------ | --------------------------------- | ------------------------------------------------- |
 | `services/portfolio.service.ts:95` | `list` — `LEFT JOIN organizations o` | `s.submitter_id = userId` (`:52`) | ok — journal name is also a search target (`:65`) |
-| `services/user.service.ts:17`      | `getProfile`                         | `users.id = $1`, caller's own id  | ok                                                |
-| `services/gdpr.service.ts:46`      | `deleteUser` existence check         | `users.id = $1`                   | ok                                                |
+
+Despite its name, `portfolioService.list` never reads `portfolio_entries`; it queries
+`submissions` and `external_submissions` and joins `organizations` only to surface journal
+names. `portfolio_entries` (user-scoped, `user_id = current_user_id()`) has no service method in
+this audit's scope, so nothing here covers its policy.
+
+| `services/user.service.ts:17` | `getProfile` | `users.id = $1`, caller's own id | ok |
+| `services/gdpr.service.ts:46` | `deleteUser` existence check | `users.id = $1` | ok |
 
 ### 4.3 UNFILTERED
 


### PR DESCRIPTION
`users` and `organizations` are the two tables with no row-level security and no
compensating `REVOKE`. On those, cross-tenant isolation is whatever the service
layer's `WHERE` clause says it is. That was known; the per-site audit was not
done, and it gates the instance principal, which removes the one-org pin the
current safety rests on. The design doc had flagged it as a prerequisite and
noted the size was unknown until someone read the service modules.

## What this is

The audit, not the fixes. No service or router code changes — the predicate work
is queued as separate PRs so each diff stays reviewable.

`docs/tenant-isolation-audit.md` classifies all 73 reads and writes across 36
files: 18 scoped, 3 user-scoped, 12 RLS-only, 34 by-id-only, 6 deliberately
unfiltered. **Nothing found is a live vulnerability** — every RLS-only path is
isolated today, and `tenant-isolation-transitive.test.ts` now proves that per
service method instead of asserting it.

One framing correction worth calling out: `users` has no `organization_id`
column, so its predicate goes on an org-bearing join partner, not the table.
"Thread `orgId` into every query" does not compile; "`users` can only be
RLS-only" is the opposite error and would excuse the gap.

## The finding that matters most was not in scope

The catalog gate added here immediately found that **the revoke-based privilege
model does not survive provisioning.** `federation_config`,
`hub_registered_instances` and `hub_fingerprint_index` are documented as safe
without RLS because migrations 0023/0029 `REVOKE ALL` from `app_user`. Measured,
`app_user` holds full DML on all three, in both the test and dev databases:

- `init-prod.sh` runs migrations, then issues `GRANT … ON ALL TABLES … TO
  app_user` and re-revokes only the seven tables from 0052/0054
- the test harness re-revokes two
- `db:reset` uses `drizzle-kit push`, which never executes migration SQL

`outbox_events` fails the same way for a different reason: migration 0022's
comment claims SELECT is withheld, but `GRANT` is additive and removes nothing.

Filed P0 rather than P2 because the planned `service_principals` table is
specified as "no RLS plus `REVOKE ALL`" on the strength of that precedent —
built as written, the hashed cross-org credential table would be readable by
`app_user`. Recorded as a hard precondition on the Phase 2 entry, alongside the
P1 predicate fixes.

**Not yet verified against staging or production.** The reasoning is a reading of
`init-prod.sh` plus measurement of two local databases; that check sets the
severity and should happen before Phase 2 is scheduled.

## Gates added

Each was made to fail before being trusted:

- Exhaustiveness and per-table `app_user` privilege assertions folded into the
  existing `rls-infrastructure.test.ts`, reading the live catalog rather than
  parsing schema source — a per-file check calls `audit.ts` protected and misses
  `dsar_requests`. This found two tables classified by nothing:
  `organization_invitations` (correctly protected, just unchecked) and
  `demo_requests` (neither RLS nor a revoke).
- `tenant-isolation-transitive.test.ts` — 8 per-method proofs on the app pool,
  each asserting a non-zero own-org count first, since "no other-org rows" is
  trivially true of an empty table.
- A file-level call-site tripwire. Billed as a review nudge, not a boundary: a
  new query in an already-listed file passes.

Expectations encode measured state with each gap annotated, so a fix flips an
expectation rather than adding a test.

## Verification

Type-check, lint, prettier clean. 142 RLS, 41 security, 1834 unit tests pass.
