### PR TITLE
fix(api): scope webhookService delivery reads and writes to the caller's org

### DIFF
--- a/apps/api/src/__tests__/rls/webhook-service.test.ts
+++ b/apps/api/src/__tests__/rls/webhook-service.test.ts
@@ -1,0 +1,506 @@
+/**
+ * Defense-in-depth: webhookService's explicit organization predicates.
+ *
+ * The same shape as `notification-service.test.ts`, and for the same reason.
+ * Every query below runs over the ADMIN pool, which connects as a superuser
+ * (`rolsuper = t, rolbypassrls = t`), so RLS does not apply — not even the
+ * `FORCE ROW LEVEL SECURITY` set by `0033_webhook_endpoints.sql`, which binds
+ * the table owner but not a superuser. The only thing separating org A's rows
+ * from org B's here is the `WHERE organization_id = $orgId` in the service.
+ *
+ * **Read the coverage note before trusting a green run.** This service was
+ * mostly already scoped: a 2026-03-04 pass fixed `getEndpoint`,
+ * `listEndpoints`, `updateEndpoint`, `deleteEndpoint` and `rotateSecret`, and
+ * missed every delivery method. So most cases below are regression pins on
+ * predicates that predate this change, and only some prove a fix:
+ *
+ *   - `retryDelivery` was the live gap — `UPDATE … WHERE id = $1` with no org
+ *     term, and its caller compared ownership *after* the mutation. Because
+ *     tRPC turns a throw into a normal reply, `db-context` committed rather
+ *     than rolled back, so another org's delivery was left permanently QUEUED
+ *     with its failure fields nulled. `refuses another org's delivery …` is the
+ *     case that catches it, and it fails twice over on the old code: the call
+ *     resolves instead of throwing, *and* the row is mutated.
+ *   - `listDeliveries` took `organizationId?` and applied it only under an
+ *     `if`. `endpointId` is caller-supplied, so `ignores an endpointId
+ *     belonging to another org` is the sharp case.
+ *   - `updateDeliveryStatus` and `countRecentFailures` are defence-in-depth,
+ *     not live fixes: their only caller resolves the delivery through the
+ *     org-scoped `getEndpointForDelivery` join first. The predicate exists
+ *     because that guard is a property of one call site, not of the statement.
+ *
+ * Do not "fix" this by switching to the app pool. That reinstates RLS and the
+ * suite would pass with or without the predicates, testing nothing. The unit
+ * spec cannot substitute either — it mocks `eq`/`and` as bare `vi.fn()`s
+ * returning `undefined`, so the assembled `where` is discarded entirely.
+ *
+ * **Non-vacuity, measured by reverting each change in turn** (23 cases total):
+ *
+ * | Reverted                                          | Failing |
+ * | ------------------------------------------------- | ------- |
+ * | `retryDelivery` predicate + throw (original code) | 2       |
+ * | `retryDelivery` throw only, predicate kept        | 2       |
+ * | `retryDelivery` predicate only, throw kept        | 2       |
+ * | `listDeliveries` seeded org condition             | 3       |
+ * | `updateDeliveryStatus` predicate                  | 1       |
+ * | `countRecentFailures` predicate                   | 1       |
+ * | the four endpoint not-found throws                | 5       |
+ *
+ * The two `retryDelivery` halves show the same *count* but different *sets*,
+ * which is the point of `does not write to another org's delivery,
+ * independently of the throw`. Removing the throw fails the two cases that
+ * assert on rejection; removing the predicate fails the write-only case
+ * instead, because a nonexistent id matches nothing either way. Without that
+ * third case the suite could not tell the two halves apart at all.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { eq } from 'drizzle-orm';
+import {
+  webhookEndpoints,
+  webhookDeliveries,
+  type Organization,
+  type User,
+} from '@colophony/db';
+import { globalSetup, getAdminPool } from './helpers/db-setup';
+import { truncateAllTables } from './helpers/cleanup';
+import {
+  createOrganization,
+  createUser,
+  createOrgMember,
+} from './helpers/factories';
+import { webhookService } from '../../services/webhook.service.js';
+
+type ServiceTx = Parameters<typeof webhookService.listDeliveries>[0];
+
+/**
+ * A Drizzle handle over the RLS-bypassing admin pool, shaped as the `tx` the
+ * service expects. The cast mirrors `helpers/factories.ts` — `@colophony/db`
+ * and the test tree resolve drizzle through different optional peer-dep
+ * contexts, so the types diverge while the runtime is a single copy.
+ */
+function adminTx(): ServiceTx {
+  return drizzle(getAdminPool());
+}
+
+function adminDb(): ReturnType<typeof drizzle> {
+  return drizzle(getAdminPool());
+}
+
+interface SeededEndpoint {
+  id: string;
+  organizationId: string;
+  url: string;
+  secret: string;
+  status: 'ACTIVE' | 'DISABLED';
+}
+
+interface SeededDelivery {
+  id: string;
+  organizationId: string;
+  webhookEndpointId: string;
+  status: string;
+  httpStatusCode: number | null;
+  errorMessage: string | null;
+  nextRetryAt: Date | null;
+}
+
+/**
+ * Insert directly rather than through `createEndpoint`.
+ *
+ * `createEndpoint` calls `validateOutboundUrl`, which would couple these
+ * fixtures to `NODE_ENV` and to DNS resolution of the seeded host.
+ */
+async function createEndpoint(
+  organizationId: string,
+  url: string,
+): Promise<SeededEndpoint> {
+  const [row] = await adminDb()
+    .insert(webhookEndpoints)
+    .values({
+      organizationId,
+      url,
+      secret: 'seeded-secret',
+      eventTypes: ['hopper/submission.submitted'],
+      status: 'ACTIVE',
+    })
+    .returning();
+  return row;
+}
+
+async function createDelivery(
+  organizationId: string,
+  webhookEndpointId: string,
+  overrides: Record<string, unknown> = {},
+): Promise<SeededDelivery> {
+  const [row] = await adminDb()
+    .insert(webhookDeliveries)
+    .values({
+      organizationId,
+      webhookEndpointId,
+      eventType: 'hopper/submission.submitted',
+      eventId: crypto.randomUUID(),
+      payload: { hello: 'world' },
+      status: 'FAILED',
+      httpStatusCode: 500,
+      errorMessage: 'boom',
+      nextRetryAt: new Date('2026-01-01T00:00:00.000Z'),
+      ...overrides,
+    })
+    .returning();
+  return row;
+}
+
+/** Read back over the admin pool, bypassing RLS — used to assert writes. */
+async function readDelivery(id: string): Promise<SeededDelivery | null> {
+  const rows = await adminDb()
+    .select()
+    .from(webhookDeliveries)
+    .where(eq(webhookDeliveries.id, id));
+  return rows[0] ?? null;
+}
+
+async function readEndpoint(id: string): Promise<SeededEndpoint | null> {
+  const rows = await adminDb()
+    .select()
+    .from(webhookEndpoints)
+    .where(eq(webhookEndpoints.id, id));
+  return rows[0] ?? null;
+}
+
+const PAGE = { page: 1, limit: 20 };
+
+describe('webhookService defense-in-depth (RLS bypassed)', () => {
+  let orgA: Organization;
+  let orgB: Organization;
+  let user: User;
+  let endpointA: SeededEndpoint;
+  let endpointB: SeededEndpoint;
+  let deliveryA: SeededDelivery;
+  let deliveryB: SeededDelivery;
+
+  beforeAll(async () => {
+    await globalSetup();
+    await truncateAllTables();
+
+    orgA = await createOrganization({ name: 'Org Alpha' });
+    orgB = await createOrganization({ name: 'Org Beta' });
+    user = await createUser();
+    await createOrgMember(orgA.id, user.id, { roles: ['ADMIN'] });
+    await createOrgMember(orgB.id, user.id, { roles: ['ADMIN'] });
+  });
+
+  // Fresh rows per test: several cases mutate, so they must not depend on each
+  // other's ordering. Deleting endpoints cascades to deliveries.
+  beforeEach(async () => {
+    await adminDb().delete(webhookDeliveries);
+    await adminDb().delete(webhookEndpoints);
+    endpointA = await createEndpoint(orgA.id, 'https://alpha.example.com/hook');
+    endpointB = await createEndpoint(orgB.id, 'https://beta.example.com/hook');
+    deliveryA = await createDelivery(orgA.id, endpointA.id);
+    deliveryB = await createDelivery(orgB.id, endpointB.id);
+  });
+
+  afterAll(async () => {
+    await truncateAllTables();
+  });
+
+  describe('getEndpoint', () => {
+    it("throws for another org's endpoint", async () => {
+      await expect(
+        webhookService.getEndpoint(adminTx(), endpointB.id, orgA.id),
+      ).rejects.toThrow(/endpoint .*not found/i);
+    });
+
+    it('throws the same error for an endpoint that does not exist at all', async () => {
+      // Indistinguishable on purpose. A distinct error for "exists but is not
+      // yours" is an existence oracle over another tenant's ids.
+      await expect(
+        webhookService.getEndpoint(adminTx(), crypto.randomUUID(), orgA.id),
+      ).rejects.toThrow(/endpoint .*not found/i);
+    });
+
+    it("returns the caller's own endpoint with the secret stripped", async () => {
+      const row = await webhookService.getEndpoint(
+        adminTx(),
+        endpointA.id,
+        orgA.id,
+      );
+      expect(row.id).toBe(endpointA.id);
+      expect(row).not.toHaveProperty('secret');
+    });
+  });
+
+  describe('listEndpoints', () => {
+    it("excludes another org's endpoints from both items and total", async () => {
+      const result = await webhookService.listEndpoints(
+        adminTx(),
+        PAGE,
+        orgA.id,
+      );
+      expect(result.items.map((e) => e.id)).toEqual([endpointA.id]);
+      // Without a predicate on the count query, `total` leaks a cross-tenant
+      // row count even when `items` is correctly filtered.
+      expect(result.total).toBe(1);
+    });
+
+    it('strips the secret from every item', async () => {
+      const result = await webhookService.listEndpoints(
+        adminTx(),
+        PAGE,
+        orgA.id,
+      );
+      for (const item of result.items) {
+        expect(item).not.toHaveProperty('secret');
+      }
+    });
+  });
+
+  describe('updateEndpoint', () => {
+    it("throws for another org's endpoint and leaves the row untouched", async () => {
+      await expect(
+        webhookService.updateEndpoint(
+          adminTx(),
+          endpointB.id,
+          { status: 'DISABLED' },
+          orgA.id,
+        ),
+      ).rejects.toThrow(/endpoint .*not found/i);
+
+      const after = await readEndpoint(endpointB.id);
+      expect(after?.status).toBe('ACTIVE');
+    });
+
+    it("updates the caller's own endpoint and returns it without the secret", async () => {
+      const row = await webhookService.updateEndpoint(
+        adminTx(),
+        endpointA.id,
+        { status: 'DISABLED' },
+        orgA.id,
+      );
+      expect(row.status).toBe('DISABLED');
+      expect(row).not.toHaveProperty('secret');
+    });
+  });
+
+  describe('deleteEndpoint', () => {
+    it("throws for another org's endpoint and leaves it present", async () => {
+      await expect(
+        webhookService.deleteEndpoint(adminTx(), endpointB.id, orgA.id),
+      ).rejects.toThrow(/endpoint .*not found/i);
+
+      expect(await readEndpoint(endpointB.id)).not.toBeNull();
+    });
+
+    it("deletes the caller's own endpoint and cascades its deliveries", async () => {
+      await webhookService.deleteEndpoint(adminTx(), endpointA.id, orgA.id);
+
+      expect(await readEndpoint(endpointA.id)).toBeNull();
+      // The worker's "endpoint deleted → discard the job" branch relies on the
+      // delivery row going with it.
+      expect(await readDelivery(deliveryA.id)).toBeNull();
+    });
+  });
+
+  describe('rotateSecret', () => {
+    it("throws for another org's endpoint and leaves the stored secret unchanged", async () => {
+      const before = await readEndpoint(endpointB.id);
+
+      await expect(
+        webhookService.rotateSecret(adminTx(), endpointB.id, orgA.id),
+      ).rejects.toThrow(/endpoint .*not found/i);
+
+      const after = await readEndpoint(endpointB.id);
+      expect(after?.secret).toBe(before?.secret);
+    });
+
+    it('returns the new plaintext secret, deliberately unredacted', async () => {
+      const row = await webhookService.rotateSecret(
+        adminTx(),
+        endpointA.id,
+        orgA.id,
+      );
+      // This and `createEndpoint` are the only two paths that hand back the
+      // plaintext secret. Redacting here would break signing setup.
+      expect(row.secret).toBeTruthy();
+      expect(row.secret).not.toBe('seeded-secret');
+    });
+  });
+
+  describe('disableEndpoint', () => {
+    it("returns null for another org's endpoint rather than throwing, and leaves it ACTIVE", async () => {
+      // Deliberately unlike `updateEndpoint`. Its only caller is the worker's
+      // onFailed tail, inside a transaction that has already written the
+      // delivery's FAILED status and audit row — a throw there would roll both
+      // back to report an endpoint that is already gone.
+      const result = await webhookService.disableEndpoint(
+        adminTx(),
+        endpointB.id,
+        orgA.id,
+      );
+      expect(result).toBeNull();
+
+      const after = await readEndpoint(endpointB.id);
+      expect(after?.status).toBe('ACTIVE');
+    });
+  });
+
+  describe('listDeliveries', () => {
+    it("excludes another org's deliveries from both items and total", async () => {
+      const result = await webhookService.listDeliveries(
+        adminTx(),
+        PAGE,
+        orgA.id,
+      );
+      expect(result.items.map((d) => d.id)).toEqual([deliveryA.id]);
+      expect(result.total).toBe(1);
+    });
+
+    it('ignores an endpointId belonging to another org', async () => {
+      // The sharp case for the old `organizationId?`: `endpointId` is
+      // caller-supplied and carries no tenancy, so with the org term applied
+      // only under an `if`, pointing it at another org's endpoint returned
+      // that org's deliveries.
+      const result = await webhookService.listDeliveries(
+        adminTx(),
+        { ...PAGE, endpointId: endpointB.id },
+        orgA.id,
+      );
+      expect(result.items).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('applies the org predicate alongside a status filter', async () => {
+      const result = await webhookService.listDeliveries(
+        adminTx(),
+        { ...PAGE, status: 'FAILED' },
+        orgA.id,
+      );
+      expect(result.items.map((d) => d.id)).toEqual([deliveryA.id]);
+    });
+  });
+
+  describe('retryDelivery', () => {
+    it("refuses another org's delivery, writes nothing, and does not requeue it", async () => {
+      // The headline case. On the old code this fails twice over: the call
+      // resolves instead of throwing, and the row is mutated to QUEUED with its
+      // failure fields nulled — a change tRPC then committed rather than rolled
+      // back, because a thrown error becomes a normal HTTP reply.
+      await expect(
+        webhookService.retryDelivery(adminTx(), deliveryB.id, orgA.id),
+      ).rejects.toThrow(/delivery .*not found/i);
+
+      const after = await readDelivery(deliveryB.id);
+      expect(after?.status).toBe('FAILED');
+      expect(after?.httpStatusCode).toBe(500);
+      expect(after?.errorMessage).toBe('boom');
+      expect(after?.nextRetryAt).not.toBeNull();
+    });
+
+    it('throws the same error for a delivery that does not exist at all', async () => {
+      await expect(
+        webhookService.retryDelivery(adminTx(), crypto.randomUUID(), orgA.id),
+      ).rejects.toThrow(/delivery .*not found/i);
+    });
+
+    it("does not write to another org's delivery, independently of the throw", async () => {
+      // Deliberately swallows the rejection rather than asserting on it.
+      //
+      // The case above stops at `rejects.toThrow`, so it fails identically
+      // whether the predicate is missing, the throw is missing, or both — it
+      // cannot tell them apart. This one asserts only the write, so it holds
+      // when the throw is removed and fails when the predicate is, which is
+      // what makes the two halves separately measurable.
+      await webhookService
+        .retryDelivery(adminTx(), deliveryB.id, orgA.id)
+        .catch(() => undefined);
+
+      const after = await readDelivery(deliveryB.id);
+      expect(after?.status).toBe('FAILED');
+      expect(after?.httpStatusCode).toBe(500);
+      expect(after?.nextRetryAt).not.toBeNull();
+    });
+
+    it("requeues the caller's own delivery and clears the previous attempt", async () => {
+      const row = await webhookService.retryDelivery(
+        adminTx(),
+        deliveryA.id,
+        orgA.id,
+      );
+      expect(row.status).toBe('QUEUED');
+
+      const after = await readDelivery(deliveryA.id);
+      expect(after?.status).toBe('QUEUED');
+      expect(after?.httpStatusCode).toBeNull();
+      expect(after?.errorMessage).toBeNull();
+      expect(after?.nextRetryAt).toBeNull();
+    });
+  });
+
+  describe('updateDeliveryStatus', () => {
+    it("refuses another org's delivery and writes nothing", async () => {
+      await webhookService.updateDeliveryStatus(
+        adminTx(),
+        deliveryB.id,
+        'DELIVERED',
+        orgA.id,
+        { httpStatusCode: 200 },
+      );
+
+      const after = await readDelivery(deliveryB.id);
+      expect(after?.status).toBe('FAILED');
+      expect(after?.httpStatusCode).toBe(500);
+    });
+
+    it("updates the caller's own delivery", async () => {
+      await webhookService.updateDeliveryStatus(
+        adminTx(),
+        deliveryA.id,
+        'DELIVERED',
+        orgA.id,
+        { httpStatusCode: 200 },
+      );
+
+      const after = await readDelivery(deliveryA.id);
+      expect(after?.status).toBe('DELIVERED');
+    });
+  });
+
+  describe('countRecentFailures', () => {
+    it("counts only the caller's org", async () => {
+      // Both orgs have one FAILED delivery seeded. Without the org predicate
+      // this would be 2 for an endpoint id that only org B owns — and this
+      // count feeds the auto-disable threshold, so another tenant's failures
+      // would help disable this org's endpoint.
+      const countA = await webhookService.countRecentFailures(
+        adminTx(),
+        endpointA.id,
+        orgA.id,
+      );
+      expect(countA).toBe(1);
+
+      const crossOrg = await webhookService.countRecentFailures(
+        adminTx(),
+        endpointB.id,
+        orgA.id,
+      );
+      expect(crossOrg).toBe(0);
+    });
+  });
+
+  describe('getEndpointForDelivery', () => {
+    it('returns null when the delivery and its endpoint sit in different orgs', async () => {
+      // The FK does not constrain org, so this row is insertable. It is the
+      // case the two-table predicate exists for, and the unit spec can only
+      // check it by asserting `eq` call arguments.
+      const mismatched = await createDelivery(orgA.id, endpointB.id);
+
+      const result = await webhookService.getEndpointForDelivery(
+        adminTx(),
+        mismatched.id,
+        orgA.id,
+      );
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/rest/error-mapper.ts
+++ b/apps/api/src/rest/error-mapper.ts
@@ -89,6 +89,12 @@ import {
   InvitationAlreadyAcceptedError,
   InvitationEmailMismatchError,
 } from '../services/invitation.service.js';
+import {
+  WebhookEndpointNotFoundError,
+  WebhookDeliveryNotFoundError,
+  WebhookEndpointDisabledError,
+  WebhookUrlValidationError,
+} from '../services/webhook.service.js';
 
 type ORPCErrorCode = ConstructorParameters<typeof ORPCError>[0];
 
@@ -174,6 +180,14 @@ const errorCodeMap: [new (...args: never[]) => Error, ORPCErrorCode][] = [
   [InvitationExpiredError, 'NOT_FOUND'],
   [InvitationAlreadyAcceptedError, 'CONFLICT'],
   [InvitationEmailMismatchError, 'FORBIDDEN'],
+  // Webhook errors
+  [WebhookEndpointNotFoundError, 'NOT_FOUND'],
+  [WebhookDeliveryNotFoundError, 'NOT_FOUND'],
+  [WebhookEndpointDisabledError, 'BAD_REQUEST'],
+  // The message is already sanitized at the throw site — it names no internal
+  // host or address — so surfacing it as a 400 leaks nothing. Unmapped, an SSRF
+  // rejection was a 500 on both surfaces.
+  [WebhookUrlValidationError, 'BAD_REQUEST'],
 ];
 
 /**

--- a/apps/api/src/services/webhook.service.spec.ts
+++ b/apps/api/src/services/webhook.service.spec.ts
@@ -114,11 +114,7 @@ describe('webhookService', () => {
       }),
     } as never;
 
-    await webhookService.listEndpoints(mockTx, {
-      organizationId: 'org-1',
-      page: 1,
-      limit: 10,
-    });
+    await webhookService.listEndpoints(mockTx, { page: 1, limit: 10 }, 'org-1');
 
     expect(eqFn).toHaveBeenCalledWith('organization_id', 'org-1');
   });
@@ -132,9 +128,12 @@ describe('webhookService', () => {
     const mockUpdate = vi.fn().mockReturnValue({ set: mockSet });
     const mockTx = { update: mockUpdate } as never;
 
-    await webhookService.updateEndpoint(mockTx, 'ep-1', 'org-1', {
-      status: 'DISABLED',
-    });
+    await webhookService.updateEndpoint(
+      mockTx,
+      'ep-1',
+      { status: 'DISABLED' },
+      'org-1',
+    );
 
     expect(andFn).toHaveBeenCalled();
     const andArgs = andFn.mock.calls[0];
@@ -146,7 +145,10 @@ describe('webhookService', () => {
   });
 
   it('filters by organizationId in deleteEndpoint', async () => {
-    const mockWhere = vi.fn().mockResolvedValue(undefined);
+    // `.returning({ id })` is what lets the method tell a real delete from a
+    // no-op; a mock without it makes the method throw not-found.
+    const mockReturning = vi.fn().mockResolvedValue([{ id: 'ep-1' }]);
+    const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
     const mockDeleteFrom = vi.fn().mockReturnValue({ where: mockWhere });
     const mockTx = { delete: mockDeleteFrom } as never;
 
@@ -201,6 +203,110 @@ describe('webhookService', () => {
     expect(andArgs[0]).toEqual({
       type: 'eq',
       args: ['organization_id', orgId],
+    });
+  });
+
+  describe('delivery methods — org predicates', () => {
+    it('seeds listDeliveries conditions with the org filter, before any caller filter', async () => {
+      const mockOrderBy = vi.fn().mockReturnValue({
+        limit: vi
+          .fn()
+          .mockReturnValue({ offset: vi.fn().mockResolvedValue([]) }),
+      });
+      const mockItemsWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+      const mockCountWhere = vi.fn().mockResolvedValue([{ count: 0 }]);
+      let call = 0;
+      const mockTx = {
+        select: vi.fn(() => ({
+          from: vi.fn(() => ({
+            where: ++call === 1 ? mockItemsWhere : mockCountWhere,
+          })),
+        })),
+      } as never;
+
+      // `endpointId` is caller-supplied and carries no tenancy of its own, so
+      // the org term must be present regardless of what the caller filtered on.
+      await webhookService.listDeliveries(
+        mockTx,
+        { page: 1, limit: 10, endpointId: 'ep-other' },
+        'org-1',
+      );
+
+      const andArgs = andFn.mock.calls[0];
+      expect(andArgs[0]).toEqual({
+        type: 'eq',
+        args: ['delivery_organization_id', 'org-1'],
+      });
+      // Page and count share one `where`, so the total cannot drift from the page.
+      expect(mockItemsWhere).toHaveBeenCalledWith(andFn.mock.results[0]?.value);
+      expect(mockCountWhere).toHaveBeenCalledWith(andFn.mock.results[0]?.value);
+    });
+
+    it('filters retryDelivery on both id and organizationId', async () => {
+      const mockReturning = vi.fn().mockResolvedValue([{ id: 'del-1' }]);
+      const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
+      const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockTx = {
+        update: vi.fn().mockReturnValue({ set: mockSet }),
+      } as never;
+
+      await webhookService.retryDelivery(mockTx, 'del-1', 'org-1');
+
+      const andArgs = andFn.mock.calls[0];
+      expect(andArgs[0]).toEqual({ type: 'eq', args: ['id', 'del-1'] });
+      expect(andArgs[1]).toEqual({
+        type: 'eq',
+        args: ['delivery_organization_id', 'org-1'],
+      });
+    });
+
+    it('throws rather than returning undefined when retryDelivery matches nothing', async () => {
+      const mockReturning = vi.fn().mockResolvedValue([]);
+      const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
+      const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockTx = {
+        update: vi.fn().mockReturnValue({ set: mockSet }),
+      } as never;
+
+      // The throw is load-bearing: without it the caller goes on to audit and
+      // enqueue a retry against a row it does not own.
+      await expect(
+        webhookService.retryDelivery(mockTx, 'del-1', 'org-1'),
+      ).rejects.toThrow(/delivery .*not found/i);
+    });
+
+    it('filters updateDeliveryStatus on both id and organizationId', async () => {
+      const mockWhere = vi.fn().mockResolvedValue(undefined);
+      const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockTx = {
+        update: vi.fn().mockReturnValue({ set: mockSet }),
+      } as never;
+
+      await webhookService.updateDeliveryStatus(
+        mockTx,
+        'del-1',
+        'DELIVERED',
+        'org-1',
+      );
+
+      const andArgs = andFn.mock.calls[0];
+      expect(andArgs[0]).toEqual({ type: 'eq', args: ['id', 'del-1'] });
+      expect(andArgs[1]).toEqual({
+        type: 'eq',
+        args: ['delivery_organization_id', 'org-1'],
+      });
+    });
+
+    it('scopes countRecentFailures to the org so another tenant cannot trip the threshold', async () => {
+      const mockWhere = vi.fn().mockResolvedValue([{ count: 0 }]);
+      const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockTx = {
+        select: vi.fn().mockReturnValue({ from: mockFrom }),
+      } as never;
+
+      await webhookService.countRecentFailures(mockTx, 'ep-1', 'org-1');
+
+      expect(eqFn).toHaveBeenCalledWith('delivery_organization_id', 'org-1');
     });
   });
 

--- a/apps/api/src/services/webhook.service.ts
+++ b/apps/api/src/services/webhook.service.ts
@@ -21,6 +21,44 @@ export class WebhookUrlValidationError extends Error {
 }
 
 /**
+ * An endpoint not available to the caller's organization.
+ *
+ * Absent and belonging-to-another-tenant are deliberately indistinguishable —
+ * a distinct "forbidden" would let a caller probe for the existence of another
+ * org's endpoints by id. Same posture as `IssueNotFoundError`.
+ */
+export class WebhookEndpointNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Webhook endpoint "${id}" not found`);
+    this.name = 'WebhookEndpointNotFoundError';
+  }
+}
+
+/** Same posture as `WebhookEndpointNotFoundError`, for deliveries. */
+export class WebhookDeliveryNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Webhook delivery "${id}" not found`);
+    this.name = 'WebhookDeliveryNotFoundError';
+  }
+}
+
+/**
+ * A test send was requested against a disabled endpoint. A 400, not a 404 —
+ * the caller can see the endpoint, it just cannot receive.
+ *
+ * Keep the word "disabled" in the message: `trpc/routers/webhooks.spec.ts`
+ * asserts `/disabled/i` against it.
+ */
+export class WebhookEndpointDisabledError extends Error {
+  constructor(id: string) {
+    super(
+      `Webhook endpoint "${id}" is disabled — re-enable it before sending a test delivery`,
+    );
+    this.name = 'WebhookEndpointDisabledError';
+  }
+}
+
+/**
  * Derived from the schema enum rather than hand-written, so adding a value to
  * `webhookDeliveryStatusEnum` cannot leave this union silently behind.
  */
@@ -49,8 +87,15 @@ interface CreateDeliveryParams {
   payload: Record<string, unknown>;
 }
 
+/**
+ * Note the absence of `organizationId` — it is a separate, required argument.
+ *
+ * It used to live here as `organizationId?`, applied only under an `if`. A
+ * caller that forgot it got every tenant's deliveries with RLS as the only
+ * defence, and `endpointId` is caller-supplied, so the filter could be pointed
+ * at another org's endpoint. Keep tenancy out of the caller-shaped params bag.
+ */
 interface ListDeliveriesParams {
-  organizationId?: string;
   endpointId?: string;
   eventType?: string;
   status?: WebhookDeliveryStatus;
@@ -100,8 +145,8 @@ export const webhookService = {
   async updateEndpoint(
     tx: DrizzleDb,
     id: string,
-    organizationId: string,
     params: UpdateEndpointParams,
+    organizationId: string,
   ) {
     if (params.url !== undefined) {
       const devMode =
@@ -136,18 +181,52 @@ export const webhookService = {
         ),
       )
       .returning();
+    // Throwing rather than returning null is what makes the callers' audit
+    // writes structurally unable to fire on a zero-row update. Both routers
+    // audited WEBHOOK_ENDPOINT_UPDATED unconditionally before this.
+    if (!row) throw new WebhookEndpointNotFoundError(id);
+    return redactSecret(row);
+  },
+
+  /**
+   * Best-effort disable for the delivery worker's auto-disable path.
+   *
+   * Returns null where `updateEndpoint` throws, deliberately. Its only caller
+   * is `webhook.worker.ts`'s `onFailed` tail, which runs inside a `withRls`
+   * transaction that has *already* written the delivery's FAILED status and its
+   * audit row. A throw there rolls both back (`packages/db/src/context.ts`) —
+   * losing the record of the failure in order to report a race in which the
+   * endpoint is already gone. Do not unify this with `updateEndpoint`.
+   */
+  async disableEndpoint(tx: DrizzleDb, id: string, organizationId: string) {
+    const [row] = await tx
+      .update(webhookEndpoints)
+      .set({ status: 'DISABLED', updatedAt: new Date() })
+      .where(
+        and(
+          eq(webhookEndpoints.id, id),
+          eq(webhookEndpoints.organizationId, organizationId),
+        ),
+      )
+      .returning();
     return row ? redactSecret(row) : null;
   },
 
   async deleteEndpoint(tx: DrizzleDb, id: string, organizationId: string) {
-    await tx
+    // `.returning({ id })` rather than a bare `.returning()`: the DELETE never
+    // needs to read the secret back. Safe under RLS because the policy is
+    // `for: "all"` with one USING clause, so SELECT and DELETE share it.
+    const [row] = await tx
       .delete(webhookEndpoints)
       .where(
         and(
           eq(webhookEndpoints.id, id),
           eq(webhookEndpoints.organizationId, organizationId),
         ),
-      );
+      )
+      .returning({ id: webhookEndpoints.id });
+    if (!row) throw new WebhookEndpointNotFoundError(id);
+    return row;
   },
 
   async getEndpoint(tx: DrizzleDb, id: string, organizationId: string) {
@@ -161,14 +240,16 @@ export const webhookService = {
         ),
       )
       .limit(1);
-    return row ? redactSecret(row) : null;
+    if (!row) throw new WebhookEndpointNotFoundError(id);
+    return redactSecret(row);
   },
 
   async listEndpoints(
     tx: DrizzleDb,
-    params: { organizationId: string; page: number; limit: number },
+    params: { page: number; limit: number },
+    organizationId: string,
   ) {
-    const { organizationId, page, limit } = params;
+    const { page, limit } = params;
     const offset = (page - 1) * limit;
 
     const orgFilter = eq(webhookEndpoints.organizationId, organizationId);
@@ -194,6 +275,11 @@ export const webhookService = {
     };
   },
 
+  /**
+   * Returns the row **unredacted** — this and `createEndpoint` are the only two
+   * paths that hand the plaintext signing secret to a caller, which is the
+   * whole point of the operation. Do not add `redactSecret` here.
+   */
   async rotateSecret(tx: DrizzleDb, id: string, organizationId: string) {
     const secret = crypto.randomBytes(32).toString('hex');
     const [row] = await tx
@@ -206,6 +292,7 @@ export const webhookService = {
         ),
       )
       .returning();
+    if (!row) throw new WebhookEndpointNotFoundError(id);
     return row;
   },
 
@@ -284,10 +371,21 @@ export const webhookService = {
     return row;
   },
 
+  /**
+   * `organizationId` is defence-in-depth, not a live fix.
+   *
+   * Every caller is the delivery worker, which has already resolved this
+   * delivery through the org-scoped `getEndpointForDelivery` join and returned
+   * early when it found nothing — so the id reaching here is known to belong to
+   * `organizationId`. The predicate exists because that guard is a property of
+   * one call site rather than of this statement, and a second caller would not
+   * inherit it. Contrast `retryDelivery`, which had no guard at all.
+   */
   async updateDeliveryStatus(
     tx: DrizzleDb,
     id: string,
     status: WebhookDeliveryStatus,
+    organizationId: string,
     params?: {
       httpStatusCode?: number;
       responseBody?: string;
@@ -313,23 +411,34 @@ export const webhookService = {
     await tx
       .update(webhookDeliveries)
       .set(update)
-      .where(eq(webhookDeliveries.id, id));
+      .where(
+        and(
+          eq(webhookDeliveries.id, id),
+          eq(webhookDeliveries.organizationId, organizationId),
+        ),
+      );
   },
 
-  async listDeliveries(tx: DrizzleDb, params: ListDeliveriesParams) {
-    const { page, limit, organizationId, endpointId, eventType, status } =
-      params;
+  async listDeliveries(
+    tx: DrizzleDb,
+    params: ListDeliveriesParams,
+    organizationId: string,
+  ) {
+    const { page, limit, endpointId, eventType, status } = params;
     const offset = (page - 1) * limit;
 
-    const conditions = [];
-    if (organizationId)
-      conditions.push(eq(webhookDeliveries.organizationId, organizationId));
+    // Seeded, not appended under an `if`. `endpointId` below is caller-supplied
+    // and carries no tenancy of its own, so without this the filter could be
+    // pointed at another org's endpoint. `where` is shared with the count query
+    // further down, so page and total cannot drift apart.
+    const conditions = [eq(webhookDeliveries.organizationId, organizationId)];
     if (endpointId)
       conditions.push(eq(webhookDeliveries.webhookEndpointId, endpointId));
     if (eventType) conditions.push(eq(webhookDeliveries.eventType, eventType));
     if (status) conditions.push(eq(webhookDeliveries.status, status));
 
-    const where = conditions.length > 0 ? and(...conditions) : undefined;
+    // Never undefined — `conditions` is seeded with the org predicate above.
+    const where = and(...conditions);
 
     const [items, countResult] = await Promise.all([
       tx
@@ -346,7 +455,26 @@ export const webhookService = {
     return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
   },
 
-  async retryDelivery(tx: DrizzleDb, deliveryId: string) {
+  /**
+   * The one genuinely live gap this change closes.
+   *
+   * This ran `UPDATE … WHERE id = $1` with no org term, and its caller compared
+   * `delivery.organizationId !== orgId` *afterwards* — so the row was already
+   * mutated by the time ownership was checked. Worse, tRPC turns a thrown error
+   * into a normal HTTP reply, so `db-context` commits on `onResponse` rather
+   * than rolling back: another org's delivery was left permanently QUEUED with
+   * its failure fields nulled, and no job enqueued. RLS was the only defence.
+   *
+   * Both halves below are load-bearing. The predicate stops the write; the
+   * throw stops the caller proceeding to audit and enqueue against a row it
+   * does not own. Unlike `updateStage` they are *not* independently sufficient
+   * — with the predicate alone nothing on the REST surface would catch it.
+   */
+  async retryDelivery(
+    tx: DrizzleDb,
+    deliveryId: string,
+    organizationId: string,
+  ) {
     const [row] = await tx
       .update(webhookDeliveries)
       .set({
@@ -356,12 +484,29 @@ export const webhookService = {
         errorMessage: null,
         nextRetryAt: null,
       })
-      .where(eq(webhookDeliveries.id, deliveryId))
+      .where(
+        and(
+          eq(webhookDeliveries.id, deliveryId),
+          eq(webhookDeliveries.organizationId, organizationId),
+        ),
+      )
       .returning();
+    if (!row) throw new WebhookDeliveryNotFoundError(deliveryId);
     return row;
   },
 
-  async countRecentFailures(tx: DrizzleDb, endpointId: string) {
+  /**
+   * `organizationId` is defence-in-depth for the same reason as
+   * `updateDeliveryStatus` — the endpoint id arrives from the org-scoped join.
+   * It matters more here than the isolation framing suggests: this count feeds
+   * the auto-disable threshold, so an unscoped one lets another tenant's
+   * failures contribute to disabling this org's endpoint.
+   */
+  async countRecentFailures(
+    tx: DrizzleDb,
+    endpointId: string,
+    organizationId: string,
+  ) {
     const since = new Date(Date.now() - 24 * 60 * 60 * 1000); // 24h window
     const [result] = await tx
       .select({ count: count() })
@@ -369,6 +514,7 @@ export const webhookService = {
       .where(
         and(
           eq(webhookDeliveries.webhookEndpointId, endpointId),
+          eq(webhookDeliveries.organizationId, organizationId),
           eq(webhookDeliveries.status, 'FAILED'),
           sql`${webhookDeliveries.createdAt} >= ${since.toISOString()}`,
         ),

--- a/apps/api/src/trpc/error-mapper.ts
+++ b/apps/api/src/trpc/error-mapper.ts
@@ -120,6 +120,12 @@ import {
   InvitationEmailMismatchError,
 } from '../services/invitation.service.js';
 import {
+  WebhookEndpointNotFoundError,
+  WebhookDeliveryNotFoundError,
+  WebhookEndpointDisabledError,
+  WebhookUrlValidationError,
+} from '../services/webhook.service.js';
+import {
   ContributorNotFoundError,
   ContributorAlreadyLinkedError,
   ContributorPublicationDuplicateError,
@@ -286,6 +292,14 @@ const errorCodeMap: [new (...args: never[]) => Error, TRPCErrorCode][] = [
   [ReaderFeedbackAlreadyForwardedError, 'CONFLICT'],
   [InvalidFeedbackTagError, 'BAD_REQUEST'],
   [CrossOrgSubmissionError, 'FORBIDDEN'],
+  // Webhook errors
+  [WebhookEndpointNotFoundError, 'NOT_FOUND'],
+  [WebhookDeliveryNotFoundError, 'NOT_FOUND'],
+  [WebhookEndpointDisabledError, 'BAD_REQUEST'],
+  // The message is already sanitized at the throw site — it names no internal
+  // host or address — so surfacing it as a 400 leaks nothing. Unmapped, an SSRF
+  // rejection was a 500 on both surfaces.
+  [WebhookUrlValidationError, 'BAD_REQUEST'],
 ];
 
 /**

--- a/apps/api/src/trpc/routers/webhooks.spec.ts
+++ b/apps/api/src/trpc/routers/webhooks.spec.ts
@@ -13,7 +13,31 @@ const mockRetryDelivery = vi.fn();
 const mockGetActiveEndpointsForEvent = vi.fn();
 const mockGetEndpointForDelivery = vi.fn();
 
+// The error classes must be re-exported from the mock, not just the service
+// object: `error-mapper.ts` builds its `errorCodeMap` from these constructors at
+// module load, and an `undefined` entry throws before any test runs.
+//
+// They are declared *inside* the factory deliberately. `vi.mock` is hoisted
+// above every top-level declaration in this file, so a class declared out here
+// is still in its temporal dead zone when the factory runs — the same reason
+// the service stubs below use the deferred-closure trampoline.
 vi.mock('../../services/webhook.service.js', () => ({
+  WebhookUrlValidationError: class extends Error {},
+  WebhookEndpointNotFoundError: class extends Error {
+    constructor(id: string) {
+      super(`Webhook endpoint "${id}" not found`);
+    }
+  },
+  WebhookDeliveryNotFoundError: class extends Error {
+    constructor(id: string) {
+      super(`Webhook delivery "${id}" not found`);
+    }
+  },
+  WebhookEndpointDisabledError: class extends Error {
+    constructor(id: string) {
+      super(`Webhook endpoint "${id}" is disabled — re-enable it first`);
+    }
+  },
   webhookService: {
     createEndpoint: (...args: unknown[]) => mockCreateEndpoint(...args),
     updateEndpoint: (...args: unknown[]) => mockUpdateEndpoint(...args),
@@ -187,7 +211,56 @@ describe('webhooksRouter', () => {
   });
 
   describe('retryDelivery', () => {
-    it('refuses when the delivery and endpoint are not in the same org', async () => {
+    it('passes the org id to the service so the predicate is on the UPDATE', async () => {
+      mockRetryDelivery.mockResolvedValue({
+        id: 'del-1',
+        organizationId: ORG_ID,
+        webhookEndpointId: 'ep-1',
+        eventType: 'submission.created',
+        payload: {},
+      });
+      mockGetEndpointForDelivery.mockResolvedValue({
+        endpointId: 'ep-1',
+        url: 'https://example.com/hook',
+        secret: 's',
+        status: 'ACTIVE',
+        eventTypes: ['submission.created'],
+      });
+
+      await resolver('retryDelivery')({
+        ctx: baseCtx(),
+        input: { deliveryId: 'del-1' },
+      });
+
+      // The full argument list, not a prefix: a dropped org id here is exactly
+      // the cross-tenant write this change closes, and the router no longer
+      // carries a post-hoc comparison that would catch it.
+      expect(mockRetryDelivery).toHaveBeenCalledWith(
+        expect.anything(),
+        'del-1',
+        ORG_ID,
+      );
+    });
+
+    it('refuses a delivery outside the caller org without enqueueing', async () => {
+      // The org predicate is on the UPDATE, so a foreign delivery matches no
+      // row and the service throws rather than returning one to compare.
+      mockRetryDelivery.mockRejectedValue(
+        new Error('Webhook delivery "del-1" not found'),
+      );
+
+      await expect(
+        resolver('retryDelivery')({
+          ctx: baseCtx(),
+          input: { deliveryId: 'del-1' },
+        }),
+      ).rejects.toThrow(/delivery .*not found/i);
+
+      expect(mockGetEndpointForDelivery).not.toHaveBeenCalled();
+      expect(mockEnqueueWebhookRetry).not.toHaveBeenCalled();
+    });
+
+    it('refuses when the endpoint is not in the same org as the delivery', async () => {
       mockRetryDelivery.mockResolvedValue({
         id: 'del-1',
         organizationId: ORG_ID,
@@ -196,6 +269,8 @@ describe('webhooksRouter', () => {
         payload: {},
       });
       // The org-scoped join finds nothing — the endpoint belongs elsewhere.
+      // Still a distinct check: the UPDATE predicate scopes the delivery, this
+      // join scopes the endpoint it points at.
       mockGetEndpointForDelivery.mockResolvedValue(null);
 
       await expect(
@@ -203,7 +278,7 @@ describe('webhooksRouter', () => {
           ctx: baseCtx(),
           input: { deliveryId: 'del-1' },
         }),
-      ).rejects.toThrow(/endpoint not found/i);
+      ).rejects.toThrow(/endpoint .*not found/i);
 
       expect(mockEnqueueWebhookRetry).not.toHaveBeenCalled();
     });

--- a/apps/api/src/trpc/routers/webhooks.ts
+++ b/apps/api/src/trpc/routers/webhooks.ts
@@ -12,7 +12,12 @@ import {
   requireScopes,
   createRouter,
 } from '../init.js';
-import { webhookService } from '../../services/webhook.service.js';
+import {
+  webhookService,
+  WebhookEndpointNotFoundError,
+  WebhookEndpointDisabledError,
+} from '../../services/webhook.service.js';
+import { mapServiceError } from '../error-mapper.js';
 import {
   enqueueWebhook,
   enqueueWebhookRetry,
@@ -24,12 +29,14 @@ export const webhooksRouter = createRouter({
     .use(requireScopes('webhooks:manage'))
     .input(createWebhookEndpointSchema)
     .mutation(async ({ ctx, input }) => {
-      const row = await webhookService.createEndpoint(ctx.dbTx, {
-        organizationId: ctx.authContext.orgId,
-        url: input.url,
-        description: input.description,
-        eventTypes: input.eventTypes,
-      });
+      const row = await webhookService
+        .createEndpoint(ctx.dbTx, {
+          organizationId: ctx.authContext.orgId,
+          url: input.url,
+          description: input.description,
+          eventTypes: input.eventTypes,
+        })
+        .catch(mapServiceError);
       await ctx.audit({
         action: AuditActions.WEBHOOK_ENDPOINT_CREATED,
         resource: AuditResources.WEBHOOK_ENDPOINT,
@@ -46,12 +53,10 @@ export const webhooksRouter = createRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { id, ...params } = input;
-      const row = await webhookService.updateEndpoint(
-        ctx.dbTx,
-        id,
-        ctx.authContext.orgId,
-        params,
-      );
+      const row = await webhookService
+        .updateEndpoint(ctx.dbTx, id, params, ctx.authContext.orgId)
+        .catch(mapServiceError);
+      // Reached only on a real update — `updateEndpoint` throws on zero rows.
       await ctx.audit({
         action: AuditActions.WEBHOOK_ENDPOINT_UPDATED,
         resource: AuditResources.WEBHOOK_ENDPOINT,
@@ -65,11 +70,10 @@ export const webhooksRouter = createRouter({
     .use(requireScopes('webhooks:manage'))
     .input(z.object({ id: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      await webhookService.deleteEndpoint(
-        ctx.dbTx,
-        input.id,
-        ctx.authContext.orgId,
-      );
+      await webhookService
+        .deleteEndpoint(ctx.dbTx, input.id, ctx.authContext.orgId)
+        .catch(mapServiceError);
+      // Reached only on a real delete — `deleteEndpoint` throws on zero rows.
       await ctx.audit({
         action: AuditActions.WEBHOOK_ENDPOINT_DELETED,
         resource: AuditResources.WEBHOOK_ENDPOINT,
@@ -82,11 +86,9 @@ export const webhooksRouter = createRouter({
     .use(requireScopes('webhooks:read'))
     .input(z.object({ id: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
-      return webhookService.getEndpoint(
-        ctx.dbTx,
-        input.id,
-        ctx.authContext.orgId,
-      );
+      return webhookService
+        .getEndpoint(ctx.dbTx, input.id, ctx.authContext.orgId)
+        .catch(mapServiceError);
     }),
 
   list: orgProcedure
@@ -98,21 +100,21 @@ export const webhooksRouter = createRouter({
       }),
     )
     .query(async ({ ctx, input }) => {
-      return webhookService.listEndpoints(ctx.dbTx, {
-        ...input,
-        organizationId: ctx.authContext.orgId,
-      });
+      return webhookService.listEndpoints(
+        ctx.dbTx,
+        input,
+        ctx.authContext.orgId,
+      );
     }),
 
   rotateSecret: adminProcedure
     .use(requireScopes('webhooks:manage'))
     .input(z.object({ id: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
-      const row = await webhookService.rotateSecret(
-        ctx.dbTx,
-        input.id,
-        ctx.authContext.orgId,
-      );
+      const row = await webhookService
+        .rotateSecret(ctx.dbTx, input.id, ctx.authContext.orgId)
+        .catch(mapServiceError);
+      // Reached only on a real rotation — `rotateSecret` throws on zero rows.
       await ctx.audit({
         action: AuditActions.WEBHOOK_ENDPOINT_SECRET_ROTATED,
         resource: AuditResources.WEBHOOK_ENDPOINT,
@@ -129,23 +131,16 @@ export const webhooksRouter = createRouter({
       const orgId = ctx.authContext.orgId;
 
       // The worker re-reads url/secret at send time, so only existence and status
-      // are needed here — the redacted read is sufficient.
-      const endpoint = await webhookService.getEndpoint(
-        ctx.dbTx,
-        input.id,
-        orgId,
-      );
-
-      if (!endpoint) {
-        throw new Error('Webhook endpoint not found');
-      }
+      // are needed here — the redacted read is sufficient. `getEndpoint` throws
+      // `WebhookEndpointNotFoundError` rather than returning null.
+      const endpoint = await webhookService
+        .getEndpoint(ctx.dbTx, input.id, orgId)
+        .catch(mapServiceError);
 
       // The worker cancels sends to a disabled endpoint, so reject here rather than
       // enqueueing a delivery that is guaranteed to be cancelled without explanation.
       if (endpoint.status === 'DISABLED') {
-        throw new Error(
-          'Cannot test a disabled webhook endpoint — re-enable it first',
-        );
+        mapServiceError(new WebhookEndpointDisabledError(input.id));
       }
 
       const delivery = await webhookService.createDelivery(ctx.dbTx, {
@@ -183,10 +178,11 @@ export const webhooksRouter = createRouter({
     .use(requireScopes('webhooks:read'))
     .input(listWebhookDeliveriesSchema)
     .query(async ({ ctx, input }) => {
-      return webhookService.listDeliveries(ctx.dbTx, {
-        ...input,
-        organizationId: ctx.authContext.orgId,
-      });
+      return webhookService.listDeliveries(
+        ctx.dbTx,
+        input,
+        ctx.authContext.orgId,
+      );
     }),
 
   retryDelivery: adminProcedure
@@ -196,21 +192,18 @@ export const webhooksRouter = createRouter({
       const env = validateEnv();
       const orgId = ctx.authContext.orgId;
 
-      const delivery = await webhookService.retryDelivery(
-        ctx.dbTx,
-        input.deliveryId,
-      );
+      // The org predicate lives on the UPDATE itself and throws on zero rows,
+      // so ownership is settled before the row is touched. This used to mutate
+      // first and compare `delivery.organizationId` afterwards — and because
+      // tRPC turns a throw into a normal reply, `db-context` committed that
+      // mutation rather than rolling it back.
+      const delivery = await webhookService
+        .retryDelivery(ctx.dbTx, input.deliveryId, orgId)
+        .catch(mapServiceError);
 
-      if (!delivery) {
-        throw new Error('Delivery not found');
-      }
-
-      if (delivery.organizationId !== orgId) {
-        throw new Error('Delivery not found');
-      }
-
-      // Confirm the delivery's endpoint is still present and belongs to the same org.
-      // The FK guarantees existence, not org affinity — this join is the only check.
+      // Still required, and not subsumed by the predicate above: that one scopes
+      // the delivery, this join scopes the *endpoint* it points at. The FK
+      // guarantees existence, not org affinity.
       // The worker re-reads url/secret itself, so nothing is taken from here.
       const endpoint = await webhookService.getEndpointForDelivery(
         ctx.dbTx,
@@ -219,7 +212,9 @@ export const webhooksRouter = createRouter({
       );
 
       if (!endpoint) {
-        throw new Error('Webhook endpoint not found');
+        mapServiceError(
+          new WebhookEndpointNotFoundError(delivery.webhookEndpointId),
+        );
       }
 
       const payload = {

--- a/apps/api/src/workers/__tests__/webhook.worker.spec.ts
+++ b/apps/api/src/workers/__tests__/webhook.worker.spec.ts
@@ -22,6 +22,7 @@ vi.mock('bullmq', () => ({
 const mockUpdateDeliveryStatus = vi.fn();
 const mockCountRecentFailures = vi.fn();
 const mockUpdateEndpoint = vi.fn();
+const mockDisableEndpoint = vi.fn();
 const mockGetEndpointForDelivery = vi.fn();
 vi.mock('../../services/webhook.service.js', () => ({
   webhookService: {
@@ -30,6 +31,7 @@ vi.mock('../../services/webhook.service.js', () => ({
     countRecentFailures: (...args: unknown[]) =>
       mockCountRecentFailures(...args),
     updateEndpoint: (...args: unknown[]) => mockUpdateEndpoint(...args),
+    disableEndpoint: (...args: unknown[]) => mockDisableEndpoint(...args),
     getEndpointForDelivery: (...args: unknown[]) =>
       mockGetEndpointForDelivery(...args),
   },
@@ -166,6 +168,7 @@ describe('webhook worker', () => {
       'mock-tx',
       'del-123',
       'DELIVERED',
+      'org-1',
       expect.objectContaining({
         httpStatusCode: 200,
         deliveredAt: expect.any(Date),
@@ -199,6 +202,7 @@ describe('webhook worker', () => {
       'mock-tx',
       'del-123',
       'DELIVERING',
+      'org-1',
       expect.objectContaining({
         httpStatusCode: 500,
         errorMessage: 'HTTP 500',
@@ -251,6 +255,7 @@ describe('webhook worker', () => {
       expect.anything(),
       'del-123',
       'FAILED',
+      'org-1',
       { errorMessage: 'HTTP 500' },
     );
   });
@@ -261,15 +266,43 @@ describe('webhook worker', () => {
 
     // The endpoint is resolved through the service join, not a raw select on tx.
     mockCountRecentFailures.mockResolvedValueOnce(5); // At threshold
+    mockDisableEndpoint.mockResolvedValueOnce({ id: 'ep-1' });
 
     await failedCallback(job, err);
 
-    // updateEndpoint should be called with orgId as 3rd arg
-    expect(mockUpdateEndpoint).toHaveBeenCalledWith(
+    // The failure count is org-scoped too — otherwise another tenant's failures
+    // against the same endpoint id would contribute to this org's threshold.
+    expect(mockCountRecentFailures).toHaveBeenCalledWith(
       expect.anything(),
       'ep-1',
       'org-1',
-      { status: 'DISABLED' },
+    );
+    // `disableEndpoint`, not `updateEndpoint`: the latter throws on zero rows,
+    // which would roll back the FAILED status and audit row written above.
+    expect(mockDisableEndpoint).toHaveBeenCalledWith(
+      expect.anything(),
+      'ep-1',
+      'org-1',
+    );
+    expect(mockUpdateEndpoint).not.toHaveBeenCalled();
+  });
+
+  it('does not audit an auto-disable that matched no row', async () => {
+    const job = makeJob({ attemptsMade: 8 });
+    const err = new Error('HTTP 500');
+
+    mockCountRecentFailures.mockResolvedValueOnce(5); // At threshold
+    // The endpoint was deleted between the join and this write.
+    mockDisableEndpoint.mockResolvedValueOnce(null);
+
+    await failedCallback(job, err);
+
+    expect(mockDisableEndpoint).toHaveBeenCalled();
+    // The row was written unconditionally before, so it could claim a disable
+    // that never happened.
+    expect(mockAuditLog).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'WEBHOOK_ENDPOINT_AUTO_DISABLED' }),
     );
   });
 
@@ -289,6 +322,7 @@ describe('webhook worker', () => {
         'mock-tx',
         'del-123',
         'CANCELLED',
+        'org-1',
         { errorMessage: expect.stringContaining('disabled') },
       );
       // Never entered DELIVERING — the attempt was not burned
@@ -327,6 +361,7 @@ describe('webhook worker', () => {
         'mock-tx',
         'del-123',
         'CANCELLED',
+        'org-1',
         { errorMessage: expect.stringContaining('no longer subscribes') },
       );
     });
@@ -349,6 +384,7 @@ describe('webhook worker', () => {
         'mock-tx',
         'del-123',
         'DELIVERED',
+        'org-1',
         expect.anything(),
       );
     });

--- a/apps/api/src/workers/webhook.worker.ts
+++ b/apps/api/src/workers/webhook.worker.ts
@@ -62,6 +62,7 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
             tx,
             deliveryId,
             'CANCELLED',
+            orgId,
             { errorMessage: `Cancelled before send: ${cancelReason}` },
           );
         });
@@ -80,6 +81,7 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
           tx,
           deliveryId,
           'DELIVERING',
+          orgId,
           {
             attempts: job.attemptsMade + 1,
           },
@@ -95,9 +97,13 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
         const errorMsg =
           err instanceof Error ? err.message : 'URL validation failed';
         await withRls({ orgId }, async (tx: DrizzleDb) => {
-          await webhookService.updateDeliveryStatus(tx, deliveryId, 'FAILED', {
-            errorMessage: `URL validation failed: ${errorMsg}`,
-          });
+          await webhookService.updateDeliveryStatus(
+            tx,
+            deliveryId,
+            'FAILED',
+            orgId,
+            { errorMessage: `URL validation failed: ${errorMsg}` },
+          );
         });
         return; // Permanent failure — do not retry
       }
@@ -136,6 +142,7 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
             tx,
             deliveryId,
             'DELIVERING',
+            orgId,
             { errorMessage: errorMsg },
           );
         });
@@ -155,6 +162,7 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
             tx,
             deliveryId,
             'DELIVERED',
+            orgId,
             {
               httpStatusCode: response.status,
               responseBody: truncatedBody,
@@ -180,6 +188,7 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
             tx,
             deliveryId,
             'DELIVERING',
+            orgId,
             {
               httpStatusCode: response.status,
               responseBody: truncatedBody,
@@ -217,9 +226,13 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
             orgId,
           );
 
-          await webhookService.updateDeliveryStatus(tx, deliveryId, 'FAILED', {
-            errorMessage: err.message,
-          });
+          await webhookService.updateDeliveryStatus(
+            tx,
+            deliveryId,
+            'FAILED',
+            orgId,
+            { errorMessage: err.message },
+          );
           await auditService.log(tx, {
             resource: AuditResources.WEBHOOK_DELIVERY,
             action: AuditActions.WEBHOOK_DELIVERY_FAILED,
@@ -240,24 +253,32 @@ export function startWebhookWorker(env: Env): Worker<WebhookJobData> {
             const failCount = await webhookService.countRecentFailures(
               tx,
               endpoint.endpointId,
+              orgId,
             );
             if (failCount >= AUTO_DISABLE_THRESHOLD) {
-              await webhookService.updateEndpoint(
+              // `disableEndpoint`, not `updateEndpoint`: the latter throws when
+              // it matches nothing, and a throw here would roll back this whole
+              // transaction — including the FAILED status and audit row written
+              // above — to report an endpoint that has already been deleted.
+              const disabled = await webhookService.disableEndpoint(
                 tx,
                 endpoint.endpointId,
                 orgId,
-                { status: 'DISABLED' },
               );
-              await auditService.log(tx, {
-                resource: AuditResources.WEBHOOK_ENDPOINT,
-                action: AuditActions.WEBHOOK_ENDPOINT_AUTO_DISABLED,
-                resourceId: endpoint.endpointId,
-                organizationId: orgId,
-                newValue: {
-                  endpointUrl: endpoint.url,
-                  consecutiveFailures: failCount,
-                },
-              });
+              // Gated on the result: this audit row was written unconditionally
+              // before, so it could claim a disable that never happened.
+              if (disabled) {
+                await auditService.log(tx, {
+                  resource: AuditResources.WEBHOOK_ENDPOINT,
+                  action: AuditActions.WEBHOOK_ENDPOINT_AUTO_DISABLED,
+                  resourceId: endpoint.endpointId,
+                  organizationId: orgId,
+                  newValue: {
+                    endpointUrl: endpoint.url,
+                    consecutiveFailures: failCount,
+                  },
+                });
+              }
             }
           }
         });

--- a/packages/db/src/schema/webhook-endpoints.ts
+++ b/packages/db/src/schema/webhook-endpoints.ts
@@ -21,7 +21,7 @@ export const webhookEndpoints = pgTable(
     url: varchar("url", { length: 2048 }).notNull(),
     secret: varchar("secret", { length: 512 }).notNull(),
     description: varchar("description", { length: 512 }),
-    eventTypes: jsonb("event_types").notNull(),
+    eventTypes: jsonb("event_types").notNull().$type<string[]>(),
     status: webhookEndpointStatusEnum("status").default("ACTIVE").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()


### PR DESCRIPTION
Closes the delivery half of the webhook org-predicate gap, ahead of putting these
methods on the public REST surface (P1.1).

## What the backlog got wrong

`docs/backlog.md` carries a **checked** item from 2026-03-04 — "Defense-in-depth
org filtering missing in webhook.service.ts — getEndpoint, listEndpoints,
rotateSecret query by ID only". That sweep landed, and it is why those methods
are fine today. It missed **every method that touches `webhook_deliveries`**, so
the item reads as closed while four methods still query by id alone.

Separately, the P1.1 entry says "four of the nine procedures throw bare `Error`".
It is **five throw sites across two procedures** — `test` and `retryDelivery`.
The larger defect was the other four returning `null`/`undefined`/`void` on a
miss. Both corrections belong in the backlog; they are folded in with the REST
port rather than here.

## One live gap, two defence-in-depth ones

The severity is not uniform and the PR should not imply it is.

**`retryDelivery` was live.** `UPDATE … WHERE id = $1` with no org term, and the
router compared `delivery.organizationId !== orgId` *afterwards* — so the row was
already mutated when ownership was checked. Because tRPC converts a thrown error
into a normal HTTP reply, `db-context` commits on `onResponse` rather than
rolling back: an admin in org A could leave org B's delivery permanently
`QUEUED` with `httpStatusCode`/`responseBody`/`errorMessage`/`nextRetryAt`
nulled, and no job enqueued. RLS was the only thing preventing it. Same family as
`pipelineService.assignCopyeditor` (#537), but worse — that one did not commit a
corrupted row.

The predicate now sits on the UPDATE and the method throws on zero rows. Both
halves are load-bearing, and unlike `updateStage` **neither is independently
sufficient**: with the predicate alone nothing on the REST surface would catch a
miss, and with the throw alone the write still lands.

**`listDeliveries` took `organizationId?`**, applied only under an `if`.
`endpointId` is caller-supplied and carries no tenancy, so the filter could be
pointed at another org's endpoint. The org term now seeds the hoisted
`conditions` array, which page and count already shared.

**`updateDeliveryStatus` and `countRecentFailures` are defence-in-depth, not live
fixes.** Their only caller resolves the delivery through the org-scoped
`getEndpointForDelivery` join first and returns early on null, so the id reaching
them is already known to belong to the org. The predicates exist because that
guard is a property of one call site rather than of the statement. Worth noting
`countRecentFailures` feeds the auto-disable threshold, so an unscoped count also
let one tenant's failures help disable another's endpoint.

## Not-found semantics, on both surfaces

`getEndpoint`/`updateEndpoint`/`deleteEndpoint`/`rotateSecret` returned `null`,
`null`, `void` and `undefined` on a miss — so `getById` answered `200 null` and
`delete` reported `{success:true}` for an id that never existed. They now throw
`WebhookEndpointNotFoundError`, which also makes the callers' audit writes
structurally unable to fire on a zero-row update. Absent and not-yours are
deliberately indistinguishable, so the error is not an existence oracle.

`WebhookUrlValidationError` was mapped in **neither** error-mapper, so an SSRF
rejection was a 500 on both surfaces rather than a 400. It and the two new
classes are registered in both. The message is sanitized at the throw site, so
surfacing it leaks no internal network detail.

## `disableEndpoint`

The worker's `onFailed` auto-disable cannot use `updateEndpoint` now that it
throws: it runs inside a `withRls` transaction that has already written the
delivery's FAILED status and audit row, and a throw would roll **both** back to
report an endpoint that is already gone. `disableEndpoint` returns `null`
instead. The auto-disable audit row is now gated on its result — it was written
unconditionally before, so it could claim a disable that never happened.

## Verification

New `src/__tests__/rls/webhook-service.test.ts`, 23 cases over the
RLS-**bypassing** admin pool. Non-vacuity measured by reverting each change in
turn:

| Reverted | Failing |
| --- | --- |
| `retryDelivery` predicate + throw (original code) | 2 |
| `retryDelivery` throw only, predicate kept | 2 |
| `retryDelivery` predicate only, throw kept | 2 |
| `listDeliveries` seeded org condition | 3 |
| `updateDeliveryStatus` predicate | 1 |
| `countRecentFailures` predicate | 1 |
| the four endpoint not-found throws | 5 |

The two `retryDelivery` halves show equal counts but **different failing sets**.
`does not write to another org's delivery, independently of the throw` exists so
they can be told apart at all — without it the `rejects.toThrow` assertion
short-circuits before the row is ever inspected, and the suite could not
distinguish a missing predicate from a missing throw.

Most other cases are regression pins on predicates that predate this change. The
file header says so rather than implying the suite proves more than it does.

Suites: 1948 unit, 220 RLS, 28 queue — all green. Type-check, lint and
`format:check` clean.

## Plan Overrides

| File | Planned | Actual | Rationale |
| --- | --- | --- | --- |
| `services/webhook.service.ts` | `getEndpoint` keeps returning `null`; both routers convert | `getEndpoint` throws | Removes four duplicated `if (!row) throw` guards across two surfaces. The plan's reason for keeping `null` was that `test` uses it as an existence check — but `test` wants a 404 there too. |
| `services/webhook.service.ts` | two unscoped methods | four | `updateDeliveryStatus` and `countRecentFailures` were also unscoped. Fixing only two would repeat the partial-sweep mistake this PR exists to correct. |
| `services/webhook.service.ts` | not planned | `disableEndpoint` added | Making `updateEndpoint` throw would roll back the worker's FAILED write and audit row. |
| `packages/db/src/schema/webhook-endpoints.ts` | not planned | `.$type<string[]>()` on `eventTypes` | Untyped `jsonb` infers `unknown`, which will not satisfy `z.array(z.string())` on the REST `.output()` in the follow-up. Compile-time only; no migration. |

## Follow-ups filed, not fixed here

- `getActiveEndpointsForEvent` is unbounded (no `LIMIT`). It is the fan-out path,
  so a truncating limit would silently stop delivering to whichever endpoints
  fell off the end — strictly worse than the unbounded read. Wants batching.
- `webhooks.test` writes a delivery row and enqueues a job but is audited on
  neither surface; there is no `WEBHOOK_ENDPOINT_TESTED` action.

Next: the REST surface for these nine procedures (P1.1).