### PR TITLE
fix(db): apply the privilege manifest after db:push

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -19,7 +19,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "generate": "drizzle-kit generate",
-    "push": "drizzle-kit push --force",
+    "push": "drizzle-kit push --force && pnpm privileges",
     "migrate": "drizzle-kit migrate && pnpm privileges",
     "privileges": "tsx --env-file-if-exists=.env src/apply-privileges.ts",
     "check": "drizzle-kit check",

--- a/packages/db/privileges.sql
+++ b/packages/db/privileges.sql
@@ -26,6 +26,11 @@
 -- Safe to run at any point: each statement is guarded on table existence, so it
 -- may run before migrations (init-db.sh) or after (everywhere else). Idempotent
 -- — revoking an absent privilege is a no-op.
+--
+-- Anything that CREATES tables must apply this afterwards, not just anything
+-- that grants. `ALTER DEFAULT PRIVILEGES` gives every newly created table full
+-- DML, so `drizzle-kit push` reopens these tables even though it issues no
+-- GRANT of its own — which is why `db:push` chains `pnpm privileges` too.
 
 DO $$
 DECLARE


### PR DESCRIPTION
Follow-up to #524, from a review of the merged commit.

`db:push` runs `drizzle-kit push --force`, which creates tables without issuing any `GRANT` of its own. That looks safe but is not: `ALTER DEFAULT PRIVILEGES` hands every newly created table full DML, so pushing against a fresh database left `federation_config`, `hub_registered_instances`, `hub_fingerprint_index`, `demo_requests` and `outbox_events` fully reachable by `app_user` — reopening precisely what #524 closed.

It is the one provisioning path that reopens the tables by **creating** them rather than by granting on them, which is why the original sweep missed it: that sweep looked for blanket `GRANT` statements.

The RLS suite would not have caught it either, since that provisions its own database through `db-setup.ts`. `db:push` is documented as a dev-iteration tool, so the blast radius is a developer's local database rather than a deployed one — an incorrect local database is still how the original finding stayed invisible for months.

## Change

Chain `pnpm privileges` onto `push`, as `migrate` already does, and record in `privileges.sql` that creating tables — not only granting on them — requires a manifest pass afterwards.

## Verification

Reproduced against the test database: re-granted full DML on all tables, confirmed the five target tables reopened, then ran the privileges step `push` now chains and confirmed they closed again with `outbox_events` correctly retaining INSERT only.

RLS suite 142 pass.