### PR TITLE
feat(api): expose notifications and preferences over REST

### DIFF
--- a/apps/api/src/rest/guard-coverage.spec.ts
+++ b/apps/api/src/rest/guard-coverage.spec.ts
@@ -95,7 +95,7 @@ describe('REST guard coverage', () => {
   it('introspects a plausible number of procedures', () => {
     // Guards against the whole suite silently passing because `'~orpc'` was
     // renamed under an @orpc/server upgrade and every assertion below started
-    // iterating an empty list. 139 operations today.
+    // iterating an empty list. 146 operations today.
     expect(allProcedures().length).toBeGreaterThan(130);
   });
 

--- a/apps/api/src/rest/openapi-spec.spec.ts
+++ b/apps/api/src/rest/openapi-spec.spec.ts
@@ -103,8 +103,11 @@ describe('generateOpenApiDocument', () => {
   });
 
   it('includes the API key scopes added in P0.1b', () => {
-    // notifications:read/write and webhooks:read are enforced by the tRPC
-    // routers but never reached the committed spec.
+    // webhooks:read is still enforced only by its tRPC router and reaches the
+    // spec solely through the create-API-key request body. notifications:read
+    // and notifications:write are now also carried by real routes, so this
+    // assertion no longer stands alone for them — keep it anyway, since it is
+    // what catches a scope silently dropped from the enum.
     const serialized = JSON.stringify(doc);
     expect(serialized).toContain('notifications:read');
     expect(serialized).toContain('notifications:write');

--- a/apps/api/src/rest/openapi-spec.ts
+++ b/apps/api/src/rest/openapi-spec.ts
@@ -18,6 +18,7 @@ import { issuesRouter } from './routers/issues.js';
 import { cmsConnectionsRouter } from './routers/cms-connections.js';
 import { csrRouter } from './routers/csr.js';
 import { collectionsRouter } from './routers/collections.js';
+import { notificationsRouter } from './routers/notifications.js';
 
 /**
  * The oRPC routers composing the `/v1` REST surface.
@@ -44,6 +45,10 @@ export const restRouter = {
   cmsConnections: cmsConnectionsRouter,
   csr: csrRouter,
   collections: collectionsRouter,
+  // Appended, not inserted: key order sets operation order in the generated
+  // document, so slotting a router mid-list reshuffles the whole spec and both
+  // SDKs for no benefit.
+  notifications: notificationsRouter,
 };
 
 /**
@@ -161,6 +166,11 @@ export const openApiDocumentConfig: OpenAPIGeneratorGenerateOptions = {
       name: 'Audit',
       description:
         'Query the audit log for security and compliance. Admin-only.',
+    },
+    {
+      name: 'Notifications',
+      description:
+        'Read in-app notifications and manage delivery preferences. The inbox belongs to the user a credential acts as, not to the organization — use webhooks for organization-level events.',
     },
   ],
   externalDocs: {

--- a/apps/api/src/rest/routers/notifications.spec.ts
+++ b/apps/api/src/rest/routers/notifications.spec.ts
@@ -1,0 +1,557 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ORPCError } from '@orpc/server';
+
+vi.mock('../../services/notification.service.js', () => ({
+  notificationService: {
+    create: vi.fn(),
+    list: vi.fn(),
+    unreadCount: vi.fn(),
+    markRead: vi.fn(),
+    markAllRead: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/notification-preference.service.js', () => ({
+  notificationPreferenceService: {
+    isEmailEnabled: vi.fn(),
+    isInAppEnabled: vi.fn(),
+    listForUser: vi.fn(),
+    upsert: vi.fn(),
+    bulkUpsert: vi.fn(),
+  },
+}));
+
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  notificationsInbox: {},
+  notificationPreferences: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  isNull: vi.fn(),
+  sql: vi.fn(),
+}));
+
+import { notificationService } from '../../services/notification.service.js';
+import { notificationPreferenceService } from '../../services/notification-preference.service.js';
+import { notificationsRouter } from './notifications.js';
+import type { RestContext } from '../context.js';
+import { createProcedureClient } from '@orpc/server';
+
+const mockNotifications = vi.mocked(notificationService);
+const mockPreferences = vi.mocked(notificationPreferenceService);
+
+const USER_ID = 'a0000000-0000-4000-a000-000000000001';
+const ORG_ID = 'b0000000-0000-4000-a000-000000000001';
+const NOTIF_ID = 'c0000000-0000-4000-a000-000000000001';
+const PREF_ID = 'd0000000-0000-4000-a000-000000000001';
+
+function baseContext(): RestContext {
+  return { authContext: null, dbTx: null, audit: vi.fn() };
+}
+
+/** Authenticated but with no organization resolved. */
+function authedContext(): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: 'zid-1',
+      email: 'writer@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+    },
+    dbTx: {} as never,
+    audit: vi.fn(),
+  };
+}
+
+function orgContext(): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: 'zid-1',
+      email: 'writer@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+      orgId: ORG_ID,
+      roles: ['READER'],
+    },
+    dbTx: {} as never,
+    audit: vi.fn(),
+  };
+}
+
+function apiKeyContext(scopes: string[]): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      email: 'writer@example.com',
+      emailVerified: true,
+      authMethod: 'apikey',
+      apiKeyId: 'k0000000-0000-4000-a000-000000000001',
+      apiKeyScopes: scopes as never,
+      orgId: ORG_ID,
+      roles: ['READER'],
+    },
+    dbTx: {} as never,
+    audit: vi.fn(),
+  };
+}
+
+function client<T>(procedure: T, context: RestContext) {
+  return createProcedureClient(procedure as never, { context }) as (
+    input?: unknown,
+  ) => Promise<never>;
+}
+
+function notificationRow() {
+  return {
+    id: NOTIF_ID,
+    eventType: 'submission.received',
+    title: 'New submission',
+    body: 'A body',
+    link: '/submissions/1',
+    readAt: null,
+    createdAt: new Date(),
+  };
+}
+
+function preferenceRow() {
+  return {
+    id: PREF_ID,
+    channel: 'email' as const,
+    eventType: 'submission.received',
+    enabled: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+/** Every route, for the blanket auth and org-context cases. */
+const ALL_ROUTES: Array<[string, unknown, unknown]> = [
+  ['list', notificationsRouter.list, { page: 1, limit: 20 }],
+  ['unreadCount', notificationsRouter.unreadCount, undefined],
+  ['markRead', notificationsRouter.markRead, { id: NOTIF_ID }],
+  ['markAllRead', notificationsRouter.markAllRead, undefined],
+  ['listPreferences', notificationsRouter.listPreferences, undefined],
+  [
+    'upsertPreference',
+    notificationsRouter.upsertPreference,
+    { channel: 'email', eventType: 'submission.received', enabled: true },
+  ],
+  [
+    'bulkUpsertPreferences',
+    notificationsRouter.bulkUpsertPreferences,
+    {
+      preferences: [
+        { channel: 'email', eventType: 'submission.received', enabled: false },
+      ],
+    },
+  ],
+];
+
+describe('notifications REST router', () => {
+  beforeEach(() => {
+    // resetAllMocks, not clearAllMocks: this suite runs under vitest's random
+    // sequencing, and `clearAllMocks` leaves queued `mockResolvedValueOnce`
+    // implementations in place. One test would then consume a value another
+    // queued, and which one depends on the seed — a failure that reproduces
+    // only on some runs.
+    vi.resetAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Auth and org context, across the whole router
+  // -------------------------------------------------------------------------
+
+  describe.each(ALL_ROUTES)('%s', (_name, procedure, input) => {
+    it('requires auth', async () => {
+      await expect(client(procedure, baseContext())(input)).rejects.toThrow(
+        ORPCError,
+      );
+    });
+
+    it('requires org context', async () => {
+      await expect(client(procedure, authedContext())(input)).rejects.toThrow(
+        'X-Organization-Id header is required',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /notifications
+  // -------------------------------------------------------------------------
+
+  describe('GET /notifications (list)', () => {
+    it('returns the paginated envelope', async () => {
+      mockNotifications.list.mockResolvedValueOnce({
+        items: [notificationRow()],
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      } as never);
+
+      const result = await client(
+        notificationsRouter.list,
+        orgContext(),
+      )({ page: 1, limit: 20 });
+
+      expect(result).toMatchObject({
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      });
+      expect((result as { items: unknown[] }).items).toHaveLength(1);
+    });
+
+    it('passes the org id through as the third argument', async () => {
+      // A dropped org argument silently widens the query to RLS alone, so this
+      // asserts the full call rather than a prefix of it.
+      mockNotifications.list.mockResolvedValueOnce({
+        items: [],
+        total: 0,
+        page: 2,
+        limit: 5,
+        totalPages: 0,
+      });
+
+      await client(
+        notificationsRouter.list,
+        orgContext(),
+      )({ page: 2, limit: 5, unreadOnly: true });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockNotifications.list).toHaveBeenCalledWith(
+        expect.anything(),
+        { userId: USER_ID, unreadOnly: true, page: 2, limit: 5 },
+        ORG_ID,
+      );
+    });
+
+    it('parses unreadOnly=false as false, not as a truthy string', async () => {
+      // z.coerce.boolean() would make "false" true here, inverting the filter.
+      mockNotifications.list.mockResolvedValueOnce({
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 0,
+      });
+
+      await client(
+        notificationsRouter.list,
+        orgContext(),
+      )({ page: '1', limit: '20', unreadOnly: 'false' });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockNotifications.list).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ unreadOnly: false }),
+        ORG_ID,
+      );
+    });
+
+    it('rejects a limit above the 50 the service accepts', async () => {
+      await expect(
+        client(notificationsRouter.list, orgContext())({ page: 1, limit: 100 }),
+      ).rejects.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /notifications/unread-count
+  // -------------------------------------------------------------------------
+
+  describe('GET /notifications/unread-count', () => {
+    it('returns the count and passes the org id', async () => {
+      mockNotifications.unreadCount.mockResolvedValueOnce(7);
+
+      const result = await client(
+        notificationsRouter.unreadCount,
+        orgContext(),
+      )();
+
+      expect(result).toEqual({ count: 7 });
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockNotifications.unreadCount).toHaveBeenCalledWith(
+        expect.anything(),
+        USER_ID,
+        ORG_ID,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /notifications/{id}/read
+  // -------------------------------------------------------------------------
+
+  describe('POST /notifications/{id}/read', () => {
+    it('marks read, audits, and passes all four arguments', async () => {
+      mockNotifications.markRead.mockResolvedValueOnce(true);
+      const ctx = orgContext();
+
+      const result = await client(
+        notificationsRouter.markRead,
+        ctx,
+      )({ id: NOTIF_ID });
+
+      expect(result).toEqual({ success: true });
+      // markRead takes (tx, id, userId, orgId) — a three-argument assertion
+      // would pass vacuously and miss exactly the dropped org id being tested.
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockNotifications.markRead).toHaveBeenCalledWith(
+        expect.anything(),
+        NOTIF_ID,
+        USER_ID,
+        ORG_ID,
+      );
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'IN_APP_NOTIFICATION_READ',
+          resource: 'notification_inbox',
+          resourceId: NOTIF_ID,
+        }),
+      );
+    });
+
+    it('does not audit when nothing matched', async () => {
+      mockNotifications.markRead.mockResolvedValueOnce(false);
+      const ctx = orgContext();
+
+      const result = await client(
+        notificationsRouter.markRead,
+        ctx,
+      )({ id: NOTIF_ID });
+
+      expect(result).toEqual({ success: false });
+      expect(ctx.audit).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-uuid id', async () => {
+      await expect(
+        client(
+          notificationsRouter.markRead,
+          orgContext(),
+        )({ id: 'not-a-uuid' }),
+      ).rejects.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /notifications/read-all
+  // -------------------------------------------------------------------------
+
+  describe('POST /notifications/read-all', () => {
+    it('returns the count, audits, and passes the org id', async () => {
+      mockNotifications.markAllRead.mockResolvedValueOnce(3);
+      const ctx = orgContext();
+
+      const result = await client(notificationsRouter.markAllRead, ctx)();
+
+      expect(result).toEqual({ count: 3 });
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockNotifications.markAllRead).toHaveBeenCalledWith(
+        expect.anything(),
+        USER_ID,
+        ORG_ID,
+      );
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'IN_APP_NOTIFICATION_ALL_READ',
+          resource: 'notification_inbox',
+          newValue: { count: 3 },
+        }),
+      );
+    });
+
+    it('does not audit when nothing was unread', async () => {
+      mockNotifications.markAllRead.mockResolvedValueOnce(0);
+      const ctx = orgContext();
+
+      const result = await client(notificationsRouter.markAllRead, ctx)();
+
+      expect(result).toEqual({ count: 0 });
+      expect(ctx.audit).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Preferences
+  // -------------------------------------------------------------------------
+
+  describe('GET /notification-preferences', () => {
+    it('returns the bare array and passes org then user', async () => {
+      mockPreferences.listForUser.mockResolvedValueOnce([
+        preferenceRow(),
+      ] as never);
+
+      const result = await client(
+        notificationsRouter.listPreferences,
+        orgContext(),
+      )();
+
+      expect(result).toHaveLength(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockPreferences.listForUser).toHaveBeenCalledWith(
+        expect.anything(),
+        ORG_ID,
+        USER_ID,
+      );
+    });
+  });
+
+  describe('PUT /notification-preferences', () => {
+    it('upserts, audits, and binds the org and user from context', async () => {
+      mockPreferences.upsert.mockResolvedValueOnce(preferenceRow() as never);
+      const ctx = orgContext();
+
+      const result = await client(
+        notificationsRouter.upsertPreference,
+        ctx,
+      )({ channel: 'email', eventType: 'submission.received', enabled: true });
+
+      expect(result).toMatchObject({ id: PREF_ID, enabled: true });
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockPreferences.upsert).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          organizationId: ORG_ID,
+          userId: USER_ID,
+          channel: 'email',
+          eventType: 'submission.received',
+          enabled: true,
+        }),
+      );
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'NOTIFICATION_PREFERENCE_UPDATED',
+          resource: 'notification_preference',
+          resourceId: PREF_ID,
+        }),
+      );
+    });
+
+    it('rejects an event type outside the enum', async () => {
+      await expect(
+        client(
+          notificationsRouter.upsertPreference,
+          orgContext(),
+        )({ channel: 'email', eventType: 'not.a.real.event', enabled: true }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('PUT /notification-preferences/batch', () => {
+    it('bulk upserts and audits the count', async () => {
+      mockPreferences.bulkUpsert.mockResolvedValueOnce([
+        preferenceRow(),
+      ] as never);
+      const ctx = orgContext();
+
+      const preferences = [
+        { channel: 'email', eventType: 'submission.received', enabled: false },
+      ];
+      await client(
+        notificationsRouter.bulkUpsertPreferences,
+        ctx,
+      )({
+        preferences,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockPreferences.bulkUpsert).toHaveBeenCalledWith(
+        expect.anything(),
+        ORG_ID,
+        USER_ID,
+        preferences,
+      );
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'NOTIFICATION_PREFERENCE_UPDATED',
+          newValue: { count: 1 },
+        }),
+      );
+    });
+
+    it('rejects an empty batch', async () => {
+      await expect(
+        client(
+          notificationsRouter.bulkUpsertPreferences,
+          orgContext(),
+        )({ preferences: [] }),
+      ).rejects.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // API key scope enforcement
+  // -------------------------------------------------------------------------
+
+  describe('API key scope enforcement', () => {
+    it('denies a key holding an unrelated scope', async () => {
+      await expect(
+        client(
+          notificationsRouter.list,
+          apiKeyContext(['submissions:read']),
+        )({ page: 1, limit: 20 }),
+      ).rejects.toThrow('Insufficient API key scope');
+    });
+
+    it('allows notifications:read on a read route', async () => {
+      mockNotifications.unreadCount.mockResolvedValueOnce(0);
+
+      const result = await client(
+        notificationsRouter.unreadCount,
+        apiKeyContext(['notifications:read']),
+      )();
+
+      expect(result).toEqual({ count: 0 });
+    });
+
+    it('does not let notifications:read satisfy a write route', async () => {
+      // Read must not imply write. If these two ever collapse into one scope,
+      // this is the test that should stop it.
+      await expect(
+        client(
+          notificationsRouter.markAllRead,
+          apiKeyContext(['notifications:read']),
+        )(),
+      ).rejects.toThrow('Insufficient API key scope');
+    });
+
+    it('allows notifications:write on a write route', async () => {
+      mockNotifications.markAllRead.mockResolvedValueOnce(2);
+
+      const result = await client(
+        notificationsRouter.markAllRead,
+        apiKeyContext(['notifications:write']),
+      )();
+
+      expect(result).toEqual({ count: 2 });
+    });
+
+    it('does not let notifications:write satisfy a read route', async () => {
+      await expect(
+        client(
+          notificationsRouter.listPreferences,
+          apiKeyContext(['notifications:write']),
+        )(),
+      ).rejects.toThrow('Insufficient API key scope');
+    });
+
+    it('bypasses scopes for interactive auth', async () => {
+      // requireScopes is a no-op for anything that is not an API key, which is
+      // what keeps the web app working without granting it scopes.
+      mockNotifications.markAllRead.mockResolvedValueOnce(1);
+
+      const result = await client(
+        notificationsRouter.markAllRead,
+        orgContext(),
+      )();
+
+      expect(result).toEqual({ count: 1 });
+    });
+  });
+});

--- a/apps/api/src/rest/routers/notifications.ts
+++ b/apps/api/src/rest/routers/notifications.ts
@@ -1,0 +1,271 @@
+import { z } from 'zod';
+import {
+  AuditActions,
+  AuditResources,
+  idParamSchema,
+  paginatedResponseSchema,
+  notificationResponseSchema,
+  unreadCountResponseSchema,
+  upsertNotificationPreferenceSchema,
+  bulkUpsertNotificationPreferencesSchema,
+  notificationPreferenceResponseSchema,
+} from '@colophony/types';
+import { restListNotificationsQuery } from '@colophony/api-contracts';
+import { notificationService } from '../../services/notification.service.js';
+import { notificationPreferenceService } from '../../services/notification-preference.service.js';
+import { orgProcedure, requireScopes } from '../context.js';
+
+// ---------------------------------------------------------------------------
+// Output schemas
+// ---------------------------------------------------------------------------
+
+const paginatedNotificationsSchema = paginatedResponseSchema(
+  notificationResponseSchema,
+);
+
+const markReadResponseSchema = z.object({
+  success: z
+    .boolean()
+    .describe(
+      'False when no unread notification matched — either it does not exist, belongs to another user or organization, or was already read.',
+    ),
+});
+
+const markAllReadResponseSchema = z.object({
+  count: z
+    .number()
+    .int()
+    .min(0)
+    .describe('Number of notifications marked read'),
+});
+
+/**
+ * Whose inbox this is.
+ *
+ * The inbox is per-user, and an API key acts as the user who created it, so a
+ * key reads exactly one person's notifications. Integrators reliably assume the
+ * opposite — that a credential scoped to an organization returns that
+ * organization's activity — so both read routes say so outright rather than
+ * leaving it to be inferred from a 200 with surprising contents.
+ */
+const INBOX_SCOPE_NOTE =
+  ' Returns the inbox of the user this credential acts as. An API key acts as ' +
+  'the user who created it, so this is that person’s notifications, not an ' +
+  'organization-wide feed. To receive organization-level events, register a ' +
+  'webhook endpoint instead.';
+
+// ---------------------------------------------------------------------------
+// Notification routes
+// ---------------------------------------------------------------------------
+
+const list = orgProcedure
+  .use(requireScopes('notifications:read'))
+  .route({
+    method: 'GET',
+    path: '/notifications',
+    summary: 'List notifications',
+    description:
+      'Returns a paginated list of in-app notifications, newest first.' +
+      INBOX_SCOPE_NOTE,
+    operationId: 'listNotifications',
+    tags: ['Notifications'],
+  })
+  .input(restListNotificationsQuery)
+  .output(paginatedNotificationsSchema)
+  .handler(async ({ input, context }) => {
+    return notificationService.list(
+      context.dbTx,
+      {
+        userId: context.authContext.userId,
+        unreadOnly: input.unreadOnly,
+        page: input.page,
+        limit: input.limit,
+      },
+      context.authContext.orgId,
+    );
+  });
+
+const unreadCount = orgProcedure
+  .use(requireScopes('notifications:read'))
+  .route({
+    method: 'GET',
+    path: '/notifications/unread-count',
+    summary: 'Get unread notification count',
+    description:
+      'Returns the number of unread in-app notifications.' + INBOX_SCOPE_NOTE,
+    operationId: 'getUnreadNotificationCount',
+    tags: ['Notifications'],
+  })
+  .output(unreadCountResponseSchema)
+  .handler(async ({ context }) => {
+    const count = await notificationService.unreadCount(
+      context.dbTx,
+      context.authContext.userId,
+      context.authContext.orgId,
+    );
+    return { count };
+  });
+
+const markRead = orgProcedure
+  .use(requireScopes('notifications:write'))
+  .route({
+    method: 'POST',
+    path: '/notifications/{id}/read',
+    summary: 'Mark a notification as read',
+    description:
+      'Marks a single unread notification as read. Returns `success: false` ' +
+      'rather than an error when nothing matched, so re-sending is safe.',
+    operationId: 'markNotificationRead',
+    tags: ['Notifications'],
+  })
+  .input(idParamSchema)
+  .output(markReadResponseSchema)
+  .handler(async ({ input, context }) => {
+    const success = await notificationService.markRead(
+      context.dbTx,
+      input.id,
+      context.authContext.userId,
+      context.authContext.orgId,
+    );
+    // Audit only a real state change, matching the tRPC twin — a no-op retry
+    // should not accumulate audit rows.
+    if (success) {
+      await context.audit({
+        action: AuditActions.IN_APP_NOTIFICATION_READ,
+        resource: AuditResources.NOTIFICATION_INBOX,
+        resourceId: input.id,
+      });
+    }
+    return { success };
+  });
+
+const markAllRead = orgProcedure
+  .use(requireScopes('notifications:write'))
+  .route({
+    method: 'POST',
+    path: '/notifications/read-all',
+    summary: 'Mark all notifications as read',
+    description:
+      'Marks every unread notification as read and returns how many changed.' +
+      INBOX_SCOPE_NOTE,
+    operationId: 'markAllNotificationsRead',
+    tags: ['Notifications'],
+  })
+  .output(markAllReadResponseSchema)
+  .handler(async ({ context }) => {
+    const count = await notificationService.markAllRead(
+      context.dbTx,
+      context.authContext.userId,
+      context.authContext.orgId,
+    );
+    if (count > 0) {
+      await context.audit({
+        action: AuditActions.IN_APP_NOTIFICATION_ALL_READ,
+        resource: AuditResources.NOTIFICATION_INBOX,
+        newValue: { count },
+      });
+    }
+    return { count };
+  });
+
+// ---------------------------------------------------------------------------
+// Notification preference routes
+// ---------------------------------------------------------------------------
+
+const listPreferences = orgProcedure
+  .use(requireScopes('notifications:read'))
+  .route({
+    method: 'GET',
+    path: '/notification-preferences',
+    summary: 'List notification preferences',
+    description:
+      'Returns the per-channel, per-event notification preferences for the ' +
+      'current user in this organization. Unpaginated: the set is bounded by ' +
+      'the number of event types and channels. An event type with no stored ' +
+      'row is enabled by default.',
+    operationId: 'listNotificationPreferences',
+    tags: ['Notifications'],
+  })
+  .output(z.array(notificationPreferenceResponseSchema))
+  .handler(async ({ context }) => {
+    return notificationPreferenceService.listForUser(
+      context.dbTx,
+      context.authContext.orgId,
+      context.authContext.userId,
+    );
+  });
+
+const upsertPreference = orgProcedure
+  .use(requireScopes('notifications:write'))
+  .route({
+    method: 'PUT',
+    path: '/notification-preferences',
+    summary: 'Set a notification preference',
+    description:
+      'Creates or updates one preference. Identity is the ' +
+      '(channel, eventType) pair carried in the body, so this is idempotent — ' +
+      'repeating a call with the same pair overwrites rather than duplicating.',
+    operationId: 'upsertNotificationPreference',
+    tags: ['Notifications'],
+  })
+  .input(upsertNotificationPreferenceSchema)
+  .output(notificationPreferenceResponseSchema)
+  .handler(async ({ input, context }) => {
+    const result = await notificationPreferenceService.upsert(context.dbTx, {
+      organizationId: context.authContext.orgId,
+      userId: context.authContext.userId,
+      channel: input.channel,
+      eventType: input.eventType,
+      enabled: input.enabled,
+    });
+    await context.audit({
+      action: AuditActions.NOTIFICATION_PREFERENCE_UPDATED,
+      resource: AuditResources.NOTIFICATION_PREFERENCE,
+      resourceId: result.id,
+      newValue: input,
+    });
+    return result;
+  });
+
+const bulkUpsertPreferences = orgProcedure
+  .use(requireScopes('notifications:write'))
+  .route({
+    method: 'PUT',
+    path: '/notification-preferences/batch',
+    summary: 'Set notification preferences in bulk',
+    description:
+      'Creates or updates up to 50 preferences in one request. Applied inside ' +
+      'a single transaction, so the batch either lands whole or not at all.',
+    operationId: 'bulkUpsertNotificationPreferences',
+    tags: ['Notifications'],
+  })
+  .input(bulkUpsertNotificationPreferencesSchema)
+  .output(z.array(notificationPreferenceResponseSchema))
+  .handler(async ({ input, context }) => {
+    const results = await notificationPreferenceService.bulkUpsert(
+      context.dbTx,
+      context.authContext.orgId,
+      context.authContext.userId,
+      input.preferences,
+    );
+    await context.audit({
+      action: AuditActions.NOTIFICATION_PREFERENCE_UPDATED,
+      resource: AuditResources.NOTIFICATION_PREFERENCE,
+      newValue: { count: input.preferences.length },
+    });
+    return results;
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const notificationsRouter = {
+  list,
+  unreadCount,
+  markRead,
+  markAllRead,
+  listPreferences,
+  upsertPreference,
+  bulkUpsertPreferences,
+};

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -571,14 +571,58 @@ invitations were assumed missing and are in fact already exposed — see §0 of 
 - [ ] **[P1] Webhook endpoint management over REST** (9 tRPC procs, `webhooks:manage`
       already exists). **Requires the subscription-model decision (D2) first** — per-org vs
       instance-level is a resource-model question, not a route question. — (design doc §1.9, P1.1)
-- [ ] **[P1] Notifications over REST** (list, unread-count, mark-read, mark-all-read + 3
+- [x] **[P1] Notifications over REST** (list, unread-count, mark-read, mark-all-read + 3
       preference procs). Only path today is SSE, unusable for consumers that cannot hold a
-      connection. — (design doc §1.7, P1.2)
+      connection. — (design doc §1.7, P1.2; done 2026-07-29, PR pending)
+      Seven operations, one router, `Notifications` declared as a tag. Both scopes already
+      existed from P0.1b, so no enum change. `orgProcedure` throughout — the
+      `notifications_inbox` policy uses the raising idiom, so no-org-context would 500
+      rather than return empty.
+      **The identity semantics are documented rather than deferred.** The inbox is per-user
+      and a key acts as its creator, so a key reads one person's notifications. Both read
+      routes say so and point at webhooks for org-level events; generalising it needs
+      acting-as, which sits behind the whole principal design.
+      **First boolean query param on the surface, and both obvious spellings are wrong.**
+      `z.coerce.boolean()` parses `"false"` as `true`; `z.stringbool()` renders as
+      `{"type":"string"}` so both SDKs type the field as a string. `z.preprocess` renders as
+      `{"type":"boolean"}` and takes both forms — now the house idiom, documented with the
+      measurements in `packages/api-contracts/src/notifications.ts`.
+- [x] **[P2] `notificationService` carried no org predicate.** All four read/write methods
+      filtered on `userId` alone while `notifications_inbox` has an `organization_id` column
+      they never touched — the `apiKeyService` shape from #521, and harder to spot because
+      `userId` looks like it is isolating. It is not: the same user id legitimately appears
+      in two orgs' inboxes whenever a writer submits to two magazines on one instance.
+      Landed ahead of the REST surface rather than inside it. Pinned by
+      `__tests__/rls/notification-service.test.ts` over the admin pool; verified non-vacuous
+      (6 of 7 fail with the predicates removed). Also a performance fix —
+      `notifications_inbox_user_unread_idx` leads on `organization_id`. —
+      (found 2026-07-29 while adding the REST surface; done 2026-07-29)
 - [ ] **[P1] File upload initiation under `/v1`.** Intake is incomplete: an integrator can
       create a submission but cannot attach a manuscript. `POST /embed/:token/prepare-upload`
       is a working template. — (design doc §1.7, P1.3)
 - [ ] **[P1] Public discovery of open submission periods.** `/v1/public/` has only
       `orgs/:slug/response-time` and the demo routes. — (design doc §1.7, P1.4)
+- [ ] **[P2] Make boolean query params work by default instead of by workaround.** P1.2 had to
+      hand-roll a `booleanQueryParam` helper because the two obvious spellings are both wrong:
+      `z.coerce.boolean()` parses `"false"` as `true`, and `z.stringbool()` renders as
+      `{"type":"string"}` so both generated SDKs type the field as a string. Only
+      `z.preprocess(...)` gives `{"type":"boolean"}` and accepts both forms. That is a
+      workaround living in one contract file, and the next person adding a boolean filter will
+      reach for `z.coerce.boolean()` and ship an inverted filter that type-checks and passes
+      tests. Three parts, in order of value:
+      (1) **Promote the helper to `packages/api-contracts/src/shared.ts`** beside
+      `restPaginationQuery`, so it is the thing in reach — the current location
+      (`notifications.ts`) is discoverable only by whoever already knows.
+      (2) **Investigate whether oRPC can coerce from the JSON-schema type** so a plain
+      `z.boolean()` just works on a query param. `OpenAPIHandler` knows the parameter is a
+      boolean; if its deserializer can be configured to act on that, the helper disappears
+      entirely and this stops being a thing to remember. Check the `@orpc/openapi` serializer
+      options before assuming not.
+      (3) **Gate it**: a lint rule or a spec asserting no `z.coerce.boolean()` appears in
+      `packages/api-contracts/` or `apps/api/src/rest/`. Cheap, and the failure it prevents is
+      silent in every other check.
+      Same reasoning as the guard-coverage gates — a convention that only lives in a doc gets
+      violated by the next person who does not read it. — (found 2026-07-29 during P1.2)
 - [ ] **[P2] Idempotency keys for integrator writes.** No `Idempotency-Key` on any `/v1`
       `POST`, including submission creation and the two batch operations. Contract surface,
       so it cannot be added cheaply later. — (design doc §1.10, D3)
@@ -840,6 +884,18 @@ invitations were assumed missing and are in fact already exposed — see §0 of 
 - [x] [P3] Flakiness and determinism CI checks — run unit tests with retries disabled and `--sequence.shuffle` on at least one CI lane; add quarantine convention (`.flaky.test.ts` suffix or skip marker) and fail PRs that introduce new flaky markers — (code review 2026-03-03; done 2026-03-04)
 - [x] [P3] Risk-based test matrix — audit coverage per domain (pipeline, federation, workspace, forms) and document minimum test layers per domain (unit + service integration + API route + E2E happy path) in `docs/testing.md`; identify high-risk low-coverage hotspots — (code review 2026-03-03; done 2026-03-04)
 - [ ] [P3] ESLint 9 → 10 upgrade — blocked by `eslint-plugin-react`, `eslint-plugin-react-hooks`, `eslint-plugin-jsx-a11y` (transitive via `eslint-config-next`); Dependabot canary will signal when unblocked; tracking issue #273 — (2026-03-16); canary verified 2026-03-22 (Dependabot PR #269 failed CI as expected, still blocked by eslint-plugin-react)
+- [ ] [P2] **`clearAllMocks` + `mockResolvedValueOnce` is seed-dependent, and specs are
+      relying on ordering luck.** `vi.clearAllMocks()` does not drain queued
+      `mockResolvedValueOnce` implementations, and this repo deliberately runs vitest with
+      `--sequence.shuffle` on a CI lane. A spec that queues a value per test therefore has
+      one test consume another's, and which one depends on the seed — a failure that
+      reproduces on some runs and not others. Hit live while writing
+      `rest/routers/notifications.spec.ts`, fixed there with `vi.resetAllMocks()`.
+      `rest/routers/audit.spec.ts` has the identical pattern and is currently passing on
+      ordering luck; sweep the other REST and tRPC router specs for it. The shuffle lane is
+      what makes this worth fixing rather than tolerating — it is designed to surface exactly
+      this, so a latent instance will eventually fail a PR that did not cause it. —
+      (found 2026-07-29 during P1.2)
 - [x] [P2] Diagnostic: plan review step dropped from workflow — root cause: plan mode system reminder's rigid Phase 5 overrides instruction; no mechanical enforcement existed. Fix: `PreToolUse` hook on `ExitPlanMode` blocks unless `code review plan` marker exists or plan is trivial — (2026-03-28, user-reported; done 2026-03-28)
 - [x] [P3] Skill update: code review should auto-add actionable out-of-scope findings to backlog — during both plan review and branch/diff review, any Important+ findings outside the current task scope should be appended to docs/backlog.md automatically — (workflow improvement 2026-03-03; done 2026-03-22 — enhanced /end-session Step 4b with systematic review finding extraction)
 - [x] [P4] Ephemeral DB/queue per test worker — standardize `TestContext` factory for isolated schemas per worker; replace ad-hoc Redis db 1 patching in `vitest-setup.ts`; add explicit contract tests around external boundaries (webhooks, auth, adapters) with fixture replay — (code review 2026-03-03; closed 2026-03-22 — current isolation via truncateAllTables, Redis db 1, singleFork is adequate)

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -11,3 +11,5 @@ export { usersContract } from "./users.js";
 export { apiKeysContract } from "./api-keys.js";
 export { formsContract } from "./forms.js";
 export { restListAuditEventsQuery } from "./audit.js";
+export { restListNotificationsQuery } from "./notifications.js";
+export type { RestListNotificationsQuery } from "./notifications.js";

--- a/packages/api-contracts/src/notifications.ts
+++ b/packages/api-contracts/src/notifications.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+import { listNotificationsSchema } from "@colophony/types";
+import { restPaginationQuery } from "./shared.js";
+
+/**
+ * Parse a boolean that may arrive as a query-string token.
+ *
+ * The first boolean query parameter on the REST surface, so this sets the
+ * idiom. Three candidates were measured against the actual schema converter:
+ *
+ *   `z.coerce.boolean()`  — parses "false" as **true**. Silently inverts the
+ *                           filter. Never use it for a query param.
+ *   `z.stringbool()`      — correct on strings, but renders as
+ *                           `{"type":"string"}` in the spec, so both generated
+ *                           SDKs would type the field as a string, and it
+ *                           rejects a real boolean outright.
+ *   `z.preprocess(...)`   — renders as `{"type":"boolean"}` and accepts both a
+ *                           real boolean and the string form.
+ *
+ * Only the exact tokens "true" and "false" convert. Anything else falls
+ * through to `z.boolean()` and is rejected, so `?unreadOnly=maybe` is a 400
+ * rather than a silent `false` — the same default-deny reasoning as
+ * `requireScopes`. OpenAPI serializes boolean query params as those two
+ * tokens, so an SDK-generated call always lands in the accepted set.
+ */
+const booleanQueryParam = (fallback: boolean) =>
+  z
+    .preprocess(
+      (v) => (v === "true" ? true : v === "false" ? false : v),
+      z.boolean(),
+    )
+    .default(fallback);
+
+/**
+ * REST query variant of `listNotificationsSchema`.
+ *
+ * Two things the tRPC schema can leave alone and this one cannot:
+ *
+ *  1. Query params arrive as strings, so `page`/`limit`/`unreadOnly` all need
+ *     parsing. `restPaginationQuery` covers the first two.
+ *  2. `restPaginationQuery` caps `limit` at 100 while the tRPC twin caps it at
+ *     50. Merging it verbatim would silently widen what this surface accepts,
+ *     so the cap is restated at 50 and the two surfaces stay in step.
+ */
+export const restListNotificationsQuery = listNotificationsSchema
+  .omit({ page: true, limit: true, unreadOnly: true })
+  .merge(restPaginationQuery)
+  .extend({
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(20)
+      .describe("Items per page (1-50, default 20)"),
+    unreadOnly: booleanQueryParam(false).describe(
+      "Return only notifications that have not been read",
+    ),
+  });
+
+export type RestListNotificationsQuery = z.infer<
+  typeof restListNotificationsQuery
+>;

--- a/sdks/openapi.json
+++ b/sdks/openapi.json
@@ -85,6 +85,10 @@
     {
       "name": "Audit",
       "description": "Query the audit log for security and compliance. Admin-only."
+    },
+    {
+      "name": "Notifications",
+      "description": "Read in-app notifications and manage delivery preferences. The inbox belongs to the user a credential acts as, not to the organization — use webhooks for organization-level events."
     }
   ],
   "externalDocs": {
@@ -23189,6 +23193,484 @@
                       "icon",
                       "addedAt",
                       "touchedAt"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications": {
+      "get": {
+        "operationId": "listNotifications",
+        "summary": "List notifications",
+        "description": "Returns a paginated list of in-app notifications, newest first. Returns the inbox of the user this credential acts as. An API key acts as the user who created it, so this is that person’s notifications, not an organization-wide feed. To receive organization-level events, register a webhook endpoint instead.",
+        "tags": ["Notifications"],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991,
+              "default": 1,
+              "description": "Page number (1-based)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 20,
+              "description": "Items per page (1-50, default 20)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "unreadOnly",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "description": "Return only notifications that have not been read"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "eventType": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "body": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "link": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "readAt": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "date-time",
+                                "x-native-type": "date"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "x-native-type": "date"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "eventType",
+                          "title",
+                          "body",
+                          "link",
+                          "readAt",
+                          "createdAt"
+                        ]
+                      },
+                      "description": "Items on the current page"
+                    },
+                    "total": {
+                      "type": "number",
+                      "description": "Total number of items across all pages"
+                    },
+                    "page": {
+                      "type": "number",
+                      "description": "Current page number"
+                    },
+                    "limit": {
+                      "type": "number",
+                      "description": "Items per page"
+                    },
+                    "totalPages": {
+                      "type": "number",
+                      "description": "Total number of pages"
+                    }
+                  },
+                  "required": ["items", "total", "page", "limit", "totalPages"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/unread-count": {
+      "get": {
+        "operationId": "getUnreadNotificationCount",
+        "summary": "Get unread notification count",
+        "description": "Returns the number of unread in-app notifications. Returns the inbox of the user this credential acts as. An API key acts as the user who created it, so this is that person’s notifications, not an organization-wide feed. To receive organization-level events, register a webhook endpoint instead.",
+        "tags": ["Notifications"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": ["count"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/{id}/read": {
+      "post": {
+        "operationId": "markNotificationRead",
+        "summary": "Mark a notification as read",
+        "description": "Marks a single unread notification as read. Returns `success: false` rather than an error when nothing matched, so re-sending is safe.",
+        "tags": ["Notifications"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Resource UUID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "False when no unread notification matched — either it does not exist, belongs to another user or organization, or was already read."
+                    }
+                  },
+                  "required": ["success"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/read-all": {
+      "post": {
+        "operationId": "markAllNotificationsRead",
+        "summary": "Mark all notifications as read",
+        "description": "Marks every unread notification as read and returns how many changed. Returns the inbox of the user this credential acts as. An API key acts as the user who created it, so this is that person’s notifications, not an organization-wide feed. To receive organization-level events, register a webhook endpoint instead.",
+        "tags": ["Notifications"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991,
+                      "description": "Number of notifications marked read"
+                    }
+                  },
+                  "required": ["count"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notification-preferences": {
+      "get": {
+        "operationId": "listNotificationPreferences",
+        "summary": "List notification preferences",
+        "description": "Returns the per-channel, per-event notification preferences for the current user in this organization. Unpaginated: the set is bounded by the number of event types and channels. An event type with no stored row is enabled by default.",
+        "tags": ["Notifications"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      "channel": {
+                        "enum": ["email", "in_app"],
+                        "type": "string"
+                      },
+                      "eventType": {
+                        "type": "string"
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "x-native-type": "date"
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "x-native-type": "date"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "channel",
+                      "eventType",
+                      "enabled",
+                      "createdAt",
+                      "updatedAt"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "upsertNotificationPreference",
+        "summary": "Set a notification preference",
+        "description": "Creates or updates one preference. Identity is the (channel, eventType) pair carried in the body, so this is idempotent — repeating a call with the same pair overwrites rather than duplicating.",
+        "tags": ["Notifications"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "channel": {
+                    "enum": ["email", "in_app"],
+                    "type": "string"
+                  },
+                  "eventType": {
+                    "enum": [
+                      "submission.received",
+                      "submission.accepted",
+                      "submission.rejected",
+                      "submission.withdrawn",
+                      "contract.ready",
+                      "copyeditor.assigned"
+                    ],
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                },
+                "required": ["channel", "eventType", "enabled"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "channel": {
+                      "enum": ["email", "in_app"],
+                      "type": "string"
+                    },
+                    "eventType": {
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "channel",
+                    "eventType",
+                    "enabled",
+                    "createdAt",
+                    "updatedAt"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notification-preferences/batch": {
+      "put": {
+        "operationId": "bulkUpsertNotificationPreferences",
+        "summary": "Set notification preferences in bulk",
+        "description": "Creates or updates up to 50 preferences in one request. Applied inside a single transaction, so the batch either lands whole or not at all.",
+        "tags": ["Notifications"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "preferences": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 50,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "channel": {
+                          "enum": ["email", "in_app"],
+                          "type": "string"
+                        },
+                        "eventType": {
+                          "enum": [
+                            "submission.received",
+                            "submission.accepted",
+                            "submission.rejected",
+                            "submission.withdrawn",
+                            "contract.ready",
+                            "copyeditor.assigned"
+                          ],
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["channel", "eventType", "enabled"]
+                    }
+                  }
+                },
+                "required": ["preferences"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      "channel": {
+                        "enum": ["email", "in_app"],
+                        "type": "string"
+                      },
+                      "eventType": {
+                        "type": "string"
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "x-native-type": "date"
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "x-native-type": "date"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "channel",
+                      "eventType",
+                      "enabled",
+                      "createdAt",
+                      "updatedAt"
                     ]
                   }
                 }

--- a/sdks/python/colophony/api/notifications/__init__.py
+++ b/sdks/python/colophony/api/notifications/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/sdks/python/colophony/api/notifications/bulk_upsert_notification_preferences.py
+++ b/sdks/python/colophony/api/notifications/bulk_upsert_notification_preferences.py
@@ -1,0 +1,179 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.bulk_upsert_notification_preferences_body import BulkUpsertNotificationPreferencesBody
+from ...models.bulk_upsert_notification_preferences_response_200_item import (
+    BulkUpsertNotificationPreferencesResponse200Item,
+)
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: BulkUpsertNotificationPreferencesBody,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/notification-preferences/batch",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> list[BulkUpsertNotificationPreferencesResponse200Item] | None:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = BulkUpsertNotificationPreferencesResponse200Item.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[list[BulkUpsertNotificationPreferencesResponse200Item]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: BulkUpsertNotificationPreferencesBody,
+) -> Response[list[BulkUpsertNotificationPreferencesResponse200Item]]:
+    """Set notification preferences in bulk
+
+     Creates or updates up to 50 preferences in one request. Applied inside a single transaction, so the
+    batch either lands whole or not at all.
+
+    Args:
+        body (BulkUpsertNotificationPreferencesBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[list[BulkUpsertNotificationPreferencesResponse200Item]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: BulkUpsertNotificationPreferencesBody,
+) -> list[BulkUpsertNotificationPreferencesResponse200Item] | None:
+    """Set notification preferences in bulk
+
+     Creates or updates up to 50 preferences in one request. Applied inside a single transaction, so the
+    batch either lands whole or not at all.
+
+    Args:
+        body (BulkUpsertNotificationPreferencesBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        list[BulkUpsertNotificationPreferencesResponse200Item]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: BulkUpsertNotificationPreferencesBody,
+) -> Response[list[BulkUpsertNotificationPreferencesResponse200Item]]:
+    """Set notification preferences in bulk
+
+     Creates or updates up to 50 preferences in one request. Applied inside a single transaction, so the
+    batch either lands whole or not at all.
+
+    Args:
+        body (BulkUpsertNotificationPreferencesBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[list[BulkUpsertNotificationPreferencesResponse200Item]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: BulkUpsertNotificationPreferencesBody,
+) -> list[BulkUpsertNotificationPreferencesResponse200Item] | None:
+    """Set notification preferences in bulk
+
+     Creates or updates up to 50 preferences in one request. Applied inside a single transaction, so the
+    batch either lands whole or not at all.
+
+    Args:
+        body (BulkUpsertNotificationPreferencesBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        list[BulkUpsertNotificationPreferencesResponse200Item]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/sdks/python/colophony/api/notifications/get_unread_notification_count.py
+++ b/sdks/python/colophony/api/notifications/get_unread_notification_count.py
@@ -1,0 +1,144 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.get_unread_notification_count_response_200 import GetUnreadNotificationCountResponse200
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/notifications/unread-count",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> GetUnreadNotificationCountResponse200 | None:
+    if response.status_code == 200:
+        response_200 = GetUnreadNotificationCountResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[GetUnreadNotificationCountResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[GetUnreadNotificationCountResponse200]:
+    """Get unread notification count
+
+     Returns the number of unread in-app notifications. Returns the inbox of the user this credential
+    acts as. An API key acts as the user who created it, so this is that person’s notifications, not an
+    organization-wide feed. To receive organization-level events, register a webhook endpoint instead.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GetUnreadNotificationCountResponse200]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+) -> GetUnreadNotificationCountResponse200 | None:
+    """Get unread notification count
+
+     Returns the number of unread in-app notifications. Returns the inbox of the user this credential
+    acts as. An API key acts as the user who created it, so this is that person’s notifications, not an
+    organization-wide feed. To receive organization-level events, register a webhook endpoint instead.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GetUnreadNotificationCountResponse200
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[GetUnreadNotificationCountResponse200]:
+    """Get unread notification count
+
+     Returns the number of unread in-app notifications. Returns the inbox of the user this credential
+    acts as. An API key acts as the user who created it, so this is that person’s notifications, not an
+    organization-wide feed. To receive organization-level events, register a webhook endpoint instead.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GetUnreadNotificationCountResponse200]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+) -> GetUnreadNotificationCountResponse200 | None:
+    """Get unread notification count
+
+     Returns the number of unread in-app notifications. Returns the inbox of the user this credential
+    acts as. An API key acts as the user who created it, so this is that person’s notifications, not an
+    organization-wide feed. To receive organization-level events, register a webhook endpoint instead.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GetUnreadNotificationCountResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/sdks/python/colophony/api/notifications/list_notification_preferences.py
+++ b/sdks/python/colophony/api/notifications/list_notification_preferences.py
@@ -1,0 +1,149 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.list_notification_preferences_response_200_item import ListNotificationPreferencesResponse200Item
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/notification-preferences",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> list[ListNotificationPreferencesResponse200Item] | None:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = ListNotificationPreferencesResponse200Item.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[list[ListNotificationPreferencesResponse200Item]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[list[ListNotificationPreferencesResponse200Item]]:
+    """List notification preferences
+
+     Returns the per-channel, per-event notification preferences for the current user in this
+    organization. Unpaginated: the set is bounded by the number of event types and channels. An event
+    type with no stored row is enabled by default.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[list[ListNotificationPreferencesResponse200Item]]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+) -> list[ListNotificationPreferencesResponse200Item] | None:
+    """List notification preferences
+
+     Returns the per-channel, per-event notification preferences for the current user in this
+    organization. Unpaginated: the set is bounded by the number of event types and channels. An event
+    type with no stored row is enabled by default.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        list[ListNotificationPreferencesResponse200Item]
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[list[ListNotificationPreferencesResponse200Item]]:
+    """List notification preferences
+
+     Returns the per-channel, per-event notification preferences for the current user in this
+    organization. Unpaginated: the set is bounded by the number of event types and channels. An event
+    type with no stored row is enabled by default.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[list[ListNotificationPreferencesResponse200Item]]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+) -> list[ListNotificationPreferencesResponse200Item] | None:
+    """List notification preferences
+
+     Returns the per-channel, per-event notification preferences for the current user in this
+    organization. Unpaginated: the set is bounded by the number of event types and channels. An event
+    type with no stored row is enabled by default.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        list[ListNotificationPreferencesResponse200Item]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/sdks/python/colophony/api/notifications/list_notifications.py
+++ b/sdks/python/colophony/api/notifications/list_notifications.py
@@ -1,0 +1,214 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.list_notifications_response_200 import ListNotificationsResponse200
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+    unread_only: bool | Unset = False,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["page"] = page
+
+    params["limit"] = limit
+
+    params["unreadOnly"] = unread_only
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/notifications",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ListNotificationsResponse200 | None:
+    if response.status_code == 200:
+        response_200 = ListNotificationsResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ListNotificationsResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+    unread_only: bool | Unset = False,
+) -> Response[ListNotificationsResponse200]:
+    """List notifications
+
+     Returns a paginated list of in-app notifications, newest first. Returns the inbox of the user this
+    credential acts as. An API key acts as the user who created it, so this is that person’s
+    notifications, not an organization-wide feed. To receive organization-level events, register a
+    webhook endpoint instead.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        limit (int | Unset): Items per page (1-50, default 20) Default: 20.
+        unread_only (bool | Unset): Return only notifications that have not been read Default:
+            False.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ListNotificationsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        page=page,
+        limit=limit,
+        unread_only=unread_only,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+    unread_only: bool | Unset = False,
+) -> ListNotificationsResponse200 | None:
+    """List notifications
+
+     Returns a paginated list of in-app notifications, newest first. Returns the inbox of the user this
+    credential acts as. An API key acts as the user who created it, so this is that person’s
+    notifications, not an organization-wide feed. To receive organization-level events, register a
+    webhook endpoint instead.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        limit (int | Unset): Items per page (1-50, default 20) Default: 20.
+        unread_only (bool | Unset): Return only notifications that have not been read Default:
+            False.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ListNotificationsResponse200
+    """
+
+    return sync_detailed(
+        client=client,
+        page=page,
+        limit=limit,
+        unread_only=unread_only,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+    unread_only: bool | Unset = False,
+) -> Response[ListNotificationsResponse200]:
+    """List notifications
+
+     Returns a paginated list of in-app notifications, newest first. Returns the inbox of the user this
+    credential acts as. An API key acts as the user who created it, so this is that person’s
+    notifications, not an organization-wide feed. To receive organization-level events, register a
+    webhook endpoint instead.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        limit (int | Unset): Items per page (1-50, default 20) Default: 20.
+        unread_only (bool | Unset): Return only notifications that have not been read Default:
+            False.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ListNotificationsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        page=page,
+        limit=limit,
+        unread_only=unread_only,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+    unread_only: bool | Unset = False,
+) -> ListNotificationsResponse200 | None:
+    """List notifications
+
+     Returns a paginated list of in-app notifications, newest first. Returns the inbox of the user this
+    credential acts as. An API key acts as the user who created it, so this is that person’s
+    notifications, not an organization-wide feed. To receive organization-level events, register a
+    webhook endpoint instead.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        limit (int | Unset): Items per page (1-50, default 20) Default: 20.
+        unread_only (bool | Unset): Return only notifications that have not been read Default:
+            False.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ListNotificationsResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            page=page,
+            limit=limit,
+            unread_only=unread_only,
+        )
+    ).parsed

--- a/sdks/python/colophony/api/notifications/mark_all_notifications_read.py
+++ b/sdks/python/colophony/api/notifications/mark_all_notifications_read.py
@@ -1,0 +1,148 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.mark_all_notifications_read_response_200 import MarkAllNotificationsReadResponse200
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/notifications/read-all",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> MarkAllNotificationsReadResponse200 | None:
+    if response.status_code == 200:
+        response_200 = MarkAllNotificationsReadResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[MarkAllNotificationsReadResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[MarkAllNotificationsReadResponse200]:
+    """Mark all notifications as read
+
+     Marks every unread notification as read and returns how many changed. Returns the inbox of the user
+    this credential acts as. An API key acts as the user who created it, so this is that person’s
+    notifications, not an organization-wide feed. To receive organization-level events, register a
+    webhook endpoint instead.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[MarkAllNotificationsReadResponse200]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+) -> MarkAllNotificationsReadResponse200 | None:
+    """Mark all notifications as read
+
+     Marks every unread notification as read and returns how many changed. Returns the inbox of the user
+    this credential acts as. An API key acts as the user who created it, so this is that person’s
+    notifications, not an organization-wide feed. To receive organization-level events, register a
+    webhook endpoint instead.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        MarkAllNotificationsReadResponse200
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[MarkAllNotificationsReadResponse200]:
+    """Mark all notifications as read
+
+     Marks every unread notification as read and returns how many changed. Returns the inbox of the user
+    this credential acts as. An API key acts as the user who created it, so this is that person’s
+    notifications, not an organization-wide feed. To receive organization-level events, register a
+    webhook endpoint instead.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[MarkAllNotificationsReadResponse200]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+) -> MarkAllNotificationsReadResponse200 | None:
+    """Mark all notifications as read
+
+     Marks every unread notification as read and returns how many changed. Returns the inbox of the user
+    this credential acts as. An API key acts as the user who created it, so this is that person’s
+    notifications, not an organization-wide feed. To receive organization-level events, register a
+    webhook endpoint instead.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        MarkAllNotificationsReadResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/sdks/python/colophony/api/notifications/mark_notification_read.py
+++ b/sdks/python/colophony/api/notifications/mark_notification_read.py
@@ -1,0 +1,168 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.mark_notification_read_response_200 import MarkNotificationReadResponse200
+from ...types import Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/notifications/{id}/read".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> MarkNotificationReadResponse200 | None:
+    if response.status_code == 200:
+        response_200 = MarkNotificationReadResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[MarkNotificationReadResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[MarkNotificationReadResponse200]:
+    """Mark a notification as read
+
+     Marks a single unread notification as read. Returns `success: false` rather than an error when
+    nothing matched, so re-sending is safe.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[MarkNotificationReadResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> MarkNotificationReadResponse200 | None:
+    """Mark a notification as read
+
+     Marks a single unread notification as read. Returns `success: false` rather than an error when
+    nothing matched, so re-sending is safe.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        MarkNotificationReadResponse200
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[MarkNotificationReadResponse200]:
+    """Mark a notification as read
+
+     Marks a single unread notification as read. Returns `success: false` rather than an error when
+    nothing matched, so re-sending is safe.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[MarkNotificationReadResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> MarkNotificationReadResponse200 | None:
+    """Mark a notification as read
+
+     Marks a single unread notification as read. Returns `success: false` rather than an error when
+    nothing matched, so re-sending is safe.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        MarkNotificationReadResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/sdks/python/colophony/api/notifications/upsert_notification_preference.py
+++ b/sdks/python/colophony/api/notifications/upsert_notification_preference.py
@@ -1,0 +1,172 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.upsert_notification_preference_body import UpsertNotificationPreferenceBody
+from ...models.upsert_notification_preference_response_200 import UpsertNotificationPreferenceResponse200
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: UpsertNotificationPreferenceBody,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/notification-preferences",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> UpsertNotificationPreferenceResponse200 | None:
+    if response.status_code == 200:
+        response_200 = UpsertNotificationPreferenceResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[UpsertNotificationPreferenceResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: UpsertNotificationPreferenceBody,
+) -> Response[UpsertNotificationPreferenceResponse200]:
+    """Set a notification preference
+
+     Creates or updates one preference. Identity is the (channel, eventType) pair carried in the body, so
+    this is idempotent — repeating a call with the same pair overwrites rather than duplicating.
+
+    Args:
+        body (UpsertNotificationPreferenceBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[UpsertNotificationPreferenceResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: UpsertNotificationPreferenceBody,
+) -> UpsertNotificationPreferenceResponse200 | None:
+    """Set a notification preference
+
+     Creates or updates one preference. Identity is the (channel, eventType) pair carried in the body, so
+    this is idempotent — repeating a call with the same pair overwrites rather than duplicating.
+
+    Args:
+        body (UpsertNotificationPreferenceBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        UpsertNotificationPreferenceResponse200
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: UpsertNotificationPreferenceBody,
+) -> Response[UpsertNotificationPreferenceResponse200]:
+    """Set a notification preference
+
+     Creates or updates one preference. Identity is the (channel, eventType) pair carried in the body, so
+    this is idempotent — repeating a call with the same pair overwrites rather than duplicating.
+
+    Args:
+        body (UpsertNotificationPreferenceBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[UpsertNotificationPreferenceResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: UpsertNotificationPreferenceBody,
+) -> UpsertNotificationPreferenceResponse200 | None:
+    """Set a notification preference
+
+     Creates or updates one preference. Identity is the (channel, eventType) pair carried in the body, so
+    this is idempotent — repeating a call with the same pair overwrites rather than duplicating.
+
+    Args:
+        body (UpsertNotificationPreferenceBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        UpsertNotificationPreferenceResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/sdks/python/colophony/models/__init__.py
+++ b/sdks/python/colophony/models/__init__.py
@@ -118,6 +118,20 @@ from .batch_update_submission_status_response_200_succeeded_item_previous_status
 from .batch_update_submission_status_response_200_succeeded_item_status import (
     BatchUpdateSubmissionStatusResponse200SucceededItemStatus,
 )
+from .bulk_upsert_notification_preferences_body import BulkUpsertNotificationPreferencesBody
+from .bulk_upsert_notification_preferences_body_preferences_item import (
+    BulkUpsertNotificationPreferencesBodyPreferencesItem,
+)
+from .bulk_upsert_notification_preferences_body_preferences_item_channel import (
+    BulkUpsertNotificationPreferencesBodyPreferencesItemChannel,
+)
+from .bulk_upsert_notification_preferences_body_preferences_item_event_type import (
+    BulkUpsertNotificationPreferencesBodyPreferencesItemEventType,
+)
+from .bulk_upsert_notification_preferences_response_200_item import BulkUpsertNotificationPreferencesResponse200Item
+from .bulk_upsert_notification_preferences_response_200_item_channel import (
+    BulkUpsertNotificationPreferencesResponse200ItemChannel,
+)
 from .cast_submission_vote_body import CastSubmissionVoteBody
 from .cast_submission_vote_body_decision import CastSubmissionVoteBodyDecision
 from .cast_submission_vote_response_201 import CastSubmissionVoteResponse201
@@ -465,6 +479,7 @@ from .get_submission_response_200_sim_sub_policy_requirement_type_0_type import 
 )
 from .get_submission_response_200_status import GetSubmissionResponse200Status
 from .get_submission_vote_summary_response_200 import GetSubmissionVoteSummaryResponse200
+from .get_unread_notification_count_response_200 import GetUnreadNotificationCountResponse200
 from .import_csr_body import ImportCsrBody
 from .import_csr_body_correspondence_item import ImportCsrBodyCorrespondenceItem
 from .import_csr_body_correspondence_item_channel import ImportCsrBodyCorrespondenceItemChannel
@@ -537,6 +552,10 @@ from .list_my_submissions_response_200_items_item_status import ListMySubmission
 from .list_my_submissions_sort_by import ListMySubmissionsSortBy
 from .list_my_submissions_sort_order import ListMySubmissionsSortOrder
 from .list_my_submissions_status import ListMySubmissionsStatus
+from .list_notification_preferences_response_200_item import ListNotificationPreferencesResponse200Item
+from .list_notification_preferences_response_200_item_channel import ListNotificationPreferencesResponse200ItemChannel
+from .list_notifications_response_200 import ListNotificationsResponse200
+from .list_notifications_response_200_items_item import ListNotificationsResponse200ItemsItem
 from .list_organization_invitations_response_200_item import ListOrganizationInvitationsResponse200Item
 from .list_organization_invitations_response_200_item_roles_item import (
     ListOrganizationInvitationsResponse200ItemRolesItem,
@@ -603,6 +622,8 @@ from .list_submissions_response_200_items_item_status import ListSubmissionsResp
 from .list_submissions_sort_by import ListSubmissionsSortBy
 from .list_submissions_sort_order import ListSubmissionsSortOrder
 from .list_submissions_status import ListSubmissionsStatus
+from .mark_all_notifications_read_response_200 import MarkAllNotificationsReadResponse200
+from .mark_notification_read_response_200 import MarkNotificationReadResponse200
 from .mark_submission_reviewer_read_response_200 import MarkSubmissionReviewerReadResponse200
 from .publish_form_response_200 import PublishFormResponse200
 from .publish_form_response_200_status import PublishFormResponse200Status
@@ -919,6 +940,11 @@ from .update_submission_status_response_200_submission_sim_sub_policy_requiremen
     UpdateSubmissionStatusResponse200SubmissionSimSubPolicyRequirementType0Type,
 )
 from .update_submission_status_response_200_submission_status import UpdateSubmissionStatusResponse200SubmissionStatus
+from .upsert_notification_preference_body import UpsertNotificationPreferenceBody
+from .upsert_notification_preference_body_channel import UpsertNotificationPreferenceBodyChannel
+from .upsert_notification_preference_body_event_type import UpsertNotificationPreferenceBodyEventType
+from .upsert_notification_preference_response_200 import UpsertNotificationPreferenceResponse200
+from .upsert_notification_preference_response_200_channel import UpsertNotificationPreferenceResponse200Channel
 from .void_contract_response_200 import VoidContractResponse200
 from .void_contract_response_200_merge_data_type_0 import VoidContractResponse200MergeDataType0
 from .void_contract_response_200_status import VoidContractResponse200Status
@@ -1019,6 +1045,12 @@ __all__ = (
     "BatchUpdateSubmissionStatusResponse200SucceededItem",
     "BatchUpdateSubmissionStatusResponse200SucceededItemPreviousStatus",
     "BatchUpdateSubmissionStatusResponse200SucceededItemStatus",
+    "BulkUpsertNotificationPreferencesBody",
+    "BulkUpsertNotificationPreferencesBodyPreferencesItem",
+    "BulkUpsertNotificationPreferencesBodyPreferencesItemChannel",
+    "BulkUpsertNotificationPreferencesBodyPreferencesItemEventType",
+    "BulkUpsertNotificationPreferencesResponse200Item",
+    "BulkUpsertNotificationPreferencesResponse200ItemChannel",
     "CastSubmissionVoteBody",
     "CastSubmissionVoteBodyDecision",
     "CastSubmissionVoteResponse201",
@@ -1250,6 +1282,7 @@ __all__ = (
     "GetSubmissionResponse200SimSubPolicyRequirementType0Type",
     "GetSubmissionResponse200Status",
     "GetSubmissionVoteSummaryResponse200",
+    "GetUnreadNotificationCountResponse200",
     "ImportCsrBody",
     "ImportCsrBodyCorrespondenceItem",
     "ImportCsrBodyCorrespondenceItemChannel",
@@ -1308,6 +1341,10 @@ __all__ = (
     "ListMySubmissionsSortBy",
     "ListMySubmissionsSortOrder",
     "ListMySubmissionsStatus",
+    "ListNotificationPreferencesResponse200Item",
+    "ListNotificationPreferencesResponse200ItemChannel",
+    "ListNotificationsResponse200",
+    "ListNotificationsResponse200ItemsItem",
     "ListOrganizationInvitationsResponse200Item",
     "ListOrganizationInvitationsResponse200ItemRolesItem",
     "ListOrganizationInvitationsResponse200ItemStatus",
@@ -1354,6 +1391,8 @@ __all__ = (
     "ListSubmissionsStatus",
     "ListSubmissionVotesResponse200Item",
     "ListSubmissionVotesResponse200ItemDecision",
+    "MarkAllNotificationsReadResponse200",
+    "MarkNotificationReadResponse200",
     "MarkSubmissionReviewerReadResponse200",
     "PublishFormResponse200",
     "PublishFormResponse200Status",
@@ -1542,6 +1581,11 @@ __all__ = (
     "UpdateSubmissionStatusResponse200SubmissionSimSubPolicyRequirementType0",
     "UpdateSubmissionStatusResponse200SubmissionSimSubPolicyRequirementType0Type",
     "UpdateSubmissionStatusResponse200SubmissionStatus",
+    "UpsertNotificationPreferenceBody",
+    "UpsertNotificationPreferenceBodyChannel",
+    "UpsertNotificationPreferenceBodyEventType",
+    "UpsertNotificationPreferenceResponse200",
+    "UpsertNotificationPreferenceResponse200Channel",
     "VoidContractResponse200",
     "VoidContractResponse200MergeDataType0",
     "VoidContractResponse200Status",

--- a/sdks/python/colophony/models/bulk_upsert_notification_preferences_body.py
+++ b/sdks/python/colophony/models/bulk_upsert_notification_preferences_body.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.bulk_upsert_notification_preferences_body_preferences_item import (
+        BulkUpsertNotificationPreferencesBodyPreferencesItem,
+    )
+
+
+T = TypeVar("T", bound="BulkUpsertNotificationPreferencesBody")
+
+
+@_attrs_define
+class BulkUpsertNotificationPreferencesBody:
+    """
+    Attributes:
+        preferences (list[BulkUpsertNotificationPreferencesBodyPreferencesItem]):
+    """
+
+    preferences: list[BulkUpsertNotificationPreferencesBodyPreferencesItem]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        preferences = []
+        for preferences_item_data in self.preferences:
+            preferences_item = preferences_item_data.to_dict()
+            preferences.append(preferences_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "preferences": preferences,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.bulk_upsert_notification_preferences_body_preferences_item import (
+            BulkUpsertNotificationPreferencesBodyPreferencesItem,
+        )
+
+        d = dict(src_dict)
+        preferences = []
+        _preferences = d.pop("preferences")
+        for preferences_item_data in _preferences:
+            preferences_item = BulkUpsertNotificationPreferencesBodyPreferencesItem.from_dict(preferences_item_data)
+
+            preferences.append(preferences_item)
+
+        bulk_upsert_notification_preferences_body = cls(
+            preferences=preferences,
+        )
+
+        bulk_upsert_notification_preferences_body.additional_properties = d
+        return bulk_upsert_notification_preferences_body
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/bulk_upsert_notification_preferences_body_preferences_item.py
+++ b/sdks/python/colophony/models/bulk_upsert_notification_preferences_body_preferences_item.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.bulk_upsert_notification_preferences_body_preferences_item_channel import (
+    BulkUpsertNotificationPreferencesBodyPreferencesItemChannel,
+)
+from ..models.bulk_upsert_notification_preferences_body_preferences_item_event_type import (
+    BulkUpsertNotificationPreferencesBodyPreferencesItemEventType,
+)
+
+T = TypeVar("T", bound="BulkUpsertNotificationPreferencesBodyPreferencesItem")
+
+
+@_attrs_define
+class BulkUpsertNotificationPreferencesBodyPreferencesItem:
+    """
+    Attributes:
+        channel (BulkUpsertNotificationPreferencesBodyPreferencesItemChannel):
+        event_type (BulkUpsertNotificationPreferencesBodyPreferencesItemEventType):
+        enabled (bool):
+    """
+
+    channel: BulkUpsertNotificationPreferencesBodyPreferencesItemChannel
+    event_type: BulkUpsertNotificationPreferencesBodyPreferencesItemEventType
+    enabled: bool
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        channel = self.channel.value
+
+        event_type = self.event_type.value
+
+        enabled = self.enabled
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "channel": channel,
+                "eventType": event_type,
+                "enabled": enabled,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        channel = BulkUpsertNotificationPreferencesBodyPreferencesItemChannel(d.pop("channel"))
+
+        event_type = BulkUpsertNotificationPreferencesBodyPreferencesItemEventType(d.pop("eventType"))
+
+        enabled = d.pop("enabled")
+
+        bulk_upsert_notification_preferences_body_preferences_item = cls(
+            channel=channel,
+            event_type=event_type,
+            enabled=enabled,
+        )
+
+        bulk_upsert_notification_preferences_body_preferences_item.additional_properties = d
+        return bulk_upsert_notification_preferences_body_preferences_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/bulk_upsert_notification_preferences_body_preferences_item_channel.py
+++ b/sdks/python/colophony/models/bulk_upsert_notification_preferences_body_preferences_item_channel.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class BulkUpsertNotificationPreferencesBodyPreferencesItemChannel(str, Enum):
+    EMAIL = "email"
+    IN_APP = "in_app"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/bulk_upsert_notification_preferences_body_preferences_item_event_type.py
+++ b/sdks/python/colophony/models/bulk_upsert_notification_preferences_body_preferences_item_event_type.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class BulkUpsertNotificationPreferencesBodyPreferencesItemEventType(str, Enum):
+    CONTRACT_READY = "contract.ready"
+    COPYEDITOR_ASSIGNED = "copyeditor.assigned"
+    SUBMISSION_ACCEPTED = "submission.accepted"
+    SUBMISSION_RECEIVED = "submission.received"
+    SUBMISSION_REJECTED = "submission.rejected"
+    SUBMISSION_WITHDRAWN = "submission.withdrawn"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/bulk_upsert_notification_preferences_response_200_item.py
+++ b/sdks/python/colophony/models/bulk_upsert_notification_preferences_response_200_item.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.bulk_upsert_notification_preferences_response_200_item_channel import (
+    BulkUpsertNotificationPreferencesResponse200ItemChannel,
+)
+
+T = TypeVar("T", bound="BulkUpsertNotificationPreferencesResponse200Item")
+
+
+@_attrs_define
+class BulkUpsertNotificationPreferencesResponse200Item:
+    """
+    Attributes:
+        id (UUID):
+        channel (BulkUpsertNotificationPreferencesResponse200ItemChannel):
+        event_type (str):
+        enabled (bool):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+    """
+
+    id: UUID
+    channel: BulkUpsertNotificationPreferencesResponse200ItemChannel
+    event_type: str
+    enabled: bool
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        channel = self.channel.value
+
+        event_type = self.event_type
+
+        enabled = self.enabled
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "channel": channel,
+                "eventType": event_type,
+                "enabled": enabled,
+                "createdAt": created_at,
+                "updatedAt": updated_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        channel = BulkUpsertNotificationPreferencesResponse200ItemChannel(d.pop("channel"))
+
+        event_type = d.pop("eventType")
+
+        enabled = d.pop("enabled")
+
+        created_at = datetime.datetime.fromisoformat(d.pop("createdAt"))
+
+        updated_at = datetime.datetime.fromisoformat(d.pop("updatedAt"))
+
+        bulk_upsert_notification_preferences_response_200_item = cls(
+            id=id,
+            channel=channel,
+            event_type=event_type,
+            enabled=enabled,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        bulk_upsert_notification_preferences_response_200_item.additional_properties = d
+        return bulk_upsert_notification_preferences_response_200_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/bulk_upsert_notification_preferences_response_200_item_channel.py
+++ b/sdks/python/colophony/models/bulk_upsert_notification_preferences_response_200_item_channel.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class BulkUpsertNotificationPreferencesResponse200ItemChannel(str, Enum):
+    EMAIL = "email"
+    IN_APP = "in_app"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/get_unread_notification_count_response_200.py
+++ b/sdks/python/colophony/models/get_unread_notification_count_response_200.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="GetUnreadNotificationCountResponse200")
+
+
+@_attrs_define
+class GetUnreadNotificationCountResponse200:
+    """
+    Attributes:
+        count (int):
+    """
+
+    count: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        count = self.count
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "count": count,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        count = d.pop("count")
+
+        get_unread_notification_count_response_200 = cls(
+            count=count,
+        )
+
+        get_unread_notification_count_response_200.additional_properties = d
+        return get_unread_notification_count_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/list_notification_preferences_response_200_item.py
+++ b/sdks/python/colophony/models/list_notification_preferences_response_200_item.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.list_notification_preferences_response_200_item_channel import (
+    ListNotificationPreferencesResponse200ItemChannel,
+)
+
+T = TypeVar("T", bound="ListNotificationPreferencesResponse200Item")
+
+
+@_attrs_define
+class ListNotificationPreferencesResponse200Item:
+    """
+    Attributes:
+        id (UUID):
+        channel (ListNotificationPreferencesResponse200ItemChannel):
+        event_type (str):
+        enabled (bool):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+    """
+
+    id: UUID
+    channel: ListNotificationPreferencesResponse200ItemChannel
+    event_type: str
+    enabled: bool
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        channel = self.channel.value
+
+        event_type = self.event_type
+
+        enabled = self.enabled
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "channel": channel,
+                "eventType": event_type,
+                "enabled": enabled,
+                "createdAt": created_at,
+                "updatedAt": updated_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        channel = ListNotificationPreferencesResponse200ItemChannel(d.pop("channel"))
+
+        event_type = d.pop("eventType")
+
+        enabled = d.pop("enabled")
+
+        created_at = datetime.datetime.fromisoformat(d.pop("createdAt"))
+
+        updated_at = datetime.datetime.fromisoformat(d.pop("updatedAt"))
+
+        list_notification_preferences_response_200_item = cls(
+            id=id,
+            channel=channel,
+            event_type=event_type,
+            enabled=enabled,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        list_notification_preferences_response_200_item.additional_properties = d
+        return list_notification_preferences_response_200_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/list_notification_preferences_response_200_item_channel.py
+++ b/sdks/python/colophony/models/list_notification_preferences_response_200_item_channel.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class ListNotificationPreferencesResponse200ItemChannel(str, Enum):
+    EMAIL = "email"
+    IN_APP = "in_app"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/list_notifications_response_200.py
+++ b/sdks/python/colophony/models/list_notifications_response_200.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.list_notifications_response_200_items_item import ListNotificationsResponse200ItemsItem
+
+
+T = TypeVar("T", bound="ListNotificationsResponse200")
+
+
+@_attrs_define
+class ListNotificationsResponse200:
+    """
+    Attributes:
+        items (list[ListNotificationsResponse200ItemsItem]): Items on the current page
+        total (float): Total number of items across all pages
+        page (float): Current page number
+        limit (float): Items per page
+        total_pages (float): Total number of pages
+    """
+
+    items: list[ListNotificationsResponse200ItemsItem]
+    total: float
+    page: float
+    limit: float
+    total_pages: float
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+        total = self.total
+
+        page = self.page
+
+        limit = self.limit
+
+        total_pages = self.total_pages
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "items": items,
+                "total": total,
+                "page": page,
+                "limit": limit,
+                "totalPages": total_pages,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.list_notifications_response_200_items_item import ListNotificationsResponse200ItemsItem
+
+        d = dict(src_dict)
+        items = []
+        _items = d.pop("items")
+        for items_item_data in _items:
+            items_item = ListNotificationsResponse200ItemsItem.from_dict(items_item_data)
+
+            items.append(items_item)
+
+        total = d.pop("total")
+
+        page = d.pop("page")
+
+        limit = d.pop("limit")
+
+        total_pages = d.pop("totalPages")
+
+        list_notifications_response_200 = cls(
+            items=items,
+            total=total,
+            page=page,
+            limit=limit,
+            total_pages=total_pages,
+        )
+
+        list_notifications_response_200.additional_properties = d
+        return list_notifications_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/list_notifications_response_200_items_item.py
+++ b/sdks/python/colophony/models/list_notifications_response_200_items_item.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ListNotificationsResponse200ItemsItem")
+
+
+@_attrs_define
+class ListNotificationsResponse200ItemsItem:
+    """
+    Attributes:
+        id (UUID):
+        event_type (str):
+        title (str):
+        body (None | str):
+        link (None | str):
+        read_at (datetime.datetime | None):
+        created_at (datetime.datetime):
+    """
+
+    id: UUID
+    event_type: str
+    title: str
+    body: None | str
+    link: None | str
+    read_at: datetime.datetime | None
+    created_at: datetime.datetime
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        event_type = self.event_type
+
+        title = self.title
+
+        body: None | str
+        body = self.body
+
+        link: None | str
+        link = self.link
+
+        read_at: None | str
+        if isinstance(self.read_at, datetime.datetime):
+            read_at = self.read_at.isoformat()
+        else:
+            read_at = self.read_at
+
+        created_at = self.created_at.isoformat()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "eventType": event_type,
+                "title": title,
+                "body": body,
+                "link": link,
+                "readAt": read_at,
+                "createdAt": created_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        event_type = d.pop("eventType")
+
+        title = d.pop("title")
+
+        def _parse_body(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        body = _parse_body(d.pop("body"))
+
+        def _parse_link(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        link = _parse_link(d.pop("link"))
+
+        def _parse_read_at(data: object) -> datetime.datetime | None:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                read_at_type_0 = datetime.datetime.fromisoformat(data)
+
+                return read_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None, data)
+
+        read_at = _parse_read_at(d.pop("readAt"))
+
+        created_at = datetime.datetime.fromisoformat(d.pop("createdAt"))
+
+        list_notifications_response_200_items_item = cls(
+            id=id,
+            event_type=event_type,
+            title=title,
+            body=body,
+            link=link,
+            read_at=read_at,
+            created_at=created_at,
+        )
+
+        list_notifications_response_200_items_item.additional_properties = d
+        return list_notifications_response_200_items_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/mark_all_notifications_read_response_200.py
+++ b/sdks/python/colophony/models/mark_all_notifications_read_response_200.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="MarkAllNotificationsReadResponse200")
+
+
+@_attrs_define
+class MarkAllNotificationsReadResponse200:
+    """
+    Attributes:
+        count (int): Number of notifications marked read
+    """
+
+    count: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        count = self.count
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "count": count,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        count = d.pop("count")
+
+        mark_all_notifications_read_response_200 = cls(
+            count=count,
+        )
+
+        mark_all_notifications_read_response_200.additional_properties = d
+        return mark_all_notifications_read_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/mark_notification_read_response_200.py
+++ b/sdks/python/colophony/models/mark_notification_read_response_200.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="MarkNotificationReadResponse200")
+
+
+@_attrs_define
+class MarkNotificationReadResponse200:
+    """
+    Attributes:
+        success (bool): False when no unread notification matched — either it does not exist, belongs to another user or
+            organization, or was already read.
+    """
+
+    success: bool
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        success = self.success
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "success": success,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        success = d.pop("success")
+
+        mark_notification_read_response_200 = cls(
+            success=success,
+        )
+
+        mark_notification_read_response_200.additional_properties = d
+        return mark_notification_read_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/upsert_notification_preference_body.py
+++ b/sdks/python/colophony/models/upsert_notification_preference_body.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.upsert_notification_preference_body_channel import UpsertNotificationPreferenceBodyChannel
+from ..models.upsert_notification_preference_body_event_type import UpsertNotificationPreferenceBodyEventType
+
+T = TypeVar("T", bound="UpsertNotificationPreferenceBody")
+
+
+@_attrs_define
+class UpsertNotificationPreferenceBody:
+    """
+    Attributes:
+        channel (UpsertNotificationPreferenceBodyChannel):
+        event_type (UpsertNotificationPreferenceBodyEventType):
+        enabled (bool):
+    """
+
+    channel: UpsertNotificationPreferenceBodyChannel
+    event_type: UpsertNotificationPreferenceBodyEventType
+    enabled: bool
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        channel = self.channel.value
+
+        event_type = self.event_type.value
+
+        enabled = self.enabled
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "channel": channel,
+                "eventType": event_type,
+                "enabled": enabled,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        channel = UpsertNotificationPreferenceBodyChannel(d.pop("channel"))
+
+        event_type = UpsertNotificationPreferenceBodyEventType(d.pop("eventType"))
+
+        enabled = d.pop("enabled")
+
+        upsert_notification_preference_body = cls(
+            channel=channel,
+            event_type=event_type,
+            enabled=enabled,
+        )
+
+        upsert_notification_preference_body.additional_properties = d
+        return upsert_notification_preference_body
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/upsert_notification_preference_body_channel.py
+++ b/sdks/python/colophony/models/upsert_notification_preference_body_channel.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class UpsertNotificationPreferenceBodyChannel(str, Enum):
+    EMAIL = "email"
+    IN_APP = "in_app"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/upsert_notification_preference_body_event_type.py
+++ b/sdks/python/colophony/models/upsert_notification_preference_body_event_type.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class UpsertNotificationPreferenceBodyEventType(str, Enum):
+    CONTRACT_READY = "contract.ready"
+    COPYEDITOR_ASSIGNED = "copyeditor.assigned"
+    SUBMISSION_ACCEPTED = "submission.accepted"
+    SUBMISSION_RECEIVED = "submission.received"
+    SUBMISSION_REJECTED = "submission.rejected"
+    SUBMISSION_WITHDRAWN = "submission.withdrawn"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/upsert_notification_preference_response_200.py
+++ b/sdks/python/colophony/models/upsert_notification_preference_response_200.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.upsert_notification_preference_response_200_channel import UpsertNotificationPreferenceResponse200Channel
+
+T = TypeVar("T", bound="UpsertNotificationPreferenceResponse200")
+
+
+@_attrs_define
+class UpsertNotificationPreferenceResponse200:
+    """
+    Attributes:
+        id (UUID):
+        channel (UpsertNotificationPreferenceResponse200Channel):
+        event_type (str):
+        enabled (bool):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+    """
+
+    id: UUID
+    channel: UpsertNotificationPreferenceResponse200Channel
+    event_type: str
+    enabled: bool
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        channel = self.channel.value
+
+        event_type = self.event_type
+
+        enabled = self.enabled
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "channel": channel,
+                "eventType": event_type,
+                "enabled": enabled,
+                "createdAt": created_at,
+                "updatedAt": updated_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        channel = UpsertNotificationPreferenceResponse200Channel(d.pop("channel"))
+
+        event_type = d.pop("eventType")
+
+        enabled = d.pop("enabled")
+
+        created_at = datetime.datetime.fromisoformat(d.pop("createdAt"))
+
+        updated_at = datetime.datetime.fromisoformat(d.pop("updatedAt"))
+
+        upsert_notification_preference_response_200 = cls(
+            id=id,
+            channel=channel,
+            event_type=event_type,
+            enabled=enabled,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        upsert_notification_preference_response_200.additional_properties = d
+        return upsert_notification_preference_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/upsert_notification_preference_response_200_channel.py
+++ b/sdks/python/colophony/models/upsert_notification_preference_response_200_channel.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class UpsertNotificationPreferenceResponse200Channel(str, Enum):
+    EMAIL = "email"
+    IN_APP = "in_app"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/typescript/src/generated/openapi.ts
+++ b/sdks/typescript/src/generated/openapi.ts
@@ -2048,6 +2048,130 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/notifications": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List notifications
+     * @description Returns a paginated list of in-app notifications, newest first. Returns the inbox of the user this credential acts as. An API key acts as the user who created it, so this is that person’s notifications, not an organization-wide feed. To receive organization-level events, register a webhook endpoint instead.
+     */
+    get: operations["listNotifications"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/notifications/unread-count": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get unread notification count
+     * @description Returns the number of unread in-app notifications. Returns the inbox of the user this credential acts as. An API key acts as the user who created it, so this is that person’s notifications, not an organization-wide feed. To receive organization-level events, register a webhook endpoint instead.
+     */
+    get: operations["getUnreadNotificationCount"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/notifications/{id}/read": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Mark a notification as read
+     * @description Marks a single unread notification as read. Returns `success: false` rather than an error when nothing matched, so re-sending is safe.
+     */
+    post: operations["markNotificationRead"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/notifications/read-all": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Mark all notifications as read
+     * @description Marks every unread notification as read and returns how many changed. Returns the inbox of the user this credential acts as. An API key acts as the user who created it, so this is that person’s notifications, not an organization-wide feed. To receive organization-level events, register a webhook endpoint instead.
+     */
+    post: operations["markAllNotificationsRead"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/notification-preferences": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List notification preferences
+     * @description Returns the per-channel, per-event notification preferences for the current user in this organization. Unpaginated: the set is bounded by the number of event types and channels. An event type with no stored row is enabled by default.
+     */
+    get: operations["listNotificationPreferences"];
+    /**
+     * Set a notification preference
+     * @description Creates or updates one preference. Identity is the (channel, eventType) pair carried in the body, so this is idempotent — repeating a call with the same pair overwrites rather than duplicating.
+     */
+    put: operations["upsertNotificationPreference"];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/notification-preferences/batch": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /**
+     * Set notification preferences in bulk
+     * @description Creates or updates up to 50 preferences in one request. Applied inside a single transaction, so the batch either lands whole or not at all.
+     */
+    put: operations["bulkUpsertNotificationPreferences"];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -12328,6 +12452,248 @@ export interface operations {
              */
             touchedAt: string;
             submissionTitle?: string | null;
+          }[];
+        };
+      };
+    };
+  };
+  listNotifications: {
+    parameters: {
+      query?: {
+        page?: number;
+        limit?: number;
+        unreadOnly?: boolean;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @description Items on the current page */
+            items: {
+              /** Format: uuid */
+              id: string;
+              eventType: string;
+              title: string;
+              body: string | null;
+              link: string | null;
+              readAt: string | null;
+              /** Format: date-time */
+              createdAt: string;
+            }[];
+            /** @description Total number of items across all pages */
+            total: number;
+            /** @description Current page number */
+            page: number;
+            /** @description Items per page */
+            limit: number;
+            /** @description Total number of pages */
+            totalPages: number;
+          };
+        };
+      };
+    };
+  };
+  getUnreadNotificationCount: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            count: number;
+          };
+        };
+      };
+    };
+  };
+  markNotificationRead: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @description False when no unread notification matched — either it does not exist, belongs to another user or organization, or was already read. */
+            success: boolean;
+          };
+        };
+      };
+    };
+  };
+  markAllNotificationsRead: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @description Number of notifications marked read */
+            count: number;
+          };
+        };
+      };
+    };
+  };
+  listNotificationPreferences: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            channel: "email" | "in_app";
+            eventType: string;
+            enabled: boolean;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+          }[];
+        };
+      };
+    };
+  };
+  upsertNotificationPreference: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** @enum {string} */
+          channel: "email" | "in_app";
+          /** @enum {string} */
+          eventType:
+            | "submission.received"
+            | "submission.accepted"
+            | "submission.rejected"
+            | "submission.withdrawn"
+            | "contract.ready"
+            | "copyeditor.assigned";
+          enabled: boolean;
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            channel: "email" | "in_app";
+            eventType: string;
+            enabled: boolean;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+          };
+        };
+      };
+    };
+  };
+  bulkUpsertNotificationPreferences: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          preferences: {
+            /** @enum {string} */
+            channel: "email" | "in_app";
+            /** @enum {string} */
+            eventType:
+              | "submission.received"
+              | "submission.accepted"
+              | "submission.rejected"
+              | "submission.withdrawn"
+              | "contract.ready"
+              | "copyeditor.assigned";
+            enabled: boolean;
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            channel: "email" | "in_app";
+            eventType: string;
+            enabled: boolean;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
           }[];
         };
       };


### PR DESCRIPTION
Stacked on #531 — review that first. Base retargets to `main` automatically when #531 merges.

## What

Closes the "notify" leg of the integrator workflow (intake → review → decision → notify). In-app notifications had no pull path: the only HTTP surface was the SSE stream, which a consumer that cannot hold a connection has no way to use.

Seven operations under `/v1`, mapped one-to-one onto the existing tRPC procedures and the same service layer.

| Method | Path | Scope |
| --- | --- | --- |
| GET | `/notifications` | `notifications:read` |
| GET | `/notifications/unread-count` | `notifications:read` |
| POST | `/notifications/{id}/read` | `notifications:write` |
| POST | `/notifications/read-all` | `notifications:write` |
| GET | `/notification-preferences` | `notifications:read` |
| PUT | `/notification-preferences` | `notifications:write` |
| PUT | `/notification-preferences/batch` | `notifications:write` |

Both scopes already existed and were enforced on tRPC only; they now have routes consuming them, so no enum change was needed.

`orgProcedure` throughout, not `userProcedure` — the `notifications_inbox` policy uses the raising `current_setting` idiom, so a request with no org context would 500 rather than return empty.

## The identity semantics are documented, not left to be inferred

The inbox is per-user, and an API key acts as its creator, so a key reads exactly one person's notifications. Integrators reliably assume the opposite of a credential scoped to an organization, and the failure is silent — a 200 with the wrong contents rather than an error.

Both read routes state this in their description and point at webhooks for organization-level events. Generalizing it needs acting-as (`X-Act-As-User`), which sits behind the cross-org principal work.

## The first boolean query param, and the obvious spellings are wrong

This sets the idiom, so all three candidates were measured against the actual schema converter rather than assumed:

| Candidate | Spec output | Behaviour |
| --- | --- | --- |
| `z.coerce.boolean()` | `boolean` | parses `"false"` as **true** — silently inverts the filter |
| `z.stringbool()` | `{"type":"string"}` | correct on strings, but both SDKs would type the field as a string; rejects a real boolean |
| `z.preprocess` ✅ | `{"type":"boolean"}` | accepts both forms |

The generated Python client now types `unread_only` as `bool`. Only the exact tokens `"true"` and `"false"` convert — anything else falls through to `z.boolean()` and is rejected, so `?unreadOnly=maybe` is a 400 rather than a silent `false`.

`limit` is restated at 50 rather than inheriting `restPaginationQuery`'s 100, which would have quietly let REST accept more than the service's own schema caps.

## One test-infrastructure note worth keeping

The router spec uses `resetAllMocks`, not `clearAllMocks`. This suite runs under vitest's random sequencing, and `clearAllMocks` leaves queued `mockResolvedValueOnce` implementations in place — so one test consumes a value another queued, and which one depends on the seed. It failed exactly that way before the change, and passes across repeated runs now. `audit.spec.ts` has the same latent pattern.

## Plan Overrides

| File | Planned | Actual | Rationale |
| --- | --- | --- | --- |
| `packages/api-contracts/src/notifications.ts` | `z.stringbool()` for `unreadOnly` | `z.preprocess` via a `booleanQueryParam` helper | `stringbool` renders as `type: string`, so both generated SDKs would type the field as a string rather than a boolean. Measured, not assumed — see the table above. |

## Generated artefacts

99 paths / 146 operations, up from 93 / 139. `Notifications` is declared as a tag rather than becoming a fourth undeclared one. `pyproject.toml`, `poetry.lock` and `tests/` are untouched, verified with `git status --porcelain`.

## Test plan

- `pnpm --filter @colophony/api test` — 1894 passed (164 files), incl. 35 new router cases
- `pnpm --filter @colophony/api test:rls` — 152 passed
- `pnpm --filter @colophony/api test:security` — 41 passed
- Both guard-coverage gates and `openapi-spec.spec.ts` pass
- `pnpm sdk:check-spec` — up to date
- `cd sdks/python && poetry run pytest` — 7 passed against the regenerated client
- `pnpm type-check`, `pnpm lint`, prettier on all tracked files — clean