### PR TITLE
fix(api): key authenticated rate limits on the credential, not the creator

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,7 +87,8 @@ NEXT_PUBLIC_TUS_URL=http://localhost:1080/files/
 # =============================================================================
 # Unauthenticated: requests per window (keyed by IP)
 RATE_LIMIT_DEFAULT_MAX=60
-# Authenticated: requests per window (keyed by userId)
+# Authenticated: requests per window, per credential (an API key is keyed by its
+# own id, an interactive session by user id — keys do not share their creator's window)
 RATE_LIMIT_AUTH_MAX=200
 # Window size in seconds
 RATE_LIMIT_WINDOW_SECONDS=60

--- a/apps/api/src/hooks/rate-limit-auth.spec.ts
+++ b/apps/api/src/hooks/rate-limit-auth.spec.ts
@@ -34,7 +34,16 @@ import fp from 'fastify-plugin';
 import rateLimitPlugin from './rate-limit.js';
 import rateLimitAuthPlugin from './rate-limit-auth.js';
 
-/** Minimal auth stub — satisfies colophony-auth dependency without real auth logic. */
+/**
+ * Minimal auth stub — satisfies colophony-auth dependency without real auth logic.
+ *
+ * `apiKeyId` and `authMethod` come from *independent* headers on purpose. In
+ * production the two always travel together (auth.ts:313–321), so a fixture that
+ * emitted them as a pair could not tell presence-based keying apart from an
+ * `authMethod === 'apikey'` implementation — every per-credential test would pass
+ * against either. Decoupling them lets one case set `apiKeyId` without the
+ * matching method, which is the only case that pins the discriminator.
+ */
 const fakeAuthPlugin = fp(
   async function fakeAuth(app: FastifyInstance) {
     app.decorateRequest('authContext', null);
@@ -42,13 +51,18 @@ const fakeAuthPlugin = fp(
       const testUserId = request.headers['x-test-user-id'] as
         string | undefined;
       if (testUserId) {
+        const apiKeyId = request.headers['x-test-api-key-id'] as
+          string | undefined;
+        const authMethod = (request.headers['x-test-auth-method'] ??
+          'test') as AuthContext['authMethod'];
         request.authContext = {
           userId: testUserId,
           zitadelUserId: testUserId,
           email:
             (request.headers['x-test-email'] as string) ?? 'test@example.com',
           emailVerified: true,
-          authMethod: 'test',
+          authMethod,
+          ...(apiKeyId ? { apiKeyId } : {}),
         } satisfies AuthContext;
       }
     });
@@ -239,6 +253,82 @@ describe('rate-limit-auth plugin (second-pass)', () => {
         headers: { 'x-test-user-id': 'user-2' },
       });
       expect(response.statusCode).toBe(200);
+    });
+  });
+
+  describe('per-credential bucketing', () => {
+    let app: FastifyInstance;
+    let redis: InstanceType<typeof RedisMock>;
+
+    /** An API key as production presents it: apiKeyId *and* authMethod together. */
+    const key = (keyId: string, creator: string) => ({
+      'x-test-user-id': creator,
+      'x-test-api-key-id': keyId,
+      'x-test-auth-method': 'apikey',
+    });
+
+    /** An interactive session — no credential id. */
+    const session = (userId: string) => ({ 'x-test-user-id': userId });
+
+    const get = (headers: Record<string, string>) =>
+      app.inject({ method: 'GET', url: '/api/test', headers });
+
+    /** Spend the whole window for `headers`, asserting each request is allowed. */
+    async function exhaust(headers: Record<string, string>) {
+      for (let i = 0; i < 3; i++) {
+        expect((await get(headers)).statusCode).toBe(200);
+      }
+      expect((await get(headers)).statusCode).toBe(429);
+    }
+
+    beforeEach(async () => {
+      const result = await buildApp({
+        RATE_LIMIT_DEFAULT_MAX: 100, // High IP limit so first-pass never blocks
+        RATE_LIMIT_AUTH_MAX: 3,
+      });
+      app = result.app;
+      redis = result.redis;
+    });
+
+    afterEach(async () => {
+      await app.close();
+      await redis.flushall();
+    });
+
+    it('a single key still enforces its own limit', async () => {
+      await exhaust(key('key-a', 'user-1'));
+    });
+
+    it('two keys from the same creator have independent limits', async () => {
+      await exhaust(key('key-a', 'user-1'));
+
+      // Same creator, different credential — must have its own window.
+      expect((await get(key('key-b', 'user-1'))).statusCode).toBe(200);
+    });
+
+    it('a key does not consume its creator’s interactive budget', async () => {
+      await exhaust(key('key-a', 'user-1'));
+
+      expect((await get(session('user-1'))).statusCode).toBe(200);
+    });
+
+    it('an interactive session does not consume its keys’ budget', async () => {
+      await exhaust(session('user-1'));
+
+      expect((await get(key('key-a', 'user-1'))).statusCode).toBe(200);
+    });
+
+    it('keys on apiKeyId presence, not on authMethod', async () => {
+      // `apiKeyId` set but authMethod left at 'test' — models the planned
+      // `col_svc_` principal, which will carry a credential id under a different
+      // authMethod. This is the only case that fails an implementation branching
+      // on `authMethod === 'apikey'`; the four above pass against either.
+      await exhaust({
+        'x-test-user-id': 'user-1',
+        'x-test-api-key-id': 'key-a',
+      });
+
+      expect((await get(session('user-1'))).statusCode).toBe(200);
     });
   });
 

