### PR TITLE
feat(api): expose webhook endpoint management over REST

### DIFF
--- a/apps/api/src/rest/guard-coverage.spec.ts
+++ b/apps/api/src/rest/guard-coverage.spec.ts
@@ -95,7 +95,7 @@ describe('REST guard coverage', () => {
   it('introspects a plausible number of procedures', () => {
     // Guards against the whole suite silently passing because `'~orpc'` was
     // renamed under an @orpc/server upgrade and every assertion below started
-    // iterating an empty list. 146 operations today.
+    // iterating an empty list. 155 operations today.
     expect(allProcedures().length).toBeGreaterThan(130);
   });
 

--- a/apps/api/src/rest/openapi-spec.spec.ts
+++ b/apps/api/src/rest/openapi-spec.spec.ts
@@ -103,14 +103,14 @@ describe('generateOpenApiDocument', () => {
   });
 
   it('includes the API key scopes added in P0.1b', () => {
-    // webhooks:read is still enforced only by its tRPC router and reaches the
-    // spec solely through the create-API-key request body. notifications:read
-    // and notifications:write are now also carried by real routes, so this
-    // assertion no longer stands alone for them — keep it anyway, since it is
-    // what catches a scope silently dropped from the enum.
+    // All four are now carried by real routes rather than reaching the spec
+    // only through the create-API-key request body — `webhooks:read` and
+    // `webhooks:manage` since the webhooks router landed. Keep the assertion
+    // anyway: it is what catches a scope silently dropped from the enum.
     const serialized = JSON.stringify(doc);
     expect(serialized).toContain('notifications:read');
     expect(serialized).toContain('notifications:write');
     expect(serialized).toContain('webhooks:read');
+    expect(serialized).toContain('webhooks:manage');
   });
 });

--- a/apps/api/src/rest/openapi-spec.ts
+++ b/apps/api/src/rest/openapi-spec.ts
@@ -19,6 +19,7 @@ import { cmsConnectionsRouter } from './routers/cms-connections.js';
 import { csrRouter } from './routers/csr.js';
 import { collectionsRouter } from './routers/collections.js';
 import { notificationsRouter } from './routers/notifications.js';
