### PR TITLE
fix(api): scope notificationService reads and writes to the caller's org

### DIFF
--- a/apps/api/src/__tests__/rls/notification-service.test.ts
+++ b/apps/api/src/__tests__/rls/notification-service.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Defense-in-depth: notificationService's explicit organization predicates.
+ *
+ * The same shape as `api-key-service.test.ts`, and for the same reason. Every
+ * query below runs over the ADMIN pool, which connects as role `test`
+ * (`rolsuper = t, rolbypassrls = t`), so RLS does not apply — not even the
+ * `FORCE ROW LEVEL SECURITY` set on `notifications_inbox` by
+ * `0034_notifications_inbox.sql`, which binds the table owner but not a
+ * superuser. The only thing separating org A's notifications from org B's here
+ * is the `WHERE organization_id = $orgId` clause in the service.
+ *
+ * This matters more than usual for this table. Its RLS policy uses the raising
+ * idiom (`current_setting('app.current_org')::uuid`), and `userId` looks like it
+ * is doing the isolating — so a reader can easily conclude these queries were
+ * already scoped. They were not: before this suite, all four methods filtered on
+ * `userId` alone, and the same user id can legitimately appear in two orgs'
+ * inboxes.
+ *
+ * Do not "fix" this by switching to the app pool. That reinstates RLS and the
+ * suite would pass with or without the predicates, testing nothing. The unit
+ * spec cannot substitute either — it mocks `eq`/`and` as bare `vi.fn()`s
+ * returning `undefined`, so the assembled `where` is discarded entirely.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { eq } from 'drizzle-orm';
+import {
+  notificationsInbox,
+  type Organization,
+  type User,
+} from '@colophony/db';
+import { globalSetup, getAdminPool } from './helpers/db-setup';
+import { truncateAllTables } from './helpers/cleanup';
+import {
+  createOrganization,
+  createUser,
+  createOrgMember,
+} from './helpers/factories';
+import { notificationService } from '../../services/notification.service.js';
+
+type ServiceTx = Parameters<typeof notificationService.list>[0];
+
+/**
+ * A Drizzle handle over the RLS-bypassing admin pool, shaped as the `tx` the
+ * service expects. The cast mirrors `helpers/factories.ts` — `@colophony/db`
+ * and the test tree resolve drizzle through different optional peer-dep
+ * contexts, so the types diverge while the runtime is a single copy.
+ */
+function adminTx(): ServiceTx {
+  return drizzle(getAdminPool());
+}
+
+function adminDb(): ReturnType<typeof drizzle> {
+  return drizzle(getAdminPool());
+}
+
+interface SeededNotification {
+  id: string;
+  organizationId: string;
+  userId: string;
+  readAt: Date | null;
+}
+
+async function createNotification(
+  organizationId: string,
+  userId: string,
+  title: string,
+): Promise<SeededNotification> {
+  const [row] = await adminDb()
+    .insert(notificationsInbox)
+    .values({
+      organizationId,
+      userId,
+      eventType: 'submission.received',
+      title,
+    })
+    .returning();
+  return row;
+}
+
+/** Read a row back over the admin pool, bypassing RLS — used to assert writes. */
+async function readNotification(
+  id: string,
+): Promise<SeededNotification | null> {
+  const rows = await adminDb()
+    .select()
+    .from(notificationsInbox)
+    .where(eq(notificationsInbox.id, id));
+  return rows[0] ?? null;
+}
+
+const PAGE = { unreadOnly: false, page: 1, limit: 20 };
+
+describe('notificationService defense-in-depth (RLS bypassed)', () => {
+  let orgA: Organization;
+  let orgB: Organization;
+  // One user, a member of both orgs. This is the case the userId-only predicate
+  // could not distinguish, and it is not contrived — a writer submitting to two
+  // magazines on one instance has exactly this shape.
+  let user: User;
+  let notifA: SeededNotification;
+  let notifB: SeededNotification;
+
+  beforeAll(async () => {
+    await globalSetup();
+    await truncateAllTables();
+
+    orgA = await createOrganization({ name: 'Org Alpha' });
+    orgB = await createOrganization({ name: 'Org Beta' });
+    user = await createUser();
+    await createOrgMember(orgA.id, user.id, { roles: ['ADMIN'] });
+    await createOrgMember(orgB.id, user.id, { roles: ['ADMIN'] });
+  });
+
+  // Fresh rows per test: markRead/markAllRead mutate, so cases must not depend
+  // on each other's ordering.
+  beforeEach(async () => {
+    await adminDb().delete(notificationsInbox);
+    notifA = await createNotification(orgA.id, user.id, 'Alpha notification');
+    notifB = await createNotification(orgB.id, user.id, 'Beta notification');
+  });
+
+  afterAll(async () => {
+    await truncateAllTables();
+  });
+
+  describe('list', () => {
+    it("returns only the caller's org notifications", async () => {
+      const result = await notificationService.list(
+        adminTx(),
+        { ...PAGE, userId: user.id },
+        orgA.id,
+      );
+
+      expect(result.items.map((n) => n.id)).toEqual([notifA.id]);
+      expect(result.items.map((n) => n.id)).not.toContain(notifB.id);
+    });
+
+    it('scopes the total count to the org', async () => {
+      // Without a predicate on the count query, `total` reports every org's rows
+      // even when `items` is correctly filtered — the pagination metadata leaks
+      // a row count across tenants.
+      const result = await notificationService.list(
+        adminTx(),
+        { ...PAGE, userId: user.id },
+        orgA.id,
+      );
+
+      expect(result.total).toBe(1);
+      expect(result.totalPages).toBe(1);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+    });
+
+    it('applies the org predicate alongside the unread filter', async () => {
+      await notificationService.markRead(
+        adminTx(),
+        notifA.id,
+        user.id,
+        orgA.id,
+      );
+
+      const result = await notificationService.list(
+        adminTx(),
+        { ...PAGE, userId: user.id, unreadOnly: true },
+        orgA.id,
+      );
+
+      // Org B's row is still unread, but belongs to another tenant.
+      expect(result.items).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe('unreadCount', () => {
+    it("counts only the caller's org", async () => {
+      const result = await notificationService.unreadCount(
+        adminTx(),
+        user.id,
+        orgA.id,
+      );
+
+      expect(result).toBe(1);
+    });
+  });
+
+  describe('markRead', () => {
+    it('refuses a notification in another org and writes nothing', async () => {
+      const result = await notificationService.markRead(
+        adminTx(),
+        notifB.id,
+        user.id,
+        orgA.id,
+      );
+
+      expect(result).toBe(false);
+
+      const stored = await readNotification(notifB.id);
+      expect(stored?.readAt).toBeNull();
+    });
+
+    it("marks a notification in the caller's own org", async () => {
+      const result = await notificationService.markRead(
+        adminTx(),
+        notifA.id,
+        user.id,
+        orgA.id,
+      );
+
+      expect(result).toBe(true);
+
+      const stored = await readNotification(notifA.id);
+      expect(stored?.readAt).not.toBeNull();
+    });
+  });
+
+  describe('markAllRead', () => {
+    it("marks only the caller's org and leaves other tenants unread", async () => {
+      const result = await notificationService.markAllRead(
+        adminTx(),
+        user.id,
+        orgA.id,
+      );
+
+      expect(result).toBe(1);
+
+      expect((await readNotification(notifA.id))?.readAt).not.toBeNull();
+      expect((await readNotification(notifB.id))?.readAt).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/services/notification.service.spec.ts
+++ b/apps/api/src/services/notification.service.spec.ts
@@ -86,14 +86,21 @@ describe('notificationService', () => {
           }),
       };
 
-      const result = await notificationService.list(mockTx as any, {
-        userId: 'user-1',
-        unreadOnly: false,
-        page: 1,
-        limit: 20,
-      });
+      const result = await notificationService.list(
+        mockTx as any,
+        {
+          userId: 'user-1',
+          unreadOnly: false,
+          page: 1,
+          limit: 20,
+        },
+        'org-1',
+      );
       expect(result.items).toHaveLength(2);
       expect(result.total).toBe(2);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(result.totalPages).toBe(1);
     });
 
     it('filters unread only when flag set', async () => {
@@ -118,14 +125,19 @@ describe('notificationService', () => {
           }),
       };
 
-      const result = await notificationService.list(mockTx as any, {
-        userId: 'user-1',
-        unreadOnly: true,
-        page: 1,
-        limit: 20,
-      });
+      const result = await notificationService.list(
+        mockTx as any,
+        {
+          userId: 'user-1',
+          unreadOnly: true,
+          page: 1,
+          limit: 20,
+        },
+        'org-1',
+      );
       expect(result.items).toHaveLength(0);
       expect(result.total).toBe(0);
+      expect(result.totalPages).toBe(0);
     });
   });
 
@@ -140,6 +152,7 @@ describe('notificationService', () => {
       const result = await notificationService.unreadCount(
         mockTx as any,
         'user-1',
+        'org-1',
       );
       expect(result).toBe(5);
     });
@@ -158,6 +171,7 @@ describe('notificationService', () => {
         mockTx as any,
         'notif-1',
         'user-1',
+        'org-1',
       );
       expect(result).toBe(true);
     });
@@ -174,6 +188,7 @@ describe('notificationService', () => {
         mockTx as any,
         'notif-999',
         'user-1',
+        'org-1',
       );
       expect(result).toBe(false);
     });
@@ -193,6 +208,7 @@ describe('notificationService', () => {
       const result = await notificationService.markAllRead(
         mockTx as any,
         'user-1',
+        'org-1',
       );
       expect(result).toBe(3);
     });

--- a/apps/api/src/services/notification.service.ts
+++ b/apps/api/src/services/notification.service.ts
@@ -40,13 +40,19 @@ export const notificationService = {
       page: number;
       limit: number;
     },
+    orgId: string,
   ) {
-    const conditions = [eq(notificationsInbox.userId, params.userId)];
+    const conditions = [
+      eq(notificationsInbox.organizationId, orgId),
+      eq(notificationsInbox.userId, params.userId),
+    ];
     if (params.unreadOnly) {
       conditions.push(isNull(notificationsInbox.readAt));
     }
 
-    const where = conditions.length === 1 ? conditions[0] : and(...conditions);
+    // One hoisted condition, reused by both queries. Filtering only the page
+    // query leaves `total` counting every org's rows.
+    const where = and(...conditions);
 
     const [items, [{ total }]] = await Promise.all([
       tx
@@ -59,15 +65,26 @@ export const notificationService = {
       tx.select({ total: count() }).from(notificationsInbox).where(where),
     ]);
 
-    return { items, total };
+    return {
+      items,
+      total,
+      page: params.page,
+      limit: params.limit,
+      totalPages: Math.ceil(total / params.limit),
+    };
   },
 
-  async unreadCount(tx: DrizzleDb, userId: string): Promise<number> {
+  async unreadCount(
+    tx: DrizzleDb,
+    userId: string,
+    orgId: string,
+  ): Promise<number> {
     const [row] = await tx
       .select({ count: count() })
       .from(notificationsInbox)
       .where(
         and(
+          eq(notificationsInbox.organizationId, orgId),
           eq(notificationsInbox.userId, userId),
           isNull(notificationsInbox.readAt),
         ),
@@ -75,13 +92,19 @@ export const notificationService = {
     return row.count;
   },
 
-  async markRead(tx: DrizzleDb, id: string, userId: string): Promise<boolean> {
+  async markRead(
+    tx: DrizzleDb,
+    id: string,
+    userId: string,
+    orgId: string,
+  ): Promise<boolean> {
     const result = await tx
       .update(notificationsInbox)
       .set({ readAt: new Date() })
       .where(
         and(
           eq(notificationsInbox.id, id),
+          eq(notificationsInbox.organizationId, orgId),
           eq(notificationsInbox.userId, userId),
           isNull(notificationsInbox.readAt),
         ),
@@ -90,12 +113,17 @@ export const notificationService = {
     return result.length > 0;
   },
 
-  async markAllRead(tx: DrizzleDb, userId: string): Promise<number> {
+  async markAllRead(
+    tx: DrizzleDb,
+    userId: string,
+    orgId: string,
+  ): Promise<number> {
     const result = await tx
       .update(notificationsInbox)
       .set({ readAt: new Date() })
       .where(
         and(
+          eq(notificationsInbox.organizationId, orgId),
           eq(notificationsInbox.userId, userId),
           isNull(notificationsInbox.readAt),
         ),

--- a/apps/api/src/trpc/routers/notifications.ts
+++ b/apps/api/src/trpc/routers/notifications.ts
@@ -21,12 +21,16 @@ export const notificationsRouter = createRouter({
       }),
     )
     .query(async ({ ctx, input }) => {
-      return notificationService.list(ctx.dbTx, {
-        userId: ctx.authContext.userId,
-        unreadOnly: input.unreadOnly,
-        page: input.page,
-        limit: input.limit,
-      });
+      return notificationService.list(
+        ctx.dbTx,
+        {
+          userId: ctx.authContext.userId,
+          unreadOnly: input.unreadOnly,
+          page: input.page,
+          limit: input.limit,
+        },
+        ctx.authContext.orgId,
+      );
     }),
 
   unreadCount: orgProcedure
@@ -36,6 +40,7 @@ export const notificationsRouter = createRouter({
       const count = await notificationService.unreadCount(
         ctx.dbTx,
         ctx.authContext.userId,
+        ctx.authContext.orgId,
       );
       return { count };
     }),
@@ -49,6 +54,7 @@ export const notificationsRouter = createRouter({
         ctx.dbTx,
         input.id,
         ctx.authContext.userId,
+        ctx.authContext.orgId,
       );
       if (success) {
         await ctx.audit({
@@ -67,6 +73,7 @@ export const notificationsRouter = createRouter({
       const count = await notificationService.markAllRead(
         ctx.dbTx,
         ctx.authContext.userId,
+        ctx.authContext.orgId,
       );
       if (count > 0) {
         await ctx.audit({

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -543,6 +543,25 @@ Ordered as the design doc's Phase 0/D.
       fail closed, so not a vulnerability — but a request with no org context gets a 500
       rather than an empty result on those four. Normalise deliberately. —
       (design doc §2.3 F6)
+- [ ] **[P1] `GET /api/notifications/stream` declares no scope guard, and neither
+      coverage gate can see it.** It is a plain Fastify route
+      (`apps/api/src/sse/notification-stream.ts:52`), not a tRPC or oRPC procedure, so
+      `requireScopes` never runs — and both `trpc/guard-coverage.spec.ts` and
+      `rest/guard-coverage.spec.ts` are structurally blind to it, because they walk
+      `appRouter` and `restRouter` respectively. The route is not in `auth.ts`'s public
+      allowlist, so default-deny still applies, but any valid API key with **any** scope
+      can open the stream and receive the org's in-app notifications. Its sibling tRPC
+      procedures all require `notifications:read`.
+      **The narrow fix is one scope check in the handler; the question worth answering
+      first is how wide the blindspot is.** Every hand-rolled Fastify route is equally
+      invisible to both gates — `routes/embed.routes.ts`, `routes/public.routes.ts`, the
+      federation admin routes under `federation/`, and `webhooks/webhook-health.route.ts`.
+      Some are deliberately public and some are not, and nothing currently distinguishes
+      them mechanically. A third gate that walks Fastify's own route table against an
+      allowlist would cover the class rather than this instance.
+      Also note the connection cap (`MAX_CONNECTIONS_PER_USER = 5`) is an in-process
+      `Map`, not Redis-backed, so it does not hold across replicas. —
+      (found 2026-07-29 while adding the REST notification surface)
 
 ### Blocking REST gaps (integrator workflow)
 


### PR DESCRIPTION
## What

All four `notificationService` read/write methods filtered on `userId` alone. `notifications_inbox` carries an `organization_id` column none of them touched, so RLS was the only thing isolating tenants — the same shape as the `apiKeyService` gap closed in #521.

`list`, `unreadCount`, `markRead` and `markAllRead` now take a required `orgId` last, matching the house `(tx, id|input, orgId)` order.

## Why it mattered here specifically

`userId` made these queries look already scoped. They were not: the same user id legitimately appears in two organizations' inboxes whenever a writer submits to two magazines on one instance. That is the ordinary case, not an edge case, and it is exactly what the old predicate could not distinguish.

This lands ahead of the REST notification surface. Publishing an RLS-only query on the public contract is the wrong moment to leave the gap open, but a tenant-isolation change should not ride inside a parity change — the same split #521 and P0.5b both made.

## Details

- **`list` keeps one hoisted `where`** across the page and count queries. Filtering only the page leaves `total` reporting every org's rows; that half is the easy one to miss.
- **Also a performance fix.** `notifications_inbox_user_unread_idx` leads on `organization_id`, so the previous `userId`-only queries could not use the index evidently built for them and fell back to the narrower `notifications_inbox_user_created_idx`.
- **`list` now returns `page`, `limit`, `totalPages`**, matching `auditService.list` and the shared paginated shape. The tRPC `.output()` is a plain object, so Zod strips the three extra keys — the web app's response is byte-identical.
- `notification-preference.service.ts` is unchanged; its reads already carry an `organizationId` predicate and its upsert binds the column as an insert value on a uniqueness key that includes it.

## Verification is the point of the new suite

`__tests__/rls/notification-service.test.ts` drives the service over the **admin pool** (`rolsuper`/`rolbypassrls`), where RLS — including the `FORCE` set by `0034_notifications_inbox.sql` — does not apply, so the `WHERE` clause is the only isolation in play. It is the deliberate mirror of `__tests__/security/defense-in-depth.test.ts`; do not "fix" it by switching to the app pool, which would make it pass either way.

**Confirmed non-vacuous:** with the predicates stripped it fails 6 of 7, and the one that still passes is the own-org baseline that should.

The existing unit spec cannot substitute — it mocks `eq`/`and` as bare functions returning `undefined`, so the assembled `where` is discarded entirely and those tests pass with or without a predicate.

## Also

Files a backlog item for a gap found while mapping this surface: `GET /api/notifications/stream` is a plain Fastify route, so it declares no scope guard and **both** coverage gates are structurally blind to it — they walk `appRouter` and `restRouter`, which a Fastify route is not in. Any valid key with any scope can open it, while its sibling tRPC procedures all require `notifications:read`. The entry is written around the wider question, since every hand-rolled Fastify route shares the blindspot.

## Test plan

- `pnpm --filter @colophony/api test:rls` — 152 passed (14 files)
- `pnpm --filter @colophony/api test` — 1859 passed (163 files)
- `pnpm type-check`, `pnpm lint` — clean