--- a/apps/api/src/hooks/rate-limit-auth.ts
+++ b/apps/api/src/hooks/rate-limit-auth.ts
@@ -19,12 +19,13 @@ function shouldSkip(request: FastifyRequest): boolean {
 }
 
 /**
- * Second-pass rate limiting: user-based, runs after auth.
+ * Second-pass rate limiting: credential-based, runs after auth.
  *
  * Hook order: ... → auth → **rate-limit-auth** → org-context → ...
  *
- * Only applies to authenticated requests. Uses userId as identifier with
- * AUTH_MAX limit (higher than the IP-based DEFAULT_MAX). Overrides the
+ * Only applies to authenticated requests. Each credential gets its own window at
+ * the AUTH_MAX limit (higher than the IP-based DEFAULT_MAX): an API key is keyed
+ * on its own id, an interactive session on the user id. Overrides the
  * X-RateLimit-* headers set by the first-pass plugin with the higher values.
  *
  * Shares Redis instance with first-pass plugin via app.rateLimitRedis.
@@ -48,13 +49,25 @@ export default fp(
         if (shouldSkip(request)) return;
 
         // Only run for authenticated requests
-        const userId = request.authContext?.userId;
-        if (!userId) return;
+        const auth = request.authContext;
+        if (!auth?.userId) return;
 
         const redis = app.rateLimitRedis;
         if (!redis) return;
 
-        const key = `${prefix}:auth:${userId}`;
+        // Key on the credential, not the creator. For API-key auth `userId` is
+        // the key's *creator* (auth.ts:314), so keying on it would put every key
+        // that admin made — and their browser session — in one bucket.
+        //
+        // Branch on the presence of `apiKeyId`, never on `authMethod`: the same
+        // allowlist-not-denylist rule that governs `internalOnly` in trpc/init.ts.
+        // A future `col_svc_` principal gets an explicit branch here rather than
+        // silently inheriting whichever bucket an authMethod test happened to pick.
+        const { scope, identifier } = auth.apiKeyId
+          ? ({ scope: 'key', identifier: auth.apiKeyId } as const)
+          : ({ scope: 'user', identifier: auth.userId } as const);
+
+        const key = `${prefix}:auth:${scope}:${identifier}`;
         const nowMs = Date.now();
         const requestId = `${nowMs}:${Math.random().toString(36).slice(2, 8)}`;
 
@@ -102,7 +115,8 @@ export default fp(
 
           request.log.warn(
             {
-              identifier: userId,
+              identifier,
+              credential: scope,
               path: request.url,
               count,
               limit,

--- a/docs/api-integration-design.md
+++ b/docs/api-integration-design.md
@@ -95,12 +95,16 @@ in-process generation) a hard prerequisite rather than a convenience. Under D4 t
 SDK-regeneration half of this job disappears entirely, since generated SDKs stop being
 committed.
 
-**(c) There are no per-key rate limits.** `apps/api/src/hooks/rate-limit-auth.ts:57` keys
-the authenticated window on `${prefix}:auth:${userId}`. For API-key auth, `userId` is the
-key's _creator_. So today every key created by one admin already shares a single bucket
-with every other key that admin created **and** with that admin's interactive browser
-session. The brief's premise — "per-key limits assume one org's traffic" — overstates the
-current state; there is nothing per-key to change, there is something per-key to add.
+**(c) There are no per-key rate limits.** — **Closed 2026-07-29.**
+`apps/api/src/hooks/rate-limit-auth.ts:57` keyed the authenticated window on
+`${prefix}:auth:${userId}`. For API-key auth, `userId` is the key's _creator_. So every key
+created by one admin shared a single bucket with every other key that admin created **and**
+with that admin's interactive browser session. The brief's premise — "per-key limits assume
+one org's traffic" — overstated the state; there was nothing per-key to change, there was
+something per-key to add.
+
+It is now keyed per credential: `auth:key:<apiKeyId>` or `auth:user:<userId>`. See the
+"Rate limiting" section below for what shipped and what did not.
 
 **(d) The audit trail cannot distinguish a key from its creator today.** `audit_events`
 (`packages/db/src/schema/audit.ts:24`) has a single `actor_id`, and `BaseAuditParams`
@@ -920,12 +924,18 @@ truth for every historical row.
 
 #### Rate limiting
 
-Three changes to `hooks/rate-limit-auth.ts`:
+Three changes to `hooks/rate-limit-auth.ts`. **(1) shipped 2026-07-29; (2) and (3) remain
+open, and will stay open until the `col_svc_` instance principal exists — both are
+principal-specific and neither applies to an org-bound `col_live_` key.**
 
-1. **Key on the credential, not the creator.** When `apiKeyId` (or `principalId`) is
-   present, use it in the Redis key instead of `userId`. This introduces per-key limits,
-   which do not exist today (finding (c)), and stops a key from consuming its creator's
-   interactive budget.
+1. ~~**Key on the credential, not the creator.**~~ **Done.** When `apiKeyId` (or
+   `principalId`) is present, use it in the Redis key instead of `userId`. This introduced
+   per-key limits, which did not exist (finding (c)), and stops a key from consuming its
+   creator's interactive budget. Shipped as a presence check on `apiKeyId` — deliberately
+   _not_ `authMethod === 'apikey'`, so a future principal must be admitted explicitly.
+   Note what this gives up: with no per-creator bucket left, and no cap on key creation in
+   `apiKeyService.create`, the aggregate per-human ceiling is unbounded. The IP limiter does
+   not substitute — it keys on source address and fails open.
 2. **Key instance principals on the `(principal, org)` pair.** Otherwise one busy tenant
    exhausts the shared window and the failure presents as an outage for every other org the
    integrator serves.
@@ -1095,11 +1105,11 @@ byte-identical behaviour.
 
 Three changes do touch existing keys, and each is independently safe:
 
-| Change                                             | Effect on existing keys                                                                                                               | Compatibility                                                                                      |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `audit_events.principal_id` / `principal_type`     | Their actions become _correctly_ attributed to the key rather than ambiguously to the creator                                         | Additive. Historical rows keep NULL, which is accurate. No behaviour change.                       |
-| Rate-limit key changes from `userId` to `apiKeyId` | Each key gets its own bucket instead of sharing the creator's                                                                         | Strictly loosening for the key holder. A creator with several keys sees _more_ headroom, not less. |
-| M1 (`internalOnly` on 7 tRPC routers)              | A key calling `webhooks.*`, `federation.*`, `hub.*`, `transfer.*`, `migration.*`, `simsub.*`, or `ops.*` over tRPC starts getting 403 | **This is the one breaking change.** It is also the point.                                         |
+| Change                                                                      | Effect on existing keys                                                                                                               | Compatibility                                                                                      |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `audit_events.principal_id` / `principal_type`                              | Their actions become _correctly_ attributed to the key rather than ambiguously to the creator                                         | Additive. Historical rows keep NULL, which is accurate. No behaviour change.                       |
+| Rate-limit key changes from `userId` to `apiKeyId` **(shipped 2026-07-29)** | Each key gets its own bucket instead of sharing the creator's                                                                         | Strictly loosening for the key holder. A creator with several keys sees _more_ headroom, not less. |
+| M1 (`internalOnly` on 7 tRPC routers)                                       | A key calling `webhooks.*`, `federation.*`, `hub.*`, `transfer.*`, `migration.*`, `simsub.*`, or `ops.*` over tRPC starts getting 403 | **This is the one breaking change.** It is also the point.                                         |
 
 M1 needs handling, not just announcing:
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -400,10 +400,23 @@ Ordered as the design doc's Phase 0/D.
       submission to them. Deliberate — it is how a known writer submitting through an embed gets
       linked — but it wants a decision on identity semantics, not a patch. — (found 2026-07-28
       during the P2.0 audit)
-- [ ] **[P1] No per-key rate limits.** `hooks/rate-limit-auth.ts:57` keys the authenticated
+- [x] **[P1] No per-key rate limits.** `hooks/rate-limit-auth.ts:57` keyed the authenticated
       window on `userId`, which for key auth is the key's _creator_ — so all of an admin's
-      keys share one bucket with each other and with that admin's browser session. Key on
-      the credential instead. — (design doc §0.1(c), P2.4)
+      keys shared one bucket with each other and with that admin's browser session. Now keyed
+      on the credential: `auth:key:<apiKeyId>` or `auth:user:<userId>`, both at
+      `RATE_LIMIT_AUTH_MAX` (no new variable). The discriminator is the **presence** of
+      `apiKeyId`, not `authMethod`, so the planned `col_svc_` principal needs an explicit
+      branch rather than inheriting one; a test sets `apiKeyId` under a non-`apikey`
+      `authMethod` to pin exactly that. This is change (1) of the three in the design doc's
+      "Rate limiting" section — (2) and (3) stay open because both are instance-principal
+      concerns. — (design doc §0.1(c), P2.4; done 2026-07-29)
+- [ ] **[P3] No aggregate ceiling per human, and no cap on key creation.** Per-credential
+      rate limiting (above) deliberately traded the per-creator ceiling for isolation
+      between keys, so a creator with N keys can now spend N × `RATE_LIMIT_AUTH_MAX` per
+      window. Nothing bounds that: the IP limiter keys on `request.ip` — a source, not a
+      principal — and fails open when Redis is unreachable, and `apiKeyService.create`
+      enforces no per-org or per-creator key count. Either a creator-level umbrella bucket
+      or a key-count cap would close it.
 - [ ] **[P1] Audit cannot distinguish an API key from its creator.** `audit_events` has a
       single `actor_id` and `BaseAuditParams` carries no `apiKeyId`, so a key's actions and
       the human's own actions are recorded identically. Add `principal_id` / `principal_type`


### PR DESCRIPTION
## Summary

The second-pass rate limiter keyed its window on `userId`. For API-key auth that is the key's **creator**, so every key one admin created shared a single 200-request window with every other key that admin created — and with that admin's own browser session. One busy integration could starve the dashboard; two integrations could starve each other.

Now keyed on the credential: `auth:key:<apiKeyId>` for a key, `auth:user:<userId>` for an interactive session, both at `RATE_LIMIT_AUTH_MAX`. No new configuration.

Closes the Track 2 P1 and finding (c) of the API integration design.

## The discriminator

The branch is on the **presence of `apiKeyId`**, deliberately not `authMethod === 'apikey'` — the same allowlist rule that governs internal-only procedures. A future instance principal must be admitted explicitly rather than inheriting whichever bucket a method check happens to select.

This is pinned by a test that sets `apiKeyId` under a non-`apikey` auth method. Verified the pin actually works: substituting a method-based implementation passes the other 14 cases and fails only that one. The test fixture drives the two fields from independent headers for this reason — emitting them as a pair would have left all five new tests green against either implementation.

## What this gives up

Stated plainly rather than implied away: there is now **no aggregate per-human ceiling**. The IP limiter bounds a *source* rather than a principal and fails open when Redis is unreachable, and `apiKeyService.create` caps nothing. That is a deliberate trade for isolation between credentials, not something another control catches. Filed as a new P3.

## Scope

Change (1) of the three in the design doc's rate-limiting section. Changes (2) — keying on `(principal, org)` — and (3) — a separate principal ceiling — are both instance-principal concerns; neither applies to an org-bound key, which already carries exactly one trustworthy `organizationId`.

## Verification

- 1859 unit tests pass, up exactly five
- Stashing the hook fails exactly four of the five new cases — the three independence cases plus the discriminator case; `a single key still enforces its own limit` passes either way, as expected
- Type-check and lint clean
- Separately, staging was re-measured across the twelve restricted tables: every one matches the privilege manifest, and `app_user` remains `NOSUPERUSER`/`NOBYPASSRLS`