### PR TITLE
fix(api): scope organizationService.listMembers and gate the REST surface

### DIFF
--- a/apps/api/src/__tests__/rls/helpers/db-setup.ts
+++ b/apps/api/src/__tests__/rls/helpers/db-setup.ts
@@ -153,6 +153,30 @@ export async function globalSetup(): Promise<void> {
   if (rows[0].usesuper) throw new Error('app_user must not be superuser');
   if (rows[0].rolbypassrls) throw new Error('app_user must not bypass RLS');
 
+  // The mirror of the check above, and it is load-bearing for a different set of
+  // suites. `api-key-service.test.ts` and the admin-pool cases in
+  // `organization-service.test.ts` prove that an explicit WHERE clause isolates
+  // tenants *without* RLS — which only means anything if this connection really
+  // does bypass RLS. ADMIN_URL comes straight from DATABASE_TEST_URL, so pointing
+  // it at a non-superuser would make those suites pass under RLS and assert
+  // nothing, while still reporting green.
+  const { rows: adminRoles } = await admin.query<{
+    rolsuper: boolean;
+    rolbypassrls: boolean;
+  }>(
+    'SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user',
+  );
+
+  if (adminRoles.length === 0) {
+    throw new Error('admin role not found after setup');
+  }
+  if (!adminRoles[0].rolsuper && !adminRoles[0].rolbypassrls) {
+    throw new Error(
+      'admin pool must bypass RLS (needs rolsuper or rolbypassrls) — ' +
+        'predicate-only suites are meaningless without it',
+    );
+  }
+
   isSetUp = true;
 }
 

--- a/apps/api/src/__tests__/rls/organization-service.test.ts
+++ b/apps/api/src/__tests__/rls/organization-service.test.ts
@@ -10,6 +10,7 @@ import {
   createOrgMember,
 } from './helpers/factories';
 import { withTestRls } from './helpers/rls-context';
