### PR TITLE
fix(api): scope auditService reads to the caller's org

### DIFF
--- a/apps/api/src/__tests__/rls/audit-service.test.ts
+++ b/apps/api/src/__tests__/rls/audit-service.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Defense-in-depth: auditService's explicit organization predicates.
+ *
+ * The same shape as `api-key-service.test.ts` and `notification-service.test.ts`,
+ * and for the same reason. Every query below runs over the ADMIN pool, which
+ * connects as role `test` (`rolsuper = t, rolbypassrls = t`), so RLS does not
+ * apply — not even the `FORCE ROW LEVEL SECURITY` set on `audit_events` by
+ * `0002_apply_triggers.sql`, which binds the table owner but not a superuser.
+ * The only thing separating org A's events from org B's here is the
+ * `WHERE organization_id = $orgId` clause in the service.
+ *
+ * The audit log is the table this matters most for: it is the record of who did
+ * what, so a cross-tenant read of it is worse than a cross-tenant read of the
+ * rows it describes. Until 2026-07-30 both `list` and `getById` filtered without
+ * any organization predicate and said so in their doc comments.
+ *
+ * `audit_events.organization_id` is NULLABLE, unlike `api_keys`'. Rows with a
+ * NULL org are written deliberately — `logDirect` records auth failures before
+ * an org is known, and `ON DELETE SET NULL` orphans rows when an org is removed.
+ * Those rows were never visible through these methods: the SELECT policy is
+ * `organization_id = current_org_id()`, and NULL never matches `=`. The
+ * `excludes a global (null-org) event` cases below pin that equivalence, so the
+ * explicit predicate cannot be accused of having narrowed the result set.
+ *
+ * Consequence: if someone deletes those predicates, this file fails while every
+ * other test in the repo still passes. Do not "fix" it by switching to the app
+ * pool — that reinstates RLS and the suite would pass with or without the
+ * predicates, testing nothing. The unit spec cannot substitute either: it mocks
+ * `eq`/`and` as bare `vi.fn()`s, so the assembled `where` is discarded entirely.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { auditEvents, type Organization, type User } from '@colophony/db';
+import { globalSetup, getAdminPool } from './helpers/db-setup';
+import { truncateAllTables } from './helpers/cleanup';
+import {
+  createOrganization,
+  createUser,
+  createOrgMember,
+  createAuditEvent,
+} from './helpers/factories';
+import { auditService } from '../../services/audit.service.js';
+
+type ServiceTx = Parameters<typeof auditService.list>[0];
+
+/**
+ * A Drizzle handle over the RLS-bypassing admin pool, shaped as the `tx` the
+ * service expects. The cast mirrors `helpers/factories.ts` — `@colophony/db`
+ * and the test tree resolve drizzle through different optional peer-dep
+ * contexts, so the types diverge while the runtime is a single copy.
+ */
+function adminTx(): ServiceTx {
+  return drizzle(getAdminPool());
+}
+
+function adminDb(): ReturnType<typeof drizzle> {
+  return drizzle(getAdminPool());
+}
+
+const PAGE = { page: 1, limit: 20 };
+
+describe('auditService defense-in-depth (RLS bypassed)', () => {
+  let orgA: Organization;
+  let orgB: Organization;
+  let user: User;
+  let eventA: { id: string };
+  let eventB: { id: string };
+  // An org-less row, as `logDirect` writes for auth failures. Invisible under
+  // the SELECT policy today; must stay invisible under the explicit predicate.
+  let eventGlobal: { id: string };
+
+  beforeAll(async () => {
+    await globalSetup();
+    await truncateAllTables();
+
+    orgA = await createOrganization({ name: 'Org Alpha' });
+    orgB = await createOrganization({ name: 'Org Beta' });
+    user = await createUser();
+    await createOrgMember(orgA.id, user.id, { roles: ['ADMIN'] });
+    await createOrgMember(orgB.id, user.id, { roles: ['ADMIN'] });
+  });
+
+  // Fresh rows per test so the count assertions cannot drift as cases are
+  // added or reordered.
+  beforeEach(async () => {
+    await adminDb().delete(auditEvents);
+
+    eventA = await createAuditEvent({
+      organizationId: orgA.id,
+      actorId: user.id,
+      action: 'USER_CREATED',
+      resource: 'user',
+    });
+    eventB = await createAuditEvent({
+      organizationId: orgB.id,
+      actorId: user.id,
+      action: 'USER_CREATED',
+      resource: 'user',
+    });
+    eventGlobal = await createAuditEvent({
+      organizationId: null,
+      action: 'USER_CREATED',
+      resource: 'user',
+    });
+  });
+
+  afterAll(async () => {
+    await truncateAllTables();
+  });
+
+  describe('list', () => {
+    it("returns only the caller's org events", async () => {
+      const result = await auditService.list(adminTx(), PAGE, orgA.id);
+
+      expect(result.items.map((e) => e.id)).toEqual([eventA.id]);
+      expect(result.items.map((e) => e.id)).not.toContain(eventB.id);
+    });
+
+    it('scopes the total count to the org', async () => {
+      // Without a predicate on the count query, `total` reports every org's
+      // events even when `items` is correctly filtered — the pagination
+      // metadata leaks a row count across tenants.
+      const result = await auditService.list(adminTx(), PAGE, orgA.id);
+
+      expect(result.total).toBe(1);
+      expect(result.totalPages).toBe(1);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+    });
+
+    it('applies the org predicate alongside an action filter', async () => {
+      // Org B's event carries the same action, so only the org predicate can
+      // exclude it.
+      const result = await auditService.list(
+        adminTx(),
+        { ...PAGE, action: 'USER_CREATED' },
+        orgA.id,
+      );
+
+      expect(result.items.map((e) => e.id)).toEqual([eventA.id]);
+      expect(result.total).toBe(1);
+    });
+
+    it('excludes a global (null-org) event', async () => {
+      const result = await auditService.list(adminTx(), PAGE, orgA.id);
+
+      expect(result.items.map((e) => e.id)).not.toContain(eventGlobal.id);
+    });
+  });
+
+  describe('getById', () => {
+    it("returns an event in the caller's own org", async () => {
+      const result = await auditService.getById(adminTx(), eventA.id, orgA.id);
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(eventA.id);
+    });
+
+    it('returns null for an event in another org', async () => {
+      const result = await auditService.getById(adminTx(), eventB.id, orgA.id);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for a global (null-org) event', async () => {
+      const result = await auditService.getById(
+        adminTx(),
+        eventGlobal.id,
+        orgA.id,
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/rest/routers/audit.spec.ts
+++ b/apps/api/src/rest/routers/audit.spec.ts
@@ -175,6 +175,7 @@ describe('audit REST router', () => {
           action: 'USER_CREATED',
           resource: 'user',
         }),
+        ORG_ID,
       );
     });
   });

--- a/apps/api/src/rest/routers/audit.ts
+++ b/apps/api/src/rest/routers/audit.ts
@@ -36,7 +36,11 @@ const list = adminProcedure
   .input(restListAuditEventsQuery)
   .output(paginatedAuditEventsSchema)
   .handler(async ({ input, context }) => {
-    const result = await auditService.list(context.dbTx, input);
+    const result = await auditService.list(
+      context.dbTx,
+      input,
+      context.authContext.orgId,
+    );
     await context.audit({
       action: AuditActions.AUDIT_ACCESSED,
       resource: AuditResources.AUDIT,
@@ -58,7 +62,11 @@ const getById = adminProcedure
   .input(idParamSchema)
   .output(auditEventResponseSchema)
   .handler(async ({ input, context }) => {
-    const event = await auditService.getById(context.dbTx, input.id);
+    const event = await auditService.getById(
+      context.dbTx,
+      input.id,
+      context.authContext.orgId,
+    );
     if (!event) {
       throw new ORPCError('NOT_FOUND', {
         message: 'Audit event not found',

--- a/apps/api/src/services/audit.service.spec.ts
+++ b/apps/api/src/services/audit.service.spec.ts
@@ -11,6 +11,7 @@ vi.mock('@colophony/db', () => ({
   auditEvents: {
     _: 'audit_events_table_ref',
     id: 'id',
+    organizationId: 'organization_id',
     action: 'action',
     resource: 'resource',
     actorId: 'actor_id',
@@ -389,7 +390,7 @@ describe('auditService.list', () => {
     const row = makeRow();
     const tx = makeQueryTx([row], 1);
 
-    const result = await auditService.list(tx, { page: 1, limit: 20 });
+    const result = await auditService.list(tx, { page: 1, limit: 20 }, 'org-1');
 
     expect(result.items).toHaveLength(1);
     expect(result.total).toBe(1);
@@ -405,7 +406,7 @@ describe('auditService.list', () => {
     });
     const tx = makeQueryTx([row], 1);
 
-    const result = await auditService.list(tx, { page: 1, limit: 20 });
+    const result = await auditService.list(tx, { page: 1, limit: 20 }, 'org-1');
 
     expect(result.items[0].oldValue).toEqual({ name: 'Old' });
     expect(result.items[0].newValue).toEqual({ name: 'New' });
@@ -415,7 +416,7 @@ describe('auditService.list', () => {
     const row = makeRow({ newValue: 'not-valid-json{' });
     const tx = makeQueryTx([row], 1);
 
-    const result = await auditService.list(tx, { page: 1, limit: 20 });
+    const result = await auditService.list(tx, { page: 1, limit: 20 }, 'org-1');
 
     // Falls back to raw string
     expect(result.items[0].newValue).toBe('not-valid-json{');
@@ -425,7 +426,7 @@ describe('auditService.list', () => {
     const row = makeRow({ oldValue: null, newValue: null });
     const tx = makeQueryTx([row], 1);
 
-    const result = await auditService.list(tx, { page: 1, limit: 20 });
+    const result = await auditService.list(tx, { page: 1, limit: 20 }, 'org-1');
 
     expect(result.items[0].oldValue).toBeNull();
     expect(result.items[0].newValue).toBeNull();
@@ -434,7 +435,7 @@ describe('auditService.list', () => {
   it('computes totalPages correctly', async () => {
     const tx = makeQueryTx([makeRow()], 45);
 
-    const result = await auditService.list(tx, { page: 1, limit: 20 });
+    const result = await auditService.list(tx, { page: 1, limit: 20 }, 'org-1');
 
     expect(result.totalPages).toBe(3);
   });
@@ -442,7 +443,7 @@ describe('auditService.list', () => {
   it('returns empty results', async () => {
     const tx = makeQueryTx([], 0);
 
-    const result = await auditService.list(tx, { page: 1, limit: 20 });
+    const result = await auditService.list(tx, { page: 1, limit: 20 }, 'org-1');
 
     expect(result.items).toHaveLength(0);
     expect(result.total).toBe(0);
@@ -458,6 +459,7 @@ describe('auditService.getById', () => {
     const result = await auditService.getById(
       tx,
       'e0000000-0000-4000-a000-000000000001',
+      'org-1',
     );
 
     expect(result).not.toBeNull();
@@ -468,7 +470,7 @@ describe('auditService.getById', () => {
   it('returns null when not found', async () => {
     const tx = makeGetByIdTx(null);
 
-    const result = await auditService.getById(tx, 'nonexistent');
+    const result = await auditService.getById(tx, 'nonexistent', 'org-1');
 
     expect(result).toBeNull();
   });

--- a/apps/api/src/services/audit.service.ts
+++ b/apps/api/src/services/audit.service.ts
@@ -175,10 +175,19 @@ export const auditService = {
   },
 
   /**
-   * List audit events with optional filters and pagination.
-   * RLS handles org scoping automatically.
+   * List audit events for an org, with optional filters and pagination.
+   * Filters on organizationId explicitly, with RLS as the backstop rather
+   * than the only defence.
+   *
+   * The count query carries the predicate too — without it, `total` reports
+   * every org's event count while `items` is correctly scoped.
+   *
+   * Rows with a NULL organizationId (auth failures logged before an org is
+   * known, and rows orphaned by ON DELETE SET NULL) are excluded, matching
+   * the SELECT policy `organization_id = current_org_id()` — they were never
+   * visible through this method.
    */
-  async list(tx: DrizzleDb, input: ListAuditEventsInput) {
+  async list(tx: DrizzleDb, input: ListAuditEventsInput, orgId: string) {
     const {
       page,
       limit,
@@ -192,7 +201,7 @@ export const auditService = {
     } = input;
     const offset = (page - 1) * limit;
 
-    const conditions = [];
+    const conditions = [eq(auditEvents.organizationId, orgId)];
     if (action) conditions.push(eq(auditEvents.action, action));
     if (resource) conditions.push(eq(auditEvents.resource, resource));
     if (actorId) conditions.push(eq(auditEvents.actorId, actorId));
@@ -201,7 +210,9 @@ export const auditService = {
     if (from) conditions.push(gte(auditEvents.createdAt, from));
     if (to) conditions.push(lte(auditEvents.createdAt, to));
 
-    const where = conditions.length > 0 ? and(...conditions) : undefined;
+    // One hoisted condition, reused by both queries. Filtering only the page
+    // query leaves `total` counting every org's rows.
+    const where = and(...conditions);
 
     const [items, countResult] = await Promise.all([
       tx
@@ -226,13 +237,15 @@ export const auditService = {
   },
 
   /**
-   * Get a single audit event by ID. RLS scoped.
+   * Get a single audit event by ID, scoped to the caller's org. Filters on
+   * organizationId explicitly, with RLS as the backstop rather than the only
+   * defence — an event belonging to another org reads as not found.
    */
-  async getById(tx: DrizzleDb, id: string) {
+  async getById(tx: DrizzleDb, id: string, orgId: string) {
     const [row] = await tx
       .select()
       .from(auditEvents)
-      .where(eq(auditEvents.id, id))
+      .where(and(eq(auditEvents.id, id), eq(auditEvents.organizationId, orgId)))
       .limit(1);
     return row ? parseAuditRow(row) : null;
   },

--- a/apps/api/src/trpc/routers/audit.spec.ts
+++ b/apps/api/src/trpc/routers/audit.spec.ts
@@ -143,6 +143,7 @@ describe('audit router', () => {
           page: 1,
           limit: 10,
         }),
+        'org-1',
       );
     });
 

--- a/apps/api/src/trpc/routers/audit.ts
+++ b/apps/api/src/trpc/routers/audit.ts
@@ -16,7 +16,11 @@ export const auditRouter = createRouter({
     .input(listAuditEventsSchema)
     .output(paginatedResponseSchema(auditEventResponseSchema))
     .query(async ({ ctx, input }) => {
-      const result = await auditService.list(ctx.dbTx, input);
+      const result = await auditService.list(
+        ctx.dbTx,
+        input,
+        ctx.authContext.orgId,
+      );
       await ctx.audit({
         action: AuditActions.AUDIT_ACCESSED,
         resource: AuditResources.AUDIT,
@@ -29,7 +33,11 @@ export const auditRouter = createRouter({
     .input(idParamSchema)
     .output(auditEventResponseSchema)
     .query(async ({ ctx, input }) => {
-      const event = await auditService.getById(ctx.dbTx, input.id);
+      const event = await auditService.getById(
+        ctx.dbTx,
+        input.id,
+        ctx.authContext.orgId,
+      );
       if (!event) {
         throw new TRPCError({
           code: 'NOT_FOUND',

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -364,15 +364,30 @@ Ordered as the design doc's Phase 0/D.
       per-surface copy is how the declarations drifted apart to begin with. The tRPC gate's seven
       tests pass unchanged.
 - [ ] **[P2] `submission.service` list/export methods carry no org predicate.** `listAll`
-      (`:290`), `exportAll` (`:392`, up to 10 000 rows) and `listAgingByOrg` (`:1526`) build
+      (`:227`), `exportAll` (`:347`, up to 10 000 rows) and `listAgingByOrg` (`:1483`) build
       their `where` from `status` / `period` / `search` / date only. `listAgingByOrg` is named
       for a scoping it does not perform — its caller supplies the org through
       `withRls({ orgId })` at `inngest/functions/submission-response-reminder.ts:64`, so it is
       correct in practice and misleading to read. — (found 2026-07-28 during the P2.0 audit)
-- [ ] **[P2] `pipeline.service.ts:309` `updateStage` filters the read but not the write.** The
-      guard is `getById(tx, id, orgId)`; the `UPDATE` that follows is
+- [ ] **[P2] `pipeline.service.ts` writes drop the org predicate — three methods, two shapes.**
+      `updateStage` (`:309`) filters the read but not the write: the guard is
+      `getById(tx, id, orgId)`, and the `UPDATE` that follows is
       `.where(eq(pipelineItems.id, id))` with no org predicate. Read-then-write with the
-      predicate on only one half. — (found 2026-07-28 during the P2.0 audit)
+      predicate on only one half.
+      **`assignCopyeditor` (`:396`) and `assignProofreader` (`:435`) are worse**: they take no
+      `orgId` parameter at all, so there is no read guard to drop — just
+      `.where(eq(pipelineItems.id, id))` on the `UPDATE`, with RLS as the only defence. Their
+      `*WithAudit` wrappers check `assertEditorOrProductionOrAdmin` but never read the item
+      org-scoped first. Both are reachable from `rest/routers/pipeline.ts` and
+      `trpc/routers/pipeline.ts`.
+      Fix all three together — one file, one signature convention `(tx, id, input, orgId)`.
+      **No test drives `pipelineService` at all**: `rls-infrastructure.test.ts` asserts the
+      `pipeline_items` policy exists in the catalog, which is not the same as proving the
+      service's own `WHERE` isolates. Needs an admin-pool suite like
+      `__tests__/rls/audit-service.test.ts`. `saveCopyedit` (`:662`) is the counter-example
+      already doing it right — it carries the org predicate on both halves.
+      — (`updateStage` found 2026-07-28 during the P2.0 audit; the two assign methods found
+      2026-07-30 while verifying the backlog against the code)
 - [ ] **[P2] `issue.service.ts:65,122` take `orgId?` as optional and apply the predicate
       conditionally.** An optional org id is a silent bypass: omit the argument and the query
       is unscoped, with nothing at the type level to flag it. Make it required, matching the
@@ -507,22 +522,24 @@ Ordered as the design doc's Phase 0/D.
       same allowlist rule as `internalOnly` and the per-credential rate limiter. Pinned twice
       (unit + end-to-end); verified an `authMethod`-based implementation fails only that one
       case out of six.
-- [ ] **[P1] `auditService.list` and `getById` carry no explicit `organizationId` predicate.**
-      `apps/api/src/services/audit.service.ts` builds `list`'s `where` from
-      action/resource/actor/resource-id/principal/date only, and `getById` filters on `id`
-      alone — RLS is the sole defense on both. The same shape as `apiKeyService` (#521),
-      `organizationService.listMembers` (#527) and `notificationService` (#531), and it is the
-      only remaining read of a tenant table in that state on this surface.
-      Fix is the house convention `(tx, input, orgId)` with **one hoisted condition reused by
-      the page and count queries** — filtering only the page leaves `total` reporting every
-      org's event count — plus an admin-pool test mirroring
-      `__tests__/rls/api-key-service.test.ts`, since the existing router specs mock the service
-      outright and would pass with or without a predicate. Callers to thread: the REST and tRPC
-      audit routers (both `adminProcedure`, so `orgId` is already resolved).
-      **Deliberately not bundled into the principal-attribution PR**, following the precedent
-      set when `apiKeyService`'s predicate fix was left out of P0.5b so a multi-tenancy change
-      would not ride inside an unrelated one. — (found 2026-07-30 by the plan review for the
-      principal-attribution work)
+- [x] **[P1] `auditService.list` and `getById` carried no explicit `organizationId` predicate.**
+      `apps/api/src/services/audit.service.ts` built `list`'s `where` from
+      action/resource/actor/resource-id/principal/date only, and `getById` filtered on `id`
+      alone — RLS was the sole defense on both. The same shape as `apiKeyService` (#521),
+      `organizationService.listMembers` (#527) and `notificationService` (#531), and the last
+      read of a tenant table in that state on this surface.
+      Fixed with the house convention `(tx, input, orgId)`, seeding the **existing** hoisted
+      `conditions` array so the count query carries the predicate too — filtering only the page
+      leaves `total` reporting every org's event count. Pinned by
+      `__tests__/rls/audit-service.test.ts` over the admin pool; verified non-vacuous (removing
+      the `list` predicate fails 4 cases, removing `getById`'s fails its 2 negative cases).
+      **Behaviour is unchanged despite `organization_id` being nullable**: the SELECT policy is
+      `organization_id = current_org_id()` and NULL never matches `=`, so org-less rows (auth
+      failures, `ON DELETE SET NULL` orphans) were already invisible — as
+      `rls-nullable-isolation.test.ts:46` already asserted. Two cases pin that equivalence.
+      No schema change: `listAuditEventsSchema` deliberately has no `organizationId`, so the
+      org cannot be spoofed from caller input. — (found 2026-07-30 by the plan review for the
+      principal-attribution work; done 2026-07-30, PR #536)
 - [ ] **[P3] The federation audit log viewer's date filters are silently dropped.**
       `apps/web/src/components/federation/audit-log-viewer.tsx` sends `dateFrom`/`dateTo` in
       its query input, but `listAuditEventsSchema` declares `from`/`to`, so both are discarded
@@ -531,7 +548,7 @@ Ordered as the design doc's Phase 0/D.
       than importing from `@colophony/types`, which is why the mismatch type-checks — fixing
       that import would have caught this. — (found 2026-07-30 while mapping the audit read
       surface)
-- [ ] **[P2] Honour `X-Act-As-User` on ordinary org-scoped API keys.** `hooks/auth.ts:314`
+- [ ] **[P2] Honour `X-Act-As-User` on ordinary org-scoped API keys.** `hooks/auth.ts:343`
       unconditionally sets `userId: creator.id` for `authMethod: 'apikey'`, so every action a
       `col_live_` key takes is attributed to whoever minted it — including `submitterId` and
       user-scoped RLS, not just the audit row. An integrator filing on behalf of several of
@@ -548,9 +565,10 @@ Ordered as the design doc's Phase 0/D.
       failure mode to avoid is falling back to the key creator, because the caller would then
       get a 2xx for a write attributed to the wrong person and never learn the header was
       ignored. Same reasoning as the `requireScopes` default-deny.
-      Depends on the `principal_id` / `principal_type` audit work above to record both
+      Depended on the `principal_id` / `principal_type` audit work above to record both
       identities; landing it before that would attribute the action to the target user with no
-      record of which key acted. — (raised 2026-07-28)
+      record of which key acted. **That dependency is satisfied** — the columns landed
+      2026-07-30 in #535, so this is now unblocked. — (raised 2026-07-28)
 - [x] **[P1] Webhook deliveries are not revalidated before send.** The worker now re-reads
       the endpoint through `webhookService.getEndpointForDelivery` as its first phase, before
       the `DELIVERING` write, and takes the URL and secret from that row rather than the job.
@@ -641,7 +659,10 @@ Ordered as the design doc's Phase 0/D.
       versus three fields. Type-only today: the contract is consumed by
       `packages/api-client` for inference, not used to validate the server response.
       — (found 2026-07-28 while removing `payments:read`)
-- [ ] **[P2] REST spec coverage.** Only 7 of 17 REST routers have a `.spec.ts`. —
+- [ ] **[P2] REST spec coverage.** Only 8 of 18 REST routers have a `.spec.ts` — the ten
+      without are `cms-connections`, `collections`, `contract-templates`, `contracts`, `csr`,
+      `issues`, `manuscripts`, `periods`, `pipeline`, `publications`. (Was "7 of 17" until the
+      notifications router landed 2026-07-29 with its spec; recounted 2026-07-30.) —
       (design doc §1.8)
 - [ ] **[P2] The served spec reports `3.1.1`; the committed one says `3.1.0`.**
       `generateOpenApiDocument()` pins the exported `sdks/openapi.json` to `3.1.0` for


### PR DESCRIPTION
## What

`auditService.list` and `getById` read `audit_events` with no explicit
`organizationId` predicate — `list` built its `where` from
action/resource/actor/resource-id/principal/date only, `getById` filtered on `id`
alone. RLS was the sole defence on both, and the doc comments said so.

This was the last read of a tenant table in that state on this surface. Same
shape as the fixes for `apiKeyService` (#521), `organizationService.listMembers`
(#527) and `notificationService` (#531).

Both methods now take a required `orgId` last, per the house convention. `list`
seeds its hoisted condition with the org predicate, so the count query carries it
too — filtering only the page would leave `total` reporting every org's event
count.

## Behaviour is unchanged, and that is pinned

`audit_events.organization_id` is nullable, unlike `api_keys`', so excluding NULL
rows is a real question rather than a formality. Rows with a NULL org are written
deliberately (auth failures logged before an org is known; rows orphaned by
`ON DELETE SET NULL`), and they were already invisible through both methods: the
SELECT policy is `organization_id = current_org_id()`, and NULL never matches
`=`. `rls-nullable-isolation.test.ts` already asserts this. Two of the new cases
pin the equivalence so the predicate cannot later be blamed for narrowing the
result set.

## Testing

New `apps/api/src/__tests__/rls/audit-service.test.ts` — 7 cases driven over the
RLS-**bypassing** admin pool, so the `WHERE` clause is the only isolation in
play. This is the only thing that can catch a regression here: the router specs
mock the service outright and the unit spec stubs `eq`/`and`, so every one of
them passed before the predicates existed.

Verified non-vacuous by hand rather than asserted in a comment: removing the
`list` predicate fails exactly its 4 cases; removing the `getById` predicate
fails both of its negative cases. The third `getById` case is a positive control
and correctly still passes.

- type-check, lint clean
- unit 1945 passed
- rls 160 passed (was 153)
- security 41, services 117, webhooks 46 passed
- all 22 CI jobs green

No contract or response-shape change, so no SDK regeneration and no migration.

## Backlog housekeeping

The second commit ticks this item and corrects entries that had gone stale,
found by checking each open Track 2 item against the code rather than trusting
the entry:

- `submission.service` line numbers had drifted; the `X-Act-As-User` entry cited
  a line that moved when #535 landed
- REST spec coverage said "7 of 17"; it is 8 of 18 since the notifications router
  landed with its spec. Names the ten routers still without one
- the `X-Act-As-User` entry's stated dependency on `principal_id`/`principal_type`
  is satisfied by #535, so it is no longer blocked
- widens the `pipeline.service` item: it covered `updateStage`, which filters the
  read but not the write. `assignCopyeditor` and `assignProofreader` take no
  `orgId` at all and have no read guard, leaving RLS as the only defence on a
  write reachable from both surfaces. All three are one file and one fix.