+import { webhooksRouter } from './routers/webhooks.js';
 
 /**
  * The oRPC routers composing the `/v1` REST surface.
@@ -49,6 +50,7 @@ export const restRouter = {
   // document, so slotting a router mid-list reshuffles the whole spec and both
   // SDKs for no benefit.
   notifications: notificationsRouter,
+  webhooks: webhooksRouter,
 };
 
 /**
@@ -171,6 +173,11 @@ export const openApiDocumentConfig: OpenAPIGeneratorGenerateOptions = {
       name: 'Notifications',
       description:
         'Read in-app notifications and manage delivery preferences. The inbox belongs to the user a credential acts as, not to the organization — use webhooks for organization-level events.',
+    },
+    {
+      name: 'Webhooks',
+      description:
+        'Register HTTPS endpoints to receive organization-level events, and inspect or retry their delivery history. Signing secrets are returned only on registration and rotation, and cannot be read back.',
     },
   ],
   externalDocs: {

--- a/apps/api/src/rest/routers/webhooks.spec.ts
+++ b/apps/api/src/rest/routers/webhooks.spec.ts
@@ -1,0 +1,865 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ORPCError } from '@orpc/server';
+
+/**
+ * The error classes are re-exported from this mock, not just the service
+ * object. `error-mapper.ts` builds `errorCodeMap` from these constructors at
+ * module load, so an `undefined` entry throws before any test body runs.
+ * Declared inside the factory because `vi.mock` is hoisted above every
+ * top-level declaration in this file.
+ */
+vi.mock('../../services/webhook.service.js', () => ({
+  WebhookUrlValidationError: class extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'WebhookUrlValidationError';
+    }
+  },
+  WebhookEndpointNotFoundError: class extends Error {
+    constructor(id: string) {
+      super(`Webhook endpoint "${id}" not found`);
+      this.name = 'WebhookEndpointNotFoundError';
+    }
+  },
+  WebhookDeliveryNotFoundError: class extends Error {
+    constructor(id: string) {
+      super(`Webhook delivery "${id}" not found`);
+      this.name = 'WebhookDeliveryNotFoundError';
+    }
+  },
+  WebhookEndpointDisabledError: class extends Error {
+    constructor(id: string) {
+      super(`Webhook endpoint "${id}" is disabled`);
+      this.name = 'WebhookEndpointDisabledError';
+    }
+  },
+  webhookService: {
+    createEndpoint: vi.fn(),
+    updateEndpoint: vi.fn(),
+    deleteEndpoint: vi.fn(),
+    getEndpoint: vi.fn(),
+    listEndpoints: vi.fn(),
+    rotateSecret: vi.fn(),
+    createDelivery: vi.fn(),
+    listDeliveries: vi.fn(),
+    retryDelivery: vi.fn(),
+    getEndpointForDelivery: vi.fn(),
+  },
+}));
+
+vi.mock('../../queues/webhook.queue.js', () => ({
+  enqueueWebhook: vi.fn(),
+  enqueueWebhookRetry: vi.fn(),
+}));
+
+vi.mock('../../config/env.js', () => ({
+  validateEnv: () => ({
+    REDIS_HOST: 'localhost',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: '',
+  }),
+}));
+
+vi.mock('@colophony/db', () => ({
+  pool: { query: vi.fn(), connect: vi.fn() },
+  db: { query: {} },
+  webhookEndpoints: {},
+  webhookDeliveries: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  sql: vi.fn(),
+}));
+
+import {
+  webhookService,
+  WebhookEndpointNotFoundError,
+  WebhookDeliveryNotFoundError,
+  WebhookUrlValidationError,
+} from '../../services/webhook.service.js';
+import {
+  enqueueWebhook,
+  enqueueWebhookRetry,
+} from '../../queues/webhook.queue.js';
+import { webhooksRouter } from './webhooks.js';
+import type { RestContext } from '../context.js';
+import { createProcedureClient } from '@orpc/server';
+
+const mockWebhooks = vi.mocked(webhookService);
+const mockEnqueue = vi.mocked(enqueueWebhook);
+const mockEnqueueRetry = vi.mocked(enqueueWebhookRetry);
+
+const USER_ID = 'a0000000-0000-4000-a000-000000000001';
+const ORG_ID = 'b0000000-0000-4000-a000-000000000001';
+const EP_ID = 'c0000000-0000-4000-a000-000000000001';
+const DEL_ID = 'd0000000-0000-4000-a000-000000000001';
+
+function baseContext(): RestContext {
+  return { authContext: null, dbTx: null, audit: vi.fn() };
+}
+
+/** Authenticated but with no organization resolved. */
+function authedContext(): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: 'zid-1',
+      email: 'editor@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+    },
+    dbTx: {} as never,
+    audit: vi.fn(),
+  };
+}
+
+/**
+ * READER, deliberately. Six of the nine routes are `adminProcedure`, so this
+ * context is what proves the role guard rejects rather than merely that the
+ * scope guard does.
+ */
+function orgContext(): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: 'zid-1',
+      email: 'editor@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+      orgId: ORG_ID,
+      roles: ['READER'],
+    },
+    dbTx: {} as never,
+    audit: vi.fn(),
+  };
+}
+
+function adminContext(): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      zitadelUserId: 'zid-1',
+      email: 'editor@example.com',
+      emailVerified: true,
+      authMethod: 'test',
+      orgId: ORG_ID,
+      roles: ['ADMIN'],
+    },
+    dbTx: {} as never,
+    audit: vi.fn(),
+  };
+}
+
+function apiKeyContext(scopes: string[]): RestContext {
+  return {
+    authContext: {
+      userId: USER_ID,
+      email: 'editor@example.com',
+      emailVerified: true,
+      authMethod: 'apikey',
+      apiKeyId: 'k0000000-0000-4000-a000-000000000001',
+      apiKeyScopes: scopes as never,
+      orgId: ORG_ID,
+      roles: ['ADMIN'],
+    },
+    dbTx: {} as never,
+    audit: vi.fn(),
+  };
+}
+
+function client<T>(procedure: T, context: RestContext) {
+  return createProcedureClient(procedure as never, { context }) as (
+    input?: unknown,
+  ) => Promise<never>;
+}
+
+/** A redacted endpoint row, as the service returns from get/list/update. */
+function endpointRow() {
+  return {
+    id: EP_ID,
+    url: 'https://example.com/hook',
+    description: null,
+    eventTypes: ['hopper/submission.submitted'],
+    status: 'ACTIVE' as const,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+}
+
+/** An unredacted row, as create/rotateSecret return. */
+function endpointRowWithSecret() {
+  return { ...endpointRow(), secret: 'plaintext-secret' };
+}
+
+function deliveryRow() {
+  return {
+    id: DEL_ID,
+    webhookEndpointId: EP_ID,
+    eventType: 'hopper/submission.submitted',
+    eventId: 'e0000000-0000-4000-a000-000000000001',
+    payload: { submissionId: 'sub-1' },
+    status: 'FAILED' as const,
+    httpStatusCode: 500,
+    responseBody: null,
+    errorMessage: 'boom',
+    attempts: 3,
+    nextRetryAt: null,
+    deliveredAt: null,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+}
+
+const ALL_ROUTES: Array<[string, unknown, unknown]> = [
+  ['list', webhooksRouter.list, { page: 1, limit: 20 }],
+  [
+    'create',
+    webhooksRouter.create,
+    { url: 'https://example.com/hook', eventTypes: ['webhook.test'] },
+  ],
+  ['getById', webhooksRouter.getById, { id: EP_ID }],
+  ['update', webhooksRouter.update, { id: EP_ID, status: 'DISABLED' }],
+  ['delete', webhooksRouter.delete, { id: EP_ID }],
+  ['rotateSecret', webhooksRouter.rotateSecret, { id: EP_ID }],
+  ['test', webhooksRouter.test, { id: EP_ID }],
+  ['deliveries', webhooksRouter.deliveries, { page: 1, limit: 20 }],
+  ['retryDelivery', webhooksRouter.retryDelivery, { deliveryId: DEL_ID }],
+];
+
+describe('webhooks REST router', () => {
+  beforeEach(() => {
+    // resetAllMocks, not clearAllMocks: this suite runs under vitest's random
+    // sequencing, and `clearAllMocks` leaves queued `mockResolvedValueOnce`
+    // implementations in place.
+    vi.resetAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Auth and org context, across the whole router
+  // -------------------------------------------------------------------------
+
+  describe.each(ALL_ROUTES)('%s', (_name, procedure, input) => {
+    it('requires auth', async () => {
+      await expect(client(procedure, baseContext())(input)).rejects.toThrow(
+        ORPCError,
+      );
+    });
+
+    it('requires org context', async () => {
+      await expect(client(procedure, authedContext())(input)).rejects.toThrow(
+        'X-Organization-Id header is required',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /webhooks
+  // -------------------------------------------------------------------------
+
+  describe('GET /webhooks', () => {
+    it('passes the org id as the third argument', async () => {
+      mockWebhooks.listEndpoints.mockResolvedValueOnce({
+        items: [endpointRow()],
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      } as never);
+
+      await client(webhooksRouter.list, orgContext())({ page: 1, limit: 20 });
+
+      // The full argument list, not a prefix: a dropped org id silently widens
+      // the query to RLS alone.
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockWebhooks.listEndpoints).toHaveBeenCalledWith(
+        expect.anything(),
+        { page: 1, limit: 20 },
+        ORG_ID,
+      );
+    });
+
+    it('never returns a secret, even if the service leaks one', async () => {
+      mockWebhooks.listEndpoints.mockResolvedValueOnce({
+        items: [endpointRowWithSecret()],
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      } as never);
+
+      const result = (await client(
+        webhooksRouter.list,
+        orgContext(),
+      )({ page: 1, limit: 20 })) as { items: unknown[] };
+
+      expect(result.items[0]).not.toHaveProperty('secret');
+    });
+
+    it('coerces page and limit from query strings', async () => {
+      mockWebhooks.listEndpoints.mockResolvedValueOnce({
+        items: [],
+        total: 0,
+        page: 2,
+        limit: 5,
+        totalPages: 0,
+      });
+
+      await client(
+        webhooksRouter.list,
+        orgContext(),
+      )({ page: '2', limit: '5' });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockWebhooks.listEndpoints).toHaveBeenCalledWith(
+        expect.anything(),
+        { page: 2, limit: 5 },
+        ORG_ID,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /webhooks
+  // -------------------------------------------------------------------------
+
+  describe('POST /webhooks', () => {
+    it('creates, audits, and returns the plaintext secret', async () => {
+      mockWebhooks.createEndpoint.mockResolvedValueOnce(
+        endpointRowWithSecret() as never,
+      );
+      const ctx = adminContext();
+
+      const result = (await client(
+        webhooksRouter.create,
+        ctx,
+      )({
+        url: 'https://example.com/hook',
+        eventTypes: ['hopper/submission.submitted'],
+      })) as { secret?: string };
+
+      // Registration is one of only two operations that may return it.
+      expect(result.secret).toBe('plaintext-secret');
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'WEBHOOK_ENDPOINT_CREATED' }),
+      );
+    });
+
+    it('binds organizationId from context, never from input', async () => {
+      mockWebhooks.createEndpoint.mockResolvedValueOnce(
+        endpointRowWithSecret() as never,
+      );
+
+      await client(
+        webhooksRouter.create,
+        adminContext(),
+      )({
+        url: 'https://example.com/hook',
+        eventTypes: ['hopper/submission.submitted'],
+        organizationId: 'f0000000-0000-4000-a000-000000000999',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockWebhooks.createEndpoint).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ organizationId: ORG_ID }),
+      );
+    });
+
+    it('maps WebhookUrlValidationError to 400, not 500', async () => {
+      // An SSRF rejection was a 500 on both surfaces until the error was
+      // registered in the mappers.
+      mockWebhooks.createEndpoint.mockRejectedValueOnce(
+        new WebhookUrlValidationError(
+          'URL is not allowed: must be a public HTTPS endpoint',
+        ),
+      );
+
+      await expect(
+        client(
+          webhooksRouter.create,
+          adminContext(),
+        )({
+          url: 'https://127.0.0.1/hook',
+          eventTypes: ['hopper/submission.submitted'],
+        }),
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    });
+
+    it('rejects an event type outside the enum', async () => {
+      await expect(
+        client(
+          webhooksRouter.create,
+          adminContext(),
+        )({
+          url: 'https://example.com/hook',
+          eventTypes: ['not.a.real.event'],
+        }),
+      ).rejects.toThrow(ORPCError);
+    });
+
+    it('requires ADMIN', async () => {
+      await expect(
+        client(
+          webhooksRouter.create,
+          orgContext(),
+        )({
+          url: 'https://example.com/hook',
+          eventTypes: ['hopper/submission.submitted'],
+        }),
+      ).rejects.toThrow('Admin role required');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /webhooks/{id}
+  // -------------------------------------------------------------------------
+
+  describe('GET /webhooks/{id}', () => {
+    it('passes all three arguments and returns no secret', async () => {
+      mockWebhooks.getEndpoint.mockResolvedValueOnce(endpointRow() as never);
+
+      const result = await client(
+        webhooksRouter.getById,
+        orgContext(),
+      )({ id: EP_ID });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockWebhooks.getEndpoint).toHaveBeenCalledWith(
+        expect.anything(),
+        EP_ID,
+        ORG_ID,
+      );
+      expect(result).not.toHaveProperty('secret');
+    });
+
+    it('maps WebhookEndpointNotFoundError to 404', async () => {
+      mockWebhooks.getEndpoint.mockRejectedValueOnce(
+        new WebhookEndpointNotFoundError(EP_ID),
+      );
+
+      await expect(
+        client(webhooksRouter.getById, orgContext())({ id: EP_ID }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    });
+
+    it('rejects a non-uuid id', async () => {
+      await expect(
+        client(webhooksRouter.getById, orgContext())({ id: 'not-a-uuid' }),
+      ).rejects.toThrow(ORPCError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // PATCH /webhooks/{id}
+  // -------------------------------------------------------------------------
+
+  describe('PATCH /webhooks/{id}', () => {
+    it('passes (tx, id, params, orgId) in that order and does not leak id into params', async () => {
+      mockWebhooks.updateEndpoint.mockResolvedValueOnce(endpointRow() as never);
+
+      await client(
+        webhooksRouter.update,
+        adminContext(),
+      )({ id: EP_ID, status: 'DISABLED' });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockWebhooks.updateEndpoint).toHaveBeenCalledWith(
+        expect.anything(),
+        EP_ID,
+        { status: 'DISABLED' },
+        ORG_ID,
+      );
+    });
+
+    it('does not audit when the endpoint was not found', async () => {
+      // The service throws on zero rows precisely so the audit below cannot
+      // record an update that never happened.
+      mockWebhooks.updateEndpoint.mockRejectedValueOnce(
+        new WebhookEndpointNotFoundError(EP_ID),
+      );
+      const ctx = adminContext();
+
+      await expect(
+        client(webhooksRouter.update, ctx)({ id: EP_ID, status: 'DISABLED' }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+      expect(ctx.audit).not.toHaveBeenCalled();
+    });
+
+    it('requires ADMIN', async () => {
+      await expect(
+        client(
+          webhooksRouter.update,
+          orgContext(),
+        )({ id: EP_ID, status: 'DISABLED' }),
+      ).rejects.toThrow('Admin role required');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // DELETE /webhooks/{id}
+  // -------------------------------------------------------------------------
+
+  describe('DELETE /webhooks/{id}', () => {
+    it('deletes, audits, and returns success', async () => {
+      mockWebhooks.deleteEndpoint.mockResolvedValueOnce({ id: EP_ID });
+      const ctx = adminContext();
+
+      const result = await client(webhooksRouter.delete, ctx)({ id: EP_ID });
+
+      expect(result).toEqual({ success: true });
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'WEBHOOK_ENDPOINT_DELETED' }),
+      );
+    });
+
+    it('maps not-found to 404 and does not audit', async () => {
+      // It reported `{success:true}` for an id that never existed before.
+      mockWebhooks.deleteEndpoint.mockRejectedValueOnce(
+        new WebhookEndpointNotFoundError(EP_ID),
+      );
+      const ctx = adminContext();
+
+      await expect(
+        client(webhooksRouter.delete, ctx)({ id: EP_ID }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+      expect(ctx.audit).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /webhooks/{id}/rotate-secret
+  // -------------------------------------------------------------------------
+
+  describe('POST /webhooks/{id}/rotate-secret', () => {
+    it('returns the new plaintext secret and audits', async () => {
+      mockWebhooks.rotateSecret.mockResolvedValueOnce(
+        endpointRowWithSecret() as never,
+      );
+      const ctx = adminContext();
+
+      const result = (await client(
+        webhooksRouter.rotateSecret,
+        ctx,
+      )({ id: EP_ID })) as { secret?: string };
+
+      expect(result.secret).toBe('plaintext-secret');
+      expect(ctx.audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'WEBHOOK_ENDPOINT_SECRET_ROTATED' }),
+      );
+    });
+
+    it('maps not-found to 404 and does not audit', async () => {
+      mockWebhooks.rotateSecret.mockRejectedValueOnce(
+        new WebhookEndpointNotFoundError(EP_ID),
+      );
+      const ctx = adminContext();
+
+      await expect(
+        client(webhooksRouter.rotateSecret, ctx)({ id: EP_ID }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+      expect(ctx.audit).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /webhooks/{id}/test
+  // -------------------------------------------------------------------------
+
+  describe('POST /webhooks/{id}/test', () => {
+    it('enqueues a job carrying no endpoint URL or secret', async () => {
+      mockWebhooks.getEndpoint.mockResolvedValueOnce(endpointRow() as never);
+      mockWebhooks.createDelivery.mockResolvedValueOnce({
+        id: DEL_ID,
+      } as never);
+
+      await client(webhooksRouter.test, adminContext())({ id: EP_ID });
+
+      const jobData = mockEnqueue.mock.calls[0]?.[1];
+      // The worker re-reads both at send time, so a rotated secret cannot be
+      // replayed out of Redis.
+      expect(jobData).not.toHaveProperty('secret');
+      expect(jobData).not.toHaveProperty('endpointUrl');
+      expect(jobData).toMatchObject({ deliveryId: DEL_ID, orgId: ORG_ID });
+    });
+
+    it('refuses a disabled endpoint with 400 and enqueues nothing', async () => {
+      mockWebhooks.getEndpoint.mockResolvedValueOnce({
+        ...endpointRow(),
+        status: 'DISABLED',
+      } as never);
+
+      await expect(
+        client(webhooksRouter.test, adminContext())({ id: EP_ID }),
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockWebhooks.createDelivery).not.toHaveBeenCalled();
+      expect(mockEnqueue).not.toHaveBeenCalled();
+    });
+
+    it('maps not-found to 404 and creates no delivery', async () => {
+      mockWebhooks.getEndpoint.mockRejectedValueOnce(
+        new WebhookEndpointNotFoundError(EP_ID),
+      );
+
+      await expect(
+        client(webhooksRouter.test, adminContext())({ id: EP_ID }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockWebhooks.createDelivery).not.toHaveBeenCalled();
+    });
+
+    it('emits no audit event, matching the tRPC twin', async () => {
+      // Pins a deliberate parity gap rather than hiding it: there is no
+      // WEBHOOK_ENDPOINT_TESTED action, and adding one has to land on both
+      // surfaces at once. Filed as a follow-up.
+      mockWebhooks.getEndpoint.mockResolvedValueOnce(endpointRow() as never);
+      mockWebhooks.createDelivery.mockResolvedValueOnce({
+        id: DEL_ID,
+      } as never);
+      const ctx = adminContext();
+
+      await client(webhooksRouter.test, ctx)({ id: EP_ID });
+
+      expect(ctx.audit).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /webhook-deliveries
+  // -------------------------------------------------------------------------
+
+  describe('GET /webhook-deliveries', () => {
+    it('passes the org id as the third argument', async () => {
+      mockWebhooks.listDeliveries.mockResolvedValueOnce({
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 0,
+      });
+
+      await client(
+        webhooksRouter.deliveries,
+        orgContext(),
+      )({ page: 1, limit: 20 });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockWebhooks.listDeliveries).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ page: 1, limit: 20 }),
+        ORG_ID,
+      );
+    });
+
+    it('forwards the endpointId, eventType and status filters', async () => {
+      // These three come from `listWebhookDeliveriesSchema`; merging bare
+      // pagination would have dropped them and stopped mirroring the tRPC twin.
+      mockWebhooks.listDeliveries.mockResolvedValueOnce({
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 0,
+      });
+
+      await client(
+        webhooksRouter.deliveries,
+        orgContext(),
+      )({
+        page: 1,
+        limit: 20,
+        endpointId: EP_ID,
+        eventType: 'hopper/submission.submitted',
+        status: 'FAILED',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockWebhooks.listDeliveries).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          endpointId: EP_ID,
+          eventType: 'hopper/submission.submitted',
+          status: 'FAILED',
+        }),
+        ORG_ID,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /webhook-deliveries/{deliveryId}/retry
+  // -------------------------------------------------------------------------
+
+  describe('POST /webhook-deliveries/{deliveryId}/retry', () => {
+    it('passes (tx, deliveryId, orgId) — all three', async () => {
+      // The argument list PR #541 exists for. Before it, the org id was not
+      // passed at all and ownership was compared after the row was mutated.
+      mockWebhooks.retryDelivery.mockResolvedValueOnce(deliveryRow() as never);
+      mockWebhooks.getEndpointForDelivery.mockResolvedValueOnce({
+        endpointId: EP_ID,
+        url: 'https://example.com/hook',
+        secret: 's',
+        status: 'ACTIVE',
+        eventTypes: ['hopper/submission.submitted'],
+      } as never);
+
+      await client(
+        webhooksRouter.retryDelivery,
+        adminContext(),
+      )({ deliveryId: DEL_ID });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockWebhooks.retryDelivery).toHaveBeenCalledWith(
+        expect.anything(),
+        DEL_ID,
+        ORG_ID,
+      );
+    });
+
+    it('retries through enqueueWebhookRetry, never a plain enqueue', async () => {
+      // A plain add is deduped into a no-op by the retained job under the same
+      // delivery id — the row would go back to QUEUED and nothing would run.
+      mockWebhooks.retryDelivery.mockResolvedValueOnce(deliveryRow() as never);
+      mockWebhooks.getEndpointForDelivery.mockResolvedValueOnce({
+        endpointId: EP_ID,
+        url: 'https://example.com/hook',
+        secret: 's',
+        status: 'ACTIVE',
+        eventTypes: ['hopper/submission.submitted'],
+      } as never);
+
+      await client(
+        webhooksRouter.retryDelivery,
+        adminContext(),
+      )({ deliveryId: DEL_ID });
+
+      expect(mockEnqueueRetry).toHaveBeenCalled();
+      expect(mockEnqueue).not.toHaveBeenCalled();
+    });
+
+    it('maps a missing delivery to 404 and does not audit or enqueue', async () => {
+      mockWebhooks.retryDelivery.mockRejectedValueOnce(
+        new WebhookDeliveryNotFoundError(DEL_ID),
+      );
+      const ctx = adminContext();
+
+      await expect(
+        client(webhooksRouter.retryDelivery, ctx)({ deliveryId: DEL_ID }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockWebhooks.getEndpointForDelivery).not.toHaveBeenCalled();
+      expect(mockEnqueueRetry).not.toHaveBeenCalled();
+      expect(ctx.audit).not.toHaveBeenCalled();
+    });
+
+    it('maps an endpoint in another org to 404 and does not enqueue', async () => {
+      // The retry predicate scopes the delivery; this join scopes the endpoint
+      // it points at. The FK guarantees existence, not org affinity.
+      mockWebhooks.retryDelivery.mockResolvedValueOnce(deliveryRow() as never);
+      mockWebhooks.getEndpointForDelivery.mockResolvedValueOnce(null as never);
+      const ctx = adminContext();
+
+      await expect(
+        client(webhooksRouter.retryDelivery, ctx)({ deliveryId: DEL_ID }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+      expect(mockEnqueueRetry).not.toHaveBeenCalled();
+      expect(ctx.audit).not.toHaveBeenCalled();
+    });
+
+    it('requires ADMIN', async () => {
+      await expect(
+        client(
+          webhooksRouter.retryDelivery,
+          orgContext(),
+        )({ deliveryId: DEL_ID }),
+      ).rejects.toThrow('Admin role required');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // API key scope enforcement
+  // -------------------------------------------------------------------------
+
+  describe('API key scope enforcement', () => {
+    it('denies a key holding an unrelated scope', async () => {
+      await expect(
+        client(
+          webhooksRouter.list,
+          apiKeyContext(['submissions:read']),
+        )({ page: 1, limit: 20 }),
+      ).rejects.toThrow('Insufficient API key scope');
+    });
+
+    it('allows webhooks:read on a read route', async () => {
+      mockWebhooks.listEndpoints.mockResolvedValueOnce({
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 0,
+      });
+
+      const result = await client(
+        webhooksRouter.list,
+        apiKeyContext(['webhooks:read']),
+      )({ page: 1, limit: 20 });
+
+      expect(result).toMatchObject({ total: 0 });
+    });
+
+    it('does not let webhooks:read satisfy a manage route', async () => {
+      // Read must not imply manage. If these ever collapse into one scope,
+      // this is the test that should stop it.
+      await expect(
+        client(
+          webhooksRouter.rotateSecret,
+          apiKeyContext(['webhooks:read']),
+        )({ id: EP_ID }),
+      ).rejects.toThrow('Insufficient API key scope');
+    });
+
+    it('allows webhooks:manage on a manage route', async () => {
+      mockWebhooks.rotateSecret.mockResolvedValueOnce(
+        endpointRowWithSecret() as never,
+      );
+
+      const result = (await client(
+        webhooksRouter.rotateSecret,
+        apiKeyContext(['webhooks:manage']),
+      )({ id: EP_ID })) as { secret?: string };
+
+      expect(result.secret).toBe('plaintext-secret');
+    });
+
+    it('does not let webhooks:manage satisfy a read route', async () => {
+      await expect(
+        client(
+          webhooksRouter.deliveries,
+          apiKeyContext(['webhooks:manage']),
+        )({ page: 1, limit: 20 }),
+      ).rejects.toThrow('Insufficient API key scope');
+    });
+
+    it('bypasses scopes entirely for interactive auth', async () => {
+      mockWebhooks.listEndpoints.mockResolvedValueOnce({
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 0,
+      });
+
+      const result = await client(
+        webhooksRouter.list,
+        orgContext(),
+      )({ page: 1, limit: 20 });
+
+      expect(result).toMatchObject({ total: 0 });
+    });
+  });
+});

--- a/apps/api/src/rest/routers/webhooks.ts
+++ b/apps/api/src/rest/routers/webhooks.ts
@@ -1,0 +1,409 @@
+import { z } from 'zod';
+import {
+  AuditActions,
+  AuditResources,
+  idParamSchema,
+  successResponseSchema,
+  paginatedResponseSchema,
+  createWebhookEndpointSchema,
+  updateWebhookEndpointSchema,
+  listWebhookDeliveriesSchema,
+  webhookEndpointResponseSchema,
+  webhookEndpointCreatedResponseSchema,
+  webhookDeliveryResponseSchema,
+} from '@colophony/types';
+import { restPaginationQuery } from '@colophony/api-contracts';
+import {
+  webhookService,
+  WebhookEndpointNotFoundError,
+  WebhookEndpointDisabledError,
+} from '../../services/webhook.service.js';
+import {
+  enqueueWebhook,
+  enqueueWebhookRetry,
+} from '../../queues/webhook.queue.js';
+import { validateEnv } from '../../config/env.js';
+import { orgProcedure, adminProcedure, requireScopes } from '../context.js';
+import { mapServiceError } from '../error-mapper.js';
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const paginatedEndpointsSchema = paginatedResponseSchema(
+  webhookEndpointResponseSchema,
+);
+
+const paginatedDeliveriesSchema = paginatedResponseSchema(
+  webhookDeliveryResponseSchema,
+);
+
+const deliveryIdParamSchema = z.object({
+  deliveryId: z.string().uuid().describe('Webhook delivery UUID'),
+});
+
+const testResponseSchema = z.object({
+  deliveryId: z
+    .string()
+    .uuid()
+    .describe('The queued test delivery — poll it via GET /webhook-deliveries'),
+});
+
+/**
+ * Only page/limit need REST treatment; the other three filters are already
+ * string-shaped. Both this and `restPaginationQuery` cap `limit` at 100, so
+ * unlike the notifications contract nothing has to be restated to avoid
+ * silently widening the surface against its tRPC twin.
+ */
+const restListWebhookDeliveriesQuery = listWebhookDeliveriesSchema
+  .omit({ page: true, limit: true })
+  .merge(restPaginationQuery);
+
+/**
+ * Why two response shapes.
+ *
+ * `redactSecret` strips `secret` in `getEndpoint`/`listEndpoints`/
+ * `updateEndpoint` but deliberately not in `createEndpoint`/`rotateSecret` —
+ * those two exist to hand the caller a signing secret it can never retrieve
+ * again. So exactly two routes below declare
+ * `webhookEndpointCreatedResponseSchema`, and every other endpoint route
+ * declares the redacted one. Zod strips unknown keys, so the schema is a second
+ * line of defence, but the spec asserts on the response rather than relying on
+ * it.
+ */
+const SECRET_NOTE =
+  ' The signing secret is returned **only** by this operation and by ' +
+  'endpoint creation — it cannot be read back afterwards. Store it before ' +
+  'discarding the response.';
+
+// ---------------------------------------------------------------------------
+// Endpoint routes
+// ---------------------------------------------------------------------------
+
+const list = orgProcedure
+  .use(requireScopes('webhooks:read'))
+  .route({
+    method: 'GET',
+    path: '/webhooks',
+    summary: 'List webhook endpoints',
+    description:
+      'Returns the organization’s registered webhook endpoints, newest first. ' +
+      'Signing secrets are never included.',
+    operationId: 'listWebhookEndpoints',
+    tags: ['Webhooks'],
+  })
+  .input(restPaginationQuery)
+  .output(paginatedEndpointsSchema)
+  .handler(async ({ input, context }) => {
+    return webhookService.listEndpoints(
+      context.dbTx,
+      input,
+      context.authContext.orgId,
+    );
+  });
+
+const create = adminProcedure
+  .use(requireScopes('webhooks:manage'))
+  .route({
+    method: 'POST',
+    path: '/webhooks',
+    successStatus: 201,
+    summary: 'Register a webhook endpoint',
+    description:
+      'Registers an HTTPS endpoint to receive the selected events. The URL is ' +
+      'validated against SSRF rules — it must be a public HTTPS address.' +
+      SECRET_NOTE,
+    operationId: 'createWebhookEndpoint',
+    tags: ['Webhooks'],
+  })
+  .input(createWebhookEndpointSchema)
+  .output(webhookEndpointCreatedResponseSchema)
+  .handler(async ({ input, context }) => {
+    const row = await webhookService
+      .createEndpoint(context.dbTx, {
+        // Never from input — tenancy is server-supplied on this surface.
+        organizationId: context.authContext.orgId,
+        url: input.url,
+        description: input.description,
+        eventTypes: input.eventTypes,
+      })
+      .catch(mapServiceError);
+    await context.audit({
+      action: AuditActions.WEBHOOK_ENDPOINT_CREATED,
+      resource: AuditResources.WEBHOOK_ENDPOINT,
+      resourceId: row.id,
+      newValue: { url: input.url, eventTypes: input.eventTypes },
+    });
+    return row;
+  });
+
+const getById = orgProcedure
+  .use(requireScopes('webhooks:read'))
+  .route({
+    method: 'GET',
+    path: '/webhooks/{id}',
+    summary: 'Get a webhook endpoint',
+    description:
+      'Returns one webhook endpoint. Responds 404 for an endpoint belonging to ' +
+      'another organization, which is indistinguishable from one that does not ' +
+      'exist. The signing secret is never included.',
+    operationId: 'getWebhookEndpoint',
+    tags: ['Webhooks'],
+  })
+  .input(idParamSchema)
+  .output(webhookEndpointResponseSchema)
+  .handler(async ({ input, context }) => {
+    return webhookService
+      .getEndpoint(context.dbTx, input.id, context.authContext.orgId)
+      .catch(mapServiceError);
+  });
+
+const update = adminProcedure
+  .use(requireScopes('webhooks:manage'))
+  .route({
+    method: 'PATCH',
+    path: '/webhooks/{id}',
+    summary: 'Update a webhook endpoint',
+    description:
+      'Updates the URL, description, subscribed events, or status. A changed ' +
+      'URL is re-validated against SSRF rules. Signing secrets are never ' +
+      'included in the response — rotate the secret to obtain a new one.',
+    operationId: 'updateWebhookEndpoint',
+    tags: ['Webhooks'],
+  })
+  .input(idParamSchema.merge(updateWebhookEndpointSchema))
+  .output(webhookEndpointResponseSchema)
+  .handler(async ({ input, context }) => {
+    const { id, ...params } = input;
+    const row = await webhookService
+      .updateEndpoint(context.dbTx, id, params, context.authContext.orgId)
+      .catch(mapServiceError);
+    // Reached only on a real update — the service throws on zero rows, so this
+    // cannot record a change that did not happen.
+    await context.audit({
+      action: AuditActions.WEBHOOK_ENDPOINT_UPDATED,
+      resource: AuditResources.WEBHOOK_ENDPOINT,
+      resourceId: id,
+      newValue: params,
+    });
+    return row;
+  });
+
+const deleteEndpoint = adminProcedure
+  .use(requireScopes('webhooks:manage'))
+  .route({
+    method: 'DELETE',
+    path: '/webhooks/{id}',
+    summary: 'Delete a webhook endpoint',
+    description:
+      'Deletes the endpoint and its delivery history. Responds 404 rather than ' +
+      'reporting success for an endpoint that does not exist.',
+    operationId: 'deleteWebhookEndpoint',
+    tags: ['Webhooks'],
+  })
+  .input(idParamSchema)
+  .output(successResponseSchema)
+  .handler(async ({ input, context }) => {
+    await webhookService
+      .deleteEndpoint(context.dbTx, input.id, context.authContext.orgId)
+      .catch(mapServiceError);
+    await context.audit({
+      action: AuditActions.WEBHOOK_ENDPOINT_DELETED,
+      resource: AuditResources.WEBHOOK_ENDPOINT,
+      resourceId: input.id,
+    });
+    return { success: true };
+  });
+
+const rotateSecret = adminProcedure
+  .use(requireScopes('webhooks:manage'))
+  .route({
+    method: 'POST',
+    path: '/webhooks/{id}/rotate-secret',
+    summary: 'Rotate a webhook signing secret',
+    description:
+      'Generates a new signing secret and invalidates the previous one. ' +
+      'In-flight deliveries are signed with whichever secret is current when ' +
+      'they are sent, so rotate during a quiet period if signature continuity ' +
+      'matters.' +
+      SECRET_NOTE,
+    operationId: 'rotateWebhookEndpointSecret',
+    tags: ['Webhooks'],
+  })
+  .input(idParamSchema)
+  .output(webhookEndpointCreatedResponseSchema)
+  .handler(async ({ input, context }) => {
+    const row = await webhookService
+      .rotateSecret(context.dbTx, input.id, context.authContext.orgId)
+      .catch(mapServiceError);
+    await context.audit({
+      action: AuditActions.WEBHOOK_ENDPOINT_SECRET_ROTATED,
+      resource: AuditResources.WEBHOOK_ENDPOINT,
+      resourceId: input.id,
+    });
+    return row;
+  });
+
+const test = adminProcedure
+  .use(requireScopes('webhooks:manage'))
+  .route({
+    method: 'POST',
+    path: '/webhooks/{id}/test',
+    successStatus: 201,
+    summary: 'Send a test delivery',
+    description:
+      'Queues a `webhook.test` delivery to the endpoint and returns its id. ' +
+      'Delivery is asynchronous — poll `GET /webhook-deliveries` for the ' +
+      'outcome. Rejected with 400 if the endpoint is disabled.',
+    operationId: 'testWebhookEndpoint',
+    tags: ['Webhooks'],
+  })
+  .input(idParamSchema)
+  .output(testResponseSchema)
+  .handler(async ({ input, context }) => {
+    const env = validateEnv();
+    const orgId = context.authContext.orgId;
+
+    // The worker re-reads url/secret at send time, so only existence and status
+    // are needed here — the redacted read is sufficient.
+    const endpoint = await webhookService
+      .getEndpoint(context.dbTx, input.id, orgId)
+      .catch(mapServiceError);
+
+    // The worker cancels sends to a disabled endpoint, so reject here rather
+    // than queueing a delivery guaranteed to be cancelled without explanation.
+    if (endpoint.status === 'DISABLED') {
+      mapServiceError(new WebhookEndpointDisabledError(input.id));
+    }
+
+    const delivery = await webhookService.createDelivery(context.dbTx, {
+      organizationId: orgId,
+      webhookEndpointId: input.id,
+      eventType: 'webhook.test',
+      eventId: crypto.randomUUID(),
+      payload: {
+        event: 'webhook.test',
+        data: { message: 'Test webhook from Colophony' },
+      },
+    });
+
+    await enqueueWebhook(env, {
+      deliveryId: delivery.id,
+      orgId,
+      payload: {
+        id: delivery.id,
+        event: 'webhook.test',
+        timestamp: new Date().toISOString(),
+        organizationId: orgId,
+        data: { message: 'Test webhook from Colophony' },
+      },
+    });
+
+    // No audit event, matching the tRPC twin. There is no
+    // `WEBHOOK_ENDPOINT_TESTED` action and the typed detail union closes
+    // `WEBHOOK_ENDPOINT` to five — adding one is a `@colophony/types` change
+    // that must land on both surfaces at once. Filed as a follow-up.
+    return { deliveryId: delivery.id };
+  });
+
+// ---------------------------------------------------------------------------
+// Delivery routes
+// ---------------------------------------------------------------------------
+
+const deliveries = orgProcedure
+  .use(requireScopes('webhooks:read'))
+  .route({
+    method: 'GET',
+    path: '/webhook-deliveries',
+    summary: 'List webhook deliveries',
+    description:
+      'Returns delivery attempts across the organization’s endpoints, newest ' +
+      'first. Filter by endpoint, event type, or status to narrow it.',
+    operationId: 'listWebhookDeliveries',
+    tags: ['Webhooks'],
+  })
+  .input(restListWebhookDeliveriesQuery)
+  .output(paginatedDeliveriesSchema)
+  .handler(async ({ input, context }) => {
+    return webhookService.listDeliveries(
+      context.dbTx,
+      input,
+      context.authContext.orgId,
+    );
+  });
+
+const retryDelivery = adminProcedure
+  .use(requireScopes('webhooks:manage'))
+  .route({
+    method: 'POST',
+    path: '/webhook-deliveries/{deliveryId}/retry',
+    summary: 'Retry a webhook delivery',
+    description:
+      'Requeues a delivery, clearing the previous attempt’s status and error. ' +
+      'Responds 404 if the delivery or its endpoint is not in this ' +
+      'organization.',
+    operationId: 'retryWebhookDelivery',
+    tags: ['Webhooks'],
+  })
+  .input(deliveryIdParamSchema)
+  .output(webhookDeliveryResponseSchema)
+  .handler(async ({ input, context }) => {
+    const env = validateEnv();
+    const orgId = context.authContext.orgId;
+
+    const delivery = await webhookService
+      .retryDelivery(context.dbTx, input.deliveryId, orgId)
+      .catch(mapServiceError);
+
+    // Not subsumed by the predicate above: that scopes the delivery, this join
+    // scopes the endpoint it points at. The FK guarantees existence, not org
+    // affinity. The worker re-reads url/secret, so nothing is taken from here.
+    const endpoint = await webhookService.getEndpointForDelivery(
+      context.dbTx,
+      input.deliveryId,
+      orgId,
+    );
+    if (!endpoint) {
+      mapServiceError(
+        new WebhookEndpointNotFoundError(delivery.webhookEndpointId),
+      );
+    }
+
+    // Retry, not a fresh enqueue: the previous job is still retained under this
+    // delivery id and would dedup a plain add into a no-op.
+    await enqueueWebhookRetry(env, {
+      deliveryId: delivery.id,
+      orgId,
+      payload: {
+        id: delivery.id,
+        event: delivery.eventType,
+        timestamp: new Date().toISOString(),
+        organizationId: orgId,
+        data: delivery.payload as Record<string, unknown>,
+      },
+    });
+
+    await context.audit({
+      action: AuditActions.WEBHOOK_DELIVERY_RETRIED,
+      resource: AuditResources.WEBHOOK_DELIVERY,
+      resourceId: input.deliveryId,
+    });
+
+    return delivery;
+  });
+
+// ---------------------------------------------------------------------------
+// Assembled router
+// ---------------------------------------------------------------------------
+
+export const webhooksRouter = {
+  list,
+  create,
+  getById,
+  update,
+  delete: deleteEndpoint,
+  rotateSecret,
+  test,
+  deliveries,
+  retryDelivery,
+};

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -490,6 +490,12 @@ Ordered as the design doc's Phase 0/D.
       — a site catching an error from a raw `pool.query` is not Drizzle-wrapped and is correct
       as written. Point the wrapped ones at `services/pg-errors.ts`. Note fixing these is a
       behaviour change: the domain errors they guard have never fired.
+      **Corrected 2026-07-31 — the list is not exhaustive.** `rest/error-mapper.ts:223` is a
+      **tenth** production direct-form site, and it matters more than the others because it
+      is the surface-wide fallback: it is why a duplicate-key error renders differently on
+      REST than on tRPC, whose mapper recurses `cause`. In `queue-preset.service.ts` the
+      declaration is `:33` as cited, but the comparison itself is `:38`. `pg-errors.ts` now
+      has two importers, `pipeline.service.ts:40` and `issue.service.ts:30`.
       — (found 2026-07-31 while fixing the `issueService` instance)
 - [x] **[P2] `pipeline.service.ts` writes drop the org predicate.** Filed as three methods; it
       was **five reachable defects**, and the two framed as "worse" were the only live ones.
@@ -535,8 +541,14 @@ Ordered as the design doc's Phase 0/D.
       `users` and returns that person's email. Needs a membership lookup against
       `organization_members`, not a predicate, which is why it was left out of the predicate
       change. Decide the semantics first: guests, deactivated users, and staff who belong to
-      both orgs are all reachable cases, and the same question applies to
-      `submission-reviewer.service.ts`. — (found 2026-07-30 while scoping `pipelineService`)
+      both orgs are all reachable cases.
+      **Corrected 2026-07-31 — `submission-reviewer.service.ts` is not a second instance.**
+      The entry claimed the same question applies there; it does not. That service already
+      validates, in `validateOrgMembership` (`:181-202`, called from `assignWithAudit:216`),
+      throwing `ReviewerNotOrgMemberError` — which is mapped on both surfaces. It is a
+      working in-repo precedent for the ~20 lines this needs, not a co-victim, and copying
+      it is most of the fix. Current lines: `assignCopyeditor` `:500`, `assignProofreader`
+      `:551`. — (found 2026-07-30 while scoping `pipelineService`)
 - [x] **[P2] `issue.service.ts:65,122` take `orgId?` as optional and apply the predicate
       conditionally.** An optional org id is a silent bypass: omit the argument and the query
       is unscoped, with nothing at the type level to flag it. Make it required, matching the
@@ -630,15 +642,26 @@ Ordered as the design doc's Phase 0/D.
       match a recorded expectation.
       **Rescoped 2026-07-30 after reading the file — two corrections.** (1) It asserts **all
       four** DML privileges via `toEqual` (`:288-310`), not SELECT alone as this entry claimed.
-      (2) A policy-expression check **already exists** at `:642-673`: it selects `qual` from
+      (2) A policy-expression check **already exists** — at `:608-674` (the entry said
+      `:642-673`, which lands mid-block; re-verified 2026-07-31). It selects `qual` from
       `pg_policies` and requires the substring `current_org_id()` _or_
       `current_setting('app.current_org`. So this is "sharpen an existing check", not "add one",
       and the specific weaknesses are: the disjunction treats the two idioms as
       interchangeable — so it can never be the gate for the two-idioms item above — no column
       name is asserted (a policy scoped to the wrong uuid column passes), `with_check` is not
-      selected, and 17 tables are excluded outright by `orgPolicyExceptions` (`:618-636`).
+      selected **by this check**, and 17 tables are excluded outright by
+      `orgPolicyExceptions` (`:618-636`, both exact).
       Note `pipeline_history` and `pipeline_comments` pass only because their subquery text
       happens to contain `current_org_id()`.
+      **Three further corrections, 2026-07-31.** (1) "`with_check` is not selected" is true
+      of this gate but **false of the file** — it is selected at `:710`, in the separate
+      nullable-policy test, so the fix is to widen an existing query rather than introduce
+      the column. (2) The second idiom is matched as an **unterminated substring**
+      (`current_setting('app.current_org` has no closing quote or paren), so a policy reading
+      `app.current_organization_anything` would satisfy it. (3) `qual` is typed non-nullable
+      while `pg_policies.qual` is NULL for WITH CHECK-only policies — such a row throws on
+      `.includes` rather than failing the assertion cleanly, so the gate would report a crash
+      instead of a violation.
       Still absent entirely: any check that the Drizzle schema and the migration SQL agree,
       which is the class of drift `db:verify` catches for FK constraints only. Deliberately left
       out of the P2.0 audit as a separate concern from F1 and too large to ride inside it. —
@@ -657,7 +680,17 @@ Ordered as the design doc's Phase 0/D.
       Sharpest edge: `embed-submission.service.ts:95` returns an existing user id
       on an email match even when that account belongs to another tenant, attributing the embed
       submission to them. Deliberate — it is how a known writer submitting through an embed gets
-      linked — but it wants a decision on identity semantics, not a patch. — (found 2026-07-28
+      linked — but it wants a decision on identity semantics, not a patch.
+      **Re-verified 2026-07-31: all nine line numbers exact, and the list is confirmed
+      exhaustive** — every other `users.email` reference in `apps/api/src` is a projection or
+      join column whose `WHERE` keys on an id. Two refinements. (1) "four unauthenticated" is
+      ambiguous and undercounts: **five** sites take no credential at all (the three embed
+      reads plus the two federation discovery routes), or four if the embed path counts once;
+      `simsub:329` and `migration:503` are S2S-authenticated by HTTP signature, which is not
+      the same as user-authenticated and should not be lumped in with the rest. (2)
+      `docs/tenant-isolation-audit.md` §4.4 is a **tracked** doc carrying the same
+      eight-vs-nine inconsistency this entry already fixed, plus stale line numbers
+      throughout — corrected 2026-07-31 in the same pass. — (found 2026-07-28
       during the P2.0 audit)
 - [x] **[P1] No per-key rate limits.** `hooks/rate-limit-auth.ts:57` keyed the authenticated
       window on `userId`, which for key auth is the key's _creator_ — so all of an admin's
@@ -800,7 +833,15 @@ Ordered as the design doc's Phase 0/D.
       interface is not the only suppression — `:100` also casts the input object to
       `Parameters<typeof trpc.audit.list.useQuery>[0]`, so both must go or the cast will swallow
       the corrected field names too; and the type to import is **`AuditEventResponse`**, since
-      `@colophony/types` exports no symbol named `AuditEvent`. — (found 2026-07-30 while mapping the audit read
+      `@colophony/types` exports no symbol named `AuditEvent`.
+      **Sharpened 2026-07-31:** a type literally named `AuditEvent` _does_ exist — exported
+      from **`@colophony/db`** at `packages/db/src/types.ts:56`, as
+      `InferSelectModel<typeof auditEvents>`. So whoever fixes this will find it by name and
+      must choose deliberately: `@colophony/db`'s is the raw row (dates as `Date`, every
+      column), while `@colophony/types`' `AuditEventResponse` is the wire shape the tRPC
+      procedure actually returns. Import the latter. Both packages are already dependencies
+      of `apps/web`, so neither choice fails at install time — which is exactly why this
+      wants stating rather than leaving to inference. — (found 2026-07-30 while mapping the audit read
       surface)
 - [ ] **[P2] Honour `X-Act-As-User` on ordinary org-scoped API keys.** `hooks/auth.ts:344`
       unconditionally sets `userId: creator.id` for `authMethod: 'apikey'`, so every action a
@@ -1201,6 +1242,15 @@ assumed missing and are in fact already exposed — see §0 of the design doc.
       today**. This needs a context change first, not just a middleware, which makes it larger
       than the equivalent tRPC work would be. The only header-reading code on the whole surface
       is in the Fastify hooks.
+      **Narrowed 2026-07-31 — the constraint is real but was overstated.** It holds for
+      _middleware_, which is what this item needs. It does not hold for oRPC as a whole:
+      1.14.10 exposes a per-route `inputStructure` option that lets an individual
+      **procedure** receive headers as part of its input. Nothing in this repo uses it, and
+      it is the wrong tool here — a per-route opt-in would put the burden on every author
+      rather than enforcing the rule centrally, which is precisely what D3 chose against.
+      Recorded because "no header can reach oRPC at all" would misinform whoever re-estimates
+      this, and the manifest test D3 specifies is only meaningful if the mechanism is
+      central.
       **D3 taken 2026-07-31: every `/v1` `POST`, not only the blocking set.** The selective
       rule was cheaper only under a cost model that assumed the header was already available,
       and the constraint above removes that. Three things from the record. The context field

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1087,19 +1087,57 @@ Ordered as the design doc's Phase 0/D.
 blocked on a decision any more. Note that votes, reviewer assignment, and invitations were
 assumed missing and are in fact already exposed — see §0 of the design doc.
 
-- [ ] **[P1] Webhook endpoint management over REST** (9 tRPC procs, `webhooks:manage`
-      already exists). **Unblocked 2026-07-31 — D2 taken:** per-org endpoints keep
-      `webhook_endpoints` unchanged and instance subscriptions get their own table, so the
-      nine procedures port with no change to their inputs or responses. None of them accepts
-      an `organizationId` and `webhookEndpointResponseSchema` declares none, so there is no
-      ownership discriminator to publish and nothing here has to change if instance
-      principals never ship. Per D3 the six mutating routes are manifest entries for
-      `Idempotency-Key` — not a prerequisite, since an optional header is additive, but they
-      should be listed rather than forgotten. Two things to fix on the way: four of the nine
-      procedures throw bare `Error` rather than domain error classes, and
-      `WebhookUrlValidationError` is absent from `rest/error-mapper.ts`, so an SSRF rejection
-      would 500 on REST. The new router is appended to `restRouter`, never inserted — key
-      order sets operation order in the spec. — (design doc §1.9, P1.1)
+- [x] **[P1] Webhook endpoint management over REST** (9 tRPC procs, `webhooks:manage`
+      already existed). **Unblocked 2026-07-31 by D2**, and shipped the same day as
+      `/v1/webhooks` + `/v1/webhook-deliveries`. D2 held exactly as predicted: per-org
+      endpoints kept `webhook_endpoints` unchanged, no procedure accepts an
+      `organizationId`, and `webhookEndpointResponseSchema` declares none, so nothing
+      published here changes if instance principals never ship. Per D3 the six mutating
+      routes are future `Idempotency-Key` manifest entries — listed, not implemented, since
+      no request header reaches the oRPC context yet. 105 paths / 155 operations.
+      **Three things this entry got wrong, corrected on the way through:**
+      (1) "four of the nine procedures throw bare `Error`" — it was **five throw sites
+      across two procedures** (`test`, `retryDelivery`); the larger defect was the other
+      four returning `null`/`undefined`/`void` on a miss, so `getById` answered `200 null`
+      and `delete` reported success for an id that never existed.
+      (2) `WebhookUrlValidationError` was absent from **both** error-mappers, not just the
+      REST one, so an SSRF rejection was a 500 on either surface.
+      (3) **No tRPC webhook procedure declared `.output()`**, so all three response schemas
+      in `packages/types/src/webhook.ts` were defined but unreferenced — the REST port is
+      their first consumer, which is also what surfaced the untyped `eventTypes` jsonb.
+      Split into two PRs: the service hardening landed first (see the org-predicate item
+      below), because the port sat on a live cross-tenant write. — (design doc §1.9, P1.1;
+      done 2026-07-31)
+- [x] **[P2] `webhookService` delivery methods carried no org predicate.** The
+      2026-03-04 defense-in-depth pass (checked off further down this file) fixed
+      `getEndpoint`, `listEndpoints`, `updateEndpoint`, `deleteEndpoint` and `rotateSecret`
+      and missed **every method touching `webhook_deliveries`**, so the item read as closed
+      while four still queried by id alone. `retryDelivery` was the live one: it updated
+      the row by id with no org term, and checked ownership only _after_ the mutation.
+      Since tRPC turns a throw into a normal reply, `db-context` **committed** that write
+      rather than rolling it back — another org's delivery was left permanently QUEUED with
+      its failure fields nulled. `listDeliveries` took
+      `organizationId?` applied under an `if`, and `endpointId` is caller-supplied.
+      `updateDeliveryStatus`/`countRecentFailures` are defence-in-depth only — their caller
+      resolves the delivery through the org-scoped join first — but an unscoped
+      `countRecentFailures` also let one tenant's failures feed another's auto-disable
+      threshold. Pinned by `__tests__/rls/webhook-service.test.ts` (23 cases; measured
+      2/2/2/3/1/1/5 failures per revert, and the two `retryDelivery` halves need a
+      write-only case to be distinguishable at all). — (found 2026-07-31 while scoping
+      P1.1; done 2026-07-31)
+- [ ] **[P2] `getActiveEndpointsForEvent` is an unbounded tenant query.**
+      `webhook.service.ts` returns every ACTIVE endpoint matching an event with no `LIMIT`
+      or pagination. Raised during the P1.1 review and deliberately **not** fixed there: it
+      is the fan-out path, so a truncating limit would silently stop delivering to whichever
+      endpoints fell off the end — strictly worse than the unbounded read. Wants batching,
+      which is its own change. — (found 2026-07-31)
+- [ ] **[P3] `webhooks.test` is audited on neither surface.** It writes a
+      `webhook_deliveries` row and enqueues a job — a real state change — but emits no audit
+      event on tRPC or REST. There is no `WEBHOOK_ENDPOINT_TESTED` action, and the typed
+      detail union in `packages/types/src/audit.ts` closes `WEBHOOK_ENDPOINT` to five, so
+      adding one is a `@colophony/types` change that has to land on both surfaces at once to
+      preserve parity. The REST router spec pins the current absence so it cannot be
+      "fixed" on one surface only. — (found 2026-07-31 during P1.1)
 - [x] **[P1] Notifications over REST** (list, unread-count, mark-read, mark-all-read + 3
       preference procs). Only path today is SSE, unusable for consumers that cannot hold a
       connection. — (design doc §1.7, P1.2; done 2026-07-29, PR pending)

--- a/docs/file-index.md
+++ b/docs/file-index.md
@@ -25,7 +25,7 @@ Quick-reference index of important files across the codebase.
 | **Fastify hooks**          | `apps/api/src/hooks/` (auth, rate-limit, org-context, db-context, audit)                                        |
 | **Service layer**          | `apps/api/src/services/`                                                                                        |
 | **tRPC**                   | `apps/api/src/trpc/` — intended internal, but API keys reach it too (see `docs/api-integration-design.md` §0.1) |
-| **REST (oRPC, public)**    | `apps/api/src/rest/` (`context.ts` = procedure builders + `requireScopes`, `routers/` = 146 operations)         |
+| **REST (oRPC, public)**    | `apps/api/src/rest/` (`context.ts` = procedure builders + `requireScopes`, `routers/` = 155 operations)         |
 | **Zitadel webhook**        | `apps/api/src/webhooks/zitadel.webhook.ts`                                                                      |
 | **Stripe webhook**         | `apps/api/src/webhooks/stripe.webhook.ts`                                                                       |
 | **Documenso webhook**      | `apps/api/src/webhooks/documenso.webhook.ts`                                                                    |
@@ -102,14 +102,14 @@ Quick-reference index of important files across the codebase.
 
 ## SDKs & Scripts
 
-| What                | Path                                                                                                                                                                                                                           |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **OpenAPI spec**    | `sdks/openapi.json` — 99 paths / 146 operations, current as of 2026-07-31. Was five months stale until 2026-07-27; `sdk-check` now gates three directions (source → spec, spec → TS SDK, spec → Python SDK), so drift fails CI |
-| **TypeScript SDK**  | `sdks/typescript/` (`@colophony/sdk` — openapi-fetch + generated types)                                                                                                                                                        |
-| **Python SDK**      | `sdks/python/` (`colophony` — openapi-python-client generated)                                                                                                                                                                 |
-| **Spec export**     | `scripts/export-openapi.ts` (builds the document in-process via `OpenAPIGenerator` — no server, database or Redis, so it runs in CI; `--check` fails on drift)                                                                 |
-| **SDK generation**  | `scripts/generate-sdks.ts` (regenerate both SDKs from committed spec)                                                                                                                                                          |
-| **SDK drift check** | `.github/workflows/ci.yml` `sdk-check` job — gates three directions since 2026-07-27: source → spec, spec → TS SDK, spec → Python SDK. Needs a workspace build first; detects Python drift with `git status`, not `git diff`   |
+| What                | Path                                                                                                                                                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **OpenAPI spec**    | `sdks/openapi.json` — 105 paths / 155 operations, current as of 2026-07-31. Was five months stale until 2026-07-27; `sdk-check` now gates three directions (source → spec, spec → TS SDK, spec → Python SDK), so drift fails CI |
+| **TypeScript SDK**  | `sdks/typescript/` (`@colophony/sdk` — openapi-fetch + generated types)                                                                                                                                                         |
+| **Python SDK**      | `sdks/python/` (`colophony` — openapi-python-client generated)                                                                                                                                                                  |
+| **Spec export**     | `scripts/export-openapi.ts` (builds the document in-process via `OpenAPIGenerator` — no server, database or Redis, so it runs in CI; `--check` fails on drift)                                                                  |
+| **SDK generation**  | `scripts/generate-sdks.ts` (regenerate both SDKs from committed spec)                                                                                                                                                           |
+| **SDK drift check** | `.github/workflows/ci.yml` `sdk-check` job — gates three directions since 2026-07-27: source → spec, spec → TS SDK, spec → Python SDK. Needs a workspace build first; detects Python drift with `git status`, not `git diff`    |
 
 ## Infrastructure & Ops
 

--- a/docs/tenant-isolation-audit.md
+++ b/docs/tenant-isolation-audit.md
@@ -143,25 +143,38 @@ All six are deliberate. Recorded so the next audit does not re-open them.
 ### 4.4 BY-ID-ONLY — cross-tenant lookup keys
 
 34 sites resolve a row by primary or natural key. Most are unremarkable. The ones worth naming
-share a property: **an email address is a cross-tenant lookup key**, and eight sites use it.
+share a property: **an email address is a cross-tenant lookup key**, and nine sites use it.
 
-| Site                                                        | Reachable without auth         |
-| ----------------------------------------------------------- | ------------------------------ |
-| `services/organization.service.ts:203` (`addMember`)        | no — ADMIN only                |
-| `services/embed-submission.service.ts:92`, `:121`, `:138`   | **yes** — embed intake         |
-| `services/federation.service.ts:437` (`resolveWebFinger`)   | **yes** — federation discovery |
-| `services/federation.service.ts:523` (`getUserDidDocument`) | **yes** — federation discovery |
-| `services/simsub.service.ts:324`                            | **yes** — inbound S2S          |
-| `services/migration.service.ts:494`                         | **yes** — inbound S2S          |
-| `hooks/auth.ts:456`                                         | no — JIT link on 23505         |
+**Corrected 2026-07-31.** The prose said "eight" while the table listed nine, and every line
+number below was stale — they pointed at the opening `await db`/`await tx` rather than the
+`where` a few lines down. Both are now the predicate lines, re-verified against the tree.
+Two were wrong beyond drift: `organization.service.ts:203` was in a different method's return
+block, and `hooks/auth.ts:456` is an `onConflictDoUpdate` keyed on `zitadelUserId`, not email.
+The list is confirmed exhaustive — every other `users.email` reference in `apps/api/src` is a
+projection or join column whose `WHERE` keys on an id.
+
+| Site                                                        | Op     | Reachable without auth         |
+| ----------------------------------------------------------- | ------ | ------------------------------ |
+| `services/organization.service.ts:220` (`addMember`)        | SELECT | no — ADMIN only                |
+| `services/embed-submission.service.ts:95`, `:124`, `:141`   | SELECT | **yes** — embed intake         |
+| `services/federation.service.ts:440` (`resolveWebFinger`)   | SELECT | **yes** — federation discovery |
+| `services/federation.service.ts:533` (`getUserDidDocument`) | SELECT | **yes** — federation discovery |
+| `services/simsub.service.ts:329`                            | SELECT | S2S signature, not user auth   |
+| `services/migration.service.ts:503`                         | SELECT | S2S signature, not user auth   |
+| `hooks/auth.ts:495`                                         | UPDATE | no — JIT link on 23505         |
+
+Two things the earlier table obscured. `hooks/auth.ts:495` is an **UPDATE**, not a SELECT,
+which matters to anyone auditing read paths only. And the two S2S rows are authenticated —
+by HTTP signature against a known peer — so the no-credential count is **five** (the three
+embed reads plus the two federation discovery routes), not seven.
 
 Two observations:
 
-- `resolveWebFinger` (`:437`) filters on email alone. Its sibling `getUserDidDocument` (`:523`)
+- `resolveWebFinger` (`:440`) filters on email alone. Its sibling `getUserDidDocument` (`:533`)
   filters `email` **and** `isNull(deletedAt)` **and** `eq(isGuest, false)`. The asymmetry looks
   unintended: the laxer of the two is the unauthenticated discovery endpoint, so a deleted or
   guest account is discoverable through one path and not the other. Tracked as P2.
-- `embed-submission.service.ts:92` returns the existing user id when the email matches, including
+- `embed-submission.service.ts:95` returns the existing user id when the email matches, including
   when that account is a real user in another tenant — the embed submission is then attributed to
   them. Deliberate (it is how a known writer submitting through an embed is linked), but it is the
   sharpest edge of email-as-key and belongs in the P3 design question rather than a patch.

--- a/sdks/openapi.json
+++ b/sdks/openapi.json
@@ -89,6 +89,10 @@
     {
       "name": "Notifications",
       "description": "Read in-app notifications and manage delivery preferences. The inbox belongs to the user a credential acts as, not to the organization — use webhooks for organization-level events."
+    },
+    {
+      "name": "Webhooks",
+      "description": "Register HTTPS endpoints to receive organization-level events, and inspect or retry their delivery history. Signing secrets are returned only on registration and rotation, and cannot be read back."
     }
   ],
   "externalDocs": {
@@ -23734,6 +23738,951 @@
                       "updatedAt"
                     ]
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webhooks": {
+      "get": {
+        "operationId": "listWebhookEndpoints",
+        "summary": "List webhook endpoints",
+        "description": "Returns the organization’s registered webhook endpoints, newest first. Signing secrets are never included.",
+        "tags": ["Webhooks"],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991,
+              "default": 1,
+              "description": "Page number (1-based)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Items per page (1-100, default 20)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "url": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "eventTypes": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "status": {
+                            "enum": ["ACTIVE", "DISABLED"],
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "x-native-type": "date"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "x-native-type": "date"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "url",
+                          "description",
+                          "eventTypes",
+                          "status",
+                          "createdAt",
+                          "updatedAt"
+                        ]
+                      },
+                      "description": "Items on the current page"
+                    },
+                    "total": {
+                      "type": "number",
+                      "description": "Total number of items across all pages"
+                    },
+                    "page": {
+                      "type": "number",
+                      "description": "Current page number"
+                    },
+                    "limit": {
+                      "type": "number",
+                      "description": "Items per page"
+                    },
+                    "totalPages": {
+                      "type": "number",
+                      "description": "Total number of pages"
+                    }
+                  },
+                  "required": ["items", "total", "page", "limit", "totalPages"]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createWebhookEndpoint",
+        "summary": "Register a webhook endpoint",
+        "description": "Registers an HTTPS endpoint to receive the selected events. The URL is validated against SSRF rules — it must be a public HTTPS address. The signing secret is returned **only** by this operation and by endpoint creation — it cannot be read back afterwards. Store it before discarding the response.",
+        "tags": ["Webhooks"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "maxLength": 2048,
+                    "format": "uri"
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 512
+                  },
+                  "eventTypes": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "enum": [
+                        "hopper/submission.submitted",
+                        "hopper/submission.accepted",
+                        "hopper/submission.rejected",
+                        "hopper/submission.withdrawn",
+                        "slate/pipeline.copyeditor-assigned",
+                        "slate/pipeline.copyedit-completed",
+                        "slate/pipeline.author-review-completed",
+                        "slate/pipeline.proofread-completed",
+                        "slate/contract.generated",
+                        "slate/issue.published",
+                        "webhook.test"
+                      ],
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": ["url", "eventTypes"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "url": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "eventTypes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "status": {
+                      "enum": ["ACTIVE", "DISABLED"],
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    },
+                    "secret": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "url",
+                    "description",
+                    "eventTypes",
+                    "status",
+                    "createdAt",
+                    "updatedAt",
+                    "secret"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webhooks/{id}": {
+      "get": {
+        "operationId": "getWebhookEndpoint",
+        "summary": "Get a webhook endpoint",
+        "description": "Returns one webhook endpoint. Responds 404 for an endpoint belonging to another organization, which is indistinguishable from one that does not exist. The signing secret is never included.",
+        "tags": ["Webhooks"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Resource UUID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "url": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "eventTypes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "status": {
+                      "enum": ["ACTIVE", "DISABLED"],
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "url",
+                    "description",
+                    "eventTypes",
+                    "status",
+                    "createdAt",
+                    "updatedAt"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateWebhookEndpoint",
+        "summary": "Update a webhook endpoint",
+        "description": "Updates the URL, description, subscribed events, or status. A changed URL is re-validated against SSRF rules. Signing secrets are never included in the response — rotate the secret to obtain a new one.",
+        "tags": ["Webhooks"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Resource UUID"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "maxLength": 2048,
+                    "format": "uri"
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 512
+                  },
+                  "eventTypes": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "enum": [
+                        "hopper/submission.submitted",
+                        "hopper/submission.accepted",
+                        "hopper/submission.rejected",
+                        "hopper/submission.withdrawn",
+                        "slate/pipeline.copyeditor-assigned",
+                        "slate/pipeline.copyedit-completed",
+                        "slate/pipeline.author-review-completed",
+                        "slate/pipeline.proofread-completed",
+                        "slate/contract.generated",
+                        "slate/issue.published",
+                        "webhook.test"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "status": {
+                    "enum": ["ACTIVE", "DISABLED"],
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "url": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "eventTypes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "status": {
+                      "enum": ["ACTIVE", "DISABLED"],
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "url",
+                    "description",
+                    "eventTypes",
+                    "status",
+                    "createdAt",
+                    "updatedAt"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteWebhookEndpoint",
+        "summary": "Delete a webhook endpoint",
+        "description": "Deletes the endpoint and its delivery history. Responds 404 rather than reporting success for an endpoint that does not exist.",
+        "tags": ["Webhooks"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Resource UUID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "const": true,
+                      "description": "Always true on success"
+                    }
+                  },
+                  "required": ["success"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webhooks/{id}/rotate-secret": {
+      "post": {
+        "operationId": "rotateWebhookEndpointSecret",
+        "summary": "Rotate a webhook signing secret",
+        "description": "Generates a new signing secret and invalidates the previous one. In-flight deliveries are signed with whichever secret is current when they are sent, so rotate during a quiet period if signature continuity matters. The signing secret is returned **only** by this operation and by endpoint creation — it cannot be read back afterwards. Store it before discarding the response.",
+        "tags": ["Webhooks"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Resource UUID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "url": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "eventTypes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "status": {
+                      "enum": ["ACTIVE", "DISABLED"],
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    },
+                    "secret": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "url",
+                    "description",
+                    "eventTypes",
+                    "status",
+                    "createdAt",
+                    "updatedAt",
+                    "secret"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webhooks/{id}/test": {
+      "post": {
+        "operationId": "testWebhookEndpoint",
+        "summary": "Send a test delivery",
+        "description": "Queues a `webhook.test` delivery to the endpoint and returns its id. Delivery is asynchronous — poll `GET /webhook-deliveries` for the outcome. Rejected with 400 if the endpoint is disabled.",
+        "tags": ["Webhooks"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Resource UUID"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "deliveryId": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "The queued test delivery — poll it via GET /webhook-deliveries"
+                    }
+                  },
+                  "required": ["deliveryId"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webhook-deliveries": {
+      "get": {
+        "operationId": "listWebhookDeliveries",
+        "summary": "List webhook deliveries",
+        "description": "Returns delivery attempts across the organization’s endpoints, newest first. Filter by endpoint, event type, or status to narrow it.",
+        "tags": ["Webhooks"],
+        "parameters": [
+          {
+            "name": "endpointId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "eventType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "QUEUED",
+                "DELIVERING",
+                "DELIVERED",
+                "FAILED",
+                "CANCELLED"
+              ],
+              "type": "string"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991,
+              "default": 1,
+              "description": "Page number (1-based)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20,
+              "description": "Items per page (1-100, default 20)"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "webhookEndpointId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "eventType": {
+                            "type": "string"
+                          },
+                          "eventId": {
+                            "type": "string"
+                          },
+                          "payload": {},
+                          "status": {
+                            "enum": [
+                              "QUEUED",
+                              "DELIVERING",
+                              "DELIVERED",
+                              "FAILED",
+                              "CANCELLED"
+                            ],
+                            "type": "string"
+                          },
+                          "httpStatusCode": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "responseBody": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "errorMessage": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "attempts": {
+                            "type": "number"
+                          },
+                          "nextRetryAt": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "date-time",
+                                "x-native-type": "date"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "deliveredAt": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "date-time",
+                                "x-native-type": "date"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "x-native-type": "date"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "webhookEndpointId",
+                          "eventType",
+                          "eventId",
+                          "status",
+                          "httpStatusCode",
+                          "responseBody",
+                          "errorMessage",
+                          "attempts",
+                          "nextRetryAt",
+                          "deliveredAt",
+                          "createdAt"
+                        ]
+                      },
+                      "description": "Items on the current page"
+                    },
+                    "total": {
+                      "type": "number",
+                      "description": "Total number of items across all pages"
+                    },
+                    "page": {
+                      "type": "number",
+                      "description": "Current page number"
+                    },
+                    "limit": {
+                      "type": "number",
+                      "description": "Items per page"
+                    },
+                    "totalPages": {
+                      "type": "number",
+                      "description": "Total number of pages"
+                    }
+                  },
+                  "required": ["items", "total", "page", "limit", "totalPages"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webhook-deliveries/{deliveryId}/retry": {
+      "post": {
+        "operationId": "retryWebhookDelivery",
+        "summary": "Retry a webhook delivery",
+        "description": "Requeues a delivery, clearing the previous attempt’s status and error. Responds 404 if the delivery or its endpoint is not in this organization.",
+        "tags": ["Webhooks"],
+        "parameters": [
+          {
+            "name": "deliveryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Webhook delivery UUID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "webhookEndpointId": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "eventType": {
+                      "type": "string"
+                    },
+                    "eventId": {
+                      "type": "string"
+                    },
+                    "payload": {},
+                    "status": {
+                      "enum": [
+                        "QUEUED",
+                        "DELIVERING",
+                        "DELIVERED",
+                        "FAILED",
+                        "CANCELLED"
+                      ],
+                      "type": "string"
+                    },
+                    "httpStatusCode": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "responseBody": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "errorMessage": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "attempts": {
+                      "type": "number"
+                    },
+                    "nextRetryAt": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date-time",
+                          "x-native-type": "date"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "deliveredAt": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date-time",
+                          "x-native-type": "date"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "webhookEndpointId",
+                    "eventType",
+                    "eventId",
+                    "status",
+                    "httpStatusCode",
+                    "responseBody",
+                    "errorMessage",
+                    "attempts",
+                    "nextRetryAt",
+                    "deliveredAt",
+                    "createdAt"
+                  ]
                 }
               }
             }

--- a/sdks/python/colophony/api/webhooks/__init__.py
+++ b/sdks/python/colophony/api/webhooks/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/sdks/python/colophony/api/webhooks/create_webhook_endpoint.py
+++ b/sdks/python/colophony/api/webhooks/create_webhook_endpoint.py
@@ -1,0 +1,176 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_webhook_endpoint_body import CreateWebhookEndpointBody
+from ...models.create_webhook_endpoint_response_201 import CreateWebhookEndpointResponse201
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: CreateWebhookEndpointBody,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/webhooks",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> CreateWebhookEndpointResponse201 | None:
+    if response.status_code == 201:
+        response_201 = CreateWebhookEndpointResponse201.from_dict(response.json())
+
+        return response_201
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[CreateWebhookEndpointResponse201]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateWebhookEndpointBody,
+) -> Response[CreateWebhookEndpointResponse201]:
+    """Register a webhook endpoint
+
+     Registers an HTTPS endpoint to receive the selected events. The URL is validated against SSRF rules
+    — it must be a public HTTPS address. The signing secret is returned **only** by this operation and
+    by endpoint creation — it cannot be read back afterwards. Store it before discarding the response.
+
+    Args:
+        body (CreateWebhookEndpointBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[CreateWebhookEndpointResponse201]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateWebhookEndpointBody,
+) -> CreateWebhookEndpointResponse201 | None:
+    """Register a webhook endpoint
+
+     Registers an HTTPS endpoint to receive the selected events. The URL is validated against SSRF rules
+    — it must be a public HTTPS address. The signing secret is returned **only** by this operation and
+    by endpoint creation — it cannot be read back afterwards. Store it before discarding the response.
+
+    Args:
+        body (CreateWebhookEndpointBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        CreateWebhookEndpointResponse201
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateWebhookEndpointBody,
+) -> Response[CreateWebhookEndpointResponse201]:
+    """Register a webhook endpoint
+
+     Registers an HTTPS endpoint to receive the selected events. The URL is validated against SSRF rules
+    — it must be a public HTTPS address. The signing secret is returned **only** by this operation and
+    by endpoint creation — it cannot be read back afterwards. Store it before discarding the response.
+
+    Args:
+        body (CreateWebhookEndpointBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[CreateWebhookEndpointResponse201]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: CreateWebhookEndpointBody,
+) -> CreateWebhookEndpointResponse201 | None:
+    """Register a webhook endpoint
+
+     Registers an HTTPS endpoint to receive the selected events. The URL is validated against SSRF rules
+    — it must be a public HTTPS address. The signing secret is returned **only** by this operation and
+    by endpoint creation — it cannot be read back afterwards. Store it before discarding the response.
+
+    Args:
+        body (CreateWebhookEndpointBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        CreateWebhookEndpointResponse201
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/sdks/python/colophony/api/webhooks/delete_webhook_endpoint.py
+++ b/sdks/python/colophony/api/webhooks/delete_webhook_endpoint.py
@@ -1,0 +1,168 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.delete_webhook_endpoint_response_200 import DeleteWebhookEndpointResponse200
+from ...types import Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/webhooks/{id}".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> DeleteWebhookEndpointResponse200 | None:
+    if response.status_code == 200:
+        response_200 = DeleteWebhookEndpointResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[DeleteWebhookEndpointResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[DeleteWebhookEndpointResponse200]:
+    """Delete a webhook endpoint
+
+     Deletes the endpoint and its delivery history. Responds 404 rather than reporting success for an
+    endpoint that does not exist.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[DeleteWebhookEndpointResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> DeleteWebhookEndpointResponse200 | None:
+    """Delete a webhook endpoint
+
+     Deletes the endpoint and its delivery history. Responds 404 rather than reporting success for an
+    endpoint that does not exist.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        DeleteWebhookEndpointResponse200
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[DeleteWebhookEndpointResponse200]:
+    """Delete a webhook endpoint
+
+     Deletes the endpoint and its delivery history. Responds 404 rather than reporting success for an
+    endpoint that does not exist.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[DeleteWebhookEndpointResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> DeleteWebhookEndpointResponse200 | None:
+    """Delete a webhook endpoint
+
+     Deletes the endpoint and its delivery history. Responds 404 rather than reporting success for an
+    endpoint that does not exist.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        DeleteWebhookEndpointResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/sdks/python/colophony/api/webhooks/get_webhook_endpoint.py
+++ b/sdks/python/colophony/api/webhooks/get_webhook_endpoint.py
@@ -1,0 +1,168 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.get_webhook_endpoint_response_200 import GetWebhookEndpointResponse200
+from ...types import Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/webhooks/{id}".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> GetWebhookEndpointResponse200 | None:
+    if response.status_code == 200:
+        response_200 = GetWebhookEndpointResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[GetWebhookEndpointResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[GetWebhookEndpointResponse200]:
+    """Get a webhook endpoint
+
+     Returns one webhook endpoint. Responds 404 for an endpoint belonging to another organization, which
+    is indistinguishable from one that does not exist. The signing secret is never included.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GetWebhookEndpointResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> GetWebhookEndpointResponse200 | None:
+    """Get a webhook endpoint
+
+     Returns one webhook endpoint. Responds 404 for an endpoint belonging to another organization, which
+    is indistinguishable from one that does not exist. The signing secret is never included.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GetWebhookEndpointResponse200
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[GetWebhookEndpointResponse200]:
+    """Get a webhook endpoint
+
+     Returns one webhook endpoint. Responds 404 for an endpoint belonging to another organization, which
+    is indistinguishable from one that does not exist. The signing secret is never included.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GetWebhookEndpointResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> GetWebhookEndpointResponse200 | None:
+    """Get a webhook endpoint
+
+     Returns one webhook endpoint. Responds 404 for an endpoint belonging to another organization, which
+    is indistinguishable from one that does not exist. The signing secret is never included.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GetWebhookEndpointResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/sdks/python/colophony/api/webhooks/list_webhook_deliveries.py
+++ b/sdks/python/colophony/api/webhooks/list_webhook_deliveries.py
@@ -1,0 +1,241 @@
+from http import HTTPStatus
+from typing import Any
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.list_webhook_deliveries_response_200 import ListWebhookDeliveriesResponse200
+from ...models.list_webhook_deliveries_status import ListWebhookDeliveriesStatus
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    endpoint_id: UUID | Unset = UNSET,
+    event_type: str | Unset = UNSET,
+    status: ListWebhookDeliveriesStatus | Unset = UNSET,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    json_endpoint_id: str | Unset = UNSET
+    if not isinstance(endpoint_id, Unset):
+        json_endpoint_id = str(endpoint_id)
+    params["endpointId"] = json_endpoint_id
+
+    params["eventType"] = event_type
+
+    json_status: str | Unset = UNSET
+    if not isinstance(status, Unset):
+        json_status = status.value
+
+    params["status"] = json_status
+
+    params["page"] = page
+
+    params["limit"] = limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/webhook-deliveries",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ListWebhookDeliveriesResponse200 | None:
+    if response.status_code == 200:
+        response_200 = ListWebhookDeliveriesResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ListWebhookDeliveriesResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    endpoint_id: UUID | Unset = UNSET,
+    event_type: str | Unset = UNSET,
+    status: ListWebhookDeliveriesStatus | Unset = UNSET,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+) -> Response[ListWebhookDeliveriesResponse200]:
+    """List webhook deliveries
+
+     Returns delivery attempts across the organization’s endpoints, newest first. Filter by endpoint,
+    event type, or status to narrow it.
+
+    Args:
+        endpoint_id (UUID | Unset):
+        event_type (str | Unset):
+        status (ListWebhookDeliveriesStatus | Unset):
+        page (int | Unset): Page number (1-based) Default: 1.
+        limit (int | Unset): Items per page (1-100, default 20) Default: 20.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ListWebhookDeliveriesResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        endpoint_id=endpoint_id,
+        event_type=event_type,
+        status=status,
+        page=page,
+        limit=limit,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    endpoint_id: UUID | Unset = UNSET,
+    event_type: str | Unset = UNSET,
+    status: ListWebhookDeliveriesStatus | Unset = UNSET,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+) -> ListWebhookDeliveriesResponse200 | None:
+    """List webhook deliveries
+
+     Returns delivery attempts across the organization’s endpoints, newest first. Filter by endpoint,
+    event type, or status to narrow it.
+
+    Args:
+        endpoint_id (UUID | Unset):
+        event_type (str | Unset):
+        status (ListWebhookDeliveriesStatus | Unset):
+        page (int | Unset): Page number (1-based) Default: 1.
+        limit (int | Unset): Items per page (1-100, default 20) Default: 20.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ListWebhookDeliveriesResponse200
+    """
+
+    return sync_detailed(
+        client=client,
+        endpoint_id=endpoint_id,
+        event_type=event_type,
+        status=status,
+        page=page,
+        limit=limit,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    endpoint_id: UUID | Unset = UNSET,
+    event_type: str | Unset = UNSET,
+    status: ListWebhookDeliveriesStatus | Unset = UNSET,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+) -> Response[ListWebhookDeliveriesResponse200]:
+    """List webhook deliveries
+
+     Returns delivery attempts across the organization’s endpoints, newest first. Filter by endpoint,
+    event type, or status to narrow it.
+
+    Args:
+        endpoint_id (UUID | Unset):
+        event_type (str | Unset):
+        status (ListWebhookDeliveriesStatus | Unset):
+        page (int | Unset): Page number (1-based) Default: 1.
+        limit (int | Unset): Items per page (1-100, default 20) Default: 20.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ListWebhookDeliveriesResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        endpoint_id=endpoint_id,
+        event_type=event_type,
+        status=status,
+        page=page,
+        limit=limit,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    endpoint_id: UUID | Unset = UNSET,
+    event_type: str | Unset = UNSET,
+    status: ListWebhookDeliveriesStatus | Unset = UNSET,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+) -> ListWebhookDeliveriesResponse200 | None:
+    """List webhook deliveries
+
+     Returns delivery attempts across the organization’s endpoints, newest first. Filter by endpoint,
+    event type, or status to narrow it.
+
+    Args:
+        endpoint_id (UUID | Unset):
+        event_type (str | Unset):
+        status (ListWebhookDeliveriesStatus | Unset):
+        page (int | Unset): Page number (1-based) Default: 1.
+        limit (int | Unset): Items per page (1-100, default 20) Default: 20.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ListWebhookDeliveriesResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            endpoint_id=endpoint_id,
+            event_type=event_type,
+            status=status,
+            page=page,
+            limit=limit,
+        )
+    ).parsed

--- a/sdks/python/colophony/api/webhooks/list_webhook_endpoints.py
+++ b/sdks/python/colophony/api/webhooks/list_webhook_endpoints.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.list_webhook_endpoints_response_200 import ListWebhookEndpointsResponse200
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["page"] = page
+
+    params["limit"] = limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/webhooks",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ListWebhookEndpointsResponse200 | None:
+    if response.status_code == 200:
+        response_200 = ListWebhookEndpointsResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ListWebhookEndpointsResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+) -> Response[ListWebhookEndpointsResponse200]:
+    """List webhook endpoints
+
+     Returns the organization’s registered webhook endpoints, newest first. Signing secrets are never
+    included.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        limit (int | Unset): Items per page (1-100, default 20) Default: 20.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ListWebhookEndpointsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        page=page,
+        limit=limit,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+) -> ListWebhookEndpointsResponse200 | None:
+    """List webhook endpoints
+
+     Returns the organization’s registered webhook endpoints, newest first. Signing secrets are never
+    included.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        limit (int | Unset): Items per page (1-100, default 20) Default: 20.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ListWebhookEndpointsResponse200
+    """
+
+    return sync_detailed(
+        client=client,
+        page=page,
+        limit=limit,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+) -> Response[ListWebhookEndpointsResponse200]:
+    """List webhook endpoints
+
+     Returns the organization’s registered webhook endpoints, newest first. Signing secrets are never
+    included.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        limit (int | Unset): Items per page (1-100, default 20) Default: 20.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ListWebhookEndpointsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        page=page,
+        limit=limit,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    page: int | Unset = 1,
+    limit: int | Unset = 20,
+) -> ListWebhookEndpointsResponse200 | None:
+    """List webhook endpoints
+
+     Returns the organization’s registered webhook endpoints, newest first. Signing secrets are never
+    included.
+
+    Args:
+        page (int | Unset): Page number (1-based) Default: 1.
+        limit (int | Unset): Items per page (1-100, default 20) Default: 20.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ListWebhookEndpointsResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            page=page,
+            limit=limit,
+        )
+    ).parsed

--- a/sdks/python/colophony/api/webhooks/retry_webhook_delivery.py
+++ b/sdks/python/colophony/api/webhooks/retry_webhook_delivery.py
@@ -1,0 +1,168 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.retry_webhook_delivery_response_200 import RetryWebhookDeliveryResponse200
+from ...types import Response
+
+
+def _get_kwargs(
+    delivery_id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/webhook-deliveries/{delivery_id}/retry".format(
+            delivery_id=quote(str(delivery_id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> RetryWebhookDeliveryResponse200 | None:
+    if response.status_code == 200:
+        response_200 = RetryWebhookDeliveryResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[RetryWebhookDeliveryResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    delivery_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[RetryWebhookDeliveryResponse200]:
+    """Retry a webhook delivery
+
+     Requeues a delivery, clearing the previous attempt’s status and error. Responds 404 if the delivery
+    or its endpoint is not in this organization.
+
+    Args:
+        delivery_id (UUID): Webhook delivery UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[RetryWebhookDeliveryResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        delivery_id=delivery_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    delivery_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> RetryWebhookDeliveryResponse200 | None:
+    """Retry a webhook delivery
+
+     Requeues a delivery, clearing the previous attempt’s status and error. Responds 404 if the delivery
+    or its endpoint is not in this organization.
+
+    Args:
+        delivery_id (UUID): Webhook delivery UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        RetryWebhookDeliveryResponse200
+    """
+
+    return sync_detailed(
+        delivery_id=delivery_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    delivery_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[RetryWebhookDeliveryResponse200]:
+    """Retry a webhook delivery
+
+     Requeues a delivery, clearing the previous attempt’s status and error. Responds 404 if the delivery
+    or its endpoint is not in this organization.
+
+    Args:
+        delivery_id (UUID): Webhook delivery UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[RetryWebhookDeliveryResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        delivery_id=delivery_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    delivery_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> RetryWebhookDeliveryResponse200 | None:
+    """Retry a webhook delivery
+
+     Requeues a delivery, clearing the previous attempt’s status and error. Responds 404 if the delivery
+    or its endpoint is not in this organization.
+
+    Args:
+        delivery_id (UUID): Webhook delivery UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        RetryWebhookDeliveryResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            delivery_id=delivery_id,
+            client=client,
+        )
+    ).parsed

--- a/sdks/python/colophony/api/webhooks/rotate_webhook_endpoint_secret.py
+++ b/sdks/python/colophony/api/webhooks/rotate_webhook_endpoint_secret.py
@@ -1,0 +1,176 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.rotate_webhook_endpoint_secret_response_200 import RotateWebhookEndpointSecretResponse200
+from ...types import Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/webhooks/{id}/rotate-secret".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> RotateWebhookEndpointSecretResponse200 | None:
+    if response.status_code == 200:
+        response_200 = RotateWebhookEndpointSecretResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[RotateWebhookEndpointSecretResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[RotateWebhookEndpointSecretResponse200]:
+    """Rotate a webhook signing secret
+
+     Generates a new signing secret and invalidates the previous one. In-flight deliveries are signed
+    with whichever secret is current when they are sent, so rotate during a quiet period if signature
+    continuity matters. The signing secret is returned **only** by this operation and by endpoint
+    creation — it cannot be read back afterwards. Store it before discarding the response.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[RotateWebhookEndpointSecretResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> RotateWebhookEndpointSecretResponse200 | None:
+    """Rotate a webhook signing secret
+
+     Generates a new signing secret and invalidates the previous one. In-flight deliveries are signed
+    with whichever secret is current when they are sent, so rotate during a quiet period if signature
+    continuity matters. The signing secret is returned **only** by this operation and by endpoint
+    creation — it cannot be read back afterwards. Store it before discarding the response.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        RotateWebhookEndpointSecretResponse200
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[RotateWebhookEndpointSecretResponse200]:
+    """Rotate a webhook signing secret
+
+     Generates a new signing secret and invalidates the previous one. In-flight deliveries are signed
+    with whichever secret is current when they are sent, so rotate during a quiet period if signature
+    continuity matters. The signing secret is returned **only** by this operation and by endpoint
+    creation — it cannot be read back afterwards. Store it before discarding the response.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[RotateWebhookEndpointSecretResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> RotateWebhookEndpointSecretResponse200 | None:
+    """Rotate a webhook signing secret
+
+     Generates a new signing secret and invalidates the previous one. In-flight deliveries are signed
+    with whichever secret is current when they are sent, so rotate during a quiet period if signature
+    continuity matters. The signing secret is returned **only** by this operation and by endpoint
+    creation — it cannot be read back afterwards. Store it before discarding the response.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        RotateWebhookEndpointSecretResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/sdks/python/colophony/api/webhooks/test_webhook_endpoint.py
+++ b/sdks/python/colophony/api/webhooks/test_webhook_endpoint.py
@@ -1,0 +1,168 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.test_webhook_endpoint_response_201 import TestWebhookEndpointResponse201
+from ...types import Response
+
+
+def _get_kwargs(
+    id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/webhooks/{id}/test".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> TestWebhookEndpointResponse201 | None:
+    if response.status_code == 201:
+        response_201 = TestWebhookEndpointResponse201.from_dict(response.json())
+
+        return response_201
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[TestWebhookEndpointResponse201]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[TestWebhookEndpointResponse201]:
+    """Send a test delivery
+
+     Queues a `webhook.test` delivery to the endpoint and returns its id. Delivery is asynchronous — poll
+    `GET /webhook-deliveries` for the outcome. Rejected with 400 if the endpoint is disabled.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[TestWebhookEndpointResponse201]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> TestWebhookEndpointResponse201 | None:
+    """Send a test delivery
+
+     Queues a `webhook.test` delivery to the endpoint and returns its id. Delivery is asynchronous — poll
+    `GET /webhook-deliveries` for the outcome. Rejected with 400 if the endpoint is disabled.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        TestWebhookEndpointResponse201
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[TestWebhookEndpointResponse201]:
+    """Send a test delivery
+
+     Queues a `webhook.test` delivery to the endpoint and returns its id. Delivery is asynchronous — poll
+    `GET /webhook-deliveries` for the outcome. Rejected with 400 if the endpoint is disabled.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[TestWebhookEndpointResponse201]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> TestWebhookEndpointResponse201 | None:
+    """Send a test delivery
+
+     Queues a `webhook.test` delivery to the endpoint and returns its id. Delivery is asynchronous — poll
+    `GET /webhook-deliveries` for the outcome. Rejected with 400 if the endpoint is disabled.
+
+    Args:
+        id (UUID): Resource UUID
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        TestWebhookEndpointResponse201
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/sdks/python/colophony/api/webhooks/update_webhook_endpoint.py
+++ b/sdks/python/colophony/api/webhooks/update_webhook_endpoint.py
@@ -1,0 +1,194 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.update_webhook_endpoint_body import UpdateWebhookEndpointBody
+from ...models.update_webhook_endpoint_response_200 import UpdateWebhookEndpointResponse200
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    id: UUID,
+    *,
+    body: UpdateWebhookEndpointBody | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "patch",
+        "url": "/webhooks/{id}".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    if not isinstance(body, Unset):
+        _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> UpdateWebhookEndpointResponse200 | None:
+    if response.status_code == 200:
+        response_200 = UpdateWebhookEndpointResponse200.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[UpdateWebhookEndpointResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: UpdateWebhookEndpointBody | Unset = UNSET,
+) -> Response[UpdateWebhookEndpointResponse200]:
+    """Update a webhook endpoint
+
+     Updates the URL, description, subscribed events, or status. A changed URL is re-validated against
+    SSRF rules. Signing secrets are never included in the response — rotate the secret to obtain a new
+    one.
+
+    Args:
+        id (UUID): Resource UUID
+        body (UpdateWebhookEndpointBody | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[UpdateWebhookEndpointResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: UpdateWebhookEndpointBody | Unset = UNSET,
+) -> UpdateWebhookEndpointResponse200 | None:
+    """Update a webhook endpoint
+
+     Updates the URL, description, subscribed events, or status. A changed URL is re-validated against
+    SSRF rules. Signing secrets are never included in the response — rotate the secret to obtain a new
+    one.
+
+    Args:
+        id (UUID): Resource UUID
+        body (UpdateWebhookEndpointBody | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        UpdateWebhookEndpointResponse200
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: UpdateWebhookEndpointBody | Unset = UNSET,
+) -> Response[UpdateWebhookEndpointResponse200]:
+    """Update a webhook endpoint
+
+     Updates the URL, description, subscribed events, or status. A changed URL is re-validated against
+    SSRF rules. Signing secrets are never included in the response — rotate the secret to obtain a new
+    one.
+
+    Args:
+        id (UUID): Resource UUID
+        body (UpdateWebhookEndpointBody | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[UpdateWebhookEndpointResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: UpdateWebhookEndpointBody | Unset = UNSET,
+) -> UpdateWebhookEndpointResponse200 | None:
+    """Update a webhook endpoint
+
+     Updates the URL, description, subscribed events, or status. A changed URL is re-validated against
+    SSRF rules. Signing secrets are never included in the response — rotate the secret to obtain a new
+    one.
+
+    Args:
+        id (UUID): Resource UUID
+        body (UpdateWebhookEndpointBody | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        UpdateWebhookEndpointResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/sdks/python/colophony/models/__init__.py
+++ b/sdks/python/colophony/models/__init__.py
@@ -230,6 +230,10 @@ from .create_submission_response_201_sim_sub_policy_requirement_type_0_type impo
     CreateSubmissionResponse201SimSubPolicyRequirementType0Type,
 )
 from .create_submission_response_201_status import CreateSubmissionResponse201Status
+from .create_webhook_endpoint_body import CreateWebhookEndpointBody
+from .create_webhook_endpoint_body_event_types_item import CreateWebhookEndpointBodyEventTypesItem
+from .create_webhook_endpoint_response_201 import CreateWebhookEndpointResponse201
+from .create_webhook_endpoint_response_201_status import CreateWebhookEndpointResponse201Status
 from .delete_api_key_response_200 import DeleteApiKeyResponse200
 from .delete_cms_connection_response_200 import DeleteCmsConnectionResponse200
 from .delete_cms_connection_response_200_adapter_type import DeleteCmsConnectionResponse200AdapterType
@@ -251,6 +255,7 @@ from .delete_organization_response_200 import DeleteOrganizationResponse200
 from .delete_period_response_200 import DeletePeriodResponse200
 from .delete_submission_response_200 import DeleteSubmissionResponse200
 from .delete_submission_vote_response_200 import DeleteSubmissionVoteResponse200
+from .delete_webhook_endpoint_response_200 import DeleteWebhookEndpointResponse200
 from .duplicate_form_response_201 import DuplicateFormResponse201
 from .duplicate_form_response_201_fields_item import DuplicateFormResponse201FieldsItem
 from .duplicate_form_response_201_fields_item_conditional_rules_type_0_item import (
@@ -480,6 +485,8 @@ from .get_submission_response_200_sim_sub_policy_requirement_type_0_type import 
 from .get_submission_response_200_status import GetSubmissionResponse200Status
 from .get_submission_vote_summary_response_200 import GetSubmissionVoteSummaryResponse200
 from .get_unread_notification_count_response_200 import GetUnreadNotificationCountResponse200
+from .get_webhook_endpoint_response_200 import GetWebhookEndpointResponse200
+from .get_webhook_endpoint_response_200_status import GetWebhookEndpointResponse200Status
 from .import_csr_body import ImportCsrBody
 from .import_csr_body_correspondence_item import ImportCsrBodyCorrespondenceItem
 from .import_csr_body_correspondence_item_channel import ImportCsrBodyCorrespondenceItemChannel
@@ -622,6 +629,13 @@ from .list_submissions_response_200_items_item_status import ListSubmissionsResp
 from .list_submissions_sort_by import ListSubmissionsSortBy
 from .list_submissions_sort_order import ListSubmissionsSortOrder
 from .list_submissions_status import ListSubmissionsStatus
+from .list_webhook_deliveries_response_200 import ListWebhookDeliveriesResponse200
+from .list_webhook_deliveries_response_200_items_item import ListWebhookDeliveriesResponse200ItemsItem
+from .list_webhook_deliveries_response_200_items_item_status import ListWebhookDeliveriesResponse200ItemsItemStatus
+from .list_webhook_deliveries_status import ListWebhookDeliveriesStatus
+from .list_webhook_endpoints_response_200 import ListWebhookEndpointsResponse200
+from .list_webhook_endpoints_response_200_items_item import ListWebhookEndpointsResponse200ItemsItem
+from .list_webhook_endpoints_response_200_items_item_status import ListWebhookEndpointsResponse200ItemsItemStatus
 from .mark_all_notifications_read_response_200 import MarkAllNotificationsReadResponse200
 from .mark_notification_read_response_200 import MarkNotificationReadResponse200
 from .mark_submission_reviewer_read_response_200 import MarkSubmissionReviewerReadResponse200
@@ -735,8 +749,12 @@ from .resubmit_submission_response_200_submission_sim_sub_policy_requirement_typ
     ResubmitSubmissionResponse200SubmissionSimSubPolicyRequirementType0Type,
 )
 from .resubmit_submission_response_200_submission_status import ResubmitSubmissionResponse200SubmissionStatus
+from .retry_webhook_delivery_response_200 import RetryWebhookDeliveryResponse200
+from .retry_webhook_delivery_response_200_status import RetryWebhookDeliveryResponse200Status
 from .revoke_api_key_response_200 import RevokeApiKeyResponse200
 from .revoke_organization_invitation_response_200 import RevokeOrganizationInvitationResponse200
+from .rotate_webhook_endpoint_secret_response_200 import RotateWebhookEndpointSecretResponse200
+from .rotate_webhook_endpoint_secret_response_200_status import RotateWebhookEndpointSecretResponse200Status
 from .send_contract_response_200 import SendContractResponse200
 from .send_contract_response_200_merge_data_type_0 import SendContractResponse200MergeDataType0
 from .send_contract_response_200_status import SendContractResponse200Status
@@ -758,6 +776,7 @@ from .submit_submission_response_200_submission_sim_sub_policy_requirement_type_
 )
 from .submit_submission_response_200_submission_status import SubmitSubmissionResponse200SubmissionStatus
 from .test_cms_connection_response_200 import TestCmsConnectionResponse200
+from .test_webhook_endpoint_response_201 import TestWebhookEndpointResponse201
 from .unassign_submission_reviewer_response_200 import UnassignSubmissionReviewerResponse200
 from .update_cms_connection_body import UpdateCmsConnectionBody
 from .update_cms_connection_body_config import UpdateCmsConnectionBodyConfig
@@ -940,6 +959,11 @@ from .update_submission_status_response_200_submission_sim_sub_policy_requiremen
     UpdateSubmissionStatusResponse200SubmissionSimSubPolicyRequirementType0Type,
 )
 from .update_submission_status_response_200_submission_status import UpdateSubmissionStatusResponse200SubmissionStatus
+from .update_webhook_endpoint_body import UpdateWebhookEndpointBody
+from .update_webhook_endpoint_body_event_types_item import UpdateWebhookEndpointBodyEventTypesItem
+from .update_webhook_endpoint_body_status import UpdateWebhookEndpointBodyStatus
+from .update_webhook_endpoint_response_200 import UpdateWebhookEndpointResponse200
+from .update_webhook_endpoint_response_200_status import UpdateWebhookEndpointResponse200Status
 from .upsert_notification_preference_body import UpsertNotificationPreferenceBody
 from .upsert_notification_preference_body_channel import UpsertNotificationPreferenceBodyChannel
 from .upsert_notification_preference_body_event_type import UpsertNotificationPreferenceBodyEventType
@@ -1131,6 +1155,10 @@ __all__ = (
     "CreateSubmissionResponse201SimSubPolicyRequirementType0",
     "CreateSubmissionResponse201SimSubPolicyRequirementType0Type",
     "CreateSubmissionResponse201Status",
+    "CreateWebhookEndpointBody",
+    "CreateWebhookEndpointBodyEventTypesItem",
+    "CreateWebhookEndpointResponse201",
+    "CreateWebhookEndpointResponse201Status",
     "DeleteApiKeyResponse200",
     "DeleteCmsConnectionResponse200",
     "DeleteCmsConnectionResponse200AdapterType",
@@ -1148,6 +1176,7 @@ __all__ = (
     "DeletePeriodResponse200",
     "DeleteSubmissionResponse200",
     "DeleteSubmissionVoteResponse200",
+    "DeleteWebhookEndpointResponse200",
     "DuplicateFormResponse201",
     "DuplicateFormResponse201FieldsItem",
     "DuplicateFormResponse201FieldsItemConditionalRulesType0Item",
@@ -1283,6 +1312,8 @@ __all__ = (
     "GetSubmissionResponse200Status",
     "GetSubmissionVoteSummaryResponse200",
     "GetUnreadNotificationCountResponse200",
+    "GetWebhookEndpointResponse200",
+    "GetWebhookEndpointResponse200Status",
     "ImportCsrBody",
     "ImportCsrBodyCorrespondenceItem",
     "ImportCsrBodyCorrespondenceItemChannel",
@@ -1391,6 +1422,13 @@ __all__ = (
     "ListSubmissionsStatus",
     "ListSubmissionVotesResponse200Item",
     "ListSubmissionVotesResponse200ItemDecision",
+    "ListWebhookDeliveriesResponse200",
+    "ListWebhookDeliveriesResponse200ItemsItem",
+    "ListWebhookDeliveriesResponse200ItemsItemStatus",
+    "ListWebhookDeliveriesStatus",
+    "ListWebhookEndpointsResponse200",
+    "ListWebhookEndpointsResponse200ItemsItem",
+    "ListWebhookEndpointsResponse200ItemsItemStatus",
     "MarkAllNotificationsReadResponse200",
     "MarkNotificationReadResponse200",
     "MarkSubmissionReviewerReadResponse200",
@@ -1454,8 +1492,12 @@ __all__ = (
     "ResubmitSubmissionResponse200SubmissionSimSubPolicyRequirementType0",
     "ResubmitSubmissionResponse200SubmissionSimSubPolicyRequirementType0Type",
     "ResubmitSubmissionResponse200SubmissionStatus",
+    "RetryWebhookDeliveryResponse200",
+    "RetryWebhookDeliveryResponse200Status",
     "RevokeApiKeyResponse200",
     "RevokeOrganizationInvitationResponse200",
+    "RotateWebhookEndpointSecretResponse200",
+    "RotateWebhookEndpointSecretResponse200Status",
     "SendContractResponse200",
     "SendContractResponse200MergeDataType0",
     "SendContractResponse200Status",
@@ -1469,6 +1511,7 @@ __all__ = (
     "SubmitSubmissionResponse200SubmissionSimSubPolicyRequirementType0Type",
     "SubmitSubmissionResponse200SubmissionStatus",
     "TestCmsConnectionResponse200",
+    "TestWebhookEndpointResponse201",
     "UnassignSubmissionReviewerResponse200",
     "UpdateCmsConnectionBody",
     "UpdateCmsConnectionBodyConfig",
@@ -1581,6 +1624,11 @@ __all__ = (
     "UpdateSubmissionStatusResponse200SubmissionSimSubPolicyRequirementType0",
     "UpdateSubmissionStatusResponse200SubmissionSimSubPolicyRequirementType0Type",
     "UpdateSubmissionStatusResponse200SubmissionStatus",
+    "UpdateWebhookEndpointBody",
+    "UpdateWebhookEndpointBodyEventTypesItem",
+    "UpdateWebhookEndpointBodyStatus",
+    "UpdateWebhookEndpointResponse200",
+    "UpdateWebhookEndpointResponse200Status",
     "UpsertNotificationPreferenceBody",
     "UpsertNotificationPreferenceBodyChannel",
     "UpsertNotificationPreferenceBodyEventType",

--- a/sdks/python/colophony/models/create_webhook_endpoint_body.py
+++ b/sdks/python/colophony/models/create_webhook_endpoint_body.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.create_webhook_endpoint_body_event_types_item import CreateWebhookEndpointBodyEventTypesItem
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CreateWebhookEndpointBody")
+
+
+@_attrs_define
+class CreateWebhookEndpointBody:
+    """
+    Attributes:
+        url (str):
+        event_types (list[CreateWebhookEndpointBodyEventTypesItem]):
+        description (str | Unset):
+    """
+
+    url: str
+    event_types: list[CreateWebhookEndpointBodyEventTypesItem]
+    description: str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        url = self.url
+
+        event_types = []
+        for event_types_item_data in self.event_types:
+            event_types_item = event_types_item_data.value
+            event_types.append(event_types_item)
+
+        description = self.description
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "url": url,
+                "eventTypes": event_types,
+            }
+        )
+        if description is not UNSET:
+            field_dict["description"] = description
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        url = d.pop("url")
+
+        event_types = []
+        _event_types = d.pop("eventTypes")
+        for event_types_item_data in _event_types:
+            event_types_item = CreateWebhookEndpointBodyEventTypesItem(event_types_item_data)
+
+            event_types.append(event_types_item)
+
+        description = d.pop("description", UNSET)
+
+        create_webhook_endpoint_body = cls(
+            url=url,
+            event_types=event_types,
+            description=description,
+        )
+
+        create_webhook_endpoint_body.additional_properties = d
+        return create_webhook_endpoint_body
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/create_webhook_endpoint_body_event_types_item.py
+++ b/sdks/python/colophony/models/create_webhook_endpoint_body_event_types_item.py
@@ -1,0 +1,18 @@
+from enum import Enum
+
+
+class CreateWebhookEndpointBodyEventTypesItem(str, Enum):
+    HOPPERSUBMISSION_ACCEPTED = "hopper/submission.accepted"
+    HOPPERSUBMISSION_REJECTED = "hopper/submission.rejected"
+    HOPPERSUBMISSION_SUBMITTED = "hopper/submission.submitted"
+    HOPPERSUBMISSION_WITHDRAWN = "hopper/submission.withdrawn"
+    SLATECONTRACT_GENERATED = "slate/contract.generated"
+    SLATEISSUE_PUBLISHED = "slate/issue.published"
+    SLATEPIPELINE_AUTHOR_REVIEW_COMPLETED = "slate/pipeline.author-review-completed"
+    SLATEPIPELINE_COPYEDITOR_ASSIGNED = "slate/pipeline.copyeditor-assigned"
+    SLATEPIPELINE_COPYEDIT_COMPLETED = "slate/pipeline.copyedit-completed"
+    SLATEPIPELINE_PROOFREAD_COMPLETED = "slate/pipeline.proofread-completed"
+    WEBHOOK_TEST = "webhook.test"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/create_webhook_endpoint_response_201.py
+++ b/sdks/python/colophony/models/create_webhook_endpoint_response_201.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.create_webhook_endpoint_response_201_status import CreateWebhookEndpointResponse201Status
+
+T = TypeVar("T", bound="CreateWebhookEndpointResponse201")
+
+
+@_attrs_define
+class CreateWebhookEndpointResponse201:
+    """
+    Attributes:
+        id (UUID):
+        url (str):
+        description (None | str):
+        event_types (list[str]):
+        status (CreateWebhookEndpointResponse201Status):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+        secret (str):
+    """
+
+    id: UUID
+    url: str
+    description: None | str
+    event_types: list[str]
+    status: CreateWebhookEndpointResponse201Status
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    secret: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        url = self.url
+
+        description: None | str
+        description = self.description
+
+        event_types = self.event_types
+
+        status = self.status.value
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        secret = self.secret
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "url": url,
+                "description": description,
+                "eventTypes": event_types,
+                "status": status,
+                "createdAt": created_at,
+                "updatedAt": updated_at,
+                "secret": secret,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        url = d.pop("url")
+
+        def _parse_description(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        description = _parse_description(d.pop("description"))
+
+        event_types = cast(list[str], d.pop("eventTypes"))
+
+        status = CreateWebhookEndpointResponse201Status(d.pop("status"))
+
+        created_at = datetime.datetime.fromisoformat(d.pop("createdAt"))
+
+        updated_at = datetime.datetime.fromisoformat(d.pop("updatedAt"))
+
+        secret = d.pop("secret")
+
+        create_webhook_endpoint_response_201 = cls(
+            id=id,
+            url=url,
+            description=description,
+            event_types=event_types,
+            status=status,
+            created_at=created_at,
+            updated_at=updated_at,
+            secret=secret,
+        )
+
+        create_webhook_endpoint_response_201.additional_properties = d
+        return create_webhook_endpoint_response_201
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/create_webhook_endpoint_response_201_status.py
+++ b/sdks/python/colophony/models/create_webhook_endpoint_response_201_status.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class CreateWebhookEndpointResponse201Status(str, Enum):
+    ACTIVE = "ACTIVE"
+    DISABLED = "DISABLED"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/delete_webhook_endpoint_response_200.py
+++ b/sdks/python/colophony/models/delete_webhook_endpoint_response_200.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="DeleteWebhookEndpointResponse200")
+
+
+@_attrs_define
+class DeleteWebhookEndpointResponse200:
+    """
+    Attributes:
+        success (Literal[True]): Always true on success
+    """
+
+    success: Literal[True]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        success = self.success
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "success": success,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        success = cast(Literal[True], d.pop("success"))
+        if success != True:
+            raise ValueError(f"success must match const True, got '{success}'")
+
+        delete_webhook_endpoint_response_200 = cls(
+            success=success,
+        )
+
+        delete_webhook_endpoint_response_200.additional_properties = d
+        return delete_webhook_endpoint_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/get_webhook_endpoint_response_200.py
+++ b/sdks/python/colophony/models/get_webhook_endpoint_response_200.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.get_webhook_endpoint_response_200_status import GetWebhookEndpointResponse200Status
+
+T = TypeVar("T", bound="GetWebhookEndpointResponse200")
+
+
+@_attrs_define
+class GetWebhookEndpointResponse200:
+    """
+    Attributes:
+        id (UUID):
+        url (str):
+        description (None | str):
+        event_types (list[str]):
+        status (GetWebhookEndpointResponse200Status):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+    """
+
+    id: UUID
+    url: str
+    description: None | str
+    event_types: list[str]
+    status: GetWebhookEndpointResponse200Status
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        url = self.url
+
+        description: None | str
+        description = self.description
+
+        event_types = self.event_types
+
+        status = self.status.value
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "url": url,
+                "description": description,
+                "eventTypes": event_types,
+                "status": status,
+                "createdAt": created_at,
+                "updatedAt": updated_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        url = d.pop("url")
+
+        def _parse_description(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        description = _parse_description(d.pop("description"))
+
+        event_types = cast(list[str], d.pop("eventTypes"))
+
+        status = GetWebhookEndpointResponse200Status(d.pop("status"))
+
+        created_at = datetime.datetime.fromisoformat(d.pop("createdAt"))
+
+        updated_at = datetime.datetime.fromisoformat(d.pop("updatedAt"))
+
+        get_webhook_endpoint_response_200 = cls(
+            id=id,
+            url=url,
+            description=description,
+            event_types=event_types,
+            status=status,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        get_webhook_endpoint_response_200.additional_properties = d
+        return get_webhook_endpoint_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/get_webhook_endpoint_response_200_status.py
+++ b/sdks/python/colophony/models/get_webhook_endpoint_response_200_status.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class GetWebhookEndpointResponse200Status(str, Enum):
+    ACTIVE = "ACTIVE"
+    DISABLED = "DISABLED"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/list_webhook_deliveries_response_200.py
+++ b/sdks/python/colophony/models/list_webhook_deliveries_response_200.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.list_webhook_deliveries_response_200_items_item import ListWebhookDeliveriesResponse200ItemsItem
+
+
+T = TypeVar("T", bound="ListWebhookDeliveriesResponse200")
+
+
+@_attrs_define
+class ListWebhookDeliveriesResponse200:
+    """
+    Attributes:
+        items (list[ListWebhookDeliveriesResponse200ItemsItem]): Items on the current page
+        total (float): Total number of items across all pages
+        page (float): Current page number
+        limit (float): Items per page
+        total_pages (float): Total number of pages
+    """
+
+    items: list[ListWebhookDeliveriesResponse200ItemsItem]
+    total: float
+    page: float
+    limit: float
+    total_pages: float
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+        total = self.total
+
+        page = self.page
+
+        limit = self.limit
+
+        total_pages = self.total_pages
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "items": items,
+                "total": total,
+                "page": page,
+                "limit": limit,
+                "totalPages": total_pages,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.list_webhook_deliveries_response_200_items_item import ListWebhookDeliveriesResponse200ItemsItem
+
+        d = dict(src_dict)
+        items = []
+        _items = d.pop("items")
+        for items_item_data in _items:
+            items_item = ListWebhookDeliveriesResponse200ItemsItem.from_dict(items_item_data)
+
+            items.append(items_item)
+
+        total = d.pop("total")
+
+        page = d.pop("page")
+
+        limit = d.pop("limit")
+
+        total_pages = d.pop("totalPages")
+
+        list_webhook_deliveries_response_200 = cls(
+            items=items,
+            total=total,
+            page=page,
+            limit=limit,
+            total_pages=total_pages,
+        )
+
+        list_webhook_deliveries_response_200.additional_properties = d
+        return list_webhook_deliveries_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/list_webhook_deliveries_response_200_items_item.py
+++ b/sdks/python/colophony/models/list_webhook_deliveries_response_200_items_item.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.list_webhook_deliveries_response_200_items_item_status import (
+    ListWebhookDeliveriesResponse200ItemsItemStatus,
+)
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ListWebhookDeliveriesResponse200ItemsItem")
+
+
+@_attrs_define
+class ListWebhookDeliveriesResponse200ItemsItem:
+    """
+    Attributes:
+        id (UUID):
+        webhook_endpoint_id (UUID):
+        event_type (str):
+        event_id (str):
+        status (ListWebhookDeliveriesResponse200ItemsItemStatus):
+        http_status_code (float | None):
+        response_body (None | str):
+        error_message (None | str):
+        attempts (float):
+        next_retry_at (datetime.datetime | None):
+        delivered_at (datetime.datetime | None):
+        created_at (datetime.datetime):
+        payload (Any | Unset):
+    """
+
+    id: UUID
+    webhook_endpoint_id: UUID
+    event_type: str
+    event_id: str
+    status: ListWebhookDeliveriesResponse200ItemsItemStatus
+    http_status_code: float | None
+    response_body: None | str
+    error_message: None | str
+    attempts: float
+    next_retry_at: datetime.datetime | None
+    delivered_at: datetime.datetime | None
+    created_at: datetime.datetime
+    payload: Any | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        webhook_endpoint_id = str(self.webhook_endpoint_id)
+
+        event_type = self.event_type
+
+        event_id = self.event_id
+
+        status = self.status.value
+
+        http_status_code: float | None
+        http_status_code = self.http_status_code
+
+        response_body: None | str
+        response_body = self.response_body
+
+        error_message: None | str
+        error_message = self.error_message
+
+        attempts = self.attempts
+
+        next_retry_at: None | str
+        if isinstance(self.next_retry_at, datetime.datetime):
+            next_retry_at = self.next_retry_at.isoformat()
+        else:
+            next_retry_at = self.next_retry_at
+
+        delivered_at: None | str
+        if isinstance(self.delivered_at, datetime.datetime):
+            delivered_at = self.delivered_at.isoformat()
+        else:
+            delivered_at = self.delivered_at
+
+        created_at = self.created_at.isoformat()
+
+        payload = self.payload
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "webhookEndpointId": webhook_endpoint_id,
+                "eventType": event_type,
+                "eventId": event_id,
+                "status": status,
+                "httpStatusCode": http_status_code,
+                "responseBody": response_body,
+                "errorMessage": error_message,
+                "attempts": attempts,
+                "nextRetryAt": next_retry_at,
+                "deliveredAt": delivered_at,
+                "createdAt": created_at,
+            }
+        )
+        if payload is not UNSET:
+            field_dict["payload"] = payload
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        webhook_endpoint_id = UUID(d.pop("webhookEndpointId"))
+
+        event_type = d.pop("eventType")
+
+        event_id = d.pop("eventId")
+
+        status = ListWebhookDeliveriesResponse200ItemsItemStatus(d.pop("status"))
+
+        def _parse_http_status_code(data: object) -> float | None:
+            if data is None:
+                return data
+            return cast(float | None, data)
+
+        http_status_code = _parse_http_status_code(d.pop("httpStatusCode"))
+
+        def _parse_response_body(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        response_body = _parse_response_body(d.pop("responseBody"))
+
+        def _parse_error_message(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        error_message = _parse_error_message(d.pop("errorMessage"))
+
+        attempts = d.pop("attempts")
+
+        def _parse_next_retry_at(data: object) -> datetime.datetime | None:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                next_retry_at_type_0 = datetime.datetime.fromisoformat(data)
+
+                return next_retry_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None, data)
+
+        next_retry_at = _parse_next_retry_at(d.pop("nextRetryAt"))
+
+        def _parse_delivered_at(data: object) -> datetime.datetime | None:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                delivered_at_type_0 = datetime.datetime.fromisoformat(data)
+
+                return delivered_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None, data)
+
+        delivered_at = _parse_delivered_at(d.pop("deliveredAt"))
+
+        created_at = datetime.datetime.fromisoformat(d.pop("createdAt"))
+
+        payload = d.pop("payload", UNSET)
+
+        list_webhook_deliveries_response_200_items_item = cls(
+            id=id,
+            webhook_endpoint_id=webhook_endpoint_id,
+            event_type=event_type,
+            event_id=event_id,
+            status=status,
+            http_status_code=http_status_code,
+            response_body=response_body,
+            error_message=error_message,
+            attempts=attempts,
+            next_retry_at=next_retry_at,
+            delivered_at=delivered_at,
+            created_at=created_at,
+            payload=payload,
+        )
+
+        list_webhook_deliveries_response_200_items_item.additional_properties = d
+        return list_webhook_deliveries_response_200_items_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/list_webhook_deliveries_response_200_items_item_status.py
+++ b/sdks/python/colophony/models/list_webhook_deliveries_response_200_items_item_status.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class ListWebhookDeliveriesResponse200ItemsItemStatus(str, Enum):
+    CANCELLED = "CANCELLED"
+    DELIVERED = "DELIVERED"
+    DELIVERING = "DELIVERING"
+    FAILED = "FAILED"
+    QUEUED = "QUEUED"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/list_webhook_deliveries_status.py
+++ b/sdks/python/colophony/models/list_webhook_deliveries_status.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class ListWebhookDeliveriesStatus(str, Enum):
+    CANCELLED = "CANCELLED"
+    DELIVERED = "DELIVERED"
+    DELIVERING = "DELIVERING"
+    FAILED = "FAILED"
+    QUEUED = "QUEUED"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/list_webhook_endpoints_response_200.py
+++ b/sdks/python/colophony/models/list_webhook_endpoints_response_200.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.list_webhook_endpoints_response_200_items_item import ListWebhookEndpointsResponse200ItemsItem
+
+
+T = TypeVar("T", bound="ListWebhookEndpointsResponse200")
+
+
+@_attrs_define
+class ListWebhookEndpointsResponse200:
+    """
+    Attributes:
+        items (list[ListWebhookEndpointsResponse200ItemsItem]): Items on the current page
+        total (float): Total number of items across all pages
+        page (float): Current page number
+        limit (float): Items per page
+        total_pages (float): Total number of pages
+    """
+
+    items: list[ListWebhookEndpointsResponse200ItemsItem]
+    total: float
+    page: float
+    limit: float
+    total_pages: float
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+        total = self.total
+
+        page = self.page
+
+        limit = self.limit
+
+        total_pages = self.total_pages
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "items": items,
+                "total": total,
+                "page": page,
+                "limit": limit,
+                "totalPages": total_pages,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.list_webhook_endpoints_response_200_items_item import ListWebhookEndpointsResponse200ItemsItem
+
+        d = dict(src_dict)
+        items = []
+        _items = d.pop("items")
+        for items_item_data in _items:
+            items_item = ListWebhookEndpointsResponse200ItemsItem.from_dict(items_item_data)
+
+            items.append(items_item)
+
+        total = d.pop("total")
+
+        page = d.pop("page")
+
+        limit = d.pop("limit")
+
+        total_pages = d.pop("totalPages")
+
+        list_webhook_endpoints_response_200 = cls(
+            items=items,
+            total=total,
+            page=page,
+            limit=limit,
+            total_pages=total_pages,
+        )
+
+        list_webhook_endpoints_response_200.additional_properties = d
+        return list_webhook_endpoints_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/list_webhook_endpoints_response_200_items_item.py
+++ b/sdks/python/colophony/models/list_webhook_endpoints_response_200_items_item.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.list_webhook_endpoints_response_200_items_item_status import (
+    ListWebhookEndpointsResponse200ItemsItemStatus,
+)
+
+T = TypeVar("T", bound="ListWebhookEndpointsResponse200ItemsItem")
+
+
+@_attrs_define
+class ListWebhookEndpointsResponse200ItemsItem:
+    """
+    Attributes:
+        id (UUID):
+        url (str):
+        description (None | str):
+        event_types (list[str]):
+        status (ListWebhookEndpointsResponse200ItemsItemStatus):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+    """
+
+    id: UUID
+    url: str
+    description: None | str
+    event_types: list[str]
+    status: ListWebhookEndpointsResponse200ItemsItemStatus
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        url = self.url
+
+        description: None | str
+        description = self.description
+
+        event_types = self.event_types
+
+        status = self.status.value
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "url": url,
+                "description": description,
+                "eventTypes": event_types,
+                "status": status,
+                "createdAt": created_at,
+                "updatedAt": updated_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        url = d.pop("url")
+
+        def _parse_description(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        description = _parse_description(d.pop("description"))
+
+        event_types = cast(list[str], d.pop("eventTypes"))
+
+        status = ListWebhookEndpointsResponse200ItemsItemStatus(d.pop("status"))
+
+        created_at = datetime.datetime.fromisoformat(d.pop("createdAt"))
+
+        updated_at = datetime.datetime.fromisoformat(d.pop("updatedAt"))
+
+        list_webhook_endpoints_response_200_items_item = cls(
+            id=id,
+            url=url,
+            description=description,
+            event_types=event_types,
+            status=status,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        list_webhook_endpoints_response_200_items_item.additional_properties = d
+        return list_webhook_endpoints_response_200_items_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/list_webhook_endpoints_response_200_items_item_status.py
+++ b/sdks/python/colophony/models/list_webhook_endpoints_response_200_items_item_status.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class ListWebhookEndpointsResponse200ItemsItemStatus(str, Enum):
+    ACTIVE = "ACTIVE"
+    DISABLED = "DISABLED"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/retry_webhook_delivery_response_200.py
+++ b/sdks/python/colophony/models/retry_webhook_delivery_response_200.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.retry_webhook_delivery_response_200_status import RetryWebhookDeliveryResponse200Status
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="RetryWebhookDeliveryResponse200")
+
+
+@_attrs_define
+class RetryWebhookDeliveryResponse200:
+    """
+    Attributes:
+        id (UUID):
+        webhook_endpoint_id (UUID):
+        event_type (str):
+        event_id (str):
+        status (RetryWebhookDeliveryResponse200Status):
+        http_status_code (float | None):
+        response_body (None | str):
+        error_message (None | str):
+        attempts (float):
+        next_retry_at (datetime.datetime | None):
+        delivered_at (datetime.datetime | None):
+        created_at (datetime.datetime):
+        payload (Any | Unset):
+    """
+
+    id: UUID
+    webhook_endpoint_id: UUID
+    event_type: str
+    event_id: str
+    status: RetryWebhookDeliveryResponse200Status
+    http_status_code: float | None
+    response_body: None | str
+    error_message: None | str
+    attempts: float
+    next_retry_at: datetime.datetime | None
+    delivered_at: datetime.datetime | None
+    created_at: datetime.datetime
+    payload: Any | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        webhook_endpoint_id = str(self.webhook_endpoint_id)
+
+        event_type = self.event_type
+
+        event_id = self.event_id
+
+        status = self.status.value
+
+        http_status_code: float | None
+        http_status_code = self.http_status_code
+
+        response_body: None | str
+        response_body = self.response_body
+
+        error_message: None | str
+        error_message = self.error_message
+
+        attempts = self.attempts
+
+        next_retry_at: None | str
+        if isinstance(self.next_retry_at, datetime.datetime):
+            next_retry_at = self.next_retry_at.isoformat()
+        else:
+            next_retry_at = self.next_retry_at
+
+        delivered_at: None | str
+        if isinstance(self.delivered_at, datetime.datetime):
+            delivered_at = self.delivered_at.isoformat()
+        else:
+            delivered_at = self.delivered_at
+
+        created_at = self.created_at.isoformat()
+
+        payload = self.payload
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "webhookEndpointId": webhook_endpoint_id,
+                "eventType": event_type,
+                "eventId": event_id,
+                "status": status,
+                "httpStatusCode": http_status_code,
+                "responseBody": response_body,
+                "errorMessage": error_message,
+                "attempts": attempts,
+                "nextRetryAt": next_retry_at,
+                "deliveredAt": delivered_at,
+                "createdAt": created_at,
+            }
+        )
+        if payload is not UNSET:
+            field_dict["payload"] = payload
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        webhook_endpoint_id = UUID(d.pop("webhookEndpointId"))
+
+        event_type = d.pop("eventType")
+
+        event_id = d.pop("eventId")
+
+        status = RetryWebhookDeliveryResponse200Status(d.pop("status"))
+
+        def _parse_http_status_code(data: object) -> float | None:
+            if data is None:
+                return data
+            return cast(float | None, data)
+
+        http_status_code = _parse_http_status_code(d.pop("httpStatusCode"))
+
+        def _parse_response_body(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        response_body = _parse_response_body(d.pop("responseBody"))
+
+        def _parse_error_message(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        error_message = _parse_error_message(d.pop("errorMessage"))
+
+        attempts = d.pop("attempts")
+
+        def _parse_next_retry_at(data: object) -> datetime.datetime | None:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                next_retry_at_type_0 = datetime.datetime.fromisoformat(data)
+
+                return next_retry_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None, data)
+
+        next_retry_at = _parse_next_retry_at(d.pop("nextRetryAt"))
+
+        def _parse_delivered_at(data: object) -> datetime.datetime | None:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                delivered_at_type_0 = datetime.datetime.fromisoformat(data)
+
+                return delivered_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None, data)
+
+        delivered_at = _parse_delivered_at(d.pop("deliveredAt"))
+
+        created_at = datetime.datetime.fromisoformat(d.pop("createdAt"))
+
+        payload = d.pop("payload", UNSET)
+
+        retry_webhook_delivery_response_200 = cls(
+            id=id,
+            webhook_endpoint_id=webhook_endpoint_id,
+            event_type=event_type,
+            event_id=event_id,
+            status=status,
+            http_status_code=http_status_code,
+            response_body=response_body,
+            error_message=error_message,
+            attempts=attempts,
+            next_retry_at=next_retry_at,
+            delivered_at=delivered_at,
+            created_at=created_at,
+            payload=payload,
+        )
+
+        retry_webhook_delivery_response_200.additional_properties = d
+        return retry_webhook_delivery_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/retry_webhook_delivery_response_200_status.py
+++ b/sdks/python/colophony/models/retry_webhook_delivery_response_200_status.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class RetryWebhookDeliveryResponse200Status(str, Enum):
+    CANCELLED = "CANCELLED"
+    DELIVERED = "DELIVERED"
+    DELIVERING = "DELIVERING"
+    FAILED = "FAILED"
+    QUEUED = "QUEUED"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/rotate_webhook_endpoint_secret_response_200.py
+++ b/sdks/python/colophony/models/rotate_webhook_endpoint_secret_response_200.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.rotate_webhook_endpoint_secret_response_200_status import RotateWebhookEndpointSecretResponse200Status
+
+T = TypeVar("T", bound="RotateWebhookEndpointSecretResponse200")
+
+
+@_attrs_define
+class RotateWebhookEndpointSecretResponse200:
+    """
+    Attributes:
+        id (UUID):
+        url (str):
+        description (None | str):
+        event_types (list[str]):
+        status (RotateWebhookEndpointSecretResponse200Status):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+        secret (str):
+    """
+
+    id: UUID
+    url: str
+    description: None | str
+    event_types: list[str]
+    status: RotateWebhookEndpointSecretResponse200Status
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    secret: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        url = self.url
+
+        description: None | str
+        description = self.description
+
+        event_types = self.event_types
+
+        status = self.status.value
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        secret = self.secret
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "url": url,
+                "description": description,
+                "eventTypes": event_types,
+                "status": status,
+                "createdAt": created_at,
+                "updatedAt": updated_at,
+                "secret": secret,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        url = d.pop("url")
+
+        def _parse_description(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        description = _parse_description(d.pop("description"))
+
+        event_types = cast(list[str], d.pop("eventTypes"))
+
+        status = RotateWebhookEndpointSecretResponse200Status(d.pop("status"))
+
+        created_at = datetime.datetime.fromisoformat(d.pop("createdAt"))
+
+        updated_at = datetime.datetime.fromisoformat(d.pop("updatedAt"))
+
+        secret = d.pop("secret")
+
+        rotate_webhook_endpoint_secret_response_200 = cls(
+            id=id,
+            url=url,
+            description=description,
+            event_types=event_types,
+            status=status,
+            created_at=created_at,
+            updated_at=updated_at,
+            secret=secret,
+        )
+
+        rotate_webhook_endpoint_secret_response_200.additional_properties = d
+        return rotate_webhook_endpoint_secret_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/rotate_webhook_endpoint_secret_response_200_status.py
+++ b/sdks/python/colophony/models/rotate_webhook_endpoint_secret_response_200_status.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class RotateWebhookEndpointSecretResponse200Status(str, Enum):
+    ACTIVE = "ACTIVE"
+    DISABLED = "DISABLED"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/test_webhook_endpoint_response_201.py
+++ b/sdks/python/colophony/models/test_webhook_endpoint_response_201.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="TestWebhookEndpointResponse201")
+
+
+@_attrs_define
+class TestWebhookEndpointResponse201:
+    """
+    Attributes:
+        delivery_id (UUID): The queued test delivery — poll it via GET /webhook-deliveries
+    """
+
+    delivery_id: UUID
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        delivery_id = str(self.delivery_id)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "deliveryId": delivery_id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        delivery_id = UUID(d.pop("deliveryId"))
+
+        test_webhook_endpoint_response_201 = cls(
+            delivery_id=delivery_id,
+        )
+
+        test_webhook_endpoint_response_201.additional_properties = d
+        return test_webhook_endpoint_response_201
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/update_webhook_endpoint_body.py
+++ b/sdks/python/colophony/models/update_webhook_endpoint_body.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.update_webhook_endpoint_body_event_types_item import UpdateWebhookEndpointBodyEventTypesItem
+from ..models.update_webhook_endpoint_body_status import UpdateWebhookEndpointBodyStatus
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="UpdateWebhookEndpointBody")
+
+
+@_attrs_define
+class UpdateWebhookEndpointBody:
+    """
+    Attributes:
+        url (str | Unset):
+        description (str | Unset):
+        event_types (list[UpdateWebhookEndpointBodyEventTypesItem] | Unset):
+        status (UpdateWebhookEndpointBodyStatus | Unset):
+    """
+
+    url: str | Unset = UNSET
+    description: str | Unset = UNSET
+    event_types: list[UpdateWebhookEndpointBodyEventTypesItem] | Unset = UNSET
+    status: UpdateWebhookEndpointBodyStatus | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        url = self.url
+
+        description = self.description
+
+        event_types: list[str] | Unset = UNSET
+        if not isinstance(self.event_types, Unset):
+            event_types = []
+            for event_types_item_data in self.event_types:
+                event_types_item = event_types_item_data.value
+                event_types.append(event_types_item)
+
+        status: str | Unset = UNSET
+        if not isinstance(self.status, Unset):
+            status = self.status.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if url is not UNSET:
+            field_dict["url"] = url
+        if description is not UNSET:
+            field_dict["description"] = description
+        if event_types is not UNSET:
+            field_dict["eventTypes"] = event_types
+        if status is not UNSET:
+            field_dict["status"] = status
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        url = d.pop("url", UNSET)
+
+        description = d.pop("description", UNSET)
+
+        _event_types = d.pop("eventTypes", UNSET)
+        event_types: list[UpdateWebhookEndpointBodyEventTypesItem] | Unset = UNSET
+        if _event_types is not UNSET:
+            event_types = []
+            for event_types_item_data in _event_types:
+                event_types_item = UpdateWebhookEndpointBodyEventTypesItem(event_types_item_data)
+
+                event_types.append(event_types_item)
+
+        _status = d.pop("status", UNSET)
+        status: UpdateWebhookEndpointBodyStatus | Unset
+        if isinstance(_status, Unset):
+            status = UNSET
+        else:
+            status = UpdateWebhookEndpointBodyStatus(_status)
+
+        update_webhook_endpoint_body = cls(
+            url=url,
+            description=description,
+            event_types=event_types,
+            status=status,
+        )
+
+        update_webhook_endpoint_body.additional_properties = d
+        return update_webhook_endpoint_body
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/update_webhook_endpoint_body_event_types_item.py
+++ b/sdks/python/colophony/models/update_webhook_endpoint_body_event_types_item.py
@@ -1,0 +1,18 @@
+from enum import Enum
+
+
+class UpdateWebhookEndpointBodyEventTypesItem(str, Enum):
+    HOPPERSUBMISSION_ACCEPTED = "hopper/submission.accepted"
+    HOPPERSUBMISSION_REJECTED = "hopper/submission.rejected"
+    HOPPERSUBMISSION_SUBMITTED = "hopper/submission.submitted"
+    HOPPERSUBMISSION_WITHDRAWN = "hopper/submission.withdrawn"
+    SLATECONTRACT_GENERATED = "slate/contract.generated"
+    SLATEISSUE_PUBLISHED = "slate/issue.published"
+    SLATEPIPELINE_AUTHOR_REVIEW_COMPLETED = "slate/pipeline.author-review-completed"
+    SLATEPIPELINE_COPYEDITOR_ASSIGNED = "slate/pipeline.copyeditor-assigned"
+    SLATEPIPELINE_COPYEDIT_COMPLETED = "slate/pipeline.copyedit-completed"
+    SLATEPIPELINE_PROOFREAD_COMPLETED = "slate/pipeline.proofread-completed"
+    WEBHOOK_TEST = "webhook.test"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/update_webhook_endpoint_body_status.py
+++ b/sdks/python/colophony/models/update_webhook_endpoint_body_status.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class UpdateWebhookEndpointBodyStatus(str, Enum):
+    ACTIVE = "ACTIVE"
+    DISABLED = "DISABLED"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/python/colophony/models/update_webhook_endpoint_response_200.py
+++ b/sdks/python/colophony/models/update_webhook_endpoint_response_200.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.update_webhook_endpoint_response_200_status import UpdateWebhookEndpointResponse200Status
+
+T = TypeVar("T", bound="UpdateWebhookEndpointResponse200")
+
+
+@_attrs_define
+class UpdateWebhookEndpointResponse200:
+    """
+    Attributes:
+        id (UUID):
+        url (str):
+        description (None | str):
+        event_types (list[str]):
+        status (UpdateWebhookEndpointResponse200Status):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+    """
+
+    id: UUID
+    url: str
+    description: None | str
+    event_types: list[str]
+    status: UpdateWebhookEndpointResponse200Status
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        url = self.url
+
+        description: None | str
+        description = self.description
+
+        event_types = self.event_types
+
+        status = self.status.value
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "url": url,
+                "description": description,
+                "eventTypes": event_types,
+                "status": status,
+                "createdAt": created_at,
+                "updatedAt": updated_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        url = d.pop("url")
+
+        def _parse_description(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        description = _parse_description(d.pop("description"))
+
+        event_types = cast(list[str], d.pop("eventTypes"))
+
+        status = UpdateWebhookEndpointResponse200Status(d.pop("status"))
+
+        created_at = datetime.datetime.fromisoformat(d.pop("createdAt"))
+
+        updated_at = datetime.datetime.fromisoformat(d.pop("updatedAt"))
+
+        update_webhook_endpoint_response_200 = cls(
+            id=id,
+            url=url,
+            description=description,
+            event_types=event_types,
+            status=status,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        update_webhook_endpoint_response_200.additional_properties = d
+        return update_webhook_endpoint_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdks/python/colophony/models/update_webhook_endpoint_response_200_status.py
+++ b/sdks/python/colophony/models/update_webhook_endpoint_response_200_status.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class UpdateWebhookEndpointResponse200Status(str, Enum):
+    ACTIVE = "ACTIVE"
+    DISABLED = "DISABLED"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdks/typescript/src/generated/openapi.ts
+++ b/sdks/typescript/src/generated/openapi.ts
@@ -2172,6 +2172,138 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/webhooks": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List webhook endpoints
+     * @description Returns the organization’s registered webhook endpoints, newest first. Signing secrets are never included.
+     */
+    get: operations["listWebhookEndpoints"];
+    put?: never;
+    /**
+     * Register a webhook endpoint
+     * @description Registers an HTTPS endpoint to receive the selected events. The URL is validated against SSRF rules — it must be a public HTTPS address. The signing secret is returned **only** by this operation and by endpoint creation — it cannot be read back afterwards. Store it before discarding the response.
+     */
+    post: operations["createWebhookEndpoint"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/webhooks/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get a webhook endpoint
+     * @description Returns one webhook endpoint. Responds 404 for an endpoint belonging to another organization, which is indistinguishable from one that does not exist. The signing secret is never included.
+     */
+    get: operations["getWebhookEndpoint"];
+    put?: never;
+    post?: never;
+    /**
+     * Delete a webhook endpoint
+     * @description Deletes the endpoint and its delivery history. Responds 404 rather than reporting success for an endpoint that does not exist.
+     */
+    delete: operations["deleteWebhookEndpoint"];
+    options?: never;
+    head?: never;
+    /**
+     * Update a webhook endpoint
+     * @description Updates the URL, description, subscribed events, or status. A changed URL is re-validated against SSRF rules. Signing secrets are never included in the response — rotate the secret to obtain a new one.
+     */
+    patch: operations["updateWebhookEndpoint"];
+    trace?: never;
+  };
+  "/webhooks/{id}/rotate-secret": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Rotate a webhook signing secret
+     * @description Generates a new signing secret and invalidates the previous one. In-flight deliveries are signed with whichever secret is current when they are sent, so rotate during a quiet period if signature continuity matters. The signing secret is returned **only** by this operation and by endpoint creation — it cannot be read back afterwards. Store it before discarding the response.
+     */
+    post: operations["rotateWebhookEndpointSecret"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/webhooks/{id}/test": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Send a test delivery
+     * @description Queues a `webhook.test` delivery to the endpoint and returns its id. Delivery is asynchronous — poll `GET /webhook-deliveries` for the outcome. Rejected with 400 if the endpoint is disabled.
+     */
+    post: operations["testWebhookEndpoint"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/webhook-deliveries": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List webhook deliveries
+     * @description Returns delivery attempts across the organization’s endpoints, newest first. Filter by endpoint, event type, or status to narrow it.
+     */
+    get: operations["listWebhookDeliveries"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/webhook-deliveries/{deliveryId}/retry": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Retry a webhook delivery
+     * @description Requeues a delivery, clearing the previous attempt’s status and error. Responds 404 if the delivery or its endpoint is not in this organization.
+     */
+    post: operations["retryWebhookDelivery"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -12704,6 +12836,385 @@ export interface operations {
             /** Format: date-time */
             updatedAt: string;
           }[];
+        };
+      };
+    };
+  };
+  listWebhookEndpoints: {
+    parameters: {
+      query?: {
+        page?: number;
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @description Items on the current page */
+            items: {
+              /** Format: uuid */
+              id: string;
+              url: string;
+              description: string | null;
+              eventTypes: string[];
+              /** @enum {string} */
+              status: "ACTIVE" | "DISABLED";
+              /** Format: date-time */
+              createdAt: string;
+              /** Format: date-time */
+              updatedAt: string;
+            }[];
+            /** @description Total number of items across all pages */
+            total: number;
+            /** @description Current page number */
+            page: number;
+            /** @description Items per page */
+            limit: number;
+            /** @description Total number of pages */
+            totalPages: number;
+          };
+        };
+      };
+    };
+  };
+  createWebhookEndpoint: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** Format: uri */
+          url: string;
+          description?: string;
+          eventTypes: (
+            | "hopper/submission.submitted"
+            | "hopper/submission.accepted"
+            | "hopper/submission.rejected"
+            | "hopper/submission.withdrawn"
+            | "slate/pipeline.copyeditor-assigned"
+            | "slate/pipeline.copyedit-completed"
+            | "slate/pipeline.author-review-completed"
+            | "slate/pipeline.proofread-completed"
+            | "slate/contract.generated"
+            | "slate/issue.published"
+            | "webhook.test"
+          )[];
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** Format: uuid */
+            id: string;
+            url: string;
+            description: string | null;
+            eventTypes: string[];
+            /** @enum {string} */
+            status: "ACTIVE" | "DISABLED";
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            secret: string;
+          };
+        };
+      };
+    };
+  };
+  getWebhookEndpoint: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** Format: uuid */
+            id: string;
+            url: string;
+            description: string | null;
+            eventTypes: string[];
+            /** @enum {string} */
+            status: "ACTIVE" | "DISABLED";
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+          };
+        };
+      };
+    };
+  };
+  deleteWebhookEndpoint: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /**
+             * @description Always true on success
+             * @constant
+             */
+            success: true;
+          };
+        };
+      };
+    };
+  };
+  updateWebhookEndpoint: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          /** Format: uri */
+          url?: string;
+          description?: string;
+          eventTypes?: (
+            | "hopper/submission.submitted"
+            | "hopper/submission.accepted"
+            | "hopper/submission.rejected"
+            | "hopper/submission.withdrawn"
+            | "slate/pipeline.copyeditor-assigned"
+            | "slate/pipeline.copyedit-completed"
+            | "slate/pipeline.author-review-completed"
+            | "slate/pipeline.proofread-completed"
+            | "slate/contract.generated"
+            | "slate/issue.published"
+            | "webhook.test"
+          )[];
+          /** @enum {string} */
+          status?: "ACTIVE" | "DISABLED";
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** Format: uuid */
+            id: string;
+            url: string;
+            description: string | null;
+            eventTypes: string[];
+            /** @enum {string} */
+            status: "ACTIVE" | "DISABLED";
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+          };
+        };
+      };
+    };
+  };
+  rotateWebhookEndpointSecret: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** Format: uuid */
+            id: string;
+            url: string;
+            description: string | null;
+            eventTypes: string[];
+            /** @enum {string} */
+            status: "ACTIVE" | "DISABLED";
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            secret: string;
+          };
+        };
+      };
+    };
+  };
+  testWebhookEndpoint: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /**
+             * Format: uuid
+             * @description The queued test delivery — poll it via GET /webhook-deliveries
+             */
+            deliveryId: string;
+          };
+        };
+      };
+    };
+  };
+  listWebhookDeliveries: {
+    parameters: {
+      query?: {
+        endpointId?: string;
+        eventType?: string;
+        status?: "QUEUED" | "DELIVERING" | "DELIVERED" | "FAILED" | "CANCELLED";
+        page?: number;
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @description Items on the current page */
+            items: {
+              /** Format: uuid */
+              id: string;
+              /** Format: uuid */
+              webhookEndpointId: string;
+              eventType: string;
+              eventId: string;
+              payload?: unknown;
+              /** @enum {string} */
+              status:
+                "QUEUED" | "DELIVERING" | "DELIVERED" | "FAILED" | "CANCELLED";
+              httpStatusCode: number | null;
+              responseBody: string | null;
+              errorMessage: string | null;
+              attempts: number;
+              nextRetryAt: string | null;
+              deliveredAt: string | null;
+              /** Format: date-time */
+              createdAt: string;
+            }[];
+            /** @description Total number of items across all pages */
+            total: number;
+            /** @description Current page number */
+            page: number;
+            /** @description Items per page */
+            limit: number;
+            /** @description Total number of pages */
+            totalPages: number;
+          };
+        };
+      };
+    };
+  };
+  retryWebhookDelivery: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        deliveryId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            webhookEndpointId: string;
+            eventType: string;
+            eventId: string;
+            payload?: unknown;
+            /** @enum {string} */
+            status:
+              "QUEUED" | "DELIVERING" | "DELIVERED" | "FAILED" | "CANCELLED";
+            httpStatusCode: number | null;
+            responseBody: string | null;
+            errorMessage: string | null;
+            attempts: number;
+            nextRetryAt: string | null;
+            deliveredAt: string | null;
+            /** Format: date-time */
+            createdAt: string;
+          };
         };
       };
     };


### PR DESCRIPTION
Ports the nine webhook tRPC procedures to `/v1`, closing the top-priority
integrator gap: a caller could create submissions over REST but could not register
a webhook to hear about them, so every event-driven integration had to poll.
Consumes `webhooks:manage`, which had been defined but unused since it was minted.

Follows #541, which had to land first — the port sat on a live cross-tenant write
in `retryDelivery`.

**D2 held exactly as predicted.** Per-org endpoints keep `webhook_endpoints`
unchanged, no procedure accepts an `organizationId`, and
`webhookEndpointResponseSchema` declares none — so there is no ownership
discriminator to publish, and nothing here has to change if instance-wide
subscriptions never ship.

## Routes

| Method | Path | Scope | Builder |
| --- | --- | --- | --- |
| GET | `/webhooks` | `webhooks:read` | org |
| POST | `/webhooks` (201) | `webhooks:manage` | admin |
| GET | `/webhooks/{id}` | `webhooks:read` | org |
| PATCH | `/webhooks/{id}` | `webhooks:manage` | admin |
| DELETE | `/webhooks/{id}` | `webhooks:manage` | admin |
| POST | `/webhooks/{id}/rotate-secret` | `webhooks:manage` | admin |
| POST | `/webhooks/{id}/test` (201) | `webhooks:manage` | admin |
| GET | `/webhook-deliveries` | `webhooks:read` | org |
| POST | `/webhook-deliveries/{deliveryId}/retry` | `webhooks:manage` | admin |

Builders and scopes mirror the tRPC twins exactly. Deliveries are a top-level
collection with an `endpointId` filter rather than nested under an endpoint,
preserving the org-wide listing the tRPC procedure already offers.

## Secret handling

Exactly two operations may return the signing secret, and the asymmetry is
deliberate: `redactSecret` strips it in `getEndpoint`/`listEndpoints`/
`updateEndpoint` but **not** in `createEndpoint`/`rotateSecret`, which exist to
hand the caller something it can never read back. So registration and rotation
declare `webhookEndpointCreatedResponseSchema`; every other endpoint route
declares the redacted one.

Zod's strip is a second line of defence, not the argument — the spec asserts on
the response. Verified against the generated document: `secret` appears under
`POST /webhooks` and `rotate-secret`, and nowhere else.

`organizationId` is stripped from delivery responses rather than added to the
schema. The caller supplies it in `X-Organization-Id`; it is not part of the
published shape.

## Query input

The delivery list merges `listWebhookDeliveriesSchema` with `restPaginationQuery`
rather than taking bare pagination, so `endpointId`/`eventType`/`status` survive —
dropping them would have stopped mirroring the tRPC procedure. Both cap `limit` at
100, so unlike the notifications contract nothing is restated. No boolean params,
so the unexported `booleanQueryParam` helper is not implicated.

## Idempotency

Per D3 the six mutating routes are future `Idempotency-Key` manifest entries.
Listed, not implemented: no request header reaches the oRPC context yet
(`rest/router.ts` passes only `{authContext, dbTx, audit}`), and an optional
header is additive, so adding it later breaks no client.

## Verification

53 cases in `rest/routers/webhooks.spec.ts`, driven through
`createProcedureClient` so `requireOrgContext`/`requireAdmin`/`requireScopes` run
for real rather than being mocked away. Every route gets requires-auth and
requires-org-context via `describe.each`. Per-route cases assert:

- the **full** service argument list including `orgId` — a dropped org argument
  silently widens the query to RLS alone
- reads never leak a `secret`, even when the service mock returns one
- not-found maps to 404 **and does not audit** — `update`/`delete`/`rotateSecret`
  audited unconditionally before #541 made the service throw
- an SSRF rejection is a 400, not a 500
- retry goes through `enqueueWebhookRetry`, never a plain add (which the retained
  job dedups into a no-op)
- ADMIN is required on all six manage routes, using a READER context — the
  notifications spec has no analogue since none of its routes are admin-only
- `test` emits **no** audit event, pinning the parity gap so it cannot be closed
  on one surface only

Spec: **105 paths / 155 operations / 19 tags**, up from 99 / 146 / 18. Both SDKs
regenerated; all three `sdk-check` legs replicated locally against the committed
state and clean. Suites: 2001 unit (up from 1948), type-check, lint and
`format:check` green.

The stale `webhooks:read is still enforced only by its tRPC router` comment in
`openapi-spec.spec.ts` is corrected, and the assertion now also covers
`webhooks:manage`.

## Backlog corrections

The P1.1 entry carried three inaccuracies, fixed as part of ticking it:

1. "four of the nine procedures throw bare `Error`" — it was **five throw sites
   across two procedures** (`test`, `retryDelivery`). The larger defect was the
   other four returning `null`/`undefined`/`void` on a miss.
2. `WebhookUrlValidationError` was absent from **both** error-mappers, not just
   the REST one — so an SSRF rejection was a 500 on either surface.
3. **No tRPC webhook procedure declared `.output()`**, so all three response
   schemas in `packages/types/src/webhook.ts` were defined but unreferenced. This
   port is their first consumer, which is what surfaced the untyped `eventTypes`
   jsonb fixed in #541.

The REST operation count recorded in `docs/file-index.md` was also stale (146
against an actual 146 that had since diverged from the paths figure); it is now
105 paths / 155 operations. Per-directory notes were updated to match.

## Follow-ups filed, not fixed here

- **`getActiveEndpointsForEvent` is unbounded** (no `LIMIT`). Raised in review and
  deliberately not fixed: it is the fan-out path, so a truncating limit would
  silently stop delivering to whichever endpoints fell off the end — strictly
  worse than the unbounded read. Wants batching.
- **`webhooks.test` is audited on neither surface.** It writes a delivery row and
  enqueues a job, but there is no `WEBHOOK_ENDPOINT_TESTED` action and the typed
  detail union closes `WEBHOOK_ENDPOINT` to five, so adding one must land on both
  surfaces together.


---

## Second commit: backlog reconciliation

`024957b1` is unrelated to webhooks and is here rather than in its own PR for one
reason: it edits `docs/backlog.md`, which this PR already modifies. Splitting it
would guarantee a conflict on that file.

It applies six metadata-drift corrections from this session's verification pass —
all items confirmed still open, nothing ticked — plus the tracked
`docs/tenant-isolation-audit.md` §4.4, which one of them pointed at. Highlights:

- `rest/error-mapper.ts:223` is a **tenth** direct-form `23505` site the backlog's
  list of nine missed. It is the surface-wide fallback, which is why a
  duplicate-key error renders differently on REST than on tRPC.
- `submission-reviewer.service.ts` is **not** a second instance of the non-member
  assignee bug, as that entry claimed — it already validates membership, so it is
  a working precedent for the fix.
- The isolation audit's §4.4 table said "eight" while listing nine, had every line
  number stale, and drew no distinction between the eight SELECTs and the one
  UPDATE.

Coverage: 12 of 30 open Track 2 code items verified; four P3s left unverified by
the 12-item cap.
