### PR TITLE
fix(api): enforce API key scopes on hand-rolled Fastify routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,12 +98,18 @@ RATE_LIMIT_KEY_PREFIX=colophony:rl
 # =============================================================================
 # INTERNAL API BOUNDARY
 # =============================================================================
-# The tRPC routers that exist only to serve the operator console (federation,
-# gdpr, hub, migration, ops, simsub, transfer) admit interactive sessions only.
+# Two surfaces admit interactive sessions only: the tRPC routers that exist to
+# serve the operator console (federation, gdpr, hub, migration, ops, simsub,
+# transfer), and the hand-rolled Fastify federation routes (/federation/peers,
+# /federation/transfers, /federation/sim-sub, /federation/hub/instances,
+# /federation/migrations, /federation/keys).
 # true  — reject API keys with 403 (default since 2026-07-27)
 # false — record the attempt as an API_KEY_INTERNAL_ROUTE audit event and let
 #         it through; the revert lever, not a normal setting
-# TRPC_INTERNAL_ONLY_ENFORCE=true
+#
+# Renamed from TRPC_INTERNAL_ONLY_ENFORCE on 2026-07-29. The old name is now
+# rejected at startup rather than ignored, so rename it wherever it is set.
+# INTERNAL_ONLY_ENFORCE=true
 
 # =============================================================================
 # VIRUS SCANNING (ClamAV - optional for dev)

