### PR TITLE
fix(api): scope pipelineService reads and writes to the caller's org

### DIFF
--- a/apps/api/src/__tests__/rls/helpers/db-setup.ts
+++ b/apps/api/src/__tests__/rls/helpers/db-setup.ts
@@ -163,12 +163,13 @@ export async function globalSetup(): Promise<void> {
   if (rows[0].rolbypassrls) throw new Error('app_user must not bypass RLS');
 
   // The mirror of the check above, and it is load-bearing for a different set of
-  // suites. `api-key-service.test.ts` and the admin-pool cases in
-  // `organization-service.test.ts` prove that an explicit WHERE clause isolates
-  // tenants *without* RLS — which only means anything if this connection really
-  // does bypass RLS. ADMIN_URL comes straight from DATABASE_TEST_URL, so pointing
-  // it at a non-superuser would make those suites pass under RLS and assert
-  // nothing, while still reporting green.
+  // suites. `api-key-service.test.ts`, `notification-service.test.ts`,
+  // `audit-service.test.ts`, `pipeline-service.test.ts` and the admin-pool cases
+  // in `organization-service.test.ts` prove that an explicit WHERE clause
+  // isolates tenants *without* RLS — which only means anything if this
+  // connection really does bypass RLS. ADMIN_URL comes straight from
+  // DATABASE_TEST_URL, so pointing it at a non-superuser would make those suites
+  // pass under RLS and assert nothing, while still reporting green.
   const { rows: adminRoles } = await admin.query<{
     rolsuper: boolean;
     rolbypassrls: boolean;

--- a/apps/api/src/__tests__/rls/helpers/factories.ts
+++ b/apps/api/src/__tests__/rls/helpers/factories.ts
@@ -22,6 +22,8 @@ import {
   submissionDiscussions,
   submissionVotes,
   submissionReviewers,
+  pipelineItems,
+  type PipelineItem,
   type Organization,
   type User,
   type OrganizationMember,
@@ -412,6 +414,37 @@ export async function createSubmissionReviewer(
     })
     .returning();
   return reviewer;
+}
+
+/**
+ * `organizationId` and `submissionId` are deliberately independent positional
+ * params rather than the org being derived from the submission. Scoping
+ * `pipelineService.create` is exactly a fix for mismatched pairs, so the suite
+ * that proves it has to be able to seed one.
+ *
+ * Note `pipeline_items_submission_id_idx` is a GLOBAL unique index on
+ * `submission_id` — one item per submission across every org, ever — so a suite
+ * seeding these wants one submission per intended item.
+ *
+ * No `createPipelineHistory` / `createPipelineComment` alongside it: both tables
+ * cascade from `pipeline_items` and no case reads them through a factory. Same
+ * rule as the `createPortfolioEntry` note below.
+ */
+export async function createPipelineItem(
+  organizationId: string,
+  submissionId: string,
+  overrides?: Partial<PipelineItem>,
+): Promise<PipelineItem> {
+  const db = adminDb();
+  const [item] = await db
+    .insert(pipelineItems)
+    .values({
+      organizationId,
+      submissionId,
+      ...overrides,
+    })
+    .returning();
+  return item;
 }
 
 // No `createPortfolioEntry` here on purpose: `portfolioService.list` reads

--- a/apps/api/src/__tests__/rls/pipeline-service.test.ts
+++ b/apps/api/src/__tests__/rls/pipeline-service.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Defense-in-depth: pipelineService's explicit organization predicates.
+ *
+ * The same shape as `api-key-service.test.ts`, `notification-service.test.ts`
+ * and `audit-service.test.ts`, and for the same reason. Every query below runs
+ * over the ADMIN pool, which connects as role `test`
+ * (`rolsuper = t, rolbypassrls = t`), so RLS does not apply — not even the
+ * `FORCE ROW LEVEL SECURITY` set on `pipeline_items` by `0017_pipeline.sql`,
+ * which binds the table owner but not a superuser. The only thing separating
+ * org A's items from org B's here is the `WHERE organization_id = $orgId` in the
+ * service. Do not "fix" this by switching to the app pool — that reinstates RLS
+ * and the suite would pass with or without the predicates, testing nothing.
+ *
+ * This is the first test of any kind to drive `pipelineService` against a real
+ * database. The unit spec cannot substitute: its `tx` is `{}`, so no `WHERE`
+ * clause is ever assembled, let alone executed.
+ *
+ * Two of the defects pinned here were live cross-tenant *writes*, not just
+ * reads. `assignCopyeditor` and `assignProofreader` took no `orgId` at all, and
+ * `create`'s submission-existence check was unscoped — so org A could attach a
+ * pipeline item to org B's submission and then read B's title back out through
+ * the `list`/`getById` joins.
+ *
+ * ON `updateStage`, WHICH IS DEFENDED TWICE. Its cross-org case is held by the
+ * org-scoped `getById` guard AND by the predicate + `if (!updated) throw` on the
+ * UPDATE itself, and **either one alone is sufficient** — measured, by reverting
+ * each in turn: neither revert on its own fails the case, and reverting both
+ * does. So do not read a green run as proof of both. That redundancy is the
+ * point rather than an oversight: the guard is what runs today, and the UPDATE
+ * predicate is what keeps the method correct if a future refactor drops it.
+ * Without the `!updated` throw that fallback is worse than nothing — the history
+ * insert below it is unconditional, so a zero-row update would still write a row
+ * against the other org's item, which `getHistory` would hand back to them.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { eq } from 'drizzle-orm';
+import {
+  pipelineItems,
+  pipelineHistory,
+  type Organization,
+  type User,
+  type Submission,
+  type PipelineItem,
+} from '@colophony/db';
+import { globalSetup, getAdminPool } from './helpers/db-setup';
+import { truncateAllTables } from './helpers/cleanup';
+import {
+  createOrganization,
+  createUser,
+  createOrgMember,
+  createSubmissionPeriod,
+  createSubmission,
+  createPipelineItem,
+} from './helpers/factories';
+import {
+  pipelineService,
+  PipelineItemNotFoundError,
+  PipelineItemAlreadyExistsError,
+  SubmissionNotAcceptedError,
+} from '../../services/pipeline.service.js';
+
+type ServiceTx = Parameters<typeof pipelineService.getById>[0];
+
+/**
+ * A Drizzle handle over the RLS-bypassing admin pool, shaped as the `tx` the
+ * service expects. The cast mirrors `helpers/factories.ts` — `@colophony/db`
+ * and the test tree resolve drizzle through different optional peer-dep
+ * contexts, so the types diverge while the runtime is a single copy.
+ */
+function adminTx(): ServiceTx {
+  return drizzle(getAdminPool());
+}
+
+function adminDb(): ReturnType<typeof drizzle> {
+  return drizzle(getAdminPool());
+}
+
+/** Read a pipeline item back over the admin pool, bypassing the service. */
+async function readItem(id: string) {
+  const [row] = await adminDb()
+    .select()
+    .from(pipelineItems)
+    .where(eq(pipelineItems.id, id))
+    .limit(1);
+  return row ?? null;
+}
+
+async function countHistoryFor(pipelineItemId: string) {
+  const rows = await adminDb()
+    .select()
+    .from(pipelineHistory)
+    .where(eq(pipelineHistory.pipelineItemId, pipelineItemId));
+  return rows.length;
+}
+
+describe('pipelineService defense-in-depth (RLS bypassed)', () => {
+  let orgA: Organization;
+  let orgB: Organization;
+  let user: User;
+  // One submission per intended pipeline item: the unique index on
+  // submission_id is global, so a submission can back at most one item ever.
+  let subA: Submission;
+  let subB: Submission;
+  let subACreate: Submission;
+  let subBCreate: Submission;
+  let subBPending: Submission;
+
+  beforeAll(async () => {
+    await globalSetup();
+    await truncateAllTables();
+
+    orgA = await createOrganization({ name: 'Org Alpha' });
+    orgB = await createOrganization({ name: 'Org Beta' });
+    user = await createUser();
+    await createOrgMember(orgA.id, user.id, { roles: ['ADMIN'] });
+    await createOrgMember(orgB.id, user.id, { roles: ['ADMIN'] });
+
+    const periodA = await createSubmissionPeriod(orgA.id);
+    const periodB = await createSubmissionPeriod(orgB.id);
+
+    [subA, subB, subACreate, subBCreate, subBPending] = await Promise.all([
+      createSubmission(orgA.id, user.id, {
+        submissionPeriodId: periodA.id,
+        status: 'ACCEPTED',
+      }),
+      createSubmission(orgB.id, user.id, {
+        submissionPeriodId: periodB.id,
+        status: 'ACCEPTED',
+      }),
+      createSubmission(orgA.id, user.id, {
+        submissionPeriodId: periodA.id,
+        status: 'ACCEPTED',
+      }),
+      createSubmission(orgB.id, user.id, {
+        submissionPeriodId: periodB.id,
+        status: 'ACCEPTED',
+      }),
+      // Org B, deliberately NOT accepted — the status-oracle case.
+      createSubmission(orgB.id, user.id, {
+        submissionPeriodId: periodB.id,
+        status: 'UNDER_REVIEW',
+      }),
+    ]);
+  });
+
+  // Fresh items per test. Deleting the parent cascades to pipeline_history and
+  // pipeline_comments, so history counts cannot drift as cases are reordered.
+  let itemA: PipelineItem;
+  let itemB: PipelineItem;
+
+  beforeEach(async () => {
+    await adminDb().delete(pipelineItems);
+    itemA = await createPipelineItem(orgA.id, subA.id);
+    itemB = await createPipelineItem(orgB.id, subB.id);
+  });
+
+  afterAll(async () => {
+    await truncateAllTables();
+  });
+
+  describe('assignCopyeditor', () => {
+    it('returns null for an item in another org and leaves it untouched', async () => {
+      const result = await pipelineService.assignCopyeditor(
+        adminTx(),
+        itemB.id,
+        { userId: user.id },
+        orgA.id,
+      );
+
+      expect(result).toBeNull();
+
+      // The read-back is the point: a predicate-less UPDATE returns the row AND
+      // mutates it, so asserting only on the return value would miss half of it.
+      const stored = await readItem(itemB.id);
+      expect(stored?.assignedCopyeditorId).toBeNull();
+    });
+
+    it("assigns within the caller's own org", async () => {
+      const result = await pipelineService.assignCopyeditor(
+        adminTx(),
+        itemA.id,
+        { userId: user.id },
+        orgA.id,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result.assignedCopyeditorId).toBe(user.id);
+
+      const stored = await readItem(itemA.id);
+      expect(stored?.assignedCopyeditorId).toBe(user.id);
+    });
+  });
+
+  describe('assignProofreader', () => {
+    it('returns null for an item in another org and leaves it untouched', async () => {
+      const result = await pipelineService.assignProofreader(
+        adminTx(),
+        itemB.id,
+        { userId: user.id },
+        orgA.id,
+      );
+
+      expect(result).toBeNull();
+
+      const stored = await readItem(itemB.id);
+      expect(stored?.assignedProofreaderId).toBeNull();
+    });
+
+    it("assigns within the caller's own org", async () => {
+      const result = await pipelineService.assignProofreader(
+        adminTx(),
+        itemA.id,
+        { userId: user.id },
+        orgA.id,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result.assignedProofreaderId).toBe(user.id);
+
+      const stored = await readItem(itemA.id);
+      expect(stored?.assignedProofreaderId).toBe(user.id);
+    });
+  });
+
+  describe('getBySubmissionId', () => {
+    it('returns null for a submission in another org', async () => {
+      const result = await pipelineService.getBySubmissionId(
+        adminTx(),
+        subB.id,
+        orgA.id,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("returns the item for a submission in the caller's own org", async () => {
+      const result = await pipelineService.getBySubmissionId(
+        adminTx(),
+        subA.id,
+        orgA.id,
+      );
+
+      expect(result?.id).toBe(itemA.id);
+    });
+  });
+
+  describe('create', () => {
+    it('refuses a submission belonging to another org, and writes nothing', async () => {
+      await expect(
+        pipelineService.create(
+          adminTx(),
+          { submissionId: subBCreate.id },
+          orgA.id,
+        ),
+      ).rejects.toThrow(PipelineItemNotFoundError);
+
+      const rows = await adminDb()
+        .select()
+        .from(pipelineItems)
+        .where(eq(pipelineItems.submissionId, subBCreate.id));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("does not leak another org's submission status", async () => {
+      // Scoping only the uniqueness check would still let this through:
+      // SubmissionNotAcceptedError interpolates the status into its message, so
+      // an unscoped existence read is a status oracle for submissions the caller
+      // cannot otherwise see. It must fail as "not found", never as "not accepted".
+      const promise = pipelineService.create(
+        adminTx(),
+        { submissionId: subBPending.id },
+        orgA.id,
+      );
+
+      await expect(promise).rejects.toThrow(PipelineItemNotFoundError);
+      await expect(promise).rejects.not.toThrow(SubmissionNotAcceptedError);
+    });
+
+    it("creates for a submission in the caller's own org", async () => {
+      const row = await pipelineService.create(
+        adminTx(),
+        { submissionId: subACreate.id },
+        orgA.id,
+      );
+
+      expect(row.organizationId).toBe(orgA.id);
+      expect(row.submissionId).toBe(subACreate.id);
+      expect(await countHistoryFor(row.id)).toBe(1);
+    });
+
+    it('surfaces a global-uniqueness collision as PipelineItemAlreadyExistsError', async () => {
+      // `pipeline_items_submission_id_idx` is unique across ALL orgs, so the
+      // org-scoped pre-check cannot pre-empt it. Seed the mismatched pair that
+      // was creatable before the predicate above existed: org B owning an item
+      // on org A's submission. Org A's create then passes the pre-check (which
+      // sees nothing in org A) and collides at the insert.
+      await createPipelineItem(orgB.id, subACreate.id);
+
+      await expect(
+        pipelineService.create(
+          adminTx(),
+          { submissionId: subACreate.id },
+          orgA.id,
+        ),
+      ).rejects.toThrow(PipelineItemAlreadyExistsError);
+    });
+  });
+
+  describe('updateStage', () => {
+    // NOTE: two independent defences hold this — see the file header. Reverting
+    // only `getById`'s predicate, or only the UPDATE's, leaves it green; revert
+    // both to see it fail.
+    it('refuses an item in another org and writes no history for it', async () => {
+      await expect(
+        pipelineService.updateStage(
+          adminTx(),
+          itemB.id,
+          { stage: 'COPYEDIT_IN_PROGRESS' },
+          orgA.id,
+        ),
+      ).rejects.toThrow(PipelineItemNotFoundError);
+
+      const stored = await readItem(itemB.id);
+      expect(stored?.stage).toBe('COPYEDIT_PENDING');
+      expect(await countHistoryFor(itemB.id)).toBe(0);
+    });
+
+    it("transitions an item in the caller's own org", async () => {
+      const updated = await pipelineService.updateStage(
+        adminTx(),
+        itemA.id,
+        { stage: 'COPYEDIT_IN_PROGRESS' },
+        orgA.id,
+      );
+
+      expect(updated.stage).toBe('COPYEDIT_IN_PROGRESS');
+      expect(await countHistoryFor(itemA.id)).toBe(1);
+    });
+  });
+
+  describe('addComment', () => {
+    it('refuses to comment on an item in another org', async () => {
+      await expect(
+        pipelineService.addComment(
+          adminTx(),
+          itemB.id,
+          { content: 'cross-tenant' },
+          user.id,
+          'COPYEDIT_PENDING',
+          orgA.id,
+        ),
+      ).rejects.toThrow(PipelineItemNotFoundError);
+
+      const comments = await pipelineService.listComments(
+        adminTx(),
+        itemB.id,
+        orgB.id,
+      );
+      expect(comments).toHaveLength(0);
+    });
+
+    it("comments on an item in the caller's own org", async () => {
+      const comment = await pipelineService.addComment(
+        adminTx(),
+        itemA.id,
+        { content: 'looks good' },
+        user.id,
+        'COPYEDIT_PENDING',
+        orgA.id,
+      );
+
+      expect(comment.pipelineItemId).toBe(itemA.id);
+    });
+  });
+
+  describe('list', () => {
+    it("returns only the caller's own items", async () => {
+      const result = await pipelineService.list(
+        adminTx(),
+        { page: 1, limit: 20 },
+        orgA.id,
+      );
+
+      expect(result.items.map((i) => i.id)).toEqual([itemA.id]);
+      expect(result.total).toBe(1);
+    });
+
+    // Deliberately NOT a proof of the search subquery's org predicate, and
+    // measured to be sure: reverting that predicate leaves this green. The outer
+    // `inArray` intersects the subquery against an already org-scoped set, so
+    // results were correct either way and no input can distinguish them. The
+    // predicate narrows what the subquery scans, which is a performance property
+    // this suite has no way to assert. Kept as a result-correctness regression
+    // guard on the search path — nothing more.
+    it("does not match another org's submission title through search", async () => {
+      const result = await pipelineService.list(
+        adminTx(),
+        { page: 1, limit: 20, search: subB.title ?? undefined },
+        orgA.id,
+      );
+
+      expect(result.items).toHaveLength(0);
+    });
+  });
+});

--- a/apps/api/src/services/pipeline.service.spec.ts
+++ b/apps/api/src/services/pipeline.service.spec.ts
@@ -48,37 +48,30 @@ describe('pipeline.service', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Defense-in-depth: explicit organizationId filters
+  // Org-id threading at the call site
   // ---------------------------------------------------------------------------
 
-  describe('defense-in-depth: organizationId filters', () => {
-    it('list() requires orgId parameter', () => {
-      // TypeScript enforces the orgId parameter at compile time.
-      // Verify the function signature accepts 3 arguments (tx, input, orgId).
-      expect(pipelineService.list.length).toBe(3);
-    });
-
-    it('getById() requires orgId parameter', () => {
-      expect(pipelineService.getById.length).toBe(3);
-    });
-
-    it('listComments() requires orgId parameter', () => {
-      expect(pipelineService.listComments.length).toBe(3);
-    });
-
-    it('getHistory() requires orgId parameter', () => {
-      expect(pipelineService.getHistory.length).toBe(3);
-    });
-
-    it('updateStage() requires orgId parameter', () => {
-      // updateStage(tx, id, input, orgId, changedBy?)
-      expect(pipelineService.updateStage.length).toBeGreaterThanOrEqual(4);
-    });
-
-    it('addCommentWithAudit passes actor orgId to getById', async () => {
+  /**
+   * These assert that each `*WithAudit` wrapper hands `ctx.actor.orgId` to its
+   * collaborator — the property the routers depend on, since they pass only a
+   * ServiceContext and never an org id of their own.
+   *
+   * They say nothing about the WHERE clauses themselves. This spec's `tx` is
+   * `{}`, so no query is ever assembled, let alone run. The predicates are proved
+   * in `src/__tests__/rls/pipeline-service.test.ts`, which drives the service
+   * over the RLS-bypassing admin pool where the WHERE clause is the only
+   * isolation in play.
+   *
+   * This block previously asserted org scoping via `Function.prototype.length`
+   * — `expect(pipelineService.updateStage.length).toBeGreaterThanOrEqual(4)` and
+   * five siblings. Those were deleted rather than kept: arity cannot distinguish
+   * a method that uses `orgId` from one that merely accepts it, which was the
+   * exact state of `updateStage`'s UPDATE and of every `assign*` caller. They
+   * passed throughout, which is part of why this went unnoticed.
+   */
+  describe('threads actor.orgId to the collaborator', () => {
+    it('addCommentWithAudit → getById', async () => {
       const ctx = makeCtx(['EDITOR']);
-      // getById will call tx.select().from().leftJoin()...where(and(eq(id), eq(orgId)))
-      // It will fail on the mock tx, but we can verify the call pattern
       const getByIdSpy = vi.spyOn(pipelineService, 'getById');
       try {
         await pipelineService.addCommentWithAudit(ctx, 'item-1', {
@@ -91,7 +84,7 @@ describe('pipeline.service', () => {
       getByIdSpy.mockRestore();
     });
 
-    it('updateStageWithAudit passes actor orgId to getById and updateStage', async () => {
+    it('updateStageWithAudit → getById', async () => {
       const ctx = makeCtx(['EDITOR']);
       const getByIdSpy = vi.spyOn(pipelineService, 'getById');
       try {
@@ -104,6 +97,44 @@ describe('pipeline.service', () => {
       expect(getByIdSpy).toHaveBeenCalledWith(ctx.tx, 'item-1', 'org-1');
       getByIdSpy.mockRestore();
     });
+
+    it('assignCopyeditorWithAudit → assignCopyeditor', async () => {
+      const ctx = makeCtx(['EDITOR']);
+      const spy = vi.spyOn(pipelineService, 'assignCopyeditor');
+      try {
+        await pipelineService.assignCopyeditorWithAudit(ctx, 'item-1', {
+          userId: 'user-2',
+        });
+      } catch {
+        // Expected: mock tx throws
+      }
+      expect(spy).toHaveBeenCalledWith(
+        ctx.tx,
+        'item-1',
+        { userId: 'user-2' },
+        'org-1',
+      );
+      spy.mockRestore();
+    });
+
+    it('assignProofreaderWithAudit → assignProofreader', async () => {
+      const ctx = makeCtx(['EDITOR']);
+      const spy = vi.spyOn(pipelineService, 'assignProofreader');
+      try {
+        await pipelineService.assignProofreaderWithAudit(ctx, 'item-1', {
+          userId: 'user-2',
+        });
+      } catch {
+        // Expected: mock tx throws
+      }
+      expect(spy).toHaveBeenCalledWith(
+        ctx.tx,
+        'item-1',
+        { userId: 'user-2' },
+        'org-1',
+      );
+      spy.mockRestore();
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -111,10 +142,6 @@ describe('pipeline.service', () => {
   // ---------------------------------------------------------------------------
 
   describe('dashboard', () => {
-    it('requires orgId parameter (3 args: tx, input, orgId)', () => {
-      expect(pipelineService.dashboard.length).toBe(3);
-    });
-
     it('returns null when no active issues exist', async () => {
       // Create a mock tx that returns empty results for the issue query
       const mockTx = {

--- a/apps/api/src/services/pipeline.service.ts
+++ b/apps/api/src/services/pipeline.service.ts
@@ -76,6 +76,29 @@ export class InvalidPipelineTransitionError extends Error {
   }
 }
 
+/**
+ * True for a Postgres unique-violation (SQLSTATE 23505).
+ *
+ * Walks the `cause` chain because Drizzle wraps driver errors in a
+ * `DrizzleQueryError` and the pg error — the one carrying `code` — is the cause.
+ * Checking `err.code` directly silently never matches, which is exactly what the
+ * first version of this did.
+ *
+ * Matches on the SQLSTATE, not the message. `saveCopyedit` below string-matches
+ * 'unique constraint' for its retry; do not copy that spelling.
+ */
+function isUniqueViolation(err: unknown): boolean {
+  let current: unknown = err;
+  // Bounded so a self-referential cause cannot spin.
+  for (let depth = 0; depth < 5; depth++) {
+    if (current === null || typeof current !== 'object') return false;
+    if ('code' in current && current.code === '23505') return true;
+    if (!('cause' in current)) return false;
+    current = current.cause;
+  }
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
@@ -111,7 +134,10 @@ export const pipelineService = {
         eq(pipelineItems.assignedProofreaderId, assignedProofreaderId),
       );
 
-    // Search by submission title via subquery
+    // Search by submission title via subquery. The subquery carries the org
+    // predicate too — the outer `inArray` intersects it with an org-scoped set,
+    // so results were already correct, but an unscoped subquery scans every
+    // tenant's titles to get there.
     if (search) {
       conditions.push(
         inArray(
@@ -119,7 +145,12 @@ export const pipelineService = {
           tx
             .select({ id: submissions.id })
             .from(submissions)
-            .where(sql`${submissions.title} ILIKE ${'%' + search + '%'}`),
+            .where(
+              and(
+                eq(submissions.organizationId, orgId),
+                sql`${submissions.title} ILIKE ${'%' + search + '%'}`,
+              ),
+            ),
         ),
       );
     }
@@ -139,10 +170,25 @@ export const pipelineService = {
           assignedProofreader: { email: proofreaders.email },
         })
         .from(pipelineItems)
-        .leftJoin(submissions, eq(pipelineItems.submissionId, submissions.id))
+        // Org predicate on the join, not just the FK. Isolation would otherwise
+        // rest entirely on the pipeline_items row being org-scoped plus FK
+        // integrity — which `create` violated until this change.
+        // The two `users` aliases carry no such term because `users` has no org
+        // column; a non-member assignee is the separate concern noted on
+        // `assignCopyeditor`.
+        .leftJoin(
+          submissions,
+          and(
+            eq(pipelineItems.submissionId, submissions.id),
+            eq(submissions.organizationId, orgId),
+          ),
+        )
         .leftJoin(
           publications,
-          eq(pipelineItems.publicationId, publications.id),
+          and(
+            eq(pipelineItems.publicationId, publications.id),
+            eq(publications.organizationId, orgId),
+          ),
         )
         .leftJoin(
           copyeditors,
@@ -197,8 +243,21 @@ export const pipelineService = {
         assignedProofreader: { email: proofreaders.email },
       })
       .from(pipelineItems)
-      .leftJoin(submissions, eq(pipelineItems.submissionId, submissions.id))
-      .leftJoin(publications, eq(pipelineItems.publicationId, publications.id))
+      // Org predicate on the join — see the note in `list` above.
+      .leftJoin(
+        submissions,
+        and(
+          eq(pipelineItems.submissionId, submissions.id),
+          eq(submissions.organizationId, orgId),
+        ),
+      )
+      .leftJoin(
+        publications,
+        and(
+          eq(pipelineItems.publicationId, publications.id),
+          eq(publications.organizationId, orgId),
+        ),
+      )
       .leftJoin(
         copyeditors,
         eq(pipelineItems.assignedCopyeditorId, copyeditors.id),
@@ -229,11 +288,23 @@ export const pipelineService = {
     };
   },
 
-  async getBySubmissionId(tx: DrizzleDb, submissionId: string) {
+  /**
+   * Look up the pipeline item for a submission, scoped to the caller's org.
+   * Filters on organizationId explicitly, with RLS as the backstop rather than
+   * the only defence. This is a bare `select()` with no projection, so without
+   * the predicate it returns another org's whole row — both assignee ids, all
+   * three due dates and the Inngest run id included.
+   */
+  async getBySubmissionId(tx: DrizzleDb, submissionId: string, orgId: string) {
     const [row] = await tx
       .select()
       .from(pipelineItems)
-      .where(eq(pipelineItems.submissionId, submissionId))
+      .where(
+        and(
+          eq(pipelineItems.submissionId, submissionId),
+          eq(pipelineItems.organizationId, orgId),
+        ),
+      )
       .limit(1);
 
     return row ?? null;
@@ -244,11 +315,21 @@ export const pipelineService = {
   // -------------------------------------------------------------------------
 
   async create(tx: DrizzleDb, input: CreatePipelineItemInput, orgId: string) {
-    // Verify the submission exists and is ACCEPTED
+    // Verify the submission exists, belongs to this org, and is ACCEPTED.
+    // The org predicate is load-bearing on both counts: without it a caller can
+    // create an item in its own org pointing at another tenant's submission —
+    // which `list`/`getById` then join and hand back — and the
+    // SubmissionNotAcceptedError below turns into a status oracle for
+    // submissions the caller cannot otherwise see.
     const [submission] = await tx
       .select({ id: submissions.id, status: submissions.status })
       .from(submissions)
-      .where(eq(submissions.id, input.submissionId))
+      .where(
+        and(
+          eq(submissions.id, input.submissionId),
+          eq(submissions.organizationId, orgId),
+        ),
+      )
       .limit(1);
 
     if (!submission) {
@@ -261,21 +342,38 @@ export const pipelineService = {
       );
     }
 
-    // Check uniqueness: one pipeline item per submission
+    // Check uniqueness: one pipeline item per submission.
+    // This is an optimisation for the common case, not the guarantee — see the
+    // 23505 handler below.
     const existing = await pipelineService.getBySubmissionId(
       tx,
       input.submissionId,
+      orgId,
     );
     if (existing) throw new PipelineItemAlreadyExistsError(input.submissionId);
 
-    const [row] = await tx
-      .insert(pipelineItems)
-      .values({
-        organizationId: orgId,
-        submissionId: input.submissionId,
-        publicationId: input.publicationId ?? null,
-      })
-      .returning();
+    // `pipeline_items_submission_id_idx` is a GLOBAL unique index on
+    // submission_id, so the org-scoped pre-check above cannot pre-empt it: a row
+    // owned by another org — creatable before this predicate existed — passes the
+    // check and then collides here. Map it rather than letting a raw 23505 surface
+    // as a 500. Match on the SQLSTATE, not the message; `saveCopyedit` string-matches
+    // 'unique constraint' and should not be copied.
+    let row: typeof pipelineItems.$inferSelect;
+    try {
+      [row] = await tx
+        .insert(pipelineItems)
+        .values({
+          organizationId: orgId,
+          submissionId: input.submissionId,
+          publicationId: input.publicationId ?? null,
+        })
+        .returning();
+    } catch (err: unknown) {
+      if (isUniqueViolation(err)) {
+        throw new PipelineItemAlreadyExistsError(input.submissionId);
+      }
+      throw err;
+    }
 
     // Write initial history entry
     await tx.insert(pipelineHistory).values({
@@ -320,11 +418,26 @@ export const pipelineService = {
       throw new InvalidPipelineTransitionError(item.stage, input.stage);
     }
 
+    // Second, independent defence. The org-scoped `getById` above already proved
+    // this primary key belongs to `orgId`, and a PK matches exactly one row, so
+    // no input makes the two WHERE forms differ while that guard stands. This
+    // predicate is what keeps the method correct if the guard is ever refactored
+    // away — verified by reverting each in turn: either alone still rejects a
+    // cross-org call, and only reverting both lets one through.
+    //
+    // The `!updated` check is not tidying. The history insert below is
+    // unconditional, so a zero-row update would still write a row against the
+    // other org's item, which `getHistory` would then hand back to them — i.e.
+    // adding the predicate without this check would be worse than adding neither.
     const [updated] = await tx
       .update(pipelineItems)
       .set({ stage: input.stage, updatedAt: new Date() })
-      .where(eq(pipelineItems.id, id))
+      .where(
+        and(eq(pipelineItems.id, id), eq(pipelineItems.organizationId, orgId)),
+      )
       .returning();
+
+    if (!updated) throw new PipelineItemNotFoundError(id);
 
     // Write history entry
     await tx.insert(pipelineHistory).values({
@@ -393,15 +506,31 @@ export const pipelineService = {
   // Assign roles
   // -------------------------------------------------------------------------
 
+  /**
+   * Assign a copyeditor, scoped to the caller's org. Filters on organizationId
+   * explicitly, with RLS as the backstop rather than the only defence — an item
+   * belonging to another org matches nothing and reads as not found.
+   *
+   * The predicate goes on the UPDATE itself because there is no preceding read
+   * to carry it: this method is a bare write, unlike `updateStage`, which guards
+   * with an org-scoped `getById` first.
+   *
+   * Note this does *not* check that `input.userId` belongs to `orgId`. Assigning
+   * a non-member is a separate, open concern — `users` carries no org column, so
+   * it needs a membership lookup rather than a predicate.
+   */
   async assignCopyeditor(
     tx: DrizzleDb,
     id: string,
     input: AssignPipelineRoleInput,
+    orgId: string,
   ) {
     const [row] = await tx
       .update(pipelineItems)
       .set({ assignedCopyeditorId: input.userId, updatedAt: new Date() })
-      .where(eq(pipelineItems.id, id))
+      .where(
+        and(eq(pipelineItems.id, id), eq(pipelineItems.organizationId, orgId)),
+      )
       .returning();
 
     return row ?? null;
@@ -413,7 +542,12 @@ export const pipelineService = {
     input: AssignPipelineRoleInput,
   ) {
     assertEditorOrProductionOrAdmin(ctx.actor.roles);
-    const updated = await pipelineService.assignCopyeditor(ctx.tx, id, input);
+    const updated = await pipelineService.assignCopyeditor(
+      ctx.tx,
+      id,
+      input,
+      ctx.actor.orgId,
+    );
     if (!updated) throw new PipelineItemNotFoundError(id);
     await ctx.audit({
       action: AuditActions.PIPELINE_COPYEDITOR_ASSIGNED,
@@ -432,15 +566,22 @@ export const pipelineService = {
     return updated;
   },
 
+  /**
+   * Assign a proofreader, scoped to the caller's org. Same shape and same
+   * reasoning as `assignCopyeditor` above, including the membership caveat.
+   */
   async assignProofreader(
     tx: DrizzleDb,
     id: string,
     input: AssignPipelineRoleInput,
+    orgId: string,
   ) {
     const [row] = await tx
       .update(pipelineItems)
       .set({ assignedProofreaderId: input.userId, updatedAt: new Date() })
-      .where(eq(pipelineItems.id, id))
+      .where(
+        and(eq(pipelineItems.id, id), eq(pipelineItems.organizationId, orgId)),
+      )
       .returning();
 
     return row ?? null;
@@ -452,7 +593,12 @@ export const pipelineService = {
     input: AssignPipelineRoleInput,
   ) {
     assertEditorOrProductionOrAdmin(ctx.actor.roles);
-    const updated = await pipelineService.assignProofreader(ctx.tx, id, input);
+    const updated = await pipelineService.assignProofreader(
+      ctx.tx,
+      id,
+      input,
+      ctx.actor.orgId,
+    );
     if (!updated) throw new PipelineItemNotFoundError(id);
     await ctx.audit({
       action: AuditActions.PIPELINE_PROOFREADER_ASSIGNED,
@@ -467,13 +613,27 @@ export const pipelineService = {
   // Comments
   // -------------------------------------------------------------------------
 
+  /**
+   * Add a comment to a pipeline item, scoped to the caller's org.
+   *
+   * `pipeline_comments` has no organizationId column of its own — its RLS policy
+   * reaches org through a subquery on the parent — so the predicate cannot go on
+   * the INSERT. It goes on an org-scoped read of the parent instead, which makes
+   * the method safe called directly. Its wrapper performs the same read; the
+   * duplicate is deliberate, so that a future caller reaching for the raw method
+   * does not inherit the wrapper's guarantee by accident.
+   */
   async addComment(
     tx: DrizzleDb,
     pipelineItemId: string,
     input: AddPipelineCommentInput,
     authorId: string | null,
     stage: PipelineStage,
+    orgId: string,
   ) {
+    const parent = await pipelineService.getById(tx, pipelineItemId, orgId);
+    if (!parent) throw new PipelineItemNotFoundError(pipelineItemId);
+
     const [row] = await tx
       .insert(pipelineComments)
       .values({
@@ -506,6 +666,7 @@ export const pipelineService = {
       input,
       ctx.actor.userId,
       item.stage,
+      ctx.actor.orgId,
     );
     await ctx.audit({
       action: AuditActions.PIPELINE_COMMENT_ADDED,
@@ -594,6 +755,12 @@ export const pipelineService = {
         versions: [],
       };
     }
+
+    // The manuscript reads below carry no org predicate, and cannot: `manuscripts`
+    // is owner-scoped (ownerId -> users) and `manuscript_versions` has no org
+    // column at all. The manuscript library is user-owned and cross-org by design,
+    // so reachability is established by the org-scoped submission read above rather
+    // than by a predicate on these tables.
 
     // Get current version content
     const [version] = await tx
@@ -1019,7 +1186,13 @@ export const pipelineService = {
           eq(pipelineItems.organizationId, orgId),
         ),
       )
-      .leftJoin(submissions, eq(pipelineItems.submissionId, submissions.id))
+      .leftJoin(
+        submissions,
+        and(
+          eq(pipelineItems.submissionId, submissions.id),
+          eq(submissions.organizationId, orgId),
+        ),
+      )
       .leftJoin(issueSections, eq(issueItems.issueSectionId, issueSections.id))
       .leftJoin(
         copyeditors,
@@ -1064,7 +1237,12 @@ export const pipelineService = {
           createdAt: contracts.createdAt,
         })
         .from(contracts)
-        .where(inArray(contracts.pipelineItemId, pipelineItemIds))
+        .where(
+          and(
+            inArray(contracts.pipelineItemId, pipelineItemIds),
+            eq(contracts.organizationId, orgId),
+          ),
+        )
         .orderBy(desc(contracts.createdAt));
 
       // Keep only the most recent per pipeline item

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -369,25 +369,52 @@ Ordered as the design doc's Phase 0/D.
       for a scoping it does not perform — its caller supplies the org through
       `withRls({ orgId })` at `inngest/functions/submission-response-reminder.ts:64`, so it is
       correct in practice and misleading to read. — (found 2026-07-28 during the P2.0 audit)
-- [ ] **[P2] `pipeline.service.ts` writes drop the org predicate — three methods, two shapes.**
-      `updateStage` (`:309`) filters the read but not the write: the guard is
-      `getById(tx, id, orgId)`, and the `UPDATE` that follows is
-      `.where(eq(pipelineItems.id, id))` with no org predicate. Read-then-write with the
-      predicate on only one half.
-      **`assignCopyeditor` (`:396`) and `assignProofreader` (`:435`) are worse**: they take no
-      `orgId` parameter at all, so there is no read guard to drop — just
-      `.where(eq(pipelineItems.id, id))` on the `UPDATE`, with RLS as the only defence. Their
-      `*WithAudit` wrappers check `assertEditorOrProductionOrAdmin` but never read the item
-      org-scoped first. Both are reachable from `rest/routers/pipeline.ts` and
-      `trpc/routers/pipeline.ts`.
-      Fix all three together — one file, one signature convention `(tx, id, input, orgId)`.
-      **No test drives `pipelineService` at all**: `rls-infrastructure.test.ts` asserts the
-      `pipeline_items` policy exists in the catalog, which is not the same as proving the
-      service's own `WHERE` isolates. Needs an admin-pool suite like
-      `__tests__/rls/audit-service.test.ts`. `saveCopyedit` (`:662`) is the counter-example
-      already doing it right — it carries the org predicate on both halves.
-      — (`updateStage` found 2026-07-28 during the P2.0 audit; the two assign methods found
-      2026-07-30 while verifying the backlog against the code)
+- [x] **[P2] `pipeline.service.ts` writes drop the org predicate.** Filed as three methods; it
+      was **five reachable defects**, and the two framed as "worse" were the only live ones.
+      `assignCopyeditor` (`:396`) and `assignProofreader` (`:435`) took no `orgId` at all —
+      bare `UPDATE … WHERE id = $1` with RLS as the sole defence. `create`'s
+      submission-existence read was unscoped, which is a cross-tenant **write** (attach an item
+      to another org's submission, then read its title back through the `list`/`getById`
+      joins) _and_ a status oracle, since `SubmissionNotAcceptedError` interpolates the status
+      of a submission the caller cannot see. `getBySubmissionId` was an unprojected `select()`
+      returning another org's whole row. `addComment` was unsafe called directly.
+      — (`updateStage` found 2026-07-28 during the P2.0 audit; the assign methods 2026-07-30;
+      the rest found 2026-07-30 while planning the fix; done 2026-07-30)
+      **`updateStage` was the least of them and is now defended twice**: the org-scoped
+      `getById` guard dominates the UPDATE, so no input distinguishes the two `WHERE` forms
+      while the guard stands. Both defences are kept, and **either alone is sufficient** —
+      measured by reverting each in turn. The `if (!updated) throw` beside the predicate is
+      load-bearing rather than tidying: the history insert after it is unconditional, so
+      adding the predicate _without_ the throw would let a zero-row update write history
+      against the other org's item, which `getHistory` returns to them.
+      **Scoping the uniqueness pre-check forced a `23505` mapping.**
+      `pipeline_items_submission_id_idx` is a **global** unique index on `submission_id`, so an
+      org-scoped pre-check cannot pre-empt it and a pre-existing mismatched row would surface
+      as a raw 500. `isUniqueViolation` walks the `cause` chain — Drizzle wraps the pg error,
+      so a direct `err.code === '23505'` check silently never matches. That was caught by the
+      test, not by review.
+      **Routers, contracts and SDKs were untouched**: the `*WithAudit` wrappers already held
+      `ctx.actor.orgId`, so only internal call sites moved.
+      Pinned by `__tests__/rls/pipeline-service.test.ts` over the admin pool — the first test of
+      any kind to drive this service against a database. The unit spec's `tx` is `{}` and it had
+      "proved" scoping with `Function.prototype.length` arity assertions, which pass whether or
+      not `orgId` is used and so were green throughout; deleted rather than kept.
+      **Two sites deliberately carry no predicate**, both recorded in comments: the manuscript
+      reads in `getCopyeditContent` (`manuscripts` is owner-scoped, `manuscript_versions` has no
+      org column — the library is user-owned and cross-org by design), and the `users` aliases.
+      One test is deliberately labelled non-proving: `list`'s search-subquery predicate cannot be
+      distinguished by any input, because the outer `inArray` already intersects against an
+      org-scoped set — it narrows what is scanned, not what is returned.
+- [ ] **[P3] `assignCopyeditor`/`assignProofreader` accept a non-member `userId`.** Both write
+      `input.userId` into `assigned_copyeditor_id` / `assigned_proofreader_id` with no check
+      that the user belongs to the item's org, and `users` carries no org column, so the org
+      predicate added 2026-07-30 does not cover it — it isolates the _item_, not the assignee.
+      Org A can therefore assign an org-B user to its own pipeline item, and `list` leftJoins
+      `users` and returns that person's email. Needs a membership lookup against
+      `organization_members`, not a predicate, which is why it was left out of the predicate
+      change. Decide the semantics first: guests, deactivated users, and staff who belong to
+      both orgs are all reachable cases, and the same question applies to
+      `submission-reviewer.service.ts`. — (found 2026-07-30 while scoping `pipelineService`)
 - [ ] **[P2] `issue.service.ts:65,122` take `orgId?` as optional and apply the predicate
       conditionally.** An optional org id is a silent bypass: omit the argument and the query
       is unscoped, with nothing at the type level to flag it. Make it required, matching the

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -115,6 +115,24 @@
       were caught and reworded before landing on 2026-07-30, which is what surfaced the
       pre-existing ones. Rewrite to describe the mechanism and the rationale without listing
       the paths; the audit's conclusions survive that edit intact. — (found 2026-07-30)
+- [ ] [P2] `reader-role.spec.ts:64` asserts nothing and flakes in the counterintuitive direction.
+      `await expect(authedPage.getByText("Email")).toBeVisible()` is commented "Member list should
+      load", but `getByText` with a string is a **case-insensitive substring** match, and
+      `org-settings.tsx:244` renders `<TabsTrigger value="email-templates">Email Templates</TabsTrigger>`
+      unconditionally in the `TabsList` — present on every tab, for every role. So the assertion is
+      satisfied by the tab trigger and has never once proven the member list rendered.
+      **It then fails when the app is _faster_.** `member-list.tsx:127` adds a second match
+      (`<TableHead>Email</TableHead>`) as soon as `organizations.members.list` resolves; the match
+      count goes 1 → 2 and Playwright raises a strict-mode violation. Passing therefore requires the
+      assertion to win a race against the members query — which it usually does, hence green on the
+      eight preceding runs and red on run 30597058259, where it passed on rerun with byte-identical
+      code. Both attempts are on record if the artifacts are wanted.
+      Fix with the role-based idiom the web testing guidance already prescribes for this class —
+      assert on a control's value rather than page text: `getByRole("columnheader", { name: "Email" })`, or
+      `getByText("Email", { exact: true })` at minimum. **Sweep for siblings while there** — any
+      `getByText` whose string is a prefix of other visible copy has the same latent race; the
+      ADMIN path is worse, since `pending-invitations.tsx:65` and `invite-member-dialog.tsx:99`
+      add third and fourth matches. — (found 2026-07-30 while diagnosing a CI failure on #537)
 - [ ] [P3] Seed data ages out of a long-lived dev database, and `db:seed` will not repair it. Submission periods are seeded at fixed offsets from the seed date, so `quarterly-review` eventually has no open period — which fails 11 of 13 `embed` tests with `No open period found`. `pnpm db:seed` is idempotent-by-skip, so it is a no-op once data exists; only the destructive `db:reset` refreshes the dates. CI is unaffected (it seeds fresh each run), so this only ever bites locally, and it looks like a code regression rather than stale data. Either make the seed refresh period dates when they have closed, or have `global-setup.ts` fail with a "run `pnpm db:reset`" message when no open period exists for the seed org — (found 2026-07-27 while verifying the E2E auth rework)
 
 ---
@@ -431,24 +449,45 @@ Ordered as the design doc's Phase 0/D.
       `packages/db/privileges.sql` and migration 0069. — (found 2026-07-28 during the P2.0
       audit; done 2026-07-28)
 - [ ] **[P3] Delete `organizationService.addMemberWithAudit`.** Zero production callers
-      (`organization.service.ts:321`); the only three references are `vi.fn()` stubs in
+      (`organization.service.ts:335`); the only three references are `vi.fn()` stubs in
       `trpc/routers/organizations.spec.ts:17`, `trpc/routers/gdpr.spec.ts:35` and
       `rest/routers/organizations.spec.ts:16` — spec files mocking a method their subject never
-      invokes. `inviteOrAddMemberWithAudit` reaches `addMember` directly at `:349`. Same shape
-      as the `getById` #521 deleted rather than fixed. — (found 2026-07-28 during the P2.0 audit)
-- [ ] **[P3] Widen the schema gate to policy semantics and schema↔migration consistency.**
-      `rls-infrastructure.test.ts` now asserts, per table, that classification is exhaustive,
-      that RLS and `FORCE` are on where expected, and that `app_user`'s SELECT privilege matches
-      a recorded expectation. It does **not** check that a policy says the right thing — a table
-      could carry a policy scoped to the wrong column, or a `USING` clause with the raising
-      `current_setting(...)::uuid` idiom where `current_org_id()` was intended, and pass. Nor
-      does it check that the Drizzle schema and the migration SQL agree, which is the class of
-      drift `db:verify` catches for FK constraints only. Deliberately left out of the P2.0 audit
-      as a separate concern from F1 and too large to ride inside it. — (plan review 2026-07-28)
-- [ ] **[P3] Email is a cross-tenant lookup key in eight places, four unauthenticated.**
-      `organization.service.ts:203`, `embed-submission.service.ts:92`/`:121`/`:138`,
-      `federation.service.ts:437`/`:523`, `simsub.service.ts:324`, `migration.service.ts:494`,
-      `auth.ts:456`. Sharpest edge: `embed-submission.service.ts:92` returns an existing user id
+      invokes, with no `mockResolvedValue` or `toHaveBeenCalled` against any of them.
+      `inviteOrAddMemberWithAudit` reaches `addMember` directly at `:363`. Same shape
+      as the `getById` #521 deleted rather than fixed. (Line numbers re-verified 2026-07-30:
+      the definition moved `:321` → `:335` and the `addMember` call `:349` → `:363` when #527
+      landed; the three spec citations are still exact.) — (found 2026-07-28 during the P2.0 audit)
+- [ ] **[P3] Sharpen the schema gate's policy-semantics check, and add schema↔migration
+      consistency.** `rls-infrastructure.test.ts` asserts, per table, that classification is
+      exhaustive, that RLS and `FORCE` are on where expected, and that `app_user`'s privileges
+      match a recorded expectation.
+      **Rescoped 2026-07-30 after reading the file — two corrections.** (1) It asserts **all
+      four** DML privileges via `toEqual` (`:288-310`), not SELECT alone as this entry claimed.
+      (2) A policy-expression check **already exists** at `:642-673`: it selects `qual` from
+      `pg_policies` and requires the substring `current_org_id()` _or_
+      `current_setting('app.current_org`. So this is "sharpen an existing check", not "add one",
+      and the specific weaknesses are: the disjunction treats the two idioms as
+      interchangeable — so it can never be the gate for the two-idioms item above — no column
+      name is asserted (a policy scoped to the wrong uuid column passes), `with_check` is not
+      selected, and 17 tables are excluded outright by `orgPolicyExceptions` (`:618-636`).
+      Note `pipeline_history` and `pipeline_comments` pass only because their subquery text
+      happens to contain `current_org_id()`.
+      Still absent entirely: any check that the Drizzle schema and the migration SQL agree,
+      which is the class of drift `db:verify` catches for FK constraints only. Deliberately left
+      out of the P2.0 audit as a separate concern from F1 and too large to ride inside it. —
+      (plan review 2026-07-28)
+- [ ] **[P3] Email is a cross-tenant lookup key in nine places, four unauthenticated.**
+      `organization.service.ts:220` (in `addMember`), `embed-submission.service.ts:95`/`:124`/`:141`,
+      `federation.service.ts:440`/`:533`, `simsub.service.ts:329`, `migration.service.ts:503`,
+      `auth.ts:495`.
+      **Corrected 2026-07-30** — the entry said "eight" while listing nine, and nine predicates
+      do exist. Seven citations pointed at the opening `await db`/`await tx` line rather than the
+      `where` a few lines below; those are now the predicate lines. Two were wrong beyond drift:
+      `organization.service.ts:203` was in a _different_ method's return block, and
+      `hooks/auth.ts:456` is an `onConflictDoUpdate` keyed on `zitadelUserId`, not email — the
+      email-keyed statement there is at `:495` and is an `UPDATE`, not a `SELECT`, which matters
+      for anyone auditing read paths only.
+      Sharpest edge: `embed-submission.service.ts:95` returns an existing user id
       on an email match even when that account belongs to another tenant, attributing the embed
       submission to them. Deliberate — it is how a known writer submitting through an embed gets
       linked — but it wants a decision on identity semantics, not a patch. — (found 2026-07-28
@@ -471,9 +510,15 @@ Ordered as the design doc's Phase 0/D.
       enforces no per-org or per-creator key count. Either a creator-level umbrella bucket
       or a key-count cap would close it.
 - [ ] **[P2] The main API rate limiter fails open on Redis error, and unlike federation's
-      it is not configurable.** `hooks/rate-limit.ts:137-143` catches any Redis failure,
+      it is not configurable.** `hooks/rate-limit.ts:138-144` catches any Redis failure,
       logs `Rate limit Redis error — allowing request without rate limiting`, and returns —
-      so a Redis outage removes rate limiting from the entire API at once. Every request
+      so a Redis outage removes rate limiting from the entire API at once.
+      **There is a second fail-open path this entry missed** (found 2026-07-30): a failed
+      `redis.connect()` at `:92-102` logs a "requests will be allowed without rate limiting"
+      warning and lets plugin registration continue, so the limiter can be absent for the
+      **whole process lifetime** rather than only failing per-request. Any fail-mode setting
+      has to cover both, or `closed` will still start wide open.
+      Every request
       then reaches `dbContextPlugin`, which opens a pooled connection and begins a
       transaction per request, so the failure mode is not merely "unlimited requests" but
       connection-pool exhaustion under load.
@@ -571,9 +616,13 @@ Ordered as the design doc's Phase 0/D.
       `apps/web/src/components/federation/audit-log-viewer.tsx` sends `dateFrom`/`dateTo` in
       its query input, but `listAuditEventsSchema` declares `from`/`to`, so both are discarded
       server-side and the From/To inputs do nothing. The user gets a full unfiltered result set
-      and no error. The same component also re-declares its own `AuditEvent` interface rather
-      than importing from `@colophony/types`, which is why the mismatch type-checks — fixing
-      that import would have caught this. — (found 2026-07-30 while mapping the audit read
+      and no error. The same component also re-declares its own `AuditEvent` interface (`:65`)
+      rather than importing from `@colophony/types`, which is why the mismatch type-checks —
+      fixing that import would have caught this. **Two details for whoever fixes it:** the local
+      interface is not the only suppression — `:100` also casts the input object to
+      `Parameters<typeof trpc.audit.list.useQuery>[0]`, so both must go or the cast will swallow
+      the corrected field names too; and the type to import is **`AuditEventResponse`**, since
+      `@colophony/types` exports no symbol named `AuditEvent`. — (found 2026-07-30 while mapping the audit read
       surface)
 - [ ] **[P2] Honour `X-Act-As-User` on ordinary org-scoped API keys.** `hooks/auth.ts:343`
       unconditionally sets `userId: creator.id` for `authMethod: 'apikey'`, so every action a
@@ -650,9 +699,15 @@ Ordered as the design doc's Phase 0/D.
       So the work is ordered: **establish a stable, source-derived event id first**, then add
       the constraint. Without that, adding the constraint yields a schema change that looks
       like idempotency and provides none — worse than the current state, which at least does
-      not claim to dedup. Worth checking what identifier the Inngest event actually carries
-      before assuming one exists. — (design review 2026-07-27; premise corrected 2026-07-30
-      after verifying against the code)
+      not claim to dedup.
+      **The "what identifier does the event carry" question is now answered** (2026-07-30): a
+      stable id _does_ exist upstream — `outboxEvents.id`
+      (`packages/db/src/schema/messaging.ts:17`, `defaultRandom().primaryKey()`) — but
+      `outbox-poller.worker.ts:56-59` calls `inngest.send({ name, data })` **without an `id`**,
+      so it is dropped at that boundary and `event.id` can only ever be Inngest-assigned.
+      Propagating the outbox row id through that call is the prerequisite step, and it is a
+      one-line change; the constraint follows it. — (design review 2026-07-27; premise corrected
+      2026-07-30 after verifying against the code)
 - [x] **[P1] `apiKeyService` carries no explicit `organizationId` predicate.** `list`
       (`apps/api/src/services/api-key.service.ts:71`), `revoke` (`:129`) and `delete`
       (`:145`) relied on RLS alone, and no caller passed an org ID
@@ -685,6 +740,10 @@ Ordered as the design doc's Phase 0/D.
       while the procedure returns `revokeApiKeyResponseSchema` — a full key object
       versus three fields. Type-only today: the contract is consumed by
       `packages/api-client` for inference, not used to validate the server response.
+      **Nothing forces parity** (confirmed 2026-07-30): `grep 'implement('` over `apps/api/src`
+      returns zero, so the server never builds its routers from the contract — the two are
+      independent declarations that happen to sit in the same repo, and only a reader will ever
+      notice them diverging. That makes the drift class recurrent, not a one-off.
       — (found 2026-07-28 while removing `payments:read`)
 - [ ] **[P2] REST spec coverage.** Only 8 of 18 REST routers have a `.spec.ts` — the ten
       without are `cms-connections`, `collections`, `contract-templates`, `contracts`, `csr`,
@@ -700,20 +759,33 @@ Ordered as the design doc's Phase 0/D.
       `3.1.1` from the live endpoint. Pre-existing — the old fetch-based export normalized
       the response the same way — and not introduced by P0.2, but the guarantee is only
       half-true today. Fix by serving `generateOpenApiDocument()` from a dedicated route and
-      pointing the reference plugin's `specPath` at it, so one function feeds both. —
+      pointing the reference plugin's `specPath` at it, so one function feeds both.
+      **Caveat recorded 2026-07-30:** the served `3.1.1` is _inferred_ from the generator's
+      behaviour and the upstream type (`OpenAPIGeneratorGenerateOptions` is
+      `Partial<Omit<Document, 'openapi'>>`, so the field is un-settable) — nobody has observed
+      the live endpoint. No test or fixture captures it, which is also why the divergence went
+      unnoticed. Confirm against a running server before writing the fix. —
       (code review 2026-07-27)
 - [ ] **[P3] Three OpenAPI tags are used but never declared.** Operations carry
-      `Collections`, `Submission Analytics`, and `Submission Votes`, but
-      `openApiDocumentConfig.tags` in `apps/api/src/rest/openapi-spec.ts` declares only 17
+      `Collections` (10 operations), `Submission Analytics` (6), and `Submission Votes` (4),
+      but `openApiDocumentConfig.tags` in `apps/api/src/rest/openapi-spec.ts` declares **18**
       tags and omits all three — so they render in `/v1/docs` with no description while the
-      other 17 have one. Add the three descriptions and regenerate the spec. Cosmetic, but
-      it is the kind of gap the spec-vs-source gate cannot catch, since both sides agree. —
+      other 18 have one. Add the three descriptions and regenerate the spec. Cosmetic, but
+      it is the kind of gap the spec-vs-source gate cannot catch, since both sides agree.
+      (Said "17" until `Notifications` landed 2026-07-29; recounted 2026-07-30 against both
+      the source and the generated `sdks/openapi.json`, which agree at 18 declared / 21 used.) —
       (found 2026-07-27 during P0.2)
-- [ ] **[P3] Two RLS idioms in the schema.** `notifications`, `notifications-inbox`,
-      `webhook-endpoints`, `transfers` use raw `current_setting('app.current_org')::uuid`
-      (raises when unset); the other 24 use `current_org_id()` (returns NULL). Both
-      fail closed, so not a vulnerability — but a request with no org context gets a 500
-      rather than an empty result on those four. Normalise deliberately. —
+- [ ] **[P3] Two RLS idioms in the schema.** The raw
+      `current_setting('app.current_org')::uuid` form (raises when unset) appears in **4 files
+      but 6 policies**: `notifications.ts:45,81`, `notifications-inbox.ts:45`,
+      `webhook-endpoints.ts:38,82`, `transfers.ts:115`. Everything else uses `current_org_id()`
+      (returns NULL). Both fail closed, so not a vulnerability — but a request with no org
+      context gets a 500 rather than an empty result on those six. Normalise deliberately.
+      **Counts corrected 2026-07-30** — the entry said "four vs the other 24", and both figures
+      were wrong units. 24 was a _file_ count, not tables or policies; the directory holds 71
+      `pgTable` declarations and 66 `pgPolicy` calls. And `transfers.ts` is in **both** groups:
+      `pieceTransfers` (`:79`) uses `current_org_id()` while `inboundTransfers` (`:115`) uses the
+      raw form, so the two sets are not disjoint and a per-file sweep would miss it. —
       (design doc §2.3 F6)
 - [x] **[P1] `GET /api/notifications/stream` declares no scope guard, and neither
       coverage gate can see it.** It is a plain Fastify route
@@ -763,6 +835,15 @@ Ordered as the design doc's Phase 0/D.
       and `docs/manual-qa-plan.md` lists them as pages for the same reason. A search
       for an HTTP caller — `fetch`/`axios` in `apps/web`, `apps/api`, `scripts/`,
       `sdks/typescript/src` — found none.
+      **Correction (verified 2026-07-30): the "found none" above is wrong.**
+      `scripts/simsub-qa.ts:573` and `:591` call `POST /federation/sim-sub/override/:submissionId`
+      and `GET /federation/sim-sub/checks/:submissionId` with an `X-Api-Key` header, so it is
+      **21 of 23** without an in-repo HTTP caller, not 23. The P0.5 entry above already recorded
+      that script's usage — this entry contradicted a fact the same document held. The two
+      `simsub-admin` routes therefore need a decision (keep, or port the QA script to tRPC)
+      rather than being swept up with the other 21. Everything else checks out: 23 admin routes
+      across five modules, each with a tRPC twin, `key-admin` the sole pair without one, and no
+      tRPC procedure doing DID key rotation.
       **That is very likely why nobody noticed they were unguarded**: unused surface
       generates no traffic and no complaints, while remaining fully reachable. They
       are guarded now (2026-07-29), so the exposure is closed either way; the
@@ -785,7 +866,16 @@ Ordered as the design doc's Phase 0/D.
       current path is affected; `/federation/trust` and `/federation/trust/*` are
       genuinely public S2S endpoints. The fix is a trailing slash plus a separate
       exact entry, but it needs checking against every `/federation/trust*` route
-      first. — (found 2026-07-29 while adding the Fastify guard gate)
+      first.
+      **Three things found 2026-07-30 that widen this.** `/api/inngest` (`:42`), `/health` and
+      `/ready` are bare prefixes with the identical hazard, so fix the class rather than the one
+      entry. `isPublicRoute` is imported by `fastify-guard-coverage.spec.ts:38` to exempt routes
+      from the guard-declaration gate — so accidentally widening a prefix does not just make a
+      route public, it **also removes it from the gate that would have caught that**. And
+      `auth.spec.ts` contains **zero** references to `PUBLIC_PREFIXES` or `isPublicRoute`,
+      despite the comment above the array instructing that every public route gets a test there;
+      the allowlist is currently untested in either direction. — (found 2026-07-29 while adding
+      the Fastify guard gate)
 - [ ] **[P3] Two route modules have no per-route API-key rejection test.**
       `hub-admin.routes.spec.ts` drives handlers directly through a synthetic mock
       app with a `getHandler` helper, so it bypasses the Fastify hook chain entirely
@@ -854,12 +944,21 @@ invitations were assumed missing and are in fact already exposed — see §0 of 
       options before assuming not.
       (3) **Gate it**: a lint rule or a spec asserting no `z.coerce.boolean()` appears in
       `packages/api-contracts/` or `apps/api/src/rest/`. Cheap, and the failure it prevents is
-      silent in every other check.
+      silent in every other check. Note `packages/api-contracts/` has **no eslint config at
+      all** (verified 2026-07-30), so the lint route means creating one — a spec is the cheaper
+      of the two. The helper is also still unexported (`notifications.ts:26`), so part (1) is a
+      prerequisite for anyone to use it anyway.
       Same reasoning as the guard-coverage gates — a convention that only lives in a doc gets
       violated by the next person who does not read it. — (found 2026-07-29 during P1.2)
 - [ ] **[P2] Idempotency keys for integrator writes.** No `Idempotency-Key` on any `/v1`
       `POST`, including submission creation and the two batch operations. Contract surface,
-      so it cannot be added cheaply later. — (design doc §1.10, D3)
+      so it cannot be added cheaply later.
+      **A structural constraint worth knowing before estimating** (found 2026-07-30):
+      `rest/router.ts:35-43` passes only `{ authContext, dbTx, audit }` into the oRPC context —
+      the raw request never reaches it — so **no oRPC middleware can read a request header
+      today**. This needs a context change first, not just a middleware, which makes it larger
+      than the equivalent tRPC work would be. The only header-reading code on the whole surface
+      is in the Fastify hooks. — (design doc §1.10, D3)
 
 ### Design Decisions
 


### PR DESCRIPTION
Continues the sequence from #521 (`apiKeyService`), #527 (`organizationService.listMembers`), #531 (`notificationService`) and #536 (`auditService`). `pipelineService` was the last service on this surface where tenant queries rested on RLS alone.

## What was actually wrong

The backlog filed three methods. It was five, and the two it flagged as secondary were the only live ones.

| Site | Before |
| --- | --- |
| `assignCopyeditor`, `assignProofreader` | **Live cross-tenant write.** No `orgId` parameter at all — `UPDATE … WHERE id = $1`, RLS the only defence. Reachable from both API surfaces. |
| `create` | **Live cross-tenant write, plus a status oracle.** The submission-existence read was unscoped, so a caller could attach a pipeline item to another org's submission and then read that submission's title back through the `list`/`getById` joins. `SubmissionNotAcceptedError` interpolates the status of a submission the caller cannot otherwise see. |
| `getBySubmissionId` | Unprojected `select()` — returned another org's entire row, both assignee ids and all due dates included. |
| `addComment` | Safe only through its wrapper; unsafe called directly. |
| `updateStage` | The one originally filed. Least severe of the five — see below. |

All now take a required `orgId` last, per the house `(tx, id|input, orgId)` convention. The `list`/`getById`/`dashboard` joins carry the org term on the join rather than trusting FK integrity.

## Three things worth review attention

**`updateStage` is deliberately defended twice, and neither defence is redundant.** The org-scoped `getById` guard dominates the UPDATE — while it stands, no input distinguishes the two `WHERE` forms, so no test can pin the predicate alone. Both are kept because **either alone is sufficient**, which was measured rather than assumed: reverting each in turn leaves the cross-org case green, and reverting both fails it. The accompanying `if (!updated) throw` is load-bearing, not tidying — the history insert after it is unconditional, so adding the predicate *without* the throw would let a zero-row update write a history row against the other org's item, which `getHistory` then hands back to them. That would have been worse than adding neither.

**Scoping the uniqueness pre-check forced a `23505` mapping.** `pipeline_items_submission_id_idx` is a **global** unique index on `submission_id`, so an org-scoped pre-check cannot pre-empt it: a pre-existing mismatched row — creatable before this change — passes the check and collides at the insert, turning a clean `PipelineItemAlreadyExistsError` into a raw 500. `isUniqueViolation` walks the `cause` chain, because Drizzle wraps the driver error and a direct `err.code === '23505'` check silently never matches. The first version did exactly that and was caught by the test, not by review.

**No router, contract or SDK changes.** The `*WithAudit` wrappers already held `ctx.actor.orgId`, so only internal call sites moved.

## Verification

`__tests__/rls/pipeline-service.test.ts` drives the service over the RLS-**bypassing** admin pool, where the `WHERE` clause is the only isolation in play. It is the first test of any kind to run this service against a database.

Non-vacuity was measured, one revert at a time:

| Revert | Cases that fail |
| --- | --- |
| `assignCopyeditor` predicate | 1 — its cross-org case |
| `assignProofreader` predicate | 1 — its cross-org case |
| `create` submission org predicate | 2 — existence *and* status-oracle |
| `getBySubmissionId` predicate | 1 |
| `getById` predicate | 1 — the `addComment` cross-org case |
| `23505` cause-chain walk | 1 |
| `getById` **and** `updateStage` UPDATE predicate | 2 |
| `updateStage` UPDATE predicate alone | 0 — expected; see above |
| `list` search-subquery predicate | 0 — expected; see below |

Suites: 176 RLS across 16 files, 1941 unit, type-check and lint clean.

## Two deliberate non-claims

The `list` search-subquery predicate **cannot** be pinned by any input: the outer `inArray` already intersects against an org-scoped set, so results were correct either way. It narrows what gets scanned, not what comes back. The test covering that path is labelled as a result-correctness guard rather than a predicate proof, and the measured zero above is the evidence.

The unit spec previously asserted org scoping with `Function.prototype.length` arity checks. Those pass whether or not `orgId` is *used* — which was precisely the state of `updateStage`'s UPDATE — so they were green throughout and are deleted rather than kept.

## Out of scope

Neither assign method checks that `input.userId` belongs to the org, and `users` carries no org column, so the predicates here isolate the *item*, not the assignee. Org A can still assign an org-B user, and `list` returns that person's email. That needs a membership lookup and a decision about guests and dual-org staff, so it is filed as a new P3 rather than folded in.

Also unchanged, with comments recording why: the manuscript reads in `getCopyeditContent` (`manuscripts` is owner-scoped, `manuscript_versions` has no org column — the library is user-owned and cross-org by design) and the `users` aliases.
