### PR TITLE
fix(slate): scope issueService and cmsConnectionService to the caller's org

### DIFF
--- a/apps/api/src/__tests__/rls/cms-connection-service.test.ts
+++ b/apps/api/src/__tests__/rls/cms-connection-service.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Defense-in-depth: cmsConnectionService's explicit organization predicates.
+ *
+ * The same shape and the same reason as `issue-service.test.ts` beside it —
+ * every query runs over the ADMIN pool, which bypasses RLS, so the service's
+ * `WHERE organization_id = $orgId` is the only thing separating org A's
+ * connections from org B's. Switching this to the app pool would make it pass
+ * with or without the predicates.
+ *
+ * All seven methods took `orgId?: string` before 2026-07-31. Unlike
+ * `issueService`, none was guard-only: `cms_connections` carries an
+ * `organization_id`, so every one of these is scoped on the statement itself and
+ * is pinned directly by the case below it.
+ *
+ * Measured: reverting the predicates fails **7 of 7**. Every case here earns its
+ * place, with no redundancy to hide behind.
+ *
+ * `testConnection` is covered through `getById`, which it delegates to — there
+ * is no separate query to scope, and a case that reached the adapter would be
+ * testing the adapter.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { eq } from 'drizzle-orm';
+import {
+  cmsConnections,
+  type Organization,
+  type Publication,
+} from '@colophony/db';
+import { globalSetup, getAdminPool } from './helpers/db-setup';
+import { truncateAllTables } from './helpers/cleanup';
+import {
+  createOrganization,
+  createPublication,
+  createCmsConnection,
+  type CmsConnectionRow,
+} from './helpers/factories';
+import {
+  cmsConnectionService,
+  CmsConnectionNotFoundError,
+} from '../../services/cms-connection.service.js';
+
+type ServiceTx = Parameters<typeof cmsConnectionService.getById>[0];
+
+function adminTx(): ServiceTx {
+  return drizzle(getAdminPool());
+}
+
+function adminDb(): ReturnType<typeof drizzle> {
+  return drizzle(getAdminPool());
+}
+
+async function readConnection(id: string) {
+  const [row] = await adminDb()
+    .select()
+    .from(cmsConnections)
+    .where(eq(cmsConnections.id, id))
+    .limit(1);
+  return row ?? null;
+}
+
+const LIST_INPUT = { page: 1, limit: 100 } as Parameters<
+  typeof cmsConnectionService.list
+>[1];
+
+describe('cmsConnectionService defense-in-depth (RLS bypassed)', () => {
+  let orgA: Organization;
+  let orgB: Organization;
+  let pubA: Publication;
+  let pubB: Publication;
+
+  beforeAll(async () => {
+    await globalSetup();
+    await truncateAllTables();
+
+    orgA = await createOrganization({ name: 'Org Alpha' });
+    orgB = await createOrganization({ name: 'Org Beta' });
+    pubA = await createPublication(orgA.id);
+    pubB = await createPublication(orgB.id);
+  });
+
+  let connA: CmsConnectionRow;
+  let connB: CmsConnectionRow;
+
+  beforeEach(async () => {
+    await adminDb().delete(cmsConnections);
+    connA = await createCmsConnection(orgA.id, {
+      name: 'Alpha CMS',
+      publicationId: pubA.id,
+    });
+    connB = await createCmsConnection(orgB.id, {
+      name: 'Beta CMS',
+      publicationId: pubB.id,
+    });
+  });
+
+  afterAll(async () => {
+    await truncateAllTables();
+  });
+
+  describe('list', () => {
+    it("excludes another org's connections from both items and total", async () => {
+      const result = await cmsConnectionService.list(
+        adminTx(),
+        LIST_INPUT,
+        orgA.id,
+      );
+
+      expect(result.items.map((c) => c.id)).toEqual([connA.id]);
+      expect(result.items.map((c) => c.id)).not.toContain(connB.id);
+      expect(result.total).toBe(1);
+    });
+  });
+
+  describe('getById', () => {
+    it('returns null for a connection in another org', async () => {
+      const result = await cmsConnectionService.getById(
+        adminTx(),
+        connB.id,
+        orgA.id,
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('update', () => {
+    it("returns null for another org's connection and leaves it untouched", async () => {
+      const result = await cmsConnectionService.update(
+        adminTx(),
+        connB.id,
+        { name: 'Hijacked' },
+        orgA.id,
+      );
+
+      expect(result).toBeNull();
+      const row = await readConnection(connB.id);
+      expect(row?.name).toBe('Beta CMS');
+    });
+  });
+
+  describe('delete', () => {
+    it("returns null for another org's connection and leaves it present", async () => {
+      const result = await cmsConnectionService.delete(
+        adminTx(),
+        connB.id,
+        orgA.id,
+      );
+
+      expect(result).toBeNull();
+      expect(await readConnection(connB.id)).not.toBeNull();
+    });
+  });
+
+  describe('testConnection', () => {
+    it("throws for another org's connection without reaching the adapter", async () => {
+      await expect(
+        cmsConnectionService.testConnection(adminTx(), connB.id, orgA.id),
+      ).rejects.toThrow(CmsConnectionNotFoundError);
+    });
+  });
+
+  describe('listByPublication', () => {
+    it("returns nothing for another org's publication", async () => {
+      const result = await cmsConnectionService.listByPublication(
+        adminTx(),
+        pubB.id,
+        orgA.id,
+      );
+      expect(result).toEqual([]);
+
+      // Sanity: A's own publication does resolve, so the empty result above is
+      // the predicate and not an empty fixture.
+      const own = await cmsConnectionService.listByPublication(
+        adminTx(),
+        pubA.id,
+        orgA.id,
+      );
+      expect(own.map((c) => c.id)).toEqual([connA.id]);
+    });
+  });
+
+  describe('updateLastSync', () => {
+    it("does not stamp another org's connection", async () => {
+      await cmsConnectionService.updateLastSync(adminTx(), connB.id, orgA.id);
+
+      const row = await readConnection(connB.id);
+      expect(row?.lastSyncAt).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/__tests__/rls/helpers/db-setup.ts
+++ b/apps/api/src/__tests__/rls/helpers/db-setup.ts
@@ -164,8 +164,9 @@ export async function globalSetup(): Promise<void> {
 
   // The mirror of the check above, and it is load-bearing for a different set of
   // suites. `api-key-service.test.ts`, `notification-service.test.ts`,
-  // `audit-service.test.ts`, `pipeline-service.test.ts` and the admin-pool cases
-  // in `organization-service.test.ts` prove that an explicit WHERE clause
+  // `audit-service.test.ts`, `pipeline-service.test.ts`,
+  // `issue-service.test.ts`, `cms-connection-service.test.ts` and the admin-pool
+  // cases in `organization-service.test.ts` prove that an explicit WHERE clause
   // isolates tenants *without* RLS — which only means anything if this
   // connection really does bypass RLS. ADMIN_URL comes straight from
   // DATABASE_TEST_URL, so pointing it at a non-superuser would make those suites

--- a/apps/api/src/__tests__/rls/helpers/factories.ts
+++ b/apps/api/src/__tests__/rls/helpers/factories.ts
@@ -23,7 +23,16 @@ import {
   submissionVotes,
   submissionReviewers,
   pipelineItems,
+  publications,
+  issues,
+  issueSections,
+  issueItems,
+  cmsConnections,
   type PipelineItem,
+  type Publication,
+  type Issue,
+  type IssueSection,
+  type IssueItem,
   type Organization,
   type User,
   type OrganizationMember,
@@ -445,6 +454,125 @@ export async function createPipelineItem(
     })
     .returning();
   return item;
+}
+
+/**
+ * `publications_org_slug_idx` is unique on `(organization_id, lower(slug))`, so
+ * the slug is randomised rather than derived from the name — two publications in
+ * one org is an ordinary fixture, and a name-derived slug would collide.
+ */
+export async function createPublication(
+  organizationId: string,
+  overrides?: Partial<Publication>,
+): Promise<Publication> {
+  const db = adminDb();
+  const [publication] = await db
+    .insert(publications)
+    .values({
+      organizationId,
+      name: faker.company.name(),
+      slug: faker.string.alphanumeric(20).toLowerCase(),
+      ...overrides,
+    })
+    .returning();
+  return publication;
+}
+
+/**
+ * Like `createPipelineItem`, `organizationId` and `publicationId` are
+ * independent positional params rather than the org being derived from the
+ * publication — a suite proving `issueService` scopes its reads needs to be able
+ * to seed a mismatched pair.
+ */
+export async function createIssue(
+  organizationId: string,
+  publicationId: string,
+  overrides?: Partial<Issue>,
+): Promise<Issue> {
+  const db = adminDb();
+  const [issue] = await db
+    .insert(issues)
+    .values({
+      organizationId,
+      publicationId,
+      title: faker.lorem.words(3),
+      ...overrides,
+    })
+    .returning();
+  return issue;
+}
+
+/**
+ * `issue_sections` carries no `organization_id` — it is scoped transitively
+ * through its issue, and its RLS policy is an EXISTS on `issues`. So the org a
+ * section belongs to is whatever `createIssue` was given; there is no second
+ * parameter to get wrong.
+ */
+export async function createIssueSection(
+  issueId: string,
+  overrides?: Partial<IssueSection>,
+): Promise<IssueSection> {
+  const db = adminDb();
+  const [section] = await db
+    .insert(issueSections)
+    .values({
+      issueId,
+      title: faker.lorem.words(2),
+      ...overrides,
+    })
+    .returning();
+  return section;
+}
+
+/**
+ * Same transitive scoping as `createIssueSection`. Two unique constraints bound
+ * how many of these a suite can seed: `issue_items_issue_pipeline_unique` on
+ * `(issue_id, pipeline_item_id)`, and — reaching back up the chain — the GLOBAL
+ * unique on `pipeline_items.submission_id`. So N issue items needs N pipeline
+ * items needs N distinct submissions.
+ */
+export async function createIssueItem(
+  issueId: string,
+  pipelineItemId: string,
+  overrides?: Partial<IssueItem>,
+): Promise<IssueItem> {
+  const db = adminDb();
+  const [item] = await db
+    .insert(issueItems)
+    .values({
+      issueId,
+      pipelineItemId,
+      ...overrides,
+    })
+    .returning();
+  return item;
+}
+
+/**
+ * `@colophony/db` exports no `CmsConnection` type, so the row type is inferred
+ * here — the same workaround as `SubmissionDiscussionRow` above.
+ *
+ * `publication_id` is nullable and therefore an override rather than a
+ * positional param; only the `listByPublication` cases need it set.
+ */
+export type CmsConnectionRow = typeof cmsConnections.$inferSelect;
+
+export async function createCmsConnection(
+  organizationId: string,
+  overrides?: Partial<CmsConnectionRow>,
+): Promise<CmsConnectionRow> {
+  const db = adminDb();
+  const [connection] = await db
+    .insert(cmsConnections)
+    .values({
+      organizationId,
+      adapterType: 'GHOST',
+      name: faker.company.name(),
+      config: { apiUrl: faker.internet.url(), apiKey: faker.string.uuid() },
+      ...overrides,
+    })
+    .returning();
+  return connection;
 }
 
 // No `createPortfolioEntry` here on purpose: `portfolioService.list` reads

--- a/apps/api/src/__tests__/rls/issue-date-filter.test.ts
+++ b/apps/api/src/__tests__/rls/issue-date-filter.test.ts
@@ -1,61 +1,16 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { faker } from '@faker-js/faker';
-import { drizzle } from 'drizzle-orm/node-postgres';
-import { globalSetup, globalTeardown, getAdminPool } from './helpers/db-setup';
+import { globalSetup, globalTeardown } from './helpers/db-setup';
 import { truncateAllTables } from './helpers/cleanup';
 import { withTestRls } from './helpers/rls-context';
 import {
   createOrganization,
   createUser,
   createOrgMember,
+  createPublication,
+  createIssue,
 } from './helpers/factories';
-import {
-  issues,
-  publications,
-  type Organization,
-  type User,
-} from '@colophony/db';
+import { type Organization, type User } from '@colophony/db';
 import { issueService } from '../../services/issue.service.js';
-
-function adminDb() {
-  return drizzle(getAdminPool());
-}
-
-async function createPublication(orgId: string) {
-  const db = adminDb();
-  const [pub] = await db
-    .insert(publications)
-    .values({
-      organizationId: orgId,
-      name: faker.company.name(),
-      slug: faker.string.alphanumeric(20).toLowerCase(),
-    })
-    .returning();
-  return pub;
-}
-
-async function createIssue(
-  orgId: string,
-  publicationId: string,
-  overrides?: Partial<{
-    title: string;
-    publicationDate: Date | null;
-    status: string;
-  }>,
-) {
-  const db = adminDb();
-  const [issue] = await db
-    .insert(issues)
-    .values({
-      organizationId: orgId,
-      publicationId,
-      title: overrides?.title ?? faker.lorem.words(3),
-      publicationDate: overrides?.publicationDate ?? null,
-      status: (overrides?.status as 'PLANNING') ?? 'PLANNING',
-    })
-    .returning();
-  return issue;
-}
 
 describe('issueService.list — date range filtering', () => {
   let org: Organization;
@@ -100,12 +55,16 @@ describe('issueService.list — date range filtering', () => {
     const result = await withTestRls(
       { orgId: org.id, userId: user.id },
       async (tx) =>
-        issueService.list(tx, {
-          from: new Date('2026-02-01T00:00:00.000Z'),
-          to: new Date('2026-02-28T23:59:59.999Z'),
-          page: 1,
-          limit: 100,
-        }),
+        issueService.list(
+          tx,
+          {
+            from: new Date('2026-02-01T00:00:00.000Z'),
+            to: new Date('2026-02-28T23:59:59.999Z'),
+            page: 1,
+            limit: 100,
+          },
+          org.id,
+        ),
     );
 
     expect(result.items).toHaveLength(1);
@@ -117,12 +76,16 @@ describe('issueService.list — date range filtering', () => {
     const result = await withTestRls(
       { orgId: org.id, userId: user.id },
       async (tx) =>
-        issueService.list(tx, {
-          from: new Date('2026-01-01T00:00:00.000Z'),
-          to: new Date('2026-12-31T23:59:59.999Z'),
-          page: 1,
-          limit: 100,
-        }),
+        issueService.list(
+          tx,
+          {
+            from: new Date('2026-01-01T00:00:00.000Z'),
+            to: new Date('2026-12-31T23:59:59.999Z'),
+            page: 1,
+            limit: 100,
+          },
+          org.id,
+        ),
     );
 
     const titles = result.items.map((i) => i.title);
@@ -134,11 +97,15 @@ describe('issueService.list — date range filtering', () => {
     const result = await withTestRls(
       { orgId: org.id, userId: user.id },
       async (tx) =>
-        issueService.list(tx, {
-          from: new Date('2026-02-01T00:00:00.000Z'),
-          page: 1,
-          limit: 100,
-        }),
+        issueService.list(
+          tx,
+          {
+            from: new Date('2026-02-01T00:00:00.000Z'),
+            page: 1,
+            limit: 100,
+          },
+          org.id,
+        ),
     );
 
     const titles = result.items.map((i) => i.title);
@@ -152,12 +119,16 @@ describe('issueService.list — date range filtering', () => {
     const result = await withTestRls(
       { orgId: org.id, userId: user.id },
       async (tx) =>
-        issueService.list(tx, {
-          from: new Date('2026-01-01T00:00:00.000Z'),
-          to: new Date('2026-12-31T23:59:59.999Z'),
-          page: 1,
-          limit: 100,
-        }),
+        issueService.list(
+          tx,
+          {
+            from: new Date('2026-01-01T00:00:00.000Z'),
+            to: new Date('2026-12-31T23:59:59.999Z'),
+            page: 1,
+            limit: 100,
+          },
+          org.id,
+        ),
     );
 
     expect(result.items[0].title).toBe('Jan Issue');
@@ -171,12 +142,16 @@ describe('issueService.list — date range filtering', () => {
     const result = await withTestRls(
       { orgId: org.id, userId: user.id },
       async (tx) =>
-        issueService.list(tx, {
-          from: new Date('2026-03-01T00:00:00.000Z'),
-          to: new Date('2026-03-31T23:59:59.999Z'),
-          page: 1,
-          limit: 100,
-        }),
+        issueService.list(
+          tx,
+          {
+            from: new Date('2026-03-01T00:00:00.000Z'),
+            to: new Date('2026-03-31T23:59:59.999Z'),
+            page: 1,
+            limit: 100,
+          },
+          org.id,
+        ),
     );
 
     expect(result.items).toHaveLength(1);

--- a/apps/api/src/__tests__/rls/issue-service.test.ts
+++ b/apps/api/src/__tests__/rls/issue-service.test.ts
@@ -1,0 +1,462 @@
+/**
+ * Defense-in-depth: issueService's explicit organization predicates.
+ *
+ * The same shape as `pipeline-service.test.ts`, `api-key-service.test.ts`,
+ * `notification-service.test.ts` and `audit-service.test.ts`, and for the same
+ * reason. Every query below runs over the ADMIN pool, which connects as a role
+ * with `rolsuper`/`rolbypassrls`, so RLS does not apply. The only thing
+ * separating org A's issues from org B's here is the `WHERE organization_id =
+ * $orgId` in the service. Do not "fix" this by switching to the app pool — that
+ * reinstates RLS and the suite would pass with or without the predicates,
+ * testing nothing. (`issue-date-filter.test.ts` deliberately does the opposite:
+ * it runs over the app pool because it is testing date filtering, not scoping.)
+ *
+ * Every method here took `orgId?: string` before 2026-07-31. An optional org id
+ * is a silent bypass: omit it and the predicate is skipped, with nothing at the
+ * type level to flag it. Twelve methods, of which seven were *guard-only* — the
+ * org check was an `if (orgId)` block and the underlying query carried no org
+ * term at all.
+ *
+ * TWO CLASSES OF DEFENCE, AND THEY ARE NOT INTERCHANGEABLE.
+ *
+ * `list`, `getById`, `update`, `updateStatus` and `saveCmsPublishResult` carry
+ * the predicate on the statement itself — `issues` has an `organization_id`
+ * column to filter on.
+ *
+ * `getItems`, `getSections`, `addItem`, `reorderItems`, `addSection`,
+ * `removeItem` and `removeSection` cannot: `issue_items` and `issue_sections`
+ * have no `organization_id`, and their RLS policies scope transitively with
+ * `EXISTS (SELECT 1 FROM issues WHERE issues.id = issue_id AND
+ * issues.organization_id = current_org_id())`. Their service-layer defence is
+ * the org-scoped `getById` guard. Duplicating that EXISTS in each statement
+ * would be a second copy of the policy to keep true, so it is deliberately not
+ * done — with one exception: `removeItem` and `removeSection` additionally
+ * resolve the row through an org-scoped join before deleting, because a DELETE
+ * that fires on an unverified row is the case where a dropped guard is
+ * unrecoverable rather than merely wrong.
+ *
+ * MEASURED, by reverting each defence in turn — do not re-derive this by
+ * reading, and do not read a green run as proof of more than it shows:
+ *
+ *   - Revert the five `issues`-table predicates → **9 of 14 fail**. That covers
+ *     every guard-only method too, since the guard is `getById`.
+ *   - Revert only `addItem`'s pipeline-item org check → **exactly 1 fails**, the
+ *     `foreign pipeline item` case. Nothing else notices, which is the point:
+ *     that hole is invisible to every other assertion here.
+ *   - Revert only the `removeItem` / `removeSection` scoped joins → **0 fail**.
+ *
+ * That last number is the one to be honest about. `removeItem` and
+ * `removeSection` are defended twice — the `getById` guard and the scoped join —
+ * and **either alone is sufficient**, exactly as with `pipelineService.updateStage`.
+ * So these two cases passing does not demonstrate the joins work; the guard
+ * above them would carry the case on its own. The joins are there for the
+ * refactor that drops the guard, and their value is that a DELETE can then no
+ * longer fire on an unverified row. If you remove them, this suite will not tell
+ * you.
+ *
+ * The five guard-only methods (`getItems`, `getSections`, `addItem`,
+ * `reorderItems`, `addSection`) are pinned once. A change that drops a guard
+ * fails here — but their child-table statements are not independently scoped,
+ * and nothing in this file claims otherwise.
+ *
+ * ON `addItem`, WHICH IS NOT JUST A SCOPING FIX. Its guard checked the *issue*
+ * and never the `pipelineItemId` it was handed, so org A could attach org B's
+ * pipeline item to an A-owned issue — a row that is valid under RLS, since
+ * `issue_items` scopes only through its parent. `getItems` then joins that item
+ * through `pipeline_items` to `submissions` and returns `submissionTitle`,
+ * handing B's submission title to A. Same shape as `pipelineService.create`'s
+ * unscoped submission read (#537): a scoped parent and an unscoped foreign key.
+ * The `foreign pipeline item` case below is the one that pins it, and it is the
+ * only case here that fails on `main` for a reason other than a missing `orgId`.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { eq } from 'drizzle-orm';
+import {
+  issues,
+  issueItems,
+  issueSections,
+  pipelineItems,
+  type Organization,
+  type User,
+  type Submission,
+  type Publication,
+  type Issue,
+  type PipelineItem,
+} from '@colophony/db';
+import { globalSetup, getAdminPool } from './helpers/db-setup';
+import { truncateAllTables } from './helpers/cleanup';
+import {
+  createOrganization,
+  createUser,
+  createOrgMember,
+  createSubmissionPeriod,
+  createSubmission,
+  createPipelineItem,
+  createPublication,
+  createIssue,
+  createIssueSection,
+  createIssueItem,
+} from './helpers/factories';
+import {
+  issueService,
+  IssueNotFoundError,
+  IssueItemAlreadyExistsError,
+} from '../../services/issue.service.js';
+
+type ServiceTx = Parameters<typeof issueService.getById>[0];
+
+/**
+ * A Drizzle handle over the RLS-bypassing admin pool, shaped as the `tx` the
+ * service expects. The cast mirrors `helpers/factories.ts` — `@colophony/db`
+ * and the test tree resolve drizzle through different optional peer-dep
+ * contexts, so the types diverge while the runtime is a single copy.
+ */
+function adminTx(): ServiceTx {
+  return drizzle(getAdminPool());
+}
+
+function adminDb(): ReturnType<typeof drizzle> {
+  return drizzle(getAdminPool());
+}
+
+/** Read an issue back over the admin pool, bypassing the service. */
+async function readIssue(id: string) {
+  const [row] = await adminDb()
+    .select()
+    .from(issues)
+    .where(eq(issues.id, id))
+    .limit(1);
+  return row ?? null;
+}
+
+async function readItem(id: string) {
+  const [row] = await adminDb()
+    .select()
+    .from(issueItems)
+    .where(eq(issueItems.id, id))
+    .limit(1);
+  return row ?? null;
+}
+
+async function readSection(id: string) {
+  const [row] = await adminDb()
+    .select()
+    .from(issueSections)
+    .where(eq(issueSections.id, id))
+    .limit(1);
+  return row ?? null;
+}
+
+async function countItemsFor(issueId: string) {
+  const rows = await adminDb()
+    .select()
+    .from(issueItems)
+    .where(eq(issueItems.issueId, issueId));
+  return rows.length;
+}
+
+const LIST_INPUT = { page: 1, limit: 100 } as Parameters<
+  typeof issueService.list
+>[1];
+
+describe('issueService defense-in-depth (RLS bypassed)', () => {
+  let orgA: Organization;
+  let orgB: Organization;
+  let user: User;
+  let pubA: Publication;
+  let pubB: Publication;
+  // One submission per intended pipeline item: the unique index on
+  // submission_id is global, so a submission can back at most one item ever.
+  let subA: Submission;
+  let subB: Submission;
+  let subASpare: Submission;
+
+  beforeAll(async () => {
+    await globalSetup();
+    await truncateAllTables();
+
+    orgA = await createOrganization({ name: 'Org Alpha' });
+    orgB = await createOrganization({ name: 'Org Beta' });
+    user = await createUser();
+    await createOrgMember(orgA.id, user.id, { roles: ['ADMIN'] });
+    await createOrgMember(orgB.id, user.id, { roles: ['ADMIN'] });
+
+    pubA = await createPublication(orgA.id);
+    pubB = await createPublication(orgB.id);
+
+    const periodA = await createSubmissionPeriod(orgA.id);
+    const periodB = await createSubmissionPeriod(orgB.id);
+
+    [subA, subB, subASpare] = await Promise.all([
+      createSubmission(orgA.id, user.id, { submissionPeriodId: periodA.id }),
+      createSubmission(orgB.id, user.id, { submissionPeriodId: periodB.id }),
+      createSubmission(orgA.id, user.id, { submissionPeriodId: periodA.id }),
+    ]);
+  });
+
+  // Fresh issues per test. Deleting the parent cascades to issue_items and
+  // issue_sections, so counts cannot drift as cases are reordered.
+  let issueA: Issue;
+  let issueB: Issue;
+  let itemB: PipelineItem;
+
+  beforeEach(async () => {
+    await adminDb().delete(issues);
+    // Deleting issues cascades to issue_items and issue_sections but not to
+    // pipeline_items, and `pipeline_items_submission_id_idx` is global — so
+    // without this a second case reusing a submission collides.
+    await adminDb().delete(pipelineItems);
+    issueA = await createIssue(orgA.id, pubA.id, { title: 'Alpha Issue' });
+    issueB = await createIssue(orgB.id, pubB.id, { title: 'Beta Issue' });
+    itemB = await createPipelineItem(orgB.id, subB.id);
+  });
+
+  afterAll(async () => {
+    await truncateAllTables();
+  });
+
+  describe('list', () => {
+    it("excludes another org's issues from both items and total", async () => {
+      const result = await issueService.list(adminTx(), LIST_INPUT, orgA.id);
+
+      expect(result.items.map((i) => i.id)).toEqual([issueA.id]);
+      expect(result.items.map((i) => i.id)).not.toContain(issueB.id);
+      // The count query shares the predicate — filtering only the page would
+      // leave `total` reporting every org's issue count.
+      expect(result.total).toBe(1);
+    });
+  });
+
+  describe('getById', () => {
+    it('returns null for an issue in another org', async () => {
+      const result = await issueService.getById(adminTx(), issueB.id, orgA.id);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getItems / getSections', () => {
+    it("returns [] for another org's issue", async () => {
+      const pipelineItemA = await createPipelineItem(orgA.id, subA.id);
+      await createIssueItem(issueB.id, itemB.id);
+      await createIssueSection(issueB.id);
+
+      expect(
+        await issueService.getItems(adminTx(), issueB.id, orgA.id),
+      ).toEqual([]);
+      expect(
+        await issueService.getSections(adminTx(), issueB.id, orgA.id),
+      ).toEqual([]);
+
+      // Sanity: the same calls against A's own issue do return rows, so the
+      // empty results above are the guard and not an empty fixture.
+      await createIssueItem(issueA.id, pipelineItemA.id);
+      expect(
+        await issueService.getItems(adminTx(), issueA.id, orgA.id),
+      ).toHaveLength(1);
+    });
+  });
+
+  describe('update', () => {
+    it("returns null for another org's issue and leaves it untouched", async () => {
+      const result = await issueService.update(
+        adminTx(),
+        issueB.id,
+        { title: 'Hijacked' },
+        orgA.id,
+      );
+
+      expect(result).toBeNull();
+      const row = await readIssue(issueB.id);
+      expect(row?.title).toBe('Beta Issue');
+    });
+  });
+
+  describe('updateStatus', () => {
+    it("returns null for another org's issue and leaves its status untouched", async () => {
+      const before = await readIssue(issueB.id);
+
+      const result = await issueService.updateStatus(
+        adminTx(),
+        issueB.id,
+        'PUBLISHED',
+        orgA.id,
+      );
+
+      expect(result).toBeNull();
+      const row = await readIssue(issueB.id);
+      expect(row?.status).toBe(before?.status);
+      expect(row?.publishedAt).toBeNull();
+    });
+  });
+
+  describe('saveCmsPublishResult', () => {
+    it("returns null for another org's issue and leaves its metadata untouched", async () => {
+      const result = await issueService.saveCmsPublishResult(
+        adminTx(),
+        issueB.id,
+        'conn-1',
+        { externalId: 'ext-1', adapterType: 'GHOST' },
+        orgA.id,
+      );
+
+      expect(result).toBeNull();
+      const row = await readIssue(issueB.id);
+      expect(row?.metadata ?? {}).toEqual({});
+    });
+  });
+
+  describe('addItem', () => {
+    it("throws for another org's issue and writes no row", async () => {
+      const pipelineItemA = await createPipelineItem(orgA.id, subA.id);
+
+      await expect(
+        issueService.addItem(
+          adminTx(),
+          issueB.id,
+          { pipelineItemId: pipelineItemA.id },
+          orgA.id,
+        ),
+      ).rejects.toThrow(IssueNotFoundError);
+
+      expect(await countItemsFor(issueB.id)).toBe(0);
+    });
+
+    /**
+     * The §0 case. A's own issue, so the guard passes — what must reject is the
+     * foreign `pipelineItemId`. Without the org-scoped pipeline-item lookup this
+     * inserts successfully and `getItems` hands back B's submission title.
+     */
+    it("rejects another org's pipeline item on the caller's own issue", async () => {
+      await expect(
+        issueService.addItem(
+          adminTx(),
+          issueA.id,
+          { pipelineItemId: itemB.id },
+          orgA.id,
+        ),
+      ).rejects.toThrow(IssueNotFoundError);
+
+      expect(await countItemsFor(issueA.id)).toBe(0);
+
+      // The read-back path that made this exploitable: nothing of B's is
+      // reachable through A's issue.
+      const items = await issueService.getItems(adminTx(), issueA.id, orgA.id);
+      expect(items).toEqual([]);
+    });
+
+    it("accepts the caller's own pipeline item", async () => {
+      const pipelineItemA = await createPipelineItem(orgA.id, subA.id);
+
+      const row = await issueService.addItem(
+        adminTx(),
+        issueA.id,
+        { pipelineItemId: pipelineItemA.id },
+        orgA.id,
+      );
+
+      expect(row.issueId).toBe(issueA.id);
+      expect(await countItemsFor(issueA.id)).toBe(1);
+    });
+  });
+
+  describe('addSection', () => {
+    it("throws for another org's issue and writes no row", async () => {
+      await expect(
+        issueService.addSection(
+          adminTx(),
+          issueB.id,
+          { title: 'Injected' },
+          orgA.id,
+        ),
+      ).rejects.toThrow(IssueNotFoundError);
+
+      const rows = await adminDb()
+        .select()
+        .from(issueSections)
+        .where(eq(issueSections.issueId, issueB.id));
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  describe('removeItem', () => {
+    it("returns null for another org's item and leaves it present", async () => {
+      const target = await createIssueItem(issueB.id, itemB.id);
+
+      const result = await issueService.removeItem(
+        adminTx(),
+        issueB.id,
+        target.id,
+        orgA.id,
+      );
+
+      expect(result).toBeNull();
+      expect(await readItem(target.id)).not.toBeNull();
+    });
+  });
+
+  describe('removeSection', () => {
+    it("returns null for another org's section and leaves it present", async () => {
+      const target = await createIssueSection(issueB.id);
+
+      const result = await issueService.removeSection(
+        adminTx(),
+        issueB.id,
+        target.id,
+        orgA.id,
+      );
+
+      expect(result).toBeNull();
+      expect(await readSection(target.id)).not.toBeNull();
+    });
+  });
+
+  describe('reorderItems', () => {
+    it("returns [] for another org's issue and leaves sort order untouched", async () => {
+      const target = await createIssueItem(issueB.id, itemB.id, {
+        sortOrder: 0,
+      });
+
+      const result = await issueService.reorderItems(
+        adminTx(),
+        issueB.id,
+        { items: [{ id: target.id, sortOrder: 99 }] },
+        orgA.id,
+      );
+
+      expect(result).toEqual([]);
+      const row = await readItem(target.id);
+      expect(row?.sortOrder).toBe(0);
+    });
+  });
+
+  /**
+   * Not a scoping case. `addItemWithAudit`'s catch checked `e.code` directly,
+   * which never matches: Drizzle wraps the pg error and the SQLSTATE lives on
+   * `.cause`, so every duplicate add rethrew as a 500 (and, because
+   * `rest/error-mapper.ts` does the same direct check while tRPC's recurses,
+   * the two surfaces disagreed about the status code). No unit spec can catch
+   * this — a mocked `tx` never produces a real driver error — which is why it
+   * is pinned here.
+   */
+  describe('addItemWithAudit duplicate handling', () => {
+    it('maps a 23505 to IssueItemAlreadyExistsError rather than rethrowing', async () => {
+      const pipelineItemA = await createPipelineItem(orgA.id, subASpare.id);
+      const ctx = {
+        tx: adminTx(),
+        actor: { orgId: orgA.id, userId: user.id, roles: ['ADMIN'] },
+        audit: async () => {},
+      } as unknown as Parameters<typeof issueService.addItemWithAudit>[0];
+
+      await issueService.addItemWithAudit(ctx, issueA.id, {
+        pipelineItemId: pipelineItemA.id,
+      });
+
+      await expect(
+        issueService.addItemWithAudit(ctx, issueA.id, {
+          pipelineItemId: pipelineItemA.id,
+        }),
+      ).rejects.toThrow(IssueItemAlreadyExistsError);
+    });
+  });
+});

--- a/apps/api/src/__tests__/rls/issue-service.test.ts
+++ b/apps/api/src/__tests__/rls/issue-service.test.ts
@@ -101,6 +101,7 @@ import {
 import {
   issueService,
   IssueNotFoundError,
+  IssuePipelineItemNotFoundError,
   IssueItemAlreadyExistsError,
 } from '../../services/issue.service.js';
 
@@ -335,7 +336,18 @@ describe('issueService defense-in-depth (RLS bypassed)', () => {
           { pipelineItemId: itemB.id },
           orgA.id,
         ),
-      ).rejects.toThrow(IssueNotFoundError);
+      ).rejects.toThrow(IssuePipelineItemNotFoundError);
+
+      // A pipeline item that does not exist at all raises the identical error,
+      // so the rejection cannot be used to probe for another org's items.
+      await expect(
+        issueService.addItem(
+          adminTx(),
+          issueA.id,
+          { pipelineItemId: '00000000-0000-4000-8000-000000000000' },
+          orgA.id,
+        ),
+      ).rejects.toThrow(IssuePipelineItemNotFoundError);
 
       expect(await countItemsFor(issueA.id)).toBe(0);
 

--- a/apps/api/src/__tests__/security/helpers/auth-app.ts
+++ b/apps/api/src/__tests__/security/helpers/auth-app.ts
@@ -121,3 +121,32 @@ export async function recentAuditActions(orgId: string): Promise<string[]> {
   );
   return result.rows.map((r) => r.action);
 }
+
+/**
+ * Wait for an audit action to appear, then return the recent actions.
+ *
+ * **Use this, not bare `recentAuditActions`, after an `app.inject()` that is
+ * expected to have audited something.** The guards write the row and throw; the
+ * row is committed by `db-context`'s `onResponse` hook, which fires *after* the
+ * response is sent — so `inject()`'s promise settles before the COMMIT lands and
+ * reading straight away races it. That race is not theoretical: it failed CI
+ * twice on 2026-07-31, once per call site, always as `expected [] to include
+ * '<ACTION>'`, and never locally — a loaded runner loses it far more often.
+ *
+ * Returns the actions either way rather than throwing its own timeout error, so
+ * the caller's `toContain` still produces a readable diff when the row genuinely
+ * never arrives.
+ */
+export async function waitForAuditAction(
+  orgId: string,
+  action: string,
+  timeoutMs = 5000,
+): Promise<string[]> {
+  const deadline = Date.now() + timeoutMs;
+  let actions = await recentAuditActions(orgId);
+  while (!actions.includes(action) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    actions = await recentAuditActions(orgId);
+  }
+  return actions;
+}

--- a/apps/api/src/__tests__/security/scope-enforcement.test.ts
+++ b/apps/api/src/__tests__/security/scope-enforcement.test.ts
@@ -25,7 +25,7 @@ import {
   buildApiKeyApp,
   buildInteractiveApp,
   insertApiKey,
-  recentAuditActions,
+  waitForAuditAction,
 } from './helpers/auth-app.js';
 
 /** A scope-guarded orgProcedure: requireScopes('notifications:read'). */
@@ -138,8 +138,11 @@ describe('requireScopes — real API key through the tRPC router', () => {
     });
 
     // The row survives only because the tRPC adapter turns a TRPCError into a
-    // normal reply, so db-context COMMITs rather than ROLLBACKs.
-    expect(await recentAuditActions(org.id)).toContain('API_KEY_SCOPE_DENIED');
+    // normal reply, so db-context COMMITs rather than ROLLBACKs. That COMMIT
+    // runs in `onResponse`, after `inject()` resolves — hence the wait.
+    expect(await waitForAuditAction(org.id, 'API_KEY_SCOPE_DENIED')).toContain(
+      'API_KEY_SCOPE_DENIED',
+    );
   });
 
   it('is a no-op for interactive auth — the same route needs no scopes', async () => {
@@ -183,10 +186,11 @@ describe('internalOnly — the boundary enforced since P0.5', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    // Log-only mode still records the crossing.
-    expect(await recentAuditActions(org.id)).toContain(
-      'API_KEY_INTERNAL_ROUTE',
-    );
+    // Log-only mode still records the crossing. Same `onResponse` COMMIT race as
+    // the scope-denial case above.
+    expect(
+      await waitForAuditAction(org.id, 'API_KEY_INTERNAL_ROUTE'),
+    ).toContain('API_KEY_INTERNAL_ROUTE');
   });
 
   it('rejects an API key with 403 once enforcement is on', async () => {

--- a/apps/api/src/rest/error-mapper.ts
+++ b/apps/api/src/rest/error-mapper.ts
@@ -50,6 +50,7 @@ import { ContractTemplateNotFoundError } from '../services/contract-template.ser
 import { ContractNotFoundError } from '../services/contract.service.js';
 import {
   IssueNotFoundError,
+  IssuePipelineItemNotFoundError,
   IssueItemAlreadyExistsError,
 } from '../services/issue.service.js';
 import { CmsConnectionNotFoundError } from '../services/cms-connection.service.js';
@@ -138,6 +139,7 @@ const errorCodeMap: [new (...args: never[]) => Error, ORPCErrorCode][] = [
   [ContractNotFoundError, 'NOT_FOUND'],
   // Issue errors
   [IssueNotFoundError, 'NOT_FOUND'],
+  [IssuePipelineItemNotFoundError, 'NOT_FOUND'],
   [IssueItemAlreadyExistsError, 'CONFLICT'],
   // CMS errors
   [CmsConnectionNotFoundError, 'NOT_FOUND'],

--- a/apps/api/src/services/cms-connection.service.ts
+++ b/apps/api/src/services/cms-connection.service.ts
@@ -30,19 +30,20 @@ export const cmsConnectionService = {
   // List / Get
   // -------------------------------------------------------------------------
 
-  async list(tx: DrizzleDb, input: ListCmsConnectionsInput, orgId?: string) {
+  async list(tx: DrizzleDb, input: ListCmsConnectionsInput, orgId: string) {
     const { publicationId, page, limit } = input;
     const offset = (page - 1) * limit;
 
-    const conditions = [];
-    if (orgId) {
-      conditions.push(eq(cmsConnections.organizationId, orgId));
-    }
+    // Seeded unconditionally, and the single `where` below is reused by both the
+    // page and the count query — filtering only the page leaves `total`
+    // reporting every org's connection count.
+    const conditions = [eq(cmsConnections.organizationId, orgId)];
     if (publicationId) {
       conditions.push(eq(cmsConnections.publicationId, publicationId));
     }
 
-    const where = conditions.length > 0 ? and(...conditions) : undefined;
+    // Never empty — the org predicate is always present.
+    const where = and(...conditions);
 
     const [items, countResult] = await Promise.all([
       tx
@@ -65,17 +66,15 @@ export const cmsConnectionService = {
     };
   },
 
-  async getById(tx: DrizzleDb, id: string, orgId?: string) {
+  async getById(tx: DrizzleDb, id: string, orgId: string) {
     const [row] = await tx
       .select()
       .from(cmsConnections)
       .where(
-        orgId
-          ? and(
-              eq(cmsConnections.id, id),
-              eq(cmsConnections.organizationId, orgId),
-            )
-          : eq(cmsConnections.id, id),
+        and(
+          eq(cmsConnections.id, id),
+          eq(cmsConnections.organizationId, orgId),
+        ),
       )
       .limit(1);
 
@@ -121,7 +120,7 @@ export const cmsConnectionService = {
     tx: DrizzleDb,
     id: string,
     input: UpdateCmsConnectionInput,
-    orgId?: string,
+    orgId: string,
   ) {
     const values: Record<string, unknown> = { updatedAt: new Date() };
     if (input.name !== undefined) values.name = input.name;
@@ -132,12 +131,10 @@ export const cmsConnectionService = {
       .update(cmsConnections)
       .set(values)
       .where(
-        orgId
-          ? and(
-              eq(cmsConnections.id, id),
-              eq(cmsConnections.organizationId, orgId),
-            )
-          : eq(cmsConnections.id, id),
+        and(
+          eq(cmsConnections.id, id),
+          eq(cmsConnections.organizationId, orgId),
+        ),
       )
       .returning();
 
@@ -170,16 +167,14 @@ export const cmsConnectionService = {
     return updated;
   },
 
-  async delete(tx: DrizzleDb, id: string, orgId?: string) {
+  async delete(tx: DrizzleDb, id: string, orgId: string) {
     const [row] = await tx
       .delete(cmsConnections)
       .where(
-        orgId
-          ? and(
-              eq(cmsConnections.id, id),
-              eq(cmsConnections.organizationId, orgId),
-            )
-          : eq(cmsConnections.id, id),
+        and(
+          eq(cmsConnections.id, id),
+          eq(cmsConnections.organizationId, orgId),
+        ),
       )
       .returning();
 
@@ -207,7 +202,7 @@ export const cmsConnectionService = {
   // Test connection
   // -------------------------------------------------------------------------
 
-  async testConnection(tx: DrizzleDb, id: string, orgId?: string) {
+  async testConnection(tx: DrizzleDb, id: string, orgId: string) {
     const connection = await cmsConnectionService.getById(tx, id, orgId);
     if (!connection) throw new CmsConnectionNotFoundError(id);
 
@@ -245,18 +240,12 @@ export const cmsConnectionService = {
   // Helpers for Inngest workers
   // -------------------------------------------------------------------------
 
-  async listByPublication(
-    tx: DrizzleDb,
-    publicationId: string,
-    orgId?: string,
-  ) {
+  async listByPublication(tx: DrizzleDb, publicationId: string, orgId: string) {
     const conditions = [
+      eq(cmsConnections.organizationId, orgId),
       eq(cmsConnections.publicationId, publicationId),
       eq(cmsConnections.isActive, true),
     ];
-    if (orgId) {
-      conditions.push(eq(cmsConnections.organizationId, orgId));
-    }
     return tx
       .select()
       .from(cmsConnections)
@@ -264,17 +253,15 @@ export const cmsConnectionService = {
       .limit(10000);
   },
 
-  async updateLastSync(tx: DrizzleDb, id: string, orgId?: string) {
+  async updateLastSync(tx: DrizzleDb, id: string, orgId: string) {
     await tx
       .update(cmsConnections)
       .set({ lastSyncAt: new Date(), updatedAt: new Date() })
       .where(
-        orgId
-          ? and(
-              eq(cmsConnections.id, id),
-              eq(cmsConnections.organizationId, orgId),
-            )
-          : eq(cmsConnections.id, id),
+        and(
+          eq(cmsConnections.id, id),
+          eq(cmsConnections.organizationId, orgId),
+        ),
       );
   },
 };

--- a/apps/api/src/services/issue.service.spec.ts
+++ b/apps/api/src/services/issue.service.spec.ts
@@ -89,6 +89,7 @@ describe('issueService.saveCmsPublishResult', () => {
         externalUrl: 'https://example.com/post/1',
         adapterType: 'GHOST',
       },
+      'org-1',
     );
 
     expect(mockSet).toHaveBeenCalledWith(
@@ -127,6 +128,7 @@ describe('issueService.saveCmsPublishResult', () => {
       'nonexistent',
       'conn-1',
       { externalId: 'ext-1', adapterType: 'GHOST' },
+      'org-1',
     );
 
     expect(result).toBeNull();
@@ -160,6 +162,7 @@ describe('issueService.saveCmsPublishResult', () => {
       'issue-2',
       'conn-2',
       { externalId: 'ext-2', adapterType: 'WORDPRESS' },
+      'org-1',
     );
 
     expect(mockSet).toHaveBeenCalledWith(
@@ -250,11 +253,12 @@ describe('issueService defense-in-depth org filtering', () => {
 // listActive
 // ---------------------------------------------------------------------------
 
+// No `Function.prototype.length` arity check here. It proved nothing: TypeScript
+// compiles `orgId?: string` to a parameter with no initializer, so `.length`
+// counted the optional org id too and the assertion passed identically before
+// and after this file's methods required it. `__tests__/rls/issue-service.test.ts`
+// is what pins the predicates now.
 describe('issueService.listActive', () => {
-  it('requires orgId parameter (2 args: tx, orgId)', () => {
-    expect(issueService.listActive.length).toBe(2);
-  });
-
   it('returns empty array when no active issues exist', async () => {
     const mockTx = {
       select: vi.fn().mockReturnValue({

--- a/apps/api/src/services/issue.service.ts
+++ b/apps/api/src/services/issue.service.ts
@@ -47,6 +47,19 @@ export class IssueSectionNotFoundError extends Error {
   }
 }
 
+/**
+ * A pipeline item that is not available to the caller's organization — whether
+ * it does not exist at all or belongs to another tenant. The two cases are
+ * deliberately indistinguishable: a caller must not be able to probe for the
+ * existence of another org's pipeline items by the error it gets back.
+ */
+export class IssuePipelineItemNotFoundError extends Error {
+  constructor(pipelineItemId: string) {
+    super(`Pipeline item "${pipelineItemId}" not found`);
+    this.name = 'IssuePipelineItemNotFoundError';
+  }
+}
+
 export class IssueItemAlreadyExistsError extends Error {
   constructor(pipelineItemId: string) {
     super(`Pipeline item "${pipelineItemId}" is already in this issue`);
@@ -371,9 +384,9 @@ export const issueService = {
     // submission's title. Same shape as `pipelineService.create`'s unscoped
     // submission read (#537): a scoped parent and an unscoped foreign key.
     //
-    // `IssueNotFoundError` rather than a distinguishable "wrong org" error, and
-    // the message names the id the caller already supplied — a more specific
-    // error here would be an existence oracle for other tenants' pipeline items.
+    // The error names only the id the caller already supplied, and an absent id
+    // and a foreign one raise the identical error — so this cannot be used to
+    // probe whether a given pipeline item exists in some other tenant.
     const [pipelineItem] = await tx
       .select({ id: pipelineItems.id })
       .from(pipelineItems)
@@ -386,9 +399,7 @@ export const issueService = {
       .limit(1);
 
     if (!pipelineItem) {
-      throw new IssueNotFoundError(
-        `Pipeline item "${input.pipelineItemId}" not found`,
-      );
+      throw new IssuePipelineItemNotFoundError(input.pipelineItemId);
     }
 
     // Validate section belongs to this issue (if provided)

--- a/apps/api/src/services/issue.service.ts
+++ b/apps/api/src/services/issue.service.ts
@@ -27,6 +27,7 @@ import { AuditActions, AuditResources } from '@colophony/types';
 import type { ServiceContext } from './types.js';
 import { assertEditorOrProductionOrAdmin } from './errors.js';
 import { enqueueOutboxEvent } from './outbox.js';
+import { isUniqueViolation } from './pg-errors.js';
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -62,19 +63,22 @@ export const issueService = {
   // List / Get
   // -------------------------------------------------------------------------
 
-  async list(tx: DrizzleDb, input: ListIssuesInput, orgId?: string) {
+  async list(tx: DrizzleDb, input: ListIssuesInput, orgId: string) {
     const { publicationId, status, search, from, to, page, limit } = input;
     const offset = (page - 1) * limit;
 
-    const conditions = [];
-    if (orgId) conditions.push(eq(issues.organizationId, orgId));
+    // Seeded unconditionally, and the single `where` below is reused by both the
+    // page and the count query — filtering only the page leaves `total` reporting
+    // every org's issue count.
+    const conditions = [eq(issues.organizationId, orgId)];
     if (publicationId) conditions.push(eq(issues.publicationId, publicationId));
     if (status) conditions.push(eq(issues.status, status));
     if (search) conditions.push(ilike(issues.title, `%${search}%`));
     if (from) conditions.push(gte(issues.publicationDate, from));
     if (to) conditions.push(lte(issues.publicationDate, to));
 
-    const where = conditions.length > 0 ? and(...conditions) : undefined;
+    // Never empty — the org predicate is always present.
+    const where = and(...conditions);
     const hasDateRange = from || to;
 
     const [items, countResult] = await Promise.all([
@@ -119,25 +123,19 @@ export const issueService = {
       .limit(50);
   },
 
-  async getById(tx: DrizzleDb, id: string, orgId?: string) {
+  async getById(tx: DrizzleDb, id: string, orgId: string) {
     const [row] = await tx
       .select()
       .from(issues)
-      .where(
-        orgId
-          ? and(eq(issues.id, id), eq(issues.organizationId, orgId))
-          : eq(issues.id, id),
-      )
+      .where(and(eq(issues.id, id), eq(issues.organizationId, orgId)))
       .limit(1);
 
     return row ?? null;
   },
 
-  async getItems(tx: DrizzleDb, issueId: string, orgId?: string) {
-    if (orgId) {
-      const issue = await issueService.getById(tx, issueId, orgId);
-      if (!issue) return [];
-    }
+  async getItems(tx: DrizzleDb, issueId: string, orgId: string) {
+    const issue = await issueService.getById(tx, issueId, orgId);
+    if (!issue) return [];
     return tx
       .select({
         ...getTableColumns(issueItems),
@@ -151,11 +149,9 @@ export const issueService = {
       .limit(10000);
   },
 
-  async getSections(tx: DrizzleDb, issueId: string, orgId?: string) {
-    if (orgId) {
-      const issue = await issueService.getById(tx, issueId, orgId);
-      if (!issue) return [];
-    }
+  async getSections(tx: DrizzleDb, issueId: string, orgId: string) {
+    const issue = await issueService.getById(tx, issueId, orgId);
+    if (!issue) return [];
     return tx
       .select()
       .from(issueSections)
@@ -202,7 +198,7 @@ export const issueService = {
     tx: DrizzleDb,
     id: string,
     input: UpdateIssueInput,
-    orgId?: string,
+    orgId: string,
   ) {
     const values: Record<string, unknown> = { updatedAt: new Date() };
     if (input.title !== undefined) values.title = input.title;
@@ -217,11 +213,7 @@ export const issueService = {
     const [row] = await tx
       .update(issues)
       .set(values)
-      .where(
-        orgId
-          ? and(eq(issues.id, id), eq(issues.organizationId, orgId))
-          : eq(issues.id, id),
-      )
+      .where(and(eq(issues.id, id), eq(issues.organizationId, orgId)))
       .returning();
 
     return row ?? null;
@@ -253,7 +245,7 @@ export const issueService = {
     tx: DrizzleDb,
     id: string,
     status: IssueStatus,
-    orgId?: string,
+    orgId: string,
   ) {
     const values: Record<string, unknown> = {
       status,
@@ -264,11 +256,7 @@ export const issueService = {
     const [row] = await tx
       .update(issues)
       .set(values)
-      .where(
-        orgId
-          ? and(eq(issues.id, id), eq(issues.organizationId, orgId))
-          : eq(issues.id, id),
-      )
+      .where(and(eq(issues.id, id), eq(issues.organizationId, orgId)))
       .returning();
 
     return row ?? null;
@@ -337,7 +325,7 @@ export const issueService = {
       externalUrl?: string;
       adapterType: string;
     },
-    orgId?: string,
+    orgId: string,
   ) {
     const issue = await issueService.getById(tx, issueId, orgId);
     if (!issue) return null;
@@ -354,11 +342,7 @@ export const issueService = {
     const [row] = await tx
       .update(issues)
       .set({ metadata: { ...metadata, cmsPublish }, updatedAt: new Date() })
-      .where(
-        orgId
-          ? and(eq(issues.id, issueId), eq(issues.organizationId, orgId))
-          : eq(issues.id, issueId),
-      )
+      .where(and(eq(issues.id, issueId), eq(issues.organizationId, orgId)))
       .returning();
 
     return row ?? null;
@@ -372,12 +356,41 @@ export const issueService = {
     tx: DrizzleDb,
     issueId: string,
     input: AddIssueItemInput,
-    orgId?: string,
+    orgId: string,
   ) {
-    if (orgId) {
-      const issue = await issueService.getById(tx, issueId, orgId);
-      if (!issue) throw new IssueNotFoundError(issueId);
+    const issue = await issueService.getById(tx, issueId, orgId);
+    if (!issue) throw new IssueNotFoundError(issueId);
+
+    // Validate the pipeline item belongs to the caller's org.
+    //
+    // Scoping the *issue* is not enough. `issue_items` has no `organization_id`
+    // of its own — its RLS policy scopes solely through its parent issue — so a
+    // row pairing this org's issue with another org's pipeline item is valid
+    // under RLS. `getItems` then joins that item through `pipeline_items` to
+    // `submissions` and returns `submissionTitle`, handing back a foreign
+    // submission's title. Same shape as `pipelineService.create`'s unscoped
+    // submission read (#537): a scoped parent and an unscoped foreign key.
+    //
+    // `IssueNotFoundError` rather than a distinguishable "wrong org" error, and
+    // the message names the id the caller already supplied — a more specific
+    // error here would be an existence oracle for other tenants' pipeline items.
+    const [pipelineItem] = await tx
+      .select({ id: pipelineItems.id })
+      .from(pipelineItems)
+      .where(
+        and(
+          eq(pipelineItems.id, input.pipelineItemId),
+          eq(pipelineItems.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+
+    if (!pipelineItem) {
+      throw new IssueNotFoundError(
+        `Pipeline item "${input.pipelineItemId}" not found`,
+      );
     }
+
     // Validate section belongs to this issue (if provided)
     if (input.issueSectionId) {
       const [section] = await tx
@@ -432,13 +445,12 @@ export const issueService = {
       });
       return item;
     } catch (e) {
-      // Unique constraint violation → already exists
-      if (
-        typeof e === 'object' &&
-        e !== null &&
-        'code' in e &&
-        (e as { code: string }).code === '23505'
-      ) {
+      // Unique constraint violation (`issue_items_issue_pipeline_unique`) →
+      // already exists. Must walk the `cause` chain: Drizzle wraps the pg error,
+      // so a direct `e.code` check silently never matches and every duplicate
+      // surfaces as a 500 on REST (tRPC's mapper recurses `cause`, so it 409s —
+      // which is why the two surfaces disagreed). See `services/pg-errors.ts`.
+      if (isUniqueViolation(e)) {
         throw new IssueItemAlreadyExistsError(input.pipelineItemId);
       }
       throw e;
@@ -449,15 +461,35 @@ export const issueService = {
     tx: DrizzleDb,
     issueId: string,
     itemId: string,
-    orgId?: string,
+    orgId: string,
   ) {
-    if (orgId) {
-      const issue = await issueService.getById(tx, issueId, orgId);
-      if (!issue) return null;
-    }
+    const issue = await issueService.getById(tx, issueId, orgId);
+    if (!issue) return null;
+
+    // Second defence: resolve the row through an org-scoped join before
+    // deleting, so the DELETE cannot fire on a row this org has not proven it
+    // owns. `issue_items` has no `organization_id` to filter on directly, and
+    // duplicating its EXISTS-on-parent RLS policy in the DELETE would be a
+    // second copy of the policy to keep true. Verifying in front of the delete
+    // is cheaper and survives a refactor that drops the guard above.
+    const [owned] = await tx
+      .select({ id: issueItems.id })
+      .from(issueItems)
+      .innerJoin(issues, eq(issueItems.issueId, issues.id))
+      .where(
+        and(
+          eq(issueItems.id, itemId),
+          eq(issueItems.issueId, issueId),
+          eq(issues.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+
+    if (!owned) return null;
+
     const [row] = await tx
       .delete(issueItems)
-      .where(and(eq(issueItems.id, itemId), eq(issueItems.issueId, issueId)))
+      .where(eq(issueItems.id, owned.id))
       .returning();
 
     return row ?? null;
@@ -490,12 +522,10 @@ export const issueService = {
     tx: DrizzleDb,
     issueId: string,
     input: ReorderItemsInput,
-    orgId?: string,
+    orgId: string,
   ) {
-    if (orgId) {
-      const issue = await issueService.getById(tx, issueId, orgId);
-      if (!issue) return [];
-    }
+    const issue = await issueService.getById(tx, issueId, orgId);
+    if (!issue) return [];
     for (const { id, sortOrder } of input.items) {
       await tx
         .update(issueItems)
@@ -513,12 +543,10 @@ export const issueService = {
     tx: DrizzleDb,
     issueId: string,
     input: AddIssueSectionInput,
-    orgId?: string,
+    orgId: string,
   ) {
-    if (orgId) {
-      const issue = await issueService.getById(tx, issueId, orgId);
-      if (!issue) throw new IssueNotFoundError(issueId);
-    }
+    const issue = await issueService.getById(tx, issueId, orgId);
+    if (!issue) throw new IssueNotFoundError(issueId);
     const [row] = await tx
       .insert(issueSections)
       .values({
@@ -535,20 +563,31 @@ export const issueService = {
     tx: DrizzleDb,
     issueId: string,
     sectionId: string,
-    orgId?: string,
+    orgId: string,
   ) {
-    if (orgId) {
-      const issue = await issueService.getById(tx, issueId, orgId);
-      if (!issue) return null;
-    }
-    const [row] = await tx
-      .delete(issueSections)
+    const issue = await issueService.getById(tx, issueId, orgId);
+    if (!issue) return null;
+
+    // Same scoped-join verification as `removeItem` above, and for the same
+    // reason — `issue_sections` carries no `organization_id` either.
+    const [owned] = await tx
+      .select({ id: issueSections.id })
+      .from(issueSections)
+      .innerJoin(issues, eq(issueSections.issueId, issues.id))
       .where(
         and(
           eq(issueSections.id, sectionId),
           eq(issueSections.issueId, issueId),
+          eq(issues.organizationId, orgId),
         ),
       )
+      .limit(1);
+
+    if (!owned) return null;
+
+    const [row] = await tx
+      .delete(issueSections)
+      .where(eq(issueSections.id, owned.id))
       .returning();
 
     return row ?? null;

--- a/apps/api/src/services/pg-errors.ts
+++ b/apps/api/src/services/pg-errors.ts
@@ -1,0 +1,38 @@
+/**
+ * Driver-level Postgres error predicates for the service layer.
+ *
+ * Separate from `errors.ts`, which holds *domain* errors and role assertions —
+ * this file is about what the database driver hands back, not what the domain
+ * means by it.
+ */
+
+/**
+ * True for a Postgres unique-violation (SQLSTATE 23505).
+ *
+ * Walks the `cause` chain because Drizzle wraps driver errors in a
+ * `DrizzleQueryError` and the pg error — the one carrying `code` — is the cause.
+ * Checking `err.code` directly silently never matches: the catch block looks
+ * correct, compiles, and quietly rethrows every unique violation as a 500. That
+ * is not hypothetical; it is what `issueService.addItemWithAudit` did until
+ * 2026-07-31, and no unit spec could catch it because a mocked `tx` never
+ * produces a real driver error.
+ *
+ * Matches on the SQLSTATE, not the message. `pipelineService.saveCopyedit`
+ * string-matches 'unique constraint' for its retry and predates this; do not
+ * copy that spelling.
+ *
+ * Lives here rather than beside its first caller so there is one copy. A
+ * per-file copy is how these drift — `queue-preset.service.ts` still carries a
+ * private function of the same name using the broken direct check.
+ */
+export function isUniqueViolation(err: unknown): boolean {
+  let current: unknown = err;
+  // Bounded so a self-referential cause cannot spin.
+  for (let depth = 0; depth < 5; depth++) {
+    if (current === null || typeof current !== 'object') return false;
+    if ('code' in current && current.code === '23505') return true;
+    if (!('cause' in current)) return false;
+    current = current.cause;
+  }
+  return false;
+}

--- a/apps/api/src/services/pipeline.service.ts
+++ b/apps/api/src/services/pipeline.service.ts
@@ -37,6 +37,7 @@ import {
 import type { ServiceContext } from './types.js';
 import { assertEditorOrProductionOrAdmin } from './errors.js';
 import { enqueueOutboxEvent } from './outbox.js';
+import { isUniqueViolation } from './pg-errors.js';
 import type { S3StorageAdapter } from '../adapters/storage/index.js';
 import { convertProseMirrorToDocx } from '../converters/prosemirror-to-docx.js';
 import { convertFile } from '../converters/index.js';
@@ -74,29 +75,6 @@ export class InvalidPipelineTransitionError extends Error {
     super(`Invalid pipeline transition from "${from}" to "${to}"`);
     this.name = 'InvalidPipelineTransitionError';
   }
-}
-
-/**
- * True for a Postgres unique-violation (SQLSTATE 23505).
- *
- * Walks the `cause` chain because Drizzle wraps driver errors in a
- * `DrizzleQueryError` and the pg error — the one carrying `code` — is the cause.
- * Checking `err.code` directly silently never matches, which is exactly what the
- * first version of this did.
- *
- * Matches on the SQLSTATE, not the message. `saveCopyedit` below string-matches
- * 'unique constraint' for its retry; do not copy that spelling.
- */
-function isUniqueViolation(err: unknown): boolean {
-  let current: unknown = err;
-  // Bounded so a self-referential cause cannot spin.
-  for (let depth = 0; depth < 5; depth++) {
-    if (current === null || typeof current !== 'object') return false;
-    if ('code' in current && current.code === '23505') return true;
-    if (!('cause' in current)) return false;
-    current = current.cause;
-  }
-  return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -50,6 +50,7 @@ import { ContractTemplateNotFoundError } from '../services/contract-template.ser
 import { ContractNotFoundError } from '../services/contract.service.js';
 import {
   IssueNotFoundError,
+  IssuePipelineItemNotFoundError,
   IssueItemAlreadyExistsError,
 } from '../services/issue.service.js';
 import { CmsConnectionNotFoundError } from '../services/cms-connection.service.js';
@@ -200,6 +201,7 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [ContractNotFoundError, 'NOT_FOUND'],
   // Issue errors
   [IssueNotFoundError, 'NOT_FOUND'],
+  [IssuePipelineItemNotFoundError, 'NOT_FOUND'],
   [IssueItemAlreadyExistsError, 'CONFLICT'],
   // CMS errors
   [CmsConnectionNotFoundError, 'NOT_FOUND'],

--- a/apps/api/src/trpc/routers/csr.spec.ts
+++ b/apps/api/src/trpc/routers/csr.spec.ts
@@ -99,9 +99,14 @@ vi.mock('../../services/contract.service.js', () => ({
   ContractNotFoundError: class extends Error {},
 }));
 
+// Every error class `trpc/error-mapper.ts` imports from this module must appear
+// here. A missing one is not a test failure — the module throws while the mapper
+// builds its error table, so the whole file collects zero tests and the run can
+// still report green.
 vi.mock('../../services/issue.service.js', () => ({
   issueService: {},
   IssueNotFoundError: class extends Error {},
+  IssuePipelineItemNotFoundError: class extends Error {},
   IssueItemAlreadyExistsError: class extends Error {},
 }));
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -511,11 +511,26 @@ Ordered as the design doc's Phase 0/D.
       `webhooks/documenso.webhook.ts:285-291` already passes `contract.organizationId` to
       `updateStatus` with a comment calling it defense-in-depth, so the intent is on record.
       — (split out of the item above 2026-07-31 after verifying all three files)
-- [ ] **[P2] `federation.service.ts:437` `resolveWebFinger` is laxer than its sibling.** It
-      filters on `email` alone, while `getUserDidDocument` (`:523`) filters `email` **and**
+- [ ] **[P2] `federation.service.ts` `resolveWebFinger` is laxer than its sibling.** It
+      filters on `email` alone, while `getUserDidDocument` filters `email` **and**
       `isNull(deletedAt)` **and** `eq(isGuest, false)`. Both are unauthenticated federation
       discovery endpoints, so a deleted or guest account is discoverable through one and not
       the other. The asymmetry looks unintended. — (found 2026-07-28 during the P2.0 audit)
+      **Line numbers corrected 2026-07-31** — the original `:437` / `:523` pointed at the
+      query bodies, not the declarations, which is why they read as off. `resolveWebFinger`
+      is declared at `:407` with its query at `:436-441`; `getUserDidDocument` at `:510`
+      with its query at `:519-538`. Both routes confirmed unauthenticated and carrying no
+      guard: `/.well-known/webfinger` matches the `'/.well-known/'` prefix in
+      `PUBLIC_PREFIXES` (`hooks/auth.ts:36-46`), and `/users/:localPart/did.json` is
+      admitted by the separate `path.endsWith('/did.json')` rule at `auth.ts:69-70`.
+      **`resolveWebFinger` is the odd one of three, not of two** — `simsub.service.ts:325-334`
+      is a third email-keyed user lookup and carries all three conditions, citing
+      `getUserDidDocument` in its comments.
+      **The existing tests will not catch the fix regressing.**
+      `federation.service.spec.ts:927,941` ("deleted user", "guest user") stub `db.select`
+      to return `[]` and assert the throw — they pin the empty-result handling, not the
+      `where` clause, and would pass unchanged with the filter conditions deleted. Whoever
+      fixes this needs a test that actually exercises the predicate.
 - [x] **[P2] `demo_requests` has neither RLS nor a `REVOKE`.** It postdates migration 0052, so
       `ALTER DEFAULT PRIVILEGES` left `app_user` full DML and no later migration narrowed it.
       Fixed alongside the P0 above: it is written through the superuser pool
@@ -596,6 +611,17 @@ Ordered as the design doc's Phase 0/D.
       then reaches `dbContextPlugin`, which opens a pooled connection and begins a
       transaction per request, so the failure mode is not merely "unlimited requests" but
       connection-pool exhaustion under load.
+      **Three framing corrections, verified 2026-07-31.** (1) The limiter is **hand-rolled**
+      — `@fastify/rate-limit` appears nowhere in the repo — so `skipOnError` and `onExceeded`
+      do not exist here and cannot be part of any fix. (2) `FEDERATION_RATE_LIMIT_FAIL_MODE`
+      **defaults to `open`**, so porting the pattern alone changes no default behaviour; the
+      value of the port is that the mode becomes settable, not that it becomes safe. (3) The
+      second-pass limiter has a **third** silent bypass beyond the catch this entry mentions:
+      `hooks/rate-limit-auth.ts:55-56` is a bare `if (!redis) return;`, which is not an error
+      path at all and no fail-mode branch would cover. Also note the federation in-process
+      fallback is hard-coded `(10, 60_000)` — roughly 6× stricter than
+      `FEDERATION_RATE_LIMIT_MAX` — so a port should decide that number deliberately rather
+      than inherit it.
       **The asymmetry is the tell.** Federation rate limiting already has
       `FEDERATION_RATE_LIMIT_FAIL_MODE` (`open` / `closed` / `fallback`, with an in-process
       fallback), added in PR #225 for exactly this concern. The main limiter — which guards
@@ -838,8 +864,17 @@ Ordered as the design doc's Phase 0/D.
       behaviour and the upstream type (`OpenAPIGeneratorGenerateOptions` is
       `Partial<Omit<Document, 'openapi'>>`, so the field is un-settable) — nobody has observed
       the live endpoint. No test or fixture captures it, which is also why the divergence went
-      unnoticed. Confirm against a running server before writing the fix. —
-      (code review 2026-07-27)
+      unnoticed. — (code review 2026-07-27)
+      **Caveat tightened 2026-07-31, without a server.** The installed generator sets the
+      value **after** spreading caller options — `@orpc/openapi@1.14.10`,
+      `dist/shared/openapi.BwdtJjDu.mjs:516-524`, which builds
+      `{ ...clone(baseDoc), info: …, openapi: '3.1.1' }` — so even an untyped `openapi` smuggled
+      through `specGenerateOptions` would be clobbered, and `dist/plugins/index.mjs:115-131`
+      serves that document with no post-processing. `3.1.1` is the only `3.1.x` literal in the
+      package. The committed spec is confirmed `3.1.0` at `sdks/openapi.json:98`. So the
+      divergence is now read from the generator source rather than assumed; one `curl` against
+      a running server is still worth doing before the fix, but it is a confirmation rather
+      than the missing evidence.
 - [ ] **[P3] Three OpenAPI tags are used but never declared.** Operations carry
       `Collections` (10 operations), `Submission Analytics` (6), and `Submission Votes` (4),
       but `openApiDocumentConfig.tags` in `apps/api/src/rest/openapi-spec.ts` declares **18**

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -133,7 +133,7 @@
       `getByText` whose string is a prefix of other visible copy has the same latent race; the
       ADMIN path is worse, since `pending-invitations.tsx:65` and `invite-member-dialog.tsx:99`
       add third and fourth matches. — (found 2026-07-30 while diagnosing a CI failure on #537)
-- [ ] [P2] `scope-enforcement.test.ts:142` races the audit COMMIT, so `Security Tests` flakes.
+- [x] [P2] `scope-enforcement.test.ts:142` races the audit COMMIT, so `Security Tests` flakes.
       The case asserts an `API_KEY_SCOPE_DENIED` row exists immediately after `app.inject()`
       resolves. It does not resolve after the row is durable: the guard writes the row and
       throws, and the row is committed by `db-context`'s `onResponse` hook — which fires
@@ -151,7 +151,20 @@
       audit-then-throw path immediately after `inject()` has the same race.
       This is the flip side of a mechanism `apps/api/CLAUDE.md` already flags as
       load-bearing-but-implicit: the row surviving at all depends on `onResponse` COMMITting
-      rather than `onError` rolling back. — (found 2026-07-31 during #538)
+      rather than `onError` rolling back. — (found 2026-07-31 during #538; done 2026-07-31)
+      **Fixed by `waitForAuditAction` in `security/helpers/auth-app.ts`** — polls for the row
+      and returns the actions either way, so a genuinely absent row still fails with a
+      readable diff instead of a bare timeout. Both call sites converted; `recentAuditActions`
+      stays for reads that are not racing a request.
+      **It failed twice before the fix, once per call site** — `:142`
+      (`API_KEY_SCOPE_DENIED`) and `:187` (`API_KEY_INTERNAL_ROUTE`) — which is what
+      established it as a property of the helper rather than of one test.
+      **The fix cannot be verified locally, and that is the interesting part.**
+      Instrumenting the poll showed **0 retries across 10 local calls**: the race never fires
+      on an unloaded machine, which is exactly why it reached CI in the first place. The
+      failing CI run took 82s for the suite against ~30s locally. So the loop is inert when
+      there is no contention (one query, as before) and only earns its keep under load — do
+      not remove it because it "never does anything".
 - [ ] [P3] Seed data ages out of a long-lived dev database, and `db:seed` will not repair it. Submission periods are seeded at fixed offsets from the seed date, so `quarterly-review` eventually has no open period — which fails 11 of 13 `embed` tests with `No open period found`. `pnpm db:seed` is idempotent-by-skip, so it is a no-op once data exists; only the destructive `db:reset` refreshes the dates. CI is unaffected (it seeds fresh each run), so this only ever bites locally, and it looks like a code regression rather than stale data. Either make the seed refresh period dates when they have closed, or have `global-setup.ts` fail with a "run `pnpm db:reset`" message when no open period exists for the seed org — (found 2026-07-27 while verifying the E2E auth rework)
 
 ---

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -133,6 +133,25 @@
       `getByText` whose string is a prefix of other visible copy has the same latent race; the
       ADMIN path is worse, since `pending-invitations.tsx:65` and `invite-member-dialog.tsx:99`
       add third and fourth matches. — (found 2026-07-30 while diagnosing a CI failure on #537)
+- [ ] [P2] `scope-enforcement.test.ts:142` races the audit COMMIT, so `Security Tests` flakes.
+      The case asserts an `API_KEY_SCOPE_DENIED` row exists immediately after `app.inject()`
+      resolves. It does not resolve after the row is durable: the guard writes the row and
+      throws, and the row is committed by `db-context`'s `onResponse` hook — which fires
+      **after** the response is sent, i.e. after `inject()`'s promise settles. So the read can
+      reach the database first and see `[]`. Failed on run 30634870874 with
+      `expected [] to include 'API_KEY_SCOPE_DENIED'`, then passed 22/22 on rerun with
+      byte-identical code; locally it passes 3/3 alone and 4/4 as a full suite.
+      **Not a row-window problem** — worth recording, since `recentAuditActions`
+      (`security/helpers/auth-app.ts:114-123`) reads `LIMIT 20` with
+      `OR organization_id IS NULL`, which looks like it could push the target row out. It
+      cannot: `afterEach` calls `truncateAllTables`, so only one test's rows ever exist.
+      Fix by waiting for the row rather than assuming it: poll `recentAuditActions` with a
+      short timeout, or hook the app's `onResponse` completion instead of the `inject`
+      promise. **Sweep for siblings** — any assertion reading a table written through the
+      audit-then-throw path immediately after `inject()` has the same race.
+      This is the flip side of a mechanism `apps/api/CLAUDE.md` already flags as
+      load-bearing-but-implicit: the row surviving at all depends on `onResponse` COMMITting
+      rather than `onError` rolling back. — (found 2026-07-31 during #538)
 - [ ] [P3] Seed data ages out of a long-lived dev database, and `db:seed` will not repair it. Submission periods are seeded at fixed offsets from the seed date, so `quarterly-review` eventually has no open period — which fails 11 of 13 `embed` tests with `No open period found`. `pnpm db:seed` is idempotent-by-skip, so it is a no-op once data exists; only the destructive `db:reset` refreshes the dates. CI is unaffected (it seeds fresh each run), so this only ever bites locally, and it looks like a code regression rather than stale data. Either make the seed refresh period dates when they have closed, or have `global-setup.ts` fail with a "run `pnpm db:reset`" message when no open period exists for the seed org — (found 2026-07-27 while verifying the E2E auth rework)
 
 ---

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -387,6 +387,44 @@ Ordered as the design doc's Phase 0/D.
       for a scoping it does not perform — its caller supplies the org through
       `withRls({ orgId })` at `inngest/functions/submission-response-reminder.ts:64`, so it is
       correct in practice and misleading to read. — (found 2026-07-28 during the P2.0 audit)
+      Line numbers re-verified 2026-07-30; all three still exact.
+- [ ] **[P2] `submissions` carries a second permissive policy that widens the first, and no
+      test can currently see it.** Beside `org_isolation`, the submissions schema
+      (`schema/submissions.ts:186-189`) declares `submissions_submitter_read`
+      (`using: submitter_id = current_user_id()`). Postgres OR-combines permissive policies,
+      and `hooks/db-context.ts:41-44` sets `app.user_id` on **every** authenticated request —
+      so the effective SELECT predicate on an HTTP path is `organization_id =
+  current_org_id() OR submitter_id = current_user_id()`. An editor who has also submitted
+      to another org on the same instance therefore sees their own foreign-org rows through
+      `submissionService.listAll`/`exportAll`. The Inngest path is unaffected
+      (`withRls({ orgId })` sets no user id). The existing coverage cannot catch this:
+      `__tests__/security/tenant-isolation-transitive.test.ts:139-173` seeds one user per org,
+      so the OR branch never fires. **Decide the intent before fixing** — the policy's own
+      comment says "submitters can see their own submissions cross-org", which may be
+      deliberate for the writer-facing surface and wrong for the editor-facing one; if so the
+      fix is to narrow the _editor_ reads rather than drop the policy. — (found 2026-07-31
+      while verifying the entry above)
+- [ ] **[P2] `rest/error-mapper.ts` does not walk the `cause` chain; `trpc/error-mapper.ts`
+      does.** `rest/error-mapper.ts:216-228` tests `error.code === '23505'` directly, while
+      `trpc/error-mapper.ts:293-310` recurses `.cause` via `extractPgError`. Drizzle wraps pg
+      errors, so **every Drizzle-originated unique violation is a 500 on REST and a 409 on
+      tRPC** — the same operation, two statuses, across all REST operations rather than any
+      one router. Port `extractPgError` (or `services/pg-errors.ts`'s `isUniqueViolation`) to
+      the REST mapper. Found via `issueService.addItemWithAudit`, whose own broken catch is
+      fixed; the mapper asymmetry is what made that fix invisible on tRPC and a 500 on REST.
+      — (found 2026-07-31 while scoping `issueService`)
+- [ ] **[P3] Nine more sites use the broken direct `.code === '23505'` check, and one of them
+      shadows the shared helper's name.** `queue-preset.service.ts:33` defines a **private
+      function also called `isUniqueViolation`** using the direct form — so the codebase now
+      has two same-named predicates with different semantics, which is exactly how the
+      guard-tag primitive drifted. The rest: `collection.service.ts:379`,
+      `submission-reviewer.service.ts:77`, `form.service.ts:610`,
+      `writer-profile.service.ts:69`, `embed-submission.service.ts:119`,
+      `trust.service.ts:477,912`, `hooks/auth.ts:485`. **Triage per site rather than sweeping**
+      — a site catching an error from a raw `pool.query` is not Drizzle-wrapped and is correct
+      as written. Point the wrapped ones at `services/pg-errors.ts`. Note fixing these is a
+      behaviour change: the domain errors they guard have never fired.
+      — (found 2026-07-31 while fixing the `issueService` instance)
 - [x] **[P2] `pipeline.service.ts` writes drop the org predicate.** Filed as three methods; it
       was **five reachable defects**, and the two framed as "worse" were the only live ones.
       `assignCopyeditor` (`:396`) and `assignProofreader` (`:435`) took no `orgId` at all —
@@ -433,10 +471,46 @@ Ordered as the design doc's Phase 0/D.
       change. Decide the semantics first: guests, deactivated users, and staff who belong to
       both orgs are all reachable cases, and the same question applies to
       `submission-reviewer.service.ts`. — (found 2026-07-30 while scoping `pipelineService`)
-- [ ] **[P2] `issue.service.ts:65,122` take `orgId?` as optional and apply the predicate
+- [x] **[P2] `issue.service.ts:65,122` take `orgId?` as optional and apply the predicate
       conditionally.** An optional org id is a silent bypass: omit the argument and the query
       is unscoped, with nothing at the type level to flag it. Make it required, matching the
-      house `(tx, id|input, orgId)` convention. — (found 2026-07-28 during the P2.0 audit)
+      house `(tx, id|input, orgId)` convention. — (found 2026-07-28 during the P2.0 audit;
+      done 2026-07-31)
+      Filed as two methods; it was **12 in `issue.service.ts` and 7 in
+      `cms-connection.service.ts`**, and the entry also had the shape wrong. Seven of the
+      twelve were _guard-only_ — an `if (orgId)` block wrapping an org-scoped `getById`, with
+      no org term on the child-table statement at all, because `issue_items` and
+      `issue_sections` have no `organization_id` and scope transitively through an `EXISTS`
+      on `issues`. Duplicating that EXISTS per statement was rejected as a second copy of the
+      policy to keep true; `removeItem`/`removeSection` instead resolve the row through an
+      org-scoped join before deleting. **Either that join or the guard alone is sufficient**
+      (measured: 0 of 14 fail with the joins reverted), so the suite cannot tell you if a
+      later change removes them — the header says so.
+      **The type was not the whole defect.** `addItem` guarded the _issue_ and never the
+      `pipelineItemId` handed to it, so org A could attach org B's pipeline item to an
+      A-owned issue and read B's submission title back through `getItems`'s join to
+      `submissions` — the `pipelineService.create` shape from #537, and unaffected by making
+      `orgId` required. Reverting only that check fails exactly 1 of 14 cases, which is how
+      invisible it was.
+      Pinned by `__tests__/rls/issue-service.test.ts` (14 cases, 9 fail with the predicates
+      reverted) and `cms-connection-service.test.ts` (7 of 7). `contract.service.ts` is
+      deliberately **not** in this change — see the item below.
+- [ ] **[P2] `contract.service.ts` is a different shape from the other two optional-`orgId`
+      services, and the only one whose bug is reachable today.** Only 2 methods take
+      `orgId?` (`getById:69`, `updateStatus:170`); **four take no org parameter at all** while
+      querying `contracts` directly — `list:37` (no org filter, and `where` is `undefined`
+      when unfiltered), `getByPipelineItemId:83`, `getByDocumensoDocumentId:91` (cross-org by
+      design, webhook path), `updateDocumensoId:203` (bare `UPDATE … WHERE id`). Unlike
+      `issue`/`cms-connection`, it has **live caller omissions**: the tRPC router
+      (`trpc/routers/contracts.ts:39`) and the REST one (`:66`) call `getById` without the org id
+      though `authContext.orgId` is in hand; `sendWithAudit:219,226` and
+      `voidWithAudit:240,242` omit it internally; `inngest/functions/contract-workflow.ts:106`
+      omits it with `orgId` in scope from the enclosing `withRls`. So this needs real
+      call-site changes, not a signature sweep. There is also **no `contract.service.spec.ts`**
+      and no RLS suite — both would be written from scratch. Note
+      `webhooks/documenso.webhook.ts:285-291` already passes `contract.organizationId` to
+      `updateStatus` with a comment calling it defense-in-depth, so the intent is on record.
+      — (split out of the item above 2026-07-31 after verifying all three files)
 - [ ] **[P2] `federation.service.ts:437` `resolveWebFinger` is laxer than its sibling.** It
       filters on `email` alone, while `getUserDidDocument` (`:523`) filters `email` **and**
       `isNull(deletedAt)` **and** `eq(isGuest, false)`. Both are unauthenticated federation

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -393,8 +393,8 @@ Ordered as the design doc's Phase 0/D.
       (`schema/submissions.ts:186-189`) declares `submissions_submitter_read`
       (`using: submitter_id = current_user_id()`). Postgres OR-combines permissive policies,
       and `hooks/db-context.ts:41-44` sets `app.user_id` on **every** authenticated request —
-      so the effective SELECT predicate on an HTTP path is `organization_id =
-  current_org_id() OR submitter_id = current_user_id()`. An editor who has also submitted
+      so on an HTTP path the effective SELECT predicate becomes the org term ORed with the
+      submitter term, rather than the org term alone. An editor who has also submitted
       to another org on the same instance therefore sees their own foreign-org rows through
       `submissionService.listAll`/`exportAll`. The Inngest path is unaffected
       (`withRls({ orgId })` sets no user id). The existing coverage cannot catch this:


### PR DESCRIPTION
Closes the `issue.service.ts` / `cms-connection.service.ts` half of the
optional-`orgId` P2. `contract.service.ts` is deliberately excluded — see below.

## What the backlog entry got wrong

It cited two methods (`issue.service.ts:65,122`). There were **12** in
`issueService` and **7** in `cmsConnectionService`. It also described the wrong
shape: seven of the twelve were *guard-only*, where the org check was an
`if (orgId)` block and the underlying statement carried no org term at all.

## Two classes of defence, deliberately not made uniform

`list`/`getById`/`update`/`updateStatus`/`saveCmsPublishResult` carry the
predicate on the statement — `issues` has an `organization_id`.

The other seven cannot. `issue_items` and `issue_sections` have no
`organization_id`; they scope transitively, and their RLS policy is
`EXISTS (SELECT 1 FROM issues WHERE issues.id = issue_id AND issues.organization_id = current_org_id())`.
Duplicating that EXISTS across seven statements would be a second copy of the
policy to keep true, so the org-scoped `getById` guard remains their defence.

`removeItem` and `removeSection` are the exception: they resolve the row through
an org-scoped join before deleting, because a DELETE firing on an unverified row
is where a dropped guard stops being recoverable.

## The type change was not the whole defect

`addItem` guarded the *issue* and never the `pipelineItemId` it was handed. One
org could attach another's pipeline item to its own issue — valid under RLS,
since `issue_items` scopes only through its parent — and then read the foreign
submission title back through `getItems`'s join to `submissions`. This is the
`pipelineService.create` shape from #537, and making `orgId` required does not
fix it.

It now reads the pipeline item scoped to the org. A nonexistent id and a foreign
id raise the identical `IssuePipelineItemNotFoundError`, so the rejection cannot
be used to probe for another tenant's items; the suite asserts both paths.

## A unique-violation handler that had never once fired

`addItemWithAudit` tested `e.code === '23505'` directly. Drizzle wraps the pg
error and the SQLSTATE lives on `.cause`, so the branch never matched and
`IssueItemAlreadyExistsError` had never been thrown. Duplicates surfaced as a
**500 on REST and a generic 409 on tRPC** — the surfaces disagree because
`rest/error-mapper.ts` does the same direct check while `trpc/error-mapper.ts`
recurses. `isUniqueViolation` moves to `services/pg-errors.ts` so there is one
copy. The REST mapper asymmetry and nine other sites using the broken check are
filed, not fixed.

## Measured, not asserted

Two new admin-pool suites (RLS bypassed, so the `WHERE` clause is the only
isolation). Non-vacuity by reverting each defence in turn:

| Reverted | Cases failing |
| --- | --- |
| the five `issues`-table predicates | **9 of 14** |
| only `addItem`'s pipeline-item check | **1 of 14** |
| only the two delete scoped-joins | **0 of 14** |
| `cmsConnection` predicates | **7 of 7** |

That last row is the honest one: `removeItem`/`removeSection` are defended twice
and **either alone suffices**, as with `updateStage`. A green run does not prove
the joins work, and the suite header says so.

## Verification

- `type-check` clean; `lint` clean
- RLS **197 passed** (was 176 — 21 new)
- Unit **1940 passed**

One caution recorded in the code: a spec that fails to *collect* contributes zero
failed **tests**, so a test-count summary reads green. Adding the new error class
broke a `vi.mock` in `csr.spec.ts` and the only tell was the total dropping by 4.
Check `numFailedTestSuites`, not just the pass line.

## Not in scope

`contract.service.ts` is a different shape and is now its own backlog item: only
2 methods take `orgId?`, **four take no org parameter at all**, and unlike these
two it has live caller omissions (`trpc/routers/contracts.ts:39`,
`rest/routers/contracts.ts:66`, `contract-workflow.ts:106` each drop an org id
already in hand). It also has no spec file. That needs real call-site changes and
a review of its own.

Also filed: the `submissions_submitter_read` policy OR-combines with org
isolation, so an editor who has also submitted elsewhere on the instance sees
their own foreign-org rows through `listAll`/`exportAll`; existing coverage seeds
one user per org and cannot fire.