--- a/apps/api/src/__tests__/helpers/guard-env.ts
+++ b/apps/api/src/__tests__/helpers/guard-env.ts
@@ -1,0 +1,49 @@
+/**
+ * `process.env` setup for specs that exercise the Fastify `internalOnly` guard.
+ *
+ * The guard calls `validateEnv()` per request — deliberately, because a
+ * module-level call breaks test imports — and `validateEnv()` re-parses
+ * `process.env` and ignores the `Env` a spec passes to a route registrar. The
+ * unit-test vitest config sets no `DATABASE_URL`, so an unprepared spec gets a
+ * ZodError out of the guard and sees a **500 where it expected a 403**, which
+ * reads like a broken guard rather than a missing variable.
+ *
+ * Prefer this over `vi.mock('../config/env.js')` in route specs: it exercises the
+ * real schema, so a spec cannot pass against an env shape that could not parse in
+ * production. The tRPC specs mock instead because they need to flip enforcement
+ * mid-file without touching the process.
+ */
+const REQUIRED = {
+  DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+} as const;
+
+/**
+ * Apply the variables the guard needs and return a restore function.
+ *
+ * ```ts
+ * let restoreEnv: () => void;
+ * beforeAll(() => { restoreEnv = applyGuardEnv(); });
+ * afterAll(() => { restoreEnv(); });
+ * ```
+ */
+export function applyGuardEnv(
+  overrides: Record<string, string> = {},
+): () => void {
+  const values = { ...REQUIRED, ...overrides };
+  const previous = new Map<string, string | undefined>();
+
+  for (const [key, value] of Object.entries(values)) {
+    previous.set(key, process.env[key]);
+    process.env[key] = value;
+  }
+
+  return function restoreGuardEnv() {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+}

--- a/apps/api/src/__tests__/security/scope-enforcement.test.ts
+++ b/apps/api/src/__tests__/security/scope-enforcement.test.ts
@@ -50,10 +50,10 @@ async function seedOrgWithAdmin() {
  * on the app would silently do nothing, so drive process.env instead.
  */
 function setInternalOnlyEnforce(value: boolean): void {
-  process.env.TRPC_INTERNAL_ONLY_ENFORCE = value ? 'true' : 'false';
+  process.env.INTERNAL_ONLY_ENFORCE = value ? 'true' : 'false';
 }
 
-const originalEnforce = process.env.TRPC_INTERNAL_ONLY_ENFORCE;
+const originalEnforce = process.env.INTERNAL_ONLY_ENFORCE;
 
 beforeAll(async () => {
   await globalSetup();
@@ -63,9 +63,9 @@ afterEach(async () => {
   await app?.close();
   await truncateAllTables();
   if (originalEnforce === undefined) {
-    delete process.env.TRPC_INTERNAL_ONLY_ENFORCE;
+    delete process.env.INTERNAL_ONLY_ENFORCE;
   } else {
-    process.env.TRPC_INTERNAL_ONLY_ENFORCE = originalEnforce;
+    process.env.INTERNAL_ONLY_ENFORCE = originalEnforce;
   }
 });
 
@@ -161,7 +161,7 @@ describe('requireScopes — real API key through the tRPC router', () => {
 
 describe('internalOnly — the boundary enforced since P0.5', () => {
   // Enforcement is the default since 2026-07-27. This pins the log-only
-  // fallback that TRPC_INTERNAL_ONLY_ENFORCE=false still buys — the revert
+  // fallback that INTERNAL_ONLY_ENFORCE=false still buys — the revert
   // path has to keep working, or the flag is not a lever.
   it('falls back to admitting an API key when explicitly set to false', async () => {
     setInternalOnlyEnforce(false);
@@ -216,7 +216,7 @@ describe('internalOnly — the boundary enforced since P0.5', () => {
   // notice the schema default silently reverting to 'false'. This one pins the
   // deployed behaviour: unset must mean enforcing.
   it('enforces by default when the variable is not set at all', async () => {
-    delete process.env.TRPC_INTERNAL_ONLY_ENFORCE;
+    delete process.env.INTERNAL_ONLY_ENFORCE;
     app = await buildApiKeyApp();
     const { org, user } = await seedOrgWithAdmin();
     const key = await insertApiKey({

--- a/apps/api/src/__tests__/webhooks/helpers/webhook-app.ts
+++ b/apps/api/src/__tests__/webhooks/helpers/webhook-app.ts
@@ -32,7 +32,7 @@ export function createTestEnv(overrides?: Partial<Env>): Env {
     PORT: 0,
     HOST: '127.0.0.1',
     NODE_ENV: 'test',
-    TRPC_INTERNAL_ONLY_ENFORCE: false,
+    INTERNAL_ONLY_ENFORCE: false,
     LOG_LEVEL: 'error',
     REDIS_HOST: 'localhost',
     REDIS_PORT: 6379,

--- a/apps/api/src/config/env.spec.ts
+++ b/apps/api/src/config/env.spec.ts
@@ -220,4 +220,43 @@ describe('validateEnv', () => {
       expect(() => validateEnv({ ...validBase, [key]: invalid })).toThrow();
     });
   });
+
+  describe('renamed variables', () => {
+    it('rejects TRPC_INTERNAL_ONLY_ENFORCE and names the replacement', () => {
+      // Ignoring the old name would let the schema default silently overrule an
+      // operator who set `false` to keep an internal surface reachable.
+      expect(() =>
+        validateEnv({
+          ...validBase,
+          TRPC_INTERNAL_ONLY_ENFORCE: 'false',
+        }),
+      ).toThrow(/renamed to INTERNAL_ONLY_ENFORCE/);
+    });
+
+    it('rejects the old name even when set to the same value as the default', () => {
+      // The failure is about the name being unread, not about the value
+      // disagreeing — a `true` that happens to match is still a stale config.
+      expect(() =>
+        validateEnv({ ...validBase, TRPC_INTERNAL_ONLY_ENFORCE: 'true' }),
+      ).toThrow(/renamed/);
+    });
+
+    it('treats an empty old name as absent', () => {
+      // docker-compose.prod.yml passes the legacy name through as
+      // `${TRPC_INTERNAL_ONLY_ENFORCE:-}` so that a stale value reaches this
+      // check at all. Unset arrives as '', which must NOT throw or every
+      // already-migrated deployment fails to boot.
+      expect(() =>
+        validateEnv({ ...validBase, TRPC_INTERNAL_ONLY_ENFORCE: '' }),
+      ).not.toThrow();
+    });
+
+    it('still parses the new name normally', () => {
+      expect(
+        validateEnv({ ...validBase, INTERNAL_ONLY_ENFORCE: 'false' })
+          .INTERNAL_ONLY_ENFORCE,
+      ).toBe(false);
+      expect(validateEnv(validBase).INTERNAL_ONLY_ENFORCE).toBe(true);
+    });
+  });
 });

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -110,11 +110,16 @@ const envSchema = z
     // Status token TTL
     STATUS_TOKEN_TTL_DAYS: z.coerce.number().int().positive().default(90),
 
-    // tRPC internal-only boundary. True = reject non-interactive credentials
-    // on the seven operator-console routers. False reverts to log-only, which
-    // records the attempt as an API_KEY_INTERNAL_ROUTE audit event and lets it
-    // through — the observation window, closed 2026-07-27.
-    TRPC_INTERNAL_ONLY_ENFORCE: z
+    // Internal-only boundary, across BOTH surfaces: the seven operator-console
+    // tRPC routers and the hand-rolled Fastify federation routes. True = reject
+    // non-interactive credentials. False reverts to log-only, which records the
+    // attempt as an API_KEY_INTERNAL_ROUTE audit event and lets it through —
+    // the observation window, closed 2026-07-27.
+    //
+    // Carried a TRPC_ prefix until 2026-07-29, when the Fastify surface started
+    // using it too. validateEnv() rejects the old name outright rather than
+    // ignoring it — see RENAMED_ENV_VARS below.
+    INTERNAL_ONLY_ENFORCE: z
       .enum(['true', 'false'])
       .default('true')
       .transform((v) => v === 'true'),
@@ -220,8 +225,40 @@ const envSchema = z
 
 export type Env = z.infer<typeof envSchema>;
 
+/**
+ * Environment variables that were renamed, mapped to their replacement.
+ *
+ * A removed name that is merely ignored is worse than one that fails: the schema
+ * default silently takes over, so an operator who set the old variable to
+ * override a default finds the default back in force with nothing to indicate it.
+ * For INTERNAL_ONLY_ENFORCE specifically, that means someone who set `false` to
+ * keep a surface reachable gets it closed with no signal. Fail at startup
+ * instead, naming the replacement.
+ */
+const RENAMED_ENV_VARS: Record<string, string> = {
+  TRPC_INTERNAL_ONLY_ENFORCE: 'INTERNAL_ONLY_ENFORCE',
+};
+
 export function validateEnv(
   env: Record<string, string | undefined> = process.env,
 ): Env {
+  for (const [legacy, replacement] of Object.entries(RENAMED_ENV_VARS)) {
+    // Empty counts as absent, and that is load-bearing rather than defensive.
+    // Compose injects only the variables named in a service's `environment:`
+    // block, so `docker-compose.prod.yml` has to pass each legacy name through
+    // explicitly for this check to see it at all — and a pass-through of an unset
+    // variable arrives as `''`, not undefined. Treating `''` as set would throw
+    // on every deployment that had already migrated.
+    if ((env[legacy] ?? '') !== '') {
+      throw new Error(
+        `${legacy} has been renamed to ${replacement}. It is no longer read, ` +
+          `so leaving it set would silently restore the default — which for ` +
+          `INTERNAL_ONLY_ENFORCE means closing a surface an operator meant to ` +
+          `keep open. Rename it wherever it is set: your .env file, and the ` +
+          `${replacement} line in docker-compose.prod.yml.`,
+      );
+    }
+  }
+
   return envSchema.parse(env);
 }

--- a/apps/api/src/federation/did.routes.spec.ts
+++ b/apps/api/src/federation/did.routes.spec.ts
@@ -31,7 +31,7 @@ const testEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,

--- a/apps/api/src/federation/discovery.routes.spec.ts
+++ b/apps/api/src/federation/discovery.routes.spec.ts
@@ -34,7 +34,7 @@ const testEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,

--- a/apps/api/src/federation/hub-admin.routes.ts
+++ b/apps/api/src/federation/hub-admin.routes.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { hubInstanceListQuerySchema } from '@colophony/types';
 import { idParamSchema } from '@colophony/types';
 import type { Env } from '../config/env.js';
+import { guardScope, internalOnly } from '../hooks/fastify-guards.js';
 import {
   hubService,
   HubNotEnabledError,
@@ -9,14 +10,21 @@ import {
 } from '../services/hub.service.js';
 
 /**
- * Hub admin routes — OIDC + ADMIN role required.
+ * Hub admin routes — interactive sessions only, ADMIN role required.
  * Only functional when federation_config.mode = 'managed_hub'.
+ *
+ * Matches the tRPC twin (`hub.*`, all `internalAdminProcedure`). The header used
+ * to claim "OIDC + ADMIN" while nothing checked the auth method; `guardScope`
+ * below is what makes that true.
  */
 export async function registerHubAdminRoutes(
   app: FastifyInstance,
   opts: { env: Env },
 ): Promise<void> {
   const { env } = opts;
+
+  // Runs before the ADMIN check so a key is refused for being a key.
+  guardScope(app, internalOnly);
 
   // preHandler: require ADMIN role
   app.addHook('preHandler', async (request, reply) => {

--- a/apps/api/src/federation/key-admin.routes.ts
+++ b/apps/api/src/federation/key-admin.routes.ts
@@ -8,6 +8,7 @@ import {
   type UserKeyListResponse,
 } from '@colophony/types';
 import type { Env } from '../config/env.js';
+import { guardScope, internalOnly } from '../hooks/fastify-guards.js';
 import {
   federationService,
   NoActiveKeyError,
@@ -18,12 +19,22 @@ import {
  *
  * No ADMIN role requirement — users manage their own DID keys.
  * User-scoped RLS provides isolation for the list endpoint.
+ *
+ * Interactive sessions only (since 2026-07-29). Unlike the other federation
+ * admin modules this has **no tRPC twin**, so the restriction is a deliberate
+ * judgement rather than parity: rotating a user's DID signing key is
+ * account-security critical, and an API key acts as its creator, so a key could
+ * otherwise rotate the key of the human who minted it. The nearest analogue —
+ * migration-admin, the other "user manages their own federation identity"
+ * surface — is `internalAuthedProcedure` on tRPC.
  */
 export async function registerKeyAdminRoutes(
   app: FastifyInstance,
   opts: { env: Env },
 ): Promise<void> {
   const { env } = opts;
+
+  guardScope(app, internalOnly);
 
   /**
    * POST /federation/keys/rotate

--- a/apps/api/src/federation/migration-admin.routes.spec.ts
+++ b/apps/api/src/federation/migration-admin.routes.spec.ts
@@ -49,6 +49,10 @@ vi.mock('../config/env.js', () => ({
   validateEnv: vi.fn().mockReturnValue({
     FEDERATION_ENABLED: true,
     FEDERATION_DOMAIN: 'local.example.com',
+    // internalOnly reads this per request. Omitting it leaves `enforced`
+    // undefined, which is falsy — the guard silently degrades to log-only and an
+    // API-key rejection test passes with a 200.
+    INTERNAL_ONLY_ENFORCE: true,
   }),
 }));
 
@@ -63,6 +67,8 @@ const testEnv = {
 
 describe('migration-admin.routes', () => {
   let app: FastifyInstance;
+  /** Same user, authenticated as an API key rather than a session. */
+  let apiKeyApp: FastifyInstance;
 
   beforeAll(async () => {
     app = Fastify({ logger: false });
@@ -87,6 +93,50 @@ describe('migration-admin.routes', () => {
     });
 
     await app.ready();
+
+    // No applyGuardEnv here: this spec mocks config/env.js wholesale, so the
+    // guard reads INTERNAL_ONLY_ENFORCE from that mock rather than process.env.
+    apiKeyApp = Fastify({ logger: false });
+    apiKeyApp.decorateRequest('authContext', null);
+    apiKeyApp.addHook('preHandler', async (request) => {
+      request.authContext = {
+        userId: testUserId,
+        authMethod: 'apikey' as const,
+        apiKeyId: '00000000-0000-4000-a000-0000000000ff',
+        apiKeyScopes: [],
+        orgId: validUuid2,
+        roles: ['ADMIN'] as const,
+        email: 'admin@local.example.com',
+        emailVerified: true,
+      };
+    });
+    await apiKeyApp.register(async (scope) => {
+      await registerMigrationAdminRoutes(scope, { env: testEnv });
+    });
+    await apiKeyApp.ready();
+  });
+
+  it('rejects an API key on every route', async () => {
+    // These were the laxest routes on the surface before internalOnly: a bare
+    // `if (!request.authContext)` per handler, no role check, so any key with
+    // any scope could approve or cancel a migration as its creator.
+    const calls: Array<['GET' | 'POST', string]> = [
+      ['GET', '/federation/migrations'],
+      ['GET', '/federation/migrations/pending'],
+      ['GET', `/federation/migrations/${validUuid}`],
+      ['POST', '/federation/migrations/request'],
+      ['POST', `/federation/migrations/${validUuid}/approve`],
+      ['POST', `/federation/migrations/${validUuid}/reject`],
+      ['POST', `/federation/migrations/${validUuid}/cancel`],
+    ];
+
+    for (const [method, url] of calls) {
+      const res = await apiKeyApp.inject({ method, url });
+      expect(res.statusCode, `${method} ${url}`).toBe(403);
+      expect(res.json(), `${method} ${url}`).toMatchObject({
+        message: 'This route is not available to API keys',
+      });
+    }
   });
 
   beforeEach(() => {
@@ -95,6 +145,7 @@ describe('migration-admin.routes', () => {
 
   afterAll(async () => {
     await app.close();
+    await apiKeyApp.close();
   });
 
   describe('GET /federation/migrations', () => {

--- a/apps/api/src/federation/migration-admin.routes.ts
+++ b/apps/api/src/federation/migration-admin.routes.ts
@@ -13,17 +13,25 @@ import {
   MigrationAlreadyActiveError,
 } from '../services/migration.service.js';
 import { validateEnv } from '../config/env.js';
+import { guardScope, internalOnly } from '../hooks/fastify-guards.js';
 
 /**
  * Migration management endpoints for authenticated users.
  *
  * No ADMIN role requirement — any authenticated user manages their own migrations.
  * User-scoped RLS provides isolation.
+ *
+ * Interactive sessions only, matching the tRPC twin (`migrations.*`, all
+ * `internalAuthedProcedure`). Without it these were the laxest routes on the
+ * surface: a bare `if (!request.authContext)` per handler, so any key with any
+ * scope could approve or cancel a migration as its creator.
  */
 export async function registerMigrationAdminRoutes(
   app: FastifyInstance,
   _opts: { env: Env },
 ): Promise<void> {
+  guardScope(app, internalOnly);
+
   /**
    * GET /federation/migrations
    *

--- a/apps/api/src/federation/migration.routes.spec.ts
+++ b/apps/api/src/federation/migration.routes.spec.ts
@@ -91,7 +91,7 @@ const testEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,

--- a/apps/api/src/federation/simsub-admin.routes.spec.ts
+++ b/apps/api/src/federation/simsub-admin.routes.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 import type { Env } from '../config/env.js';
+import { applyGuardEnv } from '../__tests__/helpers/guard-env.js';
 
 // Mock withRls and simSubChecks
 const mockWithRls = vi.fn();
@@ -35,7 +36,7 @@ const testEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,
@@ -83,31 +84,96 @@ const validUuid = '00000000-0000-4000-a000-000000000001';
 describe('simsub-admin.routes', () => {
   let app: FastifyInstance;
 
-  beforeAll(async () => {
-    app = Fastify({ logger: false });
+  /** Authenticated interactive session with no ADMIN role. */
+  let nonAdminApp: FastifyInstance;
+  /** Authenticated API key whose creator is an ADMIN. */
+  let apiKeyApp: FastifyInstance;
 
-    // Simulate auth context on requests
-    app.decorateRequest('authContext', null);
-
+  async function buildApp(
+    authContext: Record<string, unknown> | null,
+  ): Promise<FastifyInstance> {
+    const instance = Fastify({ logger: false });
+    instance.decorateRequest('authContext', null);
+    // Registered before the routes so it runs before their guards, standing in
+    // for the real auth + org-context hooks.
+    instance.addHook('preHandler', async (request) => {
+      request.authContext = authContext as never;
+    });
     const { registerSimSubAdminRoutes } =
       await import('./simsub-admin.routes.js');
-    await registerSimSubAdminRoutes(app, { env: testEnv });
-    await app.ready();
+    await registerSimSubAdminRoutes(instance, { env: testEnv });
+    await instance.ready();
+    return instance;
+  }
+
+  let restoreEnv: () => void;
+
+  beforeAll(async () => {
+    // internalOnly reads INTERNAL_ONLY_ENFORCE out of process.env per request.
+    restoreEnv = applyGuardEnv({ INTERNAL_ONLY_ENFORCE: 'true' });
+
+    // Unauthenticated.
+    app = await buildApp(null);
+
+    nonAdminApp = await buildApp({
+      userId: 'editor-user',
+      orgId: 'org-1',
+      roles: ['EDITOR'],
+      authMethod: 'oidc',
+    });
+
+    // An API key carries its creator's roles, so ADMIN here is realistic — it is
+    // exactly why the role check alone was insufficient.
+    apiKeyApp = await buildApp({
+      userId: 'admin-user',
+      orgId: 'org-1',
+      roles: ['ADMIN'],
+      authMethod: 'apikey',
+      apiKeyId: '00000000-0000-4000-a000-0000000000ff',
+      apiKeyScopes: ['simsub-groups:read', 'simsub-groups:write'],
+    });
   });
 
   afterAll(async () => {
-    await app.close();
+    await Promise.all([app.close(), nonAdminApp.close(), apiKeyApp.close()]);
+    restoreEnv();
   });
 
   describe('GET /federation/sim-sub/checks/:submissionId', () => {
-    it('returns 403 for non-admin', async () => {
+    it('returns 401 when unauthenticated', async () => {
       const res = await app.inject({
         method: 'GET',
         url: `/federation/sim-sub/checks/${validUuid}`,
         headers: {},
       });
 
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('returns 403 for non-admin', async () => {
+      const res = await nonAdminApp.inject({
+        method: 'GET',
+        url: `/federation/sim-sub/checks/${validUuid}`,
+      });
+
       expect(res.statusCode).toBe(403);
+      expect(res.json()).toMatchObject({ message: 'ADMIN role required' });
+    });
+
+    it('rejects an API key even when its creator is an ADMIN', async () => {
+      // The role check alone admits this caller: org-context resolves roles from
+      // organization_members by user id regardless of auth method, and a key
+      // carries its creator's id. internalOnly is what closes it.
+      const res = await apiKeyApp.inject({
+        method: 'GET',
+        url: `/federation/sim-sub/checks/${validUuid}`,
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(res.json()).toMatchObject({
+        error: 'forbidden',
+        message: 'This route is not available to API keys',
+      });
     });
 
     it('returns check history for submission', async () => {
@@ -162,13 +228,35 @@ describe('simsub-admin.routes', () => {
   });
 
   describe('POST /federation/sim-sub/override/:submissionId', () => {
-    it('returns 403 for non-admin', async () => {
+    it('returns 401 when unauthenticated', async () => {
       const res = await app.inject({
         method: 'POST',
         url: `/federation/sim-sub/override/${validUuid}`,
       });
 
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('returns 403 for non-admin', async () => {
+      const res = await nonAdminApp.inject({
+        method: 'POST',
+        url: `/federation/sim-sub/override/${validUuid}`,
+      });
+
       expect(res.statusCode).toBe(403);
+      expect(res.json()).toMatchObject({ message: 'ADMIN role required' });
+    });
+
+    it('rejects an API key even when its creator is an ADMIN', async () => {
+      const res = await apiKeyApp.inject({
+        method: 'POST',
+        url: `/federation/sim-sub/override/${validUuid}`,
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(res.json()).toMatchObject({
+        message: 'This route is not available to API keys',
+      });
     });
 
     it('grants override and returns success', async () => {

--- a/apps/api/src/federation/simsub-admin.routes.ts
+++ b/apps/api/src/federation/simsub-admin.routes.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance } from 'fastify';
 import { withRls, simSubChecks, eq } from '@colophony/db';
 import { desc } from 'drizzle-orm';
 import type { Env } from '../config/env.js';
+import { guardScope, internalOnly } from '../hooks/fastify-guards.js';
 import { simsubService } from '../services/simsub.service.js';
 
 const submissionIdParamSchema = z.object({
@@ -11,12 +12,18 @@ const submissionIdParamSchema = z.object({
 
 /**
  * Admin sim-sub management endpoints.
- * Behind normal auth hook chain — requires authenticated user with ADMIN role.
+ * Behind normal auth hook chain — interactive sessions only, ADMIN role.
+ *
+ * Matches the tRPC twin (`simsub.*`, all `internalAdminProcedure`). The ADMIN
+ * check alone would admit a key minted by an admin — see trust-admin.routes.ts.
  */
 export async function registerSimSubAdminRoutes(
   app: FastifyInstance,
   _opts: { env: Env },
 ): Promise<void> {
+  // Runs before the ADMIN check so a key is refused for being a key.
+  guardScope(app, internalOnly);
+
   // preHandler: require ADMIN role
   app.addHook('preHandler', async (request, reply) => {
     if (!request.authContext?.roles?.includes('ADMIN')) {

--- a/apps/api/src/federation/simsub.routes.spec.ts
+++ b/apps/api/src/federation/simsub.routes.spec.ts
@@ -45,7 +45,7 @@ const testEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,

--- a/apps/api/src/federation/transfer-admin.routes.spec.ts
+++ b/apps/api/src/federation/transfer-admin.routes.spec.ts
@@ -9,6 +9,7 @@ import {
 } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 import type { Env } from '../config/env.js';
+import { applyGuardEnv } from '../__tests__/helpers/guard-env.js';
 
 // Mock transfer service
 const mockListTransfersForOrg = vi.fn();
@@ -40,7 +41,7 @@ const testEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,
@@ -113,6 +114,18 @@ describe('transfer-admin.routes', () => {
     authMethod: 'oidc' as const,
   };
 
+  const apiKeyAuthContext = {
+    userId: validUuid,
+    orgId: validUuid,
+    roles: ['ADMIN'] as const,
+    authMethod: 'apikey' as const,
+    apiKeyId: '00000000-0000-4000-a000-0000000000ff',
+    apiKeyScopes: [] as string[],
+  };
+
+  let apiKeyApp: FastifyInstance;
+  let restoreEnv: () => void;
+
   beforeAll(async () => {
     adminApp = buildApp(adminAuthContext);
     const { registerTransferAdminRoutes } =
@@ -127,6 +140,13 @@ describe('transfer-admin.routes', () => {
       await registerTransferAdminRoutes(scope, { env: testEnv });
     });
     await readerApp.ready();
+
+    restoreEnv = applyGuardEnv({ INTERNAL_ONLY_ENFORCE: 'true' });
+    apiKeyApp = buildApp(apiKeyAuthContext);
+    await apiKeyApp.register(async (scope) => {
+      await registerTransferAdminRoutes(scope, { env: testEnv });
+    });
+    await apiKeyApp.ready();
   });
 
   beforeEach(() => {
@@ -136,6 +156,26 @@ describe('transfer-admin.routes', () => {
   afterAll(async () => {
     await adminApp.close();
     await readerApp.close();
+    await apiKeyApp.close();
+    restoreEnv();
+  });
+
+  it('rejects an API key on every route, even with an ADMIN creator', async () => {
+    // A key carries its creator's roles, so the ADMIN preHandler admits it.
+    // internalOnly is what closes these routes to keys, matching the tRPC twin.
+    const calls: Array<[string, string]> = [
+      ['GET', '/federation/transfers'],
+      ['GET', `/federation/transfers/${validUuid}`],
+      ['POST', `/federation/transfers/${validUuid}/cancel`],
+    ];
+
+    for (const [method, url] of calls) {
+      const res = await apiKeyApp.inject({ method: method as 'GET', url });
+      expect(res.statusCode, `${method} ${url}`).toBe(403);
+      expect(res.json(), `${method} ${url}`).toMatchObject({
+        message: 'This route is not available to API keys',
+      });
+    }
   });
 
   // ─── GET /federation/transfers ───

--- a/apps/api/src/federation/transfer-admin.routes.ts
+++ b/apps/api/src/federation/transfer-admin.routes.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { FastifyInstance } from 'fastify';
 import { transferListQuerySchema } from '@colophony/types';
 import type { Env } from '../config/env.js';
+import { guardScope, internalOnly } from '../hooks/fastify-guards.js';
 import {
   transferService,
   TransferNotFoundError,
@@ -10,12 +11,18 @@ import {
 
 /**
  * Admin transfer management endpoints.
- * Behind normal auth hook chain — requires authenticated user with ADMIN role.
+ * Behind normal auth hook chain — interactive sessions only, ADMIN role.
+ *
+ * Matches the tRPC twin (`transfers.*`, all `internalAdminProcedure`). The ADMIN
+ * check alone would admit a key minted by an admin — see trust-admin.routes.ts.
  */
 export async function registerTransferAdminRoutes(
   app: FastifyInstance,
   _opts: { env: Env },
 ): Promise<void> {
+  // Runs before the ADMIN check so a key is refused for being a key.
+  guardScope(app, internalOnly);
+
   // preHandler: require ADMIN role
   app.addHook('preHandler', async (request, reply) => {
     if (!request.authContext?.roles?.includes('ADMIN')) {

--- a/apps/api/src/federation/transfer.routes.spec.ts
+++ b/apps/api/src/federation/transfer.routes.spec.ts
@@ -71,7 +71,7 @@ const testEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,

--- a/apps/api/src/federation/trust-admin.routes.spec.ts
+++ b/apps/api/src/federation/trust-admin.routes.spec.ts
@@ -9,6 +9,7 @@ import {
 } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 import type { Env } from '../config/env.js';
+import { applyGuardEnv } from '../__tests__/helpers/guard-env.js';
 
 // Mock trust service
 const mockFetchRemoteMetadata = vi.fn();
@@ -64,7 +65,7 @@ const testEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,
@@ -141,6 +142,9 @@ const sampleMetadataPreview = {
 
 describe('trust-admin.routes', () => {
   let app: FastifyInstance;
+  /** Same ADMIN roles, but authenticated as an API key. */
+  let apiKeyApp: FastifyInstance;
+  let restoreEnv: () => void;
 
   beforeAll(async () => {
     const { registerFederationTrustAdminRoutes } =
@@ -162,10 +166,53 @@ describe('trust-admin.routes', () => {
 
     await registerFederationTrustAdminRoutes(app, { env: testEnv });
     await app.ready();
+
+    restoreEnv = applyGuardEnv({ INTERNAL_ONLY_ENFORCE: 'true' });
+    apiKeyApp = Fastify({ logger: false });
+    apiKeyApp.decorateRequest('authContext', null);
+    apiKeyApp.addHook('onRequest', async (request) => {
+      request.authContext = {
+        userId: testUserId,
+        email: 'admin@test.com',
+        emailVerified: true,
+        authMethod: 'apikey',
+        apiKeyId: '00000000-0000-4000-a000-0000000000ff',
+        apiKeyScopes: [],
+        orgId: testOrgId,
+        roles: ['ADMIN'],
+      } as any;
+    });
+    await registerFederationTrustAdminRoutes(apiKeyApp, { env: testEnv });
+    await apiKeyApp.ready();
   });
 
   afterAll(async () => {
     await app.close();
+    await apiKeyApp.close();
+    restoreEnv();
+  });
+
+  it('rejects an API key on every route, even with an ADMIN creator', async () => {
+    // The ADMIN preHandler admits a key minted by an admin, because org-context
+    // resolves roles by user id regardless of auth method. internalOnly closes
+    // it, matching the tRPC twin (`federation.*` is internalAdminProcedure).
+    const calls: Array<['GET' | 'POST', string]> = [
+      ['GET', '/federation/metadata/peer.example.com'],
+      ['GET', '/federation/peers'],
+      ['GET', `/federation/peers/${testPeerId}`],
+      ['POST', '/federation/peers/initiate'],
+      ['POST', `/federation/peers/${testPeerId}/accept`],
+      ['POST', `/federation/peers/${testPeerId}/reject`],
+      ['POST', `/federation/peers/${testPeerId}/revoke`],
+    ];
+
+    for (const [method, url] of calls) {
+      const res = await apiKeyApp.inject({ method, url });
+      expect(res.statusCode, `${method} ${url}`).toBe(403);
+      expect(res.json(), `${method} ${url}`).toMatchObject({
+        message: 'This route is not available to API keys',
+      });
+    }
   });
 
   beforeEach(() => {

--- a/apps/api/src/federation/trust-admin.routes.ts
+++ b/apps/api/src/federation/trust-admin.routes.ts
@@ -6,6 +6,7 @@ import {
   idParamSchema,
 } from '@colophony/types';
 import type { Env } from '../config/env.js';
+import { guardScope, internalOnly } from '../hooks/fastify-guards.js';
 import {
   trustService,
   TrustPeerNotFoundError,
@@ -16,13 +17,23 @@ import {
 
 /**
  * Admin federation trust management endpoints.
- * Behind normal auth hook chain — requires authenticated user with ADMIN role.
+ * Behind normal auth hook chain — interactive sessions only, ADMIN role.
+ *
+ * Matches the tRPC twin (`federation.*`, all `internalAdminProcedure`). The ADMIN
+ * check below is not sufficient on its own: `org-context` resolves roles from
+ * `organization_members` by user id regardless of auth method, and an API key
+ * carries its creator's user id, so a key minted by an admin arrives with
+ * `roles: ['ADMIN']`.
  */
 export async function registerFederationTrustAdminRoutes(
   app: FastifyInstance,
   opts: { env: Env },
 ): Promise<void> {
   const { env } = opts;
+
+  // Runs before the ADMIN check below, so a key is refused for being a key
+  // rather than incidentally on its role — the audit should say which.
+  guardScope(app, internalOnly);
 
   // preHandler: require ADMIN role
   app.addHook('preHandler', async (request, reply) => {

--- a/apps/api/src/federation/trust.routes.spec.ts
+++ b/apps/api/src/federation/trust.routes.spec.ts
@@ -29,7 +29,7 @@ const testEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,

--- a/apps/api/src/hooks/auth.spec.ts
+++ b/apps/api/src/hooks/auth.spec.ts
@@ -88,7 +88,7 @@ const baseEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,

--- a/apps/api/src/hooks/auth.ts
+++ b/apps/api/src/hooks/auth.ts
@@ -49,7 +49,14 @@ const PUBLIC_EXACT = [
   '/v1/docs',
 ];
 
-function isPublicRoute(url: string): boolean {
+/**
+ * Whether a route is reachable without any credential.
+ *
+ * Exported so `fastify-guard-coverage.spec.ts` exempts exactly the routes this
+ * hook lets through, rather than maintaining a second copy of the allowlist that
+ * could drift from it.
+ */
+export function isPublicRoute(url: string): boolean {
   const path = url.split('?')[0].replace(/\/+$/, '') || '/';
   if (PUBLIC_EXACT.includes(path)) return true;
   if (PUBLIC_PREFIXES.some((prefix) => path.startsWith(prefix))) return true;

--- a/apps/api/src/hooks/fastify-guard-coverage.spec.ts
+++ b/apps/api/src/hooks/fastify-guard-coverage.spec.ts
@@ -1,0 +1,439 @@
+/**
+ * Guard coverage across the hand-rolled Fastify surface.
+ *
+ * The third sibling of `rest/guard-coverage.spec.ts` and
+ * `trpc/guard-coverage.spec.ts`. `X-Api-Key` is accepted on every non-public
+ * route regardless of which surface serves it, and until 2026-07-29 not one
+ * Fastify route declared a scope or an internal-only guard — `/federation/keys/*`
+ * and `/federation/migrations*` had only a bare `if (!request.authContext)`
+ * check, and the four admin modules gated on an ADMIN role that a key minted by
+ * an admin satisfies. This is the check that stops the next one appearing.
+ *
+ * Two structural differences from the sibling gates:
+ *
+ *  1. There is no built router object to walk. Routes are collected by
+ *     registering each module into a bare instance under a root `onRoute` hook,
+ *     which fires for child plugin scopes too.
+ *  2. A guard can be declared at route level (`preHandler`) or scope level
+ *     (`guardScope`). Fastify's `onRoute` exposes only a route's own
+ *     `preHandler`, so scope-level guards arrive via `config.guardTags`.
+ *
+ * **Why there is no "the guard actually rejects" test here.** That property is
+ * proved by decomposition in `fastify-guards.spec.ts`: `guardScope` installs
+ * exactly the functions it tags (and throws on an untagged one), and
+ * `internalOnly` / `requireScopes` reject when installed. This suite asserts the
+ * remaining link — that every non-public route declares something. Asserting
+ * rejection here would mean mocking every service behind 30-odd routes to
+ * exercise middleware that never reaches them.
+ *
+ * Introspection only — no handler is invoked and no service is mocked.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import Fastify, { type FastifyInstance, type RouteOptions } from 'fastify';
+import { readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { apiKeyScopeSchema } from '@colophony/types';
+
+import { validateEnv, type Env } from '../config/env.js';
+import { isPublicRoute } from './auth.js';
+import type { GuardTag } from '../services/scope-check.js';
+import { readGuardTags } from '../services/scope-check.js';
+
+import { registerEmbedRoutes } from '../routes/embed.routes.js';
+import { registerPublicRoutes } from '../routes/public.routes.js';
+import { registerNotificationStreamRoute } from '../sse/notification-stream.js';
+import { registerInngestRoutes } from '../inngest/serve.js';
+import { registerWebhookHealthRoute } from '../webhooks/webhook-health.route.js';
+import { registerZitadelWebhooks } from '../webhooks/zitadel.webhook.js';
+import { registerStripeWebhooks } from '../webhooks/stripe.webhook.js';
+import { registerTusdWebhooks } from '../webhooks/tusd.webhook.js';
+import { registerDocumensoWebhooks } from '../webhooks/documenso.webhook.js';
+import { registerFederationDidRoutes } from '../federation/did.routes.js';
+import { registerFederationDiscoveryRoutes } from '../federation/discovery.routes.js';
+import { registerFederationTrustRoutes } from '../federation/trust.routes.js';
+import { registerFederationTrustAdminRoutes } from '../federation/trust-admin.routes.js';
+import { registerSimSubRoutes } from '../federation/simsub.routes.js';
+import { registerSimSubAdminRoutes } from '../federation/simsub-admin.routes.js';
+import { registerTransferRoutes } from '../federation/transfer.routes.js';
+import { registerTransferAdminRoutes } from '../federation/transfer-admin.routes.js';
+import { registerMigrationRoutes } from '../federation/migration.routes.js';
+import { registerMigrationAdminRoutes } from '../federation/migration-admin.routes.js';
+import { registerHubRoutes } from '../federation/hub.routes.js';
+import { registerHubAdminRoutes } from '../federation/hub-admin.routes.js';
+import { registerKeyAdminRoutes } from '../federation/key-admin.routes.js';
+
+/**
+ * Routes that deliberately declare no guard.
+ *
+ * Empty, and worth keeping that way. Every entry would be callable by any API key
+ * holding any scope, so a reason must explain why the operation is safe
+ * unconstrained — not merely why it currently lacks a guard. Public routes do not
+ * belong here; they are exempted by `isPublicRoute` instead.
+ */
+const UNGUARDED_ROUTES: Record<string, string> = {};
+
+const env: Env = validateEnv({
+  DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+  NODE_ENV: 'test',
+  LOG_LEVEL: 'fatal',
+  FEDERATION_ENABLED: 'true',
+  FEDERATION_DOMAIN: 'local.example.com',
+  DEMO_MODE: 'true',
+});
+
+/**
+ * Every module that registers routes directly on Fastify.
+ *
+ * `file` is the path relative to `apps/api/src`, and the parity test below checks
+ * this list against the filesystem — a new route module that is not registered
+ * here would otherwise be exempt from the whole gate without anyone noticing.
+ */
+const MODULES: Array<{
+  file: string;
+  register: (app: FastifyInstance) => Promise<void>;
+}> = [
+  {
+    file: 'routes/embed.routes.ts',
+    register: (app) => registerEmbedRoutes(app, { env }),
+  },
+  {
+    file: 'routes/public.routes.ts',
+    register: (app) => registerPublicRoutes(app, { env }),
+  },
+  {
+    file: 'sse/notification-stream.ts',
+    register: (app) => registerNotificationStreamRoute(app, { env }),
+  },
+  { file: 'inngest/serve.ts', register: (app) => registerInngestRoutes(app) },
+  {
+    file: 'webhooks/webhook-health.route.ts',
+    register: (app) => registerWebhookHealthRoute(app, { env }),
+  },
+  {
+    file: 'webhooks/zitadel.webhook.ts',
+    register: (app) => registerZitadelWebhooks(app, { env }),
+  },
+  {
+    file: 'webhooks/stripe.webhook.ts',
+    register: (app) => registerStripeWebhooks(app, { env }),
+  },
+  {
+    file: 'webhooks/tusd.webhook.ts',
+    register: (app) => registerTusdWebhooks(app, { env }),
+  },
+  {
+    file: 'webhooks/documenso.webhook.ts',
+    register: (app) => registerDocumensoWebhooks(app, { env }),
+  },
+  {
+    file: 'federation/did.routes.ts',
+    register: (app) => registerFederationDidRoutes(app, { env }),
+  },
+  {
+    file: 'federation/discovery.routes.ts',
+    register: (app) => registerFederationDiscoveryRoutes(app, { env }),
+  },
+  {
+    file: 'federation/trust.routes.ts',
+    register: (app) => registerFederationTrustRoutes(app, { env }),
+  },
+  {
+    file: 'federation/trust-admin.routes.ts',
+    register: (app) => registerFederationTrustAdminRoutes(app, { env }),
+  },
+  {
+    file: 'federation/simsub.routes.ts',
+    register: (app) => registerSimSubRoutes(app, { env }),
+  },
+  {
+    file: 'federation/simsub-admin.routes.ts',
+    register: (app) => registerSimSubAdminRoutes(app, { env }),
+  },
+  {
+    file: 'federation/transfer.routes.ts',
+    register: (app) => registerTransferRoutes(app, { env }),
+  },
+  {
+    file: 'federation/transfer-admin.routes.ts',
+    register: (app) => registerTransferAdminRoutes(app, { env }),
+  },
+  {
+    file: 'federation/migration.routes.ts',
+    register: (app) => registerMigrationRoutes(app, { env }),
+  },
+  {
+    file: 'federation/migration-admin.routes.ts',
+    register: (app) => registerMigrationAdminRoutes(app, { env }),
+  },
+  {
+    file: 'federation/hub.routes.ts',
+    register: (app) => registerHubRoutes(app, { env }),
+  },
+  {
+    file: 'federation/hub-admin.routes.ts',
+    register: (app) => registerHubAdminRoutes(app, { env }),
+  },
+  {
+    file: 'federation/key-admin.routes.ts',
+    register: (app) => registerKeyAdminRoutes(app, { env }),
+  },
+];
+
+/**
+ * Routes registered inline in `main.ts` rather than in a module.
+ *
+ * All four are in the auth hook's public allowlist, so they would be exempt
+ * anyway; they are listed so the parity test's accounting is complete and a
+ * future non-public inline route is a visible omission rather than an invisible
+ * one.
+ */
+const MAIN_TS_INLINE_ROUTES = ['/health', '/ready', '/', '/metrics'];
+
+interface RouteEntry {
+  method: string;
+  url: string;
+  guards: GuardTag[];
+  label: string;
+}
+
+/**
+ * One bare instance per module, rather than one shared instance.
+ *
+ * Several modules register `@fastify/cors` themselves, and two of them on one
+ * instance collide on `OPTIONS *` with `FST_ERR_DUPLICATED_ROUTE`. Separate
+ * instances also mean a scope-level hook from one module provably cannot be
+ * counted toward another's routes — the isolation is structural rather than
+ * something this file has to be careful about.
+ */
+async function collectRoutes(): Promise<RouteEntry[]> {
+  const collected: RouteEntry[] = [];
+
+  for (const mod of MODULES) {
+    const app = Fastify({ logger: false });
+    const seen: RouteOptions[] = [];
+
+    // Capture the routeOptions object and read its guards only after ready().
+    //
+    // Reading `config` inside this hook would find it empty: Fastify runs
+    // onRoute hooks in registration order, this one is registered before the
+    // module, and `guardScope`'s own onRoute hook is what writes `config`. So
+    // the reference is captured now and dereferenced later — `guardScope`
+    // mutates this same object.
+    app.addHook('onRoute', (routeOptions: RouteOptions) => {
+      seen.push(routeOptions);
+    });
+
+    // Some modules expect the decorators the real hook chain provides.
+    app.decorateRequest('authContext', null);
+
+    try {
+      await mod.register(app);
+      await app.ready();
+    } catch (error) {
+      throw new Error(
+        `Failed to register ${mod.file} for guard coverage: ${String(error)}`,
+        { cause: error },
+      );
+    } finally {
+      await app.close();
+    }
+
+    for (const routeOptions of seen) {
+      const methods = Array.isArray(routeOptions.method)
+        ? routeOptions.method
+        : [routeOptions.method];
+
+      const routeLevel = Array.isArray(routeOptions.preHandler)
+        ? routeOptions.preHandler
+        : routeOptions.preHandler
+          ? [routeOptions.preHandler]
+          : [];
+
+      const guards = [
+        ...(routeOptions.config?.guardTags ?? []),
+        ...readGuardTags(routeLevel),
+      ];
+
+      for (const method of methods) {
+        collected.push({
+          method,
+          url: routeOptions.url,
+          guards,
+          label: `${method} ${routeOptions.url}`,
+        });
+      }
+    }
+  }
+
+  return collected.filter(
+    (route) =>
+      // Synthesised by Fastify from GET; inherits its guards.
+      route.method !== 'HEAD' &&
+      // The `OPTIONS *` wildcard is @fastify/cors's preflight responder, not an
+      // API operation: it carries no credentials, reads nothing, and returns
+      // only CORS headers. Registered by whichever modules enable cors.
+      !(route.method === 'OPTIONS' && route.url === '*'),
+  );
+}
+
+/**
+ * Locate `apps/api/src` without `import.meta`, which `tsc --noEmit` rejects for
+ * this package's CommonJS-targeted config. Handles being run with the cwd at
+ * either `apps/api` (vitest's default root) or the repo root.
+ */
+function resolveSrcDir(): string {
+  const candidates = [
+    join(process.cwd(), 'src'),
+    join(process.cwd(), 'apps', 'api', 'src'),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(join(candidate, 'hooks'))) return candidate;
+  }
+
+  throw new Error(
+    `Could not locate apps/api/src from cwd ${process.cwd()} — tried:\n` +
+      candidates.map((c) => `  - ${c}`).join('\n'),
+  );
+}
+
+let routes: RouteEntry[];
+let guardable: RouteEntry[];
+
+describe('Fastify guard coverage', () => {
+  beforeAll(async () => {
+    routes = await collectRoutes();
+    guardable = routes.filter((route) => !isPublicRoute(route.url));
+  });
+
+  it('collects a plausible number of routes', () => {
+    // Guards against the whole suite passing vacuously because a Fastify change
+    // stopped `onRoute` firing, or because a registration silently no-oped.
+    // 60 routes across 22 modules today.
+    expect(routes.length).toBeGreaterThan(45);
+  });
+
+  it('finds routes that actually need a guard', () => {
+    // The companion canary: if `isPublicRoute` ever matched everything, the
+    // coverage assertion below would iterate an empty list and pass.
+    expect(guardable.length).toBeGreaterThan(20);
+  });
+
+  it('registers every hand-rolled route module', () => {
+    // A new module that nobody adds to MODULES is exempt from this entire gate.
+    // Globbing the filesystem is what makes that a failure rather than a gap.
+    const srcDir = resolveSrcDir();
+
+    const discovered = ['routes', 'federation', 'webhooks', 'sse', 'inngest']
+      .flatMap((dir) =>
+        readdirSync(join(srcDir, dir)).map((name) => `${dir}/${name}`),
+      )
+      .filter(
+        (file) =>
+          (file.endsWith('.routes.ts') ||
+            file.endsWith('.webhook.ts') ||
+            file.endsWith('.route.ts') ||
+            file.endsWith('serve.ts') ||
+            file.endsWith('notification-stream.ts')) &&
+          !file.endsWith('.spec.ts') &&
+          !file.endsWith('.test.ts'),
+      );
+
+    const registered = new Set(MODULES.map((m) => m.file));
+    const missing = discovered.filter((file) => !registered.has(file)).sort();
+
+    expect(
+      missing,
+      missing.length === 0
+        ? ''
+        : `These route modules are not registered in MODULES, so no guard ` +
+            `assertion in this file applies to them:\n\n` +
+            missing.map((f) => `  - ${f}`).join('\n') +
+            `\n\nAdd each to MODULES. If a file genuinely registers no route, ` +
+            `it should not match the route-module naming conventions.`,
+    ).toEqual([]);
+  });
+
+  it('every non-public route declares a guard', () => {
+    const offenders = guardable
+      .filter((route) => route.guards.length === 0)
+      .filter((route) => !(route.label in UNGUARDED_ROUTES))
+      .map((route) => route.label)
+      .sort();
+
+    expect(
+      offenders,
+      offenders.length === 0
+        ? ''
+        : `These Fastify routes declare no guard, so any API key with any ` +
+            `scope can call them:\n\n` +
+            offenders.map((r) => `  - ${r}`).join('\n') +
+            `\n\nAdd a route-level preHandler: [requireScopes('<scope>')], or ` +
+            `guardScope(app, internalOnly) at the top of the module if the ` +
+            `operation belongs to interactive sessions only. If the operation ` +
+            `genuinely needs no guard, add it to UNGUARDED_ROUTES with a reason.`,
+    ).toEqual([]);
+  });
+
+  it('no route declares an empty scope list', () => {
+    // requireScopes() with no arguments passes [] to checkApiKeyScopes, whose
+    // `missing.length === 0` check then allows everything. A vacuous guard reads
+    // exactly like a real one at the call site.
+    const vacuous = routes
+      .filter((route) =>
+        route.guards.some(
+          (guard) => guard.kind === 'scopes' && guard.scopes.length === 0,
+        ),
+      )
+      .map((route) => route.label)
+      .sort();
+
+    expect(vacuous).toEqual([]);
+  });
+
+  it('scope guards name only scopes defined in apiKeyScopeSchema', () => {
+    // A typo'd scope denies silently and permanently — no key can ever hold a
+    // scope that is not in the enum.
+    const unknown = routes
+      .flatMap((route) =>
+        route.guards
+          .filter((guard) => guard.kind === 'scopes')
+          .flatMap((guard) => guard.scopes)
+          .filter((scope) => !apiKeyScopeSchema.safeParse(scope).success)
+          .map((scope) => `${route.label} -> ${scope}`),
+      )
+      .sort();
+
+    expect(unknown).toEqual([]);
+  });
+
+  it('every UNGUARDED_ROUTES entry still exists and is still unguarded', () => {
+    // Reverse staleness: an allowlist entry that has since been guarded, or
+    // deleted, should be removed rather than left implying an exemption is
+    // still in force.
+    const byLabel = new Map(routes.map((route) => [route.label, route]));
+
+    const stale = Object.keys(UNGUARDED_ROUTES)
+      .map((label) => {
+        const route = byLabel.get(label);
+        if (!route) return `${label} (no longer exists — remove this entry)`;
+        if (route.guards.length > 0)
+          return `${label} (now declares a guard — remove this entry)`;
+        return null;
+      })
+      .filter((problem): problem is string => problem !== null)
+      .sort();
+
+    expect(stale).toEqual([]);
+  });
+
+  it('the inline main.ts routes are all public', () => {
+    // These are not in MODULES, so nothing above covers them. If one ever stops
+    // being public it needs a guard and a home in a real module.
+    const nonPublic = MAIN_TS_INLINE_ROUTES.filter(
+      (url) => !isPublicRoute(url),
+    ).sort();
+
+    expect(nonPublic).toEqual([]);
+  });
+});

--- a/apps/api/src/hooks/fastify-guards.spec.ts
+++ b/apps/api/src/hooks/fastify-guards.spec.ts
@@ -1,0 +1,479 @@
+/**
+ * Unit tests for the Fastify API key guards.
+ *
+ * These carry the behavioural half of the surface's coverage guarantee.
+ * `fastify-guard-coverage.spec.ts` proves every non-public route *declares* a
+ * guard; this file proves a declared guard *rejects*, and that `guardScope`
+ * installs exactly the functions it declares. The two together are what make the
+ * gate meaningful — a declaration test alone would pass unchanged if these guards
+ * stopped denying anything.
+ */
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+} from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+import { requireScopes, internalOnly, guardScope } from './fastify-guards.js';
+import { readGuardTags, markGuard } from '../services/scope-check.js';
+import { applyGuardEnv } from '../__tests__/helpers/guard-env.js';
+
+const mockWithRls = vi.fn();
+vi.mock('@colophony/db', () => ({
+  withRls: (...args: unknown[]) => mockWithRls(...args),
+}));
+
+const mockAuditLog = vi.fn();
+vi.mock('../services/audit.service.js', () => ({
+  auditService: {
+    log: (...args: unknown[]) => mockAuditLog(...args),
+  },
+}));
+
+const apiKeyContext = {
+  userId: '00000000-0000-4000-a000-000000000001',
+  email: 'key@example.com',
+  emailVerified: true,
+  authMethod: 'apikey' as const,
+  apiKeyId: '00000000-0000-4000-a000-0000000000ff',
+  apiKeyScopes: ['notifications:read'],
+  orgId: '00000000-0000-4000-a000-000000000010',
+  roles: ['ADMIN'],
+};
+
+const oidcContext = {
+  ...apiKeyContext,
+  authMethod: 'oidc' as const,
+  apiKeyId: undefined,
+  apiKeyScopes: undefined,
+};
+
+/**
+ * Build an app whose one route carries the given guards, standing in for the
+ * auth/org-context/db-context/audit hooks the real chain provides.
+ */
+async function buildApp(options: {
+  authContext: Record<string, unknown> | null;
+  guards?: Parameters<typeof guardScope>[1][];
+  scopeGuards?: Parameters<typeof guardScope>[1][];
+  withTransaction?: boolean;
+}): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.decorateRequest('authContext', null);
+  app.decorateRequest('dbTx', null);
+  app.decorateRequest('audit', async () => {});
+
+  app.addHook('preHandler', async (request) => {
+    request.authContext = options.authContext as never;
+    if (options.withTransaction) {
+      request.dbTx = {} as never;
+      request.audit = mockRequestAudit as never;
+    }
+  });
+
+  if (options.scopeGuards) {
+    guardScope(app, ...options.scopeGuards);
+  }
+
+  app.get(
+    '/probe',
+    options.guards ? { preHandler: options.guards } : {},
+    async () => ({ ok: true }),
+  );
+
+  await app.ready();
+  return app;
+}
+
+const mockRequestAudit = vi.fn();
+
+describe('fastify-guards', () => {
+  let restoreEnv: () => void;
+
+  beforeAll(() => {
+    restoreEnv = applyGuardEnv({ INTERNAL_ONLY_ENFORCE: 'true' });
+  });
+
+  afterAll(() => {
+    restoreEnv();
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // withRls runs its callback against a stub transaction by default.
+    mockWithRls.mockImplementation(
+      async (_ctx: unknown, fn: (tx: unknown) => Promise<unknown>) =>
+        fn({ execute: vi.fn() }),
+    );
+  });
+
+  afterEach(() => {
+    delete process.env.INTERNAL_ONLY_ENFORCE;
+    process.env.INTERNAL_ONLY_ENFORCE = 'true';
+  });
+
+  describe('requireScopes', () => {
+    it('is tagged so the coverage gate can see it', () => {
+      const guard = requireScopes('notifications:read');
+      expect(readGuardTags([guard])).toEqual([
+        { kind: 'scopes', scopes: ['notifications:read'] },
+      ]);
+    });
+
+    it('mints a distinct closure per call', () => {
+      // Why tagging is necessary at all: guards are not identifiable by
+      // reference, so the gate cannot compare against a known function.
+      expect(requireScopes('notifications:read')).not.toBe(
+        requireScopes('notifications:read'),
+      );
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+      const app = await buildApp({
+        authContext: null,
+        guards: [requireScopes('notifications:read')],
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/probe' });
+      expect(res.statusCode).toBe(401);
+      await app.close();
+    });
+
+    it('allows a key holding the scope', async () => {
+      const app = await buildApp({
+        authContext: apiKeyContext,
+        guards: [requireScopes('notifications:read')],
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/probe' });
+      expect(res.statusCode).toBe(200);
+      await app.close();
+    });
+
+    it('denies a key missing the scope with a machine-readable body', async () => {
+      const app = await buildApp({
+        authContext: apiKeyContext,
+        guards: [requireScopes('notifications:write')],
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/probe' });
+      expect(res.statusCode).toBe(403);
+      expect(res.json()).toMatchObject({
+        error: 'insufficient_scope',
+        required: ['notifications:write'],
+        missing: ['notifications:write'],
+      });
+      await app.close();
+    });
+
+    it('bypasses the check for an interactive session', async () => {
+      // Scopes are API-key-only, which is why adding a guard to a route cannot
+      // break the web app or Playwright E2E.
+      const app = await buildApp({
+        authContext: oidcContext,
+        guards: [requireScopes('notifications:write')],
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/probe' });
+      expect(res.statusCode).toBe(200);
+      await app.close();
+    });
+
+    it('reports every missing scope, not just the first', async () => {
+      const app = await buildApp({
+        authContext: apiKeyContext,
+        guards: [requireScopes('notifications:write', 'webhooks:manage')],
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/probe' });
+      expect(res.json().missing).toEqual([
+        'notifications:write',
+        'webhooks:manage',
+      ]);
+      await app.close();
+    });
+  });
+
+  describe('internalOnly', () => {
+    it('is tagged so the coverage gate can see it', () => {
+      expect(readGuardTags([internalOnly])).toEqual([{ kind: 'internal' }]);
+    });
+
+    it('returns 401 when unauthenticated, without auditing', async () => {
+      const app = await buildApp({
+        authContext: null,
+        scopeGuards: [internalOnly],
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/probe' });
+      expect(res.statusCode).toBe(401);
+      expect(mockAuditLog).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('allows an interactive session', async () => {
+      const app = await buildApp({
+        authContext: oidcContext,
+        scopeGuards: [internalOnly],
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/probe' });
+      expect(res.statusCode).toBe(200);
+      await app.close();
+    });
+
+    it('rejects an API key when enforcing, whatever scopes it holds', async () => {
+      process.env.INTERNAL_ONLY_ENFORCE = 'true';
+      const app = await buildApp({
+        authContext: { ...apiKeyContext, apiKeyScopes: ['notifications:read'] },
+        scopeGuards: [internalOnly],
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/probe' });
+      expect(res.statusCode).toBe(403);
+      expect(res.json()).toMatchObject({
+        error: 'forbidden',
+        message: 'This route is not available to API keys',
+      });
+      await app.close();
+    });
+
+    it('lets an API key through in log-only mode', async () => {
+      // The revert lever, not a normal setting.
+      process.env.INTERNAL_ONLY_ENFORCE = 'false';
+      const app = await buildApp({
+        authContext: apiKeyContext,
+        scopeGuards: [internalOnly],
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/probe' });
+      expect(res.statusCode).toBe(200);
+      await app.close();
+    });
+
+    it('audits the crossing in both modes', async () => {
+      for (const enforced of ['true', 'false']) {
+        vi.resetAllMocks();
+        mockWithRls.mockImplementation(
+          async (_ctx: unknown, fn: (tx: unknown) => Promise<unknown>) =>
+            fn({ execute: vi.fn() }),
+        );
+        process.env.INTERNAL_ONLY_ENFORCE = enforced;
+
+        const app = await buildApp({
+          authContext: apiKeyContext,
+          scopeGuards: [internalOnly],
+        });
+        await app.inject({ method: 'GET', url: '/probe' });
+
+        expect(mockAuditLog, `enforced=${enforced}`).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            action: 'API_KEY_INTERNAL_ROUTE',
+            newValue: expect.objectContaining({
+              route: '/probe',
+              authMethod: 'apikey',
+              enforced: enforced === 'true',
+            }),
+          }),
+        );
+        await app.close();
+      }
+    });
+
+    it('rejects a credential class that is not on the allowlist', async () => {
+      // The allowlist-not-denylist property: a future `col_svc_` principal
+      // carrying its own authMethod is excluded by construction.
+      const app = await buildApp({
+        authContext: { ...apiKeyContext, authMethod: 'service-principal' },
+        scopeGuards: [internalOnly],
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/probe' });
+      expect(res.statusCode).toBe(403);
+      await app.close();
+    });
+  });
+
+  describe('audit durability', () => {
+    it('uses request.audit when a transaction exists', async () => {
+      const app = await buildApp({
+        authContext: apiKeyContext,
+        guards: [requireScopes('notifications:write')],
+        withTransaction: true,
+      });
+
+      await app.inject({ method: 'GET', url: '/probe' });
+      expect(mockRequestAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'API_KEY_SCOPE_DENIED' }),
+      );
+      expect(mockWithRls).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('falls back to withRls when there is no transaction', async () => {
+      // The SSE route: db-context skips it, so request.audit is a warn-only stub
+      // and a denial would otherwise persist nothing at all.
+      const app = await buildApp({
+        authContext: apiKeyContext,
+        guards: [requireScopes('notifications:write')],
+        withTransaction: false,
+      });
+
+      await app.inject({ method: 'GET', url: '/probe' });
+
+      expect(mockWithRls).toHaveBeenCalledWith(
+        { orgId: apiKeyContext.orgId, userId: apiKeyContext.userId },
+        expect.any(Function),
+      );
+      expect(mockAuditLog).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'API_KEY_SCOPE_DENIED',
+          organizationId: apiKeyContext.orgId,
+          actorId: apiKeyContext.userId,
+          route: '/probe',
+          method: 'GET',
+        }),
+      );
+      await app.close();
+    });
+
+    it('still denies when the audit write fails', async () => {
+      // An audit failure is a monitoring problem; a 500 in place of the 403 would
+      // be an availability one, and would also let the caller through on retry.
+      mockWithRls.mockRejectedValue(new Error('connection refused'));
+
+      const app = await buildApp({
+        authContext: apiKeyContext,
+        guards: [requireScopes('notifications:write')],
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/probe' });
+      expect(res.statusCode).toBe(403);
+      await app.close();
+    });
+
+    it('does not throw when there is no org context to scope the row to', async () => {
+      const app = await buildApp({
+        authContext: { ...apiKeyContext, orgId: undefined },
+        guards: [requireScopes('notifications:write')],
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/probe' });
+      expect(res.statusCode).toBe(403);
+      expect(mockWithRls).not.toHaveBeenCalled();
+      await app.close();
+    });
+  });
+
+  describe('guardScope', () => {
+    it('installs exactly the guards it declares', async () => {
+      // This is the link that lets the coverage gate assert declarations and
+      // trust that enforcement follows. If tags could be produced without the
+      // corresponding hook, the gate would be decorative.
+      const app = Fastify({ logger: false });
+      const installed: unknown[] = [];
+      const originalAddHook = app.addHook.bind(app);
+      vi.spyOn(app, 'addHook').mockImplementation(
+        (name: string, fn: unknown) => {
+          if (name === 'preHandler') installed.push(fn);
+          return originalAddHook(name as never, fn as never);
+        },
+      );
+
+      const scopeGuard = requireScopes('notifications:read');
+      guardScope(app, internalOnly, scopeGuard);
+
+      expect(installed).toEqual([internalOnly, scopeGuard]);
+      await app.close();
+    });
+
+    it('declares its guards on every route in the scope', async () => {
+      const app = Fastify({ logger: false });
+      guardScope(app, internalOnly);
+
+      // Collected per route. Fastify synthesises a HEAD route from each GET and
+      // fires onRoute for it too, so filter to the declared method.
+      const tags: unknown[] = [];
+      app.addHook('onRoute', (routeOptions) => {
+        if (routeOptions.method === 'GET') {
+          tags.push(routeOptions.config?.guardTags);
+        }
+      });
+
+      app.get('/a', async () => ({}));
+      app.get('/b', async () => ({}));
+      app.post('/c', async () => ({}));
+
+      await app.ready();
+      expect(tags).toEqual([[{ kind: 'internal' }], [{ kind: 'internal' }]]);
+      await app.close();
+    });
+
+    it('refuses an untagged guard', async () => {
+      // An untagged guard would enforce correctly while reading as unguarded to
+      // the gate — the one failure mode that is invisible in both directions.
+      const app = Fastify({ logger: false });
+      const untagged = async () => {};
+
+      expect(() => guardScope(app, untagged)).toThrow(/untagged guard/);
+      await app.close();
+    });
+
+    it('accumulates tags rather than replacing them', async () => {
+      const app = Fastify({ logger: false });
+      guardScope(app, internalOnly);
+      guardScope(app, requireScopes('notifications:read'));
+
+      const tags: unknown[] = [];
+      app.addHook('onRoute', (routeOptions) => {
+        tags.push(routeOptions.config?.guardTags);
+      });
+      app.get('/probe', async () => ({}));
+
+      await app.ready();
+      expect(tags[0]).toEqual([
+        { kind: 'internal' },
+        { kind: 'scopes', scopes: ['notifications:read'] },
+      ]);
+      await app.close();
+    });
+
+    it('preserves unrelated route config', async () => {
+      const app = Fastify({ logger: false });
+      guardScope(app, internalOnly);
+
+      const configs: unknown[] = [];
+      app.addHook('onRoute', (routeOptions) => {
+        configs.push(routeOptions.config);
+      });
+      app.get(
+        '/probe',
+        { config: { rateLimit: 5 } as never },
+        async () => ({}),
+      );
+
+      await app.ready();
+      expect(configs[0]).toMatchObject({
+        rateLimit: 5,
+        guardTags: [{ kind: 'internal' }],
+      });
+      await app.close();
+    });
+  });
+
+  describe('markGuard', () => {
+    it('stores the tag non-enumerably so it survives normal object handling', () => {
+      const fn = markGuard(async () => {}, { kind: 'internal' });
+      expect(Object.keys(fn)).toEqual([]);
+      expect(readGuardTags([fn])).toEqual([{ kind: 'internal' }]);
+    });
+  });
+});

--- a/apps/api/src/hooks/fastify-guards.ts
+++ b/apps/api/src/hooks/fastify-guards.ts
@@ -1,0 +1,261 @@
+/**
+ * API key guards for hand-rolled Fastify routes.
+ *
+ * The third of three guard surfaces. oRPC declares scopes with
+ * `rest/context.ts`'s `requireScopes`; tRPC declares scopes or `internalOnly`
+ * with `trpc/init.ts`'s equivalents. Fastify routes declared neither until
+ * 2026-07-29, so every one of them was reachable by any valid API key holding any
+ * scope — `X-Api-Key` is accepted on every non-public route regardless of which
+ * surface serves it.
+ *
+ * Both guards here are tagged with `markGuard` so
+ * `fastify-guard-coverage.spec.ts` can see them on a registered route. **A new
+ * guard on this surface must be tagged the same way or the gate will read the
+ * route as unguarded.**
+ *
+ * Two behaviours are load-bearing and easy to undo by accident:
+ *
+ *  1. **Deny by replying, never by throwing.** Fastify 5 requires
+ *     `return reply.status(N).send(...)` from a preHandler; and the audit-then-deny
+ *     pattern borrowed from tRPC only persists its row because the denial is a
+ *     normal reply, so `db-context`'s `onResponse` COMMIT fires rather than its
+ *     `onError` ROLLBACK. A guard that threw would roll back its own audit row.
+ *  2. **`request.audit` is a no-op without a transaction.** `db-context.ts` skips
+ *     the per-request transaction for `/api/notifications/stream` (a hijacked
+ *     reply means `onResponse` never fires), and `audit.ts` therefore swaps
+ *     `request.audit` for a warn-only stub. `auditDenial` below routes around
+ *     that with `withRls`, the same convention the SSE handler itself uses.
+ */
+import type {
+  FastifyInstance,
+  FastifyRequest,
+  preHandlerAsyncHookHandler,
+  RouteOptions,
+} from 'fastify';
+import { withRls } from '@colophony/db';
+import type { ApiKeyScope, AuditLogParams } from '@colophony/types';
+import { AuditActions, AuditResources } from '@colophony/types';
+import {
+  checkApiKeyScopes,
+  markGuard,
+  readGuardTags,
+  INTERACTIVE_AUTH_METHODS,
+  type GuardTag,
+} from '../services/scope-check.js';
+import { auditService } from '../services/audit.service.js';
+import { validateEnv } from '../config/env.js';
+
+declare module 'fastify' {
+  interface FastifyContextConfig {
+    /**
+     * Guard tags contributed by `guardScope`, for routes whose guard is a
+     * plugin-scope hook rather than a route-level `preHandler`. Fastify's
+     * `onRoute` exposes only a route's own `preHandler`, so a scope-level guard
+     * is otherwise invisible to the coverage gate.
+     */
+    guardTags?: GuardTag[];
+  }
+}
+
+/** Audit params minus the fields this module derives from the request. */
+type DenialParams = Omit<
+  Extract<AuditLogParams, { resource: typeof AuditResources.API_KEY }>,
+  | 'actorId'
+  | 'organizationId'
+  | 'ipAddress'
+  | 'userAgent'
+  | 'requestId'
+  | 'method'
+  | 'route'
+>;
+
+/**
+ * Write a denial audit row, with or without a per-request transaction.
+ *
+ * `request.audit` is used when `dbTx` exists — it already derives actor, org, IP,
+ * user agent, request id, method and route. Without one (the SSE route) it is a
+ * warn-only stub, so fall back to `withRls` and supply those fields here so rows
+ * from either path are indistinguishable.
+ *
+ * A denial with no org context cannot be written at all: `audit_events` is
+ * org-scoped by RLS and `auditService.logDirect` explicitly refuses an
+ * `organizationId`. That combination is unreachable on the scope path — scopes
+ * apply only to `apikey` auth and `hooks/auth.ts` pre-sets `orgId` from the key's
+ * `organizationId` — but warn rather than throw if it ever happens, because
+ * throwing here would turn a 403 into a 500.
+ */
+async function auditDenial(
+  request: FastifyRequest,
+  params: DenialParams,
+): Promise<void> {
+  if (request.dbTx) {
+    await request.audit(params);
+    return;
+  }
+
+  const auth = request.authContext;
+  const orgId = auth?.orgId;
+
+  if (!orgId || !auth) {
+    request.log.warn(
+      { action: params.action },
+      'guard denial not audited: no transaction and no org context',
+    );
+    return;
+  }
+
+  try {
+    await withRls({ orgId, userId: auth.userId }, async (tx) => {
+      await auditService.log(tx, {
+        ...params,
+        actorId: auth.userId,
+        organizationId: orgId,
+        ipAddress: request.ip,
+        userAgent: request.headers['user-agent'],
+        requestId: String(request.id),
+        method: request.method,
+        route: routeLabel(request),
+      });
+    });
+  } catch (error) {
+    // The denial itself must still reach the caller. An audit write that fails
+    // is a monitoring problem; a 500 in its place is an availability one.
+    request.log.error(
+      { err: error, action: params.action },
+      'failed to write guard denial audit row',
+    );
+  }
+}
+
+/** The route pattern, not the concrete URL — `/x/:id`, not `/x/<uuid>`. */
+function routeLabel(request: FastifyRequest): string {
+  return request.routeOptions?.url ?? request.url.split('?')[0];
+}
+
+/**
+ * Factory: returns a Fastify preHandler that enforces API key scopes.
+ *
+ * OIDC/demo/test auth bypasses the check — scopes are API-key-only, so adding a
+ * guard to a route cannot break the interactive web app or Playwright E2E.
+ */
+export function requireScopes(
+  ...scopes: ApiKeyScope[]
+): preHandlerAsyncHookHandler {
+  const guard: preHandlerAsyncHookHandler = async function requireScopesGuard(
+    request,
+    reply,
+  ) {
+    if (!request.authContext) {
+      return reply.status(401).send({ error: 'unauthorized' });
+    }
+
+    const result = checkApiKeyScopes(request.authContext, scopes);
+    if (!result.allowed) {
+      await auditDenial(request, {
+        action: AuditActions.API_KEY_SCOPE_DENIED,
+        resource: AuditResources.API_KEY,
+        resourceId: request.authContext.apiKeyId,
+        newValue: { required: scopes, missing: result.missing },
+      });
+
+      return reply.status(403).send({
+        error: 'insufficient_scope',
+        message: 'Insufficient API key scope',
+        required: scopes,
+        missing: result.missing,
+      });
+    }
+  };
+
+  return markGuard(guard, { kind: 'scopes', scopes });
+}
+
+/**
+ * Restricts a route to interactive human sessions.
+ *
+ * Mirrors `trpc/init.ts`'s `internalOnly`, including the allowlist semantics:
+ * `INTERACTIVE_AUTH_METHODS` is shared between the two so a future credential
+ * class is excluded from both by construction.
+ *
+ * Enforcing by default. `INTERNAL_ONLY_ENFORCE=false` reverts to log-only,
+ * auditing the crossing and letting it through — the revert lever, not a normal
+ * setting. An unauthenticated caller is rejected in both modes, unaudited.
+ */
+export const internalOnly: preHandlerAsyncHookHandler = markGuard(
+  async function internalOnlyGuard(request, reply) {
+    if (!request.authContext) {
+      return reply.status(401).send({ error: 'unauthorized' });
+    }
+
+    if (INTERACTIVE_AUTH_METHODS.includes(request.authContext.authMethod)) {
+      return;
+    }
+
+    // validateEnv() is called here rather than at module level — a module-level
+    // call breaks test imports.
+    const enforced = validateEnv().INTERNAL_ONLY_ENFORCE;
+
+    await auditDenial(request, {
+      action: AuditActions.API_KEY_INTERNAL_ROUTE,
+      resource: AuditResources.API_KEY,
+      resourceId: request.authContext.apiKeyId,
+      newValue: {
+        route: routeLabel(request),
+        authMethod: request.authContext.authMethod,
+        enforced,
+      },
+    });
+
+    if (enforced) {
+      return reply.status(403).send({
+        error: 'forbidden',
+        message: 'This route is not available to API keys',
+      });
+    }
+  },
+  { kind: 'internal' },
+);
+
+/**
+ * Install guards on every route in a plugin scope, and declare them where the
+ * coverage gate can see them.
+ *
+ * Needed because `onRoute` exposes only a route's own `preHandler`, so a guard
+ * added with `app.addHook('preHandler', ...)` is invisible to the gate. It also
+ * gets the ordering right: scope-level preHandlers run before route-level ones,
+ * so calling this **above** an existing role check makes a key's refusal read
+ * "not available to API keys" rather than "ADMIN role required" — the audit trail
+ * should say why the call was actually refused. `trpc/init.ts` orders
+ * `internalOnly` first for the same reason.
+ *
+ * Declaration cannot drift from enforcement: the tags come from the same function
+ * objects installed as hooks.
+ */
+export function guardScope(
+  app: FastifyInstance,
+  ...guards: preHandlerAsyncHookHandler[]
+): void {
+  const tags = readGuardTags(guards);
+
+  /* c8 ignore next 5 -- defensive: every guard in this module is tagged */
+  if (tags.length !== guards.length) {
+    throw new Error(
+      'guardScope received an untagged guard — wrap it with markGuard() or the ' +
+        'coverage gate will read every route in this scope as unguarded',
+    );
+  }
+
+  for (const guard of guards) {
+    app.addHook('preHandler', guard);
+  }
+
+  app.addHook('onRoute', (routeOptions: RouteOptions) => {
+    // Fastify runs onRoute hooks before it builds the final config object, and
+    // every route here uses the `app.get(path, handler)` shorthand, so `config`
+    // is undefined at this point.
+    routeOptions.config = {
+      ...routeOptions.config,
+      guardTags: [...(routeOptions.config?.guardTags ?? []), ...tags],
+    };
+  });
+}

--- a/apps/api/src/hooks/rate-limit-auth.spec.ts
+++ b/apps/api/src/hooks/rate-limit-auth.spec.ts
@@ -78,7 +78,7 @@ const testEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,

--- a/apps/api/src/hooks/rate-limit.spec.ts
+++ b/apps/api/src/hooks/rate-limit.spec.ts
@@ -63,7 +63,7 @@ const testEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,

--- a/apps/api/src/main.spec.ts
+++ b/apps/api/src/main.spec.ts
@@ -67,7 +67,7 @@ const testEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -288,11 +288,11 @@ export async function buildApp(env: Env): Promise<FastifyInstance> {
     await app.register(async (scope) => {
       await registerHubRoutes(scope, { env });
     });
-    // Hub admin routes (OIDC + ADMIN)
+    // Hub admin routes (interactive-only via internalOnly, + ADMIN)
     await app.register(async (scope) => {
       await registerHubAdminRoutes(scope, { env });
     });
-    // Key admin routes (OIDC — user manages own DID keys)
+    // Key admin routes (interactive-only via internalOnly — own DID keys)
     await app.register(async (scope) => {
       await registerKeyAdminRoutes(scope, { env });
     });

--- a/apps/api/src/services/federation.service.spec.ts
+++ b/apps/api/src/services/federation.service.spec.ts
@@ -88,7 +88,7 @@ const baseEnv: Env = {
   PORT: 4000,
   HOST: '0.0.0.0',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,

--- a/apps/api/src/services/scope-check.ts
+++ b/apps/api/src/services/scope-check.ts
@@ -28,6 +28,30 @@ export function checkApiKeyScopes(
   return { allowed: false, missing };
 }
 
+/**
+ * Auth methods that represent an interactive human session.
+ *
+ * This is an ALLOWLIST, and the distinction is not stylistic. A denylist of
+ * 'apikey' stays correct only until the next credential class exists — the
+ * `col_svc_` service principal would carry a different authMethod and silently
+ * readmit itself to `federation.updateConfig` and `hub.revokeInstance` with
+ * broader tenancy than the credential the rule was written to exclude.
+ * Written this way, every future auth method is excluded by construction and
+ * has to be explicitly admitted here.
+ *
+ * Lives here rather than on either surface because all three now consume it —
+ * tRPC's `internalOnly`, and the Fastify `internalOnly` in
+ * `hooks/fastify-guards.ts`. A per-surface copy is the same mistake as a
+ * per-surface guard tag.
+ *
+ * See docs/api-integration-design.md §1.6 M1.
+ */
+export const INTERACTIVE_AUTH_METHODS: readonly string[] = [
+  'oidc',
+  'demo',
+  'test',
+];
+
 // ---------------------------------------------------------------------------
 // Guard tagging
 // ---------------------------------------------------------------------------

--- a/apps/api/src/sse/__tests__/notification-stream.spec.ts
+++ b/apps/api/src/sse/__tests__/notification-stream.spec.ts
@@ -22,6 +22,7 @@ vi.mock('../redis-pubsub.js', () => ({
 }));
 
 import { registerNotificationStreamRoute } from '../notification-stream.js';
+import { readGuardTags } from '../../services/scope-check.js';
 
 function createTestHarness() {
   const mockGet = vi.fn();
@@ -35,21 +36,48 @@ function createTestHarness() {
   return { mockGet, mockApp, mockEnv };
 }
 
+/**
+ * The route handler is the last argument, whether or not a route-options object
+ * is passed. Indexing it positionally is what broke every test in this file when
+ * the scope guard added an options argument.
+ */
+function getHandler(mockGet: ReturnType<typeof vi.fn>) {
+  const args = mockGet.mock.calls[0];
+  return args[args.length - 1];
+}
+
+function getRouteOptions(mockGet: ReturnType<typeof vi.fn>) {
+  return mockGet.mock.calls[0][1];
+}
+
 describe('registerNotificationStreamRoute', () => {
   it('registers a GET route at /api/notifications/stream', async () => {
     const { mockGet, mockApp, mockEnv } = createTestHarness();
     await registerNotificationStreamRoute(mockApp, { env: mockEnv });
     expect(mockGet).toHaveBeenCalledWith(
       '/api/notifications/stream',
+      expect.objectContaining({ preHandler: [expect.any(Function)] }),
       expect.any(Function),
     );
+  });
+
+  it('declares the notifications:read scope guard', async () => {
+    // The route's only guard. Without it any API key with any scope could
+    // stream another surface's inbox — the gap this file's route was filed for.
+    const { mockGet, mockApp, mockEnv } = createTestHarness();
+    await registerNotificationStreamRoute(mockApp, { env: mockEnv });
+
+    const preHandler = getRouteOptions(mockGet).preHandler as unknown[];
+    expect(readGuardTags(preHandler)).toEqual([
+      { kind: 'scopes', scopes: ['notifications:read'] },
+    ]);
   });
 
   it('returns 401 when no auth context', async () => {
     const { mockGet, mockApp, mockEnv } = createTestHarness();
     await registerNotificationStreamRoute(mockApp, { env: mockEnv });
 
-    const handler = mockGet.mock.calls[0][1];
+    const handler = getHandler(mockGet);
     const mockRequest = { authContext: null };
     const mockReply = {
       status: vi.fn().mockReturnThis(),
@@ -64,7 +92,7 @@ describe('registerNotificationStreamRoute', () => {
     const { mockGet, mockApp, mockEnv } = createTestHarness();
     await registerNotificationStreamRoute(mockApp, { env: mockEnv });
 
-    const handler = mockGet.mock.calls[0][1];
+    const handler = getHandler(mockGet);
     const mockRequest = { authContext: { userId: 'user-1', orgId: null } };
     const mockReply = {
       status: vi.fn().mockReturnThis(),
@@ -79,7 +107,7 @@ describe('registerNotificationStreamRoute', () => {
     const { mockGet, mockApp, mockEnv } = createTestHarness();
     await registerNotificationStreamRoute(mockApp, { env: mockEnv });
 
-    const handler = mockGet.mock.calls[0][1];
+    const handler = getHandler(mockGet);
 
     // Exhaust 5 connection slots for this user
     for (let i = 0; i < 5; i++) {
@@ -116,7 +144,7 @@ describe('registerNotificationStreamRoute', () => {
     const { mockGet, mockApp, mockEnv } = createTestHarness();
     await registerNotificationStreamRoute(mockApp, { env: mockEnv });
 
-    const handler = mockGet.mock.calls[0][1];
+    const handler = getHandler(mockGet);
     const rawEnd = vi.fn();
     const mockRequest = {
       authContext: { userId: 'user-redis-fail', orgId: 'org-1' },
@@ -141,7 +169,7 @@ describe('registerNotificationStreamRoute', () => {
     const { mockGet, mockApp, mockEnv } = createTestHarness();
     await registerNotificationStreamRoute(mockApp, { env: mockEnv });
 
-    const handler = mockGet.mock.calls[0][1];
+    const handler = getHandler(mockGet);
     const writeHead = vi.fn();
     const mockRequest = {
       authContext: { userId: 'user-cors', orgId: 'org-1' },
@@ -170,7 +198,7 @@ describe('registerNotificationStreamRoute', () => {
     const { mockGet, mockApp, mockEnv } = createTestHarness();
     await registerNotificationStreamRoute(mockApp, { env: mockEnv });
 
-    const handler = mockGet.mock.calls[0][1];
+    const handler = getHandler(mockGet);
     const writeHead = vi.fn();
     const mockRequest = {
       authContext: { userId: 'user-cors-bad', orgId: 'org-1' },

--- a/apps/api/src/sse/notification-stream.ts
+++ b/apps/api/src/sse/notification-stream.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import Redis from 'ioredis';
 import type { Env } from '../config/env.js';
+import { requireScopes } from '../hooks/fastify-guards.js';
 import {
   channelKey,
   trackConnection,
@@ -49,101 +50,111 @@ export async function registerNotificationStreamRoute(
   app: FastifyInstance,
   { env }: { env: Env },
 ): Promise<void> {
-  app.get('/api/notifications/stream', async (request, reply) => {
-    // Auth is handled by the auth + org-context hooks.
-    // db-context is skipped for this route (see db-context.ts).
-    if (!request.authContext?.userId) {
-      return reply.status(401).send({ error: 'unauthorized' });
-    }
-    if (!request.authContext.orgId) {
-      return reply.status(400).send({ error: 'X-Organization-Id required' });
-    }
+  app.get(
+    '/api/notifications/stream',
+    {
+      // Same scope its tRPC and REST twins declare. Interactive sessions bypass
+      // it, so the web app is unaffected. Note that the denial audit cannot use
+      // `request.audit` here — db-context skips this route, so the guard falls
+      // back to withRls (see fastify-guards.ts).
+      preHandler: [requireScopes('notifications:read')],
+    },
+    async (request, reply) => {
+      // Auth is handled by the auth + org-context hooks.
+      // db-context is skipped for this route (see db-context.ts).
+      if (!request.authContext?.userId) {
+        return reply.status(401).send({ error: 'unauthorized' });
+      }
+      if (!request.authContext.orgId) {
+        return reply.status(400).send({ error: 'X-Organization-Id required' });
+      }
 
-    const { userId, orgId } = request.authContext;
+      const { userId, orgId } = request.authContext;
 
-    // Rate limit: max SSE connections per user
-    if (!incrementUserConnections(userId)) {
-      return reply.status(429).send({ error: 'Too many SSE connections' });
-    }
+      // Rate limit: max SSE connections per user
+      if (!incrementUserConnections(userId)) {
+        return reply.status(429).send({ error: 'Too many SSE connections' });
+      }
 
-    const channel = channelKey(orgId, userId);
+      const channel = channelKey(orgId, userId);
 
-    // SSE response headers — reply.hijack() bypasses @fastify/cors,
-    // so CORS headers must be included in the manual writeHead() call.
-    const corsHeaders = buildCorsHeaders(
-      request.headers.origin,
-      env.CORS_ORIGIN.split(',').map((o) => o.trim()),
-    );
+      // SSE response headers — reply.hijack() bypasses @fastify/cors,
+      // so CORS headers must be included in the manual writeHead() call.
+      const corsHeaders = buildCorsHeaders(
+        request.headers.origin,
+        env.CORS_ORIGIN.split(',').map((o) => o.trim()),
+      );
 
-    void reply.hijack();
-    const raw = reply.raw;
-    raw.writeHead(200, {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache, no-transform',
-      Connection: 'keep-alive',
-      'X-Accel-Buffering': 'no',
-      ...corsHeaders,
-    });
+      void reply.hijack();
+      const raw = reply.raw;
+      raw.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache, no-transform',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+        ...corsHeaders,
+      });
 
-    // Send connected event
-    raw.write('event: connected\ndata: {}\n\n');
+      // Send connected event
+      raw.write('event: connected\ndata: {}\n\n');
 
-    // Per-connection subscriber (Redis requires dedicated connection for subscribe mode)
-    const sub = new Redis({
-      host: env.REDIS_HOST,
-      port: env.REDIS_PORT,
-      password: env.REDIS_PASSWORD || undefined,
-      lazyConnect: true,
-      maxRetriesPerRequest: null,
-    });
+      // Per-connection subscriber (Redis requires dedicated connection for subscribe mode)
+      const sub = new Redis({
+        host: env.REDIS_HOST,
+        port: env.REDIS_PORT,
+        password: env.REDIS_PASSWORD || undefined,
+        lazyConnect: true,
+        maxRetriesPerRequest: null,
+      });
 
-    try {
-      await sub.connect();
-    } catch {
-      decrementUserConnections(userId);
-      raw.end();
-      return;
-    }
-    trackConnection(sub);
+      try {
+        await sub.connect();
+      } catch {
+        decrementUserConnections(userId);
+        raw.end();
+        return;
+      }
+      trackConnection(sub);
 
-    // Forward messages as SSE events
-    sub.on('message', (_ch: string, message: string) => {
-      raw.write(`event: notification\ndata: ${message}\n\n`);
-    });
+      // Forward messages as SSE events
+      sub.on('message', (_ch: string, message: string) => {
+        raw.write(`event: notification\ndata: ${message}\n\n`);
+      });
 
-    try {
-      await sub.subscribe(channel);
-    } catch {
-      decrementUserConnections(userId);
-      untrackConnection(sub);
-      sub.quit().catch(() => undefined);
-      raw.end();
-      return;
-    }
+      try {
+        await sub.subscribe(channel);
+      } catch {
+        decrementUserConnections(userId);
+        untrackConnection(sub);
+        sub.quit().catch(() => undefined);
+        raw.end();
+        return;
+      }
 
-    // Keep-alive ping every 30s
-    const pingInterval = setInterval(() => {
-      raw.write(': ping\n\n');
-    }, 30_000);
+      // Keep-alive ping every 30s
+      const pingInterval = setInterval(() => {
+        raw.write(': ping\n\n');
+      }, 30_000);
 
-    // Cleanup on disconnect
-    let cleaned = false;
-    const cleanup = () => {
-      if (cleaned) return;
-      cleaned = true;
-      clearInterval(pingInterval);
-      decrementUserConnections(userId);
-      sub
-        .unsubscribe(channel)
-        .catch(() => undefined)
-        .finally(() => {
-          untrackConnection(sub);
-          sub.quit().catch(() => undefined);
-        });
-      raw.end();
-    };
+      // Cleanup on disconnect
+      let cleaned = false;
+      const cleanup = () => {
+        if (cleaned) return;
+        cleaned = true;
+        clearInterval(pingInterval);
+        decrementUserConnections(userId);
+        sub
+          .unsubscribe(channel)
+          .catch(() => undefined)
+          .finally(() => {
+            untrackConnection(sub);
+            sub.quit().catch(() => undefined);
+          });
+        raw.end();
+      };
 
-    request.raw.on('close', cleanup);
-    request.raw.on('error', cleanup);
-  });
+      request.raw.on('close', cleanup);
+      request.raw.on('error', cleanup);
+    },
+  );
 }

--- a/apps/api/src/trpc/guard-coverage.spec.ts
+++ b/apps/api/src/trpc/guard-coverage.spec.ts
@@ -14,7 +14,7 @@
  * DECLARES, not "is protected" — the distinction was load-bearing while the
  * two guards differed. A `requireScopes` declaration is also its enforcement;
  * `internalOnly` only declared, and audited the crossing, until P0.5 flipped
- * `TRPC_INTERNAL_ONLY_ENFORCE` to true on 2026-07-27. Both now enforce on
+ * `INTERNAL_ONLY_ENFORCE` to true on 2026-07-27. Both now enforce on
  * declaration. The last test pins that, so a revert to log-only cannot pass
  * silently.
  *
@@ -26,7 +26,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { apiKeyScopeSchema } from '@colophony/types';
 
 const { envState } = vi.hoisted(() => ({
-  envState: { TRPC_INTERNAL_ONLY_ENFORCE: false },
+  envState: { INTERNAL_ONLY_ENFORCE: false },
 }));
 
 vi.mock('../config/env.js', () => ({
@@ -89,7 +89,7 @@ function isUnguarded(entry: ProcedureEntry): boolean {
 
 describe('tRPC guard coverage (P0.4)', () => {
   beforeEach(() => {
-    envState.TRPC_INTERNAL_ONLY_ENFORCE = false;
+    envState.INTERNAL_ONLY_ENFORCE = false;
   });
 
   it('introspects a plausible number of procedures', () => {
@@ -188,7 +188,7 @@ describe('tRPC guard coverage (P0.4)', () => {
     // The behavioural counterpart to the declaration checks above: proves the
     // boundary actually rejects, for all internal procedures rather than the
     // single one scope-enforcement.spec.ts covers.
-    envState.TRPC_INTERNAL_ONLY_ENFORCE = true;
+    envState.INTERNAL_ONLY_ENFORCE = true;
 
     const context: TRPCContext = {
       authContext: {
@@ -247,7 +247,7 @@ describe('tRPC guard coverage (P0.4)', () => {
       admitted.length === 0
         ? ''
         : `These procedures declare internalOnly but did not reject an API ` +
-            `key under TRPC_INTERNAL_ONLY_ENFORCE=true:\n` +
+            `key under INTERNAL_ONLY_ENFORCE=true:\n` +
             admitted.map((p) => `  - ${p}`).join('\n'),
     ).toEqual([]);
   });

--- a/apps/api/src/trpc/init.spec.ts
+++ b/apps/api/src/trpc/init.spec.ts
@@ -3,7 +3,7 @@ import { TRPCError } from '@trpc/server';
 import { AuditActions } from '@colophony/types';
 
 const { envState } = vi.hoisted(() => ({
-  envState: { TRPC_INTERNAL_ONLY_ENFORCE: false },
+  envState: { INTERNAL_ONLY_ENFORCE: false },
 }));
 
 vi.mock('../config/env.js', () => ({
@@ -69,14 +69,14 @@ const call = (ctx: TRPCContext) =>
 describe('internalOnly middleware', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    envState.TRPC_INTERNAL_ONLY_ENFORCE = false;
+    envState.INTERNAL_ONLY_ENFORCE = false;
   });
 
   describe('interactive auth methods are admitted', () => {
     it.each(['oidc', 'demo', 'test'] as const)(
       'allows %s without auditing, even when enforcing',
       async (method) => {
-        envState.TRPC_INTERNAL_ONLY_ENFORCE = true;
+        envState.INTERNAL_ONLY_ENFORCE = true;
         const ctx = interactiveContext(method);
 
         await expect(call(ctx)).resolves.toBe('ok');
@@ -85,7 +85,7 @@ describe('internalOnly middleware', () => {
     );
   });
 
-  describe('log-only mode (TRPC_INTERNAL_ONLY_ENFORCE=false)', () => {
+  describe('log-only mode (INTERNAL_ONLY_ENFORCE=false)', () => {
     it('lets an API key through but records the attempt', async () => {
       const ctx = apiKeyContext();
 
@@ -115,9 +115,9 @@ describe('internalOnly middleware', () => {
     });
   });
 
-  describe('enforcing mode (TRPC_INTERNAL_ONLY_ENFORCE=true)', () => {
+  describe('enforcing mode (INTERNAL_ONLY_ENFORCE=true)', () => {
     beforeEach(() => {
-      envState.TRPC_INTERNAL_ONLY_ENFORCE = true;
+      envState.INTERNAL_ONLY_ENFORCE = true;
     });
 
     it('rejects an API key and records the attempt as enforced', async () => {
@@ -140,7 +140,7 @@ describe('internalOnly middleware', () => {
   // introduces exactly such a credential.
   describe('unknown credential classes', () => {
     it('is rejected when enforcing, without being named anywhere', async () => {
-      envState.TRPC_INTERNAL_ONLY_ENFORCE = true;
+      envState.INTERNAL_ONLY_ENFORCE = true;
       const ctx = futureCredentialContext();
 
       await expect(call(ctx)).rejects.toMatchObject({ code: 'FORBIDDEN' });

--- a/apps/api/src/trpc/init.ts
+++ b/apps/api/src/trpc/init.ts
@@ -7,6 +7,7 @@ import {
   markGuard,
   readGuardTags,
   GUARD_TAG,
+  INTERACTIVE_AUTH_METHODS,
   type GuardTag,
 } from '../services/scope-check.js';
 import { validateEnv } from '../config/env.js';
@@ -272,25 +273,13 @@ export function requireScopes(...scopes: ApiKeyScope[]) {
 }
 
 /**
- * Auth methods that represent an interactive human session.
- *
- * This is an ALLOWLIST, and the distinction is not stylistic. A denylist of
- * 'apikey' stays correct only until the next credential class exists — the
- * `col_svc_` service principal would carry a different authMethod and silently
- * readmit itself to `federation.updateConfig` and `hub.revokeInstance` with
- * broader tenancy than the credential the rule was written to exclude.
- * Written this way, every future auth method is excluded by construction and
- * has to be explicitly admitted here.
- *
- * See docs/api-integration-design.md §1.6 M1.
- */
-const INTERACTIVE_AUTH_METHODS: readonly string[] = ['oidc', 'demo', 'test'];
-
-/**
  * Restricts a procedure to interactive human sessions.
  *
+ * `INTERACTIVE_AUTH_METHODS` is shared with the Fastify surface — see
+ * `services/scope-check.ts` for why it must be an allowlist.
+ *
  * Enforcing by default: a non-interactive caller is audited and rejected with
- * 403. TRPC_INTERNAL_ONLY_ENFORCE=false reverts to log-only, auditing the
+ * 403. INTERNAL_ONLY_ENFORCE=false reverts to log-only, auditing the
  * crossing and letting it through — kept as a revert lever, not a normal
  * setting. An unauthenticated caller is rejected in both modes, unaudited.
  */
@@ -305,7 +294,7 @@ const internalOnlyMiddleware = t.middleware(async ({ ctx, path, next }) => {
 
   // validateEnv() is called here rather than at module level — a module-level
   // call breaks test imports.
-  const enforced = validateEnv().TRPC_INTERNAL_ONLY_ENFORCE;
+  const enforced = validateEnv().INTERNAL_ONLY_ENFORCE;
 
   await ctx.audit?.({
     action: AuditActions.API_KEY_INTERNAL_ROUTE,

--- a/apps/api/src/trpc/routers/__tests__/scope-enforcement.spec.ts
+++ b/apps/api/src/trpc/routers/__tests__/scope-enforcement.spec.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { envState } = vi.hoisted(() => ({
   envState: {
-    TRPC_INTERNAL_ONLY_ENFORCE: false,
+    INTERNAL_ONLY_ENFORCE: false,
     REDIS_HOST: 'localhost',
     REDIS_PORT: 6379,
     REDIS_PASSWORD: '',
@@ -144,7 +144,7 @@ function oidcCaller() {
 describe('tRPC scope enforcement (P0.1b)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    envState.TRPC_INTERNAL_ONLY_ENFORCE = false;
+    envState.INTERNAL_ONLY_ENFORCE = false;
   });
 
   describe('webhooks', () => {
@@ -233,7 +233,7 @@ describe('tRPC scope enforcement (P0.1b)', () => {
     // Enforcement is the default since 2026-07-27; this covers the revert
     // path, not pending behaviour.
     it('lets an API key reach federation when explicitly set to log-only', async () => {
-      envState.TRPC_INTERNAL_ONLY_ENFORCE = false;
+      envState.INTERNAL_ONLY_ENFORCE = false;
 
       await expect(
         keyCaller(['manuscripts:read']).federation.getConfig(),
@@ -241,7 +241,7 @@ describe('tRPC scope enforcement (P0.1b)', () => {
     });
 
     it('denies an API key once enforcing, whatever scopes it holds', async () => {
-      envState.TRPC_INTERNAL_ONLY_ENFORCE = true;
+      envState.INTERNAL_ONLY_ENFORCE = true;
 
       await expect(
         keyCaller(['manuscripts:read']).federation.getConfig(),
@@ -249,7 +249,7 @@ describe('tRPC scope enforcement (P0.1b)', () => {
     });
 
     it('still admits an interactive session when enforcing', async () => {
-      envState.TRPC_INTERNAL_ONLY_ENFORCE = true;
+      envState.INTERNAL_ONLY_ENFORCE = true;
 
       await expect(oidcCaller().federation.getConfig()).resolves.toBeDefined();
     });

--- a/apps/api/src/webhooks/stripe.webhook.spec.ts
+++ b/apps/api/src/webhooks/stripe.webhook.spec.ts
@@ -119,7 +119,7 @@ const testEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,

--- a/apps/api/src/webhooks/zitadel.webhook.spec.ts
+++ b/apps/api/src/webhooks/zitadel.webhook.spec.ts
@@ -122,7 +122,7 @@ const testEnv: Env = {
   PORT: 0,
   HOST: '127.0.0.1',
   NODE_ENV: 'test',
-  TRPC_INTERNAL_ONLY_ENFORCE: false,
+  INTERNAL_ONLY_ENFORCE: false,
   LOG_LEVEL: 'fatal',
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,

--- a/apps/web/e2e/federation/fixtures.ts
+++ b/apps/web/e2e/federation/fixtures.ts
@@ -6,7 +6,7 @@
  *
  * Most of this suite drives `internalOnly` routers (federation, simsub,
  * transfer, migration, hub). Those admit only interactive auth methods, so the
- * suite passes under TRPC_INTERNAL_ONLY_ENFORCE=true precisely because it
+ * suite passes under INTERNAL_ONLY_ENFORCE=true precisely because it
  * authenticates as `authMethod: 'test'` rather than as an API key.
  *
  * Co-located in e2e/federation/ (not e2e/helpers/) to avoid triggering

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -141,8 +141,15 @@ services:
       FEDERATION_RATE_LIMIT_FAIL_MODE: ${FEDERATION_RATE_LIMIT_FAIL_MODE:-open}
       # Status tokens
       STATUS_TOKEN_TTL_DAYS: ${STATUS_TOKEN_TTL_DAYS:-90}
-      # Internal tRPC boundary. Set false only to revert to log-only.
-      TRPC_INTERNAL_ONLY_ENFORCE: ${TRPC_INTERNAL_ONLY_ENFORCE:-true}
+      # Internal boundary, tRPC + Fastify. Set false only to revert to log-only.
+      INTERNAL_ONLY_ENFORCE: ${INTERNAL_ONLY_ENFORCE:-true}
+      # Passed through ONLY so validateEnv() can reject it. Compose injects just
+      # the variables named here, so a stale TRPC_INTERNAL_ONLY_ENFORCE=false in
+      # .env.prod would otherwise never reach the container: the API would take
+      # the default `true` and silently close a surface the operator meant to
+      # keep open. Unset resolves to '', which validateEnv() treats as absent.
+      # Delete this line once no deployment sets the old name.
+      TRPC_INTERNAL_ONLY_ENFORCE: ${TRPC_INTERNAL_ONLY_ENFORCE:-}
       # Background jobs (Inngest)
       INNGEST_EVENT_KEY: ${INNGEST_EVENT_KEY:-}
       INNGEST_SIGNING_KEY: ${INNGEST_SIGNING_KEY:-}
@@ -630,7 +637,9 @@ services:
       # A no-op here in practice — the demo API authenticates as `demo`, which
       # is on the interactive allowlist — but set explicitly so the deployed
       # value never depends on the schema default.
-      TRPC_INTERNAL_ONLY_ENFORCE: ${TRPC_INTERNAL_ONLY_ENFORCE:-true}
+      INTERNAL_ONLY_ENFORCE: ${INTERNAL_ONLY_ENFORCE:-true}
+      # See the `api` service — passed through only so validateEnv() rejects it.
+      TRPC_INTERNAL_ONLY_ENFORCE: ${TRPC_INTERNAL_ONLY_ENFORCE:-}
     depends_on:
       demo-migrate:
         condition: service_completed_successfully

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -417,6 +417,30 @@ Ordered as the design doc's Phase 0/D.
       principal — and fails open when Redis is unreachable, and `apiKeyService.create`
       enforces no per-org or per-creator key count. Either a creator-level umbrella bucket
       or a key-count cap would close it.
+- [ ] **[P2] The main API rate limiter fails open on Redis error, and unlike federation's
+      it is not configurable.** `hooks/rate-limit.ts:137-143` catches any Redis failure,
+      logs `Rate limit Redis error — allowing request without rate limiting`, and returns —
+      so a Redis outage removes rate limiting from the entire API at once. Every request
+      then reaches `dbContextPlugin`, which opens a pooled connection and begins a
+      transaction per request, so the failure mode is not merely "unlimited requests" but
+      connection-pool exhaustion under load.
+      **The asymmetry is the tell.** Federation rate limiting already has
+      `FEDERATION_RATE_LIMIT_FAIL_MODE` (`open` / `closed` / `fallback`, with an in-process
+      fallback), added in PR #225 for exactly this concern. The main limiter — which guards
+      far more surface — never got the same treatment. Port the pattern rather than
+      inventing a second one.
+      Two related gaps worth deciding at the same time: `shouldSkip` exempts the whole
+      `/webhooks/` prefix from the global limiter (those handlers do hit the database; they
+      carry their own `webhookRateLimit` preHandler, so this is defensible but undocumented
+      as a deliberate choice), and the second-pass credential limiter in
+      `hooks/rate-limit-auth.ts` should be checked for the same fail-open behaviour.
+      **Note for anyone re-triaging CodeQL:** `js/missing-rate-limiting` on
+      `hooks/db-context.ts:38` (alert #45, opened 2026-02-26) was dismissed as a false
+      positive on 2026-07-29 — the limiter is a separate `fastify-plugin` registered at
+      `main.ts:199`, ahead of `dbContextPlugin` at `:203`, and CodeQL cannot follow Fastify
+      plugin registration order across files. The query was wrong about the route being
+      unguarded; it was incidentally near this, which is the real issue. —
+      (found 2026-07-29 while triaging that alert)
 - [ ] **[P1] Audit cannot distinguish an API key from its creator.** `audit_events` has a
       single `actor_id` and `BaseAuditParams` carries no `apiKeyId`, so a key's actions and
       the human's own actions are recorded identically. Add `principal_id` / `principal_type`

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -543,7 +543,7 @@ Ordered as the design doc's Phase 0/D.
       fail closed, so not a vulnerability — but a request with no org context gets a 500
       rather than an empty result on those four. Normalise deliberately. —
       (design doc §2.3 F6)
-- [ ] **[P1] `GET /api/notifications/stream` declares no scope guard, and neither
+- [x] **[P1] `GET /api/notifications/stream` declares no scope guard, and neither
       coverage gate can see it.** It is a plain Fastify route
       (`apps/api/src/sse/notification-stream.ts:52`), not a tRPC or oRPC procedure, so
       `requireScopes` never runs — and both `trpc/guard-coverage.spec.ts` and
@@ -561,7 +561,69 @@ Ordered as the design doc's Phase 0/D.
       allowlist would cover the class rather than this instance.
       Also note the connection cap (`MAX_CONNECTIONS_PER_USER = 5`) is an in-process
       `Map`, not Redis-backed, so it does not hold across replicas. —
-      (found 2026-07-29 while adding the REST notification surface)
+      (found 2026-07-29 while adding the REST notification surface;
+      **done 2026-07-29** — closed as the class, not the instance)
+      **What landed.** `hooks/fastify-guards.ts` supplies `requireScopes`,
+      `internalOnly` and `guardScope`, all tagged with the existing `markGuard` so
+      `hooks/fastify-guard-coverage.spec.ts` — the third gate — sees them. The SSE
+      route took `notifications:read`, matching its twins. The other 25 unguarded
+      routes took `internalOnly`: 23 match tRPC twins that were already
+      `internal*Procedure`, and `/federation/keys/*` took it on separate grounds
+      (no twin exists; DID key rotation from a key is privilege escalation) —
+      **a behaviour change, not parity**.
+      **Two things the audit missed.** The ADMIN `preHandler` on the four admin
+      modules never excluded keys at all: `org-context` resolves roles from
+      `organization_members` by user id regardless of `authMethod`, so a key minted
+      by an admin arrives with `roles: ['ADMIN']`. And `request.audit` is a
+      warn-only stub on the SSE route, because `db-context` skips its transaction —
+      so a scope denial there would have persisted nothing. The guards write through
+      a transaction-aware helper that falls back to `withRls`.
+      `guardScope` exists because Fastify's `onRoute` exposes only a route's _own_
+      `preHandler`, not hooks inherited from its plugin scope; it also runs before
+      the ADMIN check so the audit records why a call was actually refused.
+      The connection-cap-across-replicas note above is untouched and still open.
+- [ ] **[P2] The 23 Fastify federation admin routes appear to have no caller, and
+      duplicate tRPC procedures that do.** Every one of them has a tRPC twin
+      (`federation.*`, `transfers.*`, `simsub.*`, `hub.*`, `migrations.*`), and the
+      twin is what the web app uses — 20+ call sites across
+      `apps/web/src/components/federation/`. The `/federation/...` strings in the web
+      app are **Next.js page paths** (`router.push`, `<Link href>`), not API calls,
+      and `docs/manual-qa-plan.md` lists them as pages for the same reason. A search
+      for an HTTP caller — `fetch`/`axios` in `apps/web`, `apps/api`, `scripts/`,
+      `sdks/typescript/src` — found none.
+      **That is very likely why nobody noticed they were unguarded**: unused surface
+      generates no traffic and no complaints, while remaining fully reachable. They
+      are guarded now (2026-07-29), so the exposure is closed either way; the
+      question is whether they should exist.
+      Deleting them would also resolve the one asymmetry left behind: `key-admin`
+      (`POST /federation/keys/rotate`, `GET /federation/keys`) is the only pair with
+      no tRPC twin, so DID key management would need a tRPC home as part of the same
+      change — which is the right place for it anyway.
+      **Do not confuse these with the S2S routes.** `/federation/trust*` and
+      `/federation/v1/*` are called by remote instances over HTTP and cannot be tRPC.
+      Only the operator-console duplicates are in question.
+      **Before deleting, establish there is genuinely no external consumer** — an
+      operator runbook or curl script outside the repo would not show up in the
+      search above. Absence of an in-repo caller is suggestive, not conclusive. —
+      (found 2026-07-29 while adding the Fastify guard gate)
+- [ ] **[P3] `'/federation/trust'` in `PUBLIC_PREFIXES` is a bare prefix.**
+      `hooks/auth.ts` tests `path.startsWith(prefix)`, and the entry has no trailing
+      slash, so any future path merely _beginning_ with that string —
+      `/federation/trusted-peers`, say — becomes unauthenticated by accident. No
+      current path is affected; `/federation/trust` and `/federation/trust/*` are
+      genuinely public S2S endpoints. The fix is a trailing slash plus a separate
+      exact entry, but it needs checking against every `/federation/trust*` route
+      first. — (found 2026-07-29 while adding the Fastify guard gate)
+- [ ] **[P3] Two route modules have no per-route API-key rejection test.**
+      `hub-admin.routes.spec.ts` drives handlers directly through a synthetic mock
+      app with a `getHandler` helper, so it bypasses the Fastify hook chain entirely
+      and cannot exercise a `preHandler` guard without being rewritten against a real
+      instance; `key-admin.routes.ts` has no spec at all. Both are covered by
+      `hooks/fastify-guard-coverage.spec.ts` (their routes declare the guard) and by
+      `hooks/fastify-guards.spec.ts` (the guard rejects, and `guardScope` installs
+      what it declares), so the property holds by decomposition — but neither module
+      has the direct end-to-end assertion the other four now carry. —
+      (found 2026-07-29 while adding the Fastify guard gate)
 
 ### Blocking REST gaps (integrator workflow)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -118,28 +118,28 @@ curl http://localhost/health
 
 ### Optional
 
-| Variable                     | Description                                                        | Default     |
-| ---------------------------- | ------------------------------------------------------------------ | ----------- |
-| `POSTGRES_USER`              | PostgreSQL superuser name                                          | `colophony` |
-| `POSTGRES_DB`                | Database name                                                      | `colophony` |
-| `HTTP_PORT`                  | Caddy HTTP listen port                                             | `80`        |
-| `HTTPS_PORT`                 | Caddy HTTPS listen port                                            | `443`       |
-| `RATE_LIMIT_DEFAULT_MAX`     | General rate limit (req/min)                                       | `60`        |
-| `RATE_LIMIT_AUTH_MAX`        | Auth rate limit (req/min)                                          | `200`       |
-| `ZITADEL_AUTHORITY`          | Zitadel issuer URL                                                 | (empty)     |
-| `ZITADEL_CLIENT_ID`          | Zitadel OIDC client ID                                             | (empty)     |
-| `STRIPE_SECRET_KEY`          | Stripe API key                                                     | (empty)     |
-| `STRIPE_WEBHOOK_SECRET`      | Stripe webhook secret                                              | (empty)     |
-| `EMAIL_PROVIDER`             | Email provider (`smtp`, `sendgrid`, `none`)                        | `none`      |
-| `SMTP_HOST`                  | SMTP server hostname                                               | (empty)     |
-| `SMTP_PORT`                  | SMTP server port                                                   | `587`       |
-| `SMTP_USER`                  | SMTP username                                                      | (empty)     |
-| `SMTP_PASS`                  | SMTP password                                                      | (empty)     |
-| `SMTP_FROM`                  | SMTP sender address                                                | (empty)     |
-| `FEDERATION_ENABLED`         | Enable federation features                                         | `false`     |
-| `TRPC_INTERNAL_ONLY_ENFORCE` | Reject API keys on internal-only tRPC routers (`false` = log only) | `true`      |
-| `SENTRY_DSN`                 | Sentry error tracking DSN                                          | (empty)     |
-| `METRICS_ENABLED`            | Enable Prometheus `/metrics`                                       | `false`     |
+| Variable                 | Description                                                                                                                                                                            | Default     |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `POSTGRES_USER`          | PostgreSQL superuser name                                                                                                                                                              | `colophony` |
+| `POSTGRES_DB`            | Database name                                                                                                                                                                          | `colophony` |
+| `HTTP_PORT`              | Caddy HTTP listen port                                                                                                                                                                 | `80`        |
+| `HTTPS_PORT`             | Caddy HTTPS listen port                                                                                                                                                                | `443`       |
+| `RATE_LIMIT_DEFAULT_MAX` | General rate limit (req/min)                                                                                                                                                           | `60`        |
+| `RATE_LIMIT_AUTH_MAX`    | Auth rate limit (req/min)                                                                                                                                                              | `200`       |
+| `ZITADEL_AUTHORITY`      | Zitadel issuer URL                                                                                                                                                                     | (empty)     |
+| `ZITADEL_CLIENT_ID`      | Zitadel OIDC client ID                                                                                                                                                                 | (empty)     |
+| `STRIPE_SECRET_KEY`      | Stripe API key                                                                                                                                                                         | (empty)     |
+| `STRIPE_WEBHOOK_SECRET`  | Stripe webhook secret                                                                                                                                                                  | (empty)     |
+| `EMAIL_PROVIDER`         | Email provider (`smtp`, `sendgrid`, `none`)                                                                                                                                            | `none`      |
+| `SMTP_HOST`              | SMTP server hostname                                                                                                                                                                   | (empty)     |
+| `SMTP_PORT`              | SMTP server port                                                                                                                                                                       | `587`       |
+| `SMTP_USER`              | SMTP username                                                                                                                                                                          | (empty)     |
+| `SMTP_PASS`              | SMTP password                                                                                                                                                                          | (empty)     |
+| `SMTP_FROM`              | SMTP sender address                                                                                                                                                                    | (empty)     |
+| `FEDERATION_ENABLED`     | Enable federation features                                                                                                                                                             | `false`     |
+| `INTERNAL_ONLY_ENFORCE`  | Reject API keys on internal-only tRPC routers and Fastify federation routes (`false` = log only). Renamed from `TRPC_INTERNAL_ONLY_ENFORCE` 2026-07-29; the old name now fails startup | `true`      |
+| `SENTRY_DSN`             | Sentry error tracking DSN                                                                                                                                                              | (empty)     |
+| `METRICS_ENABLED`        | Enable Prometheus `/metrics`                                                                                                                                                           | `false`     |
 
 ## Architecture
 


### PR DESCRIPTION
## What

`X-Api-Key` is accepted on every non-public route, but only two of the three API
surfaces enforced it. oRPC and tRPC each require a declared guard and each have a
coverage spec that fails the build without one. Hand-rolled Fastify routes
required nothing — and **not one of them declared anything**.

The backlog filed this as a single route (`GET /api/notifications/stream`, P1).
It is the whole surface: no Fastify route called `requireScopes`,
`checkApiKeyScopes`, or `markGuard`.

## Why it mattered

Two concrete exposures:

1. `/federation/keys/*` and `/federation/migrations*` carried only a bare
   `if (!request.authContext)` check, so any key with any scope reached them
   acting as its creator.
2. The four federation admin modules gated on an ADMIN role — which does not
   exclude keys at all. `hooks/org-context.ts` resolves `roles` from
   `organization_members` by `user_id` in both its branches, and a key carries its
   creator's `userId`, so a key minted by an admin arrives with `roles: ['ADMIN']`
   and satisfies every check.

## How

`apps/api/src/hooks/fastify-guards.ts` adds `requireScopes`, `internalOnly` and
`guardScope`, all reusing the existing `markGuard`/`GUARD_TAG` primitive so one
tag serves three surfaces rather than three copies drifting apart.
`INTERACTIVE_AUTH_METHODS` moves into `services/scope-check.ts` and is shared
with tRPC for the same reason.

- **SSE stream** takes `notifications:read`, matching its tRPC and REST twins.
  Chosen over `internalOnly` because #532 deliberately documented the per-user
  inbox semantics rather than closing the surface; closing only the streaming
  variant would make the two diverge.
- **23 trust/transfer/simsub/hub/migration routes** take `internalOnly`, matching
  twins that were already `internal*Procedure`.

### ⚠️ Behaviour change: `/federation/keys/*`

These two routes also take `internalOnly`, but on **different grounds** — they
have no tRPC twin, so this restricts them rather than aligning them. Rotating a
user's DID signing key from a credential that acts as that user is a
privilege-escalation shape, and the nearest analogue (migration-admin) is
`internalAuthedProcedure`.

**Any integrator rotating DID keys with a `col_live_` key will break.** A
`federation:manage` scope was the alternative and was rejected: a new enum value
appears in the create-API-key request body in `sdks/openapi.json` and would pull
SDK regeneration into this PR.

### Two behaviours that are load-bearing

- **Guards deny by replying, never throwing.** Fastify 5 requires it of a
  preHandler, and the audit-then-deny pattern borrowed from tRPC persists its row
  only because the denial is a normal reply, so `db-context`'s `onResponse` COMMIT
  fires instead of its `onError` ROLLBACK. A guard that threw would roll back its
  own audit row.
- **`request.audit` is a no-op on the SSE route.** `db-context` skips the
  per-request transaction there (a hijacked reply means `onResponse` never fires),
  so `request.audit` is a warn-only stub and a denial would have persisted
  nothing. Both guards write through a transaction-aware helper that falls back to
  `withRls`.

`guardScope` exists because `onRoute` exposes only a route's own `preHandler`, not
hooks inherited from its plugin scope, so a scope-level guard would be invisible
to the gate. It also runs before the existing ADMIN check, so a key is refused for
being a key rather than incidentally on its role — the audit should say which.
Declaration cannot drift from enforcement: the tags come from the same function
objects installed as hooks, and it throws on an untagged guard.

## Env rename

`TRPC_INTERNAL_ONLY_ENFORCE` becomes `INTERNAL_ONLY_ENFORCE` now that it governs
two surfaces. `validateEnv()` rejects the old name at startup rather than ignoring
it: the schema default would otherwise silently overrule an operator who set
`false` to keep a surface open.

`docker-compose.prod.yml` still names the old variable, deliberately, on both api
services. Compose injects only the variables listed in a service's `environment:`
block, so without that pass-through a stale `TRPC_INTERNAL_ONLY_ENFORCE=false` in
`.env.prod` would never reach the container — the API would take the new default
of `true` and quietly close a surface, with the startup check unable to see
anything wrong. The pass-through resolves to `''` when unset, which
`validateEnv()` treats as absent so migrated deployments still boot. Verified by
rendering the config both ways.

**Deploy note: no action required.** Checked staging (`/opt/colophony/.env.staging`,
the only wired environment — production is not set up): 32 keys, none matching
`INTERNAL_ONLY` in any form. So the compose default `true` applies both before and
after this change, and enforcement is unchanged. The startup rejection only fires
for a deployment that had *explicitly set* the old name.

## Tests

Three specs, structured so the guarantee holds by decomposition:

- `hooks/fastify-guard-coverage.spec.ts` — registers all 22 route modules and
  asserts every non-public route declares a guard. Includes a parity test that
  globs the filesystem, so a new route module cannot escape the gate unnoticed,
  and reuses `isPublicRoute` from the auth hook rather than keeping a second copy
  of the allowlist.
- `hooks/fastify-guards.spec.ts` — the guards reject, and `guardScope` installs
  exactly what it tags.
- Four of the six touched modules gained a direct API-key rejection case.

Verified the gate is non-vacuous rather than assuming: removing the key-admin
`guardScope` call makes it name both `/federation/keys` routes, and removing the
SSE `preHandler` makes it name that route.

1938 unit tests, type-check, and lint all pass.

## Follow-ups filed

- **[P2] The 23 guarded federation admin routes appear to have no caller.** Every
  one has a tRPC twin, and the twin is what the web app uses (20+ call sites). The
  `/federation/...` strings in `apps/web` are Next.js page paths, not API calls. No
  `fetch`/`axios` caller exists in the repo. That is plausibly why nobody noticed
  they were unguarded. Worth considering deletion, which would also give DID key
  management a tRPC home — but absence of an in-repo caller is not proof of no
  caller. The S2S routes (`/federation/trust*`, `/federation/v1/*`) genuinely need
  HTTP and are not in question.
- **[P3]** `'/federation/trust'` in `PUBLIC_PREFIXES` is a bare prefix, so a future
  path merely beginning with that string would become public by accident.
- **[P3]** Two modules lack a direct key-rejection test: `hub-admin` (its spec
  drives handlers through a synthetic mock app that bypasses the hook chain) and
  `key-admin` (no spec exists).