+import { organizationService } from '../../services/organization.service.js';
 
 describe('Organization Service RLS Integration', () => {
   beforeAll(async () => {
@@ -193,7 +194,11 @@ describe('Organization Service RLS Integration', () => {
     });
   });
 
-  describe('listMembers RLS isolation', () => {
+  // Named for the policy, not the method: this queries `organization_members`
+  // directly and never calls `listMembers`. The service-level counterpart is the
+  // admin-pool block at the bottom of this file, which isolates the WHERE clause
+  // instead of the policy.
+  describe('organization_members policy isolation', () => {
     it('org A context sees only org A members', async () => {
       const orgA = await createOrganization();
       const orgB = await createOrganization();
@@ -318,5 +323,96 @@ describe('Organization Service RLS Integration', () => {
         .where(eq(organizationMembers.id, memberA.id));
       expect(verified.roles).toEqual(['ADMIN']); // unchanged from factory default
     });
+  });
+});
+
+/**
+ * Defense-in-depth: `listMembers`' explicit organization predicate.
+ *
+ * The deliberate mirror of `__tests__/security/tenant-isolation-transitive.test.ts`,
+ * which proves RLS isolates this path. Here we prove the other layer: that the
+ * explicit filter isolates tenants when RLS is not there to help.
+ *
+ * That is why these queries run over the ADMIN pool. It connects as role `test`
+ * (`rolsuper = t, rolbypassrls = t`), so RLS does not apply — the only thing
+ * separating org A's members from org B's is the
+ * `WHERE organization_id = $orgId` clause in the service. `globalSetup()` asserts
+ * that property of the connection, so this cannot quietly degrade into an
+ * RLS-backed test.
+ *
+ * Consequence: if someone deletes that predicate, this block fails while every
+ * other test in the repo still passes. Do not "fix" it by switching to the app
+ * pool — that reinstates RLS and the suite would pass with or without the
+ * predicate, testing nothing.
+ */
+describe('organizationService.listMembers defense-in-depth (RLS bypassed)', () => {
+  const PAGINATION = { page: 1, limit: 20 };
+
+  let orgA: Awaited<ReturnType<typeof createOrganization>>;
+  let orgB: Awaited<ReturnType<typeof createOrganization>>;
+  let userA: Awaited<ReturnType<typeof createUser>>;
+  let userB: Awaited<ReturnType<typeof createUser>>;
+
+  /**
+   * A Drizzle handle over the RLS-bypassing admin pool, shaped as the service's
+   * `tx`. No cast needed — unlike the other suites in this tree, this file's
+   * drizzle resolution already matches `listMembers`' parameter type.
+   */
+  function adminTx(): Parameters<typeof organizationService.listMembers>[0] {
+    return drizzle(getAdminPool());
+  }
+
+  beforeAll(async () => {
+    await globalSetup();
+    await truncateAllTables();
+
+    orgA = await createOrganization({ name: 'Org Alpha' });
+    orgB = await createOrganization({ name: 'Org Beta' });
+    userA = await createUser();
+    userB = await createUser();
+    await createOrgMember(orgA.id, userA.id, { roles: ['ADMIN'] });
+    await createOrgMember(orgB.id, userB.id, { roles: ['ADMIN'] });
+  });
+
+  afterAll(async () => {
+    await truncateAllTables();
+  });
+
+  it("returns only the caller's org members", async () => {
+    const result = await organizationService.listMembers(
+      adminTx(),
+      PAGINATION,
+      orgA.id,
+    );
+
+    expect(result.items.map((m) => m.userId)).toEqual([userA.id]);
+    expect(result.items.map((m) => m.userId)).not.toContain(userB.id);
+  });
+
+  it('scopes the total count to the org', async () => {
+    // Without a predicate on the count query, `total` reports every org's members
+    // even when `items` is correctly filtered — the pagination metadata leaks a
+    // row count across tenants.
+    const result = await organizationService.listMembers(
+      adminTx(),
+      PAGINATION,
+      orgA.id,
+    );
+
+    expect(result.total).toBe(1);
+    expect(result.totalPages).toBe(1);
+  });
+
+  it('scopes the joined user rows, not just the membership rows', async () => {
+    // `users` has no organizationId, so the predicate lands on the join partner.
+    // If it were dropped, org B's member email would surface here.
+    const result = await organizationService.listMembers(
+      adminTx(),
+      PAGINATION,
+      orgA.id,
+    );
+
+    expect(result.items.map((m) => m.email)).toEqual([userA.email]);
+    expect(result.items.map((m) => m.email)).not.toContain(userB.email);
   });
 });

--- a/apps/api/src/__tests__/security/tenant-isolation-transitive.test.ts
+++ b/apps/api/src/__tests__/security/tenant-isolation-transitive.test.ts
@@ -6,10 +6,19 @@
  *
  * WHAT THIS DOES NOT PROVE: that these methods satisfy the house defense-in-depth
  * rule for tenant queries — always include an explicit `WHERE organization_id =
- * orgId`, never rely solely on RLS. They do not. Every method below is on
- * the fix list in `docs/tenant-isolation-audit.md` precisely because the database
- * is the only thing separating tenants in it. A green run here means the backstop
- * is intact — it is not permission to leave the predicate out.
+ * orgId`, never rely solely on RLS. Most do not. They are on the fix list in
+ * `docs/tenant-isolation-audit.md` precisely because the database is the only
+ * thing separating tenants in them. A green run here means the backstop is intact
+ * — it is not permission to leave the predicate out.
+ *
+ * ONE EXCEPTION: `organizationService.listMembers` now carries an explicit
+ * predicate on both its queries, and is deliberately kept here anyway. Scoping it
+ * did not make the policy behind it less worth pinning — a regression in
+ * `organization_members`' RLS would otherwise be invisible, since the predicate
+ * would mask it. The predicate's own coverage lives in
+ * `__tests__/rls/organization-service.test.ts`, over the RLS-bypassing admin pool.
+ * Adding a predicate to any other method below should follow the same pattern:
+ * keep the case here, add an admin-pool mirror there.
  *
  * Every query therefore runs over the APP pool via `withTestRls`, which connects
  * as `app_user` (`NOSUPERUSER`, `NOBYPASSRLS`) and sets `app.current_org` /
@@ -114,14 +123,15 @@ describe('transitive tenant isolation (RLS is the only defense)', () => {
   it('organizationService.listMembers returns only the current org, in items and total', async () => {
     const result = await withTestRls(
       { orgId: a.orgId, userId: a.userId },
-      (tx) => organizationService.listMembers(tx, PAGINATION),
+      (tx) => organizationService.listMembers(tx, PAGINATION, a.orgId),
     );
 
     expect(result.items.length).toBeGreaterThan(0);
     expect(result.items.map((m) => m.userId)).toEqual([a.userId]);
     expect(result.items.map((m) => m.userId)).not.toContain(b.userId);
-    // The count query has no predicate either — if the policy stopped covering
-    // it, `total` would report both orgs while `items` stayed correct.
+    // Both queries now carry the predicate, so this pins the policy *behind* it
+    // rather than instead of it. The predicate's own coverage is in
+    // `__tests__/rls/organization-service.test.ts`, over the admin pool.
     expect(result.total).toBe(1);
   });
 

--- a/apps/api/src/rest/context.ts
+++ b/apps/api/src/rest/context.ts
@@ -3,7 +3,7 @@ import type { AuthContext, Role, ApiKeyScope } from '@colophony/types';
 import { AuditActions, AuditResources } from '@colophony/types';
 import type { DrizzleDb } from '@colophony/db';
 import type { AuditFn } from '../services/types.js';
-import { checkApiKeyScopes } from '../services/scope-check.js';
+import { checkApiKeyScopes, markGuard } from '../services/scope-check.js';
 
 /**
  * Initial oRPC context populated by Fastify hooks.
@@ -215,33 +215,39 @@ export const requireProduction = restBase.middleware(
  * Must be chained after requireAuth or requireOrgContext.
  */
 export function requireScopes(...scopes: ApiKeyScope[]) {
-  return restBase.middleware(async ({ context, next }) => {
-    if (!context.authContext) {
-      throw new ORPCError('UNAUTHORIZED', {
-        message: 'Not authenticated',
-      });
-    }
+  // Tagged so `rest/guard-coverage.spec.ts` can see it on the built procedure's
+  // middleware chain. A new guard middleware on this surface must be tagged the
+  // same way or the gate will read the procedure as unguarded.
+  return markGuard(
+    restBase.middleware(async ({ context, next }) => {
+      if (!context.authContext) {
+        throw new ORPCError('UNAUTHORIZED', {
+          message: 'Not authenticated',
+        });
+      }
 
-    const result = checkApiKeyScopes(context.authContext, scopes);
-    if (!result.allowed) {
-      await context.audit({
-        action: AuditActions.API_KEY_SCOPE_DENIED,
-        resource: AuditResources.API_KEY,
-        resourceId: context.authContext.apiKeyId,
-        newValue: { required: scopes, missing: result.missing },
-      });
-      throw new ORPCError('FORBIDDEN', {
-        message: 'Insufficient API key scope',
-        data: {
-          error: 'insufficient_scope',
-          required: scopes,
-          missing: result.missing,
-        },
-      });
-    }
+      const result = checkApiKeyScopes(context.authContext, scopes);
+      if (!result.allowed) {
+        await context.audit({
+          action: AuditActions.API_KEY_SCOPE_DENIED,
+          resource: AuditResources.API_KEY,
+          resourceId: context.authContext.apiKeyId,
+          newValue: { required: scopes, missing: result.missing },
+        });
+        throw new ORPCError('FORBIDDEN', {
+          message: 'Insufficient API key scope',
+          data: {
+            error: 'insufficient_scope',
+            required: scopes,
+            missing: result.missing,
+          },
+        });
+      }
 
-    return next({});
-  });
+      return next({});
+    }),
+    { kind: 'scopes', scopes },
+  );
 }
 
 // Procedure builders (analogous to tRPC procedure builders)

--- a/apps/api/src/rest/guard-coverage.spec.ts
+++ b/apps/api/src/rest/guard-coverage.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Guard coverage across the whole REST surface.
+ *
+ * The mirror of `trpc/guard-coverage.spec.ts`, and it exists for the reason that
+ * suite's absence on this side allowed: `POST /v1/invitations/accept` shipped as a
+ * bare `userProcedure` while its tRPC twin declared `organizations:write`. That
+ * was the second REST/tRPC scope-parity gap found in two sessions, and both were
+ * found by audit rather than by CI. This is the check that makes the third fail
+ * the build instead.
+ *
+ * A REST procedure is only constrained if it declares `requireScopes(...)`.
+ * Authentication alone is not enough — `userProcedure` proves a caller is
+ * someone, not that their credential was granted this operation.
+ *
+ * Two structural differences from the tRPC gate:
+ *
+ *  1. `restRouter` is a nested plain object, not a flat `_def.procedures` map, so
+ *     this walks it recursively with oRPC's own `isProcedure` as the leaf test.
+ *  2. There is no `internalOnly` and no `publicProcedure` on this surface, so
+ *     there is exactly one guard kind to look for and no internal-router pin.
+ *
+ * Introspection only — no procedure is invoked and no service is mocked.
+ */
+import { describe, it, expect } from 'vitest';
+import { isProcedure } from '@orpc/server';
+import { apiKeyScopeSchema } from '@colophony/types';
+
+import { restRouter } from './openapi-spec.js';
+import { readGuardTags, type GuardTag } from '../services/scope-check.js';
+
+/**
+ * Procedures that deliberately declare no scope guard.
+ *
+ * Empty, and worth keeping that way. Every entry would be callable by any API key
+ * holding any scope, so a reason must explain why the operation is safe
+ * unconstrained — not merely why it currently lacks a guard. The tRPC gate's one
+ * entry is a credential-free liveness probe; this surface has no analogue.
+ */
+const UNGUARDED_PROCEDURES: Record<string, string> = {};
+
+/**
+ * The internal shape oRPC exposes. `'~orpc'` is deliberately marked internal by
+ * the library: it is typed and stable across 1.14.x, but the count canary below
+ * is what catches a rename on upgrade.
+ */
+interface BuiltProcedure {
+  '~orpc': {
+    middlewares?: readonly unknown[];
+    route?: { method?: string; path?: string; operationId?: string };
+  };
+}
+
+interface ProcedureEntry {
+  path: string;
+  guards: GuardTag[];
+  label: string;
+}
+
+function describeRoute(procedure: BuiltProcedure, path: string): string {
+  const route = procedure['~orpc'].route;
+  if (!route?.method || !route.path) return path;
+  const operation = route.operationId ? ` (${route.operationId})` : '';
+  return `${route.method} ${route.path}${operation}`;
+}
+
+function collect(
+  node: unknown,
+  prefix: string,
+  acc: ProcedureEntry[],
+): ProcedureEntry[] {
+  if (isProcedure(node)) {
+    const procedure = node as unknown as BuiltProcedure;
+    acc.push({
+      path: prefix,
+      guards: readGuardTags(procedure['~orpc'].middlewares ?? []),
+      label: describeRoute(procedure, prefix),
+    });
+    return acc;
+  }
+
+  if (node && typeof node === 'object') {
+    for (const [key, child] of Object.entries(node)) {
+      collect(child, prefix ? `${prefix}.${key}` : key, acc);
+    }
+  }
+
+  return acc;
+}
+
+function allProcedures(): ProcedureEntry[] {
+  return collect(restRouter, '', []);
+}
+
+describe('REST guard coverage', () => {
+  it('introspects a plausible number of procedures', () => {
+    // Guards against the whole suite silently passing because `'~orpc'` was
+    // renamed under an @orpc/server upgrade and every assertion below started
+    // iterating an empty list. 139 operations today.
+    expect(allProcedures().length).toBeGreaterThan(130);
+  });
+
+  it('every procedure declares a scope guard', () => {
+    const offenders = allProcedures()
+      .filter((entry) => entry.guards.length === 0)
+      .filter((entry) => !(entry.path in UNGUARDED_PROCEDURES))
+      .map((entry) => entry.label)
+      .sort();
+
+    expect(
+      offenders,
+      offenders.length === 0
+        ? ''
+        : `These REST procedures declare no scope guard, so any API key with ` +
+            `any scope can call them:\n\n` +
+            offenders.map((p) => `  - ${p}`).join('\n') +
+            `\n\nAdd .use(requireScopes('<scope>')) between the procedure ` +
+            `builder and .route(). If the operation has a tRPC twin, declare ` +
+            `the same scope it does. If it genuinely needs no guard, add it to ` +
+            `UNGUARDED_PROCEDURES with a reason.`,
+    ).toEqual([]);
+  });
+
+  it('no procedure declares an empty scope list', () => {
+    // requireScopes() with no arguments passes [] to checkApiKeyScopes, whose
+    // `missing.length === 0` check then allows everything. A vacuous guard reads
+    // exactly like a real one at the call site.
+    const vacuous = allProcedures()
+      .filter((entry) =>
+        entry.guards.some(
+          (guard) => guard.kind === 'scopes' && guard.scopes.length === 0,
+        ),
+      )
+      .map((entry) => entry.label)
+      .sort();
+
+    expect(vacuous).toEqual([]);
+  });
+
+  it('scope guards name only scopes defined in apiKeyScopeSchema', () => {
+    // A typo'd scope string denies silently and permanently — no key can ever
+    // hold a scope that is not in the enum.
+    const unknown = allProcedures()
+      .flatMap((entry) =>
+        entry.guards
+          .filter((guard) => guard.kind === 'scopes')
+          .flatMap((guard) => guard.scopes)
+          .filter((scope) => !apiKeyScopeSchema.safeParse(scope).success)
+          .map((scope) => `${entry.label} -> ${scope}`),
+      )
+      .sort();
+
+    expect(unknown).toEqual([]);
+  });
+
+  it('every UNGUARDED_PROCEDURES entry still exists and is still unguarded', () => {
+    // Reverse staleness: an allowlist entry that has since been guarded, or
+    // deleted, should be removed rather than left implying an exemption is
+    // still in force.
+    const byPath = new Map(
+      allProcedures().map((entry) => [entry.path, entry] as const),
+    );
+
+    const stale = Object.keys(UNGUARDED_PROCEDURES)
+      .filter((path) => {
+        const entry = byPath.get(path);
+        return entry === undefined || entry.guards.length > 0;
+      })
+      .sort();
+
+    expect(stale).toEqual([]);
+  });
+});

--- a/apps/api/src/rest/routers/organizations.spec.ts
+++ b/apps/api/src/rest/routers/organizations.spec.ts
@@ -367,6 +367,15 @@ describe('organizations REST router', () => {
       const call = client(organizationsRouter.members.list, orgContext());
       const result = await call({ orgId: ORG_ID, page: 1, limit: 20 });
       expect(result.items).toHaveLength(1);
+
+      // The org ID must reach the service — it carries the explicit tenant
+      // predicate, so a dropped argument silently widens the query to RLS alone.
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.listMembers).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ page: 1, limit: 20 }),
+        ORG_ID,
+      );
     });
   });
 
@@ -547,6 +556,21 @@ describe('organizations REST router', () => {
       const ctx = apiKeyAuthedContext(['submissions:read']);
       const call = client(organizationsRouter.list, ctx);
       await expect(call({})).rejects.toThrow('Insufficient API key scope');
+    });
+
+    // This route shipped with no scope guard at all, so any key could accept an
+    // invitation and write a membership row.
+    //
+    // `apiKeyContext`, not `apiKeyAuthedContext`: `accept` is a `userProcedure`,
+    // and `requireUserContext` runs before the scope guard and rejects a null
+    // `dbTx` first — so the authed-level fixture would fail on
+    // "Database transaction not available" and prove nothing about scopes.
+    it('denies invitations.accept with only read scope', async () => {
+      const ctx = apiKeyContext(['organizations:read']);
+      const call = client(organizationsRouter.invitations.accept, ctx);
+      await expect(call({ token: 'some-invitation-token' })).rejects.toThrow(
+        'Insufficient API key scope',
+      );
     });
 
     it('allows API key with correct read scope', async () => {

--- a/apps/api/src/rest/routers/organizations.ts
+++ b/apps/api/src/rest/routers/organizations.ts
@@ -123,10 +123,12 @@ const membersList = orgProcedure
   .output(paginatedMembersSchema)
   .handler(async ({ input, context }) => {
     assertOrgIdMatch(input.orgId, context.authContext.orgId);
-    return organizationService.listMembers(context.dbTx, {
-      page: input.page,
-      limit: input.limit,
-    });
+    return organizationService.listMembers(
+      context.dbTx,
+      { page: input.page, limit: input.limit },
+      // The header is the authority; assertOrgIdMatch above makes them equal.
+      context.authContext.orgId,
+    );
   });
 
 const membersAdd = adminProcedure
@@ -331,6 +333,7 @@ const invitationsCreate = adminProcedure
   });
 
 const invitationsAccept = userProcedure
+  .use(requireScopes('organizations:write'))
   .route({
     method: 'POST',
     path: '/invitations/accept',

--- a/apps/api/src/services/organization.service.spec.ts
+++ b/apps/api/src/services/organization.service.spec.ts
@@ -89,6 +89,7 @@ vi.mock('drizzle-orm/node-postgres', () => ({
   })),
 }));
 
+import { eq, organizationMembers } from '@colophony/db';
 import {
   organizationService,
   UserNotFoundError,
@@ -247,6 +248,81 @@ describe('organizationService', () => {
           'READER',
         ]),
       ).rejects.toThrow(UserNotFoundError);
+    });
+  });
+
+  /**
+   * These assert the *predicate*, not the results. The mock `tx` returns whatever
+   * it is told regardless of the WHERE clause, so a "wrong org returns nothing"
+   * test here would pass with the filter removed. Asserting on the mocked `eq()`
+   * and on what reaches `.where()` is what actually fails when it goes missing.
+   *
+   * The real proof lives in `src/__tests__/rls/organization-service.test.ts`,
+   * which runs this query against Postgres over an RLS-bypassing connection.
+   */
+  describe('defense-in-depth: listMembers organization predicate', () => {
+    const PREDICATE = Symbol('org-predicate');
+
+    /**
+     * `listMembers` calls `tx.select()` twice under Promise.all — once for the page
+     * (from → innerJoin → where → orderBy → limit → offset) and once for the count
+     * (from → where). Returning a different chain per call is what lets both
+     * resolve to their own shape; `wheres` collects what each was filtered on.
+     */
+    function makeListMembersTx(wheres: unknown[]) {
+      let callCount = 0;
+      return {
+        select: vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              from: vi.fn().mockReturnValue({
+                innerJoin: vi.fn().mockReturnValue({
+                  where: vi.fn().mockImplementation((w: unknown) => {
+                    wheres.push(w);
+                    return {
+                      orderBy: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockReturnValue({
+                          offset: vi.fn().mockResolvedValue([]),
+                        }),
+                      }),
+                    };
+                  }),
+                }),
+              }),
+            };
+          }
+          return {
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockImplementation((w: unknown) => {
+                wheres.push(w);
+                return Promise.resolve([{ count: 0 }]);
+              }),
+            }),
+          };
+        }),
+      } as unknown as Parameters<typeof organizationService.listMembers>[0];
+    }
+
+    it('filters both the page and the count query on the same org predicate', async () => {
+      vi.mocked(eq).mockReturnValue(PREDICATE as never);
+      const wheres: unknown[] = [];
+
+      await organizationService.listMembers(
+        makeListMembersTx(wheres),
+        { page: 1, limit: 20 },
+        'org-1',
+      );
+
+      expect(eq).toHaveBeenCalledWith(
+        organizationMembers.organizationId,
+        'org-1',
+      );
+
+      // Both halves, and both the *same* predicate. The service hoists one `eq`
+      // and reuses it, so page and count cannot drift apart — a count query
+      // without it would report every org's member total.
+      expect(wheres).toEqual([PREDICATE, PREDICATE]);
     });
   });
 });

--- a/apps/api/src/services/organization.service.ts
+++ b/apps/api/src/services/organization.service.ts
@@ -159,11 +159,23 @@ export const organizationService = {
   },
 
   /**
-   * List members of the current organization (RLS filters by org context).
+   * List members of an organization. Filters on organizationId explicitly, with
+   * RLS as the backstop rather than the only defence.
+   *
+   * The count query carries the predicate too — without it, `total` reports every
+   * org's member count while `items` is correctly scoped.
+   *
+   * `users` has no organizationId of its own, so the predicate lands on the
+   * org-bearing join partner; that scopes the joined user rows as well.
+   *
+   * Note the argument order: `orgId` goes last, following the house
+   * `(tx, id|input, orgId)` convention and `apiKeyService.list`, even though the
+   * neighbouring methods in this file take it second.
    */
-  async listMembers(tx: DrizzleDb, pagination: PaginationInput) {
+  async listMembers(tx: DrizzleDb, pagination: PaginationInput, orgId: string) {
     const { page, limit } = pagination;
     const offset = (page - 1) * limit;
+    const where = eq(organizationMembers.organizationId, orgId);
 
     const [members, countResult] = await Promise.all([
       tx
@@ -176,12 +188,14 @@ export const organizationService = {
         })
         .from(organizationMembers)
         .innerJoin(users, eq(organizationMembers.userId, users.id))
+        .where(where)
         .orderBy(organizationMembers.createdAt)
         .limit(limit)
         .offset(offset),
       tx
         .select({ count: sql<number>`count(*)::int` })
-        .from(organizationMembers),
+        .from(organizationMembers)
+        .where(where),
     ]);
 
     const total = countResult[0]?.count ?? 0;

--- a/apps/api/src/services/scope-check.ts
+++ b/apps/api/src/services/scope-check.ts
@@ -27,3 +27,47 @@ export function checkApiKeyScopes(
 
   return { allowed: false, missing };
 }
+
+// ---------------------------------------------------------------------------
+// Guard tagging
+// ---------------------------------------------------------------------------
+
+/**
+ * Marks a middleware as one of the guards that keep a procedure out of an API
+ * key's reach. Read by the guard-coverage gates on both surfaces
+ * (`trpc/guard-coverage.spec.ts`, `rest/guard-coverage.spec.ts`), which fail the
+ * build on a procedure declaring none.
+ *
+ * Tagging is necessary because no guard is identifiable by reference:
+ * `requireScopes` mints a fresh closure per call, and the middleware bodies are
+ * anonymous. Both tRPC and oRPC keep the function object itself in their built
+ * procedure's middleware array, so a non-enumerable property on it survives
+ * builder composition intact.
+ *
+ * This lives here, beside `checkApiKeyScopes`, because the two surfaces must
+ * agree on it. A per-surface copy is how the REST and tRPC scope declarations
+ * drifted apart in the first place.
+ */
+export const GUARD_TAG = Symbol.for('colophony.guard');
+
+export type GuardTag =
+  { kind: 'scopes'; scopes: readonly ApiKeyScope[] } | { kind: 'internal' };
+
+/**
+ * Tags a middleware function in place and returns it, so it can wrap a builder
+ * expression directly. Surface-specific wrappers handle unwrapping where the
+ * framework hands back a builder rather than the function (see tRPC's
+ * `tagGuard`).
+ */
+export function markGuard<T>(fn: T, tag: GuardTag): T {
+  Object.defineProperty(fn, GUARD_TAG, { value: tag, enumerable: false });
+  return fn;
+}
+
+/** Reads the guard tags declared on a built procedure's middleware chain. */
+export function readGuardTags(middlewares: readonly unknown[]): GuardTag[] {
+  return middlewares
+    .filter((mw): mw is object => typeof mw === 'function')
+    .map((mw) => (mw as Record<symbol, GuardTag | undefined>)[GUARD_TAG])
+    .filter((tag): tag is GuardTag => tag !== undefined);
+}

--- a/apps/api/src/trpc/init.ts
+++ b/apps/api/src/trpc/init.ts
@@ -2,7 +2,13 @@ import { initTRPC, TRPCError } from '@trpc/server';
 import type { ApiKeyScope } from '@colophony/types';
 import { AuditActions, AuditResources } from '@colophony/types';
 import type { TRPCContext } from './context.js';
-import { checkApiKeyScopes } from '../services/scope-check.js';
+import {
+  checkApiKeyScopes,
+  markGuard,
+  readGuardTags,
+  GUARD_TAG,
+  type GuardTag,
+} from '../services/scope-check.js';
 import { validateEnv } from '../config/env.js';
 
 export const t = initTRPC.context<TRPCContext>().create({
@@ -206,25 +212,17 @@ const isBusinessOps = t.middleware(({ ctx, next }) => {
 // ---------------------------------------------------------------------------
 
 /**
- * Marks a middleware as one of the two guards that keep a tRPC procedure out of
- * an API key's reach. Read by `guard-coverage.spec.ts`, which fails the build on
- * a procedure declaring neither.
- *
- * Tagging is necessary because neither guard is identifiable by reference:
- * `requireScopes` mints a fresh closure per call, and both are anonymous inside
- * `t.middleware(...)`. tRPC keeps the function object itself in
- * `procedure._def.middlewares`, so a non-enumerable property on it survives
- * builder composition intact.
+ * The guard tag itself is shared with the REST surface — see
+ * `services/scope-check.ts`. Both gates read the same symbol, so a guard added on
+ * either surface is visible to its own coverage test without further wiring.
  */
-export const TRPC_GUARD = Symbol.for('colophony.trpc.guard');
-
-export type GuardTag =
-  { kind: 'scopes'; scopes: readonly ApiKeyScope[] } | { kind: 'internal' };
+export { GUARD_TAG, readGuardTags, type GuardTag };
 
 /**
  * Tags the underlying function of a middleware builder, returning the builder
  * unchanged. Takes the builder rather than the raw function so the middleware
- * body keeps tRPC's parameter inference.
+ * body keeps tRPC's parameter inference — oRPC needs no such wrapper, because
+ * `restBase.middleware(...)` hands back the function directly.
  */
 function tagGuard<TBuilder extends { _middlewares: readonly unknown[] }>(
   middleware: TBuilder,
@@ -235,16 +233,8 @@ function tagGuard<TBuilder extends { _middlewares: readonly unknown[] }>(
   if (typeof fn !== 'function') {
     throw new Error('Cannot tag guard: middleware builder has no function');
   }
-  Object.defineProperty(fn, TRPC_GUARD, { value: tag, enumerable: false });
+  markGuard(fn, tag);
   return middleware;
-}
-
-/** Reads the guard tags declared on a built procedure's middleware chain. */
-export function readGuardTags(middlewares: readonly unknown[]): GuardTag[] {
-  return middlewares
-    .filter((mw): mw is object => typeof mw === 'function')
-    .map((mw) => (mw as Record<symbol, GuardTag | undefined>)[TRPC_GUARD])
-    .filter((tag): tag is GuardTag => tag !== undefined);
 }
 
 /**

--- a/apps/api/src/trpc/routers/organizations.spec.ts
+++ b/apps/api/src/trpc/routers/organizations.spec.ts
@@ -367,6 +367,15 @@ describe('organizations tRPC router', () => {
         limit: 20,
       });
       expect(result.items).toHaveLength(1);
+
+      // The org ID must reach the service — it carries the explicit tenant
+      // predicate, so a dropped argument silently widens the query to RLS alone.
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockService.listMembers).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ page: 1, limit: 20 }),
+        ORG_ID,
+      );
     });
   });
 

--- a/apps/api/src/trpc/routers/organizations.ts
+++ b/apps/api/src/trpc/routers/organizations.ts
@@ -51,7 +51,11 @@ const membersRouter = createRouter({
     .input(paginationSchema)
     .output(paginatedResponseSchema(organizationMemberSchema))
     .query(async ({ ctx, input }) => {
-      return organizationService.listMembers(ctx.dbTx, input);
+      return organizationService.listMembers(
+        ctx.dbTx,
+        input,
+        ctx.authContext.orgId,
+      );
     }),
 
   add: adminProcedure

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -131,7 +131,7 @@
 Full analysis and sequencing: [`docs/api-integration-design.md`](api-integration-design.md).
 Ordered as the design doc's Phase 0/D.
 
-- [ ] **[P0] tRPC is reachable by API keys, and 10 routers enforce no scopes.** Nothing
+- [x] **[P0] tRPC is reachable by API keys, and 10 routers enforce no scopes.** Nothing
       restricts `X-Api-Key` to the REST surface, and `requireScopes` is opt-in per procedure.
       `federation`, `gdpr`, `hub`, `migration`, `notification-preferences`, `notifications`,
       `ops`, `simsub`, `transfer`, `webhooks` called it zero times — so a key scoped
@@ -307,7 +307,7 @@ Ordered as the design doc's Phase 0/D.
       `push` (`scripts/db-reset.sh:32`, since `fb857743`) — the migration REVOKEs did run and
       were then clobbered, rather than never running. — (found 2026-07-28 during the P2.0 audit;
       done 2026-07-28)
-- [ ] **[P1] `organizationService.listMembers` has no org predicate on either query.**
+- [x] **[P1] `organizationService.listMembers` has no org predicate on either query.**
       `apps/api/src/services/organization.service.ts:168` (page) and `:182` (`count(*)`) carry
       no `WHERE` clause on any table — the only read of `users` in the codebase in that state.
       RLS on `organization_members` is the sole defense. The direct analogue of #521, and the
@@ -315,15 +315,43 @@ Ordered as the design doc's Phase 0/D.
       `eq(organizationMembers.organizationId, orgId)` on a join it performs anyway, plus an
       `orgId` parameter threaded from `ctx.authContext.orgId` / `context.authContext.orgId`.
       **Both halves** — scoping only the page query leaves `total` reporting every org's member
-      count. — (found 2026-07-28 during the P2.0 audit)
-- [ ] **[P1] REST `POST /v1/invitations/accept` declares no scopes.**
+      count. — (found 2026-07-28 during the P2.0 audit; done 2026-07-28)
+      Fixed as `listMembers(tx, pagination, orgId)` with `orgId` required and last, matching
+      `apiKeyService.list`. One hoisted `eq(organizationMembers.organizationId, orgId)` is reused
+      by both queries, so page and count cannot drift apart. Pinned by an admin-pool block in
+      `__tests__/rls/organization-service.test.ts` — the predicate is the only isolation there —
+      plus argument assertions in both router specs and a predicate assertion in the service spec.
+      The app-pool case in `tenant-isolation-transitive.test.ts` was **kept**, not moved: a
+      predicate would otherwise mask a regression in `organization_members`' policy. Verified the
+      asymmetry by hand — removing the predicate fails the admin-pool block and the service spec
+      while the app-pool suite still passes 41/41.
+      Also closed a latent hole in the harness: `globalSetup()` asserted `app_user` is not a
+      superuser but never asserted the **admin** connection bypasses RLS, so an overridden
+      `DATABASE_TEST_URL` would have made every predicate-only suite pass under RLS while
+      reporting green. That covers `api-key-service.test.ts` from #521 too, which asserted the
+      property in prose only.
+- [x] **[P1] REST `POST /v1/invitations/accept` declares no scopes.**
       `apps/api/src/rest/routers/organizations.ts:333` uses `userProcedure` with no
       `requireScopes(...)`, while its tRPC twin (`trpc/routers/organizations.ts:157`) declares
       `organizations:write`. The route is authenticated but scope-unconstrained and it writes
       membership. `trpc/guard-coverage.spec.ts` reads the tRPC router only, so REST has no
       equivalent build-time check — worth adding the mirror gate alongside the fix, since this
       is the second REST/tRPC parity gap found in two sessions. — (found 2026-07-28 during the
-      P2.0 audit)
+      P2.0 audit; done 2026-07-28)
+      The route now declares `organizations:write`, matching its twin. The mirror gate shipped
+      alongside as `apps/api/src/rest/guard-coverage.spec.ts`: it walks the nested `restRouter`
+      recursively using oRPC's `isProcedure` as the leaf test and reads guard tags off
+      `procedure['~orpc'].middlewares`. Five tests — a >130 count canary against an `'~orpc'`
+      rename, coverage, no-vacuous-`requireScopes()`, scope strings valid against
+      `apiKeyScopeSchema`, and allowlist reverse-staleness. It reports offenders as
+      `POST /invitations/accept (acceptInvitation)` rather than a dotted key, since oRPC carries
+      `route` metadata the tRPC gate has no equivalent of. `accept` was the **only** unscoped
+      procedure on the surface (139 declarations, 138 guards, `restBase` never used directly in a
+      router), so the gate went green immediately; verified it can fail by reverting the fix.
+      The guard-tag primitive (`GUARD_TAG`, `markGuard`, `readGuardTags`) moved to
+      `services/scope-check.ts`, which both surfaces already imported for `checkApiKeyScopes` — a
+      per-surface copy is how the declarations drifted apart to begin with. The tRPC gate's seven
+      tests pass unchanged.
 - [ ] **[P2] `submission.service` list/export methods carry no org predicate.** `listAll`
       (`:290`), `exportAll` (`:392`, up to 10 000 rows) and `listAgingByOrg` (`:1526`) build
       their `where` from `status` / `period` / `search` / date only. `listAgingByOrg` is named

--- a/docs/tenant-isolation-audit.md
+++ b/docs/tenant-isolation-audit.md
@@ -87,8 +87,6 @@ RLS-only. Ordered by exposure.
 
 | Site                                            | Method                      | Predicate present                   | Disposition |
 | ----------------------------------------------- | --------------------------- | ----------------------------------- | ----------- |
-| `services/organization.service.ts:168`          | `listMembers` page query    | **none**                            | fix — P1    |
-| `services/organization.service.ts:182`          | `listMembers` count query   | **none**                            | fix — P1    |
 | `services/submission.service.ts:290`            | `listAll`                   | `status` / `period` / `search` only | fix — P2    |
 | `services/submission.service.ts:392`            | `exportAll` (10 000 rows)   | same                                | fix — P2    |
 | `services/submission.service.ts:1526`           | `listAgingByOrg`            | date + status only                  | fix — P2    |
@@ -105,9 +103,11 @@ RLS-only. Ordered by exposure.
 | `services/csr.service.ts:99`                    | export org names            | ids from a `submitter_id` read      | ok          |
 | `services/migration-bundle.service.ts:99`       | bundle org names            | same                                | ok          |
 
-`organization.service.ts:168`/`:182` is the only site in the codebase reading `users` with **no
-`WHERE` clause on any table in the query**. Both halves need the predicate; scoping only the page
-query leaves `total` reporting every organization's member count.
+`organization.service.ts` `listMembers` **was** the only site in the codebase reading `users` with
+no `WHERE` clause on any table in the query. Fixed 2026-07-28 — it now carries one hoisted
+`eq(organizationMembers.organizationId, orgId)` reused by both the page and count queries, so the
+two cannot drift apart, and it has moved to §4.5. No site in the fix list below reads `users`
+entirely unfiltered any longer.
 
 `listAgingByOrg` is named for a scoping it does not perform. Its caller supplies the org through
 `withRls({ orgId })` (`inngest/functions/submission-response-reminder.ts:64`), so it is correct in
@@ -173,6 +173,12 @@ name reads (`submission-notifications.ts:41`, `slate-notifications.ts:131`,
 `discussion-notifications.ts:34`, `submission-vote.service.ts:144`, and others), org-bearing join
 conditions in `contest.service.ts:386`/`:594`/`:635`, `pipeline.service.ts:129`/`:188`/`:997`, and
 `invitation.service.ts:166`.
+
+Joined here 2026-07-28 by `organization.service.ts` `listMembers` (page and count), the first item
+off the §4.1 fix list. It is the worked example of the §2 rule: `users` has no `organizationId`, so
+the predicate lands on the org-bearing join partner — a join the method already performed. The
+predicate is hoisted once and applied to both queries, which is what makes it impossible to scope
+the page and leave the count reporting every organization's member total.
 
 ## 5. Legitimately cross-tenant families
 
@@ -262,7 +268,10 @@ appear in exactly one list.
   designed.
 
 The P1 items must merge before the instance principal ships; the backlog records that as a
-precondition on the Phase 2 entry.
+precondition on the Phase 2 entry. **`listMembers` and the REST `invitations/accept` scope gap both
+merged 2026-07-28**, clearing the two P1s this audit raised. The two remaining Track 2 P1s
+(per-key rate limits, `principal_id` in `audit_events`) are from the integration-surface review, not
+from here.
 
 ## 8. What keeps this true
 
@@ -271,7 +280,15 @@ precondition on the Phase 2 entry.
   against a recorded expectation, so a silent re-grant fails the build.
 - `apps/api/src/__tests__/security/tenant-isolation-transitive.test.ts` — per-method proof that
   RLS covers each §4.1 path, with a non-zero own-org assertion so the checks cannot pass against
-  empty tables.
+  empty tables. `listMembers` is deliberately retained here after being scoped: an explicit
+  predicate would otherwise mask a regression in `organization_members`' policy. **The pattern for
+  the remaining §4.1 fixes** is therefore to keep the app-pool case here and add an admin-pool
+  mirror, not to move the case.
+- `apps/api/src/__tests__/rls/organization-service.test.ts` and `.../api-key-service.test.ts` —
+  the other direction. Both drive the RLS-**bypassing** admin pool so an explicit `WHERE` is the
+  only isolation under test; a deleted predicate fails these while everything else stays green.
+  `globalSetup()` asserts that the admin connection really does bypass RLS, so neither can quietly
+  degrade into an RLS-backed test that passes either way.
 - `apps/api/src/__tests__/security/unprotected-table-callsites.test.ts` — file-level tripwire. A
   `users` or `organizations` query in a new file fails until it is classified here. A nudge to
   the reviewer, not a security boundary: a new query in an already-listed file passes.


### PR DESCRIPTION
Closes the two P1 findings from the 2026-07-28 tenant-isolation audit (#523) and its sibling integration-surface review. `docs/tenant-isolation-audit.md` §7 records them as a precondition on the Phase 2 instance principal, so this clears that gate.

## 1. `organizationService.listMembers` had no org predicate

`organization.service.ts` built a page query joining `users` to `organization_members` and a bare `count(*)`, and neither carried a `WHERE` clause on any table. Per audit §4.1 this was the only read of `users` in the codebase in that state — every other one of the 34 in the services layer filters on a key or hangs off an org-scoped base table. RLS on `organization_members` was the sole thing separating tenants.

The method now takes a required `orgId` last, matching `apiKeyService.list` from #521, and applies one hoisted `eq(organizationMembers.organizationId, orgId)` to both queries. Hoisting rather than repeating the expression is deliberate: it makes it structurally impossible to scope the page and leave `total` reporting every organisation's member count. `users` has no `organizationId` of its own, so the predicate lands on the org-bearing join partner — a join the method already performed.

Both callers already held a non-optional `orgId`; the REST handler was even validating the path param against it and then not passing it down.

## 2. REST `POST /v1/invitations/accept` declared no scopes

A bare `userProcedure` while its tRPC twin declared `organizations:write` — authenticated but scope-unconstrained, and it writes membership. It was the **only** unscoped procedure across 139 REST declarations (138 guards, and `restBase` is never used directly in a router), so the fix is one line. What matters is why it survived: the guard-coverage gate existed on the tRPC surface only, and this was the second REST/tRPC parity gap found by audit in two sessions.

`apps/api/src/rest/guard-coverage.spec.ts` is now the mirror. Two mechanical differences from the tRPC original: `restRouter` is a nested plain object, so the walk recurses with oRPC's `isProcedure` as the leaf test instead of iterating a flat `_def.procedures` map; and there is only one guard kind on this surface, since `internalOnly` is tRPC-only. Five tests — a count canary against an `'~orpc'` rename on upgrade, coverage, no vacuous `requireScopes()`, scope strings valid against `apiKeyScopeSchema`, and allowlist reverse-staleness. Offenders report as `POST /invitations/accept (acceptInvitation)`, since oRPC carries route metadata tRPC has no equivalent of.

The guard-tag primitive (`GUARD_TAG`, `markGuard`, `readGuardTags`) moves to `services/scope-check.ts`, which both surfaces already imported for `checkApiKeyScopes`. A per-surface copy is the root of the drift being fixed here, not just its symptom.

## Tests: two directions, kept separate

The house pattern is one suite per layer, and this preserves it:

- **Predicate isolated** — a new admin-pool block in `__tests__/rls/organization-service.test.ts`, mirroring `api-key-service.test.ts`. Connects as a role with `rolsuper`/`rolbypassrls`, so the `WHERE` clause is the only thing isolating org A from org B.
- **Policy isolated** — the app-pool case in `tenant-isolation-transitive.test.ts` is **retained**, not relocated. That file's stated scope is methods carrying no explicit predicate, so its header now records the exception and why: an explicit predicate would otherwise mask a regression in `organization_members`' RLS. The audit doc records this as the pattern for the remaining §4.1 fixes.

Verified by hand that the asymmetry is real — removing the predicate fails the three admin-pool cases and the service spec while the app-pool suite still passes 41/41. Also confirmed the new REST gate can fail, by reverting the one-line scope fix.

Router specs previously asserted only `items.toHaveLength(1)` and would have passed with the argument dropped; both now assert it reaches the service.

## Incidental: the harness could not have caught a bad admin pool

`globalSetup()` asserted `app_user` is `NOSUPERUSER`/`NOBYPASSRLS` but never asserted the mirror — that the admin connection bypasses RLS. `DATABASE_TEST_URL` is read straight from the environment, so pointing it at a non-superuser would have made every predicate-only suite pass *under* RLS and assert nothing, while reporting green. Same shape as the `vitest.config.queues.ts` pool collapse found last session. Now asserted in shared setup, which covers `api-key-service.test.ts` from #521 too — that file asserted the property in its header prose only.

## Verification

- `pnpm type-check`, `pnpm lint` — clean
- Unit 1841 passed (162 files), RLS 145 passed, security 41 passed
- Both guard-coverage gates green; the tRPC gate's seven tests pass unchanged, which is the regression check on moving the symbol
- `pnpm sdk:check-spec` — spec unchanged at 139 operations, confirming a middleware addition does not alter the contract

## Not in scope

The four P2s from the same audit series, and the two remaining Track 2 P1s (per-key rate limits, `principal_id` in `audit_events`). Staging has also not been re-measured since the privilege manifest merged, and only `vitest.config.queues.ts` was checked for the collapsed-pool problem — the RLS helper reads its two URLs directly so that suite is sound, but the other integration configs were not